### PR TITLE
Update mozlog dependency

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,7 +5,7 @@ blessings == 1.6
 mach == 0.6.0
 mozdebug == 0.1
 mozinfo == 0.8
-mozlog == 3.3
+mozlog == 3.5
 setuptools == 18.5
 toml == 0.9.2
 


### PR DESCRIPTION
wptrunner repends on mozlog 3.5, but we only require 3.3. Somehow some of the builders have 3.5 installed, but this is causing lots of problems for us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18961)
<!-- Reviewable:end -->
