### PR TITLE
Make the unrooted_must_root conditional on a default Cargo feature

### DIFF
--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -85,7 +85,7 @@ servo_geometry = {path = "../geometry" }
 servo_rand = {path = "../rand"}
 servo_url = {path = "../url"}
 smallvec = "0.4"
-style = {path = "../style"}
+style = {path = "../style", features = ["servo"]}
 style_traits = {path = "../style_traits"}
 swapper = "0.1"
 time = "0.1.12"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -14,6 +14,8 @@ path = "lib.rs"
 [features]
 debugmozjs = ['js/debugmozjs']
 unstable = ["servo_allocator/unstable"]
+unrooted_must_root_lint = ["script_plugins/unrooted_must_root_lint"]
+default = ["unrooted_must_root_lint"]
 
 [build-dependencies]
 cmake = "0.1"

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -16,6 +16,7 @@
 #![doc = "The script crate contains all matters DOM."]
 
 #![plugin(script_plugins)]
+#![cfg_attr(not(feature = "unrooted_must_root_lint"), allow(unknown_lints))]
 
 extern crate angle;
 extern crate app_units;

--- a/components/script_plugins/Cargo.toml
+++ b/components/script_plugins/Cargo.toml
@@ -8,3 +8,6 @@ publish = false
 [lib]
 path = "lib.rs"
 plugin = true
+
+[features]
+unrooted_must_root_lint = []

--- a/components/script_plugins/lib.rs
+++ b/components/script_plugins/lib.rs
@@ -14,27 +14,35 @@
 //!                       Use this for structs that correspond to a DOM type
 
 
+
 #![deny(unsafe_code)]
 #![feature(macro_vis_matcher)]
 #![feature(plugin)]
 #![feature(plugin_registrar)]
 #![feature(rustc_private)]
 
+#[cfg(feature = "unrooted_must_root_lint")]
 #[macro_use]
 extern crate rustc;
+
 extern crate rustc_plugin;
 extern crate syntax;
 
 use rustc_plugin::Registry;
 use syntax::feature_gate::AttributeType::Whitelisted;
 
+#[cfg(feature = "unrooted_must_root_lint")]
 mod unrooted_must_root;
+
 /// Utilities for writing plugins
+#[cfg(feature = "unrooted_must_root_lint")]
 mod utils;
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
+    #[cfg(feature = "unrooted_must_root_lint")]
     reg.register_late_lint_pass(Box::new(unrooted_must_root::UnrootedPass::new()));
+
     reg.register_attribute("allow_unrooted_interior".to_string(), Whitelisted);
     reg.register_attribute("must_root".to_string(), Whitelisted);
 }


### PR DESCRIPTION
Only http://perf.rust-lang.org/ will disable it, in order to be less subject to changes to rustc internal APIs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19098)
<!-- Reviewable:end -->
