### PR TITLE
style: Move -x-text-zoom outside of mako

### DIFF
--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -2239,36 +2239,13 @@ ${helpers.single_keyword("-moz-math-variant",
     }
 </%helpers:longhand>
 
-<%helpers:longhand name="-x-text-zoom" products="gecko" animation_value_type="none" internal="True"
-                   spec="Internal (not web-exposed)">
-    pub use self::computed_value::T as SpecifiedValue;
-
-    pub mod computed_value {
-        use std::fmt;
-        use style_traits::ToCss;
-
-        impl ToCss for T {
-            fn to_css<W>(&self, _: &mut W) -> fmt::Result where W: fmt::Write {
-                Ok(())
-            }
-        }
-
-        #[derive(Clone, Debug, MallocSizeOf, PartialEq, ToComputedValue)]
-        /// text-zoom. Enable if true, disable if false
-        pub struct T(pub bool);
-    }
-
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        computed_value::T(true)
-    }
-
-    pub fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
-                         -> Result<SpecifiedValue, ParseError<'i>> {
-        debug_assert!(false, "Should be set directly by presentation attributes only.");
-        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
-    }
-</%helpers:longhand>
+${helpers.predefined_type("-x-text-zoom",
+                          "XTextZoom",
+                          "computed::XTextZoom(true)",
+                          animation_value_type="none",
+                          products="gecko",
+                          internal=True,
+                          spec="Internal (not web-exposed)")}
 
 % if product == "gecko":
     pub mod system_font {

--- a/components/style/values/computed/font.rs
+++ b/components/style/values/computed/font.rs
@@ -11,6 +11,8 @@ use values::animated::ToAnimatedValue;
 use values::computed::NonNegativeLength;
 use values::specified::font as specified;
 
+pub use values::specified::font::XTextZoom;
+
 #[derive(Animate, ComputeSquaredDistance, MallocSizeOf, ToAnimatedZero)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 /// The computed value of font-size

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -36,6 +36,7 @@ pub use self::angle::Angle;
 pub use self::background::{BackgroundSize, BackgroundRepeat};
 pub use self::border::{BorderImageSlice, BorderImageWidth, BorderImageSideWidth};
 pub use self::border::{BorderRadius, BorderCornerRadius, BorderSpacing};
+pub use self::font::XTextZoom;
 pub use self::box_::{AnimationIterationCount, AnimationName, ScrollSnapType, VerticalAlign};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};

--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -8,9 +8,10 @@
 use Atom;
 use app_units::Au;
 use cssparser::Parser;
+use parser::{Parse, ParserContext};
 use properties::longhands::system_font::SystemFont;
 use std::fmt;
-use style_traits::{ToCss, ParseError};
+use style_traits::{ToCss, StyleParseErrorKind, ParseError};
 use values::computed::{font as computed, Context, NonNegativeLength, ToComputedValue};
 use values::specified::{LengthOrPercentage, NoCalcLength};
 use values::specified::length::FontBaseSize;
@@ -371,5 +372,22 @@ impl FontSize {
         } else {
             None
         }
+    }
+}
+
+#[derive(Clone, Debug, MallocSizeOf, PartialEq, ToComputedValue)]
+/// text-zoom. Enable if true, disable if false
+pub struct XTextZoom(pub bool);
+
+impl Parse for XTextZoom {
+    fn parse<'i, 't>(_: &ParserContext, input: &mut Parser<'i, 't>) -> Result<XTextZoom, ParseError<'i>> {
+        debug_assert!(false, "Should be set directly by presentation attributes only.");
+        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
+    }
+}
+
+impl ToCss for XTextZoom {
+    fn to_css<W>(&self, _: &mut W) -> fmt::Result where W: fmt::Write {
+        Ok(())
     }
 }

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -30,6 +30,7 @@ pub use self::align::{AlignItems, AlignJustifyContent, AlignJustifySelf, Justify
 pub use self::background::{BackgroundRepeat, BackgroundSize};
 pub use self::border::{BorderCornerRadius, BorderImageSlice, BorderImageWidth};
 pub use self::border::{BorderImageSideWidth, BorderRadius, BorderSideWidth, BorderSpacing};
+pub use self::font::XTextZoom;
 pub use self::box_::{AnimationIterationCount, AnimationName, ScrollSnapType, VerticalAlign};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};


### PR DESCRIPTION
Sub-PR for #19015

r? emilio 

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19020 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19030)
<!-- Reviewable:end -->
