### PR TITLE
Update gecko-media

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,19 +588,19 @@ dependencies = [
 
 [[package]]
 name = "cubeb-ffi"
-version = "0.0.1"
-source = "git+https://github.com/djg/cubeb-pulse-rs?branch=dev#864332fde124761da15c444e58889faf598a219f"
+version = "0.0.2"
+source = "git+https://github.com/djg/cubeb-pulse-rs?branch=dev#71e1ecfad94354b92263b33c232dd45ed0a45ffe"
 dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cubeb-pulse"
-version = "0.0.1"
-source = "git+https://github.com/djg/cubeb-pulse-rs?branch=dev#864332fde124761da15c444e58889faf598a219f"
+version = "0.0.2"
+source = "git+https://github.com/djg/cubeb-pulse-rs?branch=dev#71e1ecfad94354b92263b33c232dd45ed0a45ffe"
 dependencies = [
- "cubeb-ffi 0.0.1 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)",
- "pulse 0.1.0 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)",
+ "cubeb-ffi 0.0.2 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)",
+ "pulse 0.2.0 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)",
  "pulse-ffi 0.1.0 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)",
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1009,17 +1009,18 @@ dependencies = [
 [[package]]
 name = "gecko-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/gecko-media.git#0299b455a062bcbfe038bfd90bb173ad9b98d5c7"
+source = "git+https://github.com/servo/gecko-media.git#47e030fd5670c7bf16108647f6ee07fd83175401"
 dependencies = [
  "bindgen 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "cubeb-pulse 0.0.1 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)",
+ "cubeb-pulse 0.0.2 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)",
  "encoding_c 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mp4parse 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mp4parse_capi 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2413,17 +2414,17 @@ dependencies = [
 
 [[package]]
 name = "pulse"
-version = "0.1.0"
-source = "git+https://github.com/djg/cubeb-pulse-rs?branch=dev#864332fde124761da15c444e58889faf598a219f"
+version = "0.2.0"
+source = "git+https://github.com/djg/cubeb-pulse-rs?branch=dev#71e1ecfad94354b92263b33c232dd45ed0a45ffe"
 dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulse-ffi 0.1.0 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)",
 ]
 
 [[package]]
 name = "pulse-ffi"
 version = "0.1.0"
-source = "git+https://github.com/djg/cubeb-pulse-rs?branch=dev#864332fde124761da15c444e58889faf598a219f"
+source = "git+https://github.com/djg/cubeb-pulse-rs?branch=dev#71e1ecfad94354b92263b33c232dd45ed0a45ffe"
 dependencies = [
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3866,8 +3867,8 @@ dependencies = [
 "checksum core-text 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a23bef779fab70e5e6af23e36eed03a48e1c1687dea8929505d405ea48d1f5e"
 "checksum cssparser 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44313341610282488e1156ad1fedebca51c54766c87a041d0287b10499c04ba1"
 "checksum cssparser-macros 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "079adec4af52bb5275eadd004292028c79eb3c5f5b4ee8086a36d4197032f6df"
-"checksum cubeb-ffi 0.0.1 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)" = "<none>"
-"checksum cubeb-pulse 0.0.1 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)" = "<none>"
+"checksum cubeb-ffi 0.0.2 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)" = "<none>"
+"checksum cubeb-pulse 0.0.2 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)" = "<none>"
 "checksum darling 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9861a8495606435477df581bc858ccf15a3469747edf175b94a4704fd9aaedac"
 "checksum darling_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1486a8b00b45062c997f767738178b43219133dd0c8c826cb811e60563810821"
 "checksum darling_macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a86ec160aa0c3dd492dd4a14ec8104ad8f1a9400a820624db857998cc1f80f9"
@@ -4007,7 +4008,7 @@ dependencies = [
 "checksum png 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f0b0cabbbd20c2d7f06dbf015e06aad59b6ca3d9ed14848783e98af9aaf19925"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 "checksum procedural-masquerade 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c93cdc1fb30af9ddf3debc4afbdb0f35126cbd99daa229dd76cdd5349b41d989"
-"checksum pulse 0.1.0 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)" = "<none>"
+"checksum pulse 0.2.0 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)" = "<none>"
 "checksum pulse-ffi 0.1.0 (git+https://github.com/djg/cubeb-pulse-rs?branch=dev)" = "<none>"
 "checksum push-trait 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdc13b1a53bc505b526086361221aaa612fefb9b0ecf2853f9d31f807764e004"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"


### PR DESCRIPTION
The last remaining use of bitflags 0.7 is now in clap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19301)
<!-- Reviewable:end -->
