### PR TITLE
moving :dir() param serialization FIXME

### DIFF
--- a/components/style/gecko/selector_parser.rs
+++ b/components/style/gecko/selector_parser.rs
@@ -96,7 +96,6 @@ impl ToCss for NonTSPseudoClass {
                     }, )*
                     NonTSPseudoClass::Dir(ref dir) => {
                         dest.write_str(":dir(")?;
-                        // FIXME: This should be escaped as an identifier; see #19231
                         (**dir).to_css(dest)?;
                         return dest.write_char(')')
                     },

--- a/components/style/selector_parser.rs
+++ b/components/style/selector_parser.rs
@@ -191,6 +191,7 @@ impl ToCss for Direction {
         let dir_str = match *self {
             Direction::Rtl => "rtl",
             Direction::Ltr => "ltr",
+            // FIXME: This should be escaped as an identifier; see #19231
             Direction::Other(ref other) => other,
         };
         dest.write_str(dir_str)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Per emilio's comment, https://github.com/servo/servo/pull/19195#discussion_r152205644, a `FIXME` regarding `:dir()` parameter serialization has been moved.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they only modify comment lines

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19332)
<!-- Reviewable:end -->
