### PR TITLE
fix overflow_y_is_visible() in `element.rs`

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -109,7 +109,8 @@ use style::dom_apis;
 use style::element_state::ElementState;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::properties::{Importance, PropertyDeclaration, PropertyDeclarationBlock, parse_style_attribute};
-use style::properties::longhands::{self, background_image, border_spacing, font_family, font_size, overflow_x};
+use style::properties::longhands::{self, background_image, border_spacing, font_family, font_size};
+use style::properties::longhands::{overflow_x, overflow_y};
 use style::rule_tree::CascadeLevel;
 use style::selector_parser::{NonTSPseudoClass, PseudoElement, RestyleDamage, SelectorImpl, SelectorParser};
 use style::selector_parser::extended_filtering;
@@ -373,7 +374,7 @@ impl Element {
     fn overflow_y_is_visible(&self) -> bool {
         let window = window_from_node(self);
         let overflow_pair = window.overflow_query(self.upcast::<Node>().to_trusted_node_address());
-        overflow_pair.y != overflow_x::computed_value::T::visible
+        overflow_pair.y == overflow_y::computed_value::T::visible
     }
 }
 

--- a/tests/wpt/metadata/css/css-transforms/css-transforms-3d-on-anonymous-block-001.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/css-transforms-3d-on-anonymous-block-001.html.ini
@@ -1,3 +1,0 @@
-[css-transforms-3d-on-anonymous-block-001.html]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata/css/css-values/vh_not_refreshing_on_chrome.html.ini
+++ b/tests/wpt/metadata/css/css-values/vh_not_refreshing_on_chrome.html.ini
@@ -1,2 +1,0 @@
-[vh_not_refreshing_on_chrome.html]
-  expected: FAIL

--- a/tests/wpt/metadata/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
+++ b/tests/wpt/metadata/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
@@ -5,15 +5,6 @@
   [scrollWidth/scrollHeight on the root element in quirks mode]
     expected: FAIL
 
-  [scroll() on the HTML body element in quirks mode]
-    expected: FAIL
-
-  [scrollBy() on the HTML body element in quirks mode]
-    expected: FAIL
-
-  [scrollLeft/scrollTop on the HTML body element in quirks mode]
-    expected: FAIL
-
   [scrollWidth/scrollHeight on the HTML body element in quirks mode]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I think the original logic of `overflow_y_is_visible()` might be wrong.
So fix it to the correct logic, and also pass more tests.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19115)
<!-- Reviewable:end -->
