### PR TITLE
stylo: Add an FFI to get the ServoStyleContext with an extra animation value.

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -3005,6 +3005,19 @@ extern "C" {
      -> ServoStyleContextStrong;
 }
 extern "C" {
+    pub fn Servo_StyleSet_GetComputedValuesByAddingAnimation(set:
+                                                                 RawServoStyleSetBorrowed,
+                                                             element:
+                                                                 RawGeckoElementBorrowed,
+                                                             existing_style:
+                                                                 ServoStyleContextBorrowed,
+                                                             snapshots:
+                                                                 *const ServoElementSnapshotTable,
+                                                             animation:
+                                                                 RawServoAnimationValueBorrowed)
+     -> ServoStyleContextStrong;
+}
+extern "C" {
     pub fn Servo_SerializeFontValueForCanvas(declarations:
                                                  RawServoDeclarationBlockBorrowed,
                                              buffer: *mut nsAString);

--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -446,6 +446,25 @@ impl RuleTree {
         let rule = self.insert_ordered_rules_from(last.parent().unwrap().clone(), children.drain().rev());
         rule
     }
+
+    /// Returns new rule node by adding animation rules at transition level.
+    /// The additional rules must be appropriate for the transition
+    /// level of the cascade, which is the highest level of the cascade.
+    /// (This is the case for one current caller, the cover rule used
+    /// for CSS transitions.)
+    pub fn add_animation_rules_at_transition_level(
+        &self,
+        path: &StrongRuleNode,
+        pdb: Arc<Locked<PropertyDeclarationBlock>>,
+        guards: &StylesheetGuards,
+    ) -> StrongRuleNode {
+        let mut dummy = false;
+        self.update_rule_at_level(CascadeLevel::Transitions,
+                                  Some(pdb.borrow_arc()),
+                                  path,
+                                  guards,
+                                  &mut dummy).expect("Should return a valid rule node")
+    }
 }
 
 /// The number of RuleNodes added to the free list before we will consider


### PR DESCRIPTION
This is an inter-dependent patch of Bug 1303235. We add an FFI
to create a temporary ServoStyleContext with the animation value.
We need this because we calculate the Cumulative change hints to check
if we can ignore this animation segment.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1303235](https://bugzilla.mozilla.org/show_bug.cgi?id=1303235).
- [X] These changes do not require tests because we have tests on Gecko side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18945)
<!-- Reviewable:end -->
