### PR TITLE
Bump servo-websocket to 0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,7 +1970,7 @@ dependencies = [
  "profile_traits 0.0.1",
  "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "servo-websocket 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo-websocket 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_config 0.0.1",
  "servo_url 0.0.1",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2933,10 +2933,10 @@ dependencies = [
 
 [[package]]
 name = "servo-websocket"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4042,7 +4042,7 @@ dependencies = [
 "checksum servo-freetype-sys 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9232032c2e85118c0282c6562c84cab12316e655491ba0a5d1905b2320060d1b"
 "checksum servo-glutin 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "91cdbc8014ea1171264622545b9b3d653f20336abb0e924682e98c951171fa58"
 "checksum servo-skia 0.30000007.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0abf282739e8b8e987f2b69736a0287a83b0f87189f53cc786a97bd2019e543d"
-"checksum servo-websocket 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8a1ff13c5d852c2793805226e688044309f2c1d8f063784805a13e99cb75b611"
+"checksum servo-websocket 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efde78dfcf2178d5a11e1e2268e0d8df0627dfe2724546db8585d6678e1af150"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum shared_library 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fb04126b6fcfd2710fb5b6d18f4207b6c535f2850a7e1a43bcd526d44f30a79a"
 "checksum shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72f20b8f3c060374edb8046591ba28f62448c369ccbdc7b02075103fb3a9e38d"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -34,7 +34,7 @@ serde = "1.0"
 serde_json = "1.0"
 servo_config = {path = "../config"}
 servo_url = {path = "../url"}
-servo-websocket = "0.19"
+servo-websocket = "0.20"
 threadpool = "1.0"
 time = "0.1.17"
 unicase = "1.4.0"


### PR DESCRIPTION
This removes one use of an obsolete bitflags version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19247)
<!-- Reviewable:end -->
