### PR TITLE
Include OS and architecture in test-perf data

### DIFF
--- a/etc/ci/performance/runner.py
+++ b/etc/ci/performance/runner.py
@@ -9,6 +9,7 @@ import csv
 import itertools
 import json
 import os
+import platform
 import subprocess
 from datetime import datetime
 from functools import partial
@@ -17,6 +18,8 @@ from urllib.parse import urlsplit, urlunsplit, urljoin
 
 
 DATE = datetime.now().strftime("%Y%m%d")
+MACHINE = platform.machine()
+SYSTEM = platform.system()
 
 
 def load_manifest(filename):
@@ -144,6 +147,9 @@ def parse_log(log, testcase, url):
     # able to identify failed tests (successful tests have time >=0).
     def create_placeholder(testcase):
         return {
+            "system": SYSTEM,
+            "machine": MACHINE,
+            "date": DATE,
             "testcase": testcase,
             "title": "",
             "navigationStart": 0,
@@ -173,6 +179,8 @@ def parse_log(log, testcase, url):
     # rather than the url.
     def set_testcase(timing, testcase=None):
         timing['testcase'] = testcase
+        timing['system'] = SYSTEM
+        timing['machine'] = MACHINE
         timing['date'] = DATE
         return timing
 
@@ -245,6 +253,8 @@ def save_result_json(results, filename, manifest, expected_runs, base):
 def save_result_csv(results, filename, manifest, expected_runs, base):
 
     fieldnames = [
+        'system',
+        'machine',
         'date',
         'testcase',
         'title',

--- a/etc/ci/performance/test_all.sh
+++ b/etc/ci/performance/test_all.sh
@@ -48,7 +48,7 @@ python3 -m http.server > /dev/null 2>&1 &
 # MANIFEST="page_load_test/tp5n/20160509.manifest"
 MANIFEST="page_load_test/test.manifest" # A manifest that excludes
                                         # timeout test cases
-PERF_FILE="output/perf-$(date +%s).csv"
+PERF_FILE="output/perf-$(uname -s)-$(uname -m)-$(date +%s).csv"
 
 echo "Running tests"
 python3 runner.py ${engine} --runs 4 --timeout "${timeout}" --base "${base}" \


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Initially, we're just running test-perf on linux-nightly, but at some point we should run on other architectures.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because they're test infrastructure

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19305)
<!-- Reviewable:end -->
