### PR TITLE
do not pass new size to Resize event

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -647,8 +647,8 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         }
     }
 
-    pub fn on_resize_window_event(&mut self, new_size: DeviceUintSize) {
-        debug!("compositor resizing to {:?}", new_size.to_untyped());
+    pub fn on_resize_window_event(&mut self) {
+        debug!("compositor resize requested");
 
         // A size change could also mean a resolution change.
         let new_scale_factor = self.window.hidpi_factor();
@@ -665,7 +665,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             return;
         }
 
-        self.frame_size = new_size;
+        self.frame_size = self.window.framebuffer_size();
         self.window_rect = new_window_rect;
 
         self.send_window_size(WindowSizeType::Resize);

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -49,7 +49,7 @@ pub enum WindowEvent {
     /// message, the window must make the same GL context as in `PrepareRenderingEvent` current.
     Refresh,
     /// Sent when the window is resized.
-    Resize(DeviceUintSize),
+    Resize,
     /// Touchpad Pressure
     TouchpadPressure(TypedPoint2D<f32, DevicePixel>, f32, TouchpadPressurePhase),
     /// Sent when a new URL is to be loaded.
@@ -93,7 +93,7 @@ impl Debug for WindowEvent {
         match *self {
             WindowEvent::Idle => write!(f, "Idle"),
             WindowEvent::Refresh => write!(f, "Refresh"),
-            WindowEvent::Resize(..) => write!(f, "Resize"),
+            WindowEvent::Resize => write!(f, "Resize"),
             WindowEvent::TouchpadPressure(..) => write!(f, "TouchpadPressure"),
             WindowEvent::KeyEvent(..) => write!(f, "Key"),
             WindowEvent::LoadUrl(..) => write!(f, "LoadUrl"),

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -265,8 +265,8 @@ impl<Window> Servo<Window> where Window: WindowMethods + 'static {
                 self.compositor.composite();
             }
 
-            WindowEvent::Resize(size) => {
-                self.compositor.on_resize_window_event(size);
+            WindowEvent::Resize => {
+                self.compositor.on_resize_window_event();
             }
 
             WindowEvent::LoadUrl(top_level_browsing_context_id, url) => {

--- a/ports/cef/browser_host.rs
+++ b/ports/cef/browser_host.rs
@@ -12,7 +12,7 @@ use webrender_api::ScrollLocation;
 use wrappers::CefWrap;
 
 use compositing::windowing::{WindowEvent, MouseWindowEvent};
-use euclid::{TypedPoint2D, TypedVector2D, TypedSize2D};
+use euclid::{TypedPoint2D, TypedVector2D};
 use libc::{c_double, c_int};
 use msg::constellation_msg::{self, KeyModifiers, KeyState};
 use script_traits::{MouseButton, TouchEventType};
@@ -384,8 +384,7 @@ full_cef_class_impl! {
                     .get_render_handler()
                     .get_view_rect(this.downcast().browser.borrow().clone().unwrap(), &mut rect);
                }
-            let size = TypedSize2D::new(rect.width as u32, rect.height as u32);
-            this.downcast().send_window_event(WindowEvent::Resize(size));
+            this.downcast().send_window_event(WindowEvent::Resize);
         }}
 
         fn close_browser(&this, _force: c_int [c_int],) -> () {{

--- a/ports/glutin/window.rs
+++ b/ports/glutin/window.rs
@@ -351,11 +351,10 @@ impl Window {
         }
     }
 
-    fn nested_window_resize(width: u32, height: u32) {
+    fn nested_window_resize(_width: u32, _height: u32) {
         unsafe {
             if let Some(listener) = G_NESTED_EVENT_LOOP_LISTENER {
-                (*listener).handle_event_from_nested_event_loop(
-                    WindowEvent::Resize(TypedSize2D::new(width, height)));
+                (*listener).handle_event_from_nested_event_loop(WindowEvent::Resize);
             }
         }
     }
@@ -485,8 +484,8 @@ impl Window {
             Event::KeyboardInput(_, _, None) => {
                 debug!("Keyboard input without virtual key.");
             }
-            Event::Resized(width, height) => {
-                self.event_queue.borrow_mut().push(WindowEvent::Resize(TypedSize2D::new(width, height)));
+            Event::Resized(..) => {
+                self.event_queue.borrow_mut().push(WindowEvent::Resize);
             }
             Event::MouseInput(element_state, mouse_button, pos) => {
                 if mouse_button == MouseButton::Left ||

--- a/ports/servo/main.rs
+++ b/ports/servo/main.rs
@@ -207,7 +207,7 @@ struct ServoWrapper {
 impl app::NestedEventLoopListener for ServoWrapper {
     fn handle_event_from_nested_event_loop(&mut self, event: WindowEvent) -> bool {
         let is_resize = match event {
-            WindowEvent::Resize(..) => true,
+            WindowEvent::Resize => true,
             _ => false,
         };
         if !self.servo.handle_events(vec![event]) {


### PR DESCRIPTION
It's not necessary to pass the new size to the resize event as it can be retrieved via `WindowMethods::framebuffer_size()`.

From the perspective of the embedder, that makes things a bit easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19135)
<!-- Reviewable:end -->
