### PR TITLE
Use env::var_os to read paths from the environment

### DIFF
--- a/components/atoms/build.rs
+++ b/components/atoms/build.rs
@@ -10,7 +10,7 @@ use std::io::{BufReader, BufRead};
 use std::path::Path;
 
 fn main() {
-    let static_atoms = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join("static_atoms.txt");
+    let static_atoms = Path::new(&env::var_os("CARGO_MANIFEST_DIR").unwrap()).join("static_atoms.txt");
     let static_atoms = BufReader::new(File::open(&static_atoms).unwrap());
     let mut atom_type = string_cache_codegen::AtomType::new("Atom", "atom!");
 
@@ -27,6 +27,6 @@ fn main() {
 
     atom_type
         .atoms(static_atoms.lines().map(Result::unwrap))
-        .write_to_file(&Path::new(&env::var("OUT_DIR").unwrap()).join("atom.rs"))
+        .write_to_file(&Path::new(&env::var_os("OUT_DIR").unwrap()).join("atom.rs"))
         .unwrap();
 }

--- a/components/config/basedir.rs
+++ b/components/config/basedir.rs
@@ -77,9 +77,10 @@ pub fn default_config_dir() -> Option<PathBuf> {
 
 #[cfg(target_os = "windows")]
 pub fn default_config_dir() -> Option<PathBuf> {
-    let mut config_dir = match env::var("APPDATA") {
-        Ok(appdata_path) => PathBuf::from(appdata_path),
-        Err(_) => { let mut dir = env::home_dir().unwrap();
+    let mut config_dir = match env::var_os("APPDATA") {
+        Some(appdata_path) => PathBuf::from(appdata_path),
+        None => {
+            let mut dir = env::home_dir().unwrap();
             dir.push("Appdata");
             dir.push("Roaming");
             dir

--- a/components/script/build.rs
+++ b/components/script/build.rs
@@ -46,13 +46,13 @@ fn main() {
 
     println!("Binding generation completed in {}s", start.elapsed().as_secs());
 
-    let json = PathBuf::from(env::var("OUT_DIR").unwrap()).join("build").join("InterfaceObjectMapData.json");
+    let json = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("build").join("InterfaceObjectMapData.json");
     let json: Value = serde_json::from_reader(File::open(&json).unwrap()).unwrap();
     let mut map = phf_codegen::Map::new();
     for (key, value) in json.as_object().unwrap() {
         map.entry(Bytes(key), value.as_str().unwrap());
     }
-    let phf = PathBuf::from(env::var("OUT_DIR").unwrap()).join("InterfaceObjectMapPhf.rs");
+    let phf = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("InterfaceObjectMapPhf.rs");
     let mut phf = File::create(&phf).unwrap();
     write!(&mut phf, "pub static MAP: phf::Map<&'static [u8], unsafe fn(*mut JSContext, HandleObject)> = ").unwrap();
     map.build(&mut phf).unwrap();

--- a/components/selectors/build.rs
+++ b/components/selectors/build.rs
@@ -10,7 +10,7 @@ use std::io::{BufWriter, Write};
 use std::path::Path;
 
 fn main() {
-    let path = Path::new(&env::var("OUT_DIR").unwrap())
+    let path = Path::new(&env::var_os("OUT_DIR").unwrap())
         .join("ascii_case_insensitive_html_attributes.rs");
     let mut file = BufWriter::new(File::create(&path).unwrap());
 

--- a/components/style/build.rs
+++ b/components/style/build.rs
@@ -69,7 +69,7 @@ fn generate_properties() {
         }
     }
 
-    let script = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap())
+    let script = Path::new(&env::var_os("CARGO_MANIFEST_DIR").unwrap())
         .join("properties").join("build.py");
     let product = if cfg!(feature = "gecko") { "gecko" } else { "servo" };
     let status = Command::new(&*PYTHON)

--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -7,7 +7,7 @@ mod common {
     use std::path::{Path, PathBuf};
 
     lazy_static! {
-        pub static ref OUTDIR_PATH: PathBuf = PathBuf::from(env::var("OUT_DIR").unwrap()).join("gecko");
+        pub static ref OUTDIR_PATH: PathBuf = PathBuf::from(env::var_os("OUT_DIR").unwrap()).join("gecko");
     }
 
     /// Copy contents of one directory into another.
@@ -74,7 +74,7 @@ mod bindings {
     lazy_static! {
         static ref CONFIG: toml::Table = {
             // Load Gecko's binding generator config from the source tree.
-            let path = PathBuf::from(env::var("MOZ_SRC").unwrap())
+            let path = PathBuf::from(env::var_os("MOZ_SRC").unwrap())
                 .join("layout/style/ServoBindings.toml");
             read_config(&path)
         };
@@ -82,7 +82,7 @@ mod bindings {
             // Load build-specific config overrides.
             // FIXME: We should merge with CONFIG above instead of
             // forcing callers to do it.
-            let path = PathBuf::from(env::var("MOZ_TOPOBJDIR").unwrap())
+            let path = PathBuf::from(env::var_os("MOZ_TOPOBJDIR").unwrap())
                 .join("layout/style/bindgen.toml");
             read_config(&path)
         };
@@ -98,7 +98,7 @@ mod bindings {
         };
         static ref INCLUDE_RE: Regex = Regex::new(r#"#include\s*"(.+?)""#).unwrap();
         static ref DISTDIR_PATH: PathBuf = {
-            let path = PathBuf::from(env::var("MOZ_DIST").unwrap());
+            let path = PathBuf::from(env::var_os("MOZ_DIST").unwrap());
             if !path.is_absolute() || !path.is_dir() {
                 panic!("MOZ_DIST must be an absolute directory, was: {}", path.display());
             }
@@ -452,7 +452,7 @@ mod bindings {
             }
         }
 
-        if let Ok(path) = env::var("STYLO_BUILD_LOG") {
+        if let Some(path) = env::var_os("STYLO_BUILD_LOG") {
             log::set_logger(|log_level| {
                 log_level.set(log::LogLevelFilter::Debug);
                 Box::new(BuildLogger {
@@ -536,7 +536,7 @@ mod bindings {
     }
 
     fn generate_atoms() {
-        let script = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap())
+        let script = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap())
             .join("gecko").join("regen_atoms.py");
         println!("cargo:rerun-if-changed={}", script.display());
         let status = Command::new(&*PYTHON)
@@ -587,7 +587,7 @@ mod bindings {
     use super::common::*;
 
     pub fn generate() {
-        let dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("gecko/generated");
+        let dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap()).join("gecko/generated");
         println!("cargo:rerun-if-changed={}", dir.display());
         copy_dir(&dir, &*OUTDIR_PATH, |path| {
             println!("cargo:rerun-if-changed={}", path.display());

--- a/ports/servo/build.rs
+++ b/ports/servo/build.rs
@@ -17,7 +17,7 @@ fn main() {
 
 fn android_main() {
     // Get the NDK path from NDK_HOME env.
-    let ndk_path = env::var("ANDROID_NDK").ok().expect("Please set the ANDROID_NDK environment variable");
+    let ndk_path = env::var_os("ANDROID_NDK").expect("Please set the ANDROID_NDK environment variable");
     let ndk_path = Path::new(&ndk_path);
 
     // Build up the path to the NDK compilers
@@ -62,7 +62,7 @@ fn android_main() {
     println!("toolchain path is: {}", toolchain_path.to_str().unwrap());
 
     // Get the output directory.
-    let out_dir = env::var("OUT_DIR").ok().expect("Cargo should have set the OUT_DIR environment variable");
+    let out_dir = env::var("OUT_DIR").expect("Cargo should have set the OUT_DIR environment variable");
     let directory = Path::new(&out_dir);
 
     // compiling android_native_app_glue.c


### PR DESCRIPTION
This avoids unnecessary UTF-8 validation on OsStrings that we just pass
back to the OS.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are code cleanup only

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18971)
<!-- Reviewable:end -->
