### PR TITLE
Fix binding generation for overloaded functions with optionals and de…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,7 +1661,7 @@ dependencies = [
  "cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashglobe 0.1.0",
- "mozjs 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mozjs 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_arc 0.0.1",
  "smallbitvec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1811,7 +1811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mozjs"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cmake 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2536,7 +2536,7 @@ dependencies = [
  "mime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mitochondria 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "mozjs 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mozjs 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
  "nonzero 0.0.1",
@@ -3794,7 +3794,7 @@ dependencies = [
 "checksum mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9e965267d4d58496fc4f740e9861118367f13570cadf66316ed2c3f2f14d87c7"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum mitochondria 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9de3eca27871df31c33b807f834b94ef7d000956f57aa25c5aed9c5f0aae8f6f"
-"checksum mozjs 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c99a22091d3e6f7cd93caaf18bcb9ce5ff0a5d93c45aa73e443a447ab4296"
+"checksum mozjs 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "722aeeec7049d03494ef79190343c2dea89c743c2d66acfb4555aef69dd77061"
 "checksum mozjs_sys 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef1e24df9f76502cd4459919098ec1ac3af75ce694ec5b8837aa91f69f2ad0eb"
 "checksum mp3-metadata 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ab5f1d2693586420208d1200ce5a51cd44726f055b635176188137aff42c7de"
 "checksum mp4parse 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7b81651f9ede53d59281b54c7eb51ae50a868ac4765dd3bdfbbc79ce3d8aca7a"

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -16,7 +16,7 @@ app_units = "0.5.5"
 cssparser = "0.22.0"
 euclid = "0.15"
 hashglobe = { path = "../hashglobe" }
-mozjs = { version = "0.1.7", features = ["promises"], optional = true }
+mozjs = { version = "0.1.8", features = ["promises"], optional = true }
 servo_arc = { path = "../servo_arc" }
 smallbitvec = "1.0.3"
 smallvec = "0.4"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -51,7 +51,6 @@ hyper = "0.10"
 hyper_serde = "0.7"
 image = "0.16"
 ipc-channel = "0.9"
-mozjs = { version = "0.1.7", features = ["promises"]}
 jstraceable_derive = {path = "../jstraceable_derive"}
 lazy_static = "0.2"
 libc = "0.2"
@@ -62,6 +61,7 @@ metrics = {path = "../metrics"}
 mitochondria = "1.1.2"
 mime = "0.2.1"
 mime_guess = "1.8.0"
+mozjs = { version = "0.1.8", features = ["promises"]}
 msg = {path = "../msg"}
 net_traits = {path = "../net_traits"}
 nonzero = {path = "../nonzero"}

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -483,7 +483,8 @@ class CGMethodCall(CGThing):
             else:
                 # Just throw; we have no idea what we're supposed to
                 # do with this.
-                caseBody.append(CGGeneric("return Throw(cx, NS_ERROR_XPC_BAD_CONVERT_JS);"))
+                caseBody.append(CGGeneric("throw_internal_error(cx, \"Could not convert JavaScript argument\");\n"
+                                          "return false;"))
 
             argCountCases.append(CGCase(str(argCount),
                                         CGList(caseBody, "\n")))
@@ -5591,6 +5592,7 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'js::JSCLASS_RESERVED_SLOTS_MASK',
         'js::JS_CALLEE',
         'js::error::throw_type_error',
+        'js::error::throw_internal_error',
         'js::jsapi::AutoIdVector',
         'js::jsapi::Call',
         'js::jsapi::CallArgs',

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -601,6 +601,8 @@ impl TestBindingMethods for TestBinding {
     fn PassOptionalNullableStringWithNonNullDefault(&self, _: Option<DOMString>) {}
     fn PassOptionalNullableUsvstringWithNonNullDefault(&self, _: Option<USVString>) {}
     // fn PassOptionalNullableEnumWithNonNullDefault(self, _: Option<TestEnum>) {}
+    fn PassOptionalOverloaded(&self, a: &TestBinding, _: u32, _: u32) -> DomRoot<TestBinding> { DomRoot::from_ref(a) }
+    fn PassOptionalOverloaded_(&self, _: &Blob,  _: u32) { }
 
     fn PassVariadicBoolean(&self, _: Vec<bool>) {}
     fn PassVariadicBooleanAndDefault(&self, _: bool, _: Vec<bool>) {}

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -409,6 +409,9 @@ interface TestBinding {
   // void passOptionalNullableEnumWithNonNullDefault(optional TestEnum? arg = "foo");
   // void passOptionalNullableUnionWithNonNullDefault(optional (HTMLElement or long)? arg = 7);
   // void passOptionalNullableUnion2WithNonNullDefault(optional (Event or DOMString)? data = "foo");
+  TestBinding passOptionalOverloaded(TestBinding arg0, optional unsigned long arg1 = 0,
+                                     optional unsigned long arg2 = 0);
+  void passOptionalOverloaded(Blob arg0, optional unsigned long arg1 = 0);
 
   void passVariadicBoolean(boolean... args);
   void passVariadicBooleanAndDefault(optional boolean arg = true, boolean... args);


### PR DESCRIPTION
…fault values

The generated bindings for an interface like this:

```webidl
void someFunction(Foo foo, optional long a = 0, optional long b = 1);
void someFunction(Bar bar, optional long a = 0);
```
are failing to build with an error like:

```bash
    error[E0425]: cannot find function `Throw` in this scope
         --> /Users/ferjm/dev/mozilla/servo/target/debug/build/script-7b1a12ddd08207e3/out/Bindings/TestBindingBinding.rs:15395:24
          |
    15395 |                 return Throw(cx, NS_ERROR_XPC_BAD_CONVERT_JS);
          |                        ^^^^^ not found in this scope
     
    error[E0425]: cannot find value `NS_ERROR_XPC_BAD_CONVERT_JS` in this scope
         --> /Users/ferjm/dev/mozilla/servo/target/debug/build/script-7b1a12ddd08207e3/out/Bindings/TestBindingBinding.rs:15395:34
          |
    15395 |                 return Throw(cx, NS_ERROR_XPC_BAD_CONVERT_JS);
          |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
     
    error[E0425]: cannot find function `Throw` in this scope
         --> /Users/ferjm/dev/mozilla/servo/target/debug/build/script-7b1a12ddd08207e3/out/Bindings/TestBindingBinding.rs:15468:24
          |
    15468 |                 return Throw(cx, NS_ERROR_XPC_BAD_CONVERT_JS);
          |                        ^^^^^ not found in this scope
     
    error[E0425]: cannot find value `NS_ERROR_XPC_BAD_CONVERT_JS` in this scope
         --> /Users/ferjm/dev/mozilla/servo/target/debug/build/script-7b1a12ddd08207e3/out/Bindings/TestBindingBinding.rs:15468:34
          |
    15468 |                 return Throw(cx, NS_ERROR_XPC_BAD_CONVERT_JS);
          |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
     
    error: aborting due to 4 previous errors
     
    error: Could not compile `script`. 
``` 
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

** Note that this depends** on https://github.com/servo/rust-mozjs/pull/379

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19180)
<!-- Reviewable:end -->
