### PR TITLE
Fix the transition to bitflags 1.0

### DIFF
--- a/components/style/properties/longhand/background.mako.rs
+++ b/components/style/properties/longhand/background.mako.rs
@@ -45,8 +45,8 @@ ${helpers.predefined_type("background-image", "ImageLayer",
 
 <%helpers:vector_longhand name="background-repeat" animation_value_type="discrete"
                           spec="https://drafts.csswg.org/css-backgrounds/#the-background-repeat"
-                          flags="""PropertyFlags::APPLIES_TO_FIRST_LETTER PropertyFlags::APPLIES_TO_FIRST_LINE
-                          PropertyFlags::APPLIES_TO_PLACEHOLDER""">
+                          flags="PropertyFlags::APPLIES_TO_FIRST_LETTER PropertyFlags::APPLIES_TO_FIRST_LINE
+                          PropertyFlags::APPLIES_TO_PLACEHOLDER">
     use std::fmt;
     use style_traits::ToCss;
 

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -69,8 +69,8 @@ macro_rules! impl_gecko_keyword_conversions {
 </%def>
 
 <%helpers:longhand name="font-family" animation_value_type="discrete"
-                   flags="""PropertyFlags::APPLIES_TO_FIRST_LETTER PropertyFlags::APPLIES_TO_FIRST_LINE
-                   PropertyFlags::APPLIES_TO_PLACEHOLDER"""
+                   flags="PropertyFlags::APPLIES_TO_FIRST_LETTER PropertyFlags::APPLIES_TO_FIRST_LINE
+                   PropertyFlags::APPLIES_TO_PLACEHOLDER"
                    spec="https://drafts.csswg.org/css-fonts/#propdef-font-family">
     #[cfg(feature = "gecko")] use gecko_bindings::bindings;
     #[cfg(feature = "gecko")] use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
@@ -620,8 +620,8 @@ ${helpers.single_keyword_system("font-variant-caps",
                                 animation_value_type="discrete")}
 
 <%helpers:longhand name="font-weight" animation_value_type="ComputedValue"
-                   flags="""PropertyFlags::APPLIES_TO_FIRST_LETTER PropertyFlags::APPLIES_TO_FIRST_LINE
-                   PropertyFlags::APPLIES_TO_PLACEHOLDER"""
+                   flags="PropertyFlags::APPLIES_TO_FIRST_LETTER PropertyFlags::APPLIES_TO_FIRST_LINE
+                   PropertyFlags::APPLIES_TO_PLACEHOLDER"
                    spec="https://drafts.csswg.org/css-fonts/#propdef-font-weight">
     use properties::longhands::system_font::SystemFont;
 
@@ -786,8 +786,8 @@ ${helpers.single_keyword_system("font-variant-caps",
 </%helpers:longhand>
 
 <%helpers:longhand name="font-size" animation_value_type="NonNegativeLength"
-                   flags="""PropertyFlags::APPLIES_TO_FIRST_LETTER PropertyFlags::APPLIES_TO_FIRST_LINE
-                   PropertyFlags::APPLIES_TO_PLACEHOLDER"""
+                   flags="PropertyFlags::APPLIES_TO_FIRST_LETTER PropertyFlags::APPLIES_TO_FIRST_LINE
+                   PropertyFlags::APPLIES_TO_PLACEHOLDER"
                    allow_quirks="True" spec="https://drafts.csswg.org/css-fonts/#propdef-font-size">
     use app_units::Au;
     use values::specified::AllowQuirks;

--- a/components/style/properties/longhand/text.mako.rs
+++ b/components/style/properties/longhand/text.mako.rs
@@ -141,8 +141,8 @@ ${helpers.single_keyword("unicode-bidi",
 <%helpers:longhand name="text-decoration-line"
                    custom_cascade="${product == 'servo'}"
                    animation_value_type="discrete"
-                   flags="""PropertyFlags::APPLIES_TO_FIRST_LETTER PropertyFlags::APPLIES_TO_FIRST_LINE
-                   PropertyFlags::APPLIES_TO_PLACEHOLDER""",
+                   flags="PropertyFlags::APPLIES_TO_FIRST_LETTER PropertyFlags::APPLIES_TO_FIRST_LINE
+                   PropertyFlags::APPLIES_TO_PLACEHOLDER",
                    spec="https://drafts.csswg.org/css-text-decor/#propdef-text-decoration-line">
     use std::fmt;
     use style_traits::ToCss;


### PR DESCRIPTION
For some reasons helpers:vector_longhand doesn't want the flags parameter
to be between triple quotes leading to some wrong code generation (the
flags were just ignored...) leading to some test failures in m-c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18958)
<!-- Reviewable:end -->
