### PR TITLE
Implement normal for FontSettings

### DIFF
--- a/components/style/values/computed/font.rs
+++ b/components/style/values/computed/font.rs
@@ -290,14 +290,6 @@ pub type FontVariantNumeric = specified::VariantNumeric;
 /// Use FontSettings as computed type of FontFeatureSettings
 pub type FontFeatureSettings = FontSettings<FontSettingTagInt>;
 
-impl FontFeatureSettings {
-    #[inline]
-    /// Default value of `font-feature-settings` as `normal`
-    pub fn normal() -> FontFeatureSettings {
-        FontSettings::Normal
-    }
-}
-
 /// font-language-override can only have a single three-letter
 /// OpenType "language system" tag, so we should be able to compute
 /// it and store it as a 32-bit integer

--- a/components/style/values/generics/mod.rs
+++ b/components/style/values/generics/mod.rs
@@ -196,6 +196,14 @@ pub enum FontSettings<T> {
     Tag(Vec<FontSettingTag<T>>)
 }
 
+impl <T> FontSettings<T> {
+    #[inline]
+    /// Default value of font settings as `normal`
+    pub fn normal() -> Self {
+        FontSettings::Normal
+    }
+}
+
 impl<T: Parse> Parse for FontSettings<T> {
     /// <https://www.w3.org/TR/css-fonts-3/#propdef-font-feature-settings>
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {

--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -1804,14 +1804,6 @@ impl Parse for FontLanguageOverride {
 /// This property provides low-level control over OpenType or TrueType font variations.
 pub type FontVariantSettings = FontSettings<FontSettingTagFloat>;
 
-impl FontVariantSettings {
-    #[inline]
-    /// Default value of `font-variant-settings`
-    pub fn normal() -> FontVariantSettings {
-        FontSettings::Normal
-    }
-}
-
 #[derive(Clone, Debug, MallocSizeOf, PartialEq, ToComputedValue)]
 /// text-zoom. Enable if true, disable if false
 pub struct XTextZoom(pub bool);


### PR DESCRIPTION
As discussed with emilio in #19293 , this PR will move the `normal` function into `FontSettings` implementation.
r? emilio 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes will update the implementation of `normal` function of `FontSettings`.
- [x] These changes do not require tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19298)
<!-- Reviewable:end -->
