### PR TITLE
style: Avoid double-applying text-zoom for keywords.

### DIFF
--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -852,8 +852,7 @@ ${helpers.single_keyword_system("font-variant-caps",
                context.builder.get_font().gecko().mGenericID !=
                context.builder.get_parent_font().gecko().mGenericID {
                 if let Some(info) = computed.keyword_info {
-                    computed.size = context.maybe_zoom_text(info.kw.to_computed_value(context)
-                                                                .scale_by(info.factor) + info.offset)
+                    computed.size = info.to_computed_value(context);
                 }
             }
         % endif
@@ -885,8 +884,7 @@ ${helpers.single_keyword_system("font-variant-caps",
         let kw_inherited_size = context.builder.get_parent_font()
                                        .clone_font_size()
                                        .keyword_info.map(|info| {
-            context.maybe_zoom_text(SpecifiedValue::Keyword(info)
-                  .to_computed_value(context).size)
+            SpecifiedValue::Keyword(info).to_computed_value(context).size
         });
         let mut font = context.builder.take_font();
         font.inherit_font_size_from(context.builder.get_parent_font(),
@@ -904,9 +902,9 @@ ${helpers.single_keyword_system("font-variant-caps",
     pub fn cascade_initial_font_size(context: &mut Context) {
         // font-size's default ("medium") does not always
         // compute to the same value and depends on the font
-        let mut computed = longhands::font_size::get_initial_specified_value()
-                                            .to_computed_value(context);
-        computed.size = context.maybe_zoom_text(computed.size);
+        let computed =
+            longhands::font_size::get_initial_specified_value()
+                .to_computed_value(context);
         context.builder.mutate_font().set_font_size(computed);
         % if product == "gecko":
             let device = context.builder.device;

--- a/components/style/values/computed/font.rs
+++ b/components/style/values/computed/font.rs
@@ -38,6 +38,13 @@ pub struct KeywordInfo {
 }
 
 impl KeywordInfo {
+    /// Computes the final size for this font-size keyword, accounting for
+    /// text-zoom.
+    pub fn to_computed_value(&self, context: &Context) -> NonNegativeLength {
+        let base = context.maybe_zoom_text(self.kw.to_computed_value(context));
+        base.scale_by(self.factor) + context.maybe_zoom_text(self.offset)
+    }
+
     /// Given a parent keyword info (self), apply an additional factor/offset to it
     pub fn compose(self, factor: f32, offset: NonNegativeLength) -> Self {
         KeywordInfo {

--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -316,7 +316,7 @@ impl FontSize {
             FontSize::Keyword(i) => {
                 // As a specified keyword, this is keyword derived
                 info = Some(i);
-                context.maybe_zoom_text(i.kw.to_computed_value(context).scale_by(i.factor) + i.offset)
+                i.to_computed_value(context)
             }
             FontSize::Smaller => {
                 info = compose_keyword(1. / LARGER_FONT_SIZE_RATIO);


### PR DESCRIPTION
Bug: 1412743
Reviewed-by: Manishearth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19074)
<!-- Reviewable:end -->
