### PR TITLE
Implement WebGL2 Uniform Buffer Objects

### DIFF
--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -271,6 +271,16 @@ pub enum WebGLCommand {
     CreateVertexArray(WebGLSender<Option<WebGLVertexArrayId>>),
     DeleteVertexArray(WebGLVertexArrayId),
     BindVertexArray(Option<WebGLVertexArrayId>),
+    /* Uniform Buffer Objects and Transform Feedback Buffers */
+    BindBufferBase(u32, u32, Option<WebGLBufferId>),
+    BindBufferRange(u32, u32, Option<WebGLBufferId>, i64, i64),
+    GetIndexedParameter(u32, u32, WebGLSender<WebGLResult<WebGLParameter>>),
+    GetUniformIndices(WebGLProgramId, Vec<String>, WebGLSender<Vec<u32>>),
+    GetActiveUniforms(WebGLProgramId, Vec<u32>, u32, WebGLSender<WebGLResult<WebGLParameterVec>>),
+    GetUniformBlockIndex(WebGLProgramId, String, WebGLSender<u32>),
+    GetActiveUniformBlockParameter(WebGLProgramId, u32, u32, WebGLSender<WebGLResult<WebGLUniformBlockParameter>>),
+    GetActiveUniformBlockName(WebGLProgramId, u32, WebGLSender<String>),
+    UniformBlockBinding(WebGLProgramId, u32, u32),
 }
 
 macro_rules! define_resource_id_struct {
@@ -373,10 +383,27 @@ pub enum WebGLFramebufferBindingRequest {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum WebGLParameter {
     Int(i32),
+    Int64(i64),
     Bool(bool),
     String(String),
     Float(f32),
     FloatArray(Vec<f32>),
+    Invalid,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum WebGLParameterVec {
+    Int(Vec<i32>),
+    Uint(Vec<u32>),
+    Bool(Vec<bool>),
+    Invalid,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum WebGLUniformBlockParameter {
+    Uint(u32),
+    Bool(bool),
+    IntArray(Vec<i32>),
     Invalid,
 }
 
@@ -540,7 +567,16 @@ impl fmt::Debug for WebGLCommand {
             GenerateMipmap(..) => "GenerateMipmap",
             CreateVertexArray(..) => "CreateVertexArray",
             DeleteVertexArray(..) => "DeleteVertexArray",
-            BindVertexArray(..) => "BindVertexArray"
+            BindVertexArray(..) => "BindVertexArray",
+            BindBufferBase(..) => "BindBufferBase",
+            BindBufferRange(..) => "BindBufferRange",
+            GetIndexedParameter(..) => "GetIndexedParameter",
+            GetUniformIndices(..) => "GetUniformIndices",
+            GetActiveUniforms(..) => "GetActiveUniforms",
+            GetUniformBlockIndex(..) => "GetUniformBlockIndex",
+            GetActiveUniformBlockParameter(..) => "GetActiveUniformBlockParameter",
+            GetActiveUniformBlockName(..) => "GetActiveUniformBlockName",
+            UniformBlockBinding(..) => "UniformBlockBinding",
         };
 
         write!(f, "CanvasWebGLMsg::{}(..)", name)

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -557,15 +557,15 @@ interface WebGL2RenderingContextBase
   void resumeTransformFeedback();*/
 
   /* Uniform Buffer Objects and Transform Feedback Buffers */
-  // void bindBufferBase(GLenum target, GLuint index, WebGLBuffer? buffer);
-  // void bindBufferRange(GLenum target, GLuint index, WebGLBuffer? buffer, GLintptr offset, GLsizeiptr size);
-  // any getIndexedParameter(GLenum target, GLuint index);
-  // sequence<GLuint>? getUniformIndices(WebGLProgram program, sequence<DOMString> uniformNames);
-  // any getActiveUniforms(WebGLProgram program, sequence<GLuint> uniformIndices, GLenum pname);
-  // GLuint getUniformBlockIndex(WebGLProgram program, DOMString uniformBlockName);
-  // any getActiveUniformBlockParameter(WebGLProgram program, GLuint uniformBlockIndex, GLenum pname);
-  // DOMString? getActiveUniformBlockName(WebGLProgram program, GLuint uniformBlockIndex);
-  // void uniformBlockBinding(WebGLProgram program, GLuint uniformBlockIndex, GLuint uniformBlockBinding);
+  void bindBufferBase(GLenum target, GLuint index, WebGLBuffer? buffer);
+  void bindBufferRange(GLenum target, GLuint index, WebGLBuffer? buffer, GLintptr offset, GLsizeiptr size);
+  any getIndexedParameter(GLenum target, GLuint index);
+  sequence<GLuint>? getUniformIndices(WebGLProgram program, sequence<DOMString> uniformNames);
+  any getActiveUniforms(WebGLProgram program, sequence<GLuint> uniformIndices, GLenum pname);
+  GLuint getUniformBlockIndex(WebGLProgram program, DOMString uniformBlockName);
+  any getActiveUniformBlockParameter(WebGLProgram program, GLuint uniformBlockIndex, GLenum pname);
+  DOMString? getActiveUniformBlockName(WebGLProgram program, GLuint uniformBlockIndex);
+  void uniformBlockBinding(WebGLProgram program, GLuint uniformBlockIndex, GLuint uniformBlockBinding);
 
   /* Vertex Array Objects */
   /*WebGLVertexArrayObject? createVertexArray();

--- a/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/buffers/bound-buffer-size-change-test.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/buffers/bound-buffer-size-change-test.html.ini
@@ -1,5 +1,0 @@
-[bound-buffer-size-change-test.html]
-  expected: ERROR
-  [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/buffers/buffer-overflow-test.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/buffers/buffer-overflow-test.html.ini
@@ -1,5 +1,0 @@
-[buffer-overflow-test.html]
-  expected: ERROR
-  [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/buffers/buffer-type-restrictions.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/buffers/buffer-type-restrictions.html.ini
@@ -1,5 +1,313 @@
 [buffer-type-restrictions.html]
-  expected: ERROR
-  [Overall test]
-    expected: NOTRUN
+  [WebGL test #6: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.ARRAY_BUFFER and then binding buffer with bindBuffer to gl.COPY_READ_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #7: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.ARRAY_BUFFER and then binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #8: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.ARRAY_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #9: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.ARRAY_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #21: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.ELEMENT_ARRAY_BUFFER and then binding buffer with bindBuffer to gl.COPY_READ_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #22: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.ELEMENT_ARRAY_BUFFER and then binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #23: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.ELEMENT_ARRAY_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #24: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.ELEMENT_ARRAY_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #34: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and then binding buffer with bindBuffer to gl.ARRAY_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #35: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and then binding buffer with bindBuffer to gl.ELEMENT_ARRAY_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #36: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and then binding buffer with bindBuffer to gl.COPY_READ_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #37: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and then binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #38: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #39: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #40: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and then binding buffer with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #41: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and simultaneously binding buffer with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #42: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and then binding buffer with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #43: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and simultaneously binding buffer with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #44: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and then binding buffer with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #45: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and simultaneously binding buffer with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #46: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and then binding buffer with bindBuffer to gl.UNIFORM_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #47: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and then binding buffer with bindBufferRange to gl.UNIFORM_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #48: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_READ_BUFFER and then binding buffer with bindBufferBase to gl.UNIFORM_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #49: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and then binding buffer with bindBuffer to gl.ARRAY_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #50: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and then binding buffer with bindBuffer to gl.ELEMENT_ARRAY_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #51: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and then binding buffer with bindBuffer to gl.COPY_READ_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #52: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and then binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #53: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #54: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #55: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and then binding buffer with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #56: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and simultaneously binding buffer with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #57: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and then binding buffer with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #58: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and simultaneously binding buffer with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #59: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and then binding buffer with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #60: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and simultaneously binding buffer with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #61: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and then binding buffer with bindBuffer to gl.UNIFORM_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #62: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and then binding buffer with bindBufferRange to gl.UNIFORM_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #63: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.COPY_WRITE_BUFFER and then binding buffer with bindBufferBase to gl.UNIFORM_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #64: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and then binding buffer with bindBuffer to gl.ARRAY_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #65: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and then binding buffer with bindBuffer to gl.ELEMENT_ARRAY_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #66: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and then binding buffer with bindBuffer to gl.COPY_READ_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #67: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and then binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #68: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #69: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #70: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and then binding buffer with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #71: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and simultaneously binding buffer with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #72: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and then binding buffer with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #73: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and simultaneously binding buffer with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #74: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and then binding buffer with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #75: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and simultaneously binding buffer with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #76: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and then binding buffer with bindBuffer to gl.UNIFORM_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #77: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and then binding buffer with bindBufferRange to gl.UNIFORM_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #78: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_PACK_BUFFER and then binding buffer with bindBufferBase to gl.UNIFORM_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #79: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and then binding buffer with bindBuffer to gl.ARRAY_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #80: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and then binding buffer with bindBuffer to gl.ELEMENT_ARRAY_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #81: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and then binding buffer with bindBuffer to gl.COPY_READ_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #82: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and then binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #83: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #84: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #85: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and then binding buffer with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #86: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and simultaneously binding buffer with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #87: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and then binding buffer with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #88: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and simultaneously binding buffer with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #89: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and then binding buffer with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #90: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and simultaneously binding buffer with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #91: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and then binding buffer with bindBuffer to gl.UNIFORM_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #92: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and then binding buffer with bindBufferRange to gl.UNIFORM_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #93: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.PIXEL_UNPACK_BUFFER and then binding buffer with bindBufferBase to gl.UNIFORM_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #106: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER and then binding buffer with bindBuffer to gl.COPY_READ_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #107: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER and simultaneously binding buffer with bindBuffer to gl.COPY_READ_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #108: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER and then binding buffer with bindBuffer to gl.COPY_READ_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #109: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER and simultaneously binding buffer with bindBuffer to gl.COPY_READ_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #110: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER and then binding buffer with bindBuffer to gl.COPY_READ_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #111: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER and simultaneously binding buffer with bindBuffer to gl.COPY_READ_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #112: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER and then binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #113: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER and simultaneously binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #114: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER and then binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #115: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER and simultaneously binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #116: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER and then binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #117: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER and simultaneously binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #118: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #119: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER and simultaneously binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #120: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #121: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER and simultaneously binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #122: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #123: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER and simultaneously binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #124: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #125: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.TRANSFORM_FEEDBACK_BUFFER and simultaneously binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #126: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #127: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBufferRange to gl.TRANSFORM_FEEDBACK_BUFFER and simultaneously binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #128: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #129: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Binding buffer first with bindBufferBase to gl.TRANSFORM_FEEDBACK_BUFFER and simultaneously binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should FAIL]
+    expected: FAIL
+
+  [WebGL test #163: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.UNIFORM_BUFFER and then binding buffer with bindBuffer to gl.COPY_READ_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #164: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferRange to gl.UNIFORM_BUFFER and then binding buffer with bindBuffer to gl.COPY_READ_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #165: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferBase to gl.UNIFORM_BUFFER and then binding buffer with bindBuffer to gl.COPY_READ_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #166: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.UNIFORM_BUFFER and then binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #167: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferRange to gl.UNIFORM_BUFFER and then binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #168: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferBase to gl.UNIFORM_BUFFER and then binding buffer with bindBuffer to gl.COPY_WRITE_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #169: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.UNIFORM_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #170: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferRange to gl.UNIFORM_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #171: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferBase to gl.UNIFORM_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_PACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #172: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBuffer to gl.UNIFORM_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #173: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferRange to gl.UNIFORM_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should WORK]
+    expected: FAIL
+
+  [WebGL test #174: getError expected: NO_ERROR. Was INVALID_ENUM : Binding buffer first with bindBufferBase to gl.UNIFORM_BUFFER and then binding buffer with bindBuffer to gl.PIXEL_UNPACK_BUFFER should WORK]
+    expected: FAIL
 

--- a/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/buffers/uniform-buffers.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/buffers/uniform-buffers.html.ini
@@ -1,26 +1,5 @@
 [uniform-buffers.html]
   expected: ERROR
-  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : UNIFORM_BUFFER_BINDING query should succeed]
-    expected: FAIL
-
-  [WebGL test #6: getError expected: NO_ERROR. Was INVALID_ENUM : should be able to bind uniform buffer]
-    expected: FAIL
-
-  [WebGL test #7: gl.getParameter(gl.UNIFORM_BUFFER_BINDING) should be [object WebGLBuffer\]. Was null.]
-    expected: FAIL
-
-  [WebGL test #8: getError expected: NO_ERROR. Was INVALID_ENUM : should be able to update uniform buffer binding]
-    expected: FAIL
-
-  [WebGL test #9: gl.getParameter(gl.UNIFORM_BUFFER_BINDING) should be [object WebGLBuffer\]. Was null.]
-    expected: FAIL
-
-  [WebGL test #10: getError expected: NO_ERROR. Was INVALID_ENUM : should be able to unbind uniform buffer]
-    expected: FAIL
-
-  [WebGL test #12: getError expected: INVALID_OPERATION. Was INVALID_ENUM : binding a deleted buffer should generate INVALID_OPERATION]
-    expected: FAIL
-
   [WebGL test #15: Could not compile shader with uniform blocks without error]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/context/methods-2.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/context/methods-2.html.ini
@@ -242,42 +242,15 @@
   [WebGL test #80: Property either does not exist or is not a function: resumeTransformFeedback]
     expected: FAIL
 
-  [WebGL test #81: Property either does not exist or is not a function: bindBufferBase]
+  [WebGL test #81: Property either does not exist or is not a function: createVertexArray]
     expected: FAIL
 
-  [WebGL test #82: Property either does not exist or is not a function: bindBufferRange]
+  [WebGL test #82: Property either does not exist or is not a function: deleteVertexArray]
     expected: FAIL
 
-  [WebGL test #83: Property either does not exist or is not a function: getIndexedParameter]
+  [WebGL test #83: Property either does not exist or is not a function: isVertexArray]
     expected: FAIL
 
-  [WebGL test #84: Property either does not exist or is not a function: getUniformIndices]
-    expected: FAIL
-
-  [WebGL test #85: Property either does not exist or is not a function: getActiveUniforms]
-    expected: FAIL
-
-  [WebGL test #86: Property either does not exist or is not a function: getUniformBlockIndex]
-    expected: FAIL
-
-  [WebGL test #87: Property either does not exist or is not a function: getActiveUniformBlockParameter]
-    expected: FAIL
-
-  [WebGL test #88: Property either does not exist or is not a function: getActiveUniformBlockName]
-    expected: FAIL
-
-  [WebGL test #89: Property either does not exist or is not a function: uniformBlockBinding]
-    expected: FAIL
-
-  [WebGL test #90: Property either does not exist or is not a function: createVertexArray]
-    expected: FAIL
-
-  [WebGL test #91: Property either does not exist or is not a function: deleteVertexArray]
-    expected: FAIL
-
-  [WebGL test #92: Property either does not exist or is not a function: isVertexArray]
-    expected: FAIL
-
-  [WebGL test #93: Property either does not exist or is not a function: bindVertexArray]
+  [WebGL test #84: Property either does not exist or is not a function: bindVertexArray]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/state/gl-enum-tests.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/state/gl-enum-tests.html.ini
@@ -1,5 +1,5 @@
 [gl-enum-tests.html]
   expected: ERROR
-  [WebGL test #16: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #23: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/state/gl-get-calls.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/state/gl-get-calls.html.ini
@@ -188,12 +188,6 @@
   [WebGL test #80: context.getParameter(context.MIN_PROGRAM_TEXEL_OFFSET) is not an instance of Number]
     expected: FAIL
 
-  [WebGL test #81: context.getParameter(context.UNIFORM_BUFFER_OFFSET_ALIGNMENT) should be >= 1. Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #82: context.getParameter(context.UNIFORM_BUFFER_OFFSET_ALIGNMENT) is not an instance of Number]
-    expected: FAIL
-
   [WebGL test #84: context.getParameter(context.MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS) is not an instance of Number]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/transform_feedback/unwritten-output-defaults-to-zero.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-2.0.0/conformance2/transform_feedback/unwritten-output-defaults-to-zero.html.ini
@@ -1,7 +1,5 @@
 [unwritten-output-defaults-to-zero.html]
-  [WebGL test #1: Fail to set up the program]
-    expected: FAIL
-
-  [WebGL test #2: Fail to set up the program]
+  expected: ERROR
+  [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Implement WebGL2 Uniform Buffer Objects.

Note: Currently OSMesa compat profiles only support OpenGL 3.0 (GLSL 130). Some UBO shaders used in WPT can't be compiled with GLSL 130, so part of the implementation is not fully tested (e.g. `Could not compile shader with uniform blocks without error` errors in uniform-buffers.html test). All uniform-buffers.html render tests pass using the native GPU. I'll open an follow-up issue about that.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19250)
<!-- Reviewable:end -->
