### PR TITLE
Fix error reporting codepath for WPT.

### DIFF
--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/testrunner.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/testrunner.py
@@ -593,7 +593,7 @@ class TestRunnerManager(threading.Thread):
         # processing
         self.logger.debug("Wait finished")
 
-        return self.after_test_end(True)
+        return self.after_test_end(self.state.test, True)
 
     def after_test_end(self, test, restart):
         assert isinstance(self.state, RunnerManagerState.running)


### PR DESCRIPTION
I have a PR upstream too (https://github.com/w3c/web-platform-tests/pull/8300), but this will avoid the issue locally until the next upstream sync.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19269)
<!-- Reviewable:end -->
