### PR TITLE
style: Add a missing fast-path in GeckoElement::each_class.

### DIFF
--- a/components/style/gecko/snapshot_helpers.rs
+++ b/components/style/gecko/snapshot_helpers.rs
@@ -17,11 +17,12 @@ pub type ClassOrClassList<T> = unsafe extern fn (T, *mut *mut nsAtom, *mut *mut 
 
 /// Given an item `T`, a class name, and a getter function, return whether that
 /// element has the class that `name` represents.
-pub fn has_class<T>(item: T,
-                    name: &Atom,
-                    case_sensitivity: CaseSensitivity,
-                    getter: ClassOrClassList<T>) -> bool
-{
+pub fn has_class<T>(
+    item: T,
+    name: &Atom,
+    case_sensitivity: CaseSensitivity,
+    getter: ClassOrClassList<T>,
+) -> bool {
     unsafe {
         let mut class: *mut nsAtom = ptr::null_mut();
         let mut list: *mut *mut nsAtom = ptr::null_mut();
@@ -40,10 +41,13 @@ pub fn has_class<T>(item: T,
 
 /// Given an item, a callback, and a getter, execute `callback` for each class
 /// this `item` has.
-pub fn each_class<F, T>(item: T,
-                        mut callback: F,
-                        getter: ClassOrClassList<T>)
-    where F: FnMut(&Atom)
+pub fn each_class<F, T>(
+    item: T,
+    mut callback: F,
+    getter: ClassOrClassList<T>,
+)
+where
+    F: FnMut(&Atom)
 {
     unsafe {
         let mut class: *mut nsAtom = ptr::null_mut();

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -1124,6 +1124,10 @@ impl<'le> TElement for GeckoElement<'le> {
     where
         F: FnMut(&Atom),
     {
+        if !self.may_have_class() {
+            return;
+        }
+
         snapshot_helpers::each_class(self.0, callback, Gecko_ClassOrClassList)
     }
 

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -2135,10 +2135,12 @@ impl<'le> ::selectors::Element for GeckoElement<'le> {
             return false;
         }
 
-        snapshot_helpers::has_class(self.0,
-                                    name,
-                                    case_sensitivity,
-                                    Gecko_ClassOrClassList)
+        snapshot_helpers::has_class(
+            self.0,
+            name,
+            case_sensitivity,
+            Gecko_ClassOrClassList,
+        )
     }
 
     #[inline]


### PR DESCRIPTION
This shows up when inserting elements in the bloom filter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19454)
<!-- Reviewable:end -->
