### PR TITLE
Fix Stylo tests to pass on both Stable and Nightly Rust

### DIFF
--- a/components/style/build.rs
+++ b/components/style/build.rs
@@ -76,6 +76,16 @@ fn generate_properties() {
         .arg(&script)
         .arg(product)
         .arg("style-crate")
+        .envs(if std::mem::size_of::<Option<bool>>() == 1 {
+            // FIXME: remove this envs() call
+            // and make unconditional code that depends on RUSTC_HAS_PR45225
+            // once Firefox requires Rust 1.23+
+
+            // https://github.com/rust-lang/rust/pull/45225
+            vec![("RUSTC_HAS_PR45225", "1")]
+        } else {
+            vec![]
+        })
         .status()
         .unwrap();
     if !status.success() {

--- a/components/style/properties/build.py
+++ b/components/style/properties/build.py
@@ -32,7 +32,8 @@ def main():
 
     properties = data.PropertiesData(product=product)
     template = os.path.join(BASE, "properties.mako.rs")
-    rust = render(template, product=product, data=properties, __file__=template)
+    rust = render(template, product=product, data=properties, __file__=template,
+                  RUSTC_HAS_PR45225=os.environ.get("RUSTC_HAS_PR45225"))
     if output == "style-crate":
         write(os.environ["OUT_DIR"], "properties.rs", rust)
         if product == "gecko":

--- a/components/style/properties/data.py
+++ b/components/style/properties/data.py
@@ -140,7 +140,7 @@ class Keyword(object):
 def arg_to_bool(arg):
     if isinstance(arg, bool):
         return arg
-    assert arg in ["True", "False"]
+    assert arg in ["True", "False"], "Unexpected value for boolean arguement: " + repr(arg)
     return arg == "True"
 
 

--- a/components/style/properties/longhand/inherited_svg.mako.rs
+++ b/components/style/properties/longhand/inherited_svg.mako.rs
@@ -66,7 +66,6 @@ ${helpers.predefined_type(
     "stroke-width", "SVGWidth",
     "::values::computed::NonNegativeLength::new(1.).into()",
     products="gecko",
-    boxed="True",
     animation_value_type="::values::computed::SVGWidth",
     spec="https://www.w3.org/TR/SVG2/painting.html#StrokeWidth")}
 
@@ -101,7 +100,6 @@ ${helpers.predefined_type(
     "stroke-dashoffset", "SVGLength",
     "Au(0).into()",
     products="gecko",
-    boxed="True",
     animation_value_type="ComputedValue",
     spec="https://www.w3.org/TR/SVG2/painting.html#StrokeDashing")}
 

--- a/components/style/properties/longhand/inherited_svg.mako.rs
+++ b/components/style/properties/longhand/inherited_svg.mako.rs
@@ -66,6 +66,7 @@ ${helpers.predefined_type(
     "stroke-width", "SVGWidth",
     "::values::computed::NonNegativeLength::new(1.).into()",
     products="gecko",
+    boxed=not RUSTC_HAS_PR45225,
     animation_value_type="::values::computed::SVGWidth",
     spec="https://www.w3.org/TR/SVG2/painting.html#StrokeWidth")}
 
@@ -100,6 +101,7 @@ ${helpers.predefined_type(
     "stroke-dashoffset", "SVGLength",
     "Au(0).into()",
     products="gecko",
+    boxed=not RUSTC_HAS_PR45225,
     animation_value_type="ComputedValue",
     spec="https://www.w3.org/TR/SVG2/painting.html#StrokeDashing")}
 

--- a/components/style/properties/longhand/pointing.mako.rs
+++ b/components/style/properties/longhand/pointing.mako.rs
@@ -177,6 +177,7 @@ ${helpers.predefined_type(
     "Either::Second(Auto)",
     spec="https://drafts.csswg.org/css-ui/#caret-color",
     animation_value_type="Either<AnimatedColor, Auto>",
+    boxed=not RUSTC_HAS_PR45225,
     ignored_when_colors_disabled=True,
     products="gecko",
 )}

--- a/components/style/properties/longhand/pointing.mako.rs
+++ b/components/style/properties/longhand/pointing.mako.rs
@@ -177,7 +177,6 @@ ${helpers.predefined_type(
     "Either::Second(Auto)",
     spec="https://drafts.csswg.org/css-ui/#caret-color",
     animation_value_type="Either<AnimatedColor, Auto>",
-    boxed=True,
     ignored_when_colors_disabled=True,
     products="gecko",
 )}

--- a/tests/unit/stylo/build.rs
+++ b/tests/unit/stylo/build.rs
@@ -11,6 +11,11 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 
 fn main() {
+    if std::mem::size_of::<Option<bool>>() == 1 {
+         // https://github.com/rust-lang/rust/pull/45225
+         println!("cargo:rustc-cfg=rustc_has_pr45225")
+    }
+
     let root_path = Path::new("../../../");
     let bindings_file = root_path.join("components/style/gecko/generated/bindings.rs");
     let glue_file = root_path.join("ports/geckolib/glue.rs");

--- a/tests/unit/stylo/size_of.rs
+++ b/tests/unit/stylo/size_of.rs
@@ -57,5 +57,5 @@ size_of_test!(test_size_of_specified_image, specified::image::Image, 40);
 
 // FIXME(bz): These can shrink if we move the None_ value inside the
 // enum instead of paying an extra word for the Either discriminant.
-size_of_test!(test_size_of_computed_image_layer, computed::image::ImageLayer, 48);
-size_of_test!(test_size_of_specified_image_layer, specified::image::ImageLayer, 48);
+size_of_test!(test_size_of_computed_image_layer, computed::image::ImageLayer, 40);
+size_of_test!(test_size_of_specified_image_layer, specified::image::ImageLayer, 40);

--- a/tests/unit/stylo/size_of.rs
+++ b/tests/unit/stylo/size_of.rs
@@ -57,5 +57,7 @@ size_of_test!(test_size_of_specified_image, specified::image::Image, 40);
 
 // FIXME(bz): These can shrink if we move the None_ value inside the
 // enum instead of paying an extra word for the Either discriminant.
-size_of_test!(test_size_of_computed_image_layer, computed::image::ImageLayer, 40);
-size_of_test!(test_size_of_specified_image_layer, specified::image::ImageLayer, 40);
+size_of_test!(test_size_of_computed_image_layer, computed::image::ImageLayer,
+              if cfg!(rustc_has_pr45225) { 40 } else { 48 });
+size_of_test!(test_size_of_specified_image_layer, specified::image::ImageLayer,
+              if cfg!(rustc_has_pr45225) { 40 } else { 48 });


### PR DESCRIPTION
This is on top of https://github.com/servo/servo/pull/19285.

Rust Nightly has new enum memory layout optimizations: https://github.com/rust-lang/rust/pull/45225

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19316)
<!-- Reviewable:end -->
