### PR TITLE
Remove XBL as a separate cascading level in Stylo

### DIFF
--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -488,8 +488,6 @@ pub enum CascadeLevel {
     PresHints,
     /// User normal rules.
     UserNormal,
-    /// XBL <stylesheet> rules.
-    XBL,
     /// Author normal rules.
     AuthorNormal,
     /// Style attribute normal rules.
@@ -1258,7 +1256,6 @@ impl StrongRuleNode {
                     }
                     // Author rules:
                     CascadeLevel::PresHints |
-                    CascadeLevel::XBL |
                     CascadeLevel::AuthorNormal |
                     CascadeLevel::StyleAttributeNormal |
                     CascadeLevel::SMILOverride |

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -1309,7 +1309,7 @@ impl Stylist {
                     &mut matching_context,
                     stylist.quirks_mode,
                     flags_setter,
-                    CascadeLevel::XBL,
+                    CascadeLevel::AuthorNormal,
                 );
             }
         });


### PR DESCRIPTION
In Gecko, we handle XBL rules like author rules everywhere, except that XBL rules are added and sorted in an independent step, behave as if it has a separate level.

It is not clear to me why Stylo chose to add a separate level for XBL rules, but it doesn't seem that there is anything special to do with XBL rules.

This bug happens because we don't handle XBL important rules which are handled as part of author rules in Gecko due to lack of the additional level there. We should just follow what Gecko does here and handle them all the same.

(This is the Servo part of [bug 1408811](https://bugzilla.mozilla.org/show_bug.cgi?id=1408811))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18987)
<!-- Reviewable:end -->
