### PR TITLE
style: Replace "internal" properties with "enabled_in"

### DIFF
--- a/components/style/properties/data.py
+++ b/components/style/properties/data.py
@@ -146,8 +146,9 @@ def arg_to_bool(arg):
 
 class Longhand(object):
     def __init__(self, style_struct, name, spec=None, animation_value_type=None, derived_from=None, keyword=None,
-                 predefined_type=None, custom_cascade=False, servo_pref=None, gecko_pref=None, internal=False,
-                 need_index=False, custom_cascade_function=None, gecko_ffi_name=None,
+                 predefined_type=None, custom_cascade=False, servo_pref=None, gecko_pref=None,
+                 enabled_in="content", need_index=False,
+                 custom_cascade_function=None, gecko_ffi_name=None,
                  allowed_in_keyframe_block=True, cast_type='u8',
                  logical=False, alias=None, extra_prefixes=None, boxed=False,
                  flags=None, allowed_in_page_rule=False, allow_quirks=False, ignored_when_colors_disabled=False,
@@ -165,7 +166,15 @@ class Longhand(object):
         self.gecko_pref = gecko_pref
         self.custom_cascade = custom_cascade
         self.custom_cascade_function = custom_cascade_function if custom_cascade else None
-        self.internal = internal
+        # For enabled_in, the setup is as follows:
+        # It needs to be one of the four values: ["", "ua", "chrome", "content"]
+        #  * "chrome" implies "ua", and implies that they're explicitly
+        #    enabled.
+        #  * "" implies the property will never be parsed.
+        #  * "content" implies the property is accessible unconditionally,
+        #    modulo a pref, set via servo_pref / gecko_pref.
+        assert enabled_in in ["", "ua", "chrome", "content"]
+        self.enabled_in = enabled_in
         self.need_index = need_index
         self.gecko_ffi_name = gecko_ffi_name or "m" + self.camel_case
         self.derived_from = (derived_from or "").split()
@@ -212,16 +221,18 @@ class Longhand(object):
 
     # FIXME(emilio): Shorthand and Longhand should really share a base class.
     def explicitly_enabled_in_ua_sheets(self):
-        return self.internal
+        return self.enabled_in in ["ua", "chrome"]
 
-    # TODO(emilio): Change the `internal` field to something like `enabled_in`.
     def explicitly_enabled_in_chrome(self):
-        return False
+        return self.enabled_in == "chrome"
+
+    def enabled_in_content(self):
+        return self.enabled_in == "content"
 
 
 class Shorthand(object):
     def __init__(self, name, sub_properties, spec=None, servo_pref=None, gecko_pref=None,
-                 internal=False,
+                 enabled_in="content",
                  allowed_in_keyframe_block=True, alias=None, extra_prefixes=None,
                  allowed_in_page_rule=False, flags=None):
         self.name = name
@@ -234,7 +245,8 @@ class Shorthand(object):
         self.servo_pref = servo_pref
         self.gecko_pref = gecko_pref
         self.sub_properties = sub_properties
-        self.internal = internal
+        assert enabled_in in ["", "ua", "chrome", "content"]
+        self.enabled_in = enabled_in
         self.alias = alias.split() if alias else []
         self.extra_prefixes = extra_prefixes.split() if extra_prefixes else []
         self.allowed_in_page_rule = arg_to_bool(allowed_in_page_rule)
@@ -271,11 +283,15 @@ class Shorthand(object):
             return bool(self.gecko_pref)
         return bool(self.servo_pref)
 
+    # FIXME(emilio): Shorthand and Longhand should really share a base class.
     def explicitly_enabled_in_ua_sheets(self):
-        return self.internal
+        return self.enabled_in in ["ua", "chrome"]
 
     def explicitly_enabled_in_chrome(self):
-        return False
+        return self.enabled_in == "chrome"
+
+    def enabled_in_content(self):
+        return self.enabled_in == "content"
 
 
 class Alias(object):
@@ -283,7 +299,7 @@ class Alias(object):
         self.name = name
         self.ident = to_rust_ident(name)
         self.camel_case = to_camel_case(self.ident)
-        self.internal = original.internal
+        self.enabled_in = original.enabled_in
         self.servo_pref = original.servo_pref
         self.gecko_pref = original.gecko_pref
         self.allowed_in_page_rule = original.allowed_in_page_rule
@@ -295,10 +311,13 @@ class Alias(object):
         return bool(self.servo_pref)
 
     def explicitly_enabled_in_ua_sheets(self):
-        return self.internal
+        return self.enabled_in in ["ua", "chrome"]
 
     def explicitly_enabled_in_chrome(self):
-        return False
+        return self.enabled_in == "chrome"
+
+    def enabled_in_content(self):
+        return self.enabled_in == "content"
 
 
 class Method(object):

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -222,7 +222,8 @@
 ${helpers.single_keyword("-moz-top-layer", "none top",
                          gecko_constant_prefix="NS_STYLE_TOP_LAYER",
                          gecko_ffi_name="mTopLayer",
-                         products="gecko", animation_value_type="none", internal=True,
+                         products="gecko", animation_value_type="none",
+                         enabled_in="ua",
                          spec="Internal (not web-exposed)")}
 
 ${helpers.single_keyword("position", "static absolute relative fixed sticky",
@@ -368,12 +369,12 @@ ${helpers.predefined_type(
 // CSS 2.1, Section 11 - Visual effects
 
 ${helpers.single_keyword("-servo-overflow-clip-box", "padding-box content-box",
-    products="servo", animation_value_type="none", internal=True,
+    products="servo", animation_value_type="none", enabled_in="ua",
     spec="Internal, not web-exposed, \
           may be standardized in the future (https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-clip-box)")}
 
 ${helpers.single_keyword("overflow-clip-box", "padding-box content-box",
-    products="gecko", animation_value_type="discrete", internal=True,
+    products="gecko", animation_value_type="discrete", enabled_in="ua",
     gecko_pref="layout.css.overflow-clip-box.enabled",
     flags="APPLIES_TO_PLACEHOLDER",
     spec="Internal, not web-exposed, \

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -928,7 +928,8 @@ ${helpers.predefined_type("font-language-override",
                           flags="APPLIES_TO_FIRST_LETTER APPLIES_TO_FIRST_LINE APPLIES_TO_PLACEHOLDER",
                           spec="https://drafts.csswg.org/css-fonts-3/#propdef-font-language-override")}
 
-<%helpers:longhand name="-x-lang" products="gecko" animation_value_type="none" internal="True"
+<%helpers:longhand name="-x-lang" products="gecko" animation_value_type="none"
+                   enabled_in=""
                    spec="Internal (not web-exposed)">
     pub use self::computed_value::T as SpecifiedValue;
 
@@ -963,7 +964,7 @@ ${helpers.predefined_type("font-language-override",
 <%helpers:longhand name="-moz-script-size-multiplier" products="gecko" animation_value_type="none"
                    predefined_type="Number" gecko_ffi_name="mScriptSizeMultiplier"
                    spec="Internal (not web-exposed)"
-                   internal="True">
+                   enabled_in="">
     pub use self::computed_value::T as SpecifiedValue;
 
     pub mod computed_value {
@@ -987,7 +988,7 @@ ${helpers.predefined_type("-moz-script-level",
                           0,
                           animation_value_type="none",
                           products="gecko",
-                          internal=True,
+                          enabled_in="ua",
                           gecko_ffi_name="mScriptLevel",
                           spec="Internal (not web-exposed)")}
 
@@ -1016,7 +1017,7 @@ ${helpers.predefined_type("-moz-script-min-size",
                           "specified::MozScriptMinSize::get_initial_value()",
                           animation_value_type="none",
                           products="gecko",
-                          internal=True,
+                          enabled_in="",
                           gecko_ffi_name="mScriptMinSize",
                           spec="Internal (not web-exposed)")}
 
@@ -1025,7 +1026,7 @@ ${helpers.predefined_type("-x-text-zoom",
                           "computed::XTextZoom(true)",
                           animation_value_type="none",
                           products="gecko",
-                          internal=True,
+                          enabled_in="",
                           spec="Internal (not web-exposed)")}
 
 % if product == "gecko":
@@ -1232,7 +1233,7 @@ ${helpers.predefined_type("-moz-font-smoothing-background-color",
                           animation_value_type="AnimatedRGBA",
                           products="gecko",
                           gecko_ffi_name="mFont.fontSmoothingBackgroundColor",
-                          internal=True,
+                          enabled_in="ua",
                           spec="None (Nonstandard internal property)")}
 
 ${helpers.predefined_type("-moz-min-font-size-ratio",
@@ -1240,5 +1241,5 @@ ${helpers.predefined_type("-moz-min-font-size-ratio",
                           "computed::Percentage::hundred()",
                           animation_value_type="none",
                           products="gecko",
-                          internal=True,
+                          enabled_in="ua",
                           spec="Nonstandard (Internal-only)")}

--- a/components/style/properties/longhand/table.mako.rs
+++ b/components/style/properties/longhand/table.mako.rs
@@ -16,4 +16,4 @@ ${helpers.predefined_type("-x-span",
                           products="gecko",
                           spec="Internal-only (for `<col span>` pres attr)",
                           animation_value_type="none",
-                          internal=True)}
+                          enabled_in="")}

--- a/components/style/properties/longhand/ui.mako.rs
+++ b/components/style/properties/longhand/ui.mako.rs
@@ -37,20 +37,20 @@ ${helpers.single_keyword("-moz-window-shadow", "none default menu tooltip sheet"
                          gecko_ffi_name="mWindowShadow",
                          gecko_constant_prefix="NS_STYLE_WINDOW_SHADOW",
                          animation_value_type="discrete",
-                         internal=True,
+                         enabled_in="ua",
                          spec="None (Nonstandard internal property)")}
 
 ${helpers.predefined_type("-moz-window-opacity", "Opacity", "1.0", products="gecko",
                           gecko_ffi_name="mWindowOpacity",
                           animation_value_type="ComputedValue",
-                          internal=True,
+                          enabled_in="ua",
                           spec="None (Nonstandard internal property)")}
 
 ${helpers.predefined_type("-moz-window-transform", "Transform",
                           "generics::transform::Transform::none()",
                           products="gecko", gecko_ffi_name="mSpecifiedWindowTransform",
                           animation_value_type="ComputedValue",
-                          internal=True,
+                          enabled_in="ua",
                           spec="None (Nonstandard internal property)")}
 
 ${helpers.predefined_type("-moz-window-transform-origin",
@@ -60,7 +60,7 @@ ${helpers.predefined_type("-moz-window-transform-origin",
                           gecko_ffi_name="mWindowTransformOrigin",
                           products="gecko",
                           boxed=True,
-                          internal=True,
+                          enabled_in="ua",
                           spec="None (Nonstandard internal property)")}
 
 <%helpers:longhand name="-moz-force-broken-image-icon"


### PR DESCRIPTION
This allows enabling properties in ua sheets and chrome differently.

The setup is:

  * enabled_in needs to be one of the four values:
    ["", "ua", "chrome", "content"]

  * "chrome" implies "ua", and implies that they're explicitly enabled.

  * "" implies the property will never be parsed.

  * "content" implies the property is accessible unconditionally, modulo a pref.

Experimental still keeps trumping over those when the pref is enabled.

This PR replaces uses of internal="" by enabled_in="ua" or enabled_in="".

This may seem that it changes behavior, but since the properties where I added
enabled_in="" already unconditionally error from parse it's not.

Next step is annotating chrome-only properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19267)
<!-- Reviewable:end -->
