### PR TITLE
Improve system font selection under Freetype

### DIFF
--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -40,13 +40,32 @@ impl FontTemplateDescriptor {
     ///
     /// The smaller the score, the better the fonts match. 0 indicates an exact match. This must
     /// be commutative (distance(A, B) == distance(B, A)).
+    ///
+    /// The policy is care most about differences in italicness, then weight, then stretch
     #[inline]
     fn distance_from(&self, other: &FontTemplateDescriptor) -> u32 {
-        if self.stretch != other.stretch || self.italic != other.italic {
-            // A value higher than all weights.
-            return 1000
+        let italic_part = if self.italic == other.italic { 0 } else { 1000 };
+        // 0 <= weightPart <= 800
+        let weight_part = ((self.weight.0 as i16) - (other.weight.0 as i16)).abs() as u32;
+        // 0 <= stretchPart <= 8
+        let stretch_part = (self.stretch_number() - other.stretch_number()).abs() as u32;
+        italic_part + weight_part + stretch_part
+    }
+
+    /// Returns a number between 1 and 9 for the stretch property.
+    /// 1 is ultra_condensed, 5 is normal, and 9 is ultra_expanded
+    fn stretch_number(&self) -> i32 {
+        match self.stretch {
+            font_stretch::T::ultra_condensed => 1,
+            font_stretch::T::extra_condensed => 2,
+            font_stretch::T::condensed       => 3,
+            font_stretch::T::semi_condensed  => 4,
+            font_stretch::T::normal          => 5,
+            font_stretch::T::semi_expanded   => 6,
+            font_stretch::T::expanded        => 7,
+            font_stretch::T::extra_expanded  => 8,
+            font_stretch::T::ultra_expanded  => 9,
         }
-        ((self.weight.0 as i16) - (other.weight.0 as i16)).abs() as u32
     }
 }
 

--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -41,7 +41,7 @@ impl FontTemplateDescriptor {
     /// The smaller the score, the better the fonts match. 0 indicates an exact match. This must
     /// be commutative (distance(A, B) == distance(B, A)).
     ///
-    /// The policy is care most about differences in italicness, then weight, then stretch
+    /// The policy is to care most about differences in italicness, then weight, then stretch
     #[inline]
     fn distance_from(&self, other: &FontTemplateDescriptor) -> u32 {
         let italic_part = if self.italic == other.italic { 0 } else { 1000 };

--- a/components/gfx/font_template.rs
+++ b/components/gfx/font_template.rs
@@ -54,6 +54,7 @@ impl FontTemplateDescriptor {
 
     /// Returns a number between 1 and 9 for the stretch property.
     /// 1 is ultra_condensed, 5 is normal, and 9 is ultra_expanded
+    #[inline]
     fn stretch_number(&self) -> i32 {
         match self.stretch {
             font_stretch::T::ultra_condensed => 1,

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -10,7 +10,7 @@ use freetype::freetype::{FT_F26Dot6, FT_Face, FT_FaceRec};
 use freetype::freetype::{FT_Get_Char_Index, FT_Get_Postscript_Name};
 use freetype::freetype::{FT_Get_Kerning, FT_Get_Sfnt_Table, FT_Load_Sfnt_Table};
 use freetype::freetype::{FT_GlyphSlot, FT_Library, FT_Long, FT_ULong};
-use freetype::freetype::{FT_Int32, FT_Kerning_Mode, FT_STYLE_FLAG_BOLD, FT_STYLE_FLAG_ITALIC};
+use freetype::freetype::{FT_Int32, FT_Kerning_Mode, FT_STYLE_FLAG_ITALIC};
 use freetype::freetype::{FT_Load_Glyph, FT_Set_Char_Size};
 use freetype::freetype::{FT_SizeRec, FT_Size_Metrics, FT_UInt, FT_Vector};
 use freetype::freetype::FT_Sfnt_Tag;
@@ -136,24 +136,20 @@ impl FontHandleMethods for FontHandle {
     }
     fn boldness(&self) -> font_weight::T {
         let default_weight = font_weight::T::normal();
-        if unsafe { (*self.face).style_flags & FT_STYLE_FLAG_BOLD as c_long == 0 } {
-            default_weight
-        } else {
-            unsafe {
-                let os2 = FT_Get_Sfnt_Table(self.face, FT_Sfnt_Tag::FT_SFNT_OS2) as *mut TT_OS2;
-                let valid = !os2.is_null() && (*os2).version != 0xffff;
-                if valid {
-                    let weight =(*os2).usWeightClass as i32;
-                    if weight < 10 {
-                        font_weight::T::from_int(weight * 100).unwrap()
-                    } else if weight >= 100 && weight < 1000 {
-                        font_weight::T::from_int(weight / 100 * 100).unwrap()
-                    } else {
-                        default_weight
-                    }
+        unsafe {
+            let os2 = FT_Get_Sfnt_Table(self.face, FT_Sfnt_Tag::FT_SFNT_OS2) as *mut TT_OS2;
+            let valid = !os2.is_null() && (*os2).version != 0xffff;
+            if valid {
+                let weight =(*os2).usWeightClass as i32;
+                if weight < 10 {
+                    font_weight::T::from_int(weight * 100).unwrap()
+                } else if weight >= 100 && weight < 1000 {
+                    font_weight::T::from_int(weight / 100 * 100).unwrap()
                 } else {
                     default_weight
                 }
+            } else {
+                default_weight
             }
         }
     }

--- a/tests/html/font_selection.html
+++ b/tests/html/font_selection.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+<!-- for testing font selection (based on font-stretch, font-weight, etc) -->
+<style>
+body {
+    font-size: 20pt;
+    font-family: "DejaVu Sans", "Helvetica Neue", sans;
+}
+table { border-collapse: collapse; }
+td {
+    border: 1px solid #bbb;
+    padding: 2pt;
+    text-align: center;
+}
+td:nth-child(1) { font-weight: 100; }
+td:nth-child(2) { font-weight: 200; }
+td:nth-child(3) { font-weight: 300; }
+td:nth-child(4) { font-weight: 400; }
+td:nth-child(5) { font-weight: 500; }
+td:nth-child(6) { font-weight: 600; }
+td:nth-child(7) { font-weight: 700; }
+td:nth-child(8) { font-weight: 800; }
+td:nth-child(9) { font-weight: 900; }
+.s1 { font-stretch: ultra-condensed; }
+.s2 { font-stretch: extra-condensed; }
+.s3 { font-stretch: semi-condensed; }
+.s4 { font-stretch: condensed; }
+.s5 { font-stretch: normal; }
+.s6 { font-stretch: semi-expanded; }
+.s7 { font-stretch: expanded; }
+.s8 { font-stretch: extra-expanded; }
+.s9 { font-stretch: ultra-expanded; }
+</style>
+</head>
+<body>
+<table>
+<tr class="s1">
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+</tr>
+<tr class="s2">
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+</tr>
+<tr class="s3">
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+</tr>
+<tr class="s4">
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+</tr>
+<tr class="s5">
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+</tr>
+<tr class="s6">
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+</tr>
+<tr class="s7">
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+</tr>
+<tr class="s8">
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+</tr>
+<tr class="s9">
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+<td>two words</td><td>two words</td><td>two words</td>
+</tr>
+</table>
+</body>
+</htlm>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Corrected the implementations for `boldness` and `stretchiness` for the Freetype platform. The old implementation for `boldness` was incorrect for fonts which are lighter than normal and the old implementation for `stretchiness` was incomplete and returned a default value.

Improved the metric used to pick a font close to a given style.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes have tests here: `tests/html/font_selection.html`

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19026)
<!-- Reviewable:end -->
