### PR TITLE
Removed unused import in net/http_cache.rs

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -8,7 +8,6 @@
 //! and <http://tools.ietf.org/html/rfc7232>.
 
 use fetch::methods::DoneChannel;
-use http_loader::is_redirect_status;
 use hyper::header;
 use hyper::header::ContentType;
 use hyper::header::Headers;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`use http_loader::is_redirect_status;` was unused

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19319)
<!-- Reviewable:end -->
