### PR TITLE
Fixed FireMouseEventType mixup

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -168,8 +168,8 @@ impl FireMouseEventType {
     pub fn as_str(&self) -> &str {
         match self {
             &FireMouseEventType::Move => "mousemove",
-            &FireMouseEventType::Over => "mouseout",
-            &FireMouseEventType::Out => "mouseover",
+            &FireMouseEventType::Over => "mouseover",
+            &FireMouseEventType::Out => "mouseout",
         }
     }
 }


### PR DESCRIPTION
Fix for a bug I didn't catch in #18957. Thanks to rharel for pointing it out.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix issue #18943 and bug in PR #18957
- [X] These changes do not require tests as specified in #18943

r?@jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/18990)
<!-- Reviewable:end -->
