### PR TITLE
Fix new failure in Nightly 2017-11-01.

### DIFF
--- a/components/script_plugins/lib.rs
+++ b/components/script_plugins/lib.rs
@@ -15,6 +15,7 @@
 
 
 #![deny(unsafe_code)]
+#![feature(macro_vis_matcher)]
 #![feature(plugin)]
 #![feature(plugin_registrar)]
 #![feature(rustc_private)]


### PR DESCRIPTION
The rustc::declare_lints! macro started using a :vis fragment specifier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19083)
<!-- Reviewable:end -->
