### PR TITLE
Use WebRender to compute text index on click events

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -702,19 +702,19 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             None => return,
         };
 
-        let point = result.point_in_viewport.to_untyped();
-        let node_address = Some(UntrustedNodeAddress(result.tag.0 as *const c_void));
-        let event_to_send = match mouse_window_event {
-            MouseWindowEvent::Click(button, _) => {
-                MouseButtonEvent(MouseEventType::Click, button, point, node_address)
-            }
-            MouseWindowEvent::MouseDown(button, _) => {
-                MouseButtonEvent(MouseEventType::MouseDown, button, point, node_address)
-            }
-            MouseWindowEvent::MouseUp(button, _) => {
-                MouseButtonEvent(MouseEventType::MouseUp, button, point, node_address)
-            }
+        let (button, event_type) = match mouse_window_event {
+            MouseWindowEvent::Click(button, _) => (button, MouseEventType::Click),
+            MouseWindowEvent::MouseDown(button, _) => (button, MouseEventType::MouseDown),
+            MouseWindowEvent::MouseUp(button, _) => (button, MouseEventType::MouseUp),
         };
+
+        let event_to_send = MouseButtonEvent(
+            event_type,
+            button,
+            result.point_in_viewport.to_untyped(),
+            Some(UntrustedNodeAddress(result.tag.0 as *const c_void)),
+            Some(result.point_relative_to_item.to_untyped()),
+        );
 
         let pipeline_id = PipelineId::from_webrender(result.pipeline);
         let msg = ConstellationMsg::ForwardEvent(pipeline_id, event_to_send);

--- a/components/layout/webrender_helpers.rs
+++ b/components/layout/webrender_helpers.rs
@@ -10,8 +10,7 @@
 use app_units::Au;
 use euclid::{Point2D, Vector2D, Rect, SideOffsets2D, Size2D};
 use gfx::display_list::{BorderDetails, BorderRadii, BoxShadowClipMode, ClipScrollNodeType};
-use gfx::display_list::{ClippingRegion, DisplayItem, DisplayList, DisplayListTraversal};
-use gfx::display_list::StackingContextType;
+use gfx::display_list::{ClippingRegion, DisplayItem, DisplayList, StackingContextType};
 use msg::constellation_msg::PipelineId;
 use style::computed_values::{image_rendering, mix_blend_mode, transform_style};
 use style::values::computed::{BorderStyle, Filter};
@@ -222,7 +221,6 @@ impl ToTransformStyle for transform_style::T {
 
 impl WebRenderDisplayListConverter for DisplayList {
     fn convert_to_webrender(&self, pipeline_id: PipelineId) -> DisplayListBuilder {
-        let traversal = DisplayListTraversal::new(self);
         let mut builder = DisplayListBuilder::with_capacity(pipeline_id.to_webrender(),
                                                             self.bounds().size.to_sizef(),
                                                             1024 * 1024); // 1 MB of space
@@ -230,7 +228,7 @@ impl WebRenderDisplayListConverter for DisplayList {
         let mut current_clip_and_scroll_info = pipeline_id.root_clip_and_scroll_info();
         builder.push_clip_and_scroll_info(current_clip_and_scroll_info);
 
-        for item in traversal {
+        for item in &self.list {
             item.convert_to_webrender(&mut builder, &mut current_clip_and_scroll_info);
         }
         builder

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1358,18 +1358,19 @@ impl LayoutThread {
                 let node = unsafe { ServoLayoutNode::new(&node) };
                 rw_data.content_boxes_response = process_content_boxes_request(node, root_flow);
             },
-            ReflowGoal::TextIndexQuery(node, mouse_x, mouse_y) => {
+            ReflowGoal::TextIndexQuery(node, point_in_node) => {
                 let node = unsafe { ServoLayoutNode::new(&node) };
                 let opaque_node = node.opaque();
-                let client_point = Point2D::new(Au::from_px(mouse_x),
-                                                Au::from_px(mouse_y));
-                rw_data.text_index_response =
-                    TextIndexResponse(rw_data.display_list
-                                      .as_ref()
-                                      .expect("Tried to hit test with no display list")
-                                      .text_index(opaque_node,
-                                                  &client_point,
-                                                  &rw_data.scroll_offsets));
+                let point_in_node = Point2D::new(
+                    Au::from_f32_px(point_in_node.x),
+                    Au::from_f32_px(point_in_node.y)
+                );
+                rw_data.text_index_response = TextIndexResponse(
+                    rw_data.display_list
+                    .as_ref()
+                    .expect("Tried to hit test with no display list")
+                    .text_index(opaque_node, &point_in_node)
+                );
             },
             ReflowGoal::NodeGeometryQuery(node) => {
                 let node = unsafe { ServoLayoutNode::new(&node) };

--- a/components/script/dom/activation.rs
+++ b/components/script/dom/activation.rs
@@ -93,6 +93,7 @@ pub fn synthetic_click_activation(element: &Element,
                                 alt_key,
                                 meta_key,
                                 0,
+                                None,
                                 None);
     let event = mouse.upcast::<Event>();
     if source == ActivationSource::FromClick {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -836,7 +836,8 @@ impl Document {
         _button: MouseButton,
         client_point: Point2D<f32>,
         mouse_event_type: MouseEventType,
-        node_address: Option<UntrustedNodeAddress>
+        node_address: Option<UntrustedNodeAddress>,
+        point_in_node: Option<Point2D<f32>>
     ) {
         let mouse_event_type_string = match mouse_event_type {
             MouseEventType::Click => "click".to_owned(),
@@ -871,22 +872,25 @@ impl Document {
         let client_x = client_point.x as i32;
         let client_y = client_point.y as i32;
         let click_count = 1;
-        let event = MouseEvent::new(&self.window,
-                                    DOMString::from(mouse_event_type_string),
-                                    EventBubbles::Bubbles,
-                                    EventCancelable::Cancelable,
-                                    Some(&self.window),
-                                    click_count,
-                                    client_x,
-                                    client_y,
-                                    client_x,
-                                    client_y, // TODO: Get real screen coordinates?
-                                    false,
-                                    false,
-                                    false,
-                                    false,
-                                    0i16,
-                                    None);
+        let event = MouseEvent::new(
+            &self.window,
+            DOMString::from(mouse_event_type_string),
+            EventBubbles::Bubbles,
+            EventCancelable::Cancelable,
+            Some(&self.window),
+            click_count,
+            client_x,
+            client_y,
+            client_x,
+            client_y, // TODO: Get real screen coordinates?
+            false,
+            false,
+            false,
+            false,
+            0i16,
+            None,
+            point_in_node,
+        );
         let event = event.upcast::<Event>();
 
         // https://w3c.github.io/uievents/#trusted-events
@@ -943,22 +947,25 @@ impl Document {
                 let client_x = click_pos.x as i32;
                 let client_y = click_pos.y as i32;
 
-                let event = MouseEvent::new(&self.window,
-                                            DOMString::from("dblclick"),
-                                            EventBubbles::Bubbles,
-                                            EventCancelable::Cancelable,
-                                            Some(&self.window),
-                                            click_count,
-                                            client_x,
-                                            client_y,
-                                            client_x,
-                                            client_y,
-                                            false,
-                                            false,
-                                            false,
-                                            false,
-                                            0i16,
-                                            None);
+                let event = MouseEvent::new(
+                    &self.window,
+                    DOMString::from("dblclick"),
+                    EventBubbles::Bubbles,
+                    EventCancelable::Cancelable,
+                    Some(&self.window),
+                    click_count,
+                    client_x,
+                    client_y,
+                    client_x,
+                    client_y,
+                    false,
+                    false,
+                    false,
+                    false,
+                    0i16,
+                    None,
+                    None
+                );
                 event.upcast::<Event>().fire(target.upcast());
 
                 // When a double click occurs, self.last_click_info is left as None so that a
@@ -1034,22 +1041,25 @@ impl Document {
         let client_x = client_point.x.to_i32().unwrap_or(0);
         let client_y = client_point.y.to_i32().unwrap_or(0);
 
-        let mouse_event = MouseEvent::new(&self.window,
-                                          DOMString::from(event_name),
-                                          EventBubbles::Bubbles,
-                                          EventCancelable::Cancelable,
-                                          Some(&self.window),
-                                          0i32,
-                                          client_x,
-                                          client_y,
-                                          client_x,
-                                          client_y,
-                                          false,
-                                          false,
-                                          false,
-                                          false,
-                                          0i16,
-                                          None);
+        let mouse_event = MouseEvent::new(
+            &self.window,
+            DOMString::from(event_name),
+            EventBubbles::Bubbles,
+            EventCancelable::Cancelable,
+            Some(&self.window),
+            0i32,
+            client_x,
+            client_y,
+            client_x,
+            client_y,
+            false,
+            false,
+            false,
+            false,
+            0i16,
+            None,
+            None
+        );
         let event = mouse_event.upcast::<Event>();
         event.fire(target);
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1481,8 +1481,12 @@ impl Window {
         self.layout_rpc.margin_style()
     }
 
-    pub fn text_index_query(&self, node: TrustedNodeAddress, mouse_x: i32, mouse_y: i32) -> TextIndexResponse {
-        if !self.reflow(ReflowGoal::TextIndexQuery(node, mouse_x, mouse_y), ReflowReason::Query) {
+    pub fn text_index_query(
+        &self,
+        node: TrustedNodeAddress,
+        point_in_node: Point2D<f32>
+    ) -> TextIndexResponse {
+        if !self.reflow(ReflowGoal::TextIndexQuery(node, point_in_node), ReflowReason::Query) {
             return TextIndexResponse(None);
         }
         self.layout_rpc.text_index()

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2187,8 +2187,15 @@ impl ScriptThread {
                 self.handle_resize_event(pipeline_id, new_size, size_type);
             }
 
-            MouseButtonEvent(event_type, button, point, node_address) => {
-                self.handle_mouse_event(pipeline_id, event_type, button, point, node_address);
+            MouseButtonEvent(event_type, button, point, node_address, point_in_node) => {
+                self.handle_mouse_event(
+                    pipeline_id,
+                    event_type,
+                    button,
+                    point,
+                    node_address,
+                    point_in_node
+                );
             }
 
             MouseMoveEvent(point, node_address) => {
@@ -2299,7 +2306,8 @@ impl ScriptThread {
         mouse_event_type: MouseEventType,
         button: MouseButton,
         point: Point2D<f32>,
-        node_address: Option<UntrustedNodeAddress>
+        node_address: Option<UntrustedNodeAddress>,
+        point_in_node: Option<Point2D<f32>>
     ) {
         let document = match { self.documents.borrow().find_document(pipeline_id) } {
             Some(document) => document,
@@ -2310,7 +2318,8 @@ impl ScriptThread {
             button,
             point,
             mouse_event_type,
-            node_address
+            node_address,
+            point_in_node
         );
     }
 

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -120,7 +120,7 @@ pub enum ReflowGoal {
     ResolvedStyleQuery(TrustedNodeAddress, Option<PseudoElement>, PropertyId),
     OffsetParentQuery(TrustedNodeAddress),
     MarginStyleQuery(TrustedNodeAddress),
-    TextIndexQuery(TrustedNodeAddress, i32, i32),
+    TextIndexQuery(TrustedNodeAddress, Point2D<f32>),
     NodesFromPointQuery(Point2D<f32>, NodesFromPointQueryType),
 }
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -436,7 +436,13 @@ pub enum CompositorEvent {
     /// The window was resized.
     ResizeEvent(WindowSizeData, WindowSizeType),
     /// A mouse button state changed.
-    MouseButtonEvent(MouseEventType, MouseButton, Point2D<f32>, Option<UntrustedNodeAddress>),
+    MouseButtonEvent(
+        MouseEventType,
+        MouseButton,
+        Point2D<f32>,
+        Option<UntrustedNodeAddress>,
+        Option<Point2D<f32>>
+    ),
     /// The mouse was moved over a point (or was moved out of the recognizable region).
     MouseMoveEvent(Option<Point2D<f32>>, Option<UntrustedNodeAddress>),
     /// A touch event was generated with a touch ID and location.


### PR DESCRIPTION
This is the second half of switching over to WebRender for hit testing.
Now that WebRender gives us the location of the hit tested point in the
display item, we can use that to calculate text index.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they shouldn't change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18933)
<!-- Reviewable:end -->
