### PR TITLE
Enable pip error output in mach_bootstrap.py

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -8,7 +8,9 @@ import os
 import platform
 import sys
 from distutils.spawn import find_executable
-from subprocess import PIPE, Popen
+from subprocess import Popen
+import shutil
+from tempfile import TemporaryFile
 
 SEARCH_PATHS = [
     os.path.join("python", "tidy"),
@@ -101,6 +103,25 @@ def _get_virtualenv_script_dir():
     return "bin"
 
 
+def _process_exec(args):
+    with TemporaryFile() as out:
+        with TemporaryFile() as err:
+            process = Popen(args, stdout=out, stderr=err)
+            process.wait()
+            if process.returncode:
+                print('"%s" failed with error code %d:' % ('" "'.join(args), process.returncode))
+
+                print('Output:')
+                out.seek(0)
+                shutil.copyfileobj(out, sys.stdout)
+
+                print('Error:')
+                err.seek(0)
+                shutil.copyfileobj(err, sys.stdout)
+
+                sys.exit()
+
+
 def wpt_path(is_firefox, topdir, *paths):
     if is_firefox:
         rel = os.path.join("..", "testing", "web-platform")
@@ -135,16 +156,8 @@ def _activate_virtualenv(topdir, is_firefox):
         if not virtualenv:
             sys.exit("Python virtualenv is not installed. Please install it prior to running mach.")
 
-        process = Popen(
-            [virtualenv, "-p", python, "--system-site-packages", virtualenv_path],
-            stdout=PIPE,
-            stderr=PIPE
-        )
-        process.wait()
-        if process.returncode:
-            out, err = process.communicate()
-            print('Python virtualenv failed to execute properly:')
-            sys.exit('Output: %s\nError: %s' % (out, err))
+        _process_exec([virtualenv, "-p", python, "--system-site-packages", virtualenv_path])
+
         # We want to upgrade pip when virtualenv created for the first time
         need_pip_upgrade = True
 
@@ -174,12 +187,7 @@ def _activate_virtualenv(topdir, is_firefox):
         if not pip:
             sys.exit("Python pip is either not installed or not found in virtualenv.")
 
-        process = Popen([pip, "install", "-q", "-I", "-U", "pip"], stdout=PIPE, stderr=PIPE)
-        process.wait()
-        if process.returncode:
-            out, err = process.communicate()
-            print('Pip failed to upgrade itself properly:')
-            sys.exit('Output: %s\nError: %s' % (out, err))
+        _process_exec([pip, "install", "-q", "-I", "-U", "pip"])
 
     for req_rel_path in requirements_paths:
         req_path = os.path.join(topdir, req_rel_path)
@@ -196,12 +204,7 @@ def _activate_virtualenv(topdir, is_firefox):
         if not pip:
             sys.exit("Python pip is either not installed or not found in virtualenv.")
 
-        process = Popen([pip, "install", "-q", "-I", "-r", req_path], stdout=PIPE, stderr=PIPE)
-        process.wait()
-        if process.returncode:
-            out, err = process.communicate()
-            print('Pip failed to execute properly:')
-            sys.exit('Output: %s\nError: %s' % (out, err))
+        _process_exec([pip, "install", "-q", "-I", "-r", req_path])
 
         open(marker_path, 'w').close()
 

--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -187,7 +187,7 @@ def _activate_virtualenv(topdir, is_firefox):
         if not pip:
             sys.exit("Python pip is either not installed or not found in virtualenv.")
 
-        _process_exec([pip, "install", "-q", "-I", "-U", "pip"])
+        _process_exec([pip, "install", "-I", "-U", "pip"])
 
     for req_rel_path in requirements_paths:
         req_path = os.path.join(topdir, req_rel_path)
@@ -204,7 +204,7 @@ def _activate_virtualenv(topdir, is_firefox):
         if not pip:
             sys.exit("Python pip is either not installed or not found in virtualenv.")
 
-        _process_exec([pip, "install", "-q", "-I", "-r", req_path])
+        _process_exec([pip, "install", "-I", "-r", req_path])
 
         open(marker_path, 'w').close()
 


### PR DESCRIPTION
When `pip` encounters an error during mach bootstrapping in `mach_bootstrap.py` there is no error log because of `-q`. The output will only be read when an error was encountered, so this looks like an unintended mistake.

---

This gives error outputs like:
```
D:\Code\moz\servo>mach.bat -h
Pip failed to execute properly:
Output: Collecting marionette_driver>=2.4 (from -r D:\Code\moz\servo\tests\wpt\web-platform-tests\tools\wptrunner\requirements_firefox.txt (line 1))
  Using cached marionette_driver-2.4.0.tar.gz
Collecting mozprofile>=0.21 (from -r D:\Code\moz\servo\tests\wpt\web-platform-tests\tools\wptrunner\requirements_firefox.txt (line 2))
  Using cached mozprofile-0.28.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\$USER\AppData\Local\Temp\pip-build-zqivz5en\mozprofile\setup.py", line 12, in <module>
        assert sys.version_info[0] == 2
    AssertionError

    ----------------------------------------

Error: Command "python setup.py egg_info" failed with error code 1 in C:\Users\$USER\AppData\Local\Temp\pip-build-zqivz5en\mozprofile\
```

instead of:

```
D:\Code\moz\servo>mach.bat -h
Pip failed to execute properly:
Output:
Error: Command "python setup.py egg_info" failed with error code 1 in C:\Users\$USER\AppData\Local\Temp\pip-build-htd5no9k\mozprofile\
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19362)
<!-- Reviewable:end -->
