### PR TITLE
Remove unnecessary Result::ok calls

### DIFF
--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -246,7 +246,7 @@ unsafe extern fn native_handler_callback(cx: *mut JSContext, argc: u32, vp: *mut
     assert!(v.get().is_object());
 
     let handler = root_from_object::<PromiseNativeHandler>(v.to_object())
-        .ok().expect("unexpected value for native handler in promise native handler callback");
+        .expect("unexpected value for native handler in promise native handler callback");
 
     rooted!(in(cx) let v = *GetFunctionNativeReserved(args.callee(), SLOT_NATIVEHANDLER_TASK));
     match v.to_int32() {

--- a/components/style/values/specified/basic_shape.rs
+++ b/components/style/values/specified/basic_shape.rs
@@ -151,7 +151,7 @@ impl Circle {
     #[allow(missing_docs)]
     pub fn parse_function_arguments<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
                                             -> Result<Self, ParseError<'i>> {
-        let radius = input.try(|i| ShapeRadius::parse(context, i)).ok().unwrap_or_default();
+        let radius = input.try(|i| ShapeRadius::parse(context, i)).unwrap_or_default();
         let position = if input.try(|i| i.expect_ident_matching("at")).is_ok() {
             Position::parse(context, input)?
         } else {
@@ -192,7 +192,7 @@ impl Ellipse {
                                             -> Result<Self, ParseError<'i>> {
         let (a, b) = input.try(|i| -> Result<_, ParseError> {
             Ok((ShapeRadius::parse(context, i)?, ShapeRadius::parse(context, i)?))
-        }).ok().unwrap_or_default();
+        }).unwrap_or_default();
         let position = if input.try(|i| i.expect_ident_matching("at")).is_ok() {
             Position::parse(context, input)?
         } else {
@@ -319,7 +319,7 @@ impl Polygon {
             let fill = FillRule::parse(i)?;
             i.expect_comma()?;      // only eat the comma if there is something before it
             Ok(fill)
-        }).ok().unwrap_or_default();
+        }).unwrap_or_default();
 
         let buf = input.parse_comma_separated(|i| {
             Ok((LengthOrPercentage::parse(context, i)?, LengthOrPercentage::parse(context, i)?))


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are code cleanup only

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18972)
<!-- Reviewable:end -->
