### PR TITLE
style: Cleanup Angle parsing.

### DIFF
--- a/components/style/values/specified/effects.rs
+++ b/components/style/values/specified/effects.rs
@@ -205,7 +205,11 @@ impl Parse for Filter {
                     // https://drafts.fxtf.org/filter-effects/#funcdef-filter-grayscale
                     Ok(GenericFilter::Grayscale(Factor::parse_with_clamping_to_one(context, i)?))
                 },
-                "hue-rotate" => Ok(GenericFilter::HueRotate(Angle::parse(context, i)?)),
+                "hue-rotate" => {
+                    // We allow unitless zero here, see:
+                    // https://github.com/w3c/fxtf-drafts/issues/228
+                    Ok(GenericFilter::HueRotate(Angle::parse_with_unitless(context, i)?))
+                },
                 "invert" => {
                     // Values of amount over 100% are allowed but UAs must clamp the values to 1.
                     // https://drafts.fxtf.org/filter-effects/#funcdef-filter-invert

--- a/components/style/values/specified/image.rs
+++ b/components/style/values/specified/image.rs
@@ -714,6 +714,8 @@ impl LineDirection {
         let mut _angle = if *compat_mode == CompatMode::Moz {
             input.try(|i| Angle::parse(context, i)).ok()
         } else {
+            // Gradients allow unitless zero angles as an exception, see:
+            // https://github.com/w3c/csswg-drafts/issues/1162
             if let Ok(angle) = input.try(|i| Angle::parse_with_unitless(context, i)) {
                 return Ok(LineDirection::Angle(angle));
             }

--- a/components/style/values/specified/image.rs
+++ b/components/style/values/specified/image.rs
@@ -261,8 +261,10 @@ impl Parse for Gradient {
 }
 
 impl Gradient {
-    fn parse_webkit_gradient_argument<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
-                                              -> Result<Self, ParseError<'i>> {
+    fn parse_webkit_gradient_argument<'i, 't>(
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self, ParseError<'i>> {
         type Point = GenericPosition<Component<X>, Component<Y>>;
 
         #[derive(Clone, Copy)]
@@ -518,10 +520,11 @@ impl Gradient {
 impl GradientKind {
     /// Parses a linear gradient.
     /// CompatMode can change during `-moz-` prefixed gradient parsing if it come across a `to` keyword.
-    fn parse_linear<'i, 't>(context: &ParserContext,
-                            input: &mut Parser<'i, 't>,
-                            compat_mode: &mut CompatMode)
-                            -> Result<Self, ParseError<'i>> {
+    fn parse_linear<'i, 't>(
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+        compat_mode: &mut CompatMode,
+    ) -> Result<Self, ParseError<'i>> {
         let direction = if let Ok(d) = input.try(|i| LineDirection::parse(context, i, compat_mode)) {
             input.expect_comma()?;
             d
@@ -534,10 +537,11 @@ impl GradientKind {
         Ok(GenericGradientKind::Linear(direction))
     }
 
-    fn parse_radial<'i, 't>(context: &ParserContext,
-                            input: &mut Parser<'i, 't>,
-                            compat_mode: &mut CompatMode)
-                            -> Result<Self, ParseError<'i>> {
+    fn parse_radial<'i, 't>(
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+        compat_mode: &mut CompatMode,
+    ) -> Result<Self, ParseError<'i>> {
         let (shape, position, angle, moz_position) = match *compat_mode {
             CompatMode::Modern => {
                 let shape = input.try(|i| EndingShape::parse(context, i, *compat_mode));
@@ -702,10 +706,11 @@ impl GenericsLineDirection for LineDirection {
 }
 
 impl LineDirection {
-    fn parse<'i, 't>(context: &ParserContext,
-                     input: &mut Parser<'i, 't>,
-                     compat_mode: &mut CompatMode)
-                     -> Result<Self, ParseError<'i>> {
+    fn parse<'i, 't>(
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+        compat_mode: &mut CompatMode,
+    ) -> Result<Self, ParseError<'i>> {
         let mut _angle = if *compat_mode == CompatMode::Moz {
             input.try(|i| Angle::parse(context, i)).ok()
         } else {
@@ -780,10 +785,11 @@ impl ToComputedValue for GradientPosition {
 }
 
 impl EndingShape {
-    fn parse<'i, 't>(context: &ParserContext,
-                     input: &mut Parser<'i, 't>,
-                     compat_mode: CompatMode)
-                     -> Result<Self, ParseError<'i>> {
+    fn parse<'i, 't>(
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+        compat_mode: CompatMode,
+    ) -> Result<Self, ParseError<'i>> {
         if let Ok(extent) = input.try(|i| ShapeExtent::parse_with_compat_mode(i, compat_mode)) {
             if input.try(|i| i.expect_ident_matching("circle")).is_ok() {
                 return Ok(GenericEndingShape::Circle(Circle::Extent(extent)));
@@ -861,9 +867,10 @@ impl EndingShape {
 }
 
 impl ShapeExtent {
-    fn parse_with_compat_mode<'i, 't>(input: &mut Parser<'i, 't>,
-                                      compat_mode: CompatMode)
-                                      -> Result<Self, ParseError<'i>> {
+    fn parse_with_compat_mode<'i, 't>(
+        input: &mut Parser<'i, 't>,
+        compat_mode: CompatMode,
+    ) -> Result<Self, ParseError<'i>> {
         match Self::parse(input)? {
             ShapeExtent::Contain | ShapeExtent::Cover if compat_mode == CompatMode::Modern => {
                 Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
@@ -876,8 +883,10 @@ impl ShapeExtent {
 }
 
 impl GradientItem {
-    fn parse_comma_separated<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
-                                     -> Result<Vec<Self>, ParseError<'i>> {
+    fn parse_comma_separated<'i, 't>(
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Vec<Self>, ParseError<'i>> {
         let mut seen_stop = false;
         let items = input.parse_comma_separated(|input| {
             if seen_stop {

--- a/components/style/values/specified/transform.rs
+++ b/components/style/values/specified/transform.rs
@@ -29,16 +29,18 @@ pub type TransformOperation = GenericTransformOperation<
     LengthOrPercentage,
     LengthOrPercentageOrNumber,
 >;
+
 /// A specified CSS `transform`
 pub type Transform = GenericTransform<TransformOperation>;
 
 /// The specified value of a CSS `<transform-origin>`
 pub type TransformOrigin = GenericTransformOrigin<OriginComponent<X>, OriginComponent<Y>, Length>;
 
-
 impl Transform {
     /// Internal parse function for deciding if we wish to accept prefixed values or not
-    // Allow unitless zero angle for rotate() and skew() to align with gecko
+    ///
+    /// `transform` allows unitless zero angles as an exception, see:
+    /// https://github.com/w3c/csswg-drafts/issues/1162
     fn parse_internal<'i, 't>(
         context: &ParserContext,
         input: &mut Parser<'i, 't>,

--- a/tests/wpt/metadata/css/filter-effects/parsing/filter-parsing-valid.html.ini
+++ b/tests/wpt/metadata/css/filter-effects/parsing/filter-parsing-valid.html.ini
@@ -29,12 +29,6 @@
   [Serialization should round-trip after setting e.style['filter'\] = "drop-shadow(1px 2px 3px rgba(4, 5, 6, 0.75))"]
     expected: FAIL
 
-  [e.style['filter'\] = "hue-rotate(0)" should set the property value]
-    expected: FAIL
-
-  [Serialization should round-trip after setting e.style['filter'\] = "hue-rotate(0)"]
-    expected: FAIL
-
   [e.style['filter'\] = "url(picture.svg#f)" should set the property value]
     expected: FAIL
 


### PR DESCRIPTION
This PR also contains a functional change, allowing to parse unitless zero angles in hue-rotate().

See the links and the comments for why.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19462)
<!-- Reviewable:end -->
