### PR TITLE
Call children_changed on the parent node consistently

### DIFF
--- a/tests/wpt/web-platform-tests/css/cssom/stylesheet-replacedata-dynamic-ref.html
+++ b/tests/wpt/web-platform-tests/css/cssom/stylesheet-replacedata-dynamic-ref.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<title>(Ref #1) CSS Test Reference</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@mozilla.com">
+<link rel="author" title="Cheng You Bai" href="mailto:cyb.ai.815@gmail.com">
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-characterdata-replacedata">
+<style>.pass { color: green }</style>
+<div class="pass">Should be green</div>

--- a/tests/wpt/web-platform-tests/css/cssom/stylesheet-replacedata-dynamic.html
+++ b/tests/wpt/web-platform-tests/css/cssom/stylesheet-replacedata-dynamic.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<title>(Test #1) CSS Test: Dynamic changes to the stylesheet contents using replaceData are reflected</title>
+<link rel="match" href="stylesheet-replacedata-dynamic-ref.html">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@mozilla.com">
+<link rel="author" title="Cheng You Bai" href="mailto:cyb.ai.815@gmail.com">
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-characterdata-replacedata">
+<style>.fail { color: green }</style>
+<div class="pass">Should be green</div>
+<script>
+  document.body.offsetTop;
+  document.querySelector('style').firstChild.replaceData(1, 4, "pass");
+</script>


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #19177 
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19384)
<!-- Reviewable:end -->
