### PR TITLE
selectors: Allow white space in the brackets of an attribute selector.

### DIFF
--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -1365,6 +1365,9 @@ where
 {
     let namespace;
     let local_name;
+
+    input.skip_whitespace();
+
     match parse_qualified_name(parser, input, /* in_attr_selector = */ true)? {
         OptionalQName::None(t) => {
             return Err(input.new_custom_error(

--- a/tests/wpt/web-platform-tests/css/selectors/selectors-attr-white-space-001-ref.html
+++ b/tests/wpt/web-platform-tests/css/selectors/selectors-attr-white-space-001-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selectors: White space in attribute selectors (reference)</title>
+<link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au"/>
+<style>
+body { color: green; }
+</style>
+<p>This text should be green.</p>
+<p>This text should be green.</p>
+<p>This text should be green.</p>
+<p>This text should be green.</p>

--- a/tests/wpt/web-platform-tests/css/selectors/selectors-attr-white-space-001.html
+++ b/tests/wpt/web-platform-tests/css/selectors/selectors-attr-white-space-001.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selectors: White space in attribute selectors</title>
+<link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au"/>
+<link rel="help" href="https://drafts.csswg.org/selectors-3/#w3cselgrammar"/>
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#grammar"/>
+<link rel="match" href="selectors-attr-white-space-001-ref.html"/>
+<style>
+body { color: red; }
+[ data-test-1] { color: green; }
+[data-test-2 ] { color: green; }
+[data-test-3 = x] { color: green; }
+[ |data-test-4] { color: green; }
+[ | data-test-4] { color: red; }
+</style>
+<p data-test-1="">This text should be green.</p>
+<p data-test-2="">This text should be green.</p>
+<p data-test-3="x">This text should be green.</p>
+<p data-test-4="">This text should be green.</p>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19263)
<!-- Reviewable:end -->
