### PR TITLE
style: Move -moz-script-size-multiplier outside of mako

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1514,6 +1514,7 @@ impl Clone for ${style_struct.gecko_struct_name} {
         "MaxLength": impl_style_coord,
         "MozLength": impl_style_coord,
         "MozScriptMinSize": impl_absolute_length,
+        "MozScriptSizeMultiplier": impl_simple,
         "NonNegativeLengthOrPercentage": impl_style_coord,
         "NonNegativeNumber": impl_simple,
         "Number": impl_simple,

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -707,28 +707,14 @@ ${helpers.predefined_type("-x-lang",
                           enabled_in="",
                           spec="Internal (not web-exposed)")}
 
-// MathML properties
-<%helpers:longhand name="-moz-script-size-multiplier" products="gecko" animation_value_type="none"
-                   predefined_type="Number" gecko_ffi_name="mScriptSizeMultiplier"
-                   spec="Internal (not web-exposed)"
-                   enabled_in="">
-    pub use self::computed_value::T as SpecifiedValue;
-
-    pub mod computed_value {
-        pub type T = f32;
-    }
-
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        ::gecko_bindings::structs::NS_MATHML_DEFAULT_SCRIPT_SIZE_MULTIPLIER as f32
-    }
-
-    pub fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
-                         -> Result<SpecifiedValue, ParseError<'i>> {
-        debug_assert!(false, "Should be set directly by presentation attributes only.");
-        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
-    }
-</%helpers:longhand>
+${helpers.predefined_type("-moz-script-size-multiplier",
+                          "MozScriptSizeMultiplier",
+                          products="gecko",
+                          initial_value="computed::MozScriptSizeMultiplier::get_initial_value()",
+                          animation_value_type="none",
+                          gecko_ffi_name="mScriptSizeMultiplier",
+                          enabled_in="",
+                          spec="Internal (not web-exposed)")}
 
 ${helpers.predefined_type("-moz-script-level",
                           "MozScriptLevel",

--- a/components/style/values/computed/font.rs
+++ b/components/style/values/computed/font.rs
@@ -16,7 +16,7 @@ use values::specified::font as specified;
 use values::specified::length::{FontBaseSize, NoCalcLength};
 
 pub use values::computed::Length as MozScriptMinSize;
-pub use values::specified::font::{XTextZoom, XLang, FontSynthesis, FontVariantSettings};
+pub use values::specified::font::{XTextZoom, XLang, MozScriptSizeMultiplier, FontSynthesis, FontVariantSettings};
 
 /// As of CSS Fonts Module Level 3, only the following values are
 /// valid: 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -39,7 +39,7 @@ pub use self::border::{BorderRadius, BorderCornerRadius, BorderSpacing};
 pub use self::font::{FontSize, FontSizeAdjust, FontSynthesis, FontWeight, FontVariantAlternates};
 pub use self::font::{FontLanguageOverride, FontVariantSettings, FontVariantEastAsian};
 pub use self::font::{FontVariantLigatures, FontVariantNumeric, FontFeatureSettings};
-pub use self::font::{MozScriptLevel, MozScriptMinSize, XTextZoom, XLang};
+pub use self::font::{MozScriptLevel, MozScriptMinSize, MozScriptSizeMultiplier, XTextZoom, XLang};
 pub use self::box_::{AnimationIterationCount, AnimationName, ScrollSnapType, VerticalAlign};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};

--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -21,6 +21,7 @@ use values::specified::{AllowQuirks, LengthOrPercentage, NoCalcLength, Number};
 use values::specified::length::{AU_PER_PT, AU_PER_PX, FontBaseSize};
 
 const DEFAULT_SCRIPT_MIN_SIZE_PT: u32 = 8;
+const DEFAULT_SCRIPT_SIZE_MULTIPLIER: f64 = 0.71;
 
 #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq, ToCss)]
 /// A specified font-weight value
@@ -1897,5 +1898,43 @@ impl Parse for MozScriptLevel {
         }
         input.expect_ident_matching("auto")?;
         Ok(MozScriptLevel::Auto)
+    }
+}
+
+#[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
+#[derive(Clone, Copy, Debug, PartialEq, ToComputedValue, ToCss)]
+/// Specifies the multiplier to be used to adjust font size
+/// due to changes in scriptlevel.
+///
+/// Ref: https://www.w3.org/TR/MathML3/chapter3.html#presm.mstyle.attrs
+pub struct MozScriptSizeMultiplier(pub f32);
+
+impl MozScriptSizeMultiplier {
+    #[inline]
+    /// Get default value of `-moz-script-size-multiplier`
+    pub fn get_initial_value() -> MozScriptSizeMultiplier {
+        MozScriptSizeMultiplier(DEFAULT_SCRIPT_SIZE_MULTIPLIER as f32)
+    }
+}
+
+impl Parse for MozScriptSizeMultiplier {
+    fn parse<'i, 't>(
+        _: &ParserContext,
+        input: &mut Parser<'i, 't>
+    ) -> Result<MozScriptSizeMultiplier, ParseError<'i>> {
+        debug_assert!(false, "Should be set directly by presentation attributes only.");
+        Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
+    }
+}
+
+impl From<f32> for MozScriptSizeMultiplier {
+    fn from(v: f32) -> Self {
+        MozScriptSizeMultiplier(v)
+    }
+}
+
+impl From<MozScriptSizeMultiplier> for f32 {
+    fn from(v: MozScriptSizeMultiplier) -> f32 {
+        v.0
     }
 }

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -33,7 +33,7 @@ pub use self::border::{BorderImageSideWidth, BorderRadius, BorderSideWidth, Bord
 pub use self::font::{FontSize, FontSizeAdjust, FontSynthesis, FontWeight, FontVariantAlternates};
 pub use self::font::{FontLanguageOverride, FontVariantSettings, FontVariantEastAsian};
 pub use self::font::{FontVariantLigatures, FontVariantNumeric, FontFeatureSettings};
-pub use self::font::{MozScriptLevel, MozScriptMinSize, XTextZoom, XLang};
+pub use self::font::{MozScriptLevel, MozScriptMinSize, MozScriptSizeMultiplier, XTextZoom, XLang};
 pub use self::box_::{AnimationIterationCount, AnimationName, ScrollSnapType, VerticalAlign};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -3182,11 +3182,12 @@ pub extern "C" fn Servo_DeclarationBlock_SetNumberValue(
 ) {
     use style::properties::{PropertyDeclaration, LonghandId};
     use style::properties::longhands::_moz_script_level::SpecifiedValue as MozScriptLevel;
+    use style::properties::longhands::_moz_script_size_multiplier::SpecifiedValue as MozScriptSizeMultiplier;
 
     let long = get_longhand_from_id!(property);
 
     let prop = match_wrap_declared! { long,
-        MozScriptSizeMultiplier => value,
+        MozScriptSizeMultiplier => MozScriptSizeMultiplier(value),
         // Gecko uses Number values to signal that it is absolute
         MozScriptLevel => MozScriptLevel::MozAbsolute(value as i32),
     };


### PR DESCRIPTION
This is a sub-PR of #19015 
r? emilio 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #19333 
- [x] These changes do not require tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19339)
<!-- Reviewable:end -->
