### PR TITLE
Fixes #19063

### DIFF
--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -227,7 +227,7 @@ impl ProgressiveWebMetric for InteractiveMetrics {
         self.navigation_start = Some(time);
     }
 
-    fn send_queued_constellation_msg(&self, name: ProgressiveWebMetricType, time: f64) { }
+    fn send_queued_constellation_msg(&self, _name: ProgressiveWebMetricType, _time: f64) { }
 
     fn get_time_profiler_chan(&self) -> &ProfilerChan {
         &self.time_profiler_chan


### PR DESCRIPTION
This PR renames the unused variables mentioned in issue #19063. 

- [X] `./mach build --release` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [x] These changes fix #19063

- [X] This change does not require a test because it is a relatively minimal change (? happy to make a test if it's helpful) 

"Allow edits from maintainers" is checked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19078)
<!-- Reviewable:end -->
