### PR TITLE
Windows Build: Install Visual Studio at default location

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ pip install virtualenv
 settings for the installer are fine).
 
 4. Install Visual Studio Community 2017 (https://www.visualstudio.com/vs/community/). You MUST add "Visual C++" to the
-list of installed components. It is not on by default.
+list of installed components. It is not on by default. Visual Studio 2017 MUST installed to the default location or mach.bat will not find it.
 > If you encountered errors with the environment above, do the following for a workaround:
 > 1.  Download and install [Build Tools for Visual Studio 2017](https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15)
 > 2.  Install `python2.7 x86-x64` and `virtualenv`


### PR DESCRIPTION
Visual Studio 2017 has to be installed at the default location or mach.bat will show an error that Visual Studio 2017 is not installed when trying to build servo.

[X] These changes do not require tests because no code is changed, documentation only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18979)
<!-- Reviewable:end -->
