### PR TITLE
Introduce style::dom::TDocument.

### DIFF
--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -187,6 +187,10 @@ impl<'ln> TNode for ServoLayoutNode<'ln> {
         }
     }
 
+    fn owner_doc(&self) -> Self::ConcreteDocument {
+        ServoLayoutDocument::from_layout_js(unsafe { self.node.owner_doc_for_layout() })
+    }
+
     fn traversal_parent(&self) -> Option<ServoLayoutElement<'ln>> {
         self.parent_element()
     }
@@ -778,7 +782,11 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
 
     fn is_html_element_in_html_document(&self) -> bool {
         unsafe {
-            self.element.html_element_in_html_document_for_layout()
+            if !self.element.is_html_element() {
+                return false;
+            }
+
+            self.as_node().node.owner_doc_for_layout().is_html_document_for_layout()
         }
     }
 }

--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -51,7 +51,7 @@ use script_layout_interface::{OpaqueStyleAndLayoutData, StyleData};
 use script_layout_interface::wrapper_traits::{DangerousThreadSafeLayoutNode, GetLayoutData, LayoutNode};
 use script_layout_interface::wrapper_traits::{PseudoElementType, ThreadSafeLayoutElement, ThreadSafeLayoutNode};
 use selectors::attr::{AttrSelectorOperation, NamespaceConstraint, CaseSensitivity};
-use selectors::matching::{ElementSelectorFlags, MatchingContext, RelevantLinkStatus};
+use selectors::matching::{ElementSelectorFlags, MatchingContext, QuirksMode, RelevantLinkStatus};
 use selectors::matching::VisitedHandlingMode;
 use selectors::sink::Push;
 use servo_arc::{Arc, ArcBorrow};
@@ -297,6 +297,14 @@ impl<'ld> TDocument for ServoLayoutDocument<'ld> {
 
     fn as_node(&self) -> Self::ConcreteNode {
         ServoLayoutNode::from_layout_js(self.document.upcast())
+    }
+
+    fn quirks_mode(&self) -> QuirksMode {
+        unsafe { self.document.quirks_mode() }
+    }
+
+    fn is_html_document(&self) -> bool {
+        unsafe { self.document.is_html_document_for_layout() }
     }
 }
 
@@ -785,9 +793,9 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
             if !self.element.is_html_element() {
                 return false;
             }
-
-            self.as_node().node.owner_doc_for_layout().is_html_document_for_layout()
         }
+
+        self.as_node().owner_doc().is_html_document()
     }
 }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -446,7 +446,7 @@ pub trait LayoutElementHelpers {
     #[allow(unsafe_code)]
     unsafe fn get_rowspan(self) -> u32;
     #[allow(unsafe_code)]
-    unsafe fn html_element_in_html_document_for_layout(&self) -> bool;
+    unsafe fn is_html_element(&self) -> bool;
     fn id_attribute(&self) -> *const Option<Atom>;
     fn style_attribute(&self) -> *const Option<Arc<Locked<PropertyDeclarationBlock>>>;
     fn local_name(&self) -> &LocalName;
@@ -781,11 +781,8 @@ impl LayoutElementHelpers for LayoutDom<Element> {
 
     #[inline]
     #[allow(unsafe_code)]
-    unsafe fn html_element_in_html_document_for_layout(&self) -> bool {
-        if (*self.unsafe_get()).namespace != ns!(html) {
-            return false;
-        }
-        self.upcast::<Node>().owner_doc_for_layout().is_html_document_for_layout()
+    unsafe fn is_html_element(&self) -> bool {
+        (*self.unsafe_get()).namespace == ns!(html)
     }
 
     #[allow(unsafe_code)]

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -133,11 +133,23 @@ where
     }
 }
 
+/// The `TDocument` trait, to represent a document node.
+pub trait TDocument : Sized + Copy + Clone {
+    /// The concrete `TNode` type.
+    type ConcreteNode: TNode<ConcreteDocument = Self>;
+
+    /// Get this document as a `TNode`.
+    fn as_node(&self) -> Self::ConcreteNode;
+}
+
 /// The `TNode` trait. This is the main generic trait over which the style
 /// system can be implemented.
 pub trait TNode : Sized + Copy + Clone + Debug + NodeInfo + PartialEq {
     /// The concrete `TElement` type.
     type ConcreteElement: TElement<ConcreteNode = Self>;
+
+    /// The concrete `TDocument` type.
+    type ConcreteDocument: TDocument<ConcreteNode = Self>;
 
     /// Get this node's parent node.
     fn parent_node(&self) -> Option<Self>;
@@ -210,6 +222,9 @@ pub trait TNode : Sized + Copy + Clone + Debug + NodeInfo + PartialEq {
 
     /// Get this node as an element, if it's one.
     fn as_element(&self) -> Option<Self::ConcreteElement>;
+
+    /// Get this node as a document, if it's one.
+    fn as_document(&self) -> Option<Self::ConcreteDocument>;
 
     /// Whether this node can be fragmented. This is used for multicol, and only
     /// for Servo.

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -22,7 +22,7 @@ use properties::{AnimationRules, ComputedValues, PropertyDeclarationBlock};
 use rule_tree::CascadeLevel;
 use selector_parser::{AttrValue, PseudoClassStringArg, PseudoElement, SelectorImpl};
 use selectors::Element as SelectorsElement;
-use selectors::matching::{ElementSelectorFlags, VisitedHandlingMode};
+use selectors::matching::{ElementSelectorFlags, QuirksMode, VisitedHandlingMode};
 use selectors::sink::Push;
 use servo_arc::{Arc, ArcBorrow};
 use shared_lock::Locked;
@@ -140,6 +140,12 @@ pub trait TDocument : Sized + Copy + Clone {
 
     /// Get this document as a `TNode`.
     fn as_node(&self) -> Self::ConcreteNode;
+
+    /// Returns whether this document is an HTML document.
+    fn is_html_document(&self) -> bool;
+
+    /// Returns the quirks mode of this document.
+    fn quirks_mode(&self) -> QuirksMode;
 }
 
 /// The `TNode` trait. This is the main generic trait over which the style

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -166,6 +166,9 @@ pub trait TNode : Sized + Copy + Clone + Debug + NodeInfo + PartialEq {
     /// Get this node's next sibling.
     fn next_sibling(&self) -> Option<Self>;
 
+    /// Get the owner document of this node.
+    fn owner_doc(&self) -> Self::ConcreteDocument;
+
     /// Iterate over the DOM children of a node.
     fn dom_children(&self) -> DomChildren<Self> {
         DomChildren(self.first_child())

--- a/components/style/dom_apis.rs
+++ b/components/style/dom_apis.rs
@@ -6,7 +6,7 @@
 //! and Gecko.
 
 use context::QuirksMode;
-use dom::{TElement, TNode};
+use dom::{TDocument, TElement, TNode};
 use invalidation::element::invalidator::{Invalidation, InvalidationProcessor, InvalidationVector};
 use selectors::{Element, NthIndexCache, SelectorList};
 use selectors::matching::{self, MatchingContext, MatchingMode};
@@ -308,7 +308,6 @@ pub fn query_selector<E, Q>(
     root: E::ConcreteNode,
     selector_list: &SelectorList<E::Impl>,
     results: &mut Q::Output,
-    quirks_mode: QuirksMode,
 )
 where
     E: TElement,
@@ -316,6 +315,7 @@ where
 {
     use invalidation::element::invalidator::TreeStyleInvalidator;
 
+    let quirks_mode = root.owner_doc().quirks_mode();
     let fast_result = query_selector_fast::<E, Q>(
         root,
         selector_list,


### PR DESCRIPTION
The secret plan is introducing a `get_elements_with_id` for use by `querySelector` / `querySelectorAll`. 

But this allows also to make some code look a bit nicer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19024)
<!-- Reviewable:end -->
