### PR TITLE
Paint worklets: Implement timeout for worklet painter threads

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -100,8 +100,8 @@ use script_layout_interface::rpc::{LayoutRPC, MarginStyleResponse, NodeOverflowR
 use script_layout_interface::rpc::TextIndexResponse;
 use script_layout_interface::wrapper_traits::LayoutNode;
 use script_traits::{ConstellationControlMsg, LayoutControlMsg, LayoutMsg as ConstellationMsg};
+use script_traits::{DrawAPaintImageResult, PaintWorkletError};
 use script_traits::{ScrollState, UntrustedNodeAddress};
-use script_traits::DrawAPaintImageResult;
 use script_traits::Painter;
 use selectors::Element;
 use servo_arc::Arc as ServoArc;
@@ -1787,7 +1787,7 @@ impl Painter for RegisteredPainterImpl {
                           device_pixel_ratio: TypedScale<f32, CSSPixel, DevicePixel>,
                           properties: Vec<(Atom, String)>,
                           arguments: Vec<String>)
-                          -> DrawAPaintImageResult
+                          -> Result<DrawAPaintImageResult, PaintWorkletError>
     {
         self.painter.draw_a_paint_image(size, device_pixel_ratio, properties, arguments)
     }

--- a/components/script/dom/webidls/PaintWorkletGlobalScope.webidl
+++ b/components/script/dom/webidls/PaintWorkletGlobalScope.webidl
@@ -6,4 +6,8 @@
 [Global=(Worklet,PaintWorklet), Pref="dom.worklet.enabled", Exposed=PaintWorklet]
 interface PaintWorkletGlobalScope : WorkletGlobalScope {
     [Throws] void registerPaint(DOMString name, VoidFunction paintCtor);
+    // This function is to be used only for testing, and should not be
+    // accessible outside of that use.
+    [Pref="dom.worklet.blockingsleep.enabled"]
+    void sleep(unsigned long long ms);
 };

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -869,7 +869,7 @@ pub trait Painter: SpeculativePainter {
                           zoom: TypedScale<f32, CSSPixel, DevicePixel>,
                           properties: Vec<(Atom, String)>,
                           arguments: Vec<String>)
-                          -> DrawAPaintImageResult;
+                          -> Result<DrawAPaintImageResult, PaintWorkletError>;
 }
 
 impl fmt::Debug for Painter {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -7804,6 +7804,18 @@
      ],
      {}
     ]
+   ],
+   "mozilla/worklets/test_paint_worklet_timeout.html": [
+    [
+     "/_mozilla/mozilla/worklets/test_paint_worklet_timeout.html",
+     [
+      [
+       "/_mozilla/mozilla/worklets/test_paint_worklet_timeout_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
    ]
   },
   "reftest_node": {
@@ -12697,6 +12709,16 @@
     ]
    ],
    "mozilla/worklets/test_paint_worklet_size_ref.html": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/worklets/test_paint_worklet_timeout.js": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/worklets/test_paint_worklet_timeout_ref.html": [
     [
      {}
     ]
@@ -72430,6 +72452,18 @@
   ],
   "mozilla/worklets/test_paint_worklet_size_ref.html": [
    "7c92e508e08d7d146354a5be7fa256ccbd465dde",
+   "support"
+  ],
+  "mozilla/worklets/test_paint_worklet_timeout.html": [
+   "dde3d2d6359d39282cf8dfdfabebed735c7815a8",
+   "reftest"
+  ],
+  "mozilla/worklets/test_paint_worklet_timeout.js": [
+   "83cdbd59c905de898b72ba47d3ae10bb95d76301",
+   "support"
+  ],
+  "mozilla/worklets/test_paint_worklet_timeout_ref.html": [
+   "193529394981b09b56404678124f6b08ff230a74",
    "support"
   ],
   "mozilla/worklets/test_worklet.html": [

--- a/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_timeout.html
+++ b/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_timeout.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html class="reftest-wait">
+
+  <head>
+    <meta charset="utf-8">
+    <title>reftest001</title>
+    <link rel="match" href="test_paint_worklet_timeout_ref.html">
+  </head>
+
+  <body>
+    <!--
+     When the paint worklet script takes too long, we should timeout (before the
+     reftest itself timing out). The result should be the same as having
+     a broken image url as the background of the element in question.
+    -->
+    <button id="btn">Click me!</button>
+    <style>
+      #btn {
+        background-image: paint(testgreen);
+      }
+    </style>
+
+    <script>
+      window.paintWorklet.addModule('test_paint_worklet_timeout.js')
+            .then(() => document.documentElement.classList.remove('reftest-wait'));
+    </script>
+
+  </body>
+
+</html>
+

--- a/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_timeout.js
+++ b/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_timeout.js
@@ -1,0 +1,7 @@
+registerPaint("testgreen", class {
+    paint(ctx, size) {
+        ctx.fillStyle = 'green';
+        ctx.fillRect(0, 0, size.width, size.height);
+        sleep(30); // too long for a paintworklet to init
+    }
+});

--- a/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_timeout_ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_timeout_ref.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+
+  <head>
+    <meta charset="utf-8">
+    <title>reftest001</title>
+  </head>
+
+  <body>
+    <button id="btn">Click me!</button>
+
+    <style>
+      #btn {
+        background-image: url(broken.png);
+      }
+    </style>
+
+  </body>
+
+</html>


### PR DESCRIPTION
When a paint worklet thread takes too long, we would like to move on,
since we have a ~16ms budget for rendering at 60fps. At the moment, there
is no provision in the paintworklet spec to signal such timeouts to the
developer. ajeffrey opened an [issue][1] for this, but it got punted to
v2 of the spec. Hence we are silently timing out unresponsive paint
scripts.

The timeout value is chosen to be 10ms by default, and can be overridden
by setting the SERVO_PAINT_WORKLET_TIMEOUT_MS environment variable.

In the absence of such a timeout, the reftest in this commit would fail
by timing out the testrunner itself, since the paint script never
returns. From my discussions with ajeffrey, this should do until we spec
out a way to signal timeouts to the script developer.

This fixes #17370.

[1]: https://github.com/w3c/css-houdini-drafts/issues/507

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19256)
<!-- Reviewable:end -->
