### PR TITLE
style: Ensure logical longhands appear before their physical counter-part.

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -173,11 +173,37 @@ pub mod shorthands {
 
     // We don't defined the 'all' shorthand using the regular helpers:shorthand
     // mechanism, since it causes some very large types to be generated.
-    <% data.declare_shorthand("all",
-                              [p.name for p in data.longhands
-                                if p.name not in ['direction', 'unicode-bidi']
-                                      and not p.internal],
-                              spec="https://drafts.csswg.org/css-cascade-3/#all-shorthand") %>
+    //
+    // Also, make sure logical properties appear before its physical
+    // counter-parts, in order to prevent bugs like:
+    //
+    //   https://bugzilla.mozilla.org/show_bug.cgi?id=1410028
+    //
+    // FIXME(emilio): Adopt the resolution from:
+    //
+    //   https://github.com/w3c/csswg-drafts/issues/1898
+    //
+    // when there is one, whatever that is.
+    <%
+        logical_longhands = []
+        other_longhands = []
+
+        for p in data.longhands:
+            if p.name in ['direction', 'unicode-bidi']:
+                continue;
+            if p.internal:
+                continue;
+            if p.logical:
+                logical_longhands.append(p.name)
+            else:
+                other_longhands.append(p.name)
+
+        data.declare_shorthand(
+            "all",
+            logical_longhands + other_longhands,
+            spec="https://drafts.csswg.org/css-cascade-3/#all-shorthand"
+        )
+    %>
 }
 
 /// A module with all the code related to animated properties.


### PR DESCRIPTION
Bug: 1410028
Reviewed-by: xidorn
MozReview-Commit-ID: KPIbt1e2Eq

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18989)
<!-- Reviewable:end -->
