### PR TITLE
Update webrender for latest RenderNotifier changes

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -5,7 +5,7 @@
 use CompositionPipeline;
 use SendableFrameTree;
 use compositor_thread::{CompositorProxy, CompositorReceiver};
-use compositor_thread::{InitialCompositorState, Msg, RenderListener};
+use compositor_thread::{InitialCompositorState, Msg};
 use euclid::{TypedPoint2D, TypedVector2D, ScaleFactor};
 use gfx_traits::Epoch;
 use gleam::gl;
@@ -128,8 +128,6 @@ pub struct IOCompositor<Window: WindowMethods> {
 
     /// The device pixel ratio for this window.
     scale_factor: ScaleFactor<f32, DeviceIndependentPixel, DevicePixel>,
-
-    channel_to_self: CompositorProxy,
 
     /// The type of composition to perform
     composite_target: CompositeTarget,
@@ -313,13 +311,13 @@ fn initialize_png(gl: &gl::Gl, width: usize, height: usize) -> RenderTargetInfo 
     }
 }
 
-struct RenderNotifier {
+#[derive(Clone)]
+pub struct RenderNotifier {
     compositor_proxy: CompositorProxy,
 }
 
 impl RenderNotifier {
-    fn new(compositor_proxy: CompositorProxy,
-           _: Sender<ConstellationMsg>) -> RenderNotifier {
+    pub fn new(compositor_proxy: CompositorProxy) -> RenderNotifier {
         RenderNotifier {
             compositor_proxy: compositor_proxy,
         }
@@ -327,11 +325,11 @@ impl RenderNotifier {
 }
 
 impl webrender_api::RenderNotifier for RenderNotifier {
-    fn new_frame_ready(&mut self) {
+    fn new_frame_ready(&self) {
         self.compositor_proxy.recomposite(CompositingReason::NewWebRenderFrame);
     }
 
-    fn new_scroll_frame_ready(&mut self, composite_needed: bool) {
+    fn new_scroll_frame_ready(&self, composite_needed: bool) {
         self.compositor_proxy.send(Msg::NewScrollFrameReady(composite_needed));
     }
 }
@@ -357,7 +355,6 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             window_rect: window_rect,
             scale: ScaleFactor::new(1.0),
             scale_factor: scale_factor,
-            channel_to_self: state.sender.clone(),
             composition_request: CompositionRequest::NoCompositingNecessary,
             touch_handler: TouchHandler::new(),
             pending_scroll_zoom_events: Vec::new(),
@@ -386,12 +383,6 @@ impl<Window: WindowMethods> IOCompositor<Window> {
 
     pub fn create(window: Rc<Window>, state: InitialCompositorState) -> IOCompositor<Window> {
         let mut compositor = IOCompositor::new(window, state);
-
-        let compositor_proxy_for_webrender = compositor.channel_to_self
-                                                       .clone();
-        let render_notifier = RenderNotifier::new(compositor_proxy_for_webrender,
-                                                  compositor.constellation_chan.clone());
-        compositor.webrender.set_render_notifier(Box::new(render_notifier));
 
         // Set the size of the root layer.
         compositor.update_zoom_transform();

--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -107,12 +107,8 @@ impl CompositorReceiver {
     }
 }
 
-pub trait RenderListener {
-    fn recomposite(&mut self, reason: CompositingReason);
-}
-
-impl RenderListener for CompositorProxy {
-    fn recomposite(&mut self, reason: CompositingReason) {
+impl CompositorProxy {
+    pub fn recomposite(&self, reason: CompositingReason) {
         self.send(Msg::Recomposite(reason));
     }
 }

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -27,6 +27,7 @@ extern crate webrender_api;
 
 pub use compositor_thread::CompositorProxy;
 pub use compositor::IOCompositor;
+pub use compositor::RenderNotifier;
 pub use compositor::ShutdownState;
 use euclid::TypedSize2D;
 use ipc_channel::ipc::IpcSender;

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -71,7 +71,7 @@ use bluetooth::BluetoothThreadFactory;
 use bluetooth_traits::BluetoothRequest;
 use canvas::gl_context::GLContextFactory;
 use canvas::webgl_thread::WebGLThreads;
-use compositing::{IOCompositor, ShutdownState};
+use compositing::{IOCompositor, ShutdownState, RenderNotifier};
 use compositing::compositor_thread::{self, CompositorProxy, CompositorReceiver, InitialCompositorState};
 use compositing::compositor_thread::{EmbedderMsg, EmbedderProxy, EmbedderReceiver};
 use compositing::windowing::WindowEvent;
@@ -185,7 +185,9 @@ impl<Window> Servo<Window> where Window: WindowMethods + 'static {
             let mut debug_flags = webrender::DebugFlags::empty();
             debug_flags.set(webrender::DebugFlags::PROFILER_DBG, opts.webrender_stats);
 
-            webrender::Renderer::new(window.gl(), webrender::RendererOptions {
+            let render_notifier = RenderNotifier::new(compositor_proxy.clone());
+
+            webrender::Renderer::new(window.gl(), render_notifier, webrender::RendererOptions {
                 device_pixel_ratio: device_pixel_ratio,
                 resource_override_path: Some(resource_path),
                 enable_aa: opts.enable_text_antialiasing,


### PR DESCRIPTION
This addresses one of the most common intermittent test failures by making it impossible for the failure to occur. Requires https://github.com/servo/webrender/pull/1904 to be merged upstream first.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13480 
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18976)
<!-- Reviewable:end -->
