### PR TITLE
Enhance validation to check keys and values, and report hash at failure location.

### DIFF
--- a/components/hashglobe/src/diagnostic.rs
+++ b/components/hashglobe/src/diagnostic.rs
@@ -62,17 +62,21 @@ impl<K: Hash + Eq, V, S: BuildHasher> DiagnosticHashMap<K, V, S>
         let mut position = 0;
         let mut count = 0;
         let mut bad_canary = None;
-        for (_,v) in self.map.iter() {
+
+        let mut iter = self.map.iter();
+        while let Some((h, _, v)) = iter.next_with_hash() {
             let canary_ref = &v.0;
             position += 1;
+
             if *canary_ref == CANARY {
                 continue;
             }
+
             count += 1;
-            bad_canary = Some((*canary_ref, canary_ref, position));
+            bad_canary = Some((h, *canary_ref, canary_ref, position));
         }
         if let Some(c) = bad_canary {
-            self.report_corruption(c.0, c.1, c.2, count);
+            self.report_corruption(c.0, c.1, c.2, c.3, count);
         }
     }
 
@@ -158,6 +162,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> DiagnosticHashMap<K, V, S>
     #[inline(never)]
     fn report_corruption(
         &self,
+        hash: usize,
         canary: usize,
         canary_addr: *const usize,
         position: usize,
@@ -172,12 +177,14 @@ impl<K: Hash + Eq, V, S: BuildHasher> DiagnosticHashMap<K, V, S>
                 value.as_ptr(),
             );
         }
+
         panic!(
-            concat!("HashMap Corruption (sz={}, cap={}, pairsz={}, cnry={:#x}, count={}, ",
-                    "last_pos={}, base_addr={:?}, cnry_addr={:?}, jrnl_len={})"),
+            concat!("HashMap Corruption (sz={}, cap={}, pairsz={}, hash={:#x}, cnry={:#x}, ",
+                "count={}, last_pos={}, base_addr={:?}, cnry_addr={:?}, jrnl_len={})"),
             self.map.len(),
             self.map.raw_capacity(),
             ::std::mem::size_of::<(K, (usize, V))>(),
+            hash,
             canary,
             count,
             position,

--- a/components/hashglobe/src/hash_map.rs
+++ b/components/hashglobe/src/hash_map.rs
@@ -1339,6 +1339,12 @@ impl<'a, K: Debug, V: Debug> fmt::Debug for Iter<'a, K, V> {
     }
 }
 
+impl<'a, K: 'a, V: 'a>  Iter<'a, K, V> {
+    pub fn next_with_hash(&mut self) -> Option<(usize, &'a K, &'a V)> {
+        self.inner.next_with_hash()
+    }
+}
+
 /// A mutable iterator over the entries of a `HashMap`.
 ///
 /// This `struct` is created by the [`iter_mut`] method on [`HashMap`]. See its

--- a/components/hashglobe/src/table.rs
+++ b/components/hashglobe/src/table.rs
@@ -1130,6 +1130,15 @@ impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {
     }
 }
 
+impl<'a, K, V> Iter<'a, K, V> {
+    pub fn next_with_hash(&mut self) -> Option<(usize, &'a K, &'a V)> {
+        self.iter.next().map(|raw| unsafe {
+            let (hash_ptr, pair_ptr) = raw.hash_pair();
+            (*hash_ptr, &(*pair_ptr).0, &(*pair_ptr).1)
+        })
+    }
+}
+
 impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     type Item = (&'a K, &'a mut V);
 


### PR DESCRIPTION
This is hopefully the last escalation in analysis for stylo corruption detection, before we rip it all out.

We are currently trying to verify that bad bucket accesses are the result of single-bit corruptions in the hashes. This case should be detected by the canary having a value of 0xe7e7..., so all we need to do is feed the hash down and print it.

Note: It seems I have like 17 versions of python installed on my system, and so servo's copy of mach is completely unusable right now, so I haven't had a chance to actually compile this. Would appreciate, in the highly likely chance that this doesn't compile right away, if someone else (@Manishearth?) could finish this up for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18965)
<!-- Reviewable:end -->
