### PR TITLE
remove unused  script in `build_commands.py`

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -265,7 +265,6 @@ class MachCommands(CommandBase):
             shutil.copy(path.join(self.android_support_dir(), "openssl.sh"), openssl_dir)
 
             # Check if the NDK version is 12
-            env["ANDROID_NDK_ROOT"] = env["ANDROID_NDK"]
             with open(path.join(env["ANDROID_NDK"], 'source.properties')) as ndk_properties:
                 lines = ndk_properties.readlines()
                 if lines[1].split(' = ')[1].split('.')[0] != '12':


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
code in `build_commands.py` duplicates with `openssl.makefile`, so it is unused.
(It only use in openssl)
https://github.com/servo/servo/blob/ae5dca985ee58fbcd18d7e470184beb2b7e3d547/python/servo/build_commands.py#L268
https://github.com/servo/servo/blob/ae5dca985ee58fbcd18d7e470184beb2b7e3d547/support/android/openssl.makefile#L9-L10
https://github.com/servo/servo/blob/ae5dca985ee58fbcd18d7e470184beb2b7e3d547/support/android/openssl.sh#L83-L84

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19161)
<!-- Reviewable:end -->
