### PR TITLE
stylo: Honor CallerType for media query parsing.

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -14,6 +14,7 @@ use gecko_bindings::structs::mozilla::css::ErrorReporter;
 use gecko_bindings::structs::mozilla::css::ImageValue;
 use gecko_bindings::structs::mozilla::css::URLValue;
 use gecko_bindings::structs::mozilla::css::URLValueData;
+use gecko_bindings::structs::mozilla::dom::CallerType;
 use gecko_bindings::structs::mozilla::AnonymousCounterStyle;
 use gecko_bindings::structs::mozilla::AtomArray;
 use gecko_bindings::structs::mozilla::MallocSizeOf;
@@ -2868,7 +2869,8 @@ extern "C" {
 }
 extern "C" {
     pub fn Servo_MediaList_SetText(list: RawServoMediaListBorrowed,
-                                   text: *const nsACString);
+                                   text: *const nsACString,
+                                   aCallerType: CallerType);
 }
 extern "C" {
     pub fn Servo_MediaList_GetLength(list: RawServoMediaListBorrowed) -> u32;


### PR DESCRIPTION
So that matchMedia can parse internal stuff in chrome code.

Bug: 1410074
Reviewed-by: xidorn
MozReview-Commit-ID: 6M4HHqVJ1dp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19014)
<!-- Reviewable:end -->
