### PR TITLE
Use InvalidRule for nested rule list

### DIFF
--- a/components/style/stylesheets/rule_parser.rs
+++ b/components/style/stylesheets/rule_parser.rs
@@ -331,7 +331,7 @@ impl<'a, 'b, R: ParseErrorReporter> NestedRuleParser<'a, 'b, R> {
                 Ok(rule) => rules.push(rule),
                 Err((error, slice)) => {
                     let location = error.location;
-                    let error = ContextualParseError::UnsupportedRule(slice, error);
+                    let error = ContextualParseError::InvalidRule(slice, error);
                     self.context.log_css_error(self.error_context, location, error);
                 }
             }

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -354,9 +354,8 @@ fn test_report_error_stylesheet() {
         // When @font-feature-values is supported, this should be replaced with two errors
         (15, 25, "Invalid rule: '@font-feature-values "),
 
-        // FIXME: the message of these two should be consistent
         (16, 13, "Invalid rule: '@invalid'"),
-        (17, 29, "Unsupported rule: '@invalid'"),
+        (17, 29, "Invalid rule: '@invalid'"),
 
         (18, 34, "Invalid rule: '@supports "),
         (19, 26, "Invalid keyframe rule: 'from invalid '"),


### PR DESCRIPTION
This fixes [bug 1417548](https://bugzilla.mozilla.org/show_bug.cgi?id=1417548).

Apparently it makes no sense to have different error between top level rules and nested rules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19237)
<!-- Reviewable:end -->
