### PR TITLE
style: Get rid of unstyled children only traversals.

### DIFF
--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -557,11 +557,6 @@ pub trait TElement
                    !data.hint.has_animation_hint_or_recascade();
         }
 
-        if traversal_flags.contains(TraversalFlags::UnstyledOnly) {
-            // We don't process invalidations in UnstyledOnly mode.
-            return data.has_styles();
-        }
-
         if self.has_snapshot() && !self.handled_snapshot() {
             return false;
         }

--- a/components/style/traversal_flags.rs
+++ b/components/style/traversal_flags.rs
@@ -16,9 +16,6 @@ bitflags! {
         /// Traverse and update all elements with CSS animations since
         /// @keyframes rules may have changed. Triggered by CSS rule changes.
         const ForCSSRuleChanges = 1 << 1;
-        /// Styles unstyled elements, but does not handle invalidations on
-        /// already-styled elements.
-        const UnstyledOnly = 1 << 2;
         /// A forgetful traversal ignores the previous state of the frame tree, and
         /// thus does not compute damage or maintain other state describing the styles
         /// pre-traversal. A forgetful traversal is usually the right thing if you
@@ -61,7 +58,6 @@ pub fn assert_traversal_flags_match() {
     check_traversal_flags! {
         ServoTraversalFlags_AnimationOnly => TraversalFlags::AnimationOnly,
         ServoTraversalFlags_ForCSSRuleChanges => TraversalFlags::ForCSSRuleChanges,
-        ServoTraversalFlags_UnstyledOnly => TraversalFlags::UnstyledOnly,
         ServoTraversalFlags_Forgetful => TraversalFlags::Forgetful,
         ServoTraversalFlags_ClearDirtyBits => TraversalFlags::ClearDirtyBits,
         ServoTraversalFlags_ClearAnimationOnlyDirtyDescendants =>

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -294,21 +294,18 @@ pub extern "C" fn Servo_TraverseSubtree(
 
     debug!("Servo_TraverseSubtree (flags={:?})", traversal_flags);
     debug!("{:?}", ShowSubtreeData(element.as_node()));
-    // It makes no sense to do an animation restyle when we're styling
-    // newly-inserted content.
-    if !traversal_flags.contains(TraversalFlags::UnstyledOnly) {
-        let needs_animation_only_restyle =
-            element.has_animation_only_dirty_descendants() ||
-            element.has_animation_restyle_hints();
 
-        if needs_animation_only_restyle {
-            debug!("Servo_TraverseSubtree doing animation-only restyle (aodd={})",
-                   element.has_animation_only_dirty_descendants());
-            traverse_subtree(element,
-                             raw_data,
-                             traversal_flags | TraversalFlags::AnimationOnly,
-                             unsafe { &*snapshots });
-        }
+    let needs_animation_only_restyle =
+        element.has_animation_only_dirty_descendants() ||
+        element.has_animation_restyle_hints();
+
+    if needs_animation_only_restyle {
+        debug!("Servo_TraverseSubtree doing animation-only restyle (aodd={})",
+               element.has_animation_only_dirty_descendants());
+        traverse_subtree(element,
+                         raw_data,
+                         traversal_flags | TraversalFlags::AnimationOnly,
+                         unsafe { &*snapshots });
     }
 
     traverse_subtree(element,


### PR DESCRIPTION
They're useless now, provided we remove the hack to not traverse XBL-bound
elements on initial styling.

Bug: 1418456
Reviewed-by: heycam
MozReview-Commit-ID: AvBVdyF1wb6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19296)
<!-- Reviewable:end -->
