### PR TITLE
style: Expose some properties to chrome code, and hide some accidentally-exposed ones.

### DIFF
--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -768,6 +768,7 @@ ${helpers.single_keyword("-moz-math-display",
                          gecko_constant_prefix="NS_MATHML_DISPLAYSTYLE",
                          gecko_ffi_name="mMathDisplay",
                          products="gecko",
+                         enabled_in="ua",
                          spec="Internal (not web-exposed)",
                          animation_value_type="none")}
 
@@ -781,6 +782,7 @@ ${helpers.single_keyword("-moz-math-variant",
                          products="gecko",
                          spec="Internal (not web-exposed)",
                          animation_value_type="none",
+                         enabled_in="",
                          needs_conversion=True)}
 
 ${helpers.predefined_type("-moz-script-min-size",
@@ -1004,7 +1006,7 @@ ${helpers.predefined_type("-moz-font-smoothing-background-color",
                           animation_value_type="AnimatedRGBA",
                           products="gecko",
                           gecko_ffi_name="mFont.fontSmoothingBackgroundColor",
-                          enabled_in="ua",
+                          enabled_in="chrome",
                           spec="None (Nonstandard internal property)")}
 
 ${helpers.predefined_type("-moz-min-font-size-ratio",

--- a/components/style/properties/longhand/ui.mako.rs
+++ b/components/style/properties/longhand/ui.mako.rs
@@ -27,6 +27,7 @@ ${helpers.single_keyword("-moz-user-select", "auto text none all element element
                          animation_value_type="discrete",
                          spec="https://drafts.csswg.org/css-ui-4/#propdef-user-select")}
 
+// TODO(emilio): This probably should be hidden from content.
 ${helpers.single_keyword("-moz-window-dragging", "default drag no-drag", products="gecko",
                          gecko_ffi_name="mWindowDragging",
                          gecko_enum_prefix="StyleWindowDragging",
@@ -37,20 +38,20 @@ ${helpers.single_keyword("-moz-window-shadow", "none default menu tooltip sheet"
                          gecko_ffi_name="mWindowShadow",
                          gecko_constant_prefix="NS_STYLE_WINDOW_SHADOW",
                          animation_value_type="discrete",
-                         enabled_in="ua",
+                         enabled_in="chrome",
                          spec="None (Nonstandard internal property)")}
 
 ${helpers.predefined_type("-moz-window-opacity", "Opacity", "1.0", products="gecko",
                           gecko_ffi_name="mWindowOpacity",
                           animation_value_type="ComputedValue",
-                          enabled_in="ua",
+                          enabled_in="chrome",
                           spec="None (Nonstandard internal property)")}
 
 ${helpers.predefined_type("-moz-window-transform", "Transform",
                           "generics::transform::Transform::none()",
                           products="gecko", gecko_ffi_name="mSpecifiedWindowTransform",
                           animation_value_type="ComputedValue",
-                          enabled_in="ua",
+                          enabled_in="chrome",
                           spec="None (Nonstandard internal property)")}
 
 ${helpers.predefined_type("-moz-window-transform-origin",
@@ -60,9 +61,10 @@ ${helpers.predefined_type("-moz-window-transform-origin",
                           gecko_ffi_name="mWindowTransformOrigin",
                           products="gecko",
                           boxed=True,
-                          enabled_in="ua",
+                          enabled_in="chrome",
                           spec="None (Nonstandard internal property)")}
 
+// TODO(emilio): Probably also should be hidden from content.
 ${helpers.predefined_type("-moz-force-broken-image-icon",
                           "MozForceBrokenImageIcon",
                           "computed::MozForceBrokenImageIcon::false_value()",


### PR DESCRIPTION
I'm adding a test for internal properties after this in Gecko.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19297)
<!-- Reviewable:end -->
