### PR TITLE
Check if the NDK version is 12

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -261,7 +261,15 @@ class MachCommands(CommandBase):
                 os.makedirs(openssl_dir)
             shutil.copy(path.join(self.android_support_dir(), "openssl.makefile"), openssl_dir)
             shutil.copy(path.join(self.android_support_dir(), "openssl.sh"), openssl_dir)
+
+            # Check if the NDK version is 12
             env["ANDROID_NDK_ROOT"] = env["ANDROID_NDK"]
+            with open(path.join(env["ANDROID_NDK"], 'source.properties')) as ndk_properties:
+                lines = ndk_properties.readlines()
+                if lines[1].split(' = ')[1].split('.')[0] != '12':
+                    print("Currently only support NDK 12.")
+                    sys.exit(1)
+
             env["RUST_TARGET"] = target
             with cd(openssl_dir):
                 status = call(


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Since we only support NDK 12(b), we should add some script to check for that.
User might download 15 or 16, and would get some errors.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19095 (github issue number if applicable).



<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19109)
<!-- Reviewable:end -->
