### PR TITLE
Ignore aborted responses in caching

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -29,6 +29,7 @@ use std::io::Read;
 use std::mem;
 use std::str;
 use std::sync::{Arc, Mutex};
+use std::sync::atomic::Ordering;
 use std::sync::mpsc::{Sender, Receiver};
 use subresource_integrity::is_response_integrity_valid;
 
@@ -422,7 +423,7 @@ fn wait_for_response(response: &mut Response, target: Target, done_chan: &mut Do
                 },
                 Data::Done => break,
                 Data::Cancelled => {
-                    response.aborted = true;
+                    response.aborted.store(true, Ordering::Relaxed);
                     break;
                 }
             }

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -408,6 +408,12 @@ pub fn main_fetch(request: &mut Request,
     // Step 24.
     target.process_response_eof(&response);
 
+    if !response.is_network_error() {
+        if let Ok(mut http_cache) = context.state.http_cache.write() {
+            http_cache.update_awaiting_consumers(&request, &response);
+        }
+    }
+
     // Steps 25-27.
     // TODO: remove this line when only asynchronous fetches are used
     response

--- a/components/net_traits/response.rs
+++ b/components/net_traits/response.rs
@@ -10,6 +10,7 @@ use hyper::status::StatusCode;
 use hyper_serde::Serde;
 use servo_url::ServoUrl;
 use std::sync::{Arc, Mutex};
+use std::sync::atomic::AtomicBool;
 
 /// [Response type](https://fetch.spec.whatwg.org/#concept-response-type)
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
@@ -113,7 +114,8 @@ pub struct Response {
     /// whether or not to try to return the internal_response when asked for actual_response
     pub return_internal: bool,
     /// https://fetch.spec.whatwg.org/#concept-response-aborted
-    pub aborted: bool,
+    #[ignore_malloc_size_of = "AtomicBool heap size undefined"]
+    pub aborted: Arc<AtomicBool>,
 }
 
 impl Response {
@@ -135,7 +137,7 @@ impl Response {
             location_url: None,
             internal_response: None,
             return_internal: true,
-            aborted: false,
+            aborted: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -165,7 +167,7 @@ impl Response {
             location_url: None,
             internal_response: None,
             return_internal: true,
-            aborted: false,
+            aborted: Arc::new(AtomicBool::new(false)),
         }
     }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12478,6 +12478,11 @@
      {}
     ]
    ],
+   "mozilla/resources/http-cache-trickle.py": [
+    [
+     {}
+    ]
+   ],
    "mozilla/resources/http-cache.js": [
     [
      {}
@@ -33242,6 +33247,12 @@
    "mozilla/htmlspacechars.html": [
     [
      "/_mozilla/mozilla/htmlspacechars.html",
+     {}
+    ]
+   ],
+   "mozilla/http-cache-xhr.html": [
+    [
+     "/_mozilla/mozilla/http-cache-xhr.html",
      {}
     ]
    ],
@@ -66348,6 +66359,10 @@
    "592f69ee432ba5bc7a2f2649e72e083d21393496",
    "testharness"
   ],
+  "mozilla/http-cache-xhr.html": [
+   "0f8e347991f25a08ba5f8bdff0ef99055e33e7a1",
+   "testharness"
+  ],
   "mozilla/http-cache.html": [
    "33827dc9bdb0efcbcae4f730086693be315cfc14",
    "testharness"
@@ -72024,8 +72039,12 @@
    "78686147f85e4146e7fc58c1f67a613f65b099a2",
    "support"
   ],
+  "mozilla/resources/http-cache-trickle.py": [
+   "48f4e32ec2e1c1b6d47e89254045b398c1d84d40",
+   "support"
+  ],
   "mozilla/resources/http-cache.js": [
-   "c6b1ee9def26d4e12a1b93e551c225f82b4717c2",
+   "4bf71e1f328e778990eb756741a3be58f4f57ef6",
    "support"
   ],
   "mozilla/resources/iframe_contentDocument_inner.html": [

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -66360,7 +66360,7 @@
    "testharness"
   ],
   "mozilla/http-cache-xhr.html": [
-   "0f8e347991f25a08ba5f8bdff0ef99055e33e7a1",
+   "d4747fdc9ec6acc50718c13a668451987a44d219",
    "testharness"
   ],
   "mozilla/http-cache.html": [

--- a/tests/wpt/mozilla/meta/mozilla/http-cache-xhr.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/http-cache-xhr.html.ini
@@ -1,0 +1,2 @@
+[http-cache-xhr.html]
+  type: testharness

--- a/tests/wpt/mozilla/tests/mozilla/http-cache-xhr.html
+++ b/tests/wpt/mozilla/tests/mozilla/http-cache-xhr.html
@@ -24,14 +24,6 @@
             ['Last-Modified', http_date(0)]
           ],
           response_body: '12'
-        },
-        {
-          response_status: [200, 'OK'],
-          "response_headers": [
-            ['Expires', http_date(100000)],
-            ['Last-Modified', http_date(0)]
-          ],
-          response_body: '12'
         }
     ];
     var uuid = token();
@@ -45,19 +37,10 @@
           assert_equals(state.length, 2);
           // The empty, aborted response.
           assert_equals(client.response, "");
+          // The complete, non-aborted, response.
           assert_equals(client2.response, "12");
+          test.done();
         }));
-        var client3 = new XMLHttpRequest();
-        client3.onloadend = test.step_func(function(event) {
-          server_state(uuid).then(test.step_func(function(state) {
-            // No server hits, the response from client2 was cached and re-used.
-            assert_equals(state.length, 0)
-            assert_equals(client3.response, '12');
-            test.done();
-          }));
-        });
-        client3.open("GET", url);
-        client3.send();
       });
       client.onabort = test.step_func(function() {
         client2.open("GET", url);

--- a/tests/wpt/mozilla/tests/mozilla/http-cache-xhr.html
+++ b/tests/wpt/mozilla/tests/mozilla/http-cache-xhr.html
@@ -1,0 +1,73 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="resources/http-cache.js"></script>
+<script>
+  var test = async_test('The response from an aborted XHR request should not be cached');
+  test.step(function() {
+    var client = new XMLHttpRequest();
+    var requests = [
+        {
+          response_status: [200, 'OK'],
+          "response_headers": [
+            ['Expires', http_date(100000)],
+            ['Last-Modified', http_date(0)]
+          ],
+          response_body: '12'
+        },
+        {
+          response_status: [200, 'OK'],
+          "response_headers": [
+            ['Expires', http_date(100000)],
+            ['Last-Modified', http_date(0)]
+          ],
+          response_body: '12'
+        },
+        {
+          response_status: [200, 'OK'],
+          "response_headers": [
+            ['Expires', http_date(100000)],
+            ['Last-Modified', http_date(0)]
+          ],
+          response_body: '12'
+        }
+    ];
+    var uuid = token();
+    var url = make_url(uuid, requests, 0);
+    url += '&trickle=true';
+    client.onprogress = test.step_func(function() {
+      var client2 = new XMLHttpRequest();
+      client2.onloadend = test.step_func(function(event) {
+        server_state(uuid).then(test.step_func(function(state){
+          // Two server hits for two requests, no caching.
+          assert_equals(state.length, 2);
+          // The empty, aborted response.
+          assert_equals(client.response, "");
+          assert_equals(client2.response, "12");
+        }));
+        var client3 = new XMLHttpRequest();
+        client3.onloadend = test.step_func(function(event) {
+          server_state(uuid).then(test.step_func(function(state) {
+            // No server hits, the response from client2 was cached and re-used.
+            assert_equals(state.length, 0)
+            assert_equals(client3.response, '12');
+            test.done();
+          }));
+        });
+        client3.open("GET", url);
+        client3.send();
+      });
+      client.onabort = test.step_func(function() {
+        client2.open("GET", url);
+        client2.send();
+      });
+      client.abort();
+    });
+    client.open("GET", url);
+    client.send();
+  });
+</script>
+</head>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/resources/http-cache-trickle.py
+++ b/tests/wpt/mozilla/tests/mozilla/resources/http-cache-trickle.py
@@ -1,0 +1,64 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+import time
+from json import JSONEncoder, JSONDecoder
+from base64 import b64decode
+
+
+def main(request, response):
+    uuid = request.GET.first("token", None)
+    if "querystate" in request.GET:
+        response.headers.set("Content-Type", "text/plain")
+        return JSONEncoder().encode(request.server.stash.take(uuid))
+
+    server_state = request.server.stash.take(uuid)
+    if not server_state:
+        server_state = []
+
+    requests = JSONDecoder().decode(b64decode(request.GET.first("info", "")))
+    config = requests[len(server_state)]
+
+    state = dict()
+    state["request_method"] = request.method
+    state["request_headers"] = dict([[h.lower(), request.headers[h]] for h in request.headers])
+    server_state.append(state)
+    request.server.stash.put(uuid, server_state)
+
+    note_headers = ['content-type', 'access-control-allow-origin', 'last-modified', 'etag']
+    noted_headers = {}
+    for header in config.get('response_headers', []):
+        if header[0].lower() in ["location", "content-location"]:  # magic!
+            header[1] = "%s&target=%s" % (request.url, header[1])
+        response.headers.set(header[0], header[1])
+        if header[0].lower() in note_headers:
+            noted_headers[header[0].lower()] = header[1]
+
+    if "access-control-allow-origin" not in noted_headers:
+        response.headers.set("Access-Control-Allow-Origin", "*")
+    if "content-type" not in noted_headers:
+        response.headers.set("Content-Type", "text/plain")
+    response.headers.set("Server-Request-Count", len(server_state))
+
+    code, phrase = config.get("response_status", [200, "OK"])
+
+    if request.headers.get("If-Modified-Since", False) == noted_headers.get('last-modified', True):
+        code, phrase = [304, "Not Modified"]
+    if request.headers.get("If-None-Match", False) == noted_headers.get('etag', True):
+        code, phrase = [304, "Not Modified"]
+
+    response.status = (code, phrase)
+
+    if request.GET.first("trickle", None):
+        response.write_status_headers()
+        for byte in config.get("response_body", uuid):
+            response.writer.write_content(byte)
+            time.sleep(1)
+
+    content = config.get("response_body", uuid)
+    if code in [204, 304]:
+        return ""
+    else:
+        return content

--- a/tests/wpt/mozilla/tests/mozilla/resources/http-cache.js
+++ b/tests/wpt/mozilla/tests/mozilla/resources/http-cache.js
@@ -40,11 +40,11 @@ function make_url(uuid, requests, idx) {
   if ("query_arg" in requests[idx]) {
     arg = "&target=" + requests[idx].query_arg;
   }
-  return "/fetch/http-cache/resources/http-cache.py?token=" + uuid + "&info=" + btoa(JSON.stringify(requests)) + arg;
+  return "resources/http-cache-trickle.py?token=" + uuid + "&info=" + btoa(JSON.stringify(requests)) + arg;
 }
 
 function server_state(uuid) {
-  return fetch("/fetch/http-cache/resources/http-cache.py?querystate&token=" + uuid)
+  return fetch("resources/http-cache-trickle.py?querystate&token=" + uuid)
     .then(function(response) {
       return response.text();
     }).then(function(text) {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
jdm KiChjang Manishearth Follow up on https://github.com/servo/servo/pull/18676 and https://github.com/servo/servo/pull/19274 to ignore aborted responses in caching. 

I also found out the cache shouldn't return any response whose body is still in `ResponseBody::Receiving` mode, because that fails the assertion at https://github.com/servo/servo/blob/master/components/net/fetch/methods.rs#L438(we might want to add a channel as pat of the cached response later on to deal with this case). I only found out now because I needed the response from the server to trickle in so that it could be cached and aborted. 

I copied the `http-cache.py` server from the wpt folder, and added a 'trickle' option, which is necessary to actually have a failing test with a cached but aborted request, it's now passing. 

I also remove one unused import that slippled through previously.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19350)
<!-- Reviewable:end -->
