### PR TITLE
Don't confuse Cargo when building dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "ports/geckolib",
     "ports/servo",
 ]
+exclude = [".cargo"]
 
 [profile.dev]
 codegen-units = 4


### PR DESCRIPTION
It's not totally clear why this is experienced intermittently (see #19402), but this allowed mp4parse-capi to actually build on my machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19413)
<!-- Reviewable:end -->
