### PR TITLE
stylo: Remove all subgrid parsing and serialization code

### DIFF
--- a/components/style/values/specified/grid.rs
+++ b/components/style/values/specified/grid.rs
@@ -13,7 +13,7 @@ use style_traits::{ParseError, StyleParseErrorKind};
 use values::{CSSFloat, CustomIdent};
 use values::computed::{self, Context, ToComputedValue};
 use values::generics::grid::{GridTemplateComponent, RepeatCount, TrackBreadth, TrackKeyword, TrackRepeat};
-use values::generics::grid::{LineNameList, TrackSize, TrackList, TrackListType, TrackListValue};
+use values::generics::grid::{TrackSize, TrackList, TrackListType, TrackListValue};
 use values::specified::{LengthOrPercentage, Integer};
 
 /// Parse a single flexible length.
@@ -343,10 +343,6 @@ impl GridTemplateComponent<LengthOrPercentage, Integer> {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(t) = input.try(|i| TrackList::parse(context, i)) {
-            return Ok(GridTemplateComponent::TrackList(t))
-        }
-
-        LineNameList::parse(context, input).map(GridTemplateComponent::Subgrid)
+        TrackList::parse(context, input).map(GridTemplateComponent::TrackList)
     }
 }


### PR DESCRIPTION
We are incorrectly exposing subgrids right now and since it's removed
from CSS Grid L1 spec, we don't have any reason to keep it.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix [Bug 1421645](https://bugzilla.mozilla.org/show_bug.cgi?id=1421645)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19464)
<!-- Reviewable:end -->
