### PR TITLE
Add a cache for resolving property with unparsed value from shorthand

### DIFF
--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -391,10 +391,11 @@ impl AnimationValue {
     }
 
     /// Construct an AnimationValue from a property declaration.
-    pub fn from_declaration(
-        decl: &PropertyDeclaration,
+    pub fn from_declaration<'a>(
+        decl: &'a PropertyDeclaration,
         context: &mut Context,
         extra_custom_properties: Option<<&Arc<::custom_properties::CustomPropertiesMap>>,
+        substitution_cache: Option<<&mut ::properties::ParsedShorthandCache<'a>>,
         initial: &ComputedValues
     ) -> Option<Self> {
         use properties::LonghandId;
@@ -474,13 +475,18 @@ impl AnimationValue {
                     unparsed.substitute_variables(
                         id,
                         custom_properties,
-                        context.quirks_mode
+                        context.quirks_mode,
+                        substitution_cache,
                     )
                 };
                 return AnimationValue::from_declaration(
                     &substituted,
                     context,
                     extra_custom_properties,
+                    // We shouldn't need cache anymore, and you cannot put
+                    // `substitution_cache` here anyway, since `substituted`
+                    // doesn't live long enough.
+                    None,
                     initial,
                 )
             },

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -3917,6 +3917,7 @@ pub extern "C" fn Servo_AnimationValue_Compute(
                 decl,
                 &mut context,
                 None, // No extra custom properties for devtools.
+                None,
                 default_values,
             );
             animation.map_or(RawServoAnimationValueStrong::null(), |value| {


### PR DESCRIPTION
This is the another fix for [bug 1420509](https://bugzilla.mozilla.org/show_bug.cgi?id=1420509) which implements the parsed value cache for variable usage in shorthands.

My local test shows some performance gain with this change for tpaint.

Note that this patch probably shouldn't be landed at the moment, since there is an (wrong?) error reported by valgrind complaining about "Conditional jump or move depends on uninitialised value(s)" in code I don't touch here. We may need to add some suppression on Gecko side before landing this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19400)
<!-- Reviewable:end -->
