### PR TITLE
style: Move mask-size outside of mako

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -3910,7 +3910,7 @@ fn static_assert() {
         }
     </%self:simple_image_array_property>
 
-    pub fn clone_${shorthand}_size(&self) -> longhands::background_size::computed_value::T {
+    pub fn clone_${shorthand}_size(&self) -> longhands::${shorthand}_size::computed_value::T {
         use gecko_bindings::structs::nsStyleCoord_CalcValue as CalcValue;
         use gecko_bindings::structs::nsStyleImageLayers_Size_DimensionType as DimensionType;
         use values::computed::LengthOrPercentageOrAuto;
@@ -3925,7 +3925,7 @@ fn static_assert() {
             }
         }
 
-        longhands::background_size::computed_value::T(
+        longhands::${shorthand}_size::computed_value::T(
             self.gecko.${image_layers_field}.mLayers.iter().map(|ref layer| {
                 if DimensionType::eCover as u8 == layer.mSize.mWidthType {
                     debug_assert!(layer.mSize.mHeightType == DimensionType::eCover as u8);

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -76,10 +76,8 @@
     We assume that the default/initial value is an empty vector for these.
     `initial_value` need not be defined for these.
 </%doc>
-<%def name="vector_longhand(name, animation_value_type=None, allow_empty=False, separator='Comma',
-                            need_animatable=False, **kwargs)">
-    <%call expr="longhand(name, animation_value_type=animation_value_type, vector=True,
-                          need_animatable=need_animatable, **kwargs)">
+<%def name="vector_longhand(name, animation_value_type=None, allow_empty=False, separator='Comma', **kwargs)">
+    <%call expr="longhand(name, animation_value_type=animation_value_type, vector=True, **kwargs)">
         #[allow(unused_imports)]
         use smallvec::SmallVec;
         use std::fmt::{self, Write};
@@ -118,7 +116,7 @@
 
             /// The computed value, effectively a list of single values.
             #[derive(Clone, Debug, MallocSizeOf, PartialEq)]
-            % if need_animatable or animation_value_type == "ComputedValue":
+            % if animation_value_type == "ComputedValue":
             #[derive(Animate, ComputeSquaredDistance)]
             % endif
             pub struct T(
@@ -129,10 +127,8 @@
                 % endif
             );
 
-            % if need_animatable or animation_value_type == "ComputedValue":
-                use values::animated::{ToAnimatedZero};
-
-                impl ToAnimatedZero for T {
+            % if animation_value_type == "ComputedValue":
+                impl ::values::animated::ToAnimatedZero for T {
                     #[inline]
                     fn to_animated_zero(&self) -> Result<Self, ()> { Err(()) }
                 }

--- a/components/style/properties/longhand/background.mako.rs
+++ b/components/style/properties/longhand/background.mako.rs
@@ -81,8 +81,7 @@ ${helpers.predefined_type("background-size", "BackgroundSize",
     initial_specified_value="specified::BackgroundSize::auto()",
     spec="https://drafts.csswg.org/css-backgrounds/#the-background-size",
     vector=True,
-    animation_value_type="BackgroundSizeList",
-    need_animatable=True,
+    animation_value_type="ComputedValue",
     flags="APPLIES_TO_FIRST_LETTER APPLIES_TO_FIRST_LINE APPLIES_TO_PLACEHOLDER",
     extra_prefixes="webkit")}
 

--- a/components/style/properties/longhand/svg.mako.rs
+++ b/components/style/properties/longhand/svg.mako.rs
@@ -127,23 +127,17 @@ ${helpers.single_keyword("mask-origin",
                          animation_value_type="discrete",
                          spec="https://drafts.fxtf.org/css-masking/#propdef-mask-origin")}
 
-<%helpers:longhand name="mask-size" products="gecko" animation_value_type="ComputedValue" extra_prefixes="webkit"
-                   spec="https://drafts.fxtf.org/css-masking/#propdef-mask-size">
-    use properties::longhands::background_size;
-    pub use ::properties::longhands::background_size::SpecifiedValue;
-    pub use ::properties::longhands::background_size::single_value as single_value;
-    pub use ::properties::longhands::background_size::computed_value as computed_value;
-
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        background_size::get_initial_value()
-    }
-
-    pub fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
-                         -> Result<SpecifiedValue,ParseError<'i>> {
-        background_size::parse(context, input)
-    }
-</%helpers:longhand>
+${helpers.predefined_type(
+    "mask-size",
+    "background::BackgroundSize",
+    "computed::BackgroundSize::auto()",
+    initial_specified_value="specified::BackgroundSize::auto()",
+    products="gecko",
+    extra_prefixes="webkit",
+    animation_value_type="ComputedValue",
+    spec="https://drafts.fxtf.org/css-masking/#propdef-mask-size",
+    vector=True,
+)}
 
 ${helpers.single_keyword("mask-composite",
                          "add subtract intersect exclude",

--- a/components/style/values/computed/background.rs
+++ b/components/style/values/computed/background.rs
@@ -5,10 +5,8 @@
 //! Computed types for CSS values related to backgrounds.
 
 use properties::animated_properties::RepeatableListAnimatable;
-use properties::longhands::background_size::computed_value::T as BackgroundSizeList;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ToCss};
-use values::animated::{ToAnimatedValue, ToAnimatedZero};
 use values::computed::{Context, ToComputedValue};
 use values::computed::length::LengthOrPercentageOrAuto;
 use values::generics::background::BackgroundSize as GenericBackgroundSize;
@@ -28,59 +26,6 @@ impl BackgroundSize {
 }
 
 impl RepeatableListAnimatable for BackgroundSize {}
-
-impl ToAnimatedZero for BackgroundSize {
-    #[inline]
-    fn to_animated_zero(&self) -> Result<Self, ()> { Err(()) }
-}
-
-impl ToAnimatedValue for BackgroundSize {
-    type AnimatedValue = Self;
-
-    #[inline]
-    fn to_animated_value(self) -> Self {
-        self
-    }
-
-    #[inline]
-    fn from_animated_value(animated: Self::AnimatedValue) -> Self {
-        use values::computed::{Length, Percentage};
-        let clamp_animated_value = |value: LengthOrPercentageOrAuto| -> LengthOrPercentageOrAuto {
-            match value {
-                LengthOrPercentageOrAuto::Length(len) => {
-                    LengthOrPercentageOrAuto::Length(Length::new(len.px().max(0.)))
-                },
-                LengthOrPercentageOrAuto::Percentage(percent) => {
-                    LengthOrPercentageOrAuto::Percentage(Percentage(percent.0.max(0.)))
-                },
-                _ => value
-            }
-        };
-        match animated {
-            GenericBackgroundSize::Explicit { width, height } => {
-                GenericBackgroundSize::Explicit {
-                    width: clamp_animated_value(width),
-                    height: clamp_animated_value(height)
-                }
-            },
-            _ => animated
-        }
-    }
-}
-
-impl ToAnimatedValue for BackgroundSizeList {
-    type AnimatedValue = Self;
-
-    #[inline]
-    fn to_animated_value(self) -> Self {
-        self
-    }
-
-    #[inline]
-    fn from_animated_value(animated: Self::AnimatedValue) -> Self {
-        BackgroundSizeList(ToAnimatedValue::from_animated_value(animated.0))
-    }
-}
 
 /// The computed value of the `background-repeat` property:
 ///


### PR DESCRIPTION
This is a sub-PR of #19015 
r? emilio 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #19467 
- [x] These changes do not require tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19470)
<!-- Reviewable:end -->
