### PR TITLE
style: Remove the skip_applying_damage "optimization".

### DIFF
--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -466,20 +466,6 @@ impl ElementData {
         self.is_restyle() || !self.hint.is_empty() || !self.damage.is_empty()
     }
 
-    /// If an ancestor is already getting reconstructed by Gecko's top-down
-    /// frame constructor, no need to apply damage.  Similarly if we already
-    /// have an explicitly stored ReconstructFrame hint.
-    ///
-    /// See https://bugzilla.mozilla.org/show_bug.cgi?id=1301258#c12
-    /// for followup work to make the optimization here more optimal by considering
-    /// each bit individually.
-    #[cfg(feature = "gecko")]
-    pub fn skip_applying_damage(&self) -> bool { self.reconstructed_self_or_ancestor() }
-
-    /// N/A in Servo.
-    #[cfg(feature = "servo")]
-    pub fn skip_applying_damage(&self) -> bool { false }
-
     /// Returns whether it is safe to perform cousin sharing based on the ComputedValues
     /// identity of the primary style in this ElementData. There are a few subtle things
     /// to check.

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -333,7 +333,6 @@ trait PrivateMatchMethods: TElement {
     fn accumulate_damage_for(
         &self,
         shared_context: &SharedStyleContext,
-        skip_applying_damage: bool,
         damage: &mut RestyleDamage,
         old_values: &ComputedValues,
         new_values: &ComputedValues,
@@ -345,9 +344,7 @@ trait PrivateMatchMethods: TElement {
         let difference =
             self.compute_style_difference(old_values, new_values, pseudo);
 
-        if !skip_applying_damage {
-            *damage |= difference.damage;
-        }
+        *damage |= difference.damage;
 
         debug!(" > style difference: {:?}", difference);
 
@@ -590,7 +587,6 @@ pub trait MatchMethods : TElement {
             cascade_requirement,
             self.accumulate_damage_for(
                 context.shared,
-                data.skip_applying_damage(),
                 &mut data.damage,
                 &old_primary_style,
                 new_primary_style,
@@ -612,7 +608,6 @@ pub trait MatchMethods : TElement {
                 (&Some(ref old), &Some(ref new)) => {
                     self.accumulate_damage_for(
                         context.shared,
-                        data.skip_applying_damage(),
                         &mut data.damage,
                         old,
                         new,


### PR DESCRIPTION
We already remove all change hints down the tree when finding a reframe hint
using ClearServoRestyleFromSubtree in ServoRestyleManager, so this is useless.

MozReview-Commit-ID: 1twx7iPt79x

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19163)
<!-- Reviewable:end -->
