### PR TITLE
Rename `size_of_is_0!` as `malloc_size_of_is_0!`.

### DIFF
--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -415,7 +415,7 @@ impl<T: MallocSizeOf, U> MallocSizeOf for euclid::TypedSize2D<T, U> {
 
 /// For use on types where size_of() returns 0.
 #[macro_export]
-macro_rules! size_of_is_0(
+macro_rules! malloc_size_of_is_0(
     ($($ty:ty),+) => (
         $(
             impl $crate::MallocSizeOf for $ty {
@@ -438,14 +438,14 @@ macro_rules! size_of_is_0(
     );
 );
 
-size_of_is_0!(bool, char, str);
-size_of_is_0!(u8, u16, u32, u64, usize);
-size_of_is_0!(i8, i16, i32, i64, isize);
-size_of_is_0!(f32, f64);
+malloc_size_of_is_0!(bool, char, str);
+malloc_size_of_is_0!(u8, u16, u32, u64, usize);
+malloc_size_of_is_0!(i8, i16, i32, i64, isize);
+malloc_size_of_is_0!(f32, f64);
 
-size_of_is_0!(Range<u8>, Range<u16>, Range<u32>, Range<u64>, Range<usize>);
-size_of_is_0!(Range<i8>, Range<i16>, Range<i32>, Range<i64>, Range<isize>);
-size_of_is_0!(Range<f32>, Range<f64>);
+malloc_size_of_is_0!(Range<u8>, Range<u16>, Range<u32>, Range<u64>, Range<usize>);
+malloc_size_of_is_0!(Range<i8>, Range<i16>, Range<i32>, Range<i64>, Range<isize>);
+malloc_size_of_is_0!(Range<f32>, Range<f64>);
 
-size_of_is_0!(app_units::Au);
-size_of_is_0!(cssparser::RGBA, cssparser::TokenSerializationType);
+malloc_size_of_is_0!(app_units::Au);
+malloc_size_of_is_0!(cssparser::RGBA, cssparser::TokenSerializationType);

--- a/components/style/gecko_string_cache/mod.rs
+++ b/components/style/gecko_string_cache/mod.rs
@@ -389,4 +389,4 @@ impl From<*mut nsAtom> for Atom {
     }
 }
 
-size_of_is_0!(Atom);
+malloc_size_of_is_0!(Atom);

--- a/components/style/properties/longhand/color.mako.rs
+++ b/components/style/properties/longhand/color.mako.rs
@@ -72,7 +72,7 @@ pub mod system_colors {
 
     // It's hard to implement MallocSizeOf for LookAndFeel_ColorID because it
     // is a bindgen type. So we implement it on the typedef instead.
-    size_of_is_0!(SystemColor);
+    malloc_size_of_is_0!(SystemColor);
 
     impl ToCss for SystemColor {
         fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {


### PR DESCRIPTION
The new name makes it clearer that it comes from the `malloc_size_of`
crate.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's a trivial name change.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18932)
<!-- Reviewable:end -->
