### PR TITLE
Bug 1411583 - servo directory in-tree has no BUGZILLA_COMPONENTS info…

### DIFF
--- a/moz.build
+++ b/moz.build
@@ -1,0 +1,26 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+with Files("**"):
+    BUG_COMPONENT = ("Firefox", "General")
+
+with Files("components/style/**"):
+    BUG_COMPONENT = ("Core", "CSS Parsing and Computation")
+
+with Files("components/style_derive/**"):
+    BUG_COMPONENT = ("Core", "CSS Parsing and Computation")
+
+with Files("components/style_traits/**"):
+    BUG_COMPONENT = ("Core", "CSS Parsing and Computation")
+
+with Files("components/selectors/**"):
+    BUG_COMPONENT = ("Core", "CSS Parsing and Computation")
+
+with Files("ports/geckolib/**"):
+    BUG_COMPONENT = ("Core", "CSS Parsing and Computation")
+
+with Files("tests/unit/style/**"):
+    BUG_COMPONENT = ("Core", "CSS Parsing and Computation")


### PR DESCRIPTION
…rmation

<!-- Please describe your changes on the following line: -->
this is a new file which doesn't affect anything in servo, instead this is used for when servo is vendored into mozilla-central to build Firefox we expect all files in the tree to have a mapping to a bugzilla component.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
    - NOTE: I pushed to try to get this, running locally was taking a long time
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix https://bugzilla.mozilla.org/show_bug.cgi?id=1411583

<!-- Either: -->
- [X] These changes do not require tests because this is a meta data file for when this code is added to mozilla-central

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19041)
<!-- Reviewable:end -->
