### PR TITLE
style: Fix detection of animations to avoid style flushing in getComputedStyle.

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -4370,11 +4370,23 @@ pub extern "C" fn Servo_ProcessInvalidations(
 pub extern "C" fn Servo_HasPendingRestyleAncestor(element: RawGeckoElementBorrowed) -> bool {
     let mut element = Some(GeckoElement(element));
     while let Some(e) = element {
+        if e.has_animations() {
+            return true;
+        }
+
+        // If the element needs a frame, it means that we haven't styled it yet
+        // after it got inserted in the document, and thus we may need to do
+        // that for transitions and animations to trigger.
+        if e.needs_frame() {
+            return true;
+        }
+
         if let Some(data) = e.borrow_data() {
             if !data.hint.is_empty() {
                 return true;
             }
         }
+
         element = e.traversal_parent();
     }
     false


### PR DESCRIPTION
This fixes multiple things:

 * EffectCompositor was using the light tree instead of the flat tree.

 * When we insert an element inside the document, we may not style it right away
   (we mark it for lazy frame construction with the NODE_NEEDS_FRAME). Since we
   trigger animations and transitions from the traversal, we can't skip flushing
   if we call getComputedStyle on any of those.

Bug: 1406750
Reviewed-by: hiro
MozReview-Commit-ID: DpAhmLH3uJ2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19016)
<!-- Reviewable:end -->
