### PR TITLE
Get back to working dir after vcvarsall.bat

### DIFF
--- a/mach.bat
+++ b/mach.bat
@@ -1,5 +1,7 @@
 @echo off
 
+pushd .
+
 IF EXIST "%ProgramFiles(x86)%" (
   set "ProgramFiles32=%ProgramFiles(x86)%"
 ) ELSE (
@@ -31,5 +33,7 @@ IF EXIST "%VS_VCVARS%" (
   ECHO Download and install Visual Studio 2015 or 2017 from https://www.visualstudio.com/
   EXIT /B
 )
+
+popd
 
 python mach %*


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

When using cmd.exe directly (instead of `x86_x64 Cross Tools Command Prompt for VS 2017`), vcvarsall.bat changes the working directory.
To prevent this, pushd and popd could be used.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because they are part of the build process.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19324)
<!-- Reviewable:end -->
