### PR TITLE
enhance android build debug info in `build_commands.py`

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -248,6 +248,13 @@ class MachCommands(CommandBase):
             env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C debug_assertions"
 
         if android:
+            if "ANDROID_NDK" not in os.environ:
+                print("Please set the ANDROID_NDK environment variable.")
+                sys.exit(1)
+            if "ANDROID_SDK" not in os.environ:
+                print("Please set the ANDROID_SDK environment variable.")
+                sys.exit(1)
+
             android_platform = self.config["android"]["platform"]
             android_toolchain = self.config["android"]["toolchain_name"]
             android_arch = "arch-" + self.config["android"]["arch"]
@@ -265,6 +272,10 @@ class MachCommands(CommandBase):
             shutil.copy(path.join(self.android_support_dir(), "openssl.sh"), openssl_dir)
 
             # Check if the NDK version is 12
+            if not os.path.isfile(path.join(env["ANDROID_NDK"], 'source.properties')):
+                print("ANDROID_NDK should have file `source.properties`.")
+                print("The environment variable ANDROID_NDK may be set at a wrong path.")
+                sys.exit(1)
             with open(path.join(env["ANDROID_NDK"], 'source.properties')) as ndk_properties:
                 lines = ndk_properties.readlines()
                 if lines[1].split(' = ')[1].split('.')[0] != '12':


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I have some experience with building android.
Sometimes I forget  to set `ANDROID_NDK` or `ANDROID_SDK` when I create a new clean environment, and I would know only when build error message come out.(After very long time)
I think we could enhance the debug engineering at the beginning.

Also fix the previous work  #19109
I forgot to consider if `open()` crash(file not exist).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19095 (github issue number if applicable).

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19178)
<!-- Reviewable:end -->
