### PR TITLE
Added explicit UTF-8 encoding to test-perf.

### DIFF
--- a/etc/ci/performance/runner.py
+++ b/etc/ci/performance/runner.py
@@ -100,7 +100,7 @@ def parse_log(log, testcase, url):
     block = []
     copy = False
     for line_bytes in log.splitlines():
-        line = line_bytes.decode()
+        line = line_bytes.decode('utf-8')
 
         if line.strip() == ("[PERF] perf block start"):
             copy = True
@@ -281,7 +281,7 @@ def save_result_csv(results, filename, manifest, expected_runs, base):
         'unloadEventStart',
     ]
 
-    with open(filename, 'w') as csvfile:
+    with open(filename, 'w', encoding='utf-8') as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames)
         writer.writeheader()
         writer.writerows(results)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Added explicit UTF-8 encoding to test-perf, to try to avoid:
```
Traceback (most recent call last):
  File "runner.py", line 371, in <module>
    main()
  File "runner.py", line 361, in main
    save_result_csv(results, args.output_file, testcases, args.runs, args.base)
  File "runner.py", line 287, in save_result_csv
    writer.writerows(results)
  File "/usr/lib/python3.4/csv.py", line 159, in writerows
    return self.writer.writerows(rows)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 101-107: ordinal not in range(128)
```
http://build.servo.org/builders/linux-nightly/builds/526/steps/test/logs/stdio

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because this is test infrastructure

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19440)
<!-- Reviewable:end -->
