### PR TITLE
style: :dir() pseudo class now represented by enum

### DIFF
--- a/components/selectors/gecko_like_types.rs
+++ b/components/selectors/gecko_like_types.rs
@@ -10,6 +10,7 @@
 pub enum PseudoClass {
     Bare,
     String(Box<[u16]>),
+    Dir(Box<()>),
     MozAny(Box<[()]>),
 }
 

--- a/components/style/gecko/non_ts_pseudo_class_list.rs
+++ b/components/style/gecko/non_ts_pseudo_class_list.rs
@@ -120,7 +120,6 @@ macro_rules! apply_non_ts_list {
             ],
             keyword: [
                 ("-moz-locale-dir", MozLocaleDir, mozLocaleDir, _, _),
-                ("dir", Dir, dir, _, _),
             ]
         }
     }

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -74,7 +74,7 @@ use properties::animated_properties::{AnimationValue, AnimationValueMap};
 use properties::animated_properties::TransitionProperty;
 use properties::style_structs::Font;
 use rule_tree::CascadeLevel as ServoCascadeLevel;
-use selector_parser::{AttrValue, PseudoClassStringArg};
+use selector_parser::{AttrValue, Direction, PseudoClassStringArg};
 use selectors::{Element, OpaqueElement};
 use selectors::attr::{AttrSelectorOperation, AttrSelectorOperator, CaseSensitivity, NamespaceConstraint};
 use selectors::matching::{ElementSelectorFlags, MatchingContext};
@@ -2068,14 +2068,20 @@ impl<'le> ::selectors::Element for GeckoElement<'le> {
             NonTSPseudoClass::Lang(ref lang_arg) => {
                 self.match_element_lang(None, lang_arg)
             }
-            NonTSPseudoClass::MozLocaleDir(ref s) |
-            NonTSPseudoClass::Dir(ref s) => {
+            NonTSPseudoClass::MozLocaleDir(ref s) => {
                 unsafe {
                     Gecko_MatchStringArgPseudo(
                         self.0,
                         pseudo_class.to_gecko_pseudoclasstype().unwrap(),
                         s.as_ptr(),
                     )
+                }
+            }
+            NonTSPseudoClass::Dir(ref dir) => {
+                match **dir {
+                    Direction::Ltr => self.get_state().intersects(ElementState::IN_LTR_STATE),
+                    Direction::Rtl => self.get_state().intersects(ElementState::IN_RTL_STATE),
+                    Direction::Other(..) => false,
                 }
             }
         }

--- a/components/style/invalidation/element/element_wrapper.rs
+++ b/components/style/invalidation/element/element_wrapper.rs
@@ -182,9 +182,9 @@ impl<'a, E> Element for ElementWrapper<'a, E>
             // FIXME(bz): How can I set this up so once Servo adds :dir()
             // support we don't forget to update this code?
             #[cfg(feature = "gecko")]
-            NonTSPseudoClass::Dir(ref s) => {
+            NonTSPseudoClass::Dir(ref dir) => {
                 use invalidation::element::invalidation_map::dir_selector_to_state;
-                let selector_flag = dir_selector_to_state(s);
+                let selector_flag = dir_selector_to_state(dir);
                 if selector_flag.is_empty() {
                     // :dir() with some random argument; does not match.
                     return false;

--- a/components/style/invalidation/element/invalidation_map.rs
+++ b/components/style/invalidation/element/invalidation_map.rs
@@ -10,6 +10,8 @@ use element_state::ElementState;
 use fallible::FallibleVec;
 use hashglobe::FailedAllocationError;
 use selector_map::{MaybeCaseInsensitiveHashMap, SelectorMap, SelectorMapEntry};
+#[cfg(feature = "gecko")]
+use selector_parser::Direction;
 use selector_parser::SelectorImpl;
 use selectors::attr::NamespaceConstraint;
 use selectors::parser::{Combinator, Component};
@@ -19,21 +21,15 @@ use smallvec::SmallVec;
 
 #[cfg(feature = "gecko")]
 /// Gets the element state relevant to the given `:dir` pseudo-class selector.
-pub fn dir_selector_to_state(s: &[u16]) -> ElementState {
-    use element_state::ElementState;
-
-    // Jump through some hoops to deal with our Box<[u16]> thing.
-    const LTR: [u16; 4] = [b'l' as u16, b't' as u16, b'r' as u16, 0];
-    const RTL: [u16; 4] = [b'r' as u16, b't' as u16, b'l' as u16, 0];
-
-    if LTR == *s {
-        ElementState::IN_LTR_STATE
-    } else if RTL == *s {
-        ElementState::IN_RTL_STATE
-    } else {
-        // :dir(something-random) is a valid selector, but shouldn't
-        // match anything.
-        ElementState::empty()
+pub fn dir_selector_to_state(dir: &Direction) -> ElementState {
+    match *dir {
+        Direction::Ltr => ElementState::IN_LTR_STATE,
+        Direction::Rtl => ElementState::IN_RTL_STATE,
+        Direction::Other(_) => {
+            // :dir(something-random) is a valid selector, but shouldn't
+            // match anything.
+            ElementState::empty()
+        },
     }
 }
 
@@ -342,8 +338,8 @@ impl SelectorVisitor for CompoundSelectorDependencyCollector {
                 self.other_attributes |= pc.is_attr_based();
                 self.state |= match *pc {
                     #[cfg(feature = "gecko")]
-                    NonTSPseudoClass::Dir(ref s) => {
-                        dir_selector_to_state(s)
+                    NonTSPseudoClass::Dir(ref dir) => {
+                        dir_selector_to_state(dir)
                     }
                     _ => pc.state_flag(),
                 };

--- a/components/style/selector_parser.rs
+++ b/components/style/selector_parser.rs
@@ -8,8 +8,8 @@
 
 use cssparser::{Parser as CssParser, ParserInput};
 use selectors::parser::SelectorList;
-use std::fmt::{self, Debug};
-use style_traits::ParseError;
+use std::fmt::{self, Debug, Write};
+use style_traits::{ParseError, ToCss};
 use stylesheets::{Origin, Namespaces, UrlExtraData};
 
 /// A convenient alias for the type that represents an attribute value used for
@@ -171,5 +171,27 @@ impl<T> PerPseudoElementMap<T> {
     /// Get an iterator for the entries.
     pub fn iter(&self) -> ::std::slice::Iter<Option<T>> {
         self.entries.iter()
+    }
+}
+
+/// Values for the :dir() pseudo class
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Direction {
+    /// left-to-right semantic directionality
+    Ltr,
+    /// right-to-left semantic directionality
+    Rtl,
+    /// Some other provided directionality value
+    Other(Box<str>),
+}
+
+impl ToCss for Direction {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: Write {
+        let dir_str = match *self {
+            Direction::Rtl => "rtl",
+            Direction::Ltr => "ltr",
+            Direction::Other(ref other) => other,
+        };
+        dest.write_str(dir_str)
     }
 }


### PR DESCRIPTION
`:dir()` pseudo class param now represented as enum variants.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #16840
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19195)
<!-- Reviewable:end -->
