### PR TITLE
Allow unused imports for AsciiExt in style code.

### DIFF
--- a/components/selectors/attr.rs
+++ b/components/selectors/attr.rs
@@ -4,7 +4,7 @@
 
 use cssparser::ToCss;
 use parser::SelectorImpl;
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt;
 
 #[derive(Clone, Eq, PartialEq)]

--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -14,7 +14,7 @@ use precomputed_hash::PrecomputedHash;
 use servo_arc::ThinArc;
 use sink::Push;
 use smallvec::SmallVec;
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::borrow::{Borrow, Cow};
 use std::fmt::{self, Display, Debug, Write};
 use std::iter::Rev;

--- a/components/style/attr.rs
+++ b/components/style/attr.rs
@@ -16,7 +16,7 @@ use selectors::attr::AttrSelectorOperation;
 use servo_arc::Arc;
 use servo_url::ServoUrl;
 use shared_lock::Locked;
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::str::FromStr;
 use str::{HTML_SPACE_CHARACTERS, read_exponent, read_fraction};
 use str::{read_numbers, split_commas, split_html_space_chars};

--- a/components/style/counter_style/mod.rs
+++ b/components/style/counter_style/mod.rs
@@ -15,7 +15,7 @@ use error_reporting::{ContextualParseError, ParseErrorReporter};
 use parser::{ParserContext, ParserErrorContext, Parse};
 use selectors::parser::SelectorParseErrorKind;
 use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::fmt;
 use std::ops::Range;

--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -14,7 +14,7 @@ use selector_map::{PrecomputedHashSet, PrecomputedHashMap};
 use selectors::parser::SelectorParseErrorKind;
 use servo_arc::Arc;
 use smallvec::SmallVec;
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::borrow::{Borrow, Cow};
 use std::cmp;
 use std::fmt;

--- a/components/style/gecko/generated/pseudo_element_definition.rs
+++ b/components/style/gecko/generated/pseudo_element_definition.rs
@@ -1377,7 +1377,7 @@ impl PseudoElement {
     /// Returns `None` if the pseudo-element is not recognised.
     #[inline]
     pub fn from_slice(s: &str, in_ua_stylesheet: bool) -> Option<Self> {
-        use std::ascii::AsciiExt;
+        #[allow(unused_imports)] use std::ascii::AsciiExt;
 
         // We don't need to support tree pseudos because functional
         // pseudo-elements needs arguments, and thus should be created
@@ -1747,7 +1747,7 @@ impl PseudoElement {
     /// Returns `None` if the pseudo-element is not recognized.
     #[inline]
     pub fn tree_pseudo_element(name: &str, args: Box<[Atom]>) -> Option<Self> {
-        use std::ascii::AsciiExt;
+        #[allow(unused_imports)] use std::ascii::AsciiExt;
         debug_assert!(name.starts_with("-moz-tree-"));
         let tree_part = &name[10..];
             if tree_part.eq_ignore_ascii_case("column") {

--- a/components/style/gecko/pseudo_element_definition.mako.rs
+++ b/components/style/gecko/pseudo_element_definition.mako.rs
@@ -225,7 +225,7 @@ impl PseudoElement {
     /// Returns `None` if the pseudo-element is not recognised.
     #[inline]
     pub fn from_slice(s: &str, in_ua_stylesheet: bool) -> Option<Self> {
-        use std::ascii::AsciiExt;
+        #[allow(unused_imports)] use std::ascii::AsciiExt;
 
         // We don't need to support tree pseudos because functional
         // pseudo-elements needs arguments, and thus should be created
@@ -247,7 +247,7 @@ impl PseudoElement {
     /// Returns `None` if the pseudo-element is not recognized.
     #[inline]
     pub fn tree_pseudo_element(name: &str, args: Box<[Atom]>) -> Option<Self> {
-        use std::ascii::AsciiExt;
+        #[allow(unused_imports)] use std::ascii::AsciiExt;
         debug_assert!(name.starts_with("-moz-tree-"));
         let tree_part = &name[10..];
         % for pseudo in TREE_PSEUDOS:

--- a/components/style/gecko_string_cache/mod.rs
+++ b/components/style/gecko_string_cache/mod.rs
@@ -13,7 +13,7 @@ use gecko_bindings::bindings::Gecko_ReleaseAtom;
 use gecko_bindings::structs::{nsAtom, nsAtom_AtomKind, nsStaticAtom};
 use nsstring::{nsAString, nsStr};
 use precomputed_hash::PrecomputedHash;
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::borrow::{Cow, Borrow};
 use std::char::{self, DecodeUtf16};
 use std::fmt::{self, Write};

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -1577,7 +1577,7 @@ https://drafts.csswg.org/css-fonts-4/#low-level-font-variation-settings-control-
 
         #[inline]
         fn to_computed_value(&self, _context: &Context) -> computed_value::T {
-            use std::ascii::AsciiExt;
+            #[allow(unused_imports)] use std::ascii::AsciiExt;
             match *self {
                 SpecifiedValue::Normal => computed_value::T(0),
                 SpecifiedValue::Override(ref lang) => {

--- a/components/style/properties/longhand/pointing.mako.rs
+++ b/components/style/properties/longhand/pointing.mako.rs
@@ -88,7 +88,7 @@
     impl Parse for computed_value::Keyword {
         fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
                          -> Result<computed_value::Keyword, ParseError<'i>> {
-            use std::ascii::AsciiExt;
+            #[allow(unused_imports)] use std::ascii::AsciiExt;
             use style_traits::cursor::Cursor;
             let location = input.current_source_location();
             let ident = input.expect_ident()?;

--- a/components/style/str.rs
+++ b/components/style/str.rs
@@ -7,7 +7,7 @@
 #![deny(missing_docs)]
 
 use num_traits::ToPrimitive;
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::convert::AsRef;
 use std::iter::{Filter, Peekable};

--- a/components/style/stylesheets/viewport_rule.rs
+++ b/components/style/stylesheets/viewport_rule.rs
@@ -20,7 +20,7 @@ use properties::StyleBuilder;
 use rule_cache::RuleCacheConditions;
 use selectors::parser::SelectorParseErrorKind;
 use shared_lock::{SharedRwLockReadGuard, StylesheetGuards, ToCssWithGuard};
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fmt;

--- a/components/style/values/mod.rs
+++ b/components/style/values/mod.rs
@@ -12,7 +12,7 @@ use Atom;
 pub use cssparser::{RGBA, Token, Parser, serialize_identifier, CowRcStr, SourceLocation};
 use parser::{Parse, ParserContext};
 use selectors::parser::SelectorParseErrorKind;
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt::{self, Debug};
 use std::hash;
 use style_traits::{ToCss, ParseError, StyleParseErrorKind};

--- a/components/style/values/specified/align.rs
+++ b/components/style/values/specified/align.rs
@@ -10,7 +10,7 @@ use cssparser::Parser;
 use gecko_bindings::structs;
 use parser::{Parse, ParserContext};
 use selectors::parser::SelectorParseErrorKind;
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt;
 use style_traits::{ToCss, ParseError, StyleParseErrorKind};
 

--- a/components/style/values/specified/angle.rs
+++ b/components/style/values/specified/angle.rs
@@ -6,7 +6,7 @@
 
 use cssparser::{Parser, Token};
 use parser::{ParserContext, Parse};
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt;
 use style_traits::{ToCss, ParseError};
 use values::CSSFloat;

--- a/components/style/values/specified/calc.rs
+++ b/components/style/values/specified/calc.rs
@@ -8,7 +8,7 @@
 
 use cssparser::{Parser, Token};
 use parser::ParserContext;
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt;
 use style_traits::{ToCss, ParseError, StyleParseErrorKind};
 use style_traits::values::specified::AllowedNumericType;

--- a/components/style/values/specified/grid.rs
+++ b/components/style/values/specified/grid.rs
@@ -7,7 +7,7 @@
 
 use cssparser::{Parser, Token, ParseError as CssParseError};
 use parser::{Parse, ParserContext};
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::mem;
 use style_traits::{ParseError, StyleParseErrorKind};
 use values::{CSSFloat, CustomIdent};

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -12,7 +12,7 @@ use euclid::Size2D;
 use font_metrics::FontMetricsQueryResult;
 use parser::{Parse, ParserContext};
 use std::{cmp, fmt, mem};
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::ops::{Add, Mul};
 use style_traits::{ToCss, ParseError, StyleParseErrorKind};
 use style_traits::values::specified::AllowedNumericType;

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -11,7 +11,7 @@ use context::QuirksMode;
 use cssparser::{Parser, Token, serialize_identifier};
 use parser::{ParserContext, Parse};
 use self::url::SpecifiedUrl;
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::f32;
 use std::fmt;
 use style_traits::{ToCss, ParseError, StyleParseErrorKind};

--- a/components/style/values/specified/percentage.rs
+++ b/components/style/values/specified/percentage.rs
@@ -6,7 +6,7 @@
 
 use cssparser::{Parser, Token};
 use parser::{Parse, ParserContext};
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt;
 use style_traits::{ParseError, ToCss};
 use style_traits::values::specified::AllowedNumericType;

--- a/components/style/values/specified/text.rs
+++ b/components/style/values/specified/text.rs
@@ -7,7 +7,7 @@
 use cssparser::{Parser, Token};
 use parser::{Parse, ParserContext};
 use selectors::parser::SelectorParseErrorKind;
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use style_traits::ParseError;
 use values::computed::{Context, ToComputedValue};
 use values::computed::text::LineHeight as ComputedLineHeight;

--- a/components/style/values/specified/time.rs
+++ b/components/style/values/specified/time.rs
@@ -6,7 +6,7 @@
 
 use cssparser::{Parser, Token};
 use parser::{ParserContext, Parse};
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt;
 use style_traits::{ToCss, ParseError, StyleParseErrorKind};
 use style_traits::values::specified::AllowedNumericType;

--- a/components/style_traits/viewport.rs
+++ b/components/style_traits/viewport.rs
@@ -7,7 +7,7 @@
 use {CSSPixel, PinchZoomFactor, ParseError, ToCss};
 use cssparser::Parser;
 use euclid::TypedSize2D;
-use std::ascii::AsciiExt;
+#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt;
 
 define_css_keyword_enum!(UserZoom:


### PR DESCRIPTION
See #19128, this part is cherry-picked so Gecko can build with rust nightly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19162)
<!-- Reviewable:end -->
