### PR TITLE
Fix commonmark Markdown warnings in docs, part 1

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -865,7 +865,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         }
     }
 
-    /// http://w3c.github.io/touch-events/#mouse-events
+    /// <http://w3c.github.io/touch-events/#mouse-events>
     fn simulate_mouse_click(&mut self, p: TypedPoint2D<f32, DevicePixel>) {
         let button = MouseButton::Left;
         self.dispatch_mouse_window_move_event_class(p);

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -40,6 +40,7 @@ pub struct Opts {
     pub device_pixels_per_px: Option<f32>,
 
     /// `None` to disable the time profiler or `Some` to enable it with:
+    ///
     ///  - an interval in seconds to cause it to produce output on that interval.
     ///    (`i.e. -p 5`).
     ///  - a file path to write profiling info to a TSV file upon Servo's termination.
@@ -68,7 +69,7 @@ pub struct Opts {
     pub output_file: Option<String>,
 
     /// Replace unpaires surrogates in DOM strings with U+FFFD.
-    /// See https://github.com/servo/servo/issues/6564
+    /// See <https://github.com/servo/servo/issues/6564>
     pub replace_surrogates: bool,
 
     /// Log GC passes and their durations.
@@ -296,7 +297,7 @@ pub struct DebugOptions {
     pub convert_mouse_to_touch: bool,
 
     /// Replace unpaires surrogates in DOM strings with U+FFFD.
-    /// See https://github.com/servo/servo/issues/6564
+    /// See <https://github.com/servo/servo/issues/6564>
     pub replace_surrogates: bool,
 
     /// Log GC passes and their durations.

--- a/components/constellation/browsingcontext.rs
+++ b/components/constellation/browsingcontext.rs
@@ -109,7 +109,7 @@ impl BrowsingContext {
 /// When we operate on the joint session history, entries are sorted chronologically,
 /// so we timestamp the entries by when the entry was added to the session history.
 ///
-/// https://html.spec.whatwg.org/multipage/#session-history-entry
+/// <https://html.spec.whatwg.org/multipage/#session-history-entry>
 #[derive(Clone)]
 pub struct SessionHistoryEntry {
     /// The timestamp for when the session history entry was created

--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -12,7 +12,7 @@ use script_traits::ConstellationControlMsg;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
-/// https://html.spec.whatwg.org/multipage/#event-loop
+/// <https://html.spec.whatwg.org/multipage/#event-loop>
 pub struct EventLoop {
     script_chan: IpcSender<ConstellationControlMsg>,
     dont_send_or_sync: PhantomData<Rc<()>>,

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -858,7 +858,7 @@ fn get_ellipse_radius<F>(size: &Size2D<Au>, center: &Point2D<Au>, cmp: F) -> Siz
 }
 
 /// Determines the radius of a circle if it was not explictly provided.
-/// https://drafts.csswg.org/css-images-3/#typedef-size
+/// <https://drafts.csswg.org/css-images-3/#typedef-size>
 fn convert_circle_size_keyword(keyword: ShapeExtent,
                                size: &Size2D<Au>,
                                center: &Point2D<Au>) -> Size2D<Au> {
@@ -882,7 +882,7 @@ fn convert_circle_size_keyword(keyword: ShapeExtent,
 }
 
 /// Determines the radius of an ellipse if it was not explictly provided.
-/// https://drafts.csswg.org/css-images-3/#typedef-size
+/// <https://drafts.csswg.org/css-images-3/#typedef-size>
 fn convert_ellipse_size_keyword(keyword: ShapeExtent,
                                 size: &Size2D<Au>,
                                 center: &Point2D<Au>) -> Size2D<Au> {

--- a/components/layout/flex.rs
+++ b/components/layout/flex.rs
@@ -264,7 +264,7 @@ impl FlexLine {
     /// This method implements the flexible lengths resolving algorithm.
     /// The 'collapse' parameter is used to indicate whether items with 'visibility: collapse'
     /// is included in length resolving. The result main size is stored in 'item.main_size'.
-    /// https://drafts.csswg.org/css-flexbox/#resolve-flexible-lengths
+    /// <https://drafts.csswg.org/css-flexbox/#resolve-flexible-lengths>
     pub fn flex_resolve(&mut self, items: &mut [FlexItem], collapse: bool) {
         let mut total_grow = 0.0;
         let mut total_shrink = 0.0;

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -679,7 +679,7 @@ pub fn process_node_scroll_area_request< N: LayoutNode>(requested_node: N, layou
 }
 
 /// Return the resolved value of property for a given (pseudo)element.
-/// https://drafts.csswg.org/cssom/#resolved-value
+/// <https://drafts.csswg.org/cssom/#resolved-value>
 pub fn process_resolved_style_request<'a, N>(context: &LayoutContext,
                                              node: N,
                                              pseudo: &Option<PseudoElement>,

--- a/components/net/cookie.rs
+++ b/components/net/cookie.rs
@@ -42,7 +42,7 @@ impl Cookie {
             .unwrap_or(None)
     }
 
-    /// http://tools.ietf.org/html/rfc6265#section-5.3
+    /// <http://tools.ietf.org/html/rfc6265#section-5.3>
     pub fn new_wrapped(mut cookie: cookie_rs::Cookie<'static>, request: &ServoUrl, source: CookieSource)
                        -> Option<Cookie> {
         // Step 3

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -494,7 +494,7 @@ fn scheme_fetch(request: &mut Request,
     }
 }
 
-/// https://fetch.spec.whatwg.org/#cors-safelisted-request-header
+/// <https://fetch.spec.whatwg.org/#cors-safelisted-request-header>
 pub fn is_cors_safelisted_request_header(h: &HeaderView) -> bool {
     if h.is::<ContentType>() {
         match h.value() {
@@ -509,7 +509,7 @@ pub fn is_cors_safelisted_request_header(h: &HeaderView) -> bool {
     }
 }
 
-/// https://fetch.spec.whatwg.org/#cors-safelisted-method
+/// <https://fetch.spec.whatwg.org/#cors-safelisted-method>
 pub fn is_cors_safelisted_method(m: &Method) -> bool {
     match *m {
         Method::Get | Method::Head | Method::Post => true,
@@ -528,9 +528,9 @@ fn is_null_body_status(status: &Option<StatusCode>) -> bool {
     }
 }
 
-/// https://fetch.spec.whatwg.org/#should-response-to-request-be-blocked-due-to-nosniff?
+/// <https://fetch.spec.whatwg.org/#should-response-to-request-be-blocked-due-to-nosniff?>
 pub fn should_be_blocked_due_to_nosniff(request_type: Type, response_headers: &Headers) -> bool {
-    /// https://fetch.spec.whatwg.org/#x-content-type-options-header
+    /// <https://fetch.spec.whatwg.org/#x-content-type-options-header>
     /// This is needed to parse `X-Content-Type-Options` according to spec,
     /// which requires that we inspect only the first value.
     ///
@@ -572,7 +572,7 @@ pub fn should_be_blocked_due_to_nosniff(request_type: Type, response_headers: &H
     // Note: an invalid MIME type will produce a `None`.
     let content_type_header = response_headers.get::<ContentType>();
 
-    /// https://html.spec.whatwg.org/multipage/#scriptingLanguages
+    /// <https://html.spec.whatwg.org/multipage/#scriptingLanguages>
     #[inline]
     fn is_javascript_mime_type(mime_type: &Mime) -> bool {
         let javascript_mime_types: [Mime; 16] = [
@@ -619,7 +619,7 @@ pub fn should_be_blocked_due_to_nosniff(request_type: Type, response_headers: &H
     };
 }
 
-/// https://fetch.spec.whatwg.org/#should-response-to-request-be-blocked-due-to-mime-type?
+/// <https://fetch.spec.whatwg.org/#should-response-to-request-be-blocked-due-to-mime-type?>
 fn should_be_blocked_due_to_mime_type(request_type: Type, response_headers: &Headers) -> bool {
     let mime_type = match response_headers.get::<ContentType>() {
         Some(header) => header,
@@ -634,7 +634,7 @@ fn should_be_blocked_due_to_mime_type(request_type: Type, response_headers: &Hea
     }
 }
 
-/// https://fetch.spec.whatwg.org/#block-bad-port
+/// <https://fetch.spec.whatwg.org/#block-bad-port>
 pub fn should_be_blocked_due_to_bad_port(url: &ServoUrl) -> bool {
     // Step 1 is not applicable, this function just takes the URL directly.
 
@@ -662,12 +662,12 @@ pub fn should_be_blocked_due_to_bad_port(url: &ServoUrl) -> bool {
     false
 }
 
-/// https://fetch.spec.whatwg.org/#network-scheme
+/// <https://fetch.spec.whatwg.org/#network-scheme>
 fn is_network_scheme(scheme: &str) -> bool {
     scheme == "ftp" || scheme == "http" || scheme == "https"
 }
 
-/// https://fetch.spec.whatwg.org/#bad-port
+/// <https://fetch.spec.whatwg.org/#bad-port>
 fn is_bad_port(port: u16) -> bool {
     static BAD_PORTS: [u16; 64] = [
         1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42,

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -193,7 +193,7 @@ pub fn set_default_accept_language(headers: &mut Headers) {
     ]));
 }
 
-/// https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-state-no-referrer-when-downgrade
+/// <https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-state-no-referrer-when-downgrade>
 fn no_referrer_when_downgrade_header(referrer_url: ServoUrl, url: ServoUrl) -> Option<ServoUrl> {
     if referrer_url.scheme() == "https" && url.scheme() != "https" {
         return None;
@@ -201,7 +201,7 @@ fn no_referrer_when_downgrade_header(referrer_url: ServoUrl, url: ServoUrl) -> O
     return strip_url(referrer_url, false);
 }
 
-/// https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-strict-origin
+/// <https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-strict-origin>
 fn strict_origin(referrer_url: ServoUrl, url: ServoUrl) -> Option<ServoUrl> {
     if referrer_url.scheme() == "https" && url.scheme() != "https" {
         return None;
@@ -209,7 +209,7 @@ fn strict_origin(referrer_url: ServoUrl, url: ServoUrl) -> Option<ServoUrl> {
     strip_url(referrer_url, true)
 }
 
-/// https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-strict-origin-when-cross-origin
+/// <https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-strict-origin-when-cross-origin>
 fn strict_origin_when_cross_origin(referrer_url: ServoUrl, url: ServoUrl) -> Option<ServoUrl> {
     if referrer_url.scheme() == "https" && url.scheme() != "https" {
         return None;
@@ -218,7 +218,7 @@ fn strict_origin_when_cross_origin(referrer_url: ServoUrl, url: ServoUrl) -> Opt
     strip_url(referrer_url, cross_origin)
 }
 
-/// https://w3c.github.io/webappsec-referrer-policy/#strip-url
+/// <https://w3c.github.io/webappsec-referrer-policy/#strip-url>
 fn strip_url(mut referrer_url: ServoUrl, origin_only: bool) -> Option<ServoUrl> {
     if referrer_url.scheme() == "https" || referrer_url.scheme() == "http" {
         {
@@ -236,7 +236,7 @@ fn strip_url(mut referrer_url: ServoUrl, origin_only: bool) -> Option<ServoUrl> 
     return None;
 }
 
-/// https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer
+/// <https://w3c.github.io/webappsec-referrer-policy/#determine-requests-referrer>
 /// Steps 4-6.
 pub fn determine_request_referrer(headers: &mut Headers,
                                   referrer_policy: ReferrerPolicy,
@@ -1376,7 +1376,7 @@ fn response_needs_revalidation(_response: &Response) -> bool {
     false
 }
 
-/// https://fetch.spec.whatwg.org/#redirect-status
+/// <https://fetch.spec.whatwg.org/#redirect-status>
 pub fn is_redirect_status(status: StatusCode) -> bool {
     match status {
         StatusCode::MovedPermanently |

--- a/components/net/mime_classifier.rs
+++ b/components/net/mime_classifier.rs
@@ -30,7 +30,7 @@ pub enum ApacheBugFlag {
 }
 
 impl ApacheBugFlag {
-    /// https://mimesniff.spec.whatwg.org/#supplied-mime-type-detection-algorithm
+    /// <https://mimesniff.spec.whatwg.org/#supplied-mime-type-detection-algorithm>
     pub fn from_content_type(last_raw_content_type: &[u8]) -> ApacheBugFlag {
         if last_raw_content_type == b"text/plain"
                || last_raw_content_type == b"text/plain; charset=ISO-8859-1"

--- a/components/net/subresource_integrity.rs
+++ b/components/net/subresource_integrity.rs
@@ -16,7 +16,7 @@ const SUPPORTED_ALGORITHM: &'static [&'static str] = &[
 pub type StaticCharVec = &'static [char];
 /// A "space character" according to:
 ///
-/// https://html.spec.whatwg.org/multipage/#space-character
+/// <https://html.spec.whatwg.org/multipage/#space-character>
 pub static HTML_SPACE_CHARACTERS: StaticCharVec = &[
     '\u{0020}',
     '\u{0009}',
@@ -44,7 +44,7 @@ impl SriEntry {
     }
 }
 
-/// https://w3c.github.io/webappsec-subresource-integrity/#parse-metadata
+/// <https://w3c.github.io/webappsec-subresource-integrity/#parse-metadata>
 pub fn parsed_metadata(integrity_metadata: &str) -> Vec<SriEntry> {
     // Step 1
     let mut result = vec![];
@@ -77,7 +77,7 @@ pub fn parsed_metadata(integrity_metadata: &str) -> Vec<SriEntry> {
     return result;
 }
 
-/// https://w3c.github.io/webappsec-subresource-integrity/#getprioritizedhashfunction
+/// <https://w3c.github.io/webappsec-subresource-integrity/#getprioritizedhashfunction>
 pub fn get_prioritized_hash_function(hash_func_left: &str, hash_func_right: &str) -> Option<String> {
     let left_priority = SUPPORTED_ALGORITHM.iter().position(|s| s.to_owned() == hash_func_left).unwrap();
     let right_priority = SUPPORTED_ALGORITHM.iter().position(|s| s.to_owned() == hash_func_right).unwrap();
@@ -93,7 +93,7 @@ pub fn get_prioritized_hash_function(hash_func_left: &str, hash_func_right: &str
 
 }
 
-/// https://w3c.github.io/webappsec-subresource-integrity/#get-the-strongest-metadata
+/// <https://w3c.github.io/webappsec-subresource-integrity/#get-the-strongest-metadata>
 pub fn get_strongest_metadata(integrity_metadata_list: Vec<SriEntry>) -> Vec<SriEntry> {
     let mut result: Vec<SriEntry> = vec![integrity_metadata_list[0].clone()];
     let mut current_algorithm = result[0].alg.clone();
@@ -114,7 +114,7 @@ pub fn get_strongest_metadata(integrity_metadata_list: Vec<SriEntry>) -> Vec<Sri
     result
 }
 
-/// https://w3c.github.io/webappsec-subresource-integrity/#apply-algorithm-to-response
+/// <https://w3c.github.io/webappsec-subresource-integrity/#apply-algorithm-to-response>
 fn apply_algorithm_to_response(body: MutexGuard<ResponseBody>,
                                message_digest: MessageDigest)
                                -> String {
@@ -126,7 +126,7 @@ fn apply_algorithm_to_response(body: MutexGuard<ResponseBody>,
     }
 }
 
-/// https://w3c.github.io/webappsec-subresource-integrity/#is-response-eligible
+/// <https://w3c.github.io/webappsec-subresource-integrity/#is-response-eligible>
 fn is_eligible_for_integrity_validation(response: &Response) -> bool {
     match response.response_type {
         ResponseType::Basic | ResponseType::Default | ResponseType::Cors => true,
@@ -134,7 +134,7 @@ fn is_eligible_for_integrity_validation(response: &Response) -> bool {
     }
 }
 
-/// https://w3c.github.io/webappsec-subresource-integrity/#does-response-match-metadatalist
+/// <https://w3c.github.io/webappsec-subresource-integrity/#does-response-match-metadatalist>
 pub fn is_response_integrity_valid(integrity_metadata: &str, response: &Response) -> bool {
     let parsed_metadata_list: Vec<SriEntry> = parsed_metadata(integrity_metadata);
 

--- a/components/net_traits/blob_url_store.rs
+++ b/components/net_traits/blob_url_store.rs
@@ -34,7 +34,8 @@ pub struct BlobBuf {
 }
 
 /// Parse URL as Blob URL scheme's definition
-/// https://w3c.github.io/FileAPI/#DefinitionOfScheme
+///
+/// <https://w3c.github.io/FileAPI/#DefinitionOfScheme>
 pub fn parse_blob_url(url: &ServoUrl) -> Result<(Uuid, FileOrigin), ()> {
     let url_inner = Url::parse(url.path()).map_err(|_| ())?;
     let id = {
@@ -47,6 +48,7 @@ pub fn parse_blob_url(url: &ServoUrl) -> Result<(Uuid, FileOrigin), ()> {
 
 /// Given an URL, returning the Origin that a Blob created under this
 /// URL should have.
+///
 /// HACK(izgzhen): Not well-specified on spec, and it is a bit a hack
 /// both due to ambiguity of spec and that we have to serialization the
 /// Origin here.

--- a/components/net_traits/filemanager_thread.rs
+++ b/components/net_traits/filemanager_thread.rs
@@ -17,7 +17,7 @@ pub type FileOrigin = String;
 
 /// Relative slice positions of a sequence,
 /// whose semantic should be consistent with (start, end) parameters in
-/// https://w3c.github.io/FileAPI/#dfn-slice
+/// <https://w3c.github.io/FileAPI/#dfn-slice>
 #[derive(Clone, Deserialize, Serialize)]
 pub struct RelativePos {
     /// Relative to first byte if non-negative,
@@ -59,7 +59,7 @@ impl RelativePos {
     }
 
     /// Compute absolute range by giving the total size
-    /// https://w3c.github.io/FileAPI/#slice-method-algo
+    /// <https://w3c.github.io/FileAPI/#slice-method-algo>
     pub fn to_abs_range(&self, size: usize) -> Range<usize> {
         let size = size as i64;
 

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -59,7 +59,7 @@ pub mod image {
 }
 
 /// A loading context, for context-specific sniffing, as defined in
-/// https://mimesniff.spec.whatwg.org/#context-specific-sniffing
+/// <https://mimesniff.spec.whatwg.org/#context-specific-sniffing>
 #[derive(Clone, Deserialize, HeapSizeOf, Serialize)]
 pub enum LoadContext {
     Browsing,
@@ -159,17 +159,17 @@ pub enum FetchResponseMsg {
 }
 
 pub trait FetchTaskTarget {
-    /// https://fetch.spec.whatwg.org/#process-request-body
+    /// <https://fetch.spec.whatwg.org/#process-request-body>
     ///
     /// Fired when a chunk of the request body is transmitted
     fn process_request_body(&mut self, request: &Request);
 
-    /// https://fetch.spec.whatwg.org/#process-request-end-of-file
+    /// <https://fetch.spec.whatwg.org/#process-request-end-of-file>
     ///
     /// Fired when the entire request finishes being transmitted
     fn process_request_eof(&mut self, request: &Request);
 
-    /// https://fetch.spec.whatwg.org/#process-response
+    /// <https://fetch.spec.whatwg.org/#process-response>
     ///
     /// Fired when headers are received
     fn process_response(&mut self, response: &Response);
@@ -177,7 +177,7 @@ pub trait FetchTaskTarget {
     /// Fired when a chunk of response content is received
     fn process_response_chunk(&mut self, chunk: Vec<u8>);
 
-    /// https://fetch.spec.whatwg.org/#process-response-end-of-file
+    /// <https://fetch.spec.whatwg.org/#process-response-end-of-file>
     ///
     /// Fired when the response is fully fetched
     fn process_response_eof(&mut self, response: &Response);

--- a/components/net_traits/pub_domains.rs
+++ b/components/net_traits/pub_domains.rs
@@ -7,7 +7,7 @@
 //! The list is a file located on the `resources` folder and loaded once on first need.
 //!
 //! The list can be updated with `./mach update-pub-domains` from this source:
-//! https://publicsuffix.org/list/
+//! <https://publicsuffix.org/list/>
 //!
 //! This implementation is not strictly following the specification of the list. Wildcards are not
 //! restricted to appear only in the leftmost position, but the current list has no such cases so

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -201,64 +201,64 @@ impl Default for RequestInit {
 /// the Fetch spec.
 #[derive(Clone, HeapSizeOf)]
 pub struct Request {
-    /// https://fetch.spec.whatwg.org/#concept-request-method
+    /// <https://fetch.spec.whatwg.org/#concept-request-method>
     #[ignore_heap_size_of = "Defined in hyper"]
     pub method: Method,
-    /// https://fetch.spec.whatwg.org/#local-urls-only-flag
+    /// <https://fetch.spec.whatwg.org/#local-urls-only-flag>
     pub local_urls_only: bool,
-    /// https://fetch.spec.whatwg.org/#sandboxed-storage-area-urls-flag
+    /// <https://fetch.spec.whatwg.org/#sandboxed-storage-area-urls-flag>
     pub sandboxed_storage_area_urls: bool,
-    /// https://fetch.spec.whatwg.org/#concept-request-header-list
+    /// <https://fetch.spec.whatwg.org/#concept-request-header-list>
     #[ignore_heap_size_of = "Defined in hyper"]
     pub headers: Headers,
-    /// https://fetch.spec.whatwg.org/#unsafe-request-flag
+    /// <https://fetch.spec.whatwg.org/#unsafe-request-flag>
     pub unsafe_request: bool,
-    /// https://fetch.spec.whatwg.org/#concept-request-body
+    /// <https://fetch.spec.whatwg.org/#concept-request-body>
     pub body: Option<Vec<u8>>,
     // TODO: client object
     pub window: Window,
     // TODO: target browsing context
-    /// https://fetch.spec.whatwg.org/#request-keepalive-flag
+    /// <https://fetch.spec.whatwg.org/#request-keepalive-flag>
     pub keep_alive: bool,
-    /// https://fetch.spec.whatwg.org/#request-service-workers-mode
+    /// <https://fetch.spec.whatwg.org/#request-service-workers-mode>
     pub service_workers_mode: ServiceWorkersMode,
-    /// https://fetch.spec.whatwg.org/#concept-request-initiator
+    /// <https://fetch.spec.whatwg.org/#concept-request-initiator>
     pub initiator: Initiator,
-    /// https://fetch.spec.whatwg.org/#concept-request-type
+    /// <https://fetch.spec.whatwg.org/#concept-request-type>
     pub type_: Type,
-    /// https://fetch.spec.whatwg.org/#concept-request-destination
+    /// <https://fetch.spec.whatwg.org/#concept-request-destination>
     pub destination: Destination,
     // TODO: priority object
-    /// https://fetch.spec.whatwg.org/#concept-request-origin
+    /// <https://fetch.spec.whatwg.org/#concept-request-origin>
     pub origin: Origin,
-    /// https://fetch.spec.whatwg.org/#concept-request-referrer
+    /// <https://fetch.spec.whatwg.org/#concept-request-referrer>
     pub referrer: Referrer,
-    /// https://fetch.spec.whatwg.org/#concept-request-referrer-policy
+    /// <https://fetch.spec.whatwg.org/#concept-request-referrer-policy>
     pub referrer_policy: Option<ReferrerPolicy>,
     pub pipeline_id: Option<PipelineId>,
-    /// https://fetch.spec.whatwg.org/#synchronous-flag
+    /// <https://fetch.spec.whatwg.org/#synchronous-flag>
     pub synchronous: bool,
-    /// https://fetch.spec.whatwg.org/#concept-request-mode
+    /// <https://fetch.spec.whatwg.org/#concept-request-mode>
     pub mode: RequestMode,
-    /// https://fetch.spec.whatwg.org/#use-cors-preflight-flag
+    /// <https://fetch.spec.whatwg.org/#use-cors-preflight-flag>
     pub use_cors_preflight: bool,
-    /// https://fetch.spec.whatwg.org/#concept-request-credentials-mode
+    /// <https://fetch.spec.whatwg.org/#concept-request-credentials-mode>
     pub credentials_mode: CredentialsMode,
-    /// https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag
+    /// <https://fetch.spec.whatwg.org/#concept-request-use-url-credentials-flag>
     pub use_url_credentials: bool,
-    /// https://fetch.spec.whatwg.org/#concept-request-cache-mode
+    /// <https://fetch.spec.whatwg.org/#concept-request-cache-mode>
     pub cache_mode: CacheMode,
-    /// https://fetch.spec.whatwg.org/#concept-request-redirect-mode
+    /// <https://fetch.spec.whatwg.org/#concept-request-redirect-mode>
     pub redirect_mode: RedirectMode,
-    /// https://fetch.spec.whatwg.org/#concept-request-integrity-metadata
+    /// <https://fetch.spec.whatwg.org/#concept-request-integrity-metadata>
     pub integrity_metadata: String,
     // Use the last method on url_list to act as spec current url field, and
     // first method to act as spec url field
-    /// https://fetch.spec.whatwg.org/#concept-request-url-list
+    /// <https://fetch.spec.whatwg.org/#concept-request-url-list>
     pub url_list: Vec<ServoUrl>,
-    /// https://fetch.spec.whatwg.org/#concept-request-redirect-count
+    /// <https://fetch.spec.whatwg.org/#concept-request-redirect-count>
     pub redirect_count: u32,
-    /// https://fetch.spec.whatwg.org/#concept-request-response-tainting
+    /// <https://fetch.spec.whatwg.org/#concept-request-response-tainting>
     pub response_tainting: ResponseTainting,
 }
 
@@ -333,27 +333,27 @@ impl Request {
         req
     }
 
-    /// https://fetch.spec.whatwg.org/#concept-request-url
+    /// <https://fetch.spec.whatwg.org/#concept-request-url>
     pub fn url(&self) -> ServoUrl {
         self.url_list.first().unwrap().clone()
     }
 
-    /// https://fetch.spec.whatwg.org/#concept-request-current-url
+    /// <https://fetch.spec.whatwg.org/#concept-request-current-url>
     pub fn current_url(&self) -> ServoUrl {
         self.url_list.last().unwrap().clone()
     }
 
-    /// https://fetch.spec.whatwg.org/#concept-request-current-url
+    /// <https://fetch.spec.whatwg.org/#concept-request-current-url>
     pub fn current_url_mut(&mut self) -> &mut ServoUrl {
         self.url_list.last_mut().unwrap()
     }
 
-    /// https://fetch.spec.whatwg.org/#navigation-request
+    /// <https://fetch.spec.whatwg.org/#navigation-request>
     pub fn is_navigation_request(&self) -> bool {
         self.destination == Destination::Document
     }
 
-    /// https://fetch.spec.whatwg.org/#subresource-request
+    /// <https://fetch.spec.whatwg.org/#subresource-request>
     pub fn is_subresource_request(&self) -> bool {
         match self.destination {
             Destination::Font | Destination::Image | Destination::Manifest | Destination::Media |

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 //! Tracking of pending loads in a document.
-//! https://html.spec.whatwg.org/multipage/#the-end
+//!
+//! <https://html.spec.whatwg.org/multipage/#the-end>
 
 use dom::bindings::root::Dom;
 use dom::document::Document;

--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -230,10 +230,10 @@ pub struct CallSetup {
     old_compartment: *mut JSCompartment,
     /// The exception handling used for the call.
     handling: ExceptionHandling,
-    /// https://heycam.github.io/webidl/#es-invoking-callback-functions
+    /// <https://heycam.github.io/webidl/#es-invoking-callback-functions>
     /// steps 8 and 18.2.
     entry_script: Option<AutoEntryScript>,
-    /// https://heycam.github.io/webidl/#es-invoking-callback-functions
+    /// <https://heycam.github.io/webidl/#es-invoking-callback-functions>
     /// steps 9 and 18.1.
     incumbent_script: Option<AutoIncumbentScript>,
 }

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -6,31 +6,31 @@
 //!
 //! | IDL type                | Argument type   | Return type    |
 //! |-------------------------|-----------------|----------------|
-//! | any                     | `JSVal`                          |
-//! | boolean                 | `bool`                           |
-//! | byte                    | `i8`                             |
-//! | octet                   | `u8`                             |
-//! | short                   | `i16`                            |
-//! | unsigned short          | `u16`                            |
-//! | long                    | `i32`                            |
-//! | unsigned long           | `u32`                            |
-//! | long long               | `i64`                            |
-//! | unsigned long long      | `u64`                            |
-//! | unrestricted float      | `f32`                            |
-//! | float                   | `Finite<f32>`                    |
-//! | unrestricted double     | `f64`                            |
-//! | double                  | `Finite<f64>`                    |
-//! | DOMString               | `DOMString`                      |
-//! | USVString               | `USVString`                      |
-//! | ByteString              | `ByteString`                     |
-//! | object                  | `*mut JSObject`                  |
+//! | any                     | `JSVal`         |                |
+//! | boolean                 | `bool`          |                |
+//! | byte                    | `i8`            |                |
+//! | octet                   | `u8`            |                |
+//! | short                   | `i16`           |                |
+//! | unsigned short          | `u16`           |                |
+//! | long                    | `i32`           |                |
+//! | unsigned long           | `u32`           |                |
+//! | long long               | `i64`           |                |
+//! | unsigned long long      | `u64`           |                |
+//! | unrestricted float      | `f32`           |                |
+//! | float                   | `Finite<f32>`   |                |
+//! | unrestricted double     | `f64`           |                |
+//! | double                  | `Finite<f64>`   |                |
+//! | DOMString               | `DOMString`     |                |
+//! | USVString               | `USVString`     |                |
+//! | ByteString              | `ByteString`    |                |
+//! | object                  | `*mut JSObject` |                |
 //! | interface types         | `&T`            | `DomRoot<T>`   |
 //! | dictionary types        | `&T`            | *unsupported*  |
-//! | enumeration types       | `T`                              |
-//! | callback function types | `Rc<T>`                          |
-//! | nullable types          | `Option<T>`                      |
-//! | sequences               | `Vec<T>`                         |
-//! | union types             | `T`                              |
+//! | enumeration types       | `T`             |                |
+//! | callback function types | `Rc<T>`         |                |
+//! | nullable types          | `Option<T>`     |                |
+//! | sequences               | `Vec<T>`        |                |
+//! | union types             | `T`             |                |
 
 use dom::bindings::error::{Error, Fallible};
 use dom::bindings::inheritance::Castable;

--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -548,7 +548,7 @@ unsafe extern "C" fn has_instance_hook(cx: *mut JSContext,
 }
 
 /// Return whether a value is an instance of a given prototype.
-/// http://heycam.github.io/webidl/#es-interface-hasinstance
+/// <http://heycam.github.io/webidl/#es-interface-hasinstance>
 unsafe fn has_instance(
         cx: *mut JSContext,
         interface_object: HandleObject,

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -712,7 +712,7 @@ impl<T: DomObject> LayoutDom<T> {
     }
 }
 
-/// Helper trait for safer manipulations of Option<Heap<T>> values.
+/// Helper trait for safer manipulations of `Option<Heap<T>>` values.
 pub trait OptionalHeapSetter {
     type Value;
     /// Update this optional heap value with a new value.

--- a/components/script/dom/bindings/settings_stack.rs
+++ b/components/script/dom/bindings/settings_stack.rs
@@ -41,7 +41,7 @@ pub struct AutoEntryScript {
 }
 
 impl AutoEntryScript {
-    /// https://html.spec.whatwg.org/multipage/#prepare-to-run-script
+    /// <https://html.spec.whatwg.org/multipage/#prepare-to-run-script>
     pub fn new(global: &GlobalScope) -> Self {
         STACK.with(|stack| {
             trace!("Prepare to run script with {:p}", global);
@@ -58,7 +58,7 @@ impl AutoEntryScript {
 }
 
 impl Drop for AutoEntryScript {
-    /// https://html.spec.whatwg.org/multipage/#clean-up-after-running-script
+    /// <https://html.spec.whatwg.org/multipage/#clean-up-after-running-script>
     fn drop(&mut self) {
         STACK.with(|stack| {
             let mut stack = stack.borrow_mut();
@@ -96,7 +96,7 @@ pub struct AutoIncumbentScript {
 }
 
 impl AutoIncumbentScript {
-    /// https://html.spec.whatwg.org/multipage/#prepare-to-run-a-callback
+    /// <https://html.spec.whatwg.org/multipage/#prepare-to-run-a-callback>
     pub fn new(global: &GlobalScope) -> Self {
         // Step 2-3.
         unsafe {
@@ -120,7 +120,7 @@ impl AutoIncumbentScript {
 }
 
 impl Drop for AutoIncumbentScript {
-    /// https://html.spec.whatwg.org/multipage/#clean-up-after-running-a-callback
+    /// <https://html.spec.whatwg.org/multipage/#clean-up-after-running-a-callback>
     fn drop(&mut self) {
         STACK.with(|stack| {
             // Step 4.

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -194,7 +194,7 @@ pub unsafe fn find_enum_value<'a, T>(cx: *mut JSContext,
 }
 
 /// Returns wether `obj` is a platform object
-/// https://heycam.github.io/webidl/#dfn-platform-object
+/// <https://heycam.github.io/webidl/#dfn-platform-object>
 pub fn is_platform_object(obj: *mut JSObject) -> bool {
     unsafe {
         // Fast-path the common case

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -329,7 +329,7 @@ fn read_file(global: &GlobalScope, id: Uuid) -> Result<Vec<u8>, ()> {
 }
 
 /// Extract bytes from BlobParts, used by Blob and File constructor
-/// https://w3c.github.io/FileAPI/#constructorBlob
+/// <https://w3c.github.io/FileAPI/#constructorBlob>
 pub fn blob_parts_to_bytes(blobparts: Vec<BlobOrString>) -> Result<Vec<u8>, ()> {
     let mut ret = vec![];
 
@@ -376,7 +376,7 @@ impl BlobMethods for Blob {
 }
 
 /// Get the normalized, MIME-parsable type string
-/// https://w3c.github.io/FileAPI/#dfn-type
+/// <https://w3c.github.io/FileAPI/#dfn-type>
 /// XXX: We will relax the restriction here,
 /// since the spec has some problem over this part.
 /// see https://github.com/w3c/FileAPI/issues/43

--- a/components/script/dom/css.rs
+++ b/components/script/dom/css.rs
@@ -21,14 +21,14 @@ pub struct CSS {
 }
 
 impl CSS {
-    /// http://dev.w3.org/csswg/cssom/#serialize-an-identifier
+    /// <http://dev.w3.org/csswg/cssom/#serialize-an-identifier>
     pub fn Escape(_: &Window, ident: DOMString) -> Fallible<DOMString> {
         let mut escaped = String::new();
         serialize_identifier(&ident, &mut escaped).unwrap();
         Ok(DOMString::from(escaped))
     }
 
-    /// https://drafts.csswg.org/css-conditional/#dom-css-supports
+    /// <https://drafts.csswg.org/css-conditional/#dom-css-supports>
     pub fn Supports(win: &Window, property: DOMString, value: DOMString) -> bool {
         let mut decl = String::new();
         serialize_identifier(&property, &mut decl).unwrap();
@@ -45,7 +45,7 @@ impl CSS {
         decl.eval(&context)
     }
 
-    /// https://drafts.csswg.org/css-conditional/#dom-css-supports
+    /// <https://drafts.csswg.org/css-conditional/#dom-css-supports>
     pub fn Supports_(win: &Window, condition: DOMString) -> bool {
         let mut input = ParserInput::new(&condition);
         let mut input = Parser::new(&mut input);

--- a/components/script/dom/cssconditionrule.rs
+++ b/components/script/dom/cssconditionrule.rs
@@ -37,7 +37,7 @@ impl CSSConditionRule {
 }
 
 impl CSSConditionRuleMethods for CSSConditionRule {
-    /// https://drafts.csswg.org/css-conditional-3/#dom-cssconditionrule-conditiontext
+    /// <https://drafts.csswg.org/css-conditional-3/#dom-cssconditionrule-conditiontext>
     fn ConditionText(&self) -> DOMString {
         if let Some(rule) = self.downcast::<CSSMediaRule>() {
             rule.get_condition_text()
@@ -48,7 +48,7 @@ impl CSSConditionRuleMethods for CSSConditionRule {
         }
     }
 
-    /// https://drafts.csswg.org/css-conditional-3/#dom-cssconditionrule-conditiontext
+    /// <https://drafts.csswg.org/css-conditional-3/#dom-cssconditionrule-conditiontext>
     fn SetConditionText(&self, text: DOMString) {
         if let Some(rule) = self.downcast::<CSSMediaRule>() {
             rule.set_condition_text(text)

--- a/components/script/dom/cssmediarule.rs
+++ b/components/script/dom/cssmediarule.rs
@@ -59,7 +59,7 @@ impl CSSMediaRule {
         })
     }
 
-    /// https://drafts.csswg.org/css-conditional-3/#the-cssmediarule-interface
+    /// <https://drafts.csswg.org/css-conditional-3/#the-cssmediarule-interface>
     pub fn get_condition_text(&self) -> DOMString {
         let guard = self.cssconditionrule.shared_lock().read();
         let rule = self.mediarule.read_with(&guard);
@@ -67,7 +67,7 @@ impl CSSMediaRule {
         list.to_css_string().into()
     }
 
-    /// https://drafts.csswg.org/css-conditional-3/#the-cssmediarule-interface
+    /// <https://drafts.csswg.org/css-conditional-3/#the-cssmediarule-interface>
     pub fn set_condition_text(&self, text: DOMString) {
         let mut input = ParserInput::new(&text);
         let mut input = Parser::new(&mut input);

--- a/components/script/dom/cssstylevalue.rs
+++ b/components/script/dom/cssstylevalue.rs
@@ -34,7 +34,7 @@ impl CSSStyleValue {
 }
 
 impl CSSStyleValueMethods for CSSStyleValue {
-    /// https://drafts.css-houdini.org/css-typed-om-1/#CSSStyleValue-stringification-behavior
+    /// <https://drafts.css-houdini.org/css-typed-om-1/#CSSStyleValue-stringification-behavior>
     fn Stringifier(&self) -> DOMString {
         DOMString::from(&*self.value)
     }
@@ -44,7 +44,7 @@ impl CSSStyleValue {
     /// Parse the value as a `url()`.
     /// TODO: This should really always be an absolute URL, but we currently
     /// return relative URLs for computed values, so we pass in a base.
-    /// https://github.com/servo/servo/issues/17625
+    /// <https://github.com/servo/servo/issues/17625>
     pub fn get_url(&self, base_url: ServoUrl) -> Option<ServoUrl> {
         let mut input = ParserInput::new(&*self.value);
         let mut parser = Parser::new(&mut input);

--- a/components/script/dom/csssupportsrule.rs
+++ b/components/script/dom/csssupportsrule.rs
@@ -46,14 +46,14 @@ impl CSSSupportsRule {
                            CSSSupportsRuleBinding::Wrap)
     }
 
-    /// https://drafts.csswg.org/css-conditional-3/#the-csssupportsrule-interface
+    /// <https://drafts.csswg.org/css-conditional-3/#the-csssupportsrule-interface>
     pub fn get_condition_text(&self) -> DOMString {
         let guard = self.cssconditionrule.shared_lock().read();
         let rule = self.supportsrule.read_with(&guard);
         rule.condition.to_css_string().into()
     }
 
-    /// https://drafts.csswg.org/css-conditional-3/#the-csssupportsrule-interface
+    /// <https://drafts.csswg.org/css-conditional-3/#the-csssupportsrule-interface>
     pub fn set_condition_text(&self, text: DOMString) {
         let mut input = ParserInput::new(&text);
         let mut input = Parser::new(&mut input);

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -40,7 +40,7 @@ use std::ops::Deref;
 use std::ptr;
 use std::rc::Rc;
 
-/// https://html.spec.whatwg.org/multipage/#customelementregistry
+/// <https://html.spec.whatwg.org/multipage/#customelementregistry>
 #[dom_struct]
 pub struct CustomElementRegistry {
     reflector_: Reflector,
@@ -74,12 +74,12 @@ impl CustomElementRegistry {
     }
 
     /// Cleans up any active promises
-    /// https://github.com/servo/servo/issues/15318
+    /// <https://github.com/servo/servo/issues/15318>
     pub fn teardown(&self) {
         self.when_defined.borrow_mut().clear()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#look-up-a-custom-element-definition
+    /// <https://html.spec.whatwg.org/multipage/#look-up-a-custom-element-definition>
     pub fn lookup_definition(&self,
                              local_name: &LocalName,
                              is: Option<&LocalName>)
@@ -97,7 +97,7 @@ impl CustomElementRegistry {
         }).cloned()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define
+    /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
     /// Steps 10.1, 10.2
     #[allow(unsafe_code)]
     fn check_prototype(&self, constructor: HandleObject, prototype: MutableHandleValue) -> ErrorResult {
@@ -119,7 +119,7 @@ impl CustomElementRegistry {
         Ok(())
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define
+    /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
     /// Steps 10.3, 10.4
     fn get_callbacks(&self, prototype: HandleObject) -> Fallible<LifecycleCallbacks> {
         let cx = self.window.get_cx();
@@ -133,7 +133,7 @@ impl CustomElementRegistry {
         })
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define
+    /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
     /// Step 10.6
     #[allow(unsafe_code)]
     fn get_observed_attributes(&self, constructor: HandleObject) -> Fallible<Vec<DOMString>> {
@@ -161,7 +161,7 @@ impl CustomElementRegistry {
     }
 }
 
-/// https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define
+/// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
 /// Step 10.4
 #[allow(unsafe_code)]
 fn get_callback(cx: *mut JSContext, prototype: HandleObject, name: &[u8]) -> Fallible<Option<Rc<Function>>> {
@@ -188,7 +188,7 @@ fn get_callback(cx: *mut JSContext, prototype: HandleObject, name: &[u8]) -> Fal
 
 impl CustomElementRegistryMethods for CustomElementRegistry {
     #[allow(unsafe_code, unrooted_must_root)]
-    /// https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define
+    /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
     fn Define(&self, name: DOMString, constructor_: Rc<Function>, options: &ElementDefinitionOptions) -> ErrorResult {
         let cx = self.window.get_cx();
         rooted!(in(cx) let constructor = constructor_.callback());
@@ -321,7 +321,7 @@ impl CustomElementRegistryMethods for CustomElementRegistry {
         Ok(())
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-customelementregistry-get
+    /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-get>
     #[allow(unsafe_code)]
     unsafe fn Get(&self, cx: *mut JSContext, name: DOMString) -> JSVal {
         match self.definitions.borrow().get(&LocalName::from(&*name)) {
@@ -334,7 +334,7 @@ impl CustomElementRegistryMethods for CustomElementRegistry {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-customelementregistry-whendefined
+    /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-whendefined>
     #[allow(unrooted_must_root)]
     fn WhenDefined(&self, name: DOMString) -> Rc<Promise> {
         let global_scope = self.window.upcast::<GlobalScope>();
@@ -390,7 +390,7 @@ pub enum ConstructionStackEntry {
     AlreadyConstructedMarker,
 }
 
-/// https://html.spec.whatwg.org/multipage/#custom-element-definition
+/// <https://html.spec.whatwg.org/multipage/#custom-element-definition>
 #[derive(Clone, HeapSizeOf, JSTraceable)]
 pub struct CustomElementDefinition {
     pub name: LocalName,
@@ -424,7 +424,7 @@ impl CustomElementDefinition {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#autonomous-custom-element
+    /// <https://html.spec.whatwg.org/multipage/#autonomous-custom-element>
     pub fn is_autonomous(&self) -> bool {
         self.name == self.local_name
     }
@@ -480,7 +480,7 @@ impl CustomElementDefinition {
     }
 }
 
-/// https://html.spec.whatwg.org/multipage/#concept-upgrade-an-element
+/// <https://html.spec.whatwg.org/multipage/#concept-upgrade-an-element>
 #[allow(unsafe_code)]
 pub fn upgrade_element(definition: Rc<CustomElementDefinition>, element: &Element) {
     // Steps 1-2
@@ -536,7 +536,7 @@ pub fn upgrade_element(definition: Rc<CustomElementDefinition>, element: &Elemen
     element.set_custom_element_definition(definition);
 }
 
-/// https://html.spec.whatwg.org/multipage/#concept-upgrade-an-element
+/// <https://html.spec.whatwg.org/multipage/#concept-upgrade-an-element>
 /// Steps 7.1-7.2
 #[allow(unsafe_code)]
 fn run_upgrade_constructor(constructor: &Rc<Function>, element: &Element) -> ErrorResult {
@@ -567,7 +567,7 @@ fn run_upgrade_constructor(constructor: &Rc<Function>, element: &Element) -> Err
     Ok(())
 }
 
-/// https://html.spec.whatwg.org/multipage/#concept-try-upgrade
+/// <https://html.spec.whatwg.org/multipage/#concept-try-upgrade>
 pub fn try_upgrade_element(element: &Element) {
     // Step 1
     let document = document_from_node(element);
@@ -595,7 +595,7 @@ pub enum CustomElementReaction {
 }
 
 impl CustomElementReaction {
-    /// https://html.spec.whatwg.org/multipage/#invoke-custom-element-reactions
+    /// <https://html.spec.whatwg.org/multipage/#invoke-custom-element-reactions>
     #[allow(unsafe_code)]
     pub fn invoke(&self, element: &Element) {
         // Step 2.1
@@ -616,14 +616,14 @@ pub enum CallbackReaction {
     AttributeChanged(LocalName, Option<DOMString>, Option<DOMString>, Namespace),
 }
 
-/// https://html.spec.whatwg.org/multipage/#processing-the-backup-element-queue
+/// <https://html.spec.whatwg.org/multipage/#processing-the-backup-element-queue>
 #[derive(Clone, Copy, Eq, HeapSizeOf, JSTraceable, PartialEq)]
 enum BackupElementQueueFlag {
     Processing,
     NotProcessing,
 }
 
-/// https://html.spec.whatwg.org/multipage/#custom-element-reactions-stack
+/// <https://html.spec.whatwg.org/multipage/#custom-element-reactions-stack>
 #[derive(HeapSizeOf, JSTraceable)]
 #[must_root]
 pub struct CustomElementReactionStack {
@@ -658,7 +658,7 @@ impl CustomElementReactionStack {
         self.stack.borrow_mut().append(&mut *stack);
     }
 
-    /// https://html.spec.whatwg.org/multipage/#enqueue-an-element-on-the-appropriate-element-queue
+    /// <https://html.spec.whatwg.org/multipage/#enqueue-an-element-on-the-appropriate-element-queue>
     /// Step 4
     pub fn invoke_backup_element_queue(&self) {
         // Step 4.1
@@ -668,7 +668,7 @@ impl CustomElementReactionStack {
         self.processing_backup_element_queue.set(BackupElementQueueFlag::NotProcessing);
     }
 
-    /// https://html.spec.whatwg.org/multipage/#enqueue-an-element-on-the-appropriate-element-queue
+    /// <https://html.spec.whatwg.org/multipage/#enqueue-an-element-on-the-appropriate-element-queue>
     pub fn enqueue_element(&self, element: &Element) {
         if let Some(current_queue) = self.stack.borrow().last() {
             // Step 2
@@ -690,7 +690,7 @@ impl CustomElementReactionStack {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#enqueue-a-custom-element-callback-reaction
+    /// <https://html.spec.whatwg.org/multipage/#enqueue-a-custom-element-callback-reaction>
     #[allow(unsafe_code)]
     pub fn enqueue_callback_reaction(&self,
                                      element: &Element,
@@ -763,7 +763,7 @@ impl CustomElementReactionStack {
         self.enqueue_element(element);
     }
 
-    /// https://html.spec.whatwg.org/multipage/#enqueue-a-custom-element-upgrade-reaction
+    /// <https://html.spec.whatwg.org/multipage/#enqueue-a-custom-element-upgrade-reaction>
     pub fn enqueue_upgrade_reaction(&self, element: &Element, definition: Rc<CustomElementDefinition>) {
         // Step 1
         element.push_upgrade_reaction(definition);
@@ -772,7 +772,7 @@ impl CustomElementReactionStack {
     }
 }
 
-/// https://html.spec.whatwg.org/multipage/#element-queue
+/// <https://html.spec.whatwg.org/multipage/#element-queue>
 #[derive(HeapSizeOf, JSTraceable)]
 #[must_root]
 struct ElementQueue {
@@ -786,7 +786,7 @@ impl ElementQueue {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#invoke-custom-element-reactions
+    /// <https://html.spec.whatwg.org/multipage/#invoke-custom-element-reactions>
     fn invoke_reactions(&self) {
         // Steps 1-2
         while let Some(element) = self.next_element() {
@@ -804,7 +804,7 @@ impl ElementQueue {
     }
 }
 
-/// https://html.spec.whatwg.org/multipage/#valid-custom-element-name
+/// <https://html.spec.whatwg.org/multipage/#valid-custom-element-name>
 pub fn is_valid_custom_element_name(name: &str) -> bool {
     // Custom elment names must match:
     // PotentialCustomElementName ::= [a-z] (PCENChar)* '-' (PCENChar)*
@@ -847,7 +847,7 @@ pub fn is_valid_custom_element_name(name: &str) -> bool {
 }
 
 /// Check if this character is a PCENChar
-/// https://html.spec.whatwg.org/multipage/#prod-pcenchar
+/// <https://html.spec.whatwg.org/multipage/#prod-pcenchar>
 fn is_potential_custom_element_char(c: char) -> bool {
     c == '-' || c == '.' || c == '_' || c == '\u{B7}' ||
     (c >= '0' && c <= '9') ||

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -219,7 +219,7 @@ impl ::style::stylesheets::StylesheetInDocument for StyleSheetInDocument {
     }
 }
 
-/// https://dom.spec.whatwg.org/#document
+/// <https://dom.spec.whatwg.org/#document>
 #[dom_struct]
 pub struct Document {
     node: Node,
@@ -261,23 +261,23 @@ pub struct Document {
     focused: MutNullableDom<Element>,
     /// The script element that is currently executing.
     current_script: MutNullableDom<HTMLScriptElement>,
-    /// https://html.spec.whatwg.org/multipage/#pending-parsing-blocking-script
+    /// <https://html.spec.whatwg.org/multipage/#pending-parsing-blocking-script>
     pending_parsing_blocking_script: DomRefCell<Option<PendingScript>>,
     /// Number of stylesheets that block executing the next parser-inserted script
     script_blocking_stylesheets_count: Cell<u32>,
     /// https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-when-the-document-has-finished-parsing
     deferred_scripts: PendingInOrderScriptVec,
-    /// https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-in-order-as-soon-as-possible
+    /// <https://html.spec.whatwg.org/multipage/#list-of-scripts-that-will-execute-in-order-as-soon-as-possible>
     asap_in_order_scripts_list: PendingInOrderScriptVec,
-    /// https://html.spec.whatwg.org/multipage/#set-of-scripts-that-will-execute-as-soon-as-possible
+    /// <https://html.spec.whatwg.org/multipage/#set-of-scripts-that-will-execute-as-soon-as-possible>
     asap_scripts_set: DomRefCell<Vec<Dom<HTMLScriptElement>>>,
-    /// https://html.spec.whatwg.org/multipage/#concept-n-noscript
+    /// <https://html.spec.whatwg.org/multipage/#concept-n-noscript>
     /// True if scripting is enabled for all scripts in this document
     scripting_enabled: bool,
-    /// https://html.spec.whatwg.org/multipage/#animation-frame-callback-identifier
+    /// <https://html.spec.whatwg.org/multipage/#animation-frame-callback-identifier>
     /// Current identifier of animation frame callback
     animation_frame_ident: Cell<u32>,
-    /// https://html.spec.whatwg.org/multipage/#list-of-animation-frame-callbacks
+    /// <https://html.spec.whatwg.org/multipage/#list-of-animation-frame-callbacks>
     /// List of animation frame callbacks
     animation_frame_list: DomRefCell<Vec<(u32, Option<AnimationFrameCallback>)>>,
     /// Whether we're in the process of running animation callbacks.
@@ -294,7 +294,7 @@ pub struct Document {
     /// The cached first `base` element with an `href` attribute.
     base_element: MutNullableDom<HTMLBaseElement>,
     /// This field is set to the document itself for inert documents.
-    /// https://html.spec.whatwg.org/multipage/#appropriate-template-contents-owner-document
+    /// <https://html.spec.whatwg.org/multipage/#appropriate-template-contents-owner-document>
     appropriate_template_contents_owner_document: MutNullableDom<Document>,
     /// Information on elements needing restyle to ship over to the layout thread when the
     /// time comes.
@@ -302,10 +302,10 @@ pub struct Document {
     /// This flag will be true if layout suppressed a reflow attempt that was
     /// needed in order for the page to be painted.
     needs_paint: Cell<bool>,
-    /// http://w3c.github.io/touch-events/#dfn-active-touch-point
+    /// <http://w3c.github.io/touch-events/#dfn-active-touch-point>
     active_touch_points: DomRefCell<Vec<Dom<Touch>>>,
     /// Navigation Timing properties:
-    /// https://w3c.github.io/navigation-timing/#sec-PerformanceNavigationTiming
+    /// <https://w3c.github.io/navigation-timing/#sec-PerformanceNavigationTiming>
     dom_loading: Cell<u64>,
     dom_interactive: Cell<u64>,
     dom_content_loaded_event_start: Cell<u64>,
@@ -313,21 +313,21 @@ pub struct Document {
     dom_complete: Cell<u64>,
     load_event_start: Cell<u64>,
     load_event_end: Cell<u64>,
-    /// https://html.spec.whatwg.org/multipage/#concept-document-https-state
+    /// <https://html.spec.whatwg.org/multipage/#concept-document-https-state>
     https_state: Cell<HttpsState>,
     touchpad_pressure_phase: Cell<TouchpadPressurePhase>,
     /// The document's origin.
     origin: MutableOrigin,
     ///  https://w3c.github.io/webappsec-referrer-policy/#referrer-policy-states
     referrer_policy: Cell<Option<ReferrerPolicy>>,
-    /// https://html.spec.whatwg.org/multipage/#dom-document-referrer
+    /// <https://html.spec.whatwg.org/multipage/#dom-document-referrer>
     referrer: Option<String>,
-    /// https://html.spec.whatwg.org/multipage/#target-element
+    /// <https://html.spec.whatwg.org/multipage/#target-element>
     target_element: MutNullableDom<Element>,
-    /// https://w3c.github.io/uievents/#event-type-dblclick
+    /// <https://w3c.github.io/uievents/#event-type-dblclick>
     #[ignore_heap_size_of = "Defined in std"]
     last_click_info: DomRefCell<Option<(Instant, Point2D<f32>)>>,
-    /// https://html.spec.whatwg.org/multipage/#ignore-destructive-writes-counter
+    /// <https://html.spec.whatwg.org/multipage/#ignore-destructive-writes-counter>
     ignore_destructive_writes_counter: Cell<u32>,
     /// The number of spurious `requestAnimationFrame()` requests we've received.
     ///
@@ -421,7 +421,7 @@ impl Document {
     #[inline]
     pub fn has_browsing_context(&self) -> bool { self.has_browsing_context }
 
-    /// https://html.spec.whatwg.org/multipage/#concept-document-bc
+    /// <https://html.spec.whatwg.org/multipage/#concept-document-bc>
     #[inline]
     pub fn browsing_context(&self) -> Option<DomRoot<WindowProxy>> {
         if self.has_browsing_context {
@@ -524,7 +524,7 @@ impl Document {
     }
 
     /// Refresh the cached first base element in the DOM.
-    /// https://github.com/w3c/web-platform-tests/issues/2122
+    /// <https://github.com/w3c/web-platform-tests/issues/2122>
     pub fn refresh_base_element(&self) {
         let base = self.upcast::<Node>()
                        .traverse_preorder()
@@ -667,7 +667,7 @@ impl Document {
     }
 
     /// Attempt to find a named element in this page's document.
-    /// https://html.spec.whatwg.org/multipage/#the-indicated-part-of-the-document
+    /// <https://html.spec.whatwg.org/multipage/#the-indicated-part-of-the-document>
     pub fn find_fragment_node(&self, fragid: &str) -> Option<DomRoot<Element>> {
         // Step 1 is not handled here; the fragid is already obtained by the calling function
         // Step 2: Simply use None to indicate the top of the document.
@@ -682,7 +682,7 @@ impl Document {
 
     /// Scroll to the target element, and when we do not find a target
     /// and the fragment is empty or "top", scroll to the top.
-    /// https://html.spec.whatwg.org/multipage/#scroll-to-the-fragment-identifier
+    /// <https://html.spec.whatwg.org/multipage/#scroll-to-the-fragment-identifier>
     pub fn check_and_scroll_fragment(&self, fragment: &str) {
         let target = self.find_fragment_node(fragment);
 
@@ -1522,7 +1522,7 @@ impl Document {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-window-requestanimationframe
+    /// <https://html.spec.whatwg.org/multipage/#dom-window-requestanimationframe>
     pub fn request_animation_frame(&self, callback: AnimationFrameCallback) -> u32 {
         let ident = self.animation_frame_ident.get() + 1;
 
@@ -1554,7 +1554,7 @@ impl Document {
         ident
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-window-cancelanimationframe
+    /// <https://html.spec.whatwg.org/multipage/#dom-window-cancelanimationframe>
     pub fn cancel_animation_frame(&self, ident: u32) {
         let mut list = self.animation_frame_list.borrow_mut();
         if let Some(pair) = list.iter_mut().find(|pair| pair.0 == ident) {
@@ -1562,7 +1562,7 @@ impl Document {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#run-the-animation-frame-callbacks
+    /// <https://html.spec.whatwg.org/multipage/#run-the-animation-frame-callbacks>
     pub fn run_the_animation_frame_callbacks(&self) {
         rooted_vec!(let mut animation_frame_list);
         mem::swap(
@@ -2000,7 +2000,7 @@ impl Document {
         event.fire(target);
     }
 
-    /// https://html.spec.whatwg.org/multipage/#cookie-averse-document-object
+    /// <https://html.spec.whatwg.org/multipage/#cookie-averse-document-object>
     pub fn is_cookie_averse(&self) -> bool {
         !self.has_browsing_context || !url_has_network_scheme(&self.url())
     }
@@ -2013,7 +2013,7 @@ impl Document {
         self.window.layout().nodes_from_point_response()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#look-up-a-custom-element-definition
+    /// <https://html.spec.whatwg.org/multipage/#look-up-a-custom-element-definition>
     pub fn lookup_custom_element_definition(&self,
                                             namespace: &Namespace,
                                             local_name: &LocalName,
@@ -2151,7 +2151,7 @@ fn get_registrable_domain_suffix_of_or_is_equal_to(host_suffix_string: &str, ori
     Some(host)
 }
 
-/// https://url.spec.whatwg.org/#network-scheme
+/// <https://url.spec.whatwg.org/#network-scheme>
 fn url_has_network_scheme(url: &ServoUrl) -> bool {
     match url.scheme() {
         "ftp" | "http" | "https" => true,
@@ -2225,7 +2225,7 @@ impl Document {
                     /// Per-process shared lock for author-origin stylesheets
                     ///
                     /// FIXME: make it per-document or per-pipeline instead:
-                    /// https://github.com/servo/servo/issues/16027
+                    /// <https://github.com/servo/servo/issues/16027>
                     /// (Need to figure out what to do with the style attribute
                     /// of elements adopted into another document.)
                     static ref PER_PROCESS_AUTHOR_SHARED_LOCK: StyleSharedRwLock = {
@@ -2466,7 +2466,7 @@ impl Document {
         })
     }
 
-    /// https://html.spec.whatwg.org/multipage/#appropriate-template-contents-owner-document
+    /// <https://html.spec.whatwg.org/multipage/#appropriate-template-contents-owner-document>
     pub fn appropriate_template_contents_owner_document(&self) -> DomRoot<Document> {
         self.appropriate_template_contents_owner_document.or_init(|| {
             let doctype = if self.is_html_document {
@@ -3977,7 +3977,7 @@ fn update_with_current_time_ms(marker: &Cell<u64>) {
     }
 }
 
-/// https://w3c.github.io/webappsec-referrer-policy/#determine-policy-for-token
+/// <https://w3c.github.io/webappsec-referrer-policy/#determine-policy-for-token>
 pub fn determine_policy_for_token(token: &str) -> Option<ReferrerPolicy> {
     match_ignore_ascii_case! { token,
         "never" | "no-referrer" => Some(ReferrerPolicy::NoReferrer),

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -151,12 +151,12 @@ pub struct Element {
     /// when it has exclusive access to the element.
     #[ignore_heap_size_of = "bitflags defined in rust-selectors"]
     selector_flags: Cell<ElementSelectorFlags>,
-    /// https://html.spec.whatwg.org/multipage/#custom-element-reaction-queue
+    /// <https://html.spec.whatwg.org/multipage/#custom-element-reaction-queue>
     custom_element_reaction_queue: DomRefCell<Vec<CustomElementReaction>>,
-    /// https://dom.spec.whatwg.org/#concept-element-custom-element-definition
+    /// <https://dom.spec.whatwg.org/#concept-element-custom-element-definition>
     #[ignore_heap_size_of = "Rc"]
     custom_element_definition: DomRefCell<Option<Rc<CustomElementDefinition>>>,
-    /// https://dom.spec.whatwg.org/#concept-element-custom-element-state
+    /// <https://dom.spec.whatwg.org/#concept-element-custom-element-state>
     custom_element_state: Cell<CustomElementState>,
 }
 
@@ -187,7 +187,7 @@ pub enum CustomElementCreationMode {
     Asynchronous,
 }
 
-/// https://dom.spec.whatwg.org/#concept-element-custom-element-state
+/// <https://dom.spec.whatwg.org/#concept-element-custom-element-state>
 #[derive(Clone, Copy, Eq, HeapSizeOf, JSTraceable, PartialEq)]
 pub enum CustomElementState {
     Undefined,
@@ -2063,7 +2063,7 @@ impl ElementMethods for Element {
         self.upcast::<Node>().client_rect().size.height
     }
 
-    /// https://w3c.github.io/DOM-Parsing/#widl-Element-innerHTML
+    /// <https://w3c.github.io/DOM-Parsing/#widl-Element-innerHTML>
     fn GetInnerHTML(&self) -> Fallible<DOMString> {
         let qname = QualName::new(self.prefix().clone(),
                                   self.namespace().clone(),
@@ -2075,7 +2075,7 @@ impl ElementMethods for Element {
         }
     }
 
-    /// https://w3c.github.io/DOM-Parsing/#widl-Element-innerHTML
+    /// <https://w3c.github.io/DOM-Parsing/#widl-Element-innerHTML>
     fn SetInnerHTML(&self, value: DOMString) -> ErrorResult {
         // Step 1.
         let frag = self.parse_fragment(value)?;
@@ -2779,7 +2779,7 @@ impl Element {
 
     /// Please call this method *only* for real click events
     ///
-    /// https://html.spec.whatwg.org/multipage/#run-authentic-click-activation-steps
+    /// <https://html.spec.whatwg.org/multipage/#run-authentic-click-activation-steps>
     ///
     /// Use an element's synthetic click activation (or handle_event) for any script-triggered clicks.
     /// If the spec says otherwise, check with Manishearth first
@@ -2859,7 +2859,7 @@ impl Element {
         self.state.get().contains(IN_ACTIVE_STATE)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#concept-selector-active
+    /// <https://html.spec.whatwg.org/multipage/#concept-selector-active>
     pub fn set_active_state(&self, value: bool) {
         self.set_state(IN_ACTIVE_STATE, value);
 
@@ -2936,7 +2936,7 @@ impl Element {
         self.set_state(IN_FULLSCREEN_STATE, value)
     }
 
-    /// https://dom.spec.whatwg.org/#connected
+    /// <https://dom.spec.whatwg.org/#connected>
     pub fn is_connected(&self) -> bool {
         let node = self.upcast::<Node>();
         let root = node.GetRootNode();
@@ -2998,11 +2998,11 @@ impl Element {
 #[derive(Clone, Copy)]
 pub enum AttributeMutation<'a> {
     /// The attribute is set, keep track of old value.
-    /// https://dom.spec.whatwg.org/#attribute-is-set
+    /// <https://dom.spec.whatwg.org/#attribute-is-set>
     Set(Option<&'a AttrValue>),
 
     /// The attribute is removed.
-    /// https://dom.spec.whatwg.org/#attribute-is-removed
+    /// <https://dom.spec.whatwg.org/#attribute-is-removed>
     Removed,
 }
 

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -45,7 +45,7 @@ const DEFAULT_RECONNECTION_TIME: u64 = 5000;
 struct GenerationId(u32);
 
 #[derive(Clone, Copy, Debug, HeapSizeOf, JSTraceable, PartialEq)]
-/// https://html.spec.whatwg.org/multipage/#dom-eventsource-readystate
+/// <https://html.spec.whatwg.org/multipage/#dom-eventsource-readystate>
 enum ReadyState {
     Connecting = 0,
     Open = 1,
@@ -90,7 +90,7 @@ struct EventSourceContext {
 }
 
 impl EventSourceContext {
-    /// https://html.spec.whatwg.org/multipage/#announce-the-connection
+    /// <https://html.spec.whatwg.org/multipage/#announce-the-connection>
     fn announce_the_connection(&self) {
         let event_source = self.event_source.root();
         if self.gen_id != event_source.generation_id.get() {
@@ -111,7 +111,7 @@ impl EventSourceContext {
         );
     }
 
-    /// https://html.spec.whatwg.org/multipage/#fail-the-connection
+    /// <https://html.spec.whatwg.org/multipage/#fail-the-connection>
     fn fail_the_connection(&self) {
         let event_source = self.event_source.root();
         if self.gen_id != event_source.generation_id.get() {

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -71,7 +71,7 @@ pub enum ListenerPhase {
     Bubbling,
 }
 
-/// https://html.spec.whatwg.org/multipage/#internal-raw-uncompiled-handler
+/// <https://html.spec.whatwg.org/multipage/#internal-raw-uncompiled-handler>
 #[derive(Clone, JSTraceable, PartialEq)]
 struct InternalRawUncompiledHandler {
     source: DOMString,
@@ -90,7 +90,7 @@ enum InlineEventListener {
 impl InlineEventListener {
     /// Get a compiled representation of this event handler, compiling it from its
     /// raw source if necessary.
-    /// https://html.spec.whatwg.org/multipage/#getting-the-current-value-of-the-event-handler
+    /// <https://html.spec.whatwg.org/multipage/#getting-the-current-value-of-the-event-handler>
     fn get_compiled_handler(&mut self, owner: &EventTarget, ty: &Atom)
                             -> Option<CommonEventHandler> {
         match mem::replace(self, InlineEventListener::Null) {
@@ -314,7 +314,7 @@ impl EventTarget {
         *self.handlers.borrow_mut() = Default::default();
     }
 
-    /// https://html.spec.whatwg.org/multipage/#event-handler-attributes:event-handlers-11
+    /// <https://html.spec.whatwg.org/multipage/#event-handler-attributes:event-handlers-11>
     fn set_inline_event_listener(&self,
                                  ty: Atom,
                                  listener: Option<InlineEventListener>) {
@@ -353,7 +353,7 @@ impl EventTarget {
     }
 
     /// Store the raw uncompiled event handler for on-demand compilation later.
-    /// https://html.spec.whatwg.org/multipage/#event-handler-attributes:event-handler-content-attributes-3
+    /// <https://html.spec.whatwg.org/multipage/#event-handler-attributes:event-handler-content-attributes-3>
     pub fn set_event_handler_uncompiled(&self,
                                         url: ServoUrl,
                                         line: usize,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -90,7 +90,7 @@ pub struct GlobalScope {
     #[ignore_heap_size_of = "channels are hard"]
     scheduler_chan: IpcSender<TimerSchedulerMsg>,
 
-    /// https://html.spec.whatwg.org/multipage/#in-error-reporting-mode
+    /// <https://html.spec.whatwg.org/multipage/#in-error-reporting-mode>
     in_error_reporting_mode: Cell<bool>,
 
     /// Associated resource threads for use by DOM objects like XMLHttpRequest,
@@ -107,7 +107,7 @@ pub struct GlobalScope {
     /// It is refcounted because windows in the same script thread share the
     /// same microtask queue.
     ///
-    /// https://html.spec.whatwg.org/multipage/#microtask-queue
+    /// <https://html.spec.whatwg.org/multipage/#microtask-queue>
     #[ignore_heap_size_of = "Rc<T> is hard"]
     microtask_queue: Rc<MicrotaskQueue>,
 }
@@ -303,7 +303,7 @@ impl GlobalScope {
         self.downcast::<Window>().expect("expected a Window scope")
     }
 
-    /// https://html.spec.whatwg.org/multipage/#report-the-error
+    /// <https://html.spec.whatwg.org/multipage/#report-the-error>
     pub fn report_an_error(&self, error_info: ErrorInfo, value: HandleValue) {
         // Step 1.
         if self.in_error_reporting_mode.get() {

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -576,12 +576,12 @@ impl Activatable for HTMLAnchorElement {
     }
 }
 
-/// https://html.spec.whatwg.org/multipage/#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
+/// <https://html.spec.whatwg.org/multipage/#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name>
 fn is_current_browsing_context(target: DOMString) -> bool {
     target.is_empty() || target == "_self"
 }
 
-/// https://html.spec.whatwg.org/multipage/#following-hyperlinks-2
+/// <https://html.spec.whatwg.org/multipage/#following-hyperlinks-2>
 pub fn follow_hyperlink(subject: &Element, hyperlink_suffix: Option<String>, referrer_policy: Option<ReferrerPolicy>) {
     // Step 1: replace.
     // Step 2: source browsing context.

--- a/components/script/dom/htmlbaseelement.rs
+++ b/components/script/dom/htmlbaseelement.rs
@@ -38,7 +38,7 @@ impl HTMLBaseElement {
                            HTMLBaseElementBinding::Wrap)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#frozen-base-url
+    /// <https://html.spec.whatwg.org/multipage/#frozen-base-url>
     pub fn frozen_base_url(&self) -> ServoUrl {
         let href = self.upcast::<Element>().get_attribute(&ns!(), &local_name!("href"))
             .expect("The frozen base url is only defined for base elements \

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -48,7 +48,7 @@ impl HTMLBodyElement {
                            HTMLBodyElementBinding::Wrap)
     }
 
-    /// https://drafts.csswg.org/cssom-view/#the-html-body-element
+    /// <https://drafts.csswg.org/cssom-view/#the-html-body-element>
     pub fn is_the_html_body_element(&self) -> bool {
         let self_node = self.upcast::<Node>();
         let root_elem = self.upcast::<Element>().root_element();

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -144,7 +144,7 @@ impl HTMLButtonElementMethods for HTMLButtonElement {
 }
 
 impl HTMLButtonElement {
-    /// https://html.spec.whatwg.org/multipage/#constructing-the-form-data-set
+    /// <https://html.spec.whatwg.org/multipage/#constructing-the-form-data-set>
     /// Steps range from 3.1 to 3.7 (specific to HTMLButtonElement)
     pub fn form_datum(&self, submitter: Option<FormSubmitter>) -> Option<FormDatum> {
         // Step 3.1: disabled state check is in get_unclean_dataset

--- a/components/script/dom/htmlfontelement.rs
+++ b/components/script/dom/htmlfontelement.rs
@@ -130,7 +130,7 @@ impl HTMLFontElementLayoutHelpers for LayoutDom<HTMLFontElement> {
     }
 }
 
-/// https://html.spec.whatwg.org/multipage/#rules-for-parsing-a-legacy-font-size
+/// <https://html.spec.whatwg.org/multipage/#rules-for-parsing-a-legacy-font-size>
 fn parse_size(mut input: &str) -> AttrValue {
     let original_input = input;
     // Steps 1 & 2 are not relevant

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -452,7 +452,7 @@ impl HTMLFormElement {
     }
 
     /// Interactively validate the constraints of form elements
-    /// https://html.spec.whatwg.org/multipage/#interactively-validate-the-constraints
+    /// <https://html.spec.whatwg.org/multipage/#interactively-validate-the-constraints>
     fn interactive_validation(&self) -> Result<(), ()> {
         // Step 1-3
         let _unhandled_invalid_controls = match self.static_validation() {
@@ -466,7 +466,7 @@ impl HTMLFormElement {
     }
 
     /// Statitically validate the constraints of form elements
-    /// https://html.spec.whatwg.org/multipage/#statically-validate-the-constraints
+    /// <https://html.spec.whatwg.org/multipage/#statically-validate-the-constraints>
     fn static_validation(&self) -> Result<(), Vec<FormSubmittableElement>> {
         let node = self.upcast::<Node>();
         // FIXME(#3553): This is an incorrect way of getting controls owned by the
@@ -506,7 +506,7 @@ impl HTMLFormElement {
         Err(unhandled_invalid_controls)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#constructing-the-form-data-set
+    /// <https://html.spec.whatwg.org/multipage/#constructing-the-form-data-set>
     /// Steps range from 1 to 3
     fn get_unclean_dataset(&self, submitter: Option<FormSubmitter>) -> Vec<FormDatum> {
         let controls = self.controls.borrow();
@@ -564,7 +564,7 @@ impl HTMLFormElement {
         //       https://html.spec.whatwg.org/multipage/#the-directionality
     }
 
-    /// https://html.spec.whatwg.org/multipage/#constructing-the-form-data-set
+    /// <https://html.spec.whatwg.org/multipage/#constructing-the-form-data-set>
     pub fn get_form_dataset(&self, submitter: Option<FormSubmitter>) -> Vec<FormDatum> {
         fn clean_crlf(s: &str) -> DOMString {
             // Step 4

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -39,7 +39,7 @@ impl HTMLHeadElement {
                            HTMLHeadElementBinding::Wrap)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#meta-referrer
+    /// <https://html.spec.whatwg.org/multipage/#meta-referrer>
     pub fn set_document_referrer(&self) {
         let doc = document_from_node(self);
 

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -223,7 +223,7 @@ impl HTMLIFrameElement {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#process-the-iframe-attributes
+    /// <https://html.spec.whatwg.org/multipage/#process-the-iframe-attributes>
     fn process_the_iframe_attributes(&self, mode: ProcessingMode) {
         // TODO: srcdoc
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -357,7 +357,7 @@ impl HTMLImageElement {
         window.add_pending_reflow();
     }
 
-    /// https://html.spec.whatwg.org/multipage/#abort-the-image-request
+    /// <https://html.spec.whatwg.org/multipage/#abort-the-image-request>
     fn abort_request(&self, state: State, request: ImageRequestPhase) {
         let mut request = match request {
             ImageRequestPhase::Current => self.current_request.borrow_mut(),
@@ -369,7 +369,7 @@ impl HTMLImageElement {
         request.metadata = None;
     }
 
-    /// https://html.spec.whatwg.org/multipage/#update-the-source-set
+    /// <https://html.spec.whatwg.org/multipage/#update-the-source-set>
     fn update_source_set(&self) -> Vec<DOMString> {
         let elem = self.upcast::<Element>();
         // TODO: follow the algorithm
@@ -380,7 +380,7 @@ impl HTMLImageElement {
         vec![src]
     }
 
-    /// https://html.spec.whatwg.org/multipage/#select-an-image-source
+    /// <https://html.spec.whatwg.org/multipage/#select-an-image-source>
     fn select_image_source(&self) -> Option<DOMString> {
         // TODO: select an image source from source set
         self.update_source_set().first().cloned()
@@ -536,7 +536,7 @@ impl HTMLImageElement {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#update-the-image-data
+    /// <https://html.spec.whatwg.org/multipage/#update-the-image-data>
     fn update_the_image_data(&self) {
         let document = document_from_node(self);
         let window = document.window();

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -669,7 +669,7 @@ impl HTMLInputElement {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#constructing-the-form-data-set
+    /// <https://html.spec.whatwg.org/multipage/#constructing-the-form-data-set>
     /// Steps range from 3.1 to 3.7 (specific to HTMLInputElement)
     pub fn form_datums(&self, submitter: Option<FormSubmitter>) -> Vec<FormDatum> {
         // 3.1: disabled state check is in get_unclean_dataset

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -55,7 +55,7 @@ pub struct HTMLLinkElement {
     stylesheet: DomRefCell<Option<Arc<Stylesheet>>>,
     cssom_stylesheet: MutNullableDom<CSSStyleSheet>,
 
-    /// https://html.spec.whatwg.org/multipage/#a-style-sheet-that-is-blocking-scripts
+    /// <https://html.spec.whatwg.org/multipage/#a-style-sheet-that-is-blocking-scripts>
     parser_inserted: Cell<bool>,
     /// The number of loads that this link element has triggered (could be more
     /// than one because of imports) and have not yet finished.
@@ -156,7 +156,7 @@ fn string_is_stylesheet(value: &Option<String>) -> bool {
 
 /// Favicon spec usage in accordance with CEF implementation:
 /// only url of icon is required/used
-/// https://html.spec.whatwg.org/multipage/#rel-icon
+/// <https://html.spec.whatwg.org/multipage/#rel-icon>
 fn is_favicon(value: &Option<String>) -> bool {
     match *value {
         Some(ref value) => {
@@ -250,7 +250,7 @@ impl VirtualMethods for HTMLLinkElement {
 
 
 impl HTMLLinkElement {
-    /// https://html.spec.whatwg.org/multipage/#concept-link-obtain
+    /// <https://html.spec.whatwg.org/multipage/#concept-link-obtain>
     fn handle_stylesheet_url(&self, href: &str) {
         let document = document_from_node(self);
         if document.browsing_context().is_none() {

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -54,29 +54,29 @@ use time::{self, Timespec, Duration};
 // media element event task source.
 pub struct HTMLMediaElement {
     htmlelement: HTMLElement,
-    /// https://html.spec.whatwg.org/multipage/#dom-media-networkstate
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-networkstate>
     network_state: Cell<NetworkState>,
-    /// https://html.spec.whatwg.org/multipage/#dom-media-readystate
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-readystate>
     ready_state: Cell<ReadyState>,
-    /// https://html.spec.whatwg.org/multipage/#dom-media-srcobject
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-srcobject>
     src_object: MutNullableDom<Blob>,
-    /// https://html.spec.whatwg.org/multipage/#dom-media-currentsrc
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-currentsrc>
     current_src: DomRefCell<String>,
     /// Incremented whenever tasks associated with this element are cancelled.
     generation_id: Cell<u32>,
-    /// https://html.spec.whatwg.org/multipage/#fire-loadeddata
+    /// <https://html.spec.whatwg.org/multipage/#fire-loadeddata>
     ///
     /// Reset to false every time the load algorithm is invoked.
     fired_loadeddata_event: Cell<bool>,
-    /// https://html.spec.whatwg.org/multipage/#dom-media-error
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-error>
     error: MutNullableDom<MediaError>,
-    /// https://html.spec.whatwg.org/multipage/#dom-media-paused
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-paused>
     paused: Cell<bool>,
-    /// https://html.spec.whatwg.org/multipage/#attr-media-autoplay
+    /// <https://html.spec.whatwg.org/multipage/#attr-media-autoplay>
     autoplaying: Cell<bool>,
-    /// https://html.spec.whatwg.org/multipage/#delaying-the-load-event-flag
+    /// <https://html.spec.whatwg.org/multipage/#delaying-the-load-event-flag>
     delaying_the_load_event_flag: DomRefCell<Option<LoadBlocker>>,
-    /// https://html.spec.whatwg.org/multipage/#list-of-pending-play-promises
+    /// <https://html.spec.whatwg.org/multipage/#list-of-pending-play-promises>
     #[ignore_heap_size_of = "promises are hard"]
     pending_play_promises: DomRefCell<Vec<Rc<Promise>>>,
     /// Play promises which are soon to be fulfilled by a queued task.
@@ -84,7 +84,7 @@ pub struct HTMLMediaElement {
     in_flight_play_promises_queue: DomRefCell<VecDeque<(Box<[Rc<Promise>]>, ErrorResult)>>,
 }
 
-/// https://html.spec.whatwg.org/multipage/#dom-media-networkstate
+/// <https://html.spec.whatwg.org/multipage/#dom-media-networkstate>
 #[derive(Clone, Copy, HeapSizeOf, JSTraceable, PartialEq)]
 #[repr(u8)]
 pub enum NetworkState {
@@ -94,7 +94,7 @@ pub enum NetworkState {
     NoSource = HTMLMediaElementConstants::NETWORK_NO_SOURCE as u8,
 }
 
-/// https://html.spec.whatwg.org/multipage/#dom-media-readystate
+/// <https://html.spec.whatwg.org/multipage/#dom-media-readystate>
 #[derive(Clone, Copy, HeapSizeOf, JSTraceable, PartialEq, PartialOrd)]
 #[repr(u8)]
 enum ReadyState {
@@ -145,7 +145,7 @@ impl HTMLMediaElement {
     /// Nothing happens if the element was already delaying the load event and
     /// we pass true to that method again.
     ///
-    /// https://html.spec.whatwg.org/multipage/#delaying-the-load-event-flag
+    /// <https://html.spec.whatwg.org/multipage/#delaying-the-load-event-flag>
     fn delay_load_event(&self, delay: bool) {
         let mut blocker = self.delaying_the_load_event_flag.borrow_mut();
         if delay && blocker.is_none() {
@@ -155,7 +155,7 @@ impl HTMLMediaElement {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-media-play
+    /// <https://html.spec.whatwg.org/multipage/#dom-media-play>
     // FIXME(nox): Move this back to HTMLMediaElementMethods::Play once
     // Rc<Promise> doesn't require #[allow(unrooted_must_root)] anymore.
     fn play(&self, promise: &Rc<Promise>) {
@@ -236,7 +236,7 @@ impl HTMLMediaElement {
         // Not applicable here, the promise is returned from Play.
     }
 
-    /// https://html.spec.whatwg.org/multipage/#internal-pause-steps
+    /// <https://html.spec.whatwg.org/multipage/#internal-pause-steps>
     fn internal_pause_steps(&self) {
         // Step 1.
         self.autoplaying.set(false);
@@ -807,7 +807,7 @@ impl HTMLMediaElement {
 
     /// Handles insertion of `source` children.
     ///
-    /// https://html.spec.whatwg.org/multipage/#the-source-element:nodes-are-inserted
+    /// <https://html.spec.whatwg.org/multipage/#the-source-element:nodes-are-inserted>
     pub fn handle_source_child_insertion(&self) {
         if self.upcast::<Element>().has_attribute(&local_name!("src")) {
             return;

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -135,7 +135,7 @@ impl HTMLMetaElement {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#meta-referrer
+    /// <https://html.spec.whatwg.org/multipage/#meta-referrer>
     fn apply_referrer(&self) {
         if let Some(parent) = self.upcast::<Node>().GetParentElement() {
             if let Some(head) = parent.downcast::<HTMLHeadElement>() {

--- a/components/script/dom/htmloptionelement.rs
+++ b/components/script/dom/htmloptionelement.rs
@@ -32,10 +32,10 @@ use style::str::{split_html_space_chars, str_join};
 pub struct HTMLOptionElement {
     htmlelement: HTMLElement,
 
-    /// https://html.spec.whatwg.org/multipage/#attr-option-selected
+    /// <https://html.spec.whatwg.org/multipage/#attr-option-selected>
     selectedness: Cell<bool>,
 
-    /// https://html.spec.whatwg.org/multipage/#concept-option-dirtiness
+    /// <https://html.spec.whatwg.org/multipage/#concept-option-dirtiness>
     dirtiness: Cell<bool>,
 }
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -49,13 +49,13 @@ use uuid::Uuid;
 pub struct HTMLScriptElement {
     htmlelement: HTMLElement,
 
-    /// https://html.spec.whatwg.org/multipage/#already-started
+    /// <https://html.spec.whatwg.org/multipage/#already-started>
     already_started: Cell<bool>,
 
-    /// https://html.spec.whatwg.org/multipage/#parser-inserted
+    /// <https://html.spec.whatwg.org/multipage/#parser-inserted>
     parser_inserted: Cell<bool>,
 
-    /// https://html.spec.whatwg.org/multipage/#non-blocking
+    /// <https://html.spec.whatwg.org/multipage/#non-blocking>
     ///
     /// (currently unused)
     non_blocking: Cell<bool>,
@@ -190,7 +190,7 @@ impl FetchResponseListener for ScriptContext {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#fetch-a-classic-script
+    /// <https://html.spec.whatwg.org/multipage/#fetch-a-classic-script>
     /// step 4-9
     fn process_response_eof(&mut self, response: Result<(), NetworkError>) {
         // Step 5.
@@ -226,7 +226,7 @@ impl FetchResponseListener for ScriptContext {
 
 impl PreInvoke for ScriptContext {}
 
-/// https://html.spec.whatwg.org/multipage/#fetch-a-classic-script
+/// <https://html.spec.whatwg.org/multipage/#fetch-a-classic-script>
 fn fetch_a_classic_script(script: &HTMLScriptElement,
                           kind: ExternalScriptKind,
                           url: ServoUrl,
@@ -286,7 +286,7 @@ fn fetch_a_classic_script(script: &HTMLScriptElement,
 }
 
 impl HTMLScriptElement {
-    /// https://html.spec.whatwg.org/multipage/#prepare-a-script
+    /// <https://html.spec.whatwg.org/multipage/#prepare-a-script>
     pub fn prepare(&self) {
         // Step 1.
         if self.already_started.get() {
@@ -500,7 +500,7 @@ impl HTMLScriptElement {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#execute-the-script-block
+    /// <https://html.spec.whatwg.org/multipage/#execute-the-script-block>
     pub fn execute(&self, result: Result<ClassicScript, NetworkError>) {
         // Step 1.
         let doc = document_from_node(self);

--- a/components/script/dom/htmlsourceelement.rs
+++ b/components/script/dom/htmlsourceelement.rs
@@ -44,7 +44,7 @@ impl VirtualMethods for HTMLSourceElement {
         Some(self.upcast::<HTMLElement>() as &VirtualMethods)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#the-source-element:nodes-are-inserted
+    /// <https://html.spec.whatwg.org/multipage/#the-source-element:nodes-are-inserted>
     fn bind_to_tree(&self, tree_in_doc: bool) {
         self.super_type().unwrap().bind_to_tree(tree_in_doc);
         let parent = self.upcast::<Node>().GetParentNode().unwrap();

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -34,7 +34,7 @@ pub struct HTMLStyleElement {
     #[ignore_heap_size_of = "Arc"]
     stylesheet: DomRefCell<Option<Arc<Stylesheet>>>,
     cssom_stylesheet: MutNullableDom<CSSStyleSheet>,
-    /// https://html.spec.whatwg.org/multipage/#a-style-sheet-that-is-blocking-scripts
+    /// <https://html.spec.whatwg.org/multipage/#a-style-sheet-that-is-blocking-scripts>
     parser_inserted: Cell<bool>,
     in_stack_of_open_elements: Cell<bool>,
     pending_loads: Cell<u32>,

--- a/components/script/dom/htmltemplateelement.rs
+++ b/components/script/dom/htmltemplateelement.rs
@@ -20,7 +20,7 @@ use html5ever::{LocalName, Prefix};
 pub struct HTMLTemplateElement {
     htmlelement: HTMLElement,
 
-    /// https://html.spec.whatwg.org/multipage/#template-contents
+    /// <https://html.spec.whatwg.org/multipage/#template-contents>
     contents: MutNullableDom<DocumentFragment>,
 }
 
@@ -46,7 +46,7 @@ impl HTMLTemplateElement {
 }
 
 impl HTMLTemplateElementMethods for HTMLTemplateElement {
-    /// https://html.spec.whatwg.org/multipage/#dom-template-content
+    /// <https://html.spec.whatwg.org/multipage/#dom-template-content>
     fn Content(&self) -> DomRoot<DocumentFragment> {
         self.contents.or_init(|| {
             let doc = document_from_node(self);
@@ -60,7 +60,7 @@ impl VirtualMethods for HTMLTemplateElement {
         Some(self.upcast::<HTMLElement>() as &VirtualMethods)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#template-adopting-steps
+    /// <https://html.spec.whatwg.org/multipage/#template-adopting-steps>
     fn adopting_steps(&self, old_doc: &Document) {
         self.super_type().unwrap().adopting_steps(old_doc);
         // Step 1.
@@ -69,7 +69,7 @@ impl VirtualMethods for HTMLTemplateElement {
         Node::adopt(self.Content().upcast(), &doc);
     }
 
-    /// https://html.spec.whatwg.org/multipage/#the-template-element:concept-node-clone-ext
+    /// <https://html.spec.whatwg.org/multipage/#the-template-element:concept-node-clone-ext>
     fn cloning_steps(&self, copy: &Node, maybe_doc: Option<&Document>,
                      clone_children: CloneChildrenFlag) {
         self.super_type().unwrap().cloning_steps(copy, maybe_doc, clone_children);

--- a/components/script/dom/mediaquerylist.rs
+++ b/components/script/dom/mediaquerylist.rs
@@ -134,7 +134,7 @@ impl WeakMediaQueryListVec {
     }
 
     /// Evaluate media query lists and report changes
-    /// https://drafts.csswg.org/cssom-view/#evaluate-media-queries-and-report-changes
+    /// <https://drafts.csswg.org/cssom-view/#evaluate-media-queries-and-report-changes>
     pub fn evaluate_and_report_changes(&self) {
         rooted_vec!(let mut mql_list);
         self.cell.borrow_mut().update(|mql| {

--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -72,7 +72,7 @@ impl MutationObserver {
         Ok(observer)
     }
 
-    /// https://dom.spec.whatwg.org/#queue-a-mutation-observer-compound-microtask
+    /// <https://dom.spec.whatwg.org/#queue-a-mutation-observer-compound-microtask>
     pub fn queue_mutation_observer_compound_microtask() {
         // Step 1
         if ScriptThread::is_mutation_observer_compound_microtask_queued() {
@@ -84,7 +84,7 @@ impl MutationObserver {
         ScriptThread::enqueue_microtask(Microtask::NotifyMutationObservers);
     }
 
-    /// https://dom.spec.whatwg.org/#notify-mutation-observers
+    /// <https://dom.spec.whatwg.org/#notify-mutation-observers>
     pub fn notify_mutation_observers() {
         // Step 1
         ScriptThread::set_mutation_observer_compound_microtask_queued(false);
@@ -103,7 +103,7 @@ impl MutationObserver {
         // TODO: Step 6 (slot signals)
     }
 
-    /// https://dom.spec.whatwg.org/#queueing-a-mutation-record
+    /// <https://dom.spec.whatwg.org/#queueing-a-mutation-record>
     pub fn queue_a_mutation_record(target: &Node, attr_type: Mutation) {
         // Step 1
         let mut interestedObservers: Vec<(DomRoot<MutationObserver>, Option<DOMString>)> = vec![];
@@ -182,7 +182,7 @@ impl MutationObserver {
 }
 
 impl MutationObserverMethods for MutationObserver {
-    /// https://dom.spec.whatwg.org/#dom-mutationobserver-observe
+    /// <https://dom.spec.whatwg.org/#dom-mutationobserver-observe>
     fn Observe(&self, target: &Node, options: &MutationObserverInit) -> Fallible<()> {
         let attribute_filter = options.attributeFilter.clone().unwrap_or(vec![]);
         let attribute_old_value = options.attributeOldValue.unwrap_or(false);

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -198,8 +198,8 @@ impl Drop for Node {
 }
 
 /// suppress observers flag
-/// https://dom.spec.whatwg.org/#concept-node-insert
-/// https://dom.spec.whatwg.org/#concept-node-remove
+/// <https://dom.spec.whatwg.org/#concept-node-insert>
+/// <https://dom.spec.whatwg.org/#concept-node-remove>
 #[derive(Clone, Copy, HeapSizeOf)]
 enum SuppressObserver {
     Suppressed,
@@ -764,7 +764,7 @@ impl Node {
         }
     }
 
-    /// https://dom.spec.whatwg.org/#scope-match-a-selectors-string
+    /// <https://dom.spec.whatwg.org/#scope-match-a-selectors-string>
     /// Get an iterator over all nodes which match a set of selectors
     /// Be careful not to do anything which may manipulate the DOM tree
     /// whilst iterating, otherwise the iterator may be invalidated.
@@ -1887,7 +1887,7 @@ impl Node {
         copy
     }
 
-    /// https://html.spec.whatwg.org/multipage/#child-text-content
+    /// <https://html.spec.whatwg.org/multipage/#child-text-content>
     pub fn child_text_content(&self) -> DOMString {
         Node::collect_text_contents(self.children())
     }

--- a/components/script/dom/paintsize.rs
+++ b/components/script/dom/paintsize.rs
@@ -35,12 +35,12 @@ impl PaintSize {
 }
 
 impl PaintSizeMethods for PaintSize {
-    /// https://drafts.css-houdini.org/css-paint-api/#paintsize
+    /// <https://drafts.css-houdini.org/css-paint-api/#paintsize>
     fn Width(&self) -> Finite<f64> {
         self.width
     }
 
-    /// https://drafts.css-houdini.org/css-paint-api/#paintsize
+    /// <https://drafts.css-houdini.org/css-paint-api/#paintsize>
     fn Height(&self) -> Finite<f64> {
         self.height
     }

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -62,7 +62,7 @@ use style_traits::CSSPixel;
 use style_traits::DevicePixel;
 use style_traits::SpeculativePainter;
 
-/// https://drafts.css-houdini.org/css-paint-api/#paintworkletglobalscope
+/// <https://drafts.css-houdini.org/css-paint-api/#paintworkletglobalscope>
 #[dom_struct]
 pub struct PaintWorkletGlobalScope {
     /// The worklet global for this object
@@ -70,9 +70,9 @@ pub struct PaintWorkletGlobalScope {
     /// The image cache
     #[ignore_heap_size_of = "Arc"]
     image_cache: Arc<ImageCache>,
-    /// https://drafts.css-houdini.org/css-paint-api/#paint-definitions
+    /// <https://drafts.css-houdini.org/css-paint-api/#paint-definitions>
     paint_definitions: DomRefCell<HashMap<Atom, Box<PaintDefinition>>>,
-    /// https://drafts.css-houdini.org/css-paint-api/#paint-class-instances
+    /// <https://drafts.css-houdini.org/css-paint-api/#paint-class-instances>
     paint_class_instances: DomRefCell<HashMap<Atom, Box<Heap<JSVal>>>>,
     /// The most recent name the worklet was called with
     cached_name: DomRefCell<Atom>,
@@ -169,7 +169,7 @@ impl PaintWorkletGlobalScope {
         }
     }
 
-    /// https://drafts.css-houdini.org/css-paint-api/#draw-a-paint-image
+    /// <https://drafts.css-houdini.org/css-paint-api/#draw-a-paint-image>
     fn draw_a_paint_image(&self,
                           name: &Atom,
                           size_in_px: TypedSize2D<f32, CSSPixel>,
@@ -187,7 +187,7 @@ impl PaintWorkletGlobalScope {
         self.invoke_a_paint_callback(name, size_in_px, size_in_dpx, device_pixel_ratio, properties, arguments)
     }
 
-    /// https://drafts.css-houdini.org/css-paint-api/#invoke-a-paint-callback
+    /// <https://drafts.css-houdini.org/css-paint-api/#invoke-a-paint-callback>
     #[allow(unsafe_code)]
     fn invoke_a_paint_callback(&self,
                                name: &Atom,
@@ -367,7 +367,7 @@ impl PaintWorkletGlobalScope {
 impl PaintWorkletGlobalScopeMethods for PaintWorkletGlobalScope {
     #[allow(unsafe_code)]
     #[allow(unrooted_must_root)]
-    /// https://drafts.css-houdini.org/css-paint-api/#dom-paintworkletglobalscope-registerpaint
+    /// <https://drafts.css-houdini.org/css-paint-api/#dom-paintworkletglobalscope-registerpaint>
     fn RegisterPaint(&self, name: DOMString, paint_ctor: Rc<VoidFunction>) -> Fallible<()> {
         let name = Atom::from(name);
         let cx = self.worklet_global.get_cx();
@@ -461,7 +461,7 @@ pub enum PaintWorkletTask {
 }
 
 /// A paint definition
-/// https://drafts.css-houdini.org/css-paint-api/#paint-definition
+/// <https://drafts.css-houdini.org/css-paint-api/#paint-definition>
 /// This type is dangerous, because it contains uboxed `Heap<JSVal>` values,
 /// which can't be moved.
 #[derive(HeapSizeOf, JSTraceable)]

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -199,7 +199,7 @@ impl Performance {
     /// notify the observers if no other notification task is already queued.
     ///
     /// Algorithm spec:
-    /// https://w3c.github.io/performance-timeline/#queue-a-performanceentry
+    /// <https://w3c.github.io/performance-timeline/#queue-a-performanceentry>
     pub fn queue_entry(&self, entry: &PerformanceEntry,
                        add_to_performance_entries_buffer: bool) {
         // Steps 1-3.
@@ -233,7 +233,7 @@ impl Performance {
     /// Observers notifications task.
     ///
     /// Algorithm spec (step 7):
-    /// https://w3c.github.io/performance-timeline/#queue-a-performanceentry
+    /// <https://w3c.github.io/performance-timeline/#queue-a-performanceentry>
     pub fn notify_observers(&self) {
         // Step 7.1.
         self.pending_notification_observers_task.set(false);

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1031,19 +1031,19 @@ impl WeakRangeVec {
     }
 
     /// Used for steps 2.1-2. when inserting a node.
-    /// https://dom.spec.whatwg.org/#concept-node-insert
+    /// <https://dom.spec.whatwg.org/#concept-node-insert>
     pub fn increase_above(&self, node: &Node, offset: u32, delta: u32) {
         self.map_offset_above(node, offset, |offset| offset + delta);
     }
 
     /// Used for steps 4-5. when removing a node.
-    /// https://dom.spec.whatwg.org/#concept-node-remove
+    /// <https://dom.spec.whatwg.org/#concept-node-remove>
     pub fn decrease_above(&self, node: &Node, offset: u32, delta: u32) {
         self.map_offset_above(node, offset, |offset| offset - delta);
     }
 
     /// Used for steps 2-3. when removing a node.
-    /// https://dom.spec.whatwg.org/#concept-node-remove
+    /// <https://dom.spec.whatwg.org/#concept-node-remove>
     pub fn drain_to_parent(&self, context: &UnbindContext, child: &Node) {
         if self.is_empty() {
             return;
@@ -1072,7 +1072,7 @@ impl WeakRangeVec {
     }
 
     /// Used for steps 7.1-2. when normalizing a node.
-    /// https://dom.spec.whatwg.org/#dom-node-normalize
+    /// <https://dom.spec.whatwg.org/#dom-node-normalize>
     pub fn drain_to_preceding_text_sibling(&self, node: &Node, sibling: &Node, length: u32) {
         if self.is_empty() {
             return;
@@ -1099,7 +1099,7 @@ impl WeakRangeVec {
     }
 
     /// Used for steps 7.3-4. when normalizing a node.
-    /// https://dom.spec.whatwg.org/#dom-node-normalize
+    /// <https://dom.spec.whatwg.org/#dom-node-normalize>
     pub fn move_to_text_child_at(&self,
                                  node: &Node, offset: u32,
                                  child: &Node, new_offset: u32) {
@@ -1142,7 +1142,7 @@ impl WeakRangeVec {
     }
 
     /// Used for steps 8-11. when replacing character data.
-    /// https://dom.spec.whatwg.org/#concept-cd-replace
+    /// <https://dom.spec.whatwg.org/#concept-cd-replace>
     pub fn replace_code_units(&self,
                               node: &Node, offset: u32,
                               removed_code_units: u32, added_code_units: u32) {
@@ -1156,7 +1156,7 @@ impl WeakRangeVec {
     }
 
     /// Used for steps 7.2-3. when splitting a text node.
-    /// https://dom.spec.whatwg.org/#concept-text-split
+    /// <https://dom.spec.whatwg.org/#concept-text-split>
     pub fn move_to_following_text_sibling_above(&self,
                                                 node: &Node, offset: u32,
                                                 sibling: &Node) {
@@ -1202,7 +1202,7 @@ impl WeakRangeVec {
     }
 
     /// Used for steps 7.4-5. when splitting a text node.
-    /// https://dom.spec.whatwg.org/#concept-text-split
+    /// <https://dom.spec.whatwg.org/#concept-text-split>
     pub fn increment_at(&self, node: &Node, offset: u32) {
         unsafe {
             (*self.cell.get()).update(|entry| {

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -730,7 +730,7 @@ impl TreeSink for Sink {
         self.send_op(ParseOperation::ReparentChildren { parent: parent.id, new_parent: new_parent.id });
     }
 
-    /// https://html.spec.whatwg.org/multipage/#html-integration-point
+    /// <https://html.spec.whatwg.org/multipage/#html-integration-point>
     /// Specifically, the <annotation-xml> cases.
     fn is_mathml_annotation_xml_integration_point(&self, handle: &Self::Handle) -> bool {
         let node_data = self.get_parse_node_data(&handle.id);

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -88,11 +88,11 @@ pub struct ServoParser {
     last_chunk_received: Cell<bool>,
     /// Whether this parser should avoid passing any further data to the tokenizer.
     suspended: Cell<bool>,
-    /// https://html.spec.whatwg.org/multipage/#script-nesting-level
+    /// <https://html.spec.whatwg.org/multipage/#script-nesting-level>
     script_nesting_level: Cell<usize>,
-    /// https://html.spec.whatwg.org/multipage/#abort-a-parser
+    /// <https://html.spec.whatwg.org/multipage/#abort-a-parser>
     aborted: Cell<bool>,
-    /// https://html.spec.whatwg.org/multipage/#script-created-parser
+    /// <https://html.spec.whatwg.org/multipage/#script-created-parser>
     script_created_parser: bool,
 }
 
@@ -198,7 +198,7 @@ impl ServoParser {
 
     /// Corresponds to the latter part of the "Otherwise" branch of the 'An end
     /// tag whose tag name is "script"' of
-    /// https://html.spec.whatwg.org/multipage/#parsing-main-incdata
+    /// <https://html.spec.whatwg.org/multipage/#parsing-main-incdata>
     ///
     /// This first moves everything from the script input to the beginning of
     /// the network input, effectively resetting the insertion point to just
@@ -930,7 +930,7 @@ impl TreeSink for Sink {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#html-integration-point
+    /// <https://html.spec.whatwg.org/multipage/#html-integration-point>
     /// Specifically, the <annotation-xml> cases.
     fn is_mathml_annotation_xml_integration_point(&self, handle: &Dom<Node>) -> bool {
         let elem = handle.downcast::<Element>().unwrap();

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -147,7 +147,7 @@ impl StorageMethods for Storage {
 
 
 impl Storage {
-    /// https://html.spec.whatwg.org/multipage/#send-a-storage-notification
+    /// <https://html.spec.whatwg.org/multipage/#send-a-storage-notification>
     fn broadcast_change_notification(&self, key: Option<String>, old_value: Option<String>,
                                      new_value: Option<String>) {
         let storage = self.storage_type;
@@ -156,7 +156,7 @@ impl Storage {
         self.global().script_to_constellation_chan().send(msg).unwrap();
     }
 
-    /// https://html.spec.whatwg.org/multipage/#send-a-storage-notification
+    /// <https://html.spec.whatwg.org/multipage/#send-a-storage-notification>
     pub fn queue_storage_event(
         &self,
         url: ServoUrl,

--- a/components/script/dom/stylepropertymapreadonly.rs
+++ b/components/script/dom/stylepropertymapreadonly.rs
@@ -53,19 +53,19 @@ impl StylePropertyMapReadOnly {
 }
 
 impl StylePropertyMapReadOnlyMethods for StylePropertyMapReadOnly {
-    /// https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-get
+    /// <https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-get>
     fn Get(&self, property: DOMString) -> Option<DomRoot<CSSStyleValue>> {
         // TODO: avoid constructing an Atom
         self.entries.get(&Atom::from(property)).map(|value| DomRoot::from_ref(&**value))
     }
 
-    /// https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-has
+    /// <https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-has>
     fn Has(&self, property: DOMString) -> bool {
         // TODO: avoid constructing an Atom
         self.entries.contains_key(&Atom::from(property))
     }
 
-    /// https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-getproperties
+    /// <https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymapreadonly-getproperties>
     fn GetProperties(&self) -> Vec<DOMString> {
         let mut result: Vec<DOMString> = self.entries.keys()
             .map(|key| DOMString::from(&**key))

--- a/components/script/dom/textdecoder.rs
+++ b/components/script/dom/textdecoder.rs
@@ -42,7 +42,7 @@ impl TextDecoder {
                            TextDecoderBinding::Wrap)
     }
 
-    /// https://encoding.spec.whatwg.org/#dom-textdecoder
+    /// <https://encoding.spec.whatwg.org/#dom-textdecoder>
     pub fn Constructor(global: &GlobalScope,
                        label: DOMString,
                        options: &TextDecoderBinding::TextDecoderOptions)

--- a/components/script/dom/touch.rs
+++ b/components/script/dom/touch.rs
@@ -60,42 +60,42 @@ impl Touch {
 }
 
 impl TouchMethods for Touch {
-    /// https://w3c.github.io/touch-events/#widl-Touch-identifier
+    /// <https://w3c.github.io/touch-events/#widl-Touch-identifier>
     fn Identifier(&self) -> i32 {
         self.identifier
     }
 
-    /// https://w3c.github.io/touch-events/#widl-Touch-target
+    /// <https://w3c.github.io/touch-events/#widl-Touch-target>
     fn Target(&self) -> DomRoot<EventTarget> {
         self.target.get()
     }
 
-    /// https://w3c.github.io/touch-events/#widl-Touch-screenX
+    /// <https://w3c.github.io/touch-events/#widl-Touch-screenX>
     fn ScreenX(&self) -> Finite<f64> {
         Finite::wrap(self.screen_x)
     }
 
-    /// https://w3c.github.io/touch-events/#widl-Touch-screenY
+    /// <https://w3c.github.io/touch-events/#widl-Touch-screenY>
     fn ScreenY(&self) -> Finite<f64> {
         Finite::wrap(self.screen_y)
     }
 
-    /// https://w3c.github.io/touch-events/#widl-Touch-clientX
+    /// <https://w3c.github.io/touch-events/#widl-Touch-clientX>
     fn ClientX(&self) -> Finite<f64> {
         Finite::wrap(self.client_x)
     }
 
-    /// https://w3c.github.io/touch-events/#widl-Touch-clientY
+    /// <https://w3c.github.io/touch-events/#widl-Touch-clientY>
     fn ClientY(&self) -> Finite<f64> {
         Finite::wrap(self.client_y)
     }
 
-    /// https://w3c.github.io/touch-events/#widl-Touch-clientX
+    /// <https://w3c.github.io/touch-events/#widl-Touch-clientX>
     fn PageX(&self) -> Finite<f64> {
         Finite::wrap(self.page_x)
     }
 
-    /// https://w3c.github.io/touch-events/#widl-Touch-clientY
+    /// <https://w3c.github.io/touch-events/#widl-Touch-clientY>
     fn PageY(&self) -> Finite<f64> {
         Finite::wrap(self.page_y)
     }

--- a/components/script/dom/touchevent.rs
+++ b/components/script/dom/touchevent.rs
@@ -80,42 +80,42 @@ impl TouchEvent {
 }
 
 impl<'a> TouchEventMethods for &'a TouchEvent {
-    /// https://w3c.github.io/touch-events/#widl-TouchEvent-ctrlKey
+    /// <https://w3c.github.io/touch-events/#widl-TouchEvent-ctrlKey>
     fn CtrlKey(&self) -> bool {
         self.ctrl_key.get()
     }
 
-    /// https://w3c.github.io/touch-events/#widl-TouchEvent-shiftKey
+    /// <https://w3c.github.io/touch-events/#widl-TouchEvent-shiftKey>
     fn ShiftKey(&self) -> bool {
         self.shift_key.get()
     }
 
-    /// https://w3c.github.io/touch-events/#widl-TouchEvent-altKey
+    /// <https://w3c.github.io/touch-events/#widl-TouchEvent-altKey>
     fn AltKey(&self) -> bool {
         self.alt_key.get()
     }
 
-    /// https://w3c.github.io/touch-events/#widl-TouchEvent-metaKey
+    /// <https://w3c.github.io/touch-events/#widl-TouchEvent-metaKey>
     fn MetaKey(&self) -> bool {
         self.meta_key.get()
     }
 
-    /// https://w3c.github.io/touch-events/#widl-TouchEventInit-touches
+    /// <https://w3c.github.io/touch-events/#widl-TouchEventInit-touches>
     fn Touches(&self) -> DomRoot<TouchList> {
         self.touches.get()
     }
 
-    /// https://w3c.github.io/touch-events/#widl-TouchEvent-targetTouches
+    /// <https://w3c.github.io/touch-events/#widl-TouchEvent-targetTouches>
     fn TargetTouches(&self) -> DomRoot<TouchList> {
         self.target_touches.get()
     }
 
-    /// https://w3c.github.io/touch-events/#widl-TouchEvent-changedTouches
+    /// <https://w3c.github.io/touch-events/#widl-TouchEvent-changedTouches>
     fn ChangedTouches(&self) -> DomRoot<TouchList> {
         self.changed_touches.get()
     }
 
-    /// https://dom.spec.whatwg.org/#dom-event-istrusted
+    /// <https://dom.spec.whatwg.org/#dom-event-istrusted>
     fn IsTrusted(&self) -> bool {
         self.uievent.IsTrusted()
     }

--- a/components/script/dom/touchlist.rs
+++ b/components/script/dom/touchlist.rs
@@ -31,17 +31,17 @@ impl TouchList {
 }
 
 impl TouchListMethods for TouchList {
-    /// https://w3c.github.io/touch-events/#widl-TouchList-length
+    /// <https://w3c.github.io/touch-events/#widl-TouchList-length>
     fn Length(&self) -> u32 {
         self.touches.len() as u32
     }
 
-    /// https://w3c.github.io/touch-events/#widl-TouchList-item-getter-Touch-unsigned-long-index
+    /// <https://w3c.github.io/touch-events/#widl-TouchList-item-getter-Touch-unsigned-long-index>
     fn Item(&self, index: u32) -> Option<DomRoot<Touch>> {
         self.touches.get(index as usize).map(|js| DomRoot::from_ref(&**js))
     }
 
-    /// https://w3c.github.io/touch-events/#widl-TouchList-item-getter-Touch-unsigned-long-index
+    /// <https://w3c.github.io/touch-events/#widl-TouchList-item-getter-Touch-unsigned-long-index>
     fn IndexedGetter(&self, index: u32) -> Option<DomRoot<Touch>> {
         self.Item(index)
     }

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -63,8 +63,8 @@ pub trait VirtualMethods {
     fn super_type(&self) -> Option<&VirtualMethods>;
 
     /// Called when attributes of a node are mutated.
-    /// https://dom.spec.whatwg.org/#attribute-is-set
-    /// https://dom.spec.whatwg.org/#attribute-is-removed
+    /// <https://dom.spec.whatwg.org/#attribute-is-set>
+    /// <https://dom.spec.whatwg.org/#attribute-is-removed>
     fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
         if let Some(s) = self.super_type() {
             s.attribute_mutated(attr, mutation);
@@ -100,7 +100,7 @@ pub trait VirtualMethods {
     /// Called when a Node is removed from a tree, where 'tree_in_doc'
     /// indicates whether the tree is part of a Document.
     /// Implements removing steps:
-    /// https://dom.spec.whatwg.org/#concept-node-remove-ext
+    /// <https://dom.spec.whatwg.org/#concept-node-remove-ext>
     fn unbind_from_tree(&self, context: &UnbindContext) {
         if let Some(ref s) = self.super_type() {
             s.unbind_from_tree(context);
@@ -121,14 +121,14 @@ pub trait VirtualMethods {
         }
     }
 
-    /// https://dom.spec.whatwg.org/#concept-node-adopt-ext
+    /// <https://dom.spec.whatwg.org/#concept-node-adopt-ext>
     fn adopting_steps(&self, old_doc: &Document) {
         if let Some(ref s) = self.super_type() {
             s.adopting_steps(old_doc);
         }
     }
 
-    /// https://dom.spec.whatwg.org/#concept-node-clone-ext
+    /// <https://dom.spec.whatwg.org/#concept-node-clone-ext>
     fn cloning_steps(&self, copy: &Node, maybe_doc: Option<&Document>,
                      clone_children: CloneChildrenFlag) {
         if let Some(ref s) = self.super_type() {

--- a/components/script/dom/webgl_validations/tex_image_2d.rs
+++ b/components/script/dom/webgl_validations/tex_image_2d.rs
@@ -270,7 +270,7 @@ pub struct TexImage2DValidatorResult {
 }
 
 /// TexImage2d validator as per
-/// https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexImage2D.xml
+/// <https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexImage2D.xml>
 impl<'a> WebGLValidator for TexImage2DValidator<'a> {
     type ValidatedOutput = TexImage2DValidatorResult;
     type Error = TexImageValidationError;

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -129,7 +129,7 @@ impl WebSocket {
                            global, WebSocketBinding::Wrap)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-websocket
+    /// <https://html.spec.whatwg.org/multipage/#dom-websocket>
     pub fn Constructor(global: &GlobalScope,
                        url: DOMString,
                        protocols: Option<StringOrStringSequence>)
@@ -391,14 +391,14 @@ impl WebSocketMethods for WebSocket {
 
 
 /// Task queued when *the WebSocket connection is established*.
-/// https://html.spec.whatwg.org/multipage/#feedback-from-the-protocol:concept-websocket-established
+/// <https://html.spec.whatwg.org/multipage/#feedback-from-the-protocol:concept-websocket-established>
 struct ConnectionEstablishedTask {
     address: Trusted<WebSocket>,
     protocol_in_use: Option<String>,
 }
 
 impl TaskOnce for ConnectionEstablishedTask {
-    /// https://html.spec.whatwg.org/multipage/#feedback-from-the-protocol:concept-websocket-established
+    /// <https://html.spec.whatwg.org/multipage/#feedback-from-the-protocol:concept-websocket-established>
     fn run_once(self) {
         let ws = self.address.root();
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -287,7 +287,7 @@ pub struct Window {
 
     /// Worklets
     test_worklet: MutNullableDom<Worklet>,
-    /// https://drafts.css-houdini.org/css-paint-api-1/#paint-worklet
+    /// <https://drafts.css-houdini.org/css-paint-api-1/#paint-worklet>
     paint_worklet: MutNullableDom<Worklet>,
     /// The Webrender Document id associated with this window.
     #[ignore_heap_size_of = "defined in webrender_api"]
@@ -360,7 +360,7 @@ impl Window {
     }
 
     /// Returns the window proxy if it has not been discarded.
-    /// https://html.spec.whatwg.org/multipage/#a-browsing-context-is-discarded
+    /// <https://html.spec.whatwg.org/multipage/#a-browsing-context-is-discarded>
     pub fn undiscarded_window_proxy(&self) -> Option<DomRoot<WindowProxy>> {
         self.window_proxy.get()
             .and_then(|window_proxy| if window_proxy.is_browsing_context_discarded() {
@@ -742,13 +742,13 @@ impl WindowMethods for Window {
         base64_atob(atob)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-window-requestanimationframe
+    /// <https://html.spec.whatwg.org/multipage/#dom-window-requestanimationframe>
     fn RequestAnimationFrame(&self, callback: Rc<FrameRequestCallback>) -> u32 {
         self.Document()
             .request_animation_frame(AnimationFrameCallback::FrameRequestCallback { callback })
     }
 
-    /// https://html.spec.whatwg.org/multipage/#dom-window-cancelanimationframe
+    /// <https://html.spec.whatwg.org/multipage/#dom-window-cancelanimationframe>
     fn CancelAnimationFrame(&self, ident: u32) {
         let doc = self.Document();
         doc.cancel_animation_frame(ident);
@@ -1090,7 +1090,7 @@ impl Window {
         self.ignore_further_async_events.borrow().store(true, Ordering::SeqCst);
     }
 
-    /// https://drafts.csswg.org/cssom-view/#dom-window-scroll
+    /// <https://drafts.csswg.org/cssom-view/#dom-window-scroll>
     pub fn scroll(&self, x_: f64, y_: f64, behavior: ScrollBehavior) {
         // Step 3
         let xfinite = if x_.is_finite() { x_ } else { 0.0f64 };
@@ -1144,7 +1144,7 @@ impl Window {
                               None);
     }
 
-    /// https://drafts.csswg.org/cssom-view/#perform-a-scroll
+    /// <https://drafts.csswg.org/cssom-view/#perform-a-scroll>
     pub fn perform_a_scroll(&self,
                             x: f32,
                             y: f32,

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -74,7 +74,7 @@ const WORKLET_THREAD_POOL_SIZE: u32 = 3;
 const MIN_GC_THRESHOLD: u32 = 1_000_000;
 
 #[dom_struct]
-/// https://drafts.css-houdini.org/worklets/#worklet
+/// <https://drafts.css-houdini.org/worklets/#worklet>
 pub struct Worklet {
     reflector: Reflector,
     window: Dom<Window>,
@@ -109,7 +109,7 @@ impl Worklet {
 
 impl WorkletMethods for Worklet {
     #[allow(unrooted_must_root)]
-    /// https://drafts.css-houdini.org/worklets/#dom-worklet-addmodule
+    /// <https://drafts.css-houdini.org/worklets/#dom-worklet-addmodule>
     fn AddModule(&self, module_url: USVString, options: &WorkletOptions) -> Rc<Promise> {
         // Step 1.
         let promise = Promise::new(self.window.upcast());
@@ -159,7 +159,7 @@ impl WorkletId {
     }
 }
 
-/// https://drafts.css-houdini.org/worklets/#pending-tasks-struct
+/// <https://drafts.css-houdini.org/worklets/#pending-tasks-struct>
 #[derive(Clone, Debug)]
 struct PendingTasksStruct(Arc<AtomicIsize>);
 
@@ -275,7 +275,7 @@ impl WorkletThreadPool {
     /// Loads a worklet module into every worklet thread.
     /// If all of the threads load successfully, the promise is resolved.
     /// If any of the threads fails to load, the promise is rejected.
-    /// https://drafts.css-houdini.org/worklets/#fetch-and-invoke-a-worklet-script
+    /// <https://drafts.css-houdini.org/worklets/#fetch-and-invoke-a-worklet-script>
     fn fetch_and_invoke_a_worklet_script(&self,
                                          pipeline_id: PipelineId,
                                          worklet_id: WorkletId,
@@ -552,7 +552,7 @@ impl WorkletThread {
     }
 
     /// Fetch and invoke a worklet script.
-    /// https://drafts.css-houdini.org/worklets/#fetch-and-invoke-a-worklet-script
+    /// <https://drafts.css-houdini.org/worklets/#fetch-and-invoke-a-worklet-script>
     fn fetch_and_invoke_a_worklet_script(&self,
                                          global_scope: &WorkletGlobalScope,
                                          pipeline_id: PipelineId,

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -33,7 +33,7 @@ use std::sync::Arc;
 use std::sync::mpsc::Sender;
 
 #[dom_struct]
-/// https://drafts.css-houdini.org/worklets/#workletglobalscope
+/// <https://drafts.css-houdini.org/worklets/#workletglobalscope>
 pub struct WorkletGlobalScope {
     /// The global for this worklet.
     globalscope: GlobalScope,
@@ -154,7 +154,7 @@ pub struct WorkletGlobalScopeInit {
     pub image_cache: Arc<ImageCache>,
 }
 
-/// https://drafts.css-houdini.org/worklets/#worklet-global-scope-type
+/// <https://drafts.css-houdini.org/worklets/#worklet-global-scope-type>
 #[derive(Clone, Copy, Debug, HeapSizeOf, JSTraceable)]
 pub enum WorkletGlobalScopeType {
     /// A servo-specific testing worklet

--- a/components/script/microtask.rs
+++ b/components/script/microtask.rs
@@ -25,7 +25,7 @@ use std::rc::Rc;
 pub struct MicrotaskQueue {
     /// The list of enqueued microtasks that will be invoked at the next microtask checkpoint.
     microtask_queue: DomRefCell<Vec<Microtask>>,
-    /// https://html.spec.whatwg.org/multipage/#performing-a-microtask-checkpoint
+    /// <https://html.spec.whatwg.org/multipage/#performing-a-microtask-checkpoint>
     performing_a_microtask_checkpoint: Cell<bool>,
 }
 
@@ -57,7 +57,7 @@ impl MicrotaskQueue {
         self.microtask_queue.borrow_mut().push(job);
     }
 
-    /// https://html.spec.whatwg.org/multipage/#perform-a-microtask-checkpoint
+    /// <https://html.spec.whatwg.org/multipage/#perform-a-microtask-checkpoint>
     /// Perform a microtask checkpoint, executing all queued microtasks until the queue is empty.
     pub fn checkpoint<F>(&self, target_provider: F)
         where F: Fn(PipelineId) -> Option<DomRoot<GlobalScope>>

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -468,7 +468,7 @@ pub struct ScriptThread {
 
     content_process_shutdown_chan: IpcSender<()>,
 
-    /// https://html.spec.whatwg.org/multipage/#microtask-queue
+    /// <https://html.spec.whatwg.org/multipage/#microtask-queue>
     microtask_queue: Rc<MicrotaskQueue>,
 
     /// Microtask Queue for adding support for mutation observer microtasks
@@ -494,7 +494,7 @@ pub struct ScriptThread {
     /// of the transition.
     transitioning_nodes: DomRefCell<Vec<Dom<Node>>>,
 
-    /// https://html.spec.whatwg.org/multipage/#custom-element-reactions-stack
+    /// <https://html.spec.whatwg.org/multipage/#custom-element-reactions-stack>
     custom_element_reaction_stack: CustomElementReactionStack,
 
     /// The Webrender Document ID associated with this thread.
@@ -1602,7 +1602,7 @@ impl ScriptThread {
     }
 
     /// Handles a mozbrowser event, for example see:
-    /// https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowserloadstart
+    /// <https://developer.mozilla.org/en-US/docs/Web/Events/mozbrowserloadstart>
     fn handle_mozbrowser_event_msg(&self,
                                    parent_pipeline_id: PipelineId,
                                    top_level_browsing_context_id: Option<TopLevelBrowsingContextId>,
@@ -2309,7 +2309,7 @@ impl ScriptThread {
         document.handle_touch_event(self.js_runtime.rt(), event_type, identifier, point)
     }
 
-    /// https://html.spec.whatwg.org/multipage/#navigating-across-documents
+    /// <https://html.spec.whatwg.org/multipage/#navigating-across-documents>
     /// The entry point for content to notify that a new load has been requested
     /// for the given pipeline (specifically the "navigate" algorithm).
     fn handle_navigate(&self, parent_pipeline_id: PipelineId,

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -72,7 +72,7 @@ pub struct TextInput<T: ClipboardProvider> {
     clipboard_provider: T,
     /// The maximum number of UTF-16 code units this text input is allowed to hold.
     ///
-    /// https://html.spec.whatwg.org/multipage/#attr-fe-maxlength
+    /// <https://html.spec.whatwg.org/multipage/#attr-fe-maxlength>
     pub max_length: Option<usize>,
     pub min_length: Option<usize>,
     pub selection_direction: SelectionDirection,

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -158,7 +158,7 @@ pub struct LoadData {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum JsEvalResult {
     /// The js evaluation had a non-string result, 204 status code.
-    /// https://html.spec.whatwg.org/multipage/#navigate 12.11
+    /// <https://html.spec.whatwg.org/multipage/#navigate> 12.11
     NoContent,
     /// The js evaluation had a string result.
     Ok(Vec<u8>)
@@ -221,8 +221,9 @@ pub enum DiscardBrowsingContext {
 /// A document is active if it is the current active document in its session history,
 /// it is fuly active if it is active and all of its ancestors are active,
 /// and it is inactive otherwise.
-/// https://html.spec.whatwg.org/multipage/#active-document
-/// https://html.spec.whatwg.org/multipage/#fully-active
+///
+/// * <https://html.spec.whatwg.org/multipage/#active-document>
+/// * <https://html.spec.whatwg.org/multipage/#fully-active>
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, HeapSizeOf, PartialEq, Serialize)]
 pub enum DocumentActivity {
     /// An inactive document
@@ -402,7 +403,7 @@ pub enum TouchEventType {
 
 /// An opaque identifier for a touch point.
 ///
-/// http://w3c.github.io/touch-events/#widl-Touch-identifier
+/// <http://w3c.github.io/touch-events/#widl-Touch-identifier>
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TouchId(pub i32);
 
@@ -722,7 +723,7 @@ pub struct ScrollState {
 #[derive(Clone, Copy, Deserialize, HeapSizeOf, Serialize)]
 pub struct WindowSizeData {
     /// The size of the initial layout viewport, before parsing an
-    /// http://www.w3.org/TR/css-device-adapt/#initial-viewport
+    /// <http://www.w3.org/TR/css-device-adapt/#initial-viewport>
     pub initial_viewport: TypedSize2D<f32, CSSPixel>,
 
     /// The resolution of the window in dppx, not including any "pinch zoom" factor.
@@ -853,7 +854,7 @@ impl From<RecvTimeoutError> for PaintWorkletError {
 
 /// Execute paint code in the worklet thread pool.
 pub trait Painter: SpeculativePainter {
-    /// https://drafts.css-houdini.org/css-paint-api/#draw-a-paint-image
+    /// <https://drafts.css-houdini.org/css-paint-api/#draw-a-paint-image>
     fn draw_a_paint_image(&self,
                           size: TypedSize2D<f32, CSSPixel>,
                           zoom: ScaleFactor<f32, CSSPixel, DevicePixel>,
@@ -869,7 +870,8 @@ impl fmt::Debug for Painter {
 }
 
 /// The result of executing paint code: the image together with any image URLs that need to be loaded.
-/// TODO: this should return a WR display list. https://github.com/servo/servo/issues/17497
+///
+/// TODO: this should return a WR display list. <https://github.com/servo/servo/issues/17497>
 #[derive(Clone, Debug, Deserialize, HeapSizeOf, Serialize)]
 pub struct DrawAPaintImageResult {
     /// The image height

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -137,7 +137,7 @@ pub enum ScriptMsg {
     /// Scroll a page in a window
     ScrollFragmentPoint(ClipId, Point2D<f32>, bool),
     /// Set title of current page
-    /// https://html.spec.whatwg.org/multipage/#document.title
+    /// <https://html.spec.whatwg.org/multipage/#document.title>
     SetTitle(Option<String>),
     /// Send a key event
     SendKeyEvent(Option<char>, Key, KeyState, KeyModifiers),

--- a/components/selectors/build.rs
+++ b/components/selectors/build.rs
@@ -24,7 +24,7 @@ fn main() {
     write!(&mut file, "; &SET }}").unwrap();
 }
 
-/// https://html.spec.whatwg.org/multipage/#selectors
+/// <https://html.spec.whatwg.org/multipage/#selectors>
 static ASCII_CASE_INSENSITIVE_HTML_ATTRIBUTES: &'static str = r#"
     accept
     accept-charset

--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -82,7 +82,7 @@ macro_rules! with_all_bounds {
         ///
         /// NB: We need Clone so that we can derive(Clone) on struct with that
         /// are parameterized on SelectorImpl. See
-        /// https://github.com/rust-lang/rust/issues/26925
+        /// <https://github.com/rust-lang/rust/issues/26925>
         pub trait SelectorImpl: Clone + Sized + 'static {
             type AttrValue: $($InSelector)*;
             type Identifier: $($InSelector)* + PrecomputedHash;
@@ -177,7 +177,7 @@ pub struct SelectorList<Impl: SelectorImpl>(pub SmallVec<[Selector<Impl>; 1]>);
 
 impl<Impl: SelectorImpl> SelectorList<Impl> {
     /// Parse a comma-separated list of Selectors.
-    /// https://drafts.csswg.org/selectors/#grouping
+    /// <https://drafts.csswg.org/selectors/#grouping>
     ///
     /// Return the Selectors or Err if there is an invalid selector.
     pub fn parse<'i, 't, P>(parser: &P, input: &mut CssParser<'i, 't>)
@@ -898,7 +898,7 @@ impl<Impl: SelectorImpl> ToCss for Component<Impl> {
         use self::Component::*;
 
         /// Serialize <an+b> values (part of the CSS Syntax spec, but currently only used here).
-        /// https://drafts.csswg.org/css-syntax-3/#serialize-an-anb-value
+        /// <https://drafts.csswg.org/css-syntax-3/#serialize-an-anb-value>
         fn write_affine<W>(dest: &mut W, a: i32, b: i32) -> fmt::Result where W: fmt::Write {
             match (a, b) {
                 (0, 0) => dest.write_char('0'),

--- a/components/servo_arc/lib.rs
+++ b/components/servo_arc/lib.rs
@@ -9,6 +9,7 @@
 // except according to those terms.
 
 //! Fork of Arc for Servo. This has the following advantages over std::Arc:
+//!
 //! * We don't waste storage on the weak reference count.
 //! * We don't do extra RMU operations to handle the possibility of weak references.
 //! * We can experiment with arena allocation (todo).
@@ -16,7 +17,7 @@
 //! * We have support for dynamically-sized types (see from_header_and_iter).
 //! * We have support for thin arcs to unsized types (see ThinArc).
 //!
-//! [1] https://bugzilla.mozilla.org/show_bug.cgi?id=1360883
+//! [1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1360883
 
 // The semantics of Arc are alread documented in the Rust docs, so we don't
 // duplicate those here.
@@ -83,7 +84,7 @@ const MAX_REFCOUNT: usize = (isize::MAX) as usize;
 /// be thin or fat (which depends on whether or not T is sized). Given
 /// that this is all a temporary hack, this restriction is fine for now.
 ///
-/// [1] https://github.com/rust-lang/rust/issues/27730
+/// [1]: https://github.com/rust-lang/rust/issues/27730
 pub struct NonZeroPtrMut<T: ?Sized + 'static>(&'static mut T);
 impl<T: ?Sized> NonZeroPtrMut<T> {
     pub fn new(ptr: *mut T) -> Self {

--- a/components/style/attr.rs
+++ b/components/style/attr.rs
@@ -393,7 +393,7 @@ impl PartialEq<Atom> for AttrValue {
     }
 }
 
-/// https://html.spec.whatwg.org/multipage/#rules-for-parsing-non-zero-dimension-values
+/// <https://html.spec.whatwg.org/multipage/#rules-for-parsing-non-zero-dimension-values>
 pub fn parse_nonzero_length(value: &str) -> LengthOrPercentageOrAuto {
     match parse_length(value) {
         LengthOrPercentageOrAuto::Length(x) if x == Au::zero() => LengthOrPercentageOrAuto::Auto,

--- a/components/style/counter_style/mod.rs
+++ b/components/style/counter_style/mod.rs
@@ -229,55 +229,55 @@ macro_rules! counter_style_descriptors {
 }
 
 counter_style_descriptors! {
-    /// https://drafts.csswg.org/css-counter-styles/#counter-style-system
+    /// <https://drafts.csswg.org/css-counter-styles/#counter-style-system>
     "system" system / eCSSCounterDesc_System: System = {
         System::Symbolic
     }
 
-    /// https://drafts.csswg.org/css-counter-styles/#counter-style-negative
+    /// <https://drafts.csswg.org/css-counter-styles/#counter-style-negative>
     "negative" negative / eCSSCounterDesc_Negative: Negative = {
         Negative(Symbol::String("-".to_owned()), None)
     }
 
-    /// https://drafts.csswg.org/css-counter-styles/#counter-style-prefix
+    /// <https://drafts.csswg.org/css-counter-styles/#counter-style-prefix>
     "prefix" prefix / eCSSCounterDesc_Prefix: Symbol = {
         Symbol::String("".to_owned())
     }
 
-    /// https://drafts.csswg.org/css-counter-styles/#counter-style-suffix
+    /// <https://drafts.csswg.org/css-counter-styles/#counter-style-suffix>
     "suffix" suffix / eCSSCounterDesc_Suffix: Symbol = {
         Symbol::String(". ".to_owned())
     }
 
-    /// https://drafts.csswg.org/css-counter-styles/#counter-style-range
+    /// <https://drafts.csswg.org/css-counter-styles/#counter-style-range>
     "range" range / eCSSCounterDesc_Range: Ranges = {
         Ranges(Vec::new())  // Empty Vec represents 'auto'
     }
 
-    /// https://drafts.csswg.org/css-counter-styles/#counter-style-pad
+    /// <https://drafts.csswg.org/css-counter-styles/#counter-style-pad>
     "pad" pad / eCSSCounterDesc_Pad: Pad = {
         Pad(0, Symbol::String("".to_owned()))
     }
 
-    /// https://drafts.csswg.org/css-counter-styles/#counter-style-fallback
+    /// <https://drafts.csswg.org/css-counter-styles/#counter-style-fallback>
     "fallback" fallback / eCSSCounterDesc_Fallback: Fallback = {
         // FIXME https://bugzilla.mozilla.org/show_bug.cgi?id=1359323 use atom!()
         Fallback(CustomIdent(Atom::from("decimal")))
     }
 
-    /// https://drafts.csswg.org/css-counter-styles/#descdef-counter-style-symbols
+    /// <https://drafts.csswg.org/css-counter-styles/#descdef-counter-style-symbols>
     "symbols" symbols / eCSSCounterDesc_Symbols: Symbols = !
 
-    /// https://drafts.csswg.org/css-counter-styles/#descdef-counter-style-additive-symbols
+    /// <https://drafts.csswg.org/css-counter-styles/#descdef-counter-style-additive-symbols>
     "additive-symbols" additive_symbols / eCSSCounterDesc_AdditiveSymbols: AdditiveSymbols = !
 
-    /// https://drafts.csswg.org/css-counter-styles/#counter-style-speak-as
+    /// <https://drafts.csswg.org/css-counter-styles/#counter-style-speak-as>
     "speak-as" speak_as / eCSSCounterDesc_SpeakAs: SpeakAs = {
         SpeakAs::Auto
     }
 }
 
-/// https://drafts.csswg.org/css-counter-styles/#counter-style-system
+/// <https://drafts.csswg.org/css-counter-styles/#counter-style-system>
 #[derive(Clone, Debug)]
 pub enum System {
     /// 'cyclic'
@@ -343,7 +343,7 @@ impl ToCss for System {
     }
 }
 
-/// https://drafts.csswg.org/css-counter-styles/#typedef-symbol
+/// <https://drafts.csswg.org/css-counter-styles/#typedef-symbol>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[derive(Clone, Debug, Eq, PartialEq, ToComputedValue)]
 pub enum Symbol {
@@ -388,7 +388,7 @@ impl Symbol {
     }
 }
 
-/// https://drafts.csswg.org/css-counter-styles/#counter-style-negative
+/// <https://drafts.csswg.org/css-counter-styles/#counter-style-negative>
 #[derive(Clone, Debug, ToCss)]
 pub struct Negative(pub Symbol, pub Option<Symbol>);
 
@@ -401,7 +401,7 @@ impl Parse for Negative {
     }
 }
 
-/// https://drafts.csswg.org/css-counter-styles/#counter-style-range
+/// <https://drafts.csswg.org/css-counter-styles/#counter-style-range>
 ///
 /// Empty Vec represents 'auto'
 #[derive(Clone, Debug)]
@@ -467,7 +467,7 @@ fn bound_to_css<W>(range: Option<i32>, dest: &mut W) -> fmt::Result where W: fmt
     }
 }
 
-/// https://drafts.csswg.org/css-counter-styles/#counter-style-pad
+/// <https://drafts.csswg.org/css-counter-styles/#counter-style-pad>
 #[derive(Clone, Debug, ToCss)]
 pub struct Pad(pub u32, pub Symbol);
 
@@ -483,7 +483,7 @@ impl Parse for Pad {
     }
 }
 
-/// https://drafts.csswg.org/css-counter-styles/#counter-style-fallback
+/// <https://drafts.csswg.org/css-counter-styles/#counter-style-fallback>
 #[derive(Clone, Debug, ToCss)]
 pub struct Fallback(pub CustomIdent);
 
@@ -493,7 +493,7 @@ impl Parse for Fallback {
     }
 }
 
-/// https://drafts.csswg.org/css-counter-styles/#descdef-counter-style-symbols
+/// <https://drafts.csswg.org/css-counter-styles/#descdef-counter-style-symbols>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[derive(Clone, Debug, Eq, PartialEq, ToComputedValue)]
 pub struct Symbols(pub Vec<Symbol>);
@@ -528,7 +528,7 @@ impl ToCss for Symbols {
     }
 }
 
-/// https://drafts.csswg.org/css-counter-styles/#descdef-counter-style-additive-symbols
+/// <https://drafts.csswg.org/css-counter-styles/#descdef-counter-style-additive-symbols>
 #[derive(Clone, Debug, ToCss)]
 pub struct AdditiveSymbols(pub Vec<AdditiveTuple>);
 
@@ -571,7 +571,7 @@ impl Parse for AdditiveTuple {
     }
 }
 
-/// https://drafts.csswg.org/css-counter-styles/#counter-style-speak-as
+/// <https://drafts.csswg.org/css-counter-styles/#counter-style-speak-as>
 #[derive(Clone, Debug, ToCss)]
 pub enum SpeakAs {
     /// auto

--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -28,7 +28,7 @@ pub type Name = Atom;
 
 /// Parse a custom property name.
 ///
-/// https://drafts.csswg.org/css-variables/#typedef-custom-property-name
+/// <https://drafts.csswg.org/css-variables/#typedef-custom-property-name>
 pub fn parse_name(s: &str) -> Result<&str, ()> {
     if s.starts_with("--") {
         Ok(&s[2..])
@@ -317,7 +317,7 @@ fn parse_self_contained_declaration_value<'i, 't>(
     Ok((first, css, last))
 }
 
-/// https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value
+/// <https://drafts.csswg.org/css-syntax-3/#typedef-declaration-value>
 fn parse_declaration_value<'i, 't>(
     input: &mut Parser<'i, 't>,
     references: Option<&mut PrecomputedHashSet<Name>>,

--- a/components/style/dom_apis.rs
+++ b/components/style/dom_apis.rs
@@ -9,7 +9,7 @@ use context::QuirksMode;
 use selectors::{Element, NthIndexCache, SelectorList};
 use selectors::matching::{self, MatchingContext, MatchingMode};
 
-/// https://dom.spec.whatwg.org/#dom-element-matches
+/// <https://dom.spec.whatwg.org/#dom-element-matches>
 pub fn element_matches<E>(
     element: &E,
     selector_list: &SelectorList<E::Impl>,
@@ -28,7 +28,7 @@ where
     matching::matches_selector_list(selector_list, element, &mut context)
 }
 
-/// https://dom.spec.whatwg.org/#dom-element-closest
+/// <https://dom.spec.whatwg.org/#dom-element-closest>
 pub fn element_closest<E>(
     element: E,
     selector_list: &SelectorList<E::Impl>,

--- a/components/style/element_state.rs
+++ b/components/style/element_state.rs
@@ -18,35 +18,35 @@ bitflags! {
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub flags ElementState: u64 {
         /// The mouse is down on this element.
-        /// https://html.spec.whatwg.org/multipage/#selector-active
+        /// <https://html.spec.whatwg.org/multipage/#selector-active>
         /// FIXME(#7333): set/unset this when appropriate
         const IN_ACTIVE_STATE = 1 << 0,
         /// This element has focus.
-        /// https://html.spec.whatwg.org/multipage/#selector-focus
+        /// <https://html.spec.whatwg.org/multipage/#selector-focus>
         const IN_FOCUS_STATE = 1 << 1,
         /// The mouse is hovering over this element.
-        /// https://html.spec.whatwg.org/multipage/#selector-hover
+        /// <https://html.spec.whatwg.org/multipage/#selector-hover>
         const IN_HOVER_STATE = 1 << 2,
         /// Content is enabled (and can be disabled).
-        /// http://www.whatwg.org/html/#selector-enabled
+        /// <http://www.whatwg.org/html/#selector-enabled>
         const IN_ENABLED_STATE = 1 << 3,
         /// Content is disabled.
-        /// http://www.whatwg.org/html/#selector-disabled
+        /// <http://www.whatwg.org/html/#selector-disabled>
         const IN_DISABLED_STATE = 1 << 4,
         /// Content is checked.
-        /// https://html.spec.whatwg.org/multipage/#selector-checked
+        /// <https://html.spec.whatwg.org/multipage/#selector-checked>
         const IN_CHECKED_STATE = 1 << 5,
-        /// https://html.spec.whatwg.org/multipage/#selector-indeterminate
+        /// <https://html.spec.whatwg.org/multipage/#selector-indeterminate>
         const IN_INDETERMINATE_STATE = 1 << 6,
-        /// https://html.spec.whatwg.org/multipage/#selector-placeholder-shown
+        /// <https://html.spec.whatwg.org/multipage/#selector-placeholder-shown>
         const IN_PLACEHOLDER_SHOWN_STATE = 1 << 7,
-        /// https://html.spec.whatwg.org/multipage/#selector-target
+        /// <https://html.spec.whatwg.org/multipage/#selector-target>
         const IN_TARGET_STATE = 1 << 8,
-        /// https://fullscreen.spec.whatwg.org/#%3Afullscreen-pseudo-class
+        /// <https://fullscreen.spec.whatwg.org/#%3Afullscreen-pseudo-class>
         const IN_FULLSCREEN_STATE = 1 << 9,
-        /// https://html.spec.whatwg.org/multipage/#selector-valid
+        /// <https://html.spec.whatwg.org/multipage/#selector-valid>
         const IN_VALID_STATE = 1 << 10,
-        /// https://html.spec.whatwg.org/multipage/#selector-invalid
+        /// <https://html.spec.whatwg.org/multipage/#selector-invalid>
         const IN_INVALID_STATE = 1 << 11,
         /// Non-standard: https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-ui-valid
         const IN_MOZ_UI_VALID_STATE = 1 << 12,
@@ -66,31 +66,31 @@ bitflags! {
         const IN_HANDLER_DISABLED_STATE = 1 << 19,
         /// Non-standard: https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-handler-crashed
         const IN_HANDLER_CRASHED_STATE = 1 << 20,
-        /// https://html.spec.whatwg.org/multipage/#selector-required
+        /// <https://html.spec.whatwg.org/multipage/#selector-required>
         const IN_REQUIRED_STATE = 1 << 21,
-        /// https://html.spec.whatwg.org/multipage/#selector-optional
+        /// <https://html.spec.whatwg.org/multipage/#selector-optional>
         const IN_OPTIONAL_STATE = 1 << 22,
-        /// https://html.spec.whatwg.org/multipage/#selector-read-write
+        /// <https://html.spec.whatwg.org/multipage/#selector-read-write>
         const IN_READ_WRITE_STATE = 1 << 22,
         /// Non-standard: Older custom-elements spec.
         const IN_UNRESOLVED_STATE = 1 << 23,
-        /// https://html.spec.whatwg.org/multipage/#selector-visited
+        /// <https://html.spec.whatwg.org/multipage/#selector-visited>
         const IN_VISITED_STATE = 1 << 24,
-        /// https://html.spec.whatwg.org/multipage/#selector-link
+        /// <https://html.spec.whatwg.org/multipage/#selector-link>
         const IN_UNVISITED_STATE = 1 << 25,
-        /// https://drafts.csswg.org/selectors-4/#the-any-link-pseudo
+        /// <https://drafts.csswg.org/selectors-4/#the-any-link-pseudo>
         const IN_VISITED_OR_UNVISITED_STATE = IN_VISITED_STATE.bits | IN_UNVISITED_STATE.bits,
         /// Non-standard: https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-drag-over
         const IN_DRAGOVER_STATE = 1 << 26,
-        /// https://html.spec.whatwg.org/multipage/#selector-in-range
+        /// <https://html.spec.whatwg.org/multipage/#selector-in-range>
         const IN_INRANGE_STATE = 1 << 27,
-        /// https://html.spec.whatwg.org/multipage/#selector-out-of-range
+        /// <https://html.spec.whatwg.org/multipage/#selector-out-of-range>
         const IN_OUTOFRANGE_STATE = 1 << 28,
-        /// https://html.spec.whatwg.org/multipage/#selector-read-only
+        /// <https://html.spec.whatwg.org/multipage/#selector-read-only>
         const IN_MOZ_READONLY_STATE = 1 << 29,
-        /// https://html.spec.whatwg.org/multipage/#selector-read-write
+        /// <https://html.spec.whatwg.org/multipage/#selector-read-write>
         const IN_MOZ_READWRITE_STATE = 1 << 30,
-        /// https://html.spec.whatwg.org/multipage/#selector-default
+        /// <https://html.spec.whatwg.org/multipage/#selector-default>
         const IN_DEFAULT_STATE = 1 << 31,
         /// Non-standard: https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-submit-invalid
         const IN_MOZ_SUBMITINVALID_STATE = 1 << 32,
@@ -114,7 +114,7 @@ bitflags! {
         const IN_HANDLER_VULNERABLE_UPDATABLE_STATE = 1 << 41,
         /// Non-standard & undocumented.
         const IN_HANDLER_VULNERABLE_NO_UPDATE_STATE = 1 << 42,
-        /// https://drafts.csswg.org/selectors-4/#the-focus-within-pseudo
+        /// <https://drafts.csswg.org/selectors-4/#the-focus-within-pseudo>
         const IN_FOCUS_WITHIN_STATE = 1 << 43,
         /// :dir matching; the states are used for dynamic change detection.
         /// State that elements that match :dir(ltr) are in.

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -43,7 +43,7 @@ impl OneOrMoreSeparated for Source {
 /// A `UrlSource` represents a font-face source that has been specified with a
 /// `url()` function.
 ///
-/// https://drafts.csswg.org/css-fonts/#src-desc
+/// <https://drafts.csswg.org/css-fonts/#src-desc>
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 pub struct UrlSource {
@@ -235,7 +235,7 @@ macro_rules! font_face_descriptors_common {
     ) => {
         /// Data inside a `@font-face` rule.
         ///
-        /// https://drafts.csswg.org/css-fonts/#font-face-rule
+        /// <https://drafts.csswg.org/css-fonts/#font-face-rule>
         #[derive(Clone, Debug, Eq, PartialEq)]
         pub struct FontFaceRuleData {
             $(

--- a/components/style/gecko/media_queries.rs
+++ b/components/style/gecko/media_queries.rs
@@ -57,7 +57,7 @@ pub struct Device {
     /// The body text color, stored as an `nscolor`, used for the "tables
     /// inherit from body" quirk.
     ///
-    /// https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk
+    /// <https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk>
     body_text_color: AtomicUsize,
     /// Whether any styles computed in the document relied on the root font-size
     /// by using rem units.
@@ -118,7 +118,7 @@ impl Device {
 
     /// Sets the body text color for the "inherit color from body" quirk.
     ///
-    /// https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk
+    /// <https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk>
     pub fn set_body_text_color(&self, color: RGBA) {
         self.body_text_color.store(convert_rgba_to_nscolor(&color) as usize, Ordering::Relaxed)
     }

--- a/components/style/gecko/selector_parser.rs
+++ b/components/style/gecko/selector_parser.rs
@@ -165,7 +165,7 @@ impl NonTSPseudoClass {
         }
     }
 
-    /// https://drafts.csswg.org/selectors-4/#useraction-pseudos
+    /// <https://drafts.csswg.org/selectors-4/#useraction-pseudos>
     ///
     /// We intentionally skip the link-related ones.
     pub fn is_safe_user_action_state(&self) -> bool {

--- a/components/style/media_queries.rs
+++ b/components/style/media_queries.rs
@@ -47,15 +47,15 @@ impl MediaList {
     }
 }
 
-/// https://drafts.csswg.org/mediaqueries/#mq-prefix
+/// <https://drafts.csswg.org/mediaqueries/#mq-prefix>
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ToCss)]
 pub enum Qualifier {
     /// Hide a media query from legacy UAs:
-    /// https://drafts.csswg.org/mediaqueries/#mq-only
+    /// <https://drafts.csswg.org/mediaqueries/#mq-only>
     Only,
     /// Negate a media query:
-    /// https://drafts.csswg.org/mediaqueries/#mq-not
+    /// <https://drafts.csswg.org/mediaqueries/#mq-not>
     Not,
 }
 
@@ -133,7 +133,7 @@ impl ToCss for MediaQuery {
     }
 }
 
-/// http://dev.w3.org/csswg/mediaqueries-3/#media0
+/// <http://dev.w3.org/csswg/mediaqueries-3/#media0>
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum MediaQueryType {
@@ -162,7 +162,7 @@ impl MediaQueryType {
     }
 }
 
-/// https://drafts.csswg.org/mediaqueries/#media-types
+/// <https://drafts.csswg.org/mediaqueries/#media-types>
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct MediaType(pub CustomIdent);
@@ -241,7 +241,7 @@ impl MediaQuery {
 /// Always returns a media query list. If any invalid media query is found, the
 /// media query list is only filled with the equivalent of "not all", see:
 ///
-/// https://drafts.csswg.org/mediaqueries/#error-handling
+/// <https://drafts.csswg.org/mediaqueries/#error-handling>
 pub fn parse_media_query_list<R>(
     context: &ParserContext,
     input: &mut Parser,
@@ -311,7 +311,7 @@ impl MediaList {
     }
 
     /// Append a new media query item to the media list.
-    /// https://drafts.csswg.org/cssom/#dom-medialist-appendmedium
+    /// <https://drafts.csswg.org/cssom/#dom-medialist-appendmedium>
     ///
     /// Returns true if added, false if fail to parse the medium string.
     pub fn append_medium(&mut self, context: &ParserContext, new_medium: &str) -> bool {
@@ -330,7 +330,7 @@ impl MediaList {
     }
 
     /// Delete a media query from the media list.
-    /// https://drafts.csswg.org/cssom/#dom-medialist-deletemedium
+    /// <https://drafts.csswg.org/cssom/#dom-medialist-deletemedium>
     ///
     /// Returns true if found and deleted, false otherwise.
     pub fn delete_medium(&mut self, context: &ParserContext, old_medium: &str) -> bool {

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -308,7 +308,7 @@ impl PropertyDeclarationBlock {
 
     /// Find the value of the given property in this block and serialize it
     ///
-    /// https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertyvalue
+    /// <https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertyvalue>
     pub fn property_value_to_css<W>(&self, property: &PropertyId, dest: &mut W) -> fmt::Result
         where W: fmt::Write,
     {
@@ -365,7 +365,7 @@ impl PropertyDeclarationBlock {
         }
     }
 
-    /// https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertypriority
+    /// <https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertypriority>
     pub fn property_priority(&self, property: &PropertyId) -> Importance {
         // Step 1: done when parsing a string to PropertyId
 
@@ -560,7 +560,7 @@ impl PropertyDeclarationBlock {
         updated_at_least_one
     }
 
-    /// https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-removeproperty
+    /// <https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-removeproperty>
     ///
     /// Returns whether any declaration was actually removed.
     pub fn remove_property(&mut self, property: &PropertyId) -> bool {

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -57,7 +57,7 @@ use values::generics::position as generic_position;
 use values::generics::svg::{SVGLength,  SvgLengthOrPercentageOrNumber, SVGPaint};
 use values::generics::svg::{SVGPaintKind, SVGStrokeDashArray, SVGOpacity};
 
-/// https://drafts.csswg.org/css-transitions/#animtype-repeatable-list
+/// <https://drafts.csswg.org/css-transitions/#animtype-repeatable-list>
 pub trait RepeatableListAnimatable: Animate {}
 
 /// Returns true if this nsCSSPropertyID is one of the animatable properties.
@@ -655,7 +655,7 @@ macro_rules! repeated_vec_impl {
 
 repeated_vec_impl!(SmallVec<[T; 1]>, Vec<T>);
 
-/// https://drafts.csswg.org/css-transitions/#animtype-visibility
+/// <https://drafts.csswg.org/css-transitions/#animtype-visibility>
 impl Animate for Visibility {
     #[inline]
     fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
@@ -686,7 +686,7 @@ impl ToAnimatedZero for Visibility {
     }
 }
 
-/// https://drafts.csswg.org/css-transitions/#animtype-lpcalc
+/// <https://drafts.csswg.org/css-transitions/#animtype-lpcalc>
 impl Animate for CalcLengthOrPercentage {
     #[inline]
     fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
@@ -738,7 +738,7 @@ impl ToAnimatedZero for MaxLength {
     fn to_animated_zero(&self) -> Result<Self, ()> { Err(()) }
 }
 
-/// http://dev.w3.org/csswg/css-transitions/#animtype-font-weight
+/// <http://dev.w3.org/csswg/css-transitions/#animtype-font-weight>
 impl Animate for FontWeight {
     #[inline]
     fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
@@ -759,7 +759,7 @@ impl ToAnimatedZero for FontWeight {
     }
 }
 
-/// https://drafts.csswg.org/css-fonts/#font-stretch-prop
+/// <https://drafts.csswg.org/css-fonts/#font-stretch-prop>
 impl Animate for FontStretch {
     #[inline]
     fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()>
@@ -786,7 +786,7 @@ impl ToAnimatedZero for FontStretch {
 }
 
 /// We should treat font stretch as real number in order to interpolate this property.
-/// https://drafts.csswg.org/css-fonts-3/#font-stretch-animation
+/// <https://drafts.csswg.org/css-fonts-3/#font-stretch-animation>
 impl From<FontStretch> for f64 {
     fn from(stretch: FontStretch) -> f64 {
         use self::FontStretch::*;
@@ -815,7 +815,7 @@ impl Into<FontStretch> for f64 {
     }
 }
 
-/// https://drafts.csswg.org/css-fonts-4/#font-variation-settings-def
+/// <https://drafts.csswg.org/css-fonts-4/#font-variation-settings-def>
 #[cfg(feature = "gecko")]
 impl Animate for FontVariationSettings {
     #[inline]
@@ -989,7 +989,7 @@ impl<'a> Iterator for FontSettingTagIter<'a> {
 impl<H, V> RepeatableListAnimatable for generic_position::Position<H, V>
     where H: RepeatableListAnimatable, V: RepeatableListAnimatable {}
 
-/// https://drafts.csswg.org/css-transitions/#animtype-rect
+/// <https://drafts.csswg.org/css-transitions/#animtype-rect>
 impl Animate for ClipRect {
     #[inline]
     fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
@@ -1018,7 +1018,7 @@ impl ToAnimatedZero for ClipRect {
 
 /// Build an equivalent 'identity transform function list' based
 /// on an existing transform list.
-/// http://dev.w3.org/csswg/css-transforms/#none-transform-animation
+/// <http://dev.w3.org/csswg/css-transforms/#none-transform-animation>
 impl ToAnimatedZero for TransformOperation {
     fn to_animated_zero(&self) -> Result<Self, ()> {
         match *self {
@@ -1078,7 +1078,7 @@ fn animate_multiplicative_factor(
     Ok((this - 1.).animate(&(other - 1.), procedure)? + 1.)
 }
 
-/// http://dev.w3.org/csswg/css-transforms/#interpolation-of-transforms
+/// <http://dev.w3.org/csswg/css-transforms/#interpolation-of-transforms>
 impl Animate for TransformOperation {
     fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
         match (self, other) {
@@ -1159,7 +1159,7 @@ impl Animate for TransformOperation {
     }
 }
 
-/// https://www.w3.org/TR/css-transforms-1/#Rotate3dDefined
+/// <https://www.w3.org/TR/css-transforms-1/#Rotate3dDefined>
 fn rotate_to_matrix(x: f32, y: f32, z: f32, a: Angle) -> ComputedMatrix {
     let half_rad = a.radians() / 2.0;
     let sc = (half_rad).sin() * (half_rad).cos();
@@ -1246,7 +1246,7 @@ impl Animate for Scale2D {
 }
 
 impl Animate for MatrixDecomposed2D {
-    /// https://drafts.csswg.org/css-transforms/#interpolation-of-decomposed-2d-matrix-values
+    /// <https://drafts.csswg.org/css-transforms/#interpolation-of-decomposed-2d-matrix-values>
     fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
         // If x-axis of one is flipped, and y-axis of the other,
         // convert to an unflipped rotation.
@@ -1375,7 +1375,7 @@ impl ComputeSquaredDistance for ComputedMatrix {
 
 impl From<ComputedMatrix> for MatrixDecomposed2D {
     /// Decompose a 2D matrix.
-    /// https://drafts.csswg.org/css-transforms/#decomposing-a-2d-matrix
+    /// <https://drafts.csswg.org/css-transforms/#decomposing-a-2d-matrix>
     fn from(matrix: ComputedMatrix) -> MatrixDecomposed2D {
         let mut row0x = matrix.m11;
         let mut row0y = matrix.m12;
@@ -1439,7 +1439,7 @@ impl From<ComputedMatrix> for MatrixDecomposed2D {
 
 impl From<MatrixDecomposed2D> for ComputedMatrix {
     /// Recompose a 2D matrix.
-    /// https://drafts.csswg.org/css-transforms/#recomposing-to-a-2d-matrix
+    /// <https://drafts.csswg.org/css-transforms/#recomposing-to-a-2d-matrix>
     fn from(decomposed: MatrixDecomposed2D) -> ComputedMatrix {
         let mut computed_matrix = ComputedMatrix::identity();
         computed_matrix.m11 = decomposed.matrix.m11;
@@ -1577,7 +1577,7 @@ impl ComputeSquaredDistance for Quaternion {
 }
 
 /// Decompose a 3D matrix.
-/// https://drafts.csswg.org/css-transforms/#decomposing-a-3d-matrix
+/// <https://drafts.csswg.org/css-transforms/#decomposing-a-3d-matrix>
 fn decompose_3d_matrix(mut matrix: ComputedMatrix) -> Result<MatrixDecomposed3D, ()> {
     // Normalize the matrix.
     if matrix.m44 == 0.0 {
@@ -1829,7 +1829,7 @@ impl Animate for Perspective {
 }
 
 impl Animate for MatrixDecomposed3D {
-    /// https://drafts.csswg.org/css-transforms/#interpolation-of-decomposed-3d-matrix-values
+    /// <https://drafts.csswg.org/css-transforms/#interpolation-of-decomposed-3d-matrix-values>
     fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
         use std::f64;
 
@@ -1911,7 +1911,7 @@ impl Animate for MatrixDecomposed3D {
 
 impl From<MatrixDecomposed3D> for ComputedMatrix {
     /// Recompose a 3D matrix.
-    /// https://drafts.csswg.org/css-transforms/#recomposing-to-a-3d-matrix
+    /// <https://drafts.csswg.org/css-transforms/#recomposing-to-a-3d-matrix>
     fn from(decomposed: MatrixDecomposed3D) -> ComputedMatrix {
         let mut matrix = ComputedMatrix::identity();
 
@@ -2106,7 +2106,7 @@ impl ComputedMatrix {
     }
 }
 
-/// https://drafts.csswg.org/css-transforms/#interpolation-of-transforms
+/// <https://drafts.csswg.org/css-transforms/#interpolation-of-transforms>
 impl Animate for TransformList {
     #[inline]
     fn animate(
@@ -2463,7 +2463,7 @@ where
     }
 }
 
-/// https://www.w3.org/TR/SVG11/painting.html#StrokeDasharrayProperty
+/// <https://www.w3.org/TR/SVG11/painting.html#StrokeDasharrayProperty>
 impl<L> Animate for SVGStrokeDashArray<L>
 where
     L: Clone + RepeatableListAnimatable,
@@ -2521,7 +2521,7 @@ where
                          'Sepia' ]
 %>
 
-/// https://drafts.fxtf.org/filters/#animation-of-filters
+/// <https://drafts.fxtf.org/filters/#animation-of-filters>
 impl Animate for AnimatedFilter {
     fn animate(
         &self,
@@ -2553,7 +2553,7 @@ impl Animate for AnimatedFilter {
     }
 }
 
-/// http://dev.w3.org/csswg/css-transforms/#none-transform-animation
+/// <http://dev.w3.org/csswg/css-transforms/#none-transform-animation>
 impl ToAnimatedZero for AnimatedFilter {
     fn to_animated_zero(&self) -> Result<Self, ()> {
         match *self {

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1623,7 +1623,7 @@ impl PropertyDeclaration {
 
     /// The `context` parameter controls this:
     ///
-    /// https://drafts.csswg.org/css-animations/#keyframes
+    /// <https://drafts.csswg.org/css-animations/#keyframes>
     /// > The <declaration-list> inside of <keyframe-block> accepts any CSS property
     /// > except those defined in this specification,
     /// > but does accept the `animation-play-state` property and interprets it specially.
@@ -2377,7 +2377,7 @@ impl ComputedValuesInner {
            effects.mix_blend_mode != mix_blend_mode::T::normal
     }
 
-    /// https://drafts.csswg.org/css-transforms/#grouping-property-values
+    /// <https://drafts.csswg.org/css-transforms/#grouping-property-values>
     pub fn get_used_transform_style(&self) -> computed_values::transform_style::T {
         use computed_values::transform_style;
 

--- a/components/style/servo/media_queries.rs
+++ b/components/style/servo/media_queries.rs
@@ -94,7 +94,7 @@ impl Device {
 
     /// Sets the body text color for the "inherit color from body" quirk.
     ///
-    /// https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk
+    /// <https://quirks.spec.whatwg.org/#the-tables-inherit-color-from-body-quirk>
     pub fn set_body_text_color(&self, _color: RGBA) {
         // Servo doesn't implement this quirk (yet)
     }
@@ -155,13 +155,13 @@ impl Device {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum ExpressionKind {
-    /// http://dev.w3.org/csswg/mediaqueries-3/#width
+    /// <http://dev.w3.org/csswg/mediaqueries-3/#width>
     Width(Range<specified::Length>),
 }
 
 /// A single expression a per:
 ///
-/// http://dev.w3.org/csswg/mediaqueries-3/#media1
+/// <http://dev.w3.org/csswg/mediaqueries-3/#media1>
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct Expression(pub ExpressionKind);

--- a/components/style/servo/url.rs
+++ b/components/style/servo/url.rs
@@ -21,7 +21,7 @@ use values::computed::{Context, ToComputedValue, ComputedUrl};
 /// eagerly resolving with rust-url would be duplicated work.
 ///
 /// However, this approach is still not necessarily optimal: See
-/// https://bugzilla.mozilla.org/show_bug.cgi?id=1347435#c6
+/// <https://bugzilla.mozilla.org/show_bug.cgi?id=1347435#c6>
 #[derive(Clone, Debug, Deserialize, HeapSizeOf, Serialize)]
 pub struct SpecifiedUrl {
     /// The original URI. This might be optional since we may insert computed

--- a/components/style/str.rs
+++ b/components/style/str.rs
@@ -21,7 +21,7 @@ pub type StaticStringVec = &'static [&'static str];
 
 /// A "space character" according to:
 ///
-/// https://html.spec.whatwg.org/multipage/#space-character
+/// <https://html.spec.whatwg.org/multipage/#space-character>
 pub static HTML_SPACE_CHARACTERS: StaticCharVec = &[
     '\u{0020}',
     '\u{0009}',

--- a/components/style/style_adjuster.rs
+++ b/components/style/style_adjuster.rs
@@ -30,7 +30,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
         }
     }
 
-    /// https://fullscreen.spec.whatwg.org/#new-stacking-layer
+    /// <https://fullscreen.spec.whatwg.org/#new-stacking-layer>
     ///
     ///    Any position value other than 'absolute' and 'fixed' are
     ///    computed to 'absolute' if the element is in a top layer.
@@ -53,7 +53,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
     }
 
     /// Apply the blockification rules based on the table in CSS 2.2 section 9.7.
-    /// https://drafts.csswg.org/css2/visuren.html#dis-pos-flo
+    /// <https://drafts.csswg.org/css2/visuren.html#dis-pos-flo>
     fn blockify_if_necessary(
         &mut self,
         layout_parent_style: &ComputedValues,
@@ -160,7 +160,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
         }
     }
 
-    /// https://drafts.csswg.org/css-writing-modes-3/#block-flow:
+    /// <https://drafts.csswg.org/css-writing-modes-3/#block-flow:>
     ///
     ///    If a box has a different writing-mode value than its containing
     ///    block:
@@ -171,8 +171,8 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
     /// This matches the adjustment that Gecko does, not exactly following
     /// the spec. See also:
     ///
-    /// https://lists.w3.org/Archives/Public/www-style/2017Mar/0045.html
-    /// https://github.com/servo/servo/issues/15754
+    /// <https://lists.w3.org/Archives/Public/www-style/2017Mar/0045.html>
+    /// <https://github.com/servo/servo/issues/15754>
     fn adjust_for_writing_mode(
         &mut self,
         layout_parent_style: &ComputedValues,
@@ -519,7 +519,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
     /// Resolves "justify-items: auto" based on the inherited style if needed to
     /// comply with:
     ///
-    /// https://drafts.csswg.org/css-align/#valdef-justify-items-legacy
+    /// <https://drafts.csswg.org/css-align/#valdef-justify-items-legacy>
     ///
     /// (Note that "auto" is being renamed to "legacy")
     #[cfg(feature = "gecko")]

--- a/components/style/stylesheets/document_rule.rs
+++ b/components/style/stylesheets/document_rule.rs
@@ -194,7 +194,7 @@ impl ToCss for UrlMatchingFunction {
 
 /// A `@document` rule's condition.
 ///
-/// https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#at-document
+/// <https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#at-document>
 ///
 /// The `@document` rule's condition is written as a comma-separated list of
 /// URL matching functions, and the condition evaluates to true whenever any

--- a/components/style/stylesheets/keyframes_rule.rs
+++ b/components/style/stylesheets/keyframes_rule.rs
@@ -58,7 +58,7 @@ impl KeyframesRule {
     /// If the selector is not valid, or no keyframe is found, returns None.
     ///
     /// Related spec:
-    /// https://drafts.csswg.org/css-animations-1/#interface-csskeyframesrule-findrule
+    /// <https://drafts.csswg.org/css-animations-1/#interface-csskeyframesrule-findrule>
     pub fn find_rule(&self, guard: &SharedRwLockReadGuard, selector: &str) -> Option<usize> {
         let mut input = ParserInput::new(selector);
         if let Ok(selector) = Parser::new(&mut input).parse_entirely(KeyframeSelector::parse) {

--- a/components/style/stylesheets/origin.rs
+++ b/components/style/stylesheets/origin.rs
@@ -9,18 +9,18 @@ use std::ops::BitOrAssign;
 
 /// Each style rule has an origin, which determines where it enters the cascade.
 ///
-/// https://drafts.csswg.org/css-cascade/#cascading-origins
+/// <https://drafts.csswg.org/css-cascade/#cascading-origins>
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum Origin {
-    /// https://drafts.csswg.org/css-cascade/#cascade-origin-user-agent
+    /// <https://drafts.csswg.org/css-cascade/#cascade-origin-user-agent>
     UserAgent = 1 << 0,
 
-    /// https://drafts.csswg.org/css-cascade/#cascade-origin-user
+    /// <https://drafts.csswg.org/css-cascade/#cascade-origin-user>
     User = 1 << 1,
 
-    /// https://drafts.csswg.org/css-cascade/#cascade-origin-author
+    /// <https://drafts.csswg.org/css-cascade/#cascade-origin-author>
     Author = 1 << 2,
 }
 
@@ -42,11 +42,11 @@ bitflags! {
     /// A set of origins. This is equivalent to Gecko's OriginFlags.
     #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
     pub flags OriginSet: u8 {
-        /// https://drafts.csswg.org/css-cascade/#cascade-origin-user-agent
+        /// <https://drafts.csswg.org/css-cascade/#cascade-origin-user-agent>
         const ORIGIN_USER_AGENT = Origin::UserAgent as u8,
-        /// https://drafts.csswg.org/css-cascade/#cascade-origin-user
+        /// <https://drafts.csswg.org/css-cascade/#cascade-origin-user>
         const ORIGIN_USER = Origin::User as u8,
-        /// https://drafts.csswg.org/css-cascade/#cascade-origin-author
+        /// <https://drafts.csswg.org/css-cascade/#cascade-origin-author>
         const ORIGIN_AUTHOR = Origin::Author as u8,
     }
 }

--- a/components/style/stylesheets/rule_list.rs
+++ b/components/style/stylesheets/rule_list.rs
@@ -65,7 +65,7 @@ impl CssRules {
         })
     }
 
-    /// https://drafts.csswg.org/cssom/#remove-a-css-rule
+    /// <https://drafts.csswg.org/cssom/#remove-a-css-rule>
     pub fn remove_rule(&mut self, index: usize) -> Result<(), RulesMutateError> {
         // Step 1, 2
         if index >= self.0.len() {
@@ -92,7 +92,7 @@ impl CssRules {
 
 /// A trait to implement helpers for `Arc<Locked<CssRules>>`.
 pub trait CssRulesHelpers {
-    /// https://drafts.csswg.org/cssom/#insert-a-css-rule
+    /// <https://drafts.csswg.org/cssom/#insert-a-css-rule>
     ///
     /// Written in this funky way because parsing an @import rule may cause us
     /// to clone a stylesheet from the same document due to caching in the CSS

--- a/components/style/stylesheets/supports_rule.rs
+++ b/components/style/stylesheets/supports_rule.rs
@@ -75,7 +75,7 @@ impl DeepCloneWithLock for SupportsRule {
 
 /// An @supports condition
 ///
-/// https://drafts.csswg.org/css-conditional-3/#at-supports
+/// <https://drafts.csswg.org/css-conditional-3/#at-supports>
 #[derive(Clone, Debug)]
 pub enum SupportsCondition {
     /// `not (condition)`
@@ -95,7 +95,7 @@ pub enum SupportsCondition {
 impl SupportsCondition {
     /// Parse a condition
     ///
-    /// https://drafts.csswg.org/css-conditional/#supports_condition
+    /// <https://drafts.csswg.org/css-conditional/#supports_condition>
     pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<SupportsCondition, ParseError<'i>> {
         if let Ok(_) = input.try(|i| i.expect_ident_matching("not")) {
             let inner = SupportsCondition::parse_in_parens(input)?;
@@ -133,7 +133,7 @@ impl SupportsCondition {
         }
     }
 
-    /// https://drafts.csswg.org/css-conditional-3/#supports_condition_in_parens
+    /// <https://drafts.csswg.org/css-conditional-3/#supports_condition_in_parens>
     fn parse_in_parens<'i, 't>(input: &mut Parser<'i, 't>) -> Result<SupportsCondition, ParseError<'i>> {
         // Whitespace is normally taken care of in `Parser::next`,
         // but we want to not include it in `pos` for the SupportsCondition::FutureSyntax cases.
@@ -171,7 +171,7 @@ impl SupportsCondition {
 }
 
 /// supports_condition | declaration
-/// https://drafts.csswg.org/css-conditional/#dom-css-supports-conditiontext-conditiontext
+/// <https://drafts.csswg.org/css-conditional/#dom-css-supports-conditiontext-conditiontext>
 pub fn parse_condition_or_declaration<'i, 't>(input: &mut Parser<'i, 't>)
                                               -> Result<SupportsCondition, ParseError<'i>> {
     if let Ok(condition) = input.try(SupportsCondition::parse) {
@@ -237,7 +237,7 @@ impl ToCss for Declaration {
     }
 }
 
-/// https://drafts.csswg.org/css-syntax-3/#typedef-any-value
+/// <https://drafts.csswg.org/css-syntax-3/#typedef-any-value>
 fn consume_any_value<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), ParseError<'i>> {
     input.expect_no_error_token().map_err(|err| err.into())
 }
@@ -254,7 +254,7 @@ impl Declaration {
 
     /// Determine if a declaration parses
     ///
-    /// https://drafts.csswg.org/css-conditional-3/#support-definition
+    /// <https://drafts.csswg.org/css-conditional-3/#support-definition>
     pub fn eval(&self, context: &ParserContext) -> bool {
         debug_assert_eq!(context.rule_type(), CssRuleType::Style);
 

--- a/components/style/stylesheets/viewport_rule.rs
+++ b/components/style/stylesheets/viewport_rule.rs
@@ -534,7 +534,7 @@ impl ToCssWithGuard for ViewportRule {
 }
 
 /// Computes the cascade precedence as according to
-/// http://dev.w3.org/csswg/css-cascade/#cascade-origin
+/// <http://dev.w3.org/csswg/css-cascade/#cascade-origin>
 fn cascade_precendence(origin: Origin, important: bool) -> u8 {
     match (origin, important) {
         (Origin::UserAgent, true) => 1,

--- a/components/style/values/animated/effects.rs
+++ b/components/style/values/animated/effects.rs
@@ -27,7 +27,7 @@ pub type TextShadowList = ShadowList<SimpleShadow>;
 
 /// An animated value for shadow lists.
 ///
-/// https://drafts.csswg.org/css-transitions/#animtype-shadow-list
+/// <https://drafts.csswg.org/css-transitions/#animtype-shadow-list>
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ShadowList<Shadow>(Vec<Shadow>);

--- a/components/style/values/animated/mod.rs
+++ b/components/style/values/animated/mod.rs
@@ -48,15 +48,15 @@ pub trait Animate: Sized {
 
 /// An animation procedure.
 ///
-/// https://w3c.github.io/web-animations/#procedures-for-animating-properties
+/// <https://w3c.github.io/web-animations/#procedures-for-animating-properties>
 #[allow(missing_docs)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Procedure {
-    /// https://w3c.github.io/web-animations/#animation-interpolation
+    /// <https://w3c.github.io/web-animations/#animation-interpolation>
     Interpolate { progress: f64 },
-    /// https://w3c.github.io/web-animations/#animation-addition
+    /// <https://w3c.github.io/web-animations/#animation-addition>
     Add,
-    /// https://w3c.github.io/web-animations/#animation-accumulation
+    /// <https://w3c.github.io/web-animations/#animation-accumulation>
     Accumulate { count: u64 },
 }
 
@@ -113,7 +113,7 @@ impl Procedure {
     }
 }
 
-/// https://drafts.csswg.org/css-transitions/#animtype-number
+/// <https://drafts.csswg.org/css-transitions/#animtype-number>
 impl Animate for i32 {
     #[inline]
     fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
@@ -121,7 +121,7 @@ impl Animate for i32 {
     }
 }
 
-/// https://drafts.csswg.org/css-transitions/#animtype-number
+/// <https://drafts.csswg.org/css-transitions/#animtype-number>
 impl Animate for f32 {
     #[inline]
     fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
@@ -132,7 +132,7 @@ impl Animate for f32 {
     }
 }
 
-/// https://drafts.csswg.org/css-transitions/#animtype-number
+/// <https://drafts.csswg.org/css-transitions/#animtype-number>
 impl Animate for f64 {
     #[inline]
     fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {

--- a/components/style/values/computed/align.rs
+++ b/components/style/values/computed/align.rs
@@ -46,7 +46,7 @@ impl JustifyItems {
 impl ToComputedValue for specified::JustifyItems {
     type ComputedValue = JustifyItems;
 
-    /// https://drafts.csswg.org/css-align/#valdef-justify-items-legacy
+    /// <https://drafts.csswg.org/css-align/#valdef-justify-items-legacy>
     fn to_computed_value(&self, _context: &Context) -> JustifyItems {
         use values::specified::align;
         let specified = *self;

--- a/components/style/values/computed/angle.rs
+++ b/components/style/values/computed/angle.rs
@@ -67,7 +67,7 @@ impl Angle {
         Angle::Radian(0.0)
     }
 
-    /// https://drafts.csswg.org/css-transitions/#animtype-number
+    /// <https://drafts.csswg.org/css-transitions/#animtype-number>
     #[inline]
     fn animate_fallback(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
         Ok(Angle::from_radians(self.radians().animate(&other.radians(), procedure)?))

--- a/components/style/values/computed/image.rs
+++ b/components/style/values/computed/image.rs
@@ -27,11 +27,11 @@ use values::specified::position::{X, Y};
 pub type ImageLayer = Either<None_, Image>;
 
 /// Computed values for an image according to CSS-IMAGES.
-/// https://drafts.csswg.org/css-images/#image-values
+/// <https://drafts.csswg.org/css-images/#image-values>
 pub type Image = GenericImage<Gradient, MozImageRect, ComputedUrl>;
 
 /// Computed values for a CSS gradient.
-/// https://drafts.csswg.org/css-images/#gradients
+/// <https://drafts.csswg.org/css-images/#gradients>
 pub type Gradient = GenericGradient<
     LineDirection,
     Length,

--- a/components/style/values/computed/length.rs
+++ b/components/style/values/computed/length.rs
@@ -307,7 +307,7 @@ pub enum LengthOrPercentage {
 }
 
 impl LengthOrPercentage {
-    /// https://drafts.csswg.org/css-transitions/#animtype-lpcalc
+    /// <https://drafts.csswg.org/css-transitions/#animtype-lpcalc>
     fn animate_fallback(
         &self,
         other: &Self,
@@ -465,7 +465,7 @@ pub enum LengthOrPercentageOrAuto {
 }
 
 impl LengthOrPercentageOrAuto {
-    /// https://drafts.csswg.org/css-transitions/#animtype-lpcalc
+    /// <https://drafts.csswg.org/css-transitions/#animtype-lpcalc>
     fn animate_fallback(
         &self,
         other: &Self,
@@ -561,7 +561,7 @@ pub enum LengthOrPercentageOrNone {
 }
 
 impl LengthOrPercentageOrNone {
-    /// https://drafts.csswg.org/css-transitions/#animtype-lpcalc
+    /// <https://drafts.csswg.org/css-transitions/#animtype-lpcalc>
     fn animate_fallback(
         &self,
         other: &Self,

--- a/components/style/values/computed/svg.rs
+++ b/components/style/values/computed/svg.rs
@@ -37,7 +37,7 @@ impl SVGPaint {
 }
 
 /// A value of <length> | <percentage> | <number> for stroke-dashoffset.
-/// https://www.w3.org/TR/SVG11/painting.html#StrokeProperties
+/// <https://www.w3.org/TR/SVG11/painting.html#StrokeProperties>
 pub type SvgLengthOrPercentageOrNumber =
     generic::SvgLengthOrPercentageOrNumber<LengthOrPercentage, Number>;
 
@@ -52,7 +52,7 @@ impl From<Au> for SVGLength {
 }
 
 /// A value of <length> | <percentage> | <number> for stroke-width/stroke-dasharray.
-/// https://www.w3.org/TR/SVG11/painting.html#StrokeProperties
+/// <https://www.w3.org/TR/SVG11/painting.html#StrokeProperties>
 pub type NonNegativeSvgLengthOrPercentageOrNumber =
     generic::SvgLengthOrPercentageOrNumber<NonNegativeLengthOrPercentage, NonNegativeNumber>;
 

--- a/components/style/values/generics/basic_shape.rs
+++ b/components/style/values/generics/basic_shape.rs
@@ -16,7 +16,7 @@ use values::generics::rect::Rect;
 /// A clipping shape, for `clip-path`.
 pub type ClippingShape<BasicShape, Url> = ShapeSource<BasicShape, GeometryBox, Url>;
 
-/// https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box
+/// <https://drafts.fxtf.org/css-masking-1/#typedef-geometry-box>
 #[allow(missing_docs)]
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
@@ -71,7 +71,7 @@ pub enum BasicShape<H, V, LengthOrPercentage> {
     Polygon(Polygon<LengthOrPercentage>),
 }
 
-/// https://drafts.csswg.org/css-shapes/#funcdef-inset
+/// <https://drafts.csswg.org/css-shapes/#funcdef-inset>
 #[allow(missing_docs)]
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
@@ -81,7 +81,7 @@ pub struct InsetRect<LengthOrPercentage> {
     pub round: Option<BorderRadius<LengthOrPercentage>>,
 }
 
-/// https://drafts.csswg.org/css-shapes/#funcdef-circle
+/// <https://drafts.csswg.org/css-shapes/#funcdef-circle>
 #[allow(missing_docs)]
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
@@ -91,7 +91,7 @@ pub struct Circle<H, V, LengthOrPercentage> {
     pub radius: ShapeRadius<LengthOrPercentage>,
 }
 
-/// https://drafts.csswg.org/css-shapes/#funcdef-ellipse
+/// <https://drafts.csswg.org/css-shapes/#funcdef-ellipse>
 #[allow(missing_docs)]
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
@@ -102,7 +102,7 @@ pub struct Ellipse<H, V, LengthOrPercentage> {
     pub semiaxis_y: ShapeRadius<LengthOrPercentage>,
 }
 
-/// https://drafts.csswg.org/css-shapes/#typedef-shape-radius
+/// <https://drafts.csswg.org/css-shapes/#typedef-shape-radius>
 #[allow(missing_docs)]
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
@@ -121,7 +121,7 @@ pub enum ShapeRadius<LengthOrPercentage> {
 #[derive(Clone, Debug, PartialEq, ToComputedValue)]
 /// A generic type for representing the `polygon()` function
 ///
-/// https://drafts.csswg.org/css-shapes/#funcdef-polygon
+/// <https://drafts.csswg.org/css-shapes/#funcdef-polygon>
 pub struct Polygon<LengthOrPercentage> {
     /// The filling rule for a polygon.
     pub fill: FillRule,

--- a/components/style/values/generics/border.rs
+++ b/components/style/values/generics/border.rs
@@ -63,7 +63,7 @@ impl<L> BorderSpacing<L> {
 
 /// A generic value for `border-radius`, `outline-radius` and `inset()`.
 ///
-/// https://drafts.csswg.org/css-backgrounds-3/#border-radius
+/// <https://drafts.csswg.org/css-backgrounds-3/#border-radius>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Animate, Clone, ComputeSquaredDistance, Copy, Debug)]

--- a/components/style/values/generics/grid.rs
+++ b/components/style/values/generics/grid.rs
@@ -16,7 +16,7 @@ use values::specified::grid::parse_line_names;
 
 /// A `<grid-line>` type.
 ///
-/// https://drafts.csswg.org/css-grid/#typedef-grid-row-start-grid-line
+/// <https://drafts.csswg.org/css-grid/#typedef-grid-row-start-grid-line>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Clone, Debug, Default, PartialEq, ToComputedValue)]
@@ -25,7 +25,7 @@ pub struct GridLine<Integer> {
     pub is_span: bool,
     /// A custom identifier for named lines.
     ///
-    /// https://drafts.csswg.org/css-grid/#grid-placement-slot
+    /// <https://drafts.csswg.org/css-grid/#grid-placement-slot>
     pub ident: Option<CustomIdent>,
     /// Denotes the nth grid line from grid item's placement.
     pub line_num: Option<Integer>,
@@ -144,7 +144,7 @@ add_impls_for_keyword_enum!(TrackKeyword);
 /// A track breadth for explicit grid track sizing. It's generic solely to
 /// avoid re-implementing it for the computed type.
 ///
-/// https://drafts.csswg.org/css-grid/#typedef-track-breadth
+/// <https://drafts.csswg.org/css-grid/#typedef-track-breadth>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Clone, Debug, PartialEq, ToComputedValue)]
@@ -160,7 +160,7 @@ pub enum TrackBreadth<L> {
 impl<L> TrackBreadth<L> {
     /// Check whether this is a `<fixed-breadth>` (i.e., it only has `<length-percentage>`)
     ///
-    /// https://drafts.csswg.org/css-grid/#typedef-fixed-breadth
+    /// <https://drafts.csswg.org/css-grid/#typedef-fixed-breadth>
     #[inline]
     pub fn is_fixed(&self) -> bool {
         match *self {
@@ -183,7 +183,7 @@ impl<L: ToCss> ToCss for TrackBreadth<L> {
 /// A `<track-size>` type for explicit grid track sizing. Like `<track-breadth>`, this is
 /// generic only to avoid code bloat. It only takes `<length-percentage>`
 ///
-/// https://drafts.csswg.org/css-grid/#typedef-track-size
+/// <https://drafts.csswg.org/css-grid/#typedef-track-size>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Clone, Debug, PartialEq)]
@@ -193,18 +193,18 @@ pub enum TrackSize<L> {
     /// A `minmax` function for a range over an inflexible `<track-breadth>`
     /// and a flexible `<track-breadth>`
     ///
-    /// https://drafts.csswg.org/css-grid/#valdef-grid-template-columns-minmax
+    /// <https://drafts.csswg.org/css-grid/#valdef-grid-template-columns-minmax>
     Minmax(TrackBreadth<L>, TrackBreadth<L>),
     /// A `fit-content` function.
     ///
-    /// https://drafts.csswg.org/css-grid/#valdef-grid-template-columns-fit-content
+    /// <https://drafts.csswg.org/css-grid/#valdef-grid-template-columns-fit-content>
     FitContent(L),
 }
 
 impl<L> TrackSize<L> {
     /// Check whether this is a `<fixed-size>`
     ///
-    /// https://drafts.csswg.org/css-grid/#typedef-fixed-size
+    /// <https://drafts.csswg.org/css-grid/#typedef-fixed-size>
     pub fn is_fixed(&self) -> bool {
         match *self {
             TrackSize::Breadth(ref breadth) => breadth.is_fixed(),
@@ -347,7 +347,7 @@ where
 
 /// The initial argument of the `repeat` function.
 ///
-/// https://drafts.csswg.org/css-grid/#typedef-track-repeat
+/// <https://drafts.csswg.org/css-grid/#typedef-track-repeat>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Clone, Copy, Debug, PartialEq, ToComputedValue, ToCss)]
@@ -477,7 +477,7 @@ pub enum TrackListValue<LengthOrPercentage, Integer> {
 
 /// The type of a `<track-list>` as determined during parsing.
 ///
-/// https://drafts.csswg.org/css-grid/#typedef-track-list
+/// <https://drafts.csswg.org/css-grid/#typedef-track-list>
 #[derive(Clone, Copy, Debug, PartialEq, ToComputedValue)]
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
@@ -501,7 +501,7 @@ pub enum TrackListType {
 
 /// A grid `<track-list>` type.
 ///
-/// https://drafts.csswg.org/css-grid/#typedef-track-list
+/// <https://drafts.csswg.org/css-grid/#typedef-track-list>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Clone, Debug, PartialEq)]

--- a/components/style/values/generics/image.rs
+++ b/components/style/values/generics/image.rs
@@ -30,13 +30,13 @@ pub enum Image<Gradient, MozImageRect, ImageUrl> {
     /// A `-moz-element(# <element-id>)`
     Element(Atom),
     /// A paint worklet image.
-    /// https://drafts.css-houdini.org/css-paint-api/
+    /// <https://drafts.css-houdini.org/css-paint-api/>
     #[cfg(feature = "servo")]
     PaintWorklet(PaintWorklet),
 }
 
 /// A CSS gradient.
-/// https://drafts.csswg.org/css-images/#gradients
+/// <https://drafts.csswg.org/css-images/#gradients>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Clone, Debug, PartialEq, ToComputedValue)]
@@ -110,7 +110,7 @@ pub enum Ellipse<LengthOrPercentage> {
     Extent(ShapeExtent),
 }
 
-/// https://drafts.csswg.org/css-images/#typedef-extent-keyword
+/// <https://drafts.csswg.org/css-images/#typedef-extent-keyword>
 define_css_keyword_enum!(ShapeExtent:
     "closest-side" => ClosestSide,
     "farthest-side" => FarthestSide,
@@ -122,7 +122,7 @@ define_css_keyword_enum!(ShapeExtent:
 add_impls_for_keyword_enum!(ShapeExtent);
 
 /// A gradient item.
-/// https://drafts.csswg.org/css-images-4/#color-stop-syntax
+/// <https://drafts.csswg.org/css-images-4/#color-stop-syntax>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Clone, Copy, Debug, PartialEq, ToComputedValue, ToCss)]
@@ -134,7 +134,7 @@ pub enum GradientItem<Color, LengthOrPercentage> {
 }
 
 /// A color stop.
-/// https://drafts.csswg.org/css-images/#typedef-color-stop-list
+/// <https://drafts.csswg.org/css-images/#typedef-color-stop-list>
 #[derive(Clone, Copy, PartialEq, ToComputedValue, ToCss)]
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
@@ -146,7 +146,7 @@ pub struct ColorStop<Color, LengthOrPercentage> {
 }
 
 /// Specified values for a paint worklet.
-/// https://drafts.css-houdini.org/css-paint-api/
+/// <https://drafts.css-houdini.org/css-paint-api/>
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub struct PaintWorklet {

--- a/components/style/values/generics/mod.rs
+++ b/components/style/values/generics/mod.rs
@@ -68,7 +68,7 @@ impl SymbolsType {
     }
 }
 
-/// https://drafts.csswg.org/css-counter-styles/#typedef-counter-style
+/// <https://drafts.csswg.org/css-counter-styles/#typedef-counter-style>
 ///
 /// Since wherever <counter-style> is used, 'none' is a valid value as
 /// well, we combine them into one type to make code simpler.
@@ -159,8 +159,8 @@ impl<T: ToCss> ToCss for FontSettingTag<T> {
 }
 
 impl<T: Parse> Parse for FontSettingTag<T> {
-    /// https://www.w3.org/TR/css-fonts-3/#propdef-font-feature-settings
-    /// https://drafts.csswg.org/css-fonts-4/#low-level-font-variation-
+    /// <https://www.w3.org/TR/css-fonts-3/#propdef-font-feature-settings>
+    /// <https://drafts.csswg.org/css-fonts-4/#low-level-font-variation->
     /// settings-control-the-font-variation-settings-property
     /// <string> [ on | off | <integer> ]
     /// <string> <number>
@@ -201,7 +201,7 @@ pub enum FontSettings<T> {
 }
 
 impl<T: Parse> Parse for FontSettings<T> {
-    /// https://www.w3.org/TR/css-fonts-3/#propdef-font-feature-settings
+    /// <https://www.w3.org/TR/css-fonts-3/#propdef-font-feature-settings>
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
         if input.try(|i| i.expect_ident_matching("normal")).is_ok() {
             return Ok(FontSettings::Normal);

--- a/components/style/values/generics/svg.rs
+++ b/components/style/values/generics/svg.rs
@@ -15,7 +15,7 @@ use values::distance::{ComputeSquaredDistance, SquaredDistance};
 
 /// An SVG paint value
 ///
-/// https://www.w3.org/TR/SVG2/painting.html#SpecifyingPaint
+/// <https://www.w3.org/TR/SVG2/painting.html#SpecifyingPaint>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Animate, Clone, ComputeSquaredDistance, Debug, PartialEq)]
@@ -64,7 +64,7 @@ impl<ColorType, UrlPaintServer> SVGPaintKind<ColorType, UrlPaintServer> {
 
 /// Parse SVGPaint's fallback.
 /// fallback is keyword(none), Color or empty.
-/// https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint
+/// <https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint>
 fn parse_fallback<'i, 't, ColorType: Parse>(context: &ParserContext,
                                             input: &mut Parser<'i, 't>)
                                             -> Option<Either<ColorType, None_>> {
@@ -110,7 +110,7 @@ impl<ColorType: Parse, UrlPaintServer: Parse> Parse for SVGPaint<ColorType, UrlP
 }
 
 /// A value of <length> | <percentage> | <number> for svg which allow unitless length.
-/// https://www.w3.org/TR/SVG11/painting.html#StrokeProperties
+/// <https://www.w3.org/TR/SVG11/painting.html#StrokeProperties>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Clone, Copy, Debug, PartialEq, ToAnimatedValue)]

--- a/components/style/values/generics/transform.rs
+++ b/components/style/values/generics/transform.rs
@@ -39,7 +39,7 @@ pub struct TransformOrigin<H, V, Depth> {
 
 /// A generic timing function.
 ///
-/// https://drafts.csswg.org/css-timing-1/#single-timing-function-production
+/// <https://drafts.csswg.org/css-timing-1/#single-timing-function-production>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/components/style/values/mod.rs
+++ b/components/style/values/mod.rs
@@ -95,7 +95,7 @@ impl<A: Parse, B: Parse> Parse for Either<A, B> {
     }
 }
 
-/// https://drafts.csswg.org/css-values-4/#custom-idents
+/// <https://drafts.csswg.org/css-values-4/#custom-idents>
 #[derive(Clone, Debug, Eq, Hash, PartialEq, ToComputedValue)]
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
@@ -126,7 +126,7 @@ impl ToCss for CustomIdent {
     }
 }
 
-/// https://drafts.csswg.org/css-animations/#typedef-keyframes-name
+/// <https://drafts.csswg.org/css-animations/#typedef-keyframes-name>
 #[derive(Clone, Debug, ToComputedValue)]
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
@@ -138,7 +138,7 @@ pub enum KeyframesName {
 }
 
 impl KeyframesName {
-    /// https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-name
+    /// <https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-name>
     pub fn from_ident(value: &str) -> Self {
         let location = SourceLocation { line: 0, column: 0 };
         let custom_ident = CustomIdent::from_ident(location, &value.into(), &["none"]).ok();

--- a/components/style/values/specified/align.rs
+++ b/components/style/values/specified/align.rs
@@ -111,7 +111,7 @@ const ALIGN_ALL_SHIFT: u32 = structs::NS_STYLE_ALIGN_ALL_SHIFT;
 
 /// Value of the `align-content` or `justify-content` property.
 ///
-/// https://drafts.csswg.org/css-align/#content-distribution
+/// <https://drafts.csswg.org/css-align/#content-distribution>
 ///
 /// The 16-bit field stores the primary value in its lower 8 bits, and the optional fallback value
 /// in its upper 8 bits.  This matches the representation of these properties in Gecko.
@@ -135,7 +135,7 @@ impl AlignJustifyContent {
 
     /// Construct a value including a fallback alignment.
     ///
-    /// https://drafts.csswg.org/css-align/#fallback-alignment
+    /// <https://drafts.csswg.org/css-align/#fallback-alignment>
     #[inline]
     pub fn with_fallback(flags: AlignFlags, fallback: AlignFlags) -> Self {
         AlignJustifyContent(flags.bits() as u16 | ((fallback.bits() as u16) << ALIGN_ALL_SHIFT))
@@ -207,7 +207,7 @@ impl Parse for AlignJustifyContent {
 
 /// Value of the `align-self` or `justify-self` property.
 ///
-/// https://drafts.csswg.org/css-align/#self-alignment
+/// <https://drafts.csswg.org/css-align/#self-alignment>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ToComputedValue, ToCss)]
 pub struct AlignJustifySelf(pub AlignFlags);
@@ -245,7 +245,7 @@ impl Parse for AlignJustifySelf {
 
 /// Value of the `align-items` property
 ///
-/// https://drafts.csswg.org/css-align/#self-alignment
+/// <https://drafts.csswg.org/css-align/#self-alignment>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ToComputedValue, ToCss)]
 pub struct AlignItems(pub AlignFlags);
@@ -283,7 +283,7 @@ impl Parse for AlignItems {
 
 /// Value of the `justify-items` property
 ///
-/// https://drafts.csswg.org/css-align/#justify-items-property
+/// <https://drafts.csswg.org/css-align/#justify-items-property>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ToCss)]
 pub struct JustifyItems(pub AlignFlags);

--- a/components/style/values/specified/basic_shape.rs
+++ b/components/style/values/specified/basic_shape.rs
@@ -237,7 +237,7 @@ impl Parse for ShapeRadius {
     }
 }
 
-/// https://drafts.csswg.org/css-shapes/#basic-shape-serialization
+/// <https://drafts.csswg.org/css-shapes/#basic-shape-serialization>
 ///
 /// Positions get serialized differently with basic shapes. Keywords
 /// are converted to percentages where possible. Only the two or four

--- a/components/style/values/specified/calc.rs
+++ b/components/style/values/specified/calc.rs
@@ -84,7 +84,7 @@ pub struct CalcLengthOrPercentage {
 }
 
 impl ToCss for CalcLengthOrPercentage {
-    /// https://drafts.csswg.org/css-values/#calc-serialize
+    /// <https://drafts.csswg.org/css-values/#calc-serialize>
     ///
     /// FIXME(emilio): Should this simplify away zeros?
     #[allow(unused_assignments)]

--- a/components/style/values/specified/color.rs
+++ b/components/style/values/specified/color.rs
@@ -128,7 +128,7 @@ impl Color {
 
     /// Parse a color, with quirks.
     ///
-    /// https://quirks.spec.whatwg.org/#the-hashless-hex-color-quirk
+    /// <https://quirks.spec.whatwg.org/#the-hashless-hex-color-quirk>
     pub fn parse_quirky<'i, 't>(context: &ParserContext,
                                 input: &mut Parser<'i, 't>,
                                 allow_quirks: AllowQuirks)
@@ -145,7 +145,7 @@ impl Color {
 
     /// Parse a <quirky-color> value.
     ///
-    /// https://quirks.spec.whatwg.org/#the-hashless-hex-color-quirk
+    /// <https://quirks.spec.whatwg.org/#the-hashless-hex-color-quirk>
     fn parse_quirky_color<'i, 't>(input: &mut Parser<'i, 't>) -> Result<RGBA, ParseError<'i>> {
         let location = input.current_source_location();
         let (value, unit) = match *input.next()? {

--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -239,7 +239,7 @@ impl ToComputedValue for KeywordSize {
 }
 
 impl FontSize {
-    /// https://html.spec.whatwg.org/multipage/#rules-for-parsing-a-legacy-font-size
+    /// <https://html.spec.whatwg.org/multipage/#rules-for-parsing-a-legacy-font-size>
     pub fn from_html_size(size: u8) -> Self {
         FontSize::Keyword(match size {
             // If value is less than 1, let it be 1.

--- a/components/style/values/specified/gecko.rs
+++ b/components/style/values/specified/gecko.rs
@@ -85,7 +85,7 @@ impl ToNsCssValue for PixelOrPercentage {
 /// Only bare px or percentage values are allowed. Other length units and
 /// calc() values are not allowed.
 ///
-/// https://w3c.github.io/IntersectionObserver/#parse-a-root-margin
+/// <https://w3c.github.io/IntersectionObserver/#parse-a-root-margin>
 pub struct IntersectionObserverRootMargin(pub Rect<PixelOrPercentage>);
 
 impl Parse for IntersectionObserverRootMargin {

--- a/components/style/values/specified/grid.rs
+++ b/components/style/values/specified/grid.rs
@@ -70,7 +70,7 @@ impl Parse for TrackSize<LengthOrPercentage> {
 
 /// Parse the grid line names into a vector of owned strings.
 ///
-/// https://drafts.csswg.org/css-grid/#typedef-line-names
+/// <https://drafts.csswg.org/css-grid/#typedef-line-names>
 pub fn parse_line_names<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Box<[CustomIdent]>, ParseError<'i>> {
     input.expect_square_bracket_block()?;
     input.parse_nested_block(|input| {
@@ -88,7 +88,7 @@ pub fn parse_line_names<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Box<[Custo
 
 /// The type of `repeat` function (only used in parsing).
 ///
-/// https://drafts.csswg.org/css-grid/#typedef-track-repeat
+/// <https://drafts.csswg.org/css-grid/#typedef-track-repeat>
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 enum RepeatType {

--- a/components/style/values/specified/image.rs
+++ b/components/style/values/specified/image.rs
@@ -37,11 +37,11 @@ use values::specified::url::SpecifiedUrl;
 pub type ImageLayer = Either<None_, Image>;
 
 /// Specified values for an image according to CSS-IMAGES.
-/// https://drafts.csswg.org/css-images/#image-values
+/// <https://drafts.csswg.org/css-images/#image-values>
 pub type Image = GenericImage<Gradient, MozImageRect, SpecifiedUrl>;
 
 /// Specified values for a CSS gradient.
-/// https://drafts.csswg.org/css-images/#gradients
+/// <https://drafts.csswg.org/css-images/#gradients>
 #[cfg(not(feature = "gecko"))]
 pub type Gradient = GenericGradient<
     LineDirection,
@@ -53,7 +53,7 @@ pub type Gradient = GenericGradient<
 >;
 
 /// Specified values for a CSS gradient.
-/// https://drafts.csswg.org/css-images/#gradients
+/// <https://drafts.csswg.org/css-images/#gradients>
 #[cfg(feature = "gecko")]
 pub type Gradient = GenericGradient<
     LineDirection,

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -213,15 +213,15 @@ impl FontRelativeLength {
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 /// A viewport-relative length.
 ///
-/// https://drafts.csswg.org/css-values/#viewport-relative-lengths
+/// <https://drafts.csswg.org/css-values/#viewport-relative-lengths>
 pub enum ViewportPercentageLength {
     /// A vw unit: https://drafts.csswg.org/css-values/#vw
     Vw(CSSFloat),
     /// A vh unit: https://drafts.csswg.org/css-values/#vh
     Vh(CSSFloat),
-    /// https://drafts.csswg.org/css-values/#vmin
+    /// <https://drafts.csswg.org/css-values/#vmin>
     Vmin(CSSFloat),
-    /// https://drafts.csswg.org/css-values/#vmax
+    /// <https://drafts.csswg.org/css-values/#vmax>
     Vmax(CSSFloat)
 }
 
@@ -440,24 +440,24 @@ impl Mul<CSSFloat> for PhysicalLength {
 
 /// A `<length>` without taking `calc` expressions into account
 ///
-/// https://drafts.csswg.org/css-values/#lengths
+/// <https://drafts.csswg.org/css-values/#lengths>
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum NoCalcLength {
     /// An absolute length
     ///
-    /// https://drafts.csswg.org/css-values/#absolute-length
+    /// <https://drafts.csswg.org/css-values/#absolute-length>
     Absolute(AbsoluteLength),
 
     /// A font-relative length:
     ///
-    /// https://drafts.csswg.org/css-values/#font-relative-lengths
+    /// <https://drafts.csswg.org/css-values/#font-relative-lengths>
     FontRelative(FontRelativeLength),
 
     /// A viewport-relative length.
     ///
-    /// https://drafts.csswg.org/css-values/#viewport-relative-lengths
+    /// <https://drafts.csswg.org/css-values/#viewport-relative-lengths>
     ViewportPercentage(ViewportPercentageLength),
 
     /// HTML5 "character width", as defined in HTML5 § 14.5.4.
@@ -581,7 +581,7 @@ impl NoCalcLength {
 /// An extension to `NoCalcLength` to parse `calc` expressions.
 /// This is commonly used for the `<length>` values.
 ///
-/// https://drafts.csswg.org/css-values/#lengths
+/// <https://drafts.csswg.org/css-values/#lengths>
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 #[derive(Clone, Debug, PartialEq, ToCss)]
@@ -590,7 +590,7 @@ pub enum Length {
     NoCalc(NoCalcLength),
     /// A calc expression.
     ///
-    /// https://drafts.csswg.org/css-values/#calc-notation
+    /// <https://drafts.csswg.org/css-values/#calc-notation>
     Calc(Box<CalcLengthOrPercentage>),
 }
 
@@ -908,7 +908,7 @@ impl LengthOrPercentage {
 
     /// Parse a length, treating dimensionless numbers as pixels
     ///
-    /// https://www.w3.org/TR/SVG2/types.html#presentation-attribute-css-value
+    /// <https://www.w3.org/TR/SVG2/types.html#presentation-attribute-css-value>
     pub fn parse_numbers_are_pixels<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
                                             -> Result<LengthOrPercentage, ParseError<'i>> {
         if let Ok(lop) = input.try(|i| Self::parse(context, i)) {
@@ -959,7 +959,7 @@ impl Parse for LengthOrPercentage {
 
 impl LengthOrPercentage {
     /// Parses a length or a percentage, allowing the unitless length quirk.
-    /// https://quirks.spec.whatwg.org/#the-unitless-length-quirk
+    /// <https://quirks.spec.whatwg.org/#the-unitless-length-quirk>
     #[inline]
     pub fn parse_quirky<'i, 't>(context: &ParserContext,
                                 input: &mut Parser<'i, 't>,
@@ -1191,7 +1191,7 @@ impl NonNegativeLengthOrPercentage {
     }
 
     /// Parses a length or a percentage, allowing the unitless length quirk.
-    /// https://quirks.spec.whatwg.org/#the-unitless-length-quirk
+    /// <https://quirks.spec.whatwg.org/#the-unitless-length-quirk>
     #[inline]
     pub fn parse_quirky<'i, 't>(context: &ParserContext,
                                 input: &mut Parser<'i, 't>,

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -365,7 +365,7 @@ impl ToComputedValue for Opacity {
 
 /// An specified `<integer>`, optionally coming from a `calc()` expression.
 ///
-/// https://drafts.csswg.org/css-values/#integers
+/// <https://drafts.csswg.org/css-values/#integers>
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]

--- a/components/style/values/specified/svg.rs
+++ b/components/style/values/specified/svg.rs
@@ -43,7 +43,7 @@ fn parse_context_value<'i, 't, T>(input: &mut Parser<'i, 't>, value: T)
 }
 
 /// A value of <length> | <percentage> | <number> for stroke-dashoffset.
-/// https://www.w3.org/TR/SVG11/painting.html#StrokeProperties
+/// <https://www.w3.org/TR/SVG11/painting.html#StrokeProperties>
 pub type SvgLengthOrPercentageOrNumber =
     generic::SvgLengthOrPercentageOrNumber<LengthOrPercentage, Number>;
 
@@ -66,7 +66,7 @@ impl From<SvgLengthOrPercentageOrNumber> for SVGLength {
 }
 
 /// A value of <length> | <percentage> | <number> for stroke-width/stroke-dasharray.
-/// https://www.w3.org/TR/SVG11/painting.html#StrokeProperties
+/// <https://www.w3.org/TR/SVG11/painting.html#StrokeProperties>
 pub type NonNegativeSvgLengthOrPercentageOrNumber =
     generic::SvgLengthOrPercentageOrNumber<NonNegativeLengthOrPercentage, NonNegativeNumber>;
 

--- a/components/style_traits/cursor.rs
+++ b/components/style_traits/cursor.rs
@@ -15,7 +15,7 @@ macro_rules! define_cursor {
             $( $g_css: expr => $g_variant: ident = $g_value: expr, )+
         ]
     ) => {
-        /// https://drafts.csswg.org/css-ui/#cursor
+        /// <https://drafts.csswg.org/css-ui/#cursor>
         #[derive(Clone, Copy, Debug, Eq, PartialEq)]
         #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
         #[cfg_attr(feature = "servo", derive(Deserialize, Serialize, HeapSizeOf))]

--- a/components/style_traits/lib.rs
+++ b/components/style_traits/lib.rs
@@ -57,7 +57,7 @@ impl PinchZoomFactor {
 }
 
 /// One CSS "px" in the coordinate system of the "initial viewport":
-/// http://www.w3.org/TR/css-device-adapt/#initial-viewport
+/// <http://www.w3.org/TR/css-device-adapt/#initial-viewport>
 ///
 /// `CSSPixel` is equal to `DeviceIndependentPixel` times a "page zoom" factor controlled by the user.  This is
 /// the desktop-style "full page" zoom that enlarges content but then reflows the layout viewport
@@ -201,14 +201,14 @@ bitflags! {
     /// The mode to use when parsing values.
     pub flags ParsingMode: u8 {
         /// In CSS, lengths must have units, except for zero values, where the unit can be omitted.
-        /// https://www.w3.org/TR/css3-values/#lengths
+        /// <https://www.w3.org/TR/css3-values/#lengths>
         const PARSING_MODE_DEFAULT = 0x00,
         /// In SVG, a coordinate or length value without a unit identifier (e.g., "25") is assumed
         /// to be in user units (px).
-        /// https://www.w3.org/TR/SVG/coords.html#Units
+        /// <https://www.w3.org/TR/SVG/coords.html#Units>
         const PARSING_MODE_ALLOW_UNITLESS_LENGTH = 0x01,
         /// In SVG, out-of-range values are not treated as an error in parsing.
-        /// https://www.w3.org/TR/SVG/implnote.html#RangeClamping
+        /// <https://www.w3.org/TR/SVG/implnote.html#RangeClamping>
         const PARSING_MODE_ALLOW_ALL_NUMERIC_VALUES = 0x02,
     }
 }
@@ -228,6 +228,6 @@ impl ParsingMode {
 #[cfg(feature = "servo")]
 /// Speculatively execute paint code in the worklet thread pool.
 pub trait SpeculativePainter: Send + Sync {
-    /// https://drafts.css-houdini.org/css-paint-api/#draw-a-paint-image
+    /// <https://drafts.css-houdini.org/css-paint-api/#draw-a-paint-image>
     fn speculatively_draw_a_paint_image(&self, properties: Vec<(Atom, String)>, arguments: Vec<String>);
 }

--- a/components/style_traits/viewport.rs
+++ b/components/style_traits/viewport.rs
@@ -21,7 +21,7 @@ define_css_keyword_enum!(Orientation:
 
 /// A set of viewport descriptors:
 ///
-/// https://drafts.csswg.org/css-device-adapt/#viewport-desc
+/// <https://drafts.csswg.org/css-device-adapt/#viewport-desc>
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "servo", derive(Deserialize, Serialize, HeapSizeOf))]
 pub struct ViewportConstraints {
@@ -29,15 +29,15 @@ pub struct ViewportConstraints {
     ///  * https://drafts.csswg.org/css-device-adapt/#width-desc
     ///  * https://drafts.csswg.org/css-device-adapt/#height-desc
     pub size: TypedSize2D<f32, CSSPixel>,
-    /// https://drafts.csswg.org/css-device-adapt/#zoom-desc
+    /// <https://drafts.csswg.org/css-device-adapt/#zoom-desc>
     pub initial_zoom: PinchZoomFactor,
-    /// https://drafts.csswg.org/css-device-adapt/#min-max-width-desc
+    /// <https://drafts.csswg.org/css-device-adapt/#min-max-width-desc>
     pub min_zoom: Option<PinchZoomFactor>,
-    /// https://drafts.csswg.org/css-device-adapt/#min-max-width-desc
+    /// <https://drafts.csswg.org/css-device-adapt/#min-max-width-desc>
     pub max_zoom: Option<PinchZoomFactor>,
-    /// https://drafts.csswg.org/css-device-adapt/#user-zoom-desc
+    /// <https://drafts.csswg.org/css-device-adapt/#user-zoom-desc>
     pub user_zoom: UserZoom,
-    /// https://drafts.csswg.org/css-device-adapt/#orientation-desc
+    /// <https://drafts.csswg.org/css-device-adapt/#orientation-desc>
     pub orientation: Orientation
 }
 
@@ -73,7 +73,7 @@ impl ToCss for ViewportConstraints {
     }
 }
 
-/// https://drafts.csswg.org/css-device-adapt/#descdef-viewport-zoom
+/// <https://drafts.csswg.org/css-device-adapt/#descdef-viewport-zoom>
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "servo", derive(HeapSizeOf))]
 pub enum Zoom {
@@ -103,7 +103,7 @@ impl ToCss for Zoom {
 impl Zoom {
     /// Parse a zoom value per:
     ///
-    /// https://drafts.csswg.org/css-device-adapt/#descdef-viewport-zoom
+    /// <https://drafts.csswg.org/css-device-adapt/#descdef-viewport-zoom>
     pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Zoom, ParseError<'i>> {
         use PARSING_MODE_DEFAULT;
         use cssparser::Token;

--- a/components/url/origin.rs
+++ b/components/url/origin.rs
@@ -83,12 +83,12 @@ impl ImmutableOrigin {
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/#ascii-serialisation-of-an-origin
+    /// <https://html.spec.whatwg.org/multipage/#ascii-serialisation-of-an-origin>
     pub fn ascii_serialization(&self) -> String {
         self.clone().into_url_origin().ascii_serialization()
     }
 
-    /// https://html.spec.whatwg.org/multipage/#unicode-serialisation-of-an-origin
+    /// <https://html.spec.whatwg.org/multipage/#unicode-serialisation-of-an-origin>
     pub fn unicode_serialization(&self) -> String {
         self.clone().into_url_origin().unicode_serialization()
     }

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -852,7 +852,7 @@ def check_spec(file_name, lines):
     macro_patt = re.compile("^\s*\S+!(.*)$")
 
     # Pattern representing a line with comment containing a spec link
-    link_patt = re.compile("^\s*///? https://.+$")
+    link_patt = re.compile("^\s*///? (<https://.+>|https://.+)$")
 
     # Pattern representing a line with comment or attribute
     comment_patt = re.compile("^\s*(///?.+|#\[.+\])$")

--- a/python/tidy/servo_tidy_tests/speclink.rs
+++ b/python/tidy/servo_tidy_tests/speclink.rs
@@ -19,11 +19,11 @@ impl SpecLinkMethods for SpecLink {
     fn Foo() {}
 
     /// A spec link.
-    /// https://example.com/
+    /// <https://example.com/>
     fn Foo() {}
 
     /// A spec link.
-    /// https://example.com/
+    /// <https://example.com/>
     /// Doc comments are OK
     // Regular comments are OK
     #[allow(attributes_too)]


### PR DESCRIPTION
Fixes warnings from rust-lang/rust#44229 when `--enable-commonmark` is passed to rustdoc.

This is mostly a global find-and-replace for bare URIs on lines by themselves in doc comments.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are doc formatting changes only

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18924)
<!-- Reviewable:end -->
