### PR TITLE
style: Make MatchingContext generic over SelectorImpl.

### DIFF
--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -686,21 +686,23 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
         self.element.namespace()
     }
 
-    fn match_pseudo_element(&self,
-                            _pseudo: &PseudoElement,
-                            _context: &mut MatchingContext)
-                            -> bool
-    {
+    fn match_pseudo_element(
+        &self,
+        _pseudo: &PseudoElement,
+        _context: &mut MatchingContext<Self::Impl>,
+    ) -> bool {
         false
     }
 
-    fn match_non_ts_pseudo_class<F>(&self,
-                                    pseudo_class: &NonTSPseudoClass,
-                                    _: &mut MatchingContext,
-                                    _: &RelevantLinkStatus,
-                                    _: &mut F)
-                                    -> bool
-        where F: FnMut(&Self, ElementSelectorFlags),
+    fn match_non_ts_pseudo_class<F>(
+        &self,
+        pseudo_class: &NonTSPseudoClass,
+        _: &mut MatchingContext<Self::Impl>,
+        _: &RelevantLinkStatus,
+        _: &mut F,
+    ) -> bool
+    where
+        F: FnMut(&Self, ElementSelectorFlags),
     {
         match *pseudo_class {
             // https://github.com/servo/servo/issues/8718
@@ -1176,11 +1178,11 @@ impl<'le> ::selectors::Element for ServoThreadSafeLayoutElement<'le> {
         self.element.get_namespace()
     }
 
-    fn match_pseudo_element(&self,
-                            _pseudo: &PseudoElement,
-                            _context: &mut MatchingContext)
-                            -> bool
-    {
+    fn match_pseudo_element(
+        &self,
+        _pseudo: &PseudoElement,
+        _context: &mut MatchingContext<Self::Impl>
+    ) -> bool {
         false
     }
 
@@ -1203,13 +1205,15 @@ impl<'le> ::selectors::Element for ServoThreadSafeLayoutElement<'le> {
         }
     }
 
-    fn match_non_ts_pseudo_class<F>(&self,
-                                    _: &NonTSPseudoClass,
-                                    _: &mut MatchingContext,
-                                    _: &RelevantLinkStatus,
-                                    _: &mut F)
-                                    -> bool
-        where F: FnMut(&Self, ElementSelectorFlags),
+    fn match_non_ts_pseudo_class<F>(
+        &self,
+        _: &NonTSPseudoClass,
+        _: &mut MatchingContext<Self::Impl>,
+        _: &RelevantLinkStatus,
+        _: &mut F,
+    ) -> bool
+    where
+        F: FnMut(&Self, ElementSelectorFlags),
     {
         // NB: This could maybe be implemented
         warn!("ServoThreadSafeLayoutElement::match_non_ts_pseudo_class called");

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2528,11 +2528,11 @@ impl<'a> SelectorsElement for DomRoot<Element> {
         self.upcast::<Node>().GetParentElement()
     }
 
-    fn match_pseudo_element(&self,
-                            _pseudo: &PseudoElement,
-                            _context: &mut MatchingContext)
-                            -> bool
-    {
+    fn match_pseudo_element(
+        &self,
+        _pseudo: &PseudoElement,
+        _context: &mut MatchingContext<Self::Impl>,
+    ) -> bool {
         false
     }
 
@@ -2594,13 +2594,15 @@ impl<'a> SelectorsElement for DomRoot<Element> {
         self.namespace()
     }
 
-    fn match_non_ts_pseudo_class<F>(&self,
-                                    pseudo_class: &NonTSPseudoClass,
-                                    _: &mut MatchingContext,
-                                    _: &RelevantLinkStatus,
-                                    _: &mut F)
-                                    -> bool
-        where F: FnMut(&Self, ElementSelectorFlags),
+    fn match_non_ts_pseudo_class<F>(
+        &self,
+        pseudo_class: &NonTSPseudoClass,
+        _: &mut MatchingContext<Self::Impl>,
+        _: &RelevantLinkStatus,
+        _: &mut F,
+    ) -> bool
+    where
+        F: FnMut(&Self, ElementSelectorFlags),
     {
         match *pseudo_class {
             // https://github.com/servo/servo/issues/8718

--- a/components/selectors/context.rs
+++ b/components/selectors/context.rs
@@ -5,6 +5,7 @@
 use attr::CaseSensitivity;
 use bloom::BloomFilter;
 use nth_index_cache::NthIndexCache;
+use parser::SelectorImpl;
 use tree::OpaqueElement;
 
 /// What kind of selector matching mode we should use.
@@ -74,7 +75,10 @@ impl QuirksMode {
 /// Data associated with the matching process for a element.  This context is
 /// used across many selectors for an element, so it's not appropriate for
 /// transient data that applies to only a single selector.
-pub struct MatchingContext<'a> {
+pub struct MatchingContext<'a, Impl>
+where
+    Impl: SelectorImpl,
+{
     /// Input with the matching mode we should use when matching selectors.
     pub matching_mode: MatchingMode,
     /// Input with the bloom filter used to fast-reject selectors.
@@ -107,9 +111,13 @@ pub struct MatchingContext<'a> {
 
     quirks_mode: QuirksMode,
     classes_and_ids_case_sensitivity: CaseSensitivity,
+    _impl: ::std::marker::PhantomData<Impl>,
 }
 
-impl<'a> MatchingContext<'a> {
+impl<'a, Impl> MatchingContext<'a, Impl>
+where
+    Impl: SelectorImpl,
+{
     /// Constructs a new `MatchingContext`.
     pub fn new(
         matching_mode: MatchingMode,
@@ -144,6 +152,7 @@ impl<'a> MatchingContext<'a> {
             classes_and_ids_case_sensitivity: quirks_mode.classes_and_ids_case_sensitivity(),
             scope_element: None,
             nesting_level: 0,
+            _impl: ::std::marker::PhantomData,
         }
     }
 

--- a/components/selectors/tree.rs
+++ b/components/selectors/tree.rs
@@ -67,17 +67,18 @@ pub trait Element: Sized + Clone + Debug {
     fn match_non_ts_pseudo_class<F>(
         &self,
         pc: &<Self::Impl as SelectorImpl>::NonTSPseudoClass,
-        context: &mut MatchingContext,
+        context: &mut MatchingContext<Self::Impl>,
         relevant_link: &RelevantLinkStatus,
         flags_setter: &mut F,
     ) -> bool
     where
         F: FnMut(&Self, ElementSelectorFlags);
 
-    fn match_pseudo_element(&self,
-                            pe: &<Self::Impl as SelectorImpl>::PseudoElement,
-                            context: &mut MatchingContext)
-                            -> bool;
+    fn match_pseudo_element(
+        &self,
+        pe: &<Self::Impl as SelectorImpl>::PseudoElement,
+        context: &mut MatchingContext<Self::Impl>,
+    ) -> bool;
 
     /// Whether this element is a `link`.
     fn is_link(&self) -> bool;

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -1834,7 +1834,7 @@ impl<'le> ::selectors::Element for GeckoElement<'le> {
     fn match_non_ts_pseudo_class<F>(
         &self,
         pseudo_class: &NonTSPseudoClass,
-        context: &mut MatchingContext,
+        context: &mut MatchingContext<Self::Impl>,
         relevant_link: &RelevantLinkStatus,
         flags_setter: &mut F,
     ) -> bool
@@ -1975,7 +1975,7 @@ impl<'le> ::selectors::Element for GeckoElement<'le> {
     fn match_pseudo_element(
         &self,
         pseudo_element: &PseudoElement,
-        _context: &mut MatchingContext
+        _context: &mut MatchingContext<Self::Impl>,
     ) -> bool {
         // TODO(emilio): I believe we could assert we are a pseudo-element and
         // match the proper pseudo-element, given how we rulehash the stuff

--- a/components/style/invalidation/element/element_wrapper.rs
+++ b/components/style/invalidation/element/element_wrapper.rs
@@ -152,7 +152,7 @@ impl<'a, E> Element for ElementWrapper<'a, E>
     fn match_non_ts_pseudo_class<F>(
         &self,
         pseudo_class: &NonTSPseudoClass,
-        context: &mut MatchingContext,
+        context: &mut MatchingContext<Self::Impl>,
         relevant_link: &RelevantLinkStatus,
         _setter: &mut F,
     ) -> bool
@@ -258,7 +258,7 @@ impl<'a, E> Element for ElementWrapper<'a, E>
     fn match_pseudo_element(
         &self,
         pseudo_element: &PseudoElement,
-        context: &mut MatchingContext,
+        context: &mut MatchingContext<Self::Impl>,
     ) -> bool {
         self.element.match_pseudo_element(pseudo_element, context)
     }

--- a/components/style/selector_map.rs
+++ b/components/style/selector_map.rs
@@ -162,17 +162,20 @@ impl SelectorMap<Rule> {
     ///
     /// Extract matching rules as per element's ID, classes, tag name, etc..
     /// Sort the Rules at the end to maintain cascading order.
-    pub fn get_all_matching_rules<E, V, F>(&self,
-                                           element: &E,
-                                           rule_hash_target: &E,
-                                           matching_rules_list: &mut V,
-                                           context: &mut MatchingContext,
-                                           quirks_mode: QuirksMode,
-                                           flags_setter: &mut F,
-                                           cascade_level: CascadeLevel)
-        where E: TElement,
-              V: VecLike<ApplicableDeclarationBlock>,
-              F: FnMut(&E, ElementSelectorFlags),
+    pub fn get_all_matching_rules<E, V, F>(
+        &self,
+        element: &E,
+        rule_hash_target: &E,
+        matching_rules_list: &mut V,
+        context: &mut MatchingContext<E::Impl>,
+        quirks_mode: QuirksMode,
+        flags_setter: &mut F,
+        cascade_level: CascadeLevel,
+    )
+    where
+        E: TElement,
+        V: VecLike<ApplicableDeclarationBlock>,
+        F: FnMut(&E, ElementSelectorFlags),
     {
         if self.is_empty() {
             return
@@ -223,15 +226,18 @@ impl SelectorMap<Rule> {
     }
 
     /// Adds rules in `rules` that match `element` to the `matching_rules` list.
-    fn get_matching_rules<E, V, F>(element: &E,
-                                   rules: &[Rule],
-                                   matching_rules: &mut V,
-                                   context: &mut MatchingContext,
-                                   flags_setter: &mut F,
-                                   cascade_level: CascadeLevel)
-        where E: TElement,
-              V: VecLike<ApplicableDeclarationBlock>,
-              F: FnMut(&E, ElementSelectorFlags),
+    fn get_matching_rules<E, V, F>(
+        element: &E,
+        rules: &[Rule],
+        matching_rules: &mut V,
+        context: &mut MatchingContext<E::Impl>,
+        flags_setter: &mut F,
+        cascade_level: CascadeLevel,
+    )
+    where
+        E: TElement,
+        V: VecLike<ApplicableDeclarationBlock>,
+        F: FnMut(&E, ElementSelectorFlags),
     {
         for rule in rules {
             if matches_selector(&rule.selector,

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -1198,7 +1198,7 @@ impl Stylist {
         animation_rules: AnimationRules,
         rule_inclusion: RuleInclusion,
         applicable_declarations: &mut V,
-        context: &mut MatchingContext,
+        context: &mut MatchingContext<E::Impl>,
         flags_setter: &mut F,
     )
     where


### PR DESCRIPTION
This will help Xidorn implement tree pseudos, and in general makes sense,
allowing to put specific matching data in a selectors implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18934)
<!-- Reviewable:end -->
