### PR TITLE
Add support for filtering WebGL extensions based on WebGL version

### DIFF
--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -74,7 +74,7 @@ pub enum WebGLContextShareMode {
 }
 
 /// Defines the WebGL version
-#[derive(Clone, Copy, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Copy, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
 pub enum WebGLVersion {
     /// https://www.khronos.org/registry/webgl/specs/1.0.2/
     /// Conforms closely to the OpenGL ES 2.0 API

--- a/components/script/dom/webgl_extensions/ext/mod.rs
+++ b/components/script/dom/webgl_extensions/ext/mod.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextConstants as constants;
-use super::{ext_constants, WebGLExtension, WebGLExtensions};
+use super::{ext_constants, WebGLExtension, WebGLExtensions, WebGLExtensionSpec};
 
 pub mod oesstandardderivatives;
 pub mod oestexturefloat;

--- a/components/script/dom/webgl_extensions/ext/oesstandardderivatives.rs
+++ b/components/script/dom/webgl_extensions/ext/oesstandardderivatives.rs
@@ -2,13 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use canvas_traits::webgl::WebGLVersion;
 use dom::bindings::codegen::Bindings::OESStandardDerivativesBinding;
 use dom::bindings::codegen::Bindings::OESStandardDerivativesBinding::OESStandardDerivativesConstants;
 use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
 use dom::bindings::root::DomRoot;
 use dom::webglrenderingcontext::WebGLRenderingContext;
 use dom_struct::dom_struct;
-use super::{WebGLExtension, WebGLExtensions};
+use super::{WebGLExtension, WebGLExtensions, WebGLExtensionSpec};
 
 #[dom_struct]
 pub struct OESStandardDerivatives {
@@ -29,6 +30,10 @@ impl WebGLExtension for OESStandardDerivatives {
         reflect_dom_object(Box::new(OESStandardDerivatives::new_inherited()),
                            &*ctx.global(),
                            OESStandardDerivativesBinding::Wrap)
+    }
+
+    fn spec() -> WebGLExtensionSpec {
+        WebGLExtensionSpec::Specific(WebGLVersion::WebGL1)
     }
 
     fn is_supported(ext: &WebGLExtensions) -> bool {

--- a/components/script/dom/webgl_extensions/ext/oestexturefloat.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturefloat.rs
@@ -2,12 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use canvas_traits::webgl::WebGLVersion;
 use dom::bindings::codegen::Bindings::OESTextureFloatBinding;
 use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
 use dom::bindings::root::DomRoot;
 use dom::webglrenderingcontext::WebGLRenderingContext;
 use dom_struct::dom_struct;
-use super::{constants as webgl, ext_constants as gl, WebGLExtension, WebGLExtensions};
+use super::{constants as webgl, ext_constants as gl, WebGLExtension, WebGLExtensions, WebGLExtensionSpec};
 
 #[dom_struct]
 pub struct OESTextureFloat {
@@ -28,6 +29,10 @@ impl WebGLExtension for OESTextureFloat {
         reflect_dom_object(Box::new(OESTextureFloat::new_inherited()),
                            &*ctx.global(),
                            OESTextureFloatBinding::Wrap)
+    }
+
+    fn spec() -> WebGLExtensionSpec {
+        WebGLExtensionSpec::Specific(WebGLVersion::WebGL1)
     }
 
     fn is_supported(ext: &WebGLExtensions) -> bool {

--- a/components/script/dom/webgl_extensions/ext/oestexturefloatlinear.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturefloatlinear.rs
@@ -7,7 +7,7 @@ use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
 use dom::bindings::root::DomRoot;
 use dom::webglrenderingcontext::WebGLRenderingContext;
 use dom_struct::dom_struct;
-use super::{constants as webgl, WebGLExtension, WebGLExtensions};
+use super::{constants as webgl, WebGLExtension, WebGLExtensions, WebGLExtensionSpec};
 
 #[dom_struct]
 pub struct OESTextureFloatLinear {
@@ -28,6 +28,10 @@ impl WebGLExtension for OESTextureFloatLinear {
         reflect_dom_object(Box::new(OESTextureFloatLinear::new_inherited()),
                            &*ctx.global(),
                            OESTextureFloatLinearBinding::Wrap)
+    }
+
+    fn spec() -> WebGLExtensionSpec {
+        WebGLExtensionSpec::All
     }
 
     fn is_supported(ext: &WebGLExtensions) -> bool {

--- a/components/script/dom/webgl_extensions/ext/oestexturehalffloat.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturehalffloat.rs
@@ -2,12 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use canvas_traits::webgl::WebGLVersion;
 use dom::bindings::codegen::Bindings::OESTextureHalfFloatBinding::{self, OESTextureHalfFloatConstants};
 use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
 use dom::bindings::root::DomRoot;
 use dom::webglrenderingcontext::WebGLRenderingContext;
 use dom_struct::dom_struct;
-use super::{constants as webgl, ext_constants as gl, WebGLExtension, WebGLExtensions};
+use super::{constants as webgl, ext_constants as gl, WebGLExtension, WebGLExtensions, WebGLExtensionSpec};
 
 #[dom_struct]
 pub struct OESTextureHalfFloat {
@@ -28,6 +29,10 @@ impl WebGLExtension for OESTextureHalfFloat {
         reflect_dom_object(Box::new(OESTextureHalfFloat::new_inherited()),
                            &*ctx.global(),
                            OESTextureHalfFloatBinding::Wrap)
+    }
+
+    fn spec() -> WebGLExtensionSpec {
+        WebGLExtensionSpec::Specific(WebGLVersion::WebGL1)
     }
 
     fn is_supported(ext: &WebGLExtensions) -> bool {

--- a/components/script/dom/webgl_extensions/ext/oestexturehalffloatlinear.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturehalffloatlinear.rs
@@ -8,7 +8,7 @@ use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
 use dom::bindings::root::DomRoot;
 use dom::webglrenderingcontext::WebGLRenderingContext;
 use dom_struct::dom_struct;
-use super::{WebGLExtension, WebGLExtensions};
+use super::{WebGLExtension, WebGLExtensions, WebGLExtensionSpec};
 
 #[dom_struct]
 pub struct OESTextureHalfFloatLinear {
@@ -29,6 +29,10 @@ impl WebGLExtension for OESTextureHalfFloatLinear {
         reflect_dom_object(Box::new(OESTextureHalfFloatLinear::new_inherited()),
                            &*ctx.global(),
                            OESTextureHalfFloatLinearBinding::Wrap)
+    }
+
+    fn spec() -> WebGLExtensionSpec {
+        WebGLExtensionSpec::All
     }
 
     fn is_supported(ext: &WebGLExtensions) -> bool {

--- a/components/script/dom/webgl_extensions/ext/oesvertexarrayobject.rs
+++ b/components/script/dom/webgl_extensions/ext/oesvertexarrayobject.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use canvas_traits::webgl::{webgl_channel, WebGLCommand, WebGLError};
+use canvas_traits::webgl::{webgl_channel, WebGLCommand, WebGLError, WebGLVersion};
 use dom::bindings::codegen::Bindings::OESVertexArrayObjectBinding::{self, OESVertexArrayObjectMethods};
 use dom::bindings::codegen::Bindings::OESVertexArrayObjectBinding::OESVertexArrayObjectConstants;
 use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
@@ -14,7 +14,7 @@ use js::conversions::ToJSValConvertible;
 use js::jsapi::JSContext;
 use js::jsval::{JSVal, NullValue};
 use std::iter;
-use super::{WebGLExtension, WebGLExtensions};
+use super::{WebGLExtension, WebGLExtensions, WebGLExtensionSpec};
 
 #[dom_struct]
 pub struct OESVertexArrayObject {
@@ -136,6 +136,10 @@ impl WebGLExtension for OESVertexArrayObject {
         reflect_dom_object(Box::new(OESVertexArrayObject::new_inherited(ctx)),
                            &*ctx.global(),
                            OESVertexArrayObjectBinding::Wrap)
+    }
+
+    fn spec() -> WebGLExtensionSpec {
+        WebGLExtensionSpec::Specific(WebGLVersion::WebGL1)
     }
 
     fn is_supported(ext: &WebGLExtensions) -> bool {

--- a/components/script/dom/webgl_extensions/extension.rs
+++ b/components/script/dom/webgl_extensions/extension.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use canvas_traits::webgl::WebGLVersion;
 use dom::bindings::reflector::DomObject;
 use dom::bindings::root::DomRoot;
 use dom::bindings::trace::JSTraceable;
@@ -15,6 +16,9 @@ pub trait WebGLExtension: Sized where Self::Extension: DomObject + JSTraceable {
     /// Creates the DOM object of the WebGL extension.
     fn new(ctx: &WebGLRenderingContext) -> DomRoot<Self::Extension>;
 
+    /// Returns which WebGL spec is this extension written against.
+    fn spec() -> WebGLExtensionSpec;
+
     /// Checks if the extension is supported.
     fn is_supported(ext: &WebGLExtensions) -> bool;
 
@@ -23,4 +27,11 @@ pub trait WebGLExtension: Sized where Self::Extension: DomObject + JSTraceable {
 
     /// Name of the WebGL Extension.
     fn name() -> &'static str;
+}
+
+pub enum WebGLExtensionSpec {
+    /// Extensions written against both WebGL and WebGL2 specs.
+    All,
+    /// Extensions writen against a specific WebGL version spec.
+    Specific(WebGLVersion)
 }

--- a/components/script/dom/webgl_extensions/mod.rs
+++ b/components/script/dom/webgl_extensions/mod.rs
@@ -22,4 +22,5 @@ pub mod ext_constants {
 }
 
 pub use self::extension::WebGLExtension;
+pub use self::extension::WebGLExtensionSpec;
 pub use self::extensions::WebGLExtensions;

--- a/components/script/dom/webgl_extensions/wrapper.rs
+++ b/components/script/dom/webgl_extensions/wrapper.rs
@@ -9,7 +9,7 @@ use dom::bindings::trace::JSTraceable;
 use dom::webglrenderingcontext::WebGLRenderingContext;
 use malloc_size_of::MallocSizeOf;
 use std::any::Any;
-use super::{WebGLExtension, WebGLExtensions};
+use super::{WebGLExtension, WebGLExtensions, WebGLExtensionSpec};
 
 /// Trait used internally by WebGLExtensions to store and
 /// handle the different WebGL extensions in a common list.
@@ -18,6 +18,7 @@ pub trait WebGLExtensionWrapper: JSTraceable + MallocSizeOf {
                         ctx: &WebGLRenderingContext,
                         ext: &WebGLExtensions)
                         -> NonNullJSObjectPtr;
+    fn spec(&self) -> WebGLExtensionSpec;
     fn is_supported(&self, &WebGLExtensions) -> bool;
     fn is_enabled(&self) -> bool;
     fn enable(&self, ext: &WebGLExtensions);
@@ -59,6 +60,10 @@ impl<T> WebGLExtensionWrapper for TypedWebGLExtensionWrapper<T>
         unsafe {
             NonNullJSObjectPtr::new_unchecked(extension.reflector().get_jsobject().get())
         }
+    }
+
+    fn spec(&self) -> WebGLExtensionSpec {
+         T::spec()
     }
 
     fn is_supported(&self, ext: &WebGLExtensions) -> bool {

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -252,7 +252,7 @@ impl WebGLRenderingContext {
                 current_vertex_attrib_0: Cell::new((0f32, 0f32, 0f32, 1f32)),
                 current_scissor: Cell::new((0, 0, size.width, size.height)),
                 current_clear_color: Cell::new((0.0, 0.0, 0.0, 0.0)),
-                extension_manager: WebGLExtensions::new()
+                extension_manager: WebGLExtensions::new(webgl_version)
             }
         })
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Add support for filtering WebGL extensions based on WebGL version

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19040)
<!-- Reviewable:end -->
