### PR TITLE
Implement EventTarget constructor

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -15,18 +15,20 @@ use dom::bindings::codegen::Bindings::EventListenerBinding::EventListener;
 use dom::bindings::codegen::Bindings::EventTargetBinding::AddEventListenerOptions;
 use dom::bindings::codegen::Bindings::EventTargetBinding::EventListenerOptions;
 use dom::bindings::codegen::Bindings::EventTargetBinding::EventTargetMethods;
+use dom::bindings::codegen::Bindings::EventTargetBinding::Wrap;
 use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::codegen::UnionTypes::AddEventListenerOptionsOrBoolean;
 use dom::bindings::codegen::UnionTypes::EventListenerOptionsOrBoolean;
 use dom::bindings::codegen::UnionTypes::EventOrString;
 use dom::bindings::error::{Error, Fallible, report_pending_exception};
 use dom::bindings::inheritance::Castable;
-use dom::bindings::reflector::{DomObject, Reflector};
+use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
 use dom::bindings::root::DomRoot;
 use dom::bindings::str::DOMString;
 use dom::element::Element;
 use dom::errorevent::ErrorEvent;
 use dom::event::{Event, EventBubbles, EventCancelable, EventStatus};
+use dom::globalscope::GlobalScope;
 use dom::node::document_from_node;
 use dom::virtualmethods::VirtualMethods;
 use dom::window::Window;
@@ -289,6 +291,16 @@ impl EventTarget {
             reflector_: Reflector::new(),
             handlers: DomRefCell::new(Default::default()),
         }
+    }
+
+    fn new(global: &GlobalScope) -> DomRoot<EventTarget> {
+        reflect_dom_object(Box::new(EventTarget::new_inherited()),
+                           global,
+                           Wrap)
+    }
+
+    pub fn Constructor(global: &GlobalScope) -> Fallible<DomRoot<EventTarget>> {
+        Ok(EventTarget::new(global))
     }
 
     pub fn get_listeners_for(&self,

--- a/components/script/dom/webidls/EventTarget.webidl
+++ b/components/script/dom/webidls/EventTarget.webidl
@@ -5,7 +5,7 @@
  * https://dom.spec.whatwg.org/#interface-eventtarget
  */
 
-[Abstract, Exposed=(Window,Worker,Worklet)]
+[Constructor, Exposed=(Window,Worker,Worklet)]
 interface EventTarget {
   void addEventListener(
     DOMString type,

--- a/tests/wpt/metadata/dom/events/EventTarget-constructible.any.js.ini
+++ b/tests/wpt/metadata/dom/events/EventTarget-constructible.any.js.ini
@@ -1,17 +1,11 @@
 [EventTarget-constructible.any.worker.html]
   type: testharness
-  [A constructed EventTarget can be used as expected]
-    expected: FAIL
-
   [EventTarget can be subclassed]
     expected: FAIL
 
 
 [EventTarget-constructible.any.html]
   type: testharness
-  [A constructed EventTarget can be used as expected]
-    expected: FAIL
-
   [EventTarget can be subclassed]
     expected: FAIL
 

--- a/tests/wpt/metadata/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/dom/interfaces.html.ini
@@ -354,13 +354,7 @@
   [EventTarget interface: document.querySelector("[id\]").attributes[0\] must inherit property "addEventListener" with the proper type (0)]
     expected: FAIL
 
-  [EventTarget interface: calling addEventListener(DOMString,EventListener,[object Object\],[object Object\]) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
   [EventTarget interface: document.querySelector("[id\]").attributes[0\] must inherit property "removeEventListener" with the proper type (1)]
-    expected: FAIL
-
-  [EventTarget interface: calling removeEventListener(DOMString,EventListener,[object Object\],[object Object\]) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
     expected: FAIL
 
   [EventTarget interface: document.querySelector("[id\]").attributes[0\] must inherit property "dispatchEvent" with the proper type (2)]
@@ -484,30 +478,6 @@
     expected: FAIL
 
   [CustomEvent interface: operation initCustomEvent(DOMString, boolean, boolean, any)]
-    expected: FAIL
-
-  [EventTarget must be primary interface of new EventTarget()]
-    expected: FAIL
-
-  [Stringification of new EventTarget()]
-    expected: FAIL
-
-  [EventTarget interface: new EventTarget() must inherit property "addEventListener(DOMString, EventListener, [object Object\],[object Object\])" with the proper type]
-    expected: FAIL
-
-  [EventTarget interface: calling addEventListener(DOMString, EventListener, [object Object\],[object Object\]) on new EventTarget() with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [EventTarget interface: new EventTarget() must inherit property "removeEventListener(DOMString, EventListener, [object Object\],[object Object\])" with the proper type]
-    expected: FAIL
-
-  [EventTarget interface: calling removeEventListener(DOMString, EventListener, [object Object\],[object Object\]) on new EventTarget() with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [EventTarget interface: new EventTarget() must inherit property "dispatchEvent(Event)" with the proper type]
-    expected: FAIL
-
-  [EventTarget interface: calling dispatchEvent(Event) on new EventTarget() with too few arguments must throw TypeError]
     expected: FAIL
 
   [AbortController interface: existence and properties of interface object]


### PR DESCRIPTION
Resolves #19283
Do "Wrap" functions only created for elements that aren't marked Abstract in .webidl file?
How can I see code that was generated from webidls?

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19283 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they are covered by webplatform tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19288)
<!-- Reviewable:end -->
