### PR TITLE
style: Move -x-lang outside of mako

### DIFF
--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -699,37 +699,13 @@ ${helpers.predefined_type("font-language-override",
                           flags="APPLIES_TO_FIRST_LETTER APPLIES_TO_FIRST_LINE APPLIES_TO_PLACEHOLDER",
                           spec="https://drafts.csswg.org/css-fonts-3/#propdef-font-language-override")}
 
-<%helpers:longhand name="-x-lang" products="gecko" animation_value_type="none"
-                   enabled_in=""
-                   spec="Internal (not web-exposed)">
-    pub use self::computed_value::T as SpecifiedValue;
-
-    pub mod computed_value {
-        use Atom;
-        use std::fmt;
-        use style_traits::ToCss;
-
-        impl ToCss for T {
-            fn to_css<W>(&self, _: &mut W) -> fmt::Result where W: fmt::Write {
-                Ok(())
-            }
-        }
-
-        #[derive(Clone, Debug, MallocSizeOf, PartialEq, ToComputedValue)]
-        pub struct T(pub Atom);
-    }
-
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        computed_value::T(atom!(""))
-    }
-
-    pub fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
-                         -> Result<SpecifiedValue, ParseError<'i>> {
-        debug_assert!(false, "Should be set directly by presentation attributes only.");
-        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
-    }
-</%helpers:longhand>
+${helpers.predefined_type("-x-lang",
+                          "XLang",
+                          products="gecko",
+                          initial_value="computed::XLang::get_initial_value()",
+                          animation_value_type="none",
+                          enabled_in="",
+                          spec="Internal (not web-exposed)")}
 
 // MathML properties
 <%helpers:longhand name="-moz-script-size-multiplier" products="gecko" animation_value_type="none"

--- a/components/style/values/computed/font.rs
+++ b/components/style/values/computed/font.rs
@@ -16,7 +16,7 @@ use values::specified::font as specified;
 use values::specified::length::{FontBaseSize, NoCalcLength};
 
 pub use values::computed::Length as MozScriptMinSize;
-pub use values::specified::font::{XTextZoom, FontSynthesis, FontVariantSettings};
+pub use values::specified::font::{XTextZoom, XLang, FontSynthesis, FontVariantSettings};
 
 /// As of CSS Fonts Module Level 3, only the following values are
 /// valid: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -39,7 +39,7 @@ pub use self::border::{BorderRadius, BorderCornerRadius, BorderSpacing};
 pub use self::font::{FontSize, FontSizeAdjust, FontSynthesis, FontWeight, FontVariantAlternates};
 pub use self::font::{FontLanguageOverride, FontVariantSettings, FontVariantEastAsian};
 pub use self::font::{FontVariantLigatures, FontVariantNumeric, FontFeatureSettings};
-pub use self::font::{MozScriptLevel, MozScriptMinSize, XTextZoom};
+pub use self::font::{MozScriptLevel, MozScriptMinSize, XTextZoom, XLang};
 pub use self::box_::{AnimationIterationCount, AnimationName, ScrollSnapType, VerticalAlign};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};

--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -4,7 +4,6 @@
 
 //! Specified values for font properties
 
-#[cfg(feature = "gecko")]
 use Atom;
 use app_units::Au;
 use byteorder::{BigEndian, ByteOrder};
@@ -1816,6 +1815,34 @@ impl Parse for XTextZoom {
 }
 
 impl ToCss for XTextZoom {
+    fn to_css<W>(&self, _: &mut W) -> fmt::Result where W: fmt::Write {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, MallocSizeOf, PartialEq, ToComputedValue)]
+/// Internal property that reflects the lang attribute
+pub struct XLang(pub Atom);
+
+impl XLang {
+    #[inline]
+    /// Get default value for `-x-lang`
+    pub fn get_initial_value() -> XLang {
+        XLang(atom!(""))
+    }
+}
+
+impl Parse for XLang {
+    fn parse<'i, 't>(
+        _: &ParserContext,
+        input: &mut Parser<'i, 't>
+    ) -> Result<XLang, ParseError<'i>> {
+        debug_assert!(false, "Should be set directly by presentation attributes only.");
+        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
+    }
+}
+
+impl ToCss for XLang {
     fn to_css<W>(&self, _: &mut W) -> fmt::Result where W: fmt::Write {
         Ok(())
     }

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -33,7 +33,7 @@ pub use self::border::{BorderImageSideWidth, BorderRadius, BorderSideWidth, Bord
 pub use self::font::{FontSize, FontSizeAdjust, FontSynthesis, FontWeight, FontVariantAlternates};
 pub use self::font::{FontLanguageOverride, FontVariantSettings, FontVariantEastAsian};
 pub use self::font::{FontVariantLigatures, FontVariantNumeric, FontFeatureSettings};
-pub use self::font::{MozScriptLevel, MozScriptMinSize, XTextZoom};
+pub use self::font::{MozScriptLevel, MozScriptMinSize, XTextZoom, XLang};
 pub use self::box_::{AnimationIterationCount, AnimationName, ScrollSnapType, VerticalAlign};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};


### PR DESCRIPTION
This is a sub-PR of #19015 
r? emilio 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #19320 
- [x] These changes do not require tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19322)
<!-- Reviewable:end -->
