### PR TITLE
Parse HTML input speculatively using the async tokenizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1038,7 +1038,7 @@ dependencies = [
  "unicode-script 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_api 0.57.0 (git+https://github.com/servo/webrender)",
  "xi-unicode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml5ever 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml5ever 0.12.0 (git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state)",
 ]
 
 [[package]]
@@ -1165,11 +1165,11 @@ dependencies = [
 [[package]]
 name = "html5ever"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state#f56de08b62b6a4d1316766d2d35738776ab183b3"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "markup5ever 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "markup5ever 0.7.2 (git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state)",
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1394,7 +1394,7 @@ dependencies = [
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.0.1",
  "gfx_traits 0.0.1",
- "html5ever 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "html5ever 0.22.0 (git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state)",
  "ipc-channel 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1436,7 +1436,7 @@ dependencies = [
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.0.1",
  "gfx_traits 0.0.1",
- "html5ever 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "html5ever 0.22.0 (git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state)",
  "ipc-channel 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "layout 0.0.1",
  "layout_traits 0.0.1",
@@ -1636,7 +1636,7 @@ dependencies = [
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_api 0.57.0 (git+https://github.com/servo/webrender)",
- "xml5ever 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml5ever 0.12.0 (git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state)",
 ]
 
 [[package]]
@@ -1658,8 +1658,8 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.7.2"
+source = "git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state#f56de08b62b6a4d1316766d2d35738776ab183b3"
 dependencies = [
  "phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2445,7 +2445,7 @@ dependencies = [
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "half 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "html5ever 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "html5ever 0.22.0 (git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2498,7 +2498,7 @@ dependencies = [
  "uuid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_api 0.57.0 (git+https://github.com/servo/webrender)",
  "webvr_traits 0.0.1",
- "xml5ever 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml5ever 0.12.0 (git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state)",
 ]
 
 [[package]]
@@ -2511,7 +2511,7 @@ dependencies = [
  "cssparser 0.23.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
- "html5ever 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "html5ever 0.22.0 (git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state)",
  "ipc-channel 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2952,7 +2952,7 @@ dependencies = [
  "fallible 0.0.1",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashglobe 0.1.0",
- "html5ever 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "html5ever 0.22.0 (git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state)",
  "itertools 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3009,7 +3009,7 @@ dependencies = [
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.23.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "html5ever 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "html5ever 0.22.0 (git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state)",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.19.0",
@@ -3679,11 +3679,11 @@ dependencies = [
 [[package]]
 name = "xml5ever"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state#f56de08b62b6a4d1316766d2d35738776ab183b3"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "markup5ever 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "markup5ever 0.7.2 (git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3792,7 +3792,7 @@ dependencies = [
 "checksum harfbuzz-sys 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "52aa65c5649a0a2f1b27ab30093b3cc84681e17ddb552267e21948c5a6fa6b05"
 "checksum heartbeats-simple 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ad003ce233955e9d95f2c69cde84e68302ba9ba4a673d351c9bff93c738aadc"
 "checksum heartbeats-simple-sys 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e1a408c0011427cc0e0049f7861c70377819aedfc006e8c901b1c70fd98fb1a4"
-"checksum html5ever 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e579ac8647178ab915d400d7d22938bda5cd351c6c62e1c294d56884ccfc75fe"
+"checksum html5ever 0.22.0 (git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state)" = "<none>"
 "checksum httparse 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e7a63e511f9edffbab707141fbb8707d1a3098615fb2adbd5769cdfcc9b17d"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum hyper-openssl 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "85a372eb692590b3fe014c196c30f9f52d4c42f58cd49dd94caeee1593c9cc37"
@@ -3828,7 +3828,7 @@ dependencies = [
 "checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
 "checksum mac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-"checksum markup5ever 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c220b3a3d75543b76e5c1fcab6635a8430ab5f9bfa011d003c3787ae0abf4ffa"
+"checksum markup5ever 0.7.2 (git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state)" = "<none>"
 "checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
@@ -3990,4 +3990,4 @@ dependencies = [
 "checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"
 "checksum xi-unicode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12ea8eda4b1eb72f02d148402e23832d56a33f55d8c1b2d5bcdde91d79d47cb1"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
-"checksum xml5ever 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ead952cf8bab253fb5cb56e1fff780747bbf7a7258fb0451afe645a166050b1f"
+"checksum xml5ever 0.12.0 (git+https://github.com/cynicaldevil/html5ever?branch=clone-tokenizer-state)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ opt-level = 3
 #
 #     [patch."https://github.com/servo/<repository>"]
 #     <crate> = { path = "/path/to/local/checkout" }
+html5ever = { git = "https://github.com/cynicaldevil/html5ever", branch= "clone-tokenizer-state" }
+xml5ever = { git = "https://github.com/cynicaldevil/html5ever", branch= "clone-tokenizer-state" }
+# html5ever = { path = "../html5ever/html5ever" }
+# xml5ever = { path = "../html5ever/xml5ever" }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

Do not merge: This PR needs some changes in h5e, and I'm testing this using my h5e fork with the changes to see if it all works well.
h5e side changes: https://github.com/cynicaldevil/html5ever/tree/clone-tokenizer-state. These changes mostly consist of creating new types which correspond to the Tokenizer and TreeBuilder, which are `Send`able.

The biggest change on the Servo side is the creation of the `ParseOperationExecutor` type, which actually receives parse operations and executes them. Before this, the code for doing this resided directly inside the `Tokenizer`, but I had to create a separate type for this because the `Sink` needs to use this while parsing speculatively.
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19203)
<!-- Reviewable:end -->
