### PR TITLE
Print the full path for errors occurring in the servo crate

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,13 +1,13 @@
 [target.arm-linux-androideabi]
-linker = "./fake-ld-arm.sh"
+linker = "./ports/servo/fake-ld-arm.sh"
 ar = "arm-linux-androideabi-ar"
 
 [target.armv7-linux-androideabi]
-linker = "./fake-ld-armv7.sh"
+linker = "./ports/servo/fake-ld-armv7.sh"
 ar = "arm-linux-androideabi-ar"
 
 [target.aarch64-linux-android]
-linker = "./fake-ld-arm64.sh"
+linker = "./ports/servo/fake-ld-arm64.sh"
 ar = "aarch64-linux-android-ar"
 
 [target.arm-unknown-linux-gnueabihf]
@@ -19,4 +19,4 @@ linker = "aarch64-linux-gnu-gcc"
 ar = "aarch64-linux-gnu-ar"
 
 [target.'cfg(target_os=windows)']
-linker = "./fake-ld.cmd"
+linker = "./ports/servo/fake-ld.cmd"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.servo
-/.cargo
+/.cargo/*
+!/.cargo/config.*
 /.servobuild
 /target
 /ports/android/bin

--- a/ports/servo/fake-ld-arm.sh
+++ b/ports/servo/fake-ld-arm.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source fake-ld.sh
+source ./ports/servo/fake-ld.sh
 
 export _GCC_PARAMS="${@}"
 call_gcc "arch-arm" "arm-linux-androideabi" "android-18" "armeabi"

--- a/ports/servo/fake-ld-arm64.sh
+++ b/ports/servo/fake-ld-arm64.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source fake-ld.sh
+source ./ports/servo/fake-ld.sh
 
 export _GCC_PARAMS="${@}"
 call_gcc "arch-arm64" "aarch64-linux-android" "android-21" "arm64-v8a"

--- a/ports/servo/fake-ld-armv7.sh
+++ b/ports/servo/fake-ld-armv7.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source fake-ld.sh
+source ./ports/servo/fake-ld.sh
 
 export _GCC_PARAMS="${@}"
 call_gcc "arch-arm" "arm-linux-androideabi" "android-18" "armeabi-v7a"

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -176,11 +176,13 @@ class MachCommands(CommandBase):
     def build(self, target=None, release=False, dev=False, jobs=None,
               features=None, android=None, verbose=False, debug_mozjs=False, params=None,
               with_debug_assertions=False):
+
+        opts = params or []
+        opts += ["--manifest-path", self.servo_manifest()]
+
         if android is None:
             android = self.config["build"]["android"]
         features = features or self.servo_features()
-
-        opts = params or []
 
         base_path = self.get_target_dir()
         release_path = path.join(base_path, "release", "servo")
@@ -318,8 +320,7 @@ class MachCommands(CommandBase):
         cargo_binary = "cargo" + BIN_SUFFIX
 
         status = call(
-            [cargo_binary, "build"] + opts,
-            env=env, cwd=self.servo_crate(), verbose=verbose)
+            [cargo_binary, "build"] + opts, env=env, verbose=verbose)
         elapsed = time() - build_start
 
         # Do some additional things if the build succeeded
@@ -384,6 +385,8 @@ class MachCommands(CommandBase):
 
         ret = None
         opts = []
+        opts += ["--manifest-path", self.cef_manifest()]
+
         if jobs is not None:
             opts += ["-j", jobs]
         if verbose:
@@ -407,10 +410,7 @@ class MachCommands(CommandBase):
             # common dependencies with the same flags.
             opts += ["--", "-C", "link-args=-Xlinker -undefined -Xlinker dynamic_lookup"]
 
-        with cd(path.join("ports", "cef")):
-            ret = call(["cargo", "rustc"] + opts,
-                       env=env,
-                       verbose=verbose)
+        ret = call(["cargo", "rustc"] + opts, env=env, verbose=verbose)
         elapsed = time() - build_start
 
         # Generate Desktop Notification if elapsed-time > some threshold value
@@ -441,20 +441,20 @@ class MachCommands(CommandBase):
 
         ret = None
         opts = []
+        opts += ["--manifest-path", self.geckolib_manifest()]
         features = []
+
         if jobs is not None:
             opts += ["-j", jobs]
         if verbose:
             opts += ["-v"]
         if release:
             opts += ["--release"]
-
         if features:
             opts += ["--features", ' '.join(features)]
 
         build_start = time()
-        with cd(path.join("ports", "geckolib")):
-            ret = call(["cargo", "build"] + opts, env=env, verbose=verbose)
+        ret = call(["cargo", "build"] + opts, env=env, verbose=verbose)
         elapsed = time() - build_start
 
         # Generate Desktop Notification if elapsed-time > some threshold value

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -545,6 +545,15 @@ class CommandBase(object):
     def servo_crate(self):
         return path.join(self.context.topdir, "ports", "servo")
 
+    def servo_manifest(self):
+        return path.join(self.context.topdir, "ports", "servo", "Cargo.toml")
+
+    def geckolib_manifest(self):
+        return path.join(self.context.topdir, "ports", "geckolib", "Cargo.toml")
+
+    def cef_manifest(self):
+        return path.join(self.context.topdir, "ports", "cef", "Cargo.toml")
+
     def servo_features(self):
         """Return a list of optional features to enable for the Servo crate"""
         features = []


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`Cargo` will print the path where it runs.
Origin python script `cd` into the crate folder, so the root path is set in  the crate.
Now I use `--manifest-path PATH` to `cargo build`, so the root path is at `servo`.

Origin path in error message:
```
error: expected one of `!` or `::`, found `#`
  --> lib.rs:24:1
```

Now it would be:
```
error: expected one of `!` or `::`, found `use`
  --> ports/geckolib/glue.rs:11:1
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #9895 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19017)
<!-- Reviewable:end -->
