### PR TITLE
Support multi lines declarations in the parsing of the Fx header files

### DIFF
--- a/components/style/gecko/regen_atoms.py
+++ b/components/style/gecko/regen_atoms.py
@@ -39,14 +39,16 @@ def msvc32_symbolify(source, ident):
 
 
 class GkAtomSource:
-    PATTERN = re.compile('^(GK_ATOM)\((.+),\s*"(.*)"\)')
+    PATTERN = re.compile('^(GK_ATOM)\(([^,]*),[^"]*"([^"]*)"\)',
+                         re.MULTILINE)
     FILE = "include/nsGkAtomList.h"
     CLASS = "nsGkAtoms"
     TYPE = "nsStaticAtom"
 
 
 class CSSPseudoElementsAtomSource:
-    PATTERN = re.compile('^(CSS_PSEUDO_ELEMENT)\((.+),\s*"(.*)",')
+    PATTERN = re.compile('^(CSS_PSEUDO_ELEMENT)\(([^,]*),[^"]*"([^"]*)",',
+                         re.MULTILINE)
     FILE = "include/nsCSSPseudoElementList.h"
     CLASS = "nsCSSPseudoElements"
     # NB: nsICSSPseudoElement is effectively the same as a nsStaticAtom, but we need
@@ -55,7 +57,8 @@ class CSSPseudoElementsAtomSource:
 
 
 class CSSAnonBoxesAtomSource:
-    PATTERN = re.compile('^(CSS_ANON_BOX|CSS_NON_INHERITING_ANON_BOX|CSS_WRAPPER_ANON_BOX)\((.+),\s*"(.*)"\)')
+    PATTERN = re.compile('^(CSS_ANON_BOX|CSS_NON_INHERITING_ANON_BOX|CSS_WRAPPER_ANON_BOX)\(([^,]*),[^"]*"([^"]*)"\)',
+                         re.MULTILINE)
     FILE = "include/nsCSSAnonBoxList.h"
     CLASS = "nsCSSAnonBoxes"
     TYPE = "nsICSSAnonBoxPseudo"
@@ -123,10 +126,9 @@ def collect_atoms(objdir):
         path = os.path.abspath(os.path.join(objdir, source.FILE))
         print("cargo:rerun-if-changed={}".format(path))
         with open(path) as f:
-            for line in f.readlines():
-                result = re.match(source.PATTERN, line)
-                if result:
-                    atoms.append(Atom(source, result.group(1), result.group(2), result.group(3)))
+            content = f.read()
+            for result in source.PATTERN.finditer(content):
+                atoms.append(Atom(source, result.group(1), result.group(2), result.group(3)))
     return atoms
 
 


### PR DESCRIPTION
For example, in dom/base/nsGkAtomList.h, we currently have:

`GK_ATOM(mouseWheel, "mouseWheel")  // For discrete wheel events (e.g. not OSX magic mouse)`

but if we change to
```
GK_ATOM(mouseWheel,
        "mouseWheel")  // For discrete wheel events (e.g. not OSX magic mouse)
```
The parser didn't handle the declaration

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19039)
<!-- Reviewable:end -->
