### PR TITLE
style: Make -moz-border-colors chrome only.

### DIFF
--- a/components/style/properties/longhand/border.mako.rs
+++ b/components/style/properties/longhand/border.mako.rs
@@ -74,6 +74,7 @@ ${helpers.gecko_keyword_conversion(Keyword('border-style',
                        spec="Nonstandard (https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-border-*-colors)"
                        products="gecko"
                        flags="APPLIES_TO_FIRST_LETTER"
+                       enabled_in="chrome"
                        ignored_when_colors_disabled="True">
         use std::fmt;
         use style_traits::ToCss;

--- a/components/style/properties/shorthand/border.mako.rs
+++ b/components/style/properties/shorthand/border.mako.rs
@@ -131,15 +131,8 @@ pub fn parse_border<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
         for side in PHYSICAL_SIDES
         for prop in ['color', 'style', 'width'])}
         ${' '.join('border-image-%s' % name
-        for name in ['outset', 'repeat', 'slice', 'source', 'width'])}
-        ${' '.join('-moz-border-%s-colors' % side
-        for side in PHYSICAL_SIDES) if product == 'gecko' else ''}"
+        for name in ['outset', 'repeat', 'slice', 'source', 'width'])}"
     spec="https://drafts.csswg.org/css-backgrounds/#border">
-
-    % if product == "gecko":
-        use properties::longhands::{_moz_border_top_colors, _moz_border_right_colors,
-                                    _moz_border_bottom_colors, _moz_border_left_colors};
-    % endif
 
     pub fn parse_value<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
                                -> Result<Longhands, ParseError<'i>> {
@@ -152,9 +145,6 @@ pub fn parse_border<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
                 border_${side}_color: color.clone(),
                 border_${side}_style: style,
                 border_${side}_width: width.clone(),
-                % if product == "gecko":
-                    _moz_border_${side}_colors: _moz_border_${side}_colors::get_initial_specified_value(),
-                % endif
             % endfor
 
             // The ‘border’ shorthand resets ‘border-image’ to its initial value.

--- a/tests/unit/stylo/size_of.rs
+++ b/tests/unit/stylo/size_of.rs
@@ -50,7 +50,7 @@ size_of_test!(test_size_of_rule_node, RuleNode, 80);
 
 // This is huge, but we allocate it on the stack and then never move it,
 // we only pass `&mut SourcePropertyDeclaration` references around.
-size_of_test!(test_size_of_parsed_declaration, style::properties::SourcePropertyDeclaration, 704);
+size_of_test!(test_size_of_parsed_declaration, style::properties::SourcePropertyDeclaration, 576);
 
 size_of_test!(test_size_of_computed_image, computed::image::Image, 40);
 size_of_test!(test_size_of_specified_image, specified::image::Image, 40);


### PR DESCRIPTION
This also makes the `border` shorthand not reset them.

Bug: 1417200
Reviewed-by: xidorn
MozReview-Commit-ID: KNais1e5FnE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19446)
<!-- Reviewable:end -->
