### PR TITLE
[WIP] fix scroll area about scrollHeight and scrollWidth

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -463,16 +463,16 @@ impl FragmentBorderBoxIterator for UnioningFragmentScrollAreaIterator {
         let bottom_padding = (border_box.size.height.to_f32_px() - bottom_border - top_border) as i32;
         let top_padding = top_border as i32;
         let left_padding = left_border as i32;
+        let top_margin = top_padding + fragment.margin.top(fragment.style.writing_mode).to_px();
+        let left_margin = left_padding + fragment.margin.left(fragment.style.writing_mode).to_px();
+        let bottom_margin = bottom_padding + fragment.margin.bottom(fragment.style.writing_mode).to_px();
+        let right_margin = right_padding + fragment.margin.right(fragment.style.writing_mode).to_px();
 
         match self.level {
             Some(start_level) if level <= start_level => { self.is_child = false; }
             Some(_) => {
                 let padding = Rect::new(Point2D::new(left_padding, top_padding),
                                         Size2D::new(right_padding, bottom_padding));
-                let top_margin = fragment.margin.top(fragment.style.writing_mode).to_px();
-                let left_margin = fragment.margin.left(fragment.style.writing_mode).to_px();
-                let bottom_margin = fragment.margin.bottom(fragment.style.writing_mode).to_px();
-                let right_margin = fragment.margin.right(fragment.style.writing_mode).to_px();
                 let margin = Rect::new(Point2D::new(left_margin, top_margin),
                                        Size2D::new(right_margin, bottom_margin));
                 self.union_rect = self.union_rect.union(&margin).union(&padding);
@@ -639,18 +639,18 @@ pub fn process_node_scroll_area_request< N: LayoutNode>(requested_node: N, layou
             let bottom = max(iterator.union_rect.size.height, iterator.origin_rect.size.height);
             let left = max(iterator.union_rect.origin.x, iterator.origin_rect.origin.x);
             Rect::new(Point2D::new(left, iterator.origin_rect.origin.y),
-                      Size2D::new(iterator.origin_rect.size.width, bottom))
+                      Size2D::new(iterator.union_rect.size.width, bottom))
         },
         OverflowDirection::LeftAndUp => {
             let top = min(iterator.union_rect.origin.y, iterator.origin_rect.origin.y);
             let left = min(iterator.union_rect.origin.x, iterator.origin_rect.origin.x);
-            Rect::new(Point2D::new(left, top), iterator.origin_rect.size)
+            Rect::new(Point2D::new(left, top), iterator.union_rect.size)
         },
         OverflowDirection::RightAndUp => {
             let top = min(iterator.union_rect.origin.y, iterator.origin_rect.origin.y);
             let right = max(iterator.union_rect.size.width, iterator.origin_rect.size.width);
             Rect::new(Point2D::new(iterator.origin_rect.origin.x, top),
-                      Size2D::new(right, iterator.origin_rect.size.height))
+                      Size2D::new(right, iterator.union_rect.size.height))
         }
     }
 }

--- a/tests/wpt/web-platform-tests/css/cssom-view/elementScroll-002.html
+++ b/tests/wpt/web-platform-tests/css/cssom-view/elementScroll-002.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>elementScroll-002</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollheight">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+    #scroller1 {
+        height: 80px;
+        width: 80px;
+        overflow: hidden;
+        background: red;
+    }
+
+    #container1 {
+        background: green;
+        padding-top: 10px;
+        margin-top: 200px;
+        padding-left: 10px;
+        margin-left: 200px;
+        width: 300px;
+        height: 300px;
+    }
+
+    #scroller2 {
+        height: 80px;
+        width: 80px;
+        overflow: hidden;
+        background: red;
+    }
+
+    #container2 {
+        background: green;
+        margin-bottom: 200px;
+        margin-right: 200px;
+        width: 300px;
+        height: 300px;
+    }
+
+    #scroller3 {
+        height: 80px;
+        width: 80px;
+        overflow: scroll;
+        background: red;
+    }
+
+    #container3 {
+        background: green;
+        padding-top: 10px;
+        padding-left: 10px;
+        width: 300px;
+        height: 300px;
+    }
+</style>
+<div id="scroller1">
+    <div id="container1"></div>
+</div>
+<div id="scroller2">
+    <div id="container2"></div>
+</div>
+<div id="scroller3">
+    <div id="container3"></div>
+</div>
+<script>
+    var scroller;
+    test(function () {
+        scroller = document.getElementById("scroller1");
+        assert_equals(scroller.scrollHeight, 10 + 200 + 300, "initial scrollHeight should be 510");
+        assert_equals(scroller.scrollWidth, 10 + 200 + 300, "initial scrollWidth should be 510");
+    }, "Element scrollHeight/scrollWidth getter test with padding + height/width + margin");
+
+    test(function () {
+        scroller = document.getElementById("scroller2");
+        assert_equals(scroller.scrollHeight, 200 + 300 , "initial scrollHeight should be 500");
+        assert_equals(scroller.scrollWidth, 200 + 300, "initial scrollWidth should be 500");
+    }, "Element scrollHeight/scrollWidth getter test with height/width + margin");
+
+    test(function () {
+        scroller = document.getElementById("scroller3");
+        assert_equals(scroller.scrollHeight, 10 + 300, "initial scrollHeight should be 310");
+        assert_equals(scroller.scrollWidth, 10 + 300, "initial scrollWidth should be 310");
+    }, "Element scrollHeight/scrollWidth getter test with height/width + padding");
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Currently `scrollHeight` will get the result that `max(height + padding, margin)`
It should be `scrollHeight = height + padding + margin`
Same as `scrollWidth`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19280 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19469)
<!-- Reviewable:end -->
