### PR TITLE
style: Get rid of parse_specified.

### DIFF
--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -402,14 +402,10 @@
             % endif
         }
         % if not property.derived_from:
-            pub fn parse_specified<'i, 't>(
+            pub fn parse_declared<'i, 't>(
                 context: &ParserContext,
                 input: &mut Parser<'i, 't>,
-            % if property.boxed:
-            ) -> Result<Box<SpecifiedValue>, ParseError<'i>> {
-            % else:
-            ) -> Result<SpecifiedValue, ParseError<'i>> {
-            % endif
+            ) -> Result<PropertyDeclaration, ParseError<'i>> {
                 % if property.allow_quirks:
                     parse_quirky(context, input, specified::AllowQuirks::Yes)
                 % else:
@@ -418,13 +414,6 @@
                 % if property.boxed:
                     .map(Box::new)
                 % endif
-            }
-
-            pub fn parse_declared<'i, 't>(
-                context: &ParserContext,
-                input: &mut Parser<'i, 't>,
-            ) -> Result<PropertyDeclaration, ParseError<'i>> {
-                parse_specified(context, input)
                     .map(PropertyDeclaration::${property.camel_case})
             }
         % endif
@@ -938,6 +927,8 @@
 
 // Define property that supports prefixed intrinsic size keyword values for gecko.
 // E.g. -moz-max-content, -moz-min-content, etc.
+//
+// FIXME(emilio): This feels a lot like a huge hack, get rid of this.
 <%def name="gecko_size_type(name, length_type, initial_value, logical, **kwargs)">
     <%call expr="longhand(name,
                           predefined_type=length_type,
@@ -982,20 +973,32 @@
             use values::computed::${length_type};
             ${length_type}::${initial_value}
         }
-        fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
-                         -> Result<SpecifiedValue, ParseError<'i>> {
-            % if logical:
-            let ret = ${length_type}::parse(context, input);
-            % else:
-            let ret = ${length_type}::parse_quirky(context, input, AllowQuirks::Yes);
-            % endif
-            // Keyword values don't make sense in the block direction; don't parse them
-            % if "block" in name:
-                if let Ok(${length_type}::ExtremumLength(..)) = ret {
-                    return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
-                }
-            % endif
-            ret.map(SpecifiedValue)
+
+        impl Parse for SpecifiedValue {
+            fn parse<'i, 't>(
+                context: &ParserContext,
+                input: &mut Parser<'i, 't>,
+            ) -> Result<SpecifiedValue, ParseError<'i>> {
+                % if logical:
+                let ret = ${length_type}::parse(context, input);
+                % else:
+                let ret = ${length_type}::parse_quirky(context, input, AllowQuirks::Yes);
+                % endif
+                // Keyword values don't make sense in the block direction; don't parse them
+                % if "block" in name:
+                    if let Ok(${length_type}::ExtremumLength(..)) = ret {
+                        return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
+                    }
+                % endif
+                ret.map(SpecifiedValue)
+            }
+        }
+
+        fn parse<'i, 't>(
+            context: &ParserContext,
+            input: &mut Parser<'i, 't>,
+        ) -> Result<SpecifiedValue, ParseError<'i>> {
+            SpecifiedValue::parse(context, input)
         }
 
         impl ToComputedValue for SpecifiedValue {

--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -160,6 +160,11 @@ ${helpers.predefined_type("order", "Integer", "0",
                           animation_value_type="ComputedValue",
                           spec="https://drafts.csswg.org/css-flexbox/#order-property")}
 
+// FIXME(emilio): All the sizes stuff, and the MozLength values should be
+// unified with Servo, or at least be less hacky.
+//
+// The block direction ones don't even accept extremum lengths during parsing,
+// and should be converted to just LengthOrPercentage.
 % if product == "gecko":
     // FIXME: Gecko doesn't support content value yet.
     ${helpers.gecko_size_type("flex-basis", "MozLength", "auto()",

--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -48,6 +48,7 @@
                     spec="https://drafts.csswg.org/css-flexbox/#flex-property">
     use parser::Parse;
     use values::specified::NonNegativeNumber;
+    use properties::longhands::flex_basis::SpecifiedValue as FlexBasis;
 
     fn parse_flexibility<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
                                  -> Result<(NonNegativeNumber, Option<NonNegativeNumber>),ParseError<'i>> {
@@ -66,7 +67,7 @@
             return Ok(expanded! {
                 flex_grow: NonNegativeNumber::new(0.0),
                 flex_shrink: NonNegativeNumber::new(0.0),
-                flex_basis: longhands::flex_basis::SpecifiedValue::auto(),
+                flex_basis: FlexBasis::auto(),
             })
         }
         loop {
@@ -78,7 +79,7 @@
                 }
             }
             if basis.is_none() {
-                if let Ok(value) = input.try(|input| longhands::flex_basis::parse_specified(context, input)) {
+                if let Ok(value) = input.try(|input| FlexBasis::parse(context, input)) {
                     basis = Some(value);
                     continue
                 }
@@ -96,7 +97,7 @@
             // browsers currently agree on using `0%`. This is a spec
             // change which hasn't been adopted by browsers:
             // https://github.com/w3c/csswg-drafts/commit/2c446befdf0f686217905bdd7c92409f6bd3921b
-            flex_basis: basis.unwrap_or(longhands::flex_basis::SpecifiedValue::zero_percent()),
+            flex_basis: basis.unwrap_or(FlexBasis::zero_percent()),
         })
     }
 </%helpers:shorthand>


### PR DESCRIPTION
It has a single use, and I don't think we should use it in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19139)
<!-- Reviewable:end -->
