### PR TITLE
Update Browser.html again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 [[package]]
 name = "browserhtml"
 version = "0.1.17"
-source = "git+https://github.com/browserhtml/browserhtml?branch=crate#70ad96070f86a8f76b7309ca3cf3b34b88a9da2a"
+source = "git+https://github.com/browserhtml/browserhtml?branch=crate#84913eafd817c92fbb6bdbb8a8f7480baddee3d3"
 
 [[package]]
 name = "byteorder"


### PR DESCRIPTION
Update Browser.html again to latest version to pick up Font Awseome WOFF file change that got lost in the process. Should fix the missing interface icons on Windows.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes fix #15255 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19025)
<!-- Reviewable:end -->
