### PR TITLE
Make wdspec tests runnable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3596,16 +3604,17 @@ dependencies = [
 
 [[package]]
 name = "webdriver"
-version = "0.22.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3628,7 +3637,7 @@ dependencies = [
  "servo_url 0.0.1",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "webdriver 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webdriver 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3860,6 +3869,7 @@ dependencies = [
 "checksum color_quant 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a475fc4af42d83d28adf72968d9bcfaf035a1a9381642d8e85d8a04957767b0d"
 "checksum compiletest_rs 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "617b23d0ed4f57b3bcff6b5fe0a78f0010f1efb636298317665a960b6dbc0533"
 "checksum cookie 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30b3493e12a550c2f96be785088d1da8d93189e7237c8a8d0d871bc9070334c3"
+"checksum cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "477eb650753e319be2ae77ec368a58c638f9f0c4d941c39bad95e950fb1d1d0d"
 "checksum core-foundation 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5909502e547762013619f4c4e01cc7393c20fe2d52d7fa471c1210adb2320dc7"
 "checksum core-foundation-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bc9fb3d6cb663e6fd7cf1c63f9b144ee2b1e4a78595a0451dd34bff85b9a3387"
 "checksum core-graphics 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2fd47addfc77b7e574d24e5434f95bb64a863769dfd4f1d451ca4ff5530ba01a"
@@ -4099,7 +4109,7 @@ dependencies = [
 "checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"
-"checksum webdriver 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d548aabf87411b1b4ba91fd07eacd8b238135c7131a452b8a9f6386209167e18"
+"checksum webdriver 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b982fb5fe268cc124931035ca0c4b65d39e6d9c9fed319186b7d17493bf98984"
 "checksum webrender 0.53.2 (git+https://github.com/servo/webrender)" = "<none>"
 "checksum webrender_api 0.53.2 (git+https://github.com/servo/webrender)" = "<none>"
 "checksum which 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4be6cfa54dab45266e98b5d7be2f8ce959ddd49abd141a05d52dce4b07f803bb"

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -26,4 +26,4 @@ servo_config = {path = "../config"}
 servo_url = {path = "../url"}
 url = "1.2"
 uuid = {version = "0.5", features = ["v4"]}
-webdriver = "0.22"
+webdriver = "0.32"

--- a/components/webdriver_server/keys.rs
+++ b/components/webdriver_server/keys.rs
@@ -168,11 +168,11 @@ fn key_from_char(key_string: &char) -> Option<(Key, bool)> {
     }
 }
 
-pub fn keycodes_to_keys(key_codes: &[char]) -> Result<Vec<(Key, KeyModifiers, KeyState)>, String> {
+pub fn keycodes_to_keys(key_codes: &str) -> Result<Vec<(Key, KeyModifiers, KeyState)>, String> {
     let mut rv = vec![];
 
-    for char_code in key_codes.iter() {
-        let (key, with_shift) = key_from_char(char_code).ok_or(format!("Unsupported character code {}", char_code))?;
+    for char_code in key_codes.chars() {
+        let (key, with_shift) = key_from_char(&char_code).ok_or(format!("Unsupported character code {}", char_code))?;
         let modifiers = if with_shift {
             KeyModifiers::SHIFT
         } else {

--- a/ports/servo/Cargo.toml
+++ b/ports/servo/Cargo.toml
@@ -32,7 +32,7 @@ style_tests = {path = "../../tests/unit/style"}
 default = ["unstable", "default-except-unstable"]
 default-except-unstable = ["webdriver", "max_log_level"]
 max_log_level = ["log/release_max_level_info"]
-webdriver = ["libservo/webdriver_server"]
+webdriver = ["libservo/webdriver"]
 energy-profiling = ["libservo/energy-profiling"]
 debugmozjs = ["libservo/debugmozjs"]
 googlevr = ["libservo/googlevr"]

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -35,6 +35,7 @@ num = []
 # Ignored packages with duplicated versions
 packages = [
   "bitflags",
+  "cookie",
   "mime",
   "semver",
   "toml",

--- a/tests/wpt/run.py
+++ b/tests/wpt/run.py
@@ -35,7 +35,7 @@ def run_tests(paths=None, **kwargs):
     use_mach_logging = False
     if len(kwargs["test_list"]) == 1:
         file_ext = os.path.splitext(kwargs["test_list"][0])[1].lower()
-        if file_ext in [".htm", ".html", ".js", ".xhtml", ".xht"]:
+        if file_ext in [".htm", ".html", ".js", ".xhtml", ".xht", ".py"]:
             use_mach_logging = True
 
     if use_mach_logging:

--- a/tests/wpt/run.py
+++ b/tests/wpt/run.py
@@ -65,6 +65,7 @@ def set_defaults(paths, kwargs):
         bin_path = servo_path("target", bin_dir, bin_name)
 
         kwargs["binary"] = bin_path
+        kwargs["webdriver_binary"] = bin_path
 
     if kwargs["processes"] is None:
         kwargs["processes"] = multiprocessing.cpu_count()

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servo.py
@@ -42,6 +42,8 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     rv = base_executor_kwargs(test_type, server_config,
                               cache_manager, **kwargs)
     rv["pause_after_test"] = kwargs["pause_after_test"]
+    if test_type == "wdspec":
+        rv["capabilities"] = {}
     return rv
 
 

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/webdriver_server.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/webdriver_server.py
@@ -195,10 +195,11 @@ class GeckoDriverServer(WebDriverServer):
 
 
 class ServoDriverServer(WebDriverServer):
-    def __init__(self, logger, binary="servo", binary_args=None, host="127.0.0.1", port=None):
+    def __init__(self, logger, binary="servo", binary_args=None, host="127.0.0.1",
+                 port=None, args=None):
         env = os.environ.copy()
         env["RUST_BACKTRACE"] = "1"
-        WebDriverServer.__init__(self, logger, binary, host=host, port=port, env=env)
+        WebDriverServer.__init__(self, logger, binary, host=host, port=port, env=env, args=args)
         self.binary_args = binary_args
 
     def make_command(self):


### PR DESCRIPTION
This makes it possible to run tests in tests/wpt/web-platform-tests/webdriver/tests and focus on investigating why they fail.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix (partially) #15274.
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19318)
<!-- Reviewable:end -->
