### PR TITLE
style: Move font -moz-script-min-size outside of mako

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1119,6 +1119,7 @@ impl Clone for ${style_struct.gecko_struct_name} {
         "LengthOrNormal": impl_style_coord,
         "MaxLength": impl_style_coord,
         "MozLength": impl_style_coord,
+        "MozScriptMinSize": impl_absolute_length,
         "NonNegativeLengthOrPercentage": impl_style_coord,
         "NonNegativeNumber": impl_simple,
         "Number": impl_simple,

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -2187,57 +2187,14 @@ ${helpers.single_keyword("-moz-math-variant",
                          animation_value_type="none",
                          needs_conversion=True)}
 
-<%helpers:longhand name="-moz-script-min-size" products="gecko" animation_value_type="none"
-                   predefined_type="Length" gecko_ffi_name="mScriptMinSize"
-                   spec="Internal (not web-exposed)"
-                   internal="True">
-    use gecko_bindings::structs::NS_MATHML_DEFAULT_SCRIPT_MIN_SIZE_PT;
-    use values::computed::Length;
-    use values::specified::length::{AU_PER_PT, AU_PER_PX, FontBaseSize, NoCalcLength};
-
-    #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
-    #[derive(Clone, Debug, PartialEq, ToCss)]
-    pub struct SpecifiedValue(pub NoCalcLength);
-
-    pub mod computed_value {
-        pub type T = ::values::computed::Length;
-    }
-
-    impl ToComputedValue for SpecifiedValue {
-        type ComputedValue = computed_value::T;
-
-        fn to_computed_value(&self, cx: &Context) -> Length {
-            // this value is used in the computation of font-size, so
-            // we use the parent size
-            let base_size = FontBaseSize::InheritedStyle;
-            match self.0 {
-                NoCalcLength::FontRelative(value) => {
-                    value.to_computed_value(cx, base_size)
-                }
-                NoCalcLength::ServoCharacterWidth(value) => {
-                    value.to_computed_value(base_size.resolve(cx))
-                }
-                ref l => {
-                    l.to_computed_value(cx)
-                }
-            }
-        }
-        fn from_computed_value(other: &computed_value::T) -> Self {
-            SpecifiedValue(ToComputedValue::from_computed_value(other))
-        }
-    }
-
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        Length::new(NS_MATHML_DEFAULT_SCRIPT_MIN_SIZE_PT as f32 * (AU_PER_PT / AU_PER_PX))
-    }
-
-    pub fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
-                         -> Result<SpecifiedValue, ParseError<'i>> {
-        debug_assert!(false, "Should be set directly by presentation attributes only.");
-        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
-    }
-</%helpers:longhand>
+${helpers.predefined_type("-moz-script-min-size",
+                          "MozScriptMinSize",
+                          "specified::MozScriptMinSize::get_initial_value()",
+                          animation_value_type="none",
+                          products="gecko",
+                          internal=True,
+                          gecko_ffi_name="mScriptMinSize",
+                          spec="Internal (not web-exposed)")}
 
 ${helpers.predefined_type("-x-text-zoom",
                           "XTextZoom",

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -36,7 +36,7 @@ pub use self::angle::Angle;
 pub use self::background::{BackgroundSize, BackgroundRepeat};
 pub use self::border::{BorderImageSlice, BorderImageWidth, BorderImageSideWidth};
 pub use self::border::{BorderRadius, BorderCornerRadius, BorderSpacing};
-pub use self::font::XTextZoom;
+pub use self::font::{XTextZoom, MozScriptMinSize};
 pub use self::box_::{AnimationIterationCount, AnimationName, ScrollSnapType, VerticalAlign};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};

--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -12,9 +12,11 @@ use parser::{Parse, ParserContext};
 use properties::longhands::system_font::SystemFont;
 use std::fmt;
 use style_traits::{ToCss, StyleParseErrorKind, ParseError};
-use values::computed::{font as computed, Context, NonNegativeLength, ToComputedValue};
+use values::computed::{font as computed, Context, Length, NonNegativeLength, ToComputedValue};
 use values::specified::{LengthOrPercentage, NoCalcLength};
-use values::specified::length::FontBaseSize;
+use values::specified::length::{AU_PER_PT, AU_PER_PX, FontBaseSize};
+
+const DEFAULT_SCRIPT_MIN_SIZE_PT: u32 = 8;
 
 #[derive(Clone, Debug, MallocSizeOf, PartialEq)]
 /// A specified font-size value
@@ -389,5 +391,26 @@ impl Parse for XTextZoom {
 impl ToCss for XTextZoom {
     fn to_css<W>(&self, _: &mut W) -> fmt::Result where W: fmt::Write {
         Ok(())
+    }
+}
+
+#[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
+#[derive(Clone, Debug, PartialEq, ToCss)]
+/// Specifies the minimum font size allowed due to changes in scriptlevel.
+/// Ref: https://wiki.mozilla.org/MathML:mstyle
+pub struct MozScriptMinSize(pub NoCalcLength);
+
+impl MozScriptMinSize {
+    #[inline]
+    /// Calculate initial value of -moz-script-min-size.
+    pub fn get_initial_value() -> Length {
+        Length::new(DEFAULT_SCRIPT_MIN_SIZE_PT as f32 * (AU_PER_PT / AU_PER_PX))
+    }
+}
+
+impl Parse for MozScriptMinSize {
+    fn parse<'i, 't>(_: &ParserContext, input: &mut Parser<'i, 't>) -> Result<MozScriptMinSize, ParseError<'i>> {
+        debug_assert!(false, "Should be set directly by presentation attributes only.");
+        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
     }
 }

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -30,7 +30,7 @@ pub use self::align::{AlignItems, AlignJustifyContent, AlignJustifySelf, Justify
 pub use self::background::{BackgroundRepeat, BackgroundSize};
 pub use self::border::{BorderCornerRadius, BorderImageSlice, BorderImageWidth};
 pub use self::border::{BorderImageSideWidth, BorderRadius, BorderSideWidth, BorderSpacing};
-pub use self::font::XTextZoom;
+pub use self::font::{XTextZoom, MozScriptMinSize};
 pub use self::box_::{AnimationIterationCount, AnimationName, ScrollSnapType, VerticalAlign};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};


### PR DESCRIPTION
This is a sub-PR for #19015 
r? emilio 

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19034 (github issue number if applicable).
- [X] These changes do not require tests because _____

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19051)
<!-- Reviewable:end -->
