### PR TITLE
Use same build environment during mutation testing.

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -68,7 +68,7 @@ linux-rel-nogate:
   - ./mach clean-nightlies --keep 3 --force
   - env CC=gcc-5 CXX=g++-5 ./mach build --release
   - python ./etc/ci/chaos_monkey_test.py
-  - bash ./etc/ci/mutation_test.sh
+  - env CC=gcc-5 CXX=g++-5 bash ./etc/ci/mutation_test.sh
 
 mac-rel-intermittent:
   - ./mach clean-nightlies --keep 3 --force


### PR DESCRIPTION
ccache complains that the C++ compiler doesn't match the cached version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19326)
<!-- Reviewable:end -->
