### PR TITLE
style: Account for fallback content in GetFlattenedTreeParent.

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -227,8 +227,10 @@ impl<'ln> GeckoNode<'ln> {
             return false;
         }
 
-        if parent_el.map_or(false, |el| el.has_shadow_root()) {
-            return false;
+        if let Some(parent) = parent_el {
+            if parent.has_shadow_root() || parent.get_xbl_binding().is_some() {
+                return false;
+            }
         }
 
         true


### PR DESCRIPTION
Otherwise we may inappropriately style it or what not. This asserts with the
patches of bug 1414999 plus the cleanup of bug 1418456, since we no longer do
StyleNewChildren (which walks over the flattened tree children).

Too bad that GetXBLBinding is a virtual call in Gecko, probably can do just
MAY_BE_IN_BINDING_MGR...

Bug: 1418560
Reviewed-by: heycam
MozReview-Commit-ID: CNU0YdKeaR0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19303)
<!-- Reviewable:end -->
