### PR TITLE
Remove obsolete command from Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
         - export CC=gcc-5 CXX=g++-5
       script:
          - ./mach build -d --verbose
-         - ./mach test-compiletest
          - ./mach test-unit
          - ./mach clean
          - ./mach build-geckolib


### PR DESCRIPTION
This unbreaks the travisCI builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19343)
<!-- Reviewable:end -->
