### PR TITLE
style: Remove redundant style sharing check.

### DIFF
--- a/components/style/sharing/mod.rs
+++ b/components/style/sharing/mod.rs
@@ -648,19 +648,14 @@ impl<E: TElement> StyleSharingCache<E> {
         nth_index_cache: &mut NthIndexCache,
         selector_flags_map: &mut SelectorFlagsMap<E>
     ) -> Option<ResolvedElementStyles> {
+        debug_assert!(!target.is_native_anonymous());
+
         // Check that we have the same parent, or at least that the parents
         // share styles and permit sharing across their children. The latter
         // check allows us to share style between cousins if the parents
         // shared style.
         if !checks::parents_allow_sharing(target, candidate) {
             trace!("Miss: Parent");
-            return None;
-        }
-
-        if target.is_native_anonymous() {
-            debug_assert!(!candidate.element.is_native_anonymous(),
-                          "Why inserting NAC into the cache?");
-            trace!("Miss: Native Anonymous Content");
             return None;
         }
 


### PR DESCRIPTION
We check that a few lines before calling test_candidate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19438)
<!-- Reviewable:end -->
