### PR TITLE
Add iterpath and iterdir to CSS test runner.

### DIFF
--- a/tests/wpt/css-tests/tools/manifest/manifest.py
+++ b/tests/wpt/css-tests/tools/manifest/manifest.py
@@ -46,6 +46,20 @@ class Manifest(object):
             for path, tests in sorted(iteritems(self._data[item_type])):
                 yield item_type, path, tests
 
+    def iterpath(self, path):
+        for type_tests in self._data.values():
+            for test in type_tests.get(path, set()):
+                yield test
+
+    def iterdir(self, dir_name):
+        if not dir_name.endswith(os.path.sep):
+            dir_name = dir_name + os.path.sep
+        for type_tests in self._data.values():
+            for path, tests in type_tests.iteritems():
+                if path.startswith(dir_name):
+                    for test in tests:
+                        yield test
+
     @property
     def reftest_nodes_by_url(self):
         if self._reftest_nodes_by_url is None:


### PR DESCRIPTION
This allows running a subset of the CSS tests again, by specifying
a directory or single test.

Fixes #18931.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18959)
<!-- Reviewable:end -->
