### PR TITLE
style: Move font-variant-numeric outside of mako

### DIFF
--- a/components/style/macros.rs
+++ b/components/style/macros.rs
@@ -14,6 +14,23 @@ macro_rules! exclusive_value {
     }
 }
 
+#[cfg(feature = "gecko")]
+macro_rules! impl_gecko_keyword_conversions {
+    ($name: ident, $utype: ty) => {
+        impl From<$utype> for $name {
+            fn from(bits: $utype) -> $name {
+                $name::from_gecko_keyword(bits)
+            }
+        }
+
+        impl From<$name> for $utype {
+            fn from(v: $name) -> $utype {
+                v.to_gecko_keyword()
+            }
+        }
+    };
+}
+
 macro_rules! trivial_to_computed_value {
     ($name:ty) => {
         impl $crate::values::computed::ToComputedValue for $name {

--- a/components/style/values/computed/font.rs
+++ b/components/style/values/computed/font.rs
@@ -283,6 +283,9 @@ pub type FontVariantEastAsian = specified::VariantEastAsian;
 /// Use VariantLigatures as computed type of FontVariantLigatures
 pub type FontVariantLigatures = specified::VariantLigatures;
 
+/// Use VariantNumeric as computed type of FontVariantNumeric
+pub type FontVariantNumeric = specified::VariantNumeric;
+
 /// font-language-override can only have a single three-letter
 /// OpenType "language system" tag, so we should be able to compute
 /// it and store it as a 32-bit integer

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -38,7 +38,7 @@ pub use self::border::{BorderImageSlice, BorderImageWidth, BorderImageSideWidth}
 pub use self::border::{BorderRadius, BorderCornerRadius, BorderSpacing};
 pub use self::font::{FontSize, FontSizeAdjust, FontSynthesis, FontWeight, FontVariantAlternates};
 pub use self::font::{FontLanguageOverride, FontVariantSettings, FontVariantEastAsian};
-pub use self::font::{FontVariantLigatures, MozScriptLevel, MozScriptMinSize, XTextZoom};
+pub use self::font::{FontVariantLigatures, FontVariantNumeric, MozScriptLevel, MozScriptMinSize, XTextZoom};
 pub use self::box_::{AnimationIterationCount, AnimationName, ScrollSnapType, VerticalAlign};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -32,7 +32,7 @@ pub use self::border::{BorderCornerRadius, BorderImageSlice, BorderImageWidth};
 pub use self::border::{BorderImageSideWidth, BorderRadius, BorderSideWidth, BorderSpacing};
 pub use self::font::{FontSize, FontSizeAdjust, FontSynthesis, FontWeight, FontVariantAlternates};
 pub use self::font::{FontLanguageOverride, FontVariantSettings, FontVariantEastAsian};
-pub use self::font::{FontVariantLigatures, MozScriptLevel, MozScriptMinSize, XTextZoom};
+pub use self::font::{FontVariantLigatures, FontVariantNumeric, MozScriptLevel, MozScriptMinSize, XTextZoom};
 pub use self::box_::{AnimationIterationCount, AnimationName, ScrollSnapType, VerticalAlign};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};


### PR DESCRIPTION
This is a sub-PR of #19015 
r? emilio 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #19276 
- [x] These changes do not require tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19277)
<!-- Reviewable:end -->
