### PR TITLE
style: Disable :visited if the document is being used as an image.

### DIFF
--- a/components/style/gecko/data.rs
+++ b/components/style/gecko/data.rs
@@ -164,10 +164,18 @@ impl PerDocumentStyleDataImpl {
     }
 
     /// Returns whether private browsing is enabled.
-    pub fn is_private_browsing_enabled(&self) -> bool {
+    fn is_private_browsing_enabled(&self) -> bool {
         let doc =
             self.stylist.device().pres_context().mDocument.raw::<nsIDocument>();
         unsafe { bindings::Gecko_IsPrivateBrowsingEnabled(doc) }
+    }
+
+    /// Returns whether the document is being used as an image.
+    fn is_being_used_as_an_image(&self) -> bool {
+        let doc =
+            self.stylist.device().pres_context().mDocument.raw::<nsIDocument>();
+
+        unsafe { (*doc).mIsBeingUsedAsImage() }
     }
 
     /// Get the default computed values for this document.
@@ -179,9 +187,22 @@ impl PerDocumentStyleDataImpl {
     fn visited_links_enabled(&self) -> bool {
         unsafe { structs::StylePrefs_sVisitedLinksEnabled }
     }
+
     /// Returns whether visited styles are enabled.
     pub fn visited_styles_enabled(&self) -> bool {
-        self.visited_links_enabled() && !self.is_private_browsing_enabled()
+        if !self.visited_links_enabled() {
+            return false;
+        }
+
+        if self.is_private_browsing_enabled() {
+            return false;
+        }
+
+        if self.is_being_used_as_an_image() {
+            return false;
+        }
+
+        true
     }
 
     /// Measure heap usage.


### PR DESCRIPTION
Bug: 1420001
Reviewed-by: dholbert
MozReview-Commit-ID: F9MeT1kXZER

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19398)
<!-- Reviewable:end -->
