### PR TITLE
style: Don't insert into the `seen` set before ignoring document colors.

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -3330,7 +3330,6 @@ where
             if seen.contains(physical_longhand_id) {
                 continue
             }
-            seen.insert(physical_longhand_id);
 
             let mut declaration = match *declaration {
                 PropertyDeclaration::WithVariables(id, ref unparsed) => {
@@ -3375,6 +3374,8 @@ where
                         Cow::Owned(PropertyDeclaration::BackgroundColor(color.into()));
                 }
             }
+
+            seen.insert(physical_longhand_id);
 
             % if category_to_cascade_now == "early":
                 if LonghandId::FontSize == longhand_id {


### PR DESCRIPTION
Otherwise we may stop honoring other colors in other cascade levels.

Fixes: #19370

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19371)
<!-- Reviewable:end -->
