### PR TITLE
Handle cases where selection API doesn't apply

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -408,6 +408,18 @@ impl TextControl for HTMLInputElement {
     fn textinput(&self) -> &DomRefCell<TextInput<ScriptToConstellationChan>> {
         &self.textinput
     }
+
+    // https://html.spec.whatwg.org/multipage/#concept-input-apply
+    fn selection_api_applies(&self) -> bool {
+        match self.input_type() {
+            InputType::Text | InputType::Search | InputType::Url
+            | InputType::Tel | InputType::Password => {
+                true
+            },
+
+            _ => false
+        }
+    }
 }
 
 impl HTMLInputElementMethods for HTMLInputElement {
@@ -679,38 +691,38 @@ impl HTMLInputElementMethods for HTMLInputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart
-    fn SelectionStart(&self) -> u32 {
-        self.dom_selection_start()
+    fn GetSelectionStart(&self) -> Option<u32> {
+        self.get_dom_selection_start()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart
-    fn SetSelectionStart(&self, start: u32) {
-        self.set_dom_selection_start(start);
+    fn SetSelectionStart(&self, start: Option<u32>) -> ErrorResult {
+        self.set_dom_selection_start(start)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend
-    fn SelectionEnd(&self) -> u32 {
-        self.dom_selection_end()
+    fn GetSelectionEnd(&self) -> Option<u32> {
+        self.get_dom_selection_end()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend
-    fn SetSelectionEnd(&self, end: u32) {
+    fn SetSelectionEnd(&self, end: Option<u32>) -> ErrorResult {
         self.set_dom_selection_end(end)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectiondirection
-    fn SelectionDirection(&self) -> DOMString {
-        self.dom_selection_direction()
+    fn GetSelectionDirection(&self) -> Option<DOMString> {
+        self.get_dom_selection_direction()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectiondirection
-    fn SetSelectionDirection(&self, direction: DOMString) {
-        self.set_dom_selection_direction(direction);
+    fn SetSelectionDirection(&self, direction: Option<DOMString>) -> ErrorResult {
+        self.set_dom_selection_direction(direction)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-setselectionrange
-    fn SetSelectionRange(&self, start: u32, end: u32, direction: Option<DOMString>) {
-        self.set_dom_selection_range(start, end, direction);
+    fn SetSelectionRange(&self, start: u32, end: u32, direction: Option<DOMString>) -> ErrorResult {
+        self.set_dom_selection_range(start, end, direction)
     }
 
     // Select the files based on filepaths passed in,

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -8,6 +8,7 @@ use dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use dom::bindings::codegen::Bindings::HTMLTextAreaElementBinding;
 use dom::bindings::codegen::Bindings::HTMLTextAreaElementBinding::HTMLTextAreaElementMethods;
 use dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
+use dom::bindings::error::ErrorResult;
 use dom::bindings::inheritance::Castable;
 use dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
 use dom::bindings::str::DOMString;
@@ -145,6 +146,10 @@ impl TextControl for HTMLTextAreaElement {
     fn textinput(&self) -> &DomRefCell<TextInput<ScriptToConstellationChan>> {
         &self.textinput
     }
+
+    fn selection_api_applies(&self) -> bool {
+        true
+    }
 }
 
 impl HTMLTextAreaElementMethods for HTMLTextAreaElement {
@@ -260,38 +265,38 @@ impl HTMLTextAreaElementMethods for HTMLTextAreaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart
-    fn SelectionStart(&self) -> u32 {
-        self.dom_selection_start()
+    fn GetSelectionStart(&self) -> Option<u32> {
+        self.get_dom_selection_start()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionstart
-    fn SetSelectionStart(&self, start: u32) {
-        self.set_dom_selection_start(start);
+    fn SetSelectionStart(&self, start: Option<u32>) -> ErrorResult {
+        self.set_dom_selection_start(start)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend
-    fn SelectionEnd(&self) -> u32 {
-        self.dom_selection_end()
+    fn GetSelectionEnd(&self) -> Option<u32> {
+        self.get_dom_selection_end()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectionend
-    fn SetSelectionEnd(&self, end: u32) {
-        self.set_dom_selection_end(end);
+    fn SetSelectionEnd(&self, end: Option<u32>) -> ErrorResult {
+        self.set_dom_selection_end(end)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectiondirection
-    fn SelectionDirection(&self) -> DOMString {
-        self.dom_selection_direction()
+    fn GetSelectionDirection(&self) -> Option<DOMString> {
+        self.get_dom_selection_direction()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-selectiondirection
-    fn SetSelectionDirection(&self, direction: DOMString) {
-        self.set_dom_selection_direction(direction);
+    fn SetSelectionDirection(&self, direction: Option<DOMString>) -> ErrorResult {
+        self.set_dom_selection_direction(direction)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea/input-setselectionrange
-    fn SetSelectionRange(&self, start: u32, end: u32, direction: Option<DOMString>) {
-        self.set_dom_selection_range(start, end, direction);
+    fn SetSelectionRange(&self, start: u32, end: u32, direction: Option<DOMString>) -> ErrorResult {
+        self.set_dom_selection_range(start, end, direction)
     }
 }
 

--- a/components/script/dom/webidls/HTMLInputElement.webidl
+++ b/components/script/dom/webidls/HTMLInputElement.webidl
@@ -90,13 +90,17 @@ interface HTMLInputElement : HTMLElement {
   readonly attribute NodeList labels;
 
   //void select();
-           attribute unsigned long selectionStart;
-           attribute unsigned long selectionEnd;
-           attribute DOMString selectionDirection;
+  [SetterThrows]
+           attribute unsigned long? selectionStart;
+  [SetterThrows]
+           attribute unsigned long? selectionEnd;
+  [SetterThrows]
+           attribute DOMString? selectionDirection;
   //void setRangeText(DOMString replacement);
   //void setRangeText(DOMString replacement, unsigned long start, unsigned long end,
   //                  optional SelectionMode selectionMode = "preserve");
-  void setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
+  [Throws]
+           void setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 
   // also has obsolete members
 

--- a/components/script/dom/webidls/HTMLTextAreaElement.webidl
+++ b/components/script/dom/webidls/HTMLTextAreaElement.webidl
@@ -51,11 +51,15 @@ interface HTMLTextAreaElement : HTMLElement {
   readonly attribute NodeList labels;
 
   // void select();
-           attribute unsigned long selectionStart;
-           attribute unsigned long selectionEnd;
-           attribute DOMString selectionDirection;
+  [SetterThrows]
+           attribute unsigned long? selectionStart;
+  [SetterThrows]
+           attribute unsigned long? selectionEnd;
+  [SetterThrows]
+           attribute DOMString? selectionDirection;
   // void setRangeText(DOMString replacement);
   // void setRangeText(DOMString replacement, unsigned long start, unsigned long end,
   //                   optional SelectionMode selectionMode = "preserve");
-  void setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
+  [Throws]
+           void setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 };

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -21,7 +21,7 @@ pub enum Selection {
     NotSelected
 }
 
-#[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]
+#[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf, PartialEq)]
 pub enum SelectionDirection {
     Forward,
     Backward,
@@ -825,7 +825,7 @@ impl<T: ClipboardProvider> TextInput<T> {
         }
     }
 
-    pub fn set_selection_range(&mut self, start: u32, end: u32) {
+    pub fn set_selection_range(&mut self, start: u32, end: u32, direction: SelectionDirection) {
         let mut start = start as usize;
         let mut end = end as usize;
         let text_end = self.get_content().len();
@@ -837,7 +837,9 @@ impl<T: ClipboardProvider> TextInput<T> {
             start = end;
         }
 
-        match self.selection_direction {
+        self.selection_direction = direction;
+
+        match direction {
             SelectionDirection::None |
             SelectionDirection::Forward => {
                 self.selection_begin = Some(self.get_text_point_for_absolute_point(start));

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -583,19 +583,19 @@ fn test_textinput_cursor_position_correct_after_clearing_selection() {
 #[test]
 fn test_textinput_set_selection_with_direction() {
     let mut textinput = text_input(Lines::Single, "abcdef");
-    textinput.selection_direction = SelectionDirection::Forward;
-    textinput.set_selection_range(2, 6);
+    textinput.set_selection_range(2, 6, SelectionDirection::Forward);
     assert_eq!(textinput.edit_point.line, 0);
     assert_eq!(textinput.edit_point.index, 6);
+    assert_eq!(textinput.selection_direction, SelectionDirection::Forward);
 
     assert!(textinput.selection_begin.is_some());
     assert_eq!(textinput.selection_begin.unwrap().line, 0);
     assert_eq!(textinput.selection_begin.unwrap().index, 2);
 
-    textinput.selection_direction = SelectionDirection::Backward;
-    textinput.set_selection_range(2, 6);
+    textinput.set_selection_range(2, 6, SelectionDirection::Backward);
     assert_eq!(textinput.edit_point.line, 0);
     assert_eq!(textinput.edit_point.index, 2);
+    assert_eq!(textinput.selection_direction, SelectionDirection::Backward);
 
     assert!(textinput.selection_begin.is_some());
     assert_eq!(textinput.selection_begin.unwrap().line, 0);

--- a/tests/wpt/metadata/html/semantics/forms/textfieldselection/select-event.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/textfieldselection/select-event.html.ini
@@ -1,23 +1,146 @@
 [select-event.html]
   type: testharness
-  [select() on textarea queues select event]
+  [textarea: select()]
     expected: FAIL
 
-  [select() on input type text queues select event]
+  [textarea: select() a second time (must not fire select)]
     expected: FAIL
 
-  [select() on input type search queues select event]
+  [textarea: selectionStart a second time (must not fire select)]
     expected: FAIL
 
-  [select() on input type tel queues select event]
+  [textarea: selectionEnd a second time (must not fire select)]
     expected: FAIL
 
-  [select() on input type url queues select event]
+  [textarea: selectionDirection a second time (must not fire select)]
     expected: FAIL
 
-  [select() on input type password queues select event]
+  [textarea: setSelectionRange() a second time (must not fire select)]
     expected: FAIL
 
-  [text field selection: select()]
+  [textarea: setRangeText()]
+    expected: FAIL
+
+  [textarea: setRangeText() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type text: select()]
+    expected: FAIL
+
+  [input type text: select() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type text: selectionStart a second time (must not fire select)]
+    expected: FAIL
+
+  [input type text: selectionEnd a second time (must not fire select)]
+    expected: FAIL
+
+  [input type text: selectionDirection a second time (must not fire select)]
+    expected: FAIL
+
+  [input type text: setSelectionRange() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type text: setRangeText()]
+    expected: FAIL
+
+  [input type text: setRangeText() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type search: select()]
+    expected: FAIL
+
+  [input type search: select() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type search: selectionStart a second time (must not fire select)]
+    expected: FAIL
+
+  [input type search: selectionEnd a second time (must not fire select)]
+    expected: FAIL
+
+  [input type search: selectionDirection a second time (must not fire select)]
+    expected: FAIL
+
+  [input type search: setSelectionRange() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type search: setRangeText()]
+    expected: FAIL
+
+  [input type search: setRangeText() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type tel: select()]
+    expected: FAIL
+
+  [input type tel: select() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type tel: selectionStart a second time (must not fire select)]
+    expected: FAIL
+
+  [input type tel: selectionEnd a second time (must not fire select)]
+    expected: FAIL
+
+  [input type tel: selectionDirection a second time (must not fire select)]
+    expected: FAIL
+
+  [input type tel: setSelectionRange() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type tel: setRangeText()]
+    expected: FAIL
+
+  [input type tel: setRangeText() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type url: select()]
+    expected: FAIL
+
+  [input type url: select() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type url: selectionStart a second time (must not fire select)]
+    expected: FAIL
+
+  [input type url: selectionEnd a second time (must not fire select)]
+    expected: FAIL
+
+  [input type url: selectionDirection a second time (must not fire select)]
+    expected: FAIL
+
+  [input type url: setSelectionRange() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type url: setRangeText()]
+    expected: FAIL
+
+  [input type url: setRangeText() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type password: select()]
+    expected: FAIL
+
+  [input type password: select() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type password: selectionStart a second time (must not fire select)]
+    expected: FAIL
+
+  [input type password: selectionEnd a second time (must not fire select)]
+    expected: FAIL
+
+  [input type password: selectionDirection a second time (must not fire select)]
+    expected: FAIL
+
+  [input type password: setSelectionRange() a second time (must not fire select)]
+    expected: FAIL
+
+  [input type password: setRangeText()]
+    expected: FAIL
+
+  [input type password: setRangeText() a second time (must not fire select)]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/forms/textfieldselection/selection-not-application.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/textfieldselection/selection-not-application.html.ini
@@ -1,71 +1,74 @@
 [selection-not-application.html]
   type: testharness
-  [text field selection for the input hidden]
+  [setRangeText on an input[type=hidden\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input email]
+  [setRangeText on an input[type=email\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input datetime]
+  [setRangeText on an input[type=datetime-local\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input date]
+  [setRangeText on an input[type=date\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input month]
+  [setRangeText on an input[type=month\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input week]
+  [setRangeText on an input[type=week\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input time]
+  [setRangeText on an input[type=time\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input number]
+  [setRangeText on an input[type=number\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input range]
+  [setRangeText on an input[type=range\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input color]
+  [setRangeText on an input[type=color\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input checkbox]
+  [setRangeText on an input[type=checkbox\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input radio]
+  [setRangeText on an input[type=radio\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input file]
+  [setRangeText on an input[type=file\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input submit]
+  [setRangeText on an input[type=submit\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input image]
+  [setRangeText on an input[type=image\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input reset]
+  [setRangeText on an input[type=reset\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input button]
+  [setRangeText on an input[type=button\] throws InvalidStateError]
     expected: FAIL
 
-  [text field selection for the input text]
+  [setRangeText on an input[type=text\] doesn't throw an exception]
     expected: FAIL
 
-  [text field selection for the input search]
+  [setRangeText on an input[type=search\] doesn't throw an exception]
     expected: FAIL
 
-  [text field selection for the input tel]
+  [setRangeText on an input[type=tel\] doesn't throw an exception]
     expected: FAIL
 
-  [text field selection for the input url]
+  [setRangeText on an input[type=url\] doesn't throw an exception]
     expected: FAIL
 
-  [text field selection for the input password]
+  [setRangeText on an input[type=password\] doesn't throw an exception]
     expected: FAIL
 
-  [text field selection for the input datetime-local]
+  [setRangeText on an input[type=null\] doesn't throw an exception]
+    expected: FAIL
+
+  [setRangeText on an input[type=aninvalidtype\] doesn't throw an exception]
     expected: FAIL
 

--- a/tests/wpt/web-platform-tests/html/semantics/forms/textfieldselection/select-event.html
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/textfieldselection/select-event.html
@@ -47,10 +47,10 @@ const actions = [
   }
 ];
 
-for (const el of els) {
+els.forEach((el) => {
   const elLabel = el.localName === "textarea" ? "textarea" : "input type " + el.type;
 
-  for (const action of actions) {
+  actions.forEach((action) => {
     // promise_test instead of async_test is important because these need to happen in sequence (to test that events
     // fire if and only if the selection changes).
     promise_test(t => {
@@ -79,6 +79,6 @@ for (const el of els) {
         }, 200);
       });
     }, `${elLabel}: ${action.label} a second time (must not fire select)`);
-  }
-}
+  });
+});
 </script>

--- a/tests/wpt/web-platform-tests/html/semantics/forms/textfieldselection/selection-not-application.html
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/textfieldselection/selection-not-application.html
@@ -7,45 +7,90 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var types = ["hidden", "email", "datetime-local", "date", "month", "week", "time", "number", "range", "color", "checkbox", "radio", "file", "submit", "image", "reset", "button"]; //types for which the API doesn't apply
-  var types2 = ["text", "search", "tel", "url", "password"]; //types for which the API applies
+  var nonApplicableTypes = ["hidden", "email", "datetime-local", "date", "month", "week", "time", "number", "range", "color", "checkbox", "radio", "file", "submit", "image", "reset", "button"];
+  var applicableTypes = ["text", "search", "tel", "url", "password", "aninvalidtype", null];
 
-  types.forEach(function(type){
-    test(function(){
-      var el = document.createElement("input");
-      el.type = type;
+  nonApplicableTypes.forEach(function(type){
+    var el = document.createElement("input");
+    el.type = type;
+
+    test(() => {
       assert_equals(el.selectionStart, null);
+    }, `selectionStart on an input[type=${type}] returns null`);
+
+    test(() => {
       assert_equals(el.selectionEnd, null);
+    }, `selectionEnd on an input[type=${type}] returns null`);
+
+    test(() => {
       assert_equals(el.selectionDirection, null);
+    }, `selectionDirection on an input[type=${type}] returns null`);
+
+    test(() => {
       assert_throws("InvalidStateError", function(){
         el.selectionStart = 0;
       });
+    }, `assigning selectionStart on an input[type=${type}] throws InvalidStateError`);
+
+    test(() => {
       assert_throws("InvalidStateError", function(){
         el.selectionEnd = 0;
       });
+    }, `assigning selectionEnd on an input[type=${type}] throws InvalidStateError`);
+
+    test(() => {
       assert_throws("InvalidStateError", function(){
         el.selectionDirection = 'none';
       });
+    }, `assigning selectionDirection on an input[type=${type}] throws InvalidStateError`);
+
+    test(() => {
       assert_throws("InvalidStateError", function(){
         el.setRangeText("foobar");
       });
+    }, `setRangeText on an input[type=${type}] throws InvalidStateError`);
+
+    test(() => {
       assert_throws("InvalidStateError", function(){
         el.setSelectionRange(0, 1);
       });
-    }, "text field selection for the input " + type);
+    }, `setSelectionRange on an input[type=${type}] throws InvalidStateError`);
   });
 
-  types2.forEach(function(type) {
-    test(function() {
-      var el = document.createElement("input");
-      el.type = type;
+  applicableTypes.forEach(function(type) {
+    var el = document.createElement("input");
+    if (type) el.type = type;
+
+    test(() => {
       assert_equals(el.selectionStart, 0);
+    }, `selectionStart on an input[type=${type}] returns a value`);
+
+    test(() => {
       assert_equals(el.selectionEnd, 0);
+    }, `selectionEnd on an input[type=${type}] returns a value`);
+
+    test(() => {
+      assert_equals(el.selectionDirection, "none");
+    }, `selectionDirection on an input[type=${type}] returns a value`);
+
+    test(() => {
       el.selectionStart = 1;
+    }, `assigning selectionStart on an input[type=${type}] doesn't throw an exception`);
+
+    test(() => {
       el.selectionEnd = 1;
+    }, `assigning selectionEnd on an input[type=${type}] doesn't throw an exception`);
+
+    test(() => {
       el.selectionDirection = "forward";
+    }, `assigning selectionDirection on an input[type=${type}] doesn't throw an exception`);
+
+    test(() => {
       el.setRangeText("foobar");
+    }, `setRangeText on an input[type=${type}] doesn't throw an exception`);
+
+    test(() => {
       el.setSelectionRange(0, 1);
-    }, "text field selection for the input " + type);
+    }, `setSelectionRange on an input[type=${type}] doesn't throw an exception`);
   });
 </script>


### PR DESCRIPTION
The selection API only applies to certain <input> types:

https://html.spec.whatwg.org/multipage/#do-not-apply

This commit ensures that we handle that correctly.

Some notes:

1. TextControl::set_dom_selection_direction now calls
   set_selection_range(), which means that setting selectionDirection will
   now fire a selection event, as it should per the spec.

2. There is a test for the firing of the select event in
   tests/wpt/web-platform-tests/html/semantics/forms/textfieldselection/select-event.html,
   however the test did not run due to this syntax error:

   (pid:26017) "ERROR:script::dom::bindings::error: Error at http://web-platform.test:8000/html/semantics/forms/textfieldselection/select-event.html:50:11 missing = in const declaration"

   This happens due to the us of the "for (const foo of ...)" construct.
   Per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of
   this should actually work, so it's somewhat unsatisfying to have to
   change the test.

3. I removed tests/wpt/web-platform-tests/html/semantics/forms/textfieldselection/selection-not-application-textarea.html
   because it doesn't seem to add any extra value - the selection API
   always applies to textarea elements, and the API is tested elsewhere.

4. If an `<input>`'s type is unset, it defaults to a text, and the
   selection API applies. Also, if an `<input>`'s type is set to an
   invalid value, it defaults to a text too. This second case doesn't
   currently work, and I'll need to do more restructuring of the code in
   a future commit. See discussion with nox in IRC:
   https://mozilla.logbot.info/servo/20171201#c13946454-c13946594

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19461)
<!-- Reviewable:end -->
