### PR TITLE
Fix Const IDL value compilation errors in codegen

### DIFF
--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -151,6 +151,13 @@ interface TestBinding {
   [BinaryName="BinaryRenamedAttribute2"] attribute DOMString attr-to-binary-rename;
   attribute DOMString attr-to-automatically-rename;
 
+  const long long constantInt64 = -1;
+  const unsigned long long constantUint64 = 1;
+  const float constantFloat32 = 1.0;
+  const double constantFloat64 = 1.0;
+  const unrestricted float constantUnrestrictedFloat32 = 1.0;
+  const unrestricted double constantUnrestrictedFloat64 = 1.0;
+
   [PutForwards=booleanAttribute]
   readonly attribute TestBinding forwardedAttribute;
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

I found that some const WebIDL values fail at rust compile time.

Example:

const long long TIMEOUT_IGNORED  = -1;

```
906 |     ConstantSpec { name: b"TIMEOUT_IGNORED\0", value: ConstantVal::DoubleVal(-1) }]
    |                                                                              ^^ expected f64, found integral variable
    |
    = note: expected type `f64`
               found type `{integer}`
```

I added a explicit cast to to fix the problem in conversions that may fail to compile.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).



<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19007)
<!-- Reviewable:end -->
