### PR TITLE
style: Collect more debugging info when collecting rules of detached pseudos.

### DIFF
--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -756,11 +756,18 @@ pub trait TElement
     /// element-backed pseudo-element, in which case we return the originating
     /// element.
     fn rule_hash_target(&self) -> Self {
-        let is_implemented_pseudo =
-            self.implemented_pseudo_element().is_some();
-
-        if is_implemented_pseudo {
-            self.closest_non_native_anonymous_ancestor().unwrap()
+        if let Some(pseudo) = self.implemented_pseudo_element() {
+            match self.closest_non_native_anonymous_ancestor() {
+                Some(e) => e,
+                None => {
+                    panic!(
+                        "Trying to collect rules for a detached pseudo-element: \
+                        {:?} {:?}",
+                        pseudo,
+                        self,
+                    )
+                }
+            }
         } else {
             *self
         }


### PR DESCRIPTION
Called Option::unwrap() on a None value is not a helpful crash message.

This will hopefully help figure out what is causing bug 1418856.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19294)
<!-- Reviewable:end -->
