### PR TITLE
style: Make a Servo-only assertion apply to Gecko too.

### DIFF
--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -256,8 +256,10 @@ pub trait DomTraversal<E: TElement> : Sync {
         parent: E,
         parent_data: &ElementData,
     ) -> bool {
-        debug_assert!(cfg!(feature = "gecko") ||
-                      parent.has_current_styles_for_traversal(parent_data, context.shared.traversal_flags));
+        debug_assert!(parent.has_current_styles_for_traversal(
+            parent_data,
+            context.shared.traversal_flags,
+        ));
 
         // If the parent computed display:none, we don't style the subtree.
         if parent_data.styles.is_display_none() {


### PR DESCRIPTION
Gecko passes it now, and we want to know if that ever changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19367)
<!-- Reviewable:end -->
