### PR TITLE
Save test-perf data in csv

### DIFF
--- a/etc/ci/performance/page_load_test/example/example_sync.html
+++ b/etc/ci/performance/page_load_test/example/example_sync.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
-    <title></title>
+    <title>An example pageload test</title>
   </head>
   <body>
   Hello World

--- a/etc/ci/performance/runner.py
+++ b/etc/ci/performance/runner.py
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import argparse
+import csv
 import itertools
 import json
 import os
@@ -236,6 +237,40 @@ def save_result_json(results, filename, manifest, expected_runs, base):
     print("Result saved to {}".format(filename))
 
 
+def save_result_csv(results, filename, manifest, expected_runs, base):
+
+    fieldnames = [
+        'testcase',
+        'title',
+        'connectEnd',
+        'connectStart',
+        'domComplete',
+        'domContentLoadedEventEnd',
+        'domContentLoadedEventStart',
+        'domInteractive',
+        'domLoading',
+        'domainLookupEnd',
+        'domainLookupStart',
+        'fetchStart',
+        'loadEventEnd',
+        'loadEventStart',
+        'navigationStart',
+        'redirectEnd',
+        'redirectStart',
+        'requestStart',
+        'responseEnd',
+        'responseStart',
+        'secureConnectionStart',
+        'unloadEventEnd',
+        'unloadEventStart',
+    ]
+
+    with open(filename, 'w') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames)
+        writer.writeheader()
+        writer.writerows(results)
+
+
 def format_result_summary(results):
     failures = list(filter(lambda x: x['domComplete'] == -1, results))
     result_log = """
@@ -306,7 +341,10 @@ def main():
                 # TODO: Record and analyze other performance.timing properties
 
         print(format_result_summary(results))
-        save_result_json(results, args.output_file, testcases, args.runs, args.base)
+        if args.output_file.endswith('.csv'):
+            save_result_csv(results, args.output_file, testcases, args.runs, args.base)
+        else:
+            save_result_json(results, args.output_file, testcases, args.runs, args.base)
 
     except KeyboardInterrupt:
         print("Test stopped by user, saving partial result")

--- a/etc/ci/performance/test_all.sh
+++ b/etc/ci/performance/test_all.sh
@@ -49,7 +49,7 @@ python3 -m http.server > /dev/null 2>&1 &
 # MANIFEST="page_load_test/tp5n/20160509.manifest" # A manifest that excludes
 MANIFEST="page_load_test/example.manifest" # A manifest that excludes
                                                  # timeout test cases
-PERF_FILE="output/perf-$(date +%s).json"
+PERF_FILE="output/perf-$(date +%s).csv"
 
 echo "Running tests"
 python3 runner.py ${engine} --runs 4 --timeout "${timeout}" --base "${base}" \


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Most data analytics and visualization tools (e.g. Google Data Studio and Amazon Quick Sight) seem to want .csv input, not .json. This PR makes .csv the default data format.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it's test infrastructure

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19233)
<!-- Reviewable:end -->
