### PR TITLE
style: Move font -moz-script-level outside of mako

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -2397,6 +2397,7 @@ fn static_assert() {
         self.copy__x_lang_from(other)
     }
 
+    ${impl_simple("_moz_script_level", "mScriptLevel")}
     <% impl_simple_type_with_conversion("font_language_override", "mFont.languageOverride") %>
 
     pub fn set_font_variant_alternates(&mut self,

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -1936,82 +1936,14 @@ https://drafts.csswg.org/css-fonts-4/#low-level-font-variation-settings-control-
     }
 </%helpers:longhand>
 
-<%helpers:longhand name="-moz-script-level" products="gecko" animation_value_type="none"
-                   predefined_type="Integer" gecko_ffi_name="mScriptLevel"
-                   spec="Internal (not web-exposed)"
-                   internal="True">
-    use std::fmt;
-    use style_traits::ToCss;
-
-
-    pub mod computed_value {
-        pub type T = i8;
-    }
-
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        0
-    }
-
-    #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
-    #[derive(Clone, Copy, Debug, PartialEq)]
-    pub enum SpecifiedValue {
-        Relative(i32),
-        Absolute(i32),
-        Auto
-    }
-
-    impl ToCss for SpecifiedValue {
-        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            match *self {
-                SpecifiedValue::Auto => dest.write_str("auto"),
-                SpecifiedValue::Relative(rel) => rel.to_css(dest),
-                // can only be specified by pres attrs; should not
-                // serialize to anything else
-                SpecifiedValue::Absolute(_) => Ok(()),
-            }
-        }
-    }
-
-    impl ToComputedValue for SpecifiedValue {
-        type ComputedValue = computed_value::T;
-
-        fn to_computed_value(&self, cx: &Context) -> i8 {
-            use properties::longhands::_moz_math_display::SpecifiedValue as DisplayValue;
-            use std::{cmp, i8};
-
-            let int = match *self {
-                SpecifiedValue::Auto => {
-                    let parent = cx.builder.get_parent_font().clone__moz_script_level() as i32;
-                    let display = cx.builder.get_parent_font().clone__moz_math_display();
-                    if display == DisplayValue::inline {
-                        parent + 1
-                    } else {
-                        parent
-                    }
-                }
-                SpecifiedValue::Relative(rel) => {
-                    let parent = cx.builder.get_parent_font().clone__moz_script_level();
-                    parent as i32 + rel
-                }
-                SpecifiedValue::Absolute(abs) => abs,
-            };
-            cmp::min(int, i8::MAX as i32) as i8
-        }
-        fn from_computed_value(other: &computed_value::T) -> Self {
-            SpecifiedValue::Absolute(*other as i32)
-        }
-    }
-
-    pub fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
-                         -> Result<SpecifiedValue, ParseError<'i>> {
-        if let Ok(i) = input.try(|i| i.expect_integer()) {
-            return Ok(SpecifiedValue::Relative(i))
-        }
-        input.expect_ident_matching("auto")?;
-        Ok(SpecifiedValue::Auto)
-    }
-</%helpers:longhand>
+${helpers.predefined_type("-moz-script-level",
+                          "MozScriptLevel",
+                          0,
+                          animation_value_type="none",
+                          products="gecko",
+                          internal=True,
+                          gecko_ffi_name="mScriptLevel",
+                          spec="Internal (not web-exposed)")}
 
 ${helpers.single_keyword("-moz-math-display",
                          "inline block",

--- a/components/style/values/computed/font.rs
+++ b/components/style/values/computed/font.rs
@@ -192,3 +192,38 @@ impl ToComputedValue for specified::MozScriptMinSize {
         specified::MozScriptMinSize(ToComputedValue::from_computed_value(other))
     }
 }
+
+/// The computed value of the -moz-script-level property.
+pub type MozScriptLevel = i8;
+
+#[cfg(feature = "gecko")]
+impl ToComputedValue for specified::MozScriptLevel {
+    type ComputedValue = MozScriptLevel;
+
+    fn to_computed_value(&self, cx: &Context) -> i8 {
+        use properties::longhands::_moz_math_display::SpecifiedValue as DisplayValue;
+        use std::{cmp, i8};
+
+        let int = match *self {
+            specified::MozScriptLevel::Auto => {
+                let parent = cx.builder.get_parent_font().clone__moz_script_level() as i32;
+                let display = cx.builder.get_parent_font().clone__moz_math_display();
+                if display == DisplayValue::inline {
+                    parent + 1
+                } else {
+                    parent
+                }
+            }
+            specified::MozScriptLevel::Relative(rel) => {
+                let parent = cx.builder.get_parent_font().clone__moz_script_level();
+                parent as i32 + rel
+            }
+            specified::MozScriptLevel::Absolute(abs) => abs,
+        };
+        cmp::min(int, i8::MAX as i32) as i8
+    }
+
+    fn from_computed_value(other: &i8) -> Self {
+        specified::MozScriptLevel::Absolute(*other as i32)
+    }
+}

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -36,7 +36,7 @@ pub use self::angle::Angle;
 pub use self::background::{BackgroundSize, BackgroundRepeat};
 pub use self::border::{BorderImageSlice, BorderImageWidth, BorderImageSideWidth};
 pub use self::border::{BorderRadius, BorderCornerRadius, BorderSpacing};
-pub use self::font::{FontWeight, MozScriptMinSize, XTextZoom};
+pub use self::font::{FontWeight, MozScriptLevel, MozScriptMinSize, XTextZoom};
 pub use self::box_::{AnimationIterationCount, AnimationName, ScrollSnapType, VerticalAlign};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -30,7 +30,7 @@ pub use self::align::{AlignItems, AlignJustifyContent, AlignJustifySelf, Justify
 pub use self::background::{BackgroundRepeat, BackgroundSize};
 pub use self::border::{BorderCornerRadius, BorderImageSlice, BorderImageWidth};
 pub use self::border::{BorderImageSideWidth, BorderRadius, BorderSideWidth, BorderSpacing};
-pub use self::font::{FontWeight, MozScriptMinSize, XTextZoom};
+pub use self::font::{FontWeight, MozScriptLevel, MozScriptMinSize, XTextZoom};
 pub use self::box_::{AnimationIterationCount, AnimationName, ScrollSnapType, VerticalAlign};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};


### PR DESCRIPTION
This is a sub-PR of #19015 
r? emilio 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #19068 (github issue number if applicable).
- [x] These changes do not require tests because _____

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19101)
<!-- Reviewable:end -->
