### PR TITLE
Make test-stylo compile an empty crate on Windows without Gecko

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -146,6 +146,7 @@ windows-msvc-dev:
   - mach.bat test-unit
   - mach.bat package --dev
   - mach.bat build-geckolib
+  - mach.bat test-stylo
 
 windows-msvc-nightly:
   - mach.bat clean-nightlies --keep 3 --force

--- a/tests/unit/stylo/build.rs
+++ b/tests/unit/stylo/build.rs
@@ -63,4 +63,8 @@ fn main() {
         .write_all(format!("include!(concat!({:?}, \"/gecko/structs.rs\"));",
                            style_out_dir).as_bytes())
         .unwrap();
+
+    if env::var_os("MOZ_SRC").is_some() {
+        println!("cargo:rustc-cfg=linking_with_gecko")
+    }
 }

--- a/tests/unit/stylo/lib.rs
+++ b/tests/unit/stylo/lib.rs
@@ -2,6 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// Disable this entire crate on Windows when Gecko symbols are not available
+// as linking would fail:
+// https://github.com/rust-lang/rust/pull/44603#issuecomment-338807312
+//
+// On Linux and OS X linking succeeds anyway.
+// Presumably these symbol declarations don’t need to be resolved
+// as they’re not used in any code called from this crate.
+#![cfg(any(linking_with_gecko, not(windows)))]
+
 extern crate atomic_refcell;
 extern crate cssparser;
 extern crate env_logger;


### PR DESCRIPTION
That is, in cases where it would fail to link.

This will help make Rust CI be gated on compiling Stylo: https://github.com/rust-lang/rust/pull/44603

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19003)
<!-- Reviewable:end -->
