### PR TITLE
change parse_own_css to queue event not fire synchronously

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1885,6 +1885,13 @@ impl Document {
         self.current_parser.get()
     }
 
+    pub fn can_invoke_script(&self) -> bool {
+        match self.get_current_parser() {
+            Some(parser) => parser.parser_is_not_active(),
+            None => true,
+        }
+    }
+
     /// Iterate over all iframes in the document.
     pub fn iter_iframes(&self) -> impl Iterator<Item=DomRoot<HTMLIFrameElement>> {
         self.upcast::<Node>()

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -315,10 +315,21 @@ impl EventTarget {
     pub fn dispatch_event_with_target(&self,
                                       target: &EventTarget,
                                       event: &Event) -> EventStatus {
+        if let Some(window) = target.global().downcast::<Window>() {
+            if window.has_document() {
+                assert!(window.Document().can_invoke_script());
+            }
+        };
+
         event.dispatch(self, Some(target))
     }
 
     pub fn dispatch_event(&self, event: &Event) -> EventStatus {
+        if let Some(window) = self.global().downcast::<Window>() {
+            if window.has_document() {
+                assert!(window.Document().can_invoke_script());
+            }
+        };
         event.dispatch(self, None)
     }
 

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -12,7 +12,6 @@ use dom::bindings::root::{DomRoot, MutNullableDom};
 use dom::cssstylesheet::CSSStyleSheet;
 use dom::document::Document;
 use dom::element::{Element, ElementCreator};
-use dom::eventtarget::EventTarget;
 use dom::htmlelement::HTMLElement;
 use dom::node::{ChildrenMutation, Node, UnbindContext, document_from_node, window_from_node};
 use dom::stylesheet::StyleSheet as DOMStyleSheet;
@@ -105,9 +104,10 @@ impl HTMLStyleElement {
 
         let sheet = Arc::new(sheet);
 
-        // No subresource loads were triggered, just fire the load event now.
+        // No subresource loads were triggered, queue load event
         if self.pending_loads.get() == 0 {
-            self.upcast::<EventTarget>().fire_event(atom!("load"));
+            let window = window_from_node(self);
+            window.dom_manipulation_task_source().queue_simple_event(self.upcast(), atom!("load"), &window);
         }
 
         self.set_stylesheet(sheet);

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -102,6 +102,10 @@ enum LastChunkState {
 }
 
 impl ServoParser {
+    pub fn parser_is_not_active(&self) -> bool {
+        self.can_write() || self.tokenizer.try_borrow_mut().is_ok()
+    }
+
     pub fn parse_html_document(document: &Document, input: DOMString, url: ServoUrl) {
         let parser = if PREFS.get("dom.servoparser.async_html_tokenizer.enabled").as_boolean().unwrap() {
             ServoParser::new(document,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1048,6 +1048,10 @@ impl Window {
         self.navigation_start_precise.get()
     }
 
+    pub fn has_document(&self) -> bool {
+        self.document.get().is_some()
+    }
+
     /// Cancels all the tasks associated with that window.
     ///
     /// This sets the current `ignore_further_async_events` sentinel value to

--- a/tests/wpt/metadata/custom-elements/microtasks-and-constructors.html.ini
+++ b/tests/wpt/metadata/custom-elements/microtasks-and-constructors.html.ini
@@ -1,0 +1,4 @@
+[microtasks-and-constructors.html]
+  expected: CRASH
+  bug: https://github.com/servo/servo/issues/19392
+

--- a/tests/wpt/metadata/custom-elements/parser/parser-fallsback-to-unknown-element.html.ini
+++ b/tests/wpt/metadata/custom-elements/parser/parser-fallsback-to-unknown-element.html.ini
@@ -1,0 +1,4 @@
+[parser-fallsback-to-unknown-element.html]
+  expected: CRASH
+  bug: https://github.com/servo/servo/issues/19392
+  

--- a/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-style-element/style_load_async.html
+++ b/tests/wpt/web-platform-tests/html/semantics/document-metadata/the-style-element/style_load_async.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<meta charset="utf-8">
+<title>Style load event should be async</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    var t = async_test("style load should be async");
+    var sync = true;
+    function check() {
+        assert_false(sync);
+        t.done();
+    }
+</script>
+<style onload="t.step(check)">
+</style>
+<script>
+  sync = false
+</script>
+
+<body>
+  <div id="log"></div>
+  <div id="test"></div>
+</body>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
fixes a panic and aligns with spec

I've also added checks around each mutable borrow of the tokenizer to see if we can catch any other panics


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #18930 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19307)
<!-- Reviewable:end -->
