### PR TITLE
Remove unused generic from push_applicable_declarations

### DIFF
--- a/components/style/selector_map.rs
+++ b/components/style/selector_map.rs
@@ -6,7 +6,7 @@
 //! name, ids and hash.
 
 use {Atom, LocalName};
-use applicable_declarations::ApplicableDeclarationBlock;
+use applicable_declarations::ApplicableDeclarationList;
 use context::QuirksMode;
 use dom::TElement;
 use fallible::FallibleVec;
@@ -18,7 +18,7 @@ use rule_tree::CascadeLevel;
 use selector_parser::SelectorImpl;
 use selectors::matching::{matches_selector, MatchingContext, ElementSelectorFlags};
 use selectors::parser::{Component, Combinator, SelectorIter};
-use smallvec::{SmallVec, VecLike};
+use smallvec::SmallVec;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 use stylist::Rule;
 
@@ -146,11 +146,11 @@ impl SelectorMap<Rule> {
     ///
     /// Extract matching rules as per element's ID, classes, tag name, etc..
     /// Sort the Rules at the end to maintain cascading order.
-    pub fn get_all_matching_rules<E, V, F>(
+    pub fn get_all_matching_rules<E, F>(
         &self,
         element: &E,
         rule_hash_target: &E,
-        matching_rules_list: &mut V,
+        matching_rules_list: &mut ApplicableDeclarationList,
         context: &mut MatchingContext<E::Impl>,
         quirks_mode: QuirksMode,
         flags_setter: &mut F,
@@ -158,7 +158,6 @@ impl SelectorMap<Rule> {
     )
     where
         E: TElement,
-        V: VecLike<ApplicableDeclarationBlock>,
         F: FnMut(&E, ElementSelectorFlags),
     {
         if self.is_empty() {
@@ -210,17 +209,16 @@ impl SelectorMap<Rule> {
     }
 
     /// Adds rules in `rules` that match `element` to the `matching_rules` list.
-    fn get_matching_rules<E, V, F>(
+    fn get_matching_rules<E, F>(
         element: &E,
         rules: &[Rule],
-        matching_rules: &mut V,
+        matching_rules: &mut ApplicableDeclarationList,
         context: &mut MatchingContext<E::Impl>,
         flags_setter: &mut F,
         cascade_level: CascadeLevel,
     )
     where
         E: TElement,
-        V: VecLike<ApplicableDeclarationBlock>,
         F: FnMut(&E, ElementSelectorFlags),
     {
         for rule in rules {

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -32,13 +32,10 @@ use selectors::matching::{ElementSelectorFlags, matches_selector, MatchingContex
 use selectors::matching::VisitedHandlingMode;
 use selectors::parser::{AncestorHashes, Combinator, Component, Selector};
 use selectors::parser::{SelectorIter, SelectorMethods};
-use selectors::sink::Push;
 use selectors::visitor::SelectorVisitor;
 use servo_arc::{Arc, ArcBorrow};
 use shared_lock::{Locked, SharedRwLockReadGuard, StylesheetGuards};
 use smallbitvec::SmallBitVec;
-use smallvec::VecLike;
-use std::fmt::Debug;
 use std::ops;
 use std::sync::Mutex;
 use style_traits::viewport::ViewportConstraints;
@@ -1205,7 +1202,7 @@ impl Stylist {
     /// Returns the applicable CSS declarations for the given element.
     ///
     /// This corresponds to `ElementRuleCollector` in WebKit.
-    pub fn push_applicable_declarations<E, V, F>(
+    pub fn push_applicable_declarations<E, F>(
         &self,
         element: &E,
         pseudo_element: Option<&PseudoElement>,
@@ -1213,13 +1210,12 @@ impl Stylist {
         smil_override: Option<ArcBorrow<Locked<PropertyDeclarationBlock>>>,
         animation_rules: AnimationRules,
         rule_inclusion: RuleInclusion,
-        applicable_declarations: &mut V,
+        applicable_declarations: &mut ApplicableDeclarationList,
         context: &mut MatchingContext<E::Impl>,
         flags_setter: &mut F,
     )
     where
         E: TElement,
-        V: Push<ApplicableDeclarationBlock> + VecLike<ApplicableDeclarationBlock> + Debug,
         F: FnMut(&E, ElementSelectorFlags),
     {
         // Gecko definitely has pseudo-elements with style attributes, like
@@ -1343,8 +1339,7 @@ impl Stylist {
         if !only_default_rules {
             // Step 4: Normal style attributes.
             if let Some(sa) = style_attribute {
-                Push::push(
-                    applicable_declarations,
+                applicable_declarations.push(
                     ApplicableDeclarationBlock::from_declarations(
                         sa.clone_arc(),
                         CascadeLevel::StyleAttributeNormal
@@ -1355,8 +1350,7 @@ impl Stylist {
             // Step 5: SMIL override.
             // Declarations from SVG SMIL animation elements.
             if let Some(so) = smil_override {
-                Push::push(
-                    applicable_declarations,
+                applicable_declarations.push(
                     ApplicableDeclarationBlock::from_declarations(
                         so.clone_arc(),
                         CascadeLevel::SMILOverride
@@ -1368,8 +1362,7 @@ impl Stylist {
             // The animations sheet (CSS animations, script-generated animations,
             // and CSS transitions that are no longer tied to CSS markup)
             if let Some(anim) = animation_rules.0 {
-                Push::push(
-                    applicable_declarations,
+                applicable_declarations.push(
                     ApplicableDeclarationBlock::from_declarations(
                         anim.clone(),
                         CascadeLevel::Animations
@@ -1389,8 +1382,7 @@ impl Stylist {
             // Step 11: Transitions.
             // The transitions sheet (CSS transitions that are tied to CSS markup)
             if let Some(anim) = animation_rules.1 {
-                Push::push(
-                    applicable_declarations,
+                applicable_declarations.push(
                     ApplicableDeclarationBlock::from_declarations(
                         anim.clone(),
                         CascadeLevel::Transitions


### PR DESCRIPTION
This function is only ever used with one type.

This gets rid of the only use of the `smallvec::VecLike` trait, which we may want to deprecate (servo/rust-smallvec#35).  If we do need to make this function generic in the future, we can do it using standard traits instead.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are removing unused code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19424)
<!-- Reviewable:end -->
