### PR TITLE
Expand InputType to cover all possible types

### DIFF
--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -55,6 +55,7 @@ playing
 print
 progress
 radio
+range
 readystatechange
 reftest-wait
 reset

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -22,7 +22,7 @@ use dom::eventtarget::EventTarget;
 use dom::htmlbodyelement::HTMLBodyElement;
 use dom::htmlframesetelement::HTMLFrameSetElement;
 use dom::htmlhtmlelement::HTMLHtmlElement;
-use dom::htmlinputelement::HTMLInputElement;
+use dom::htmlinputelement::{HTMLInputElement, InputType};
 use dom::htmllabelelement::HTMLLabelElement;
 use dom::node::{Node, NodeFlags};
 use dom::node::{document_from_node, window_from_node};
@@ -497,7 +497,7 @@ impl HTMLElement {
             NodeTypeId::Element(ElementTypeId::HTMLElement(type_id)) =>
                 match type_id {
                     HTMLElementTypeId::HTMLInputElement =>
-                        self.downcast::<HTMLInputElement>().unwrap().type_() != atom!("hidden"),
+                        self.downcast::<HTMLInputElement>().unwrap().input_type() != InputType::Hidden,
                     HTMLElementTypeId::HTMLButtonElement |
                         HTMLElementTypeId::HTMLMeterElement |
                         HTMLElementTypeId::HTMLOutputElement |

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -30,7 +30,7 @@ use dom::htmlelement::HTMLElement;
 use dom::htmlfieldsetelement::HTMLFieldSetElement;
 use dom::htmlformcontrolscollection::HTMLFormControlsCollection;
 use dom::htmlimageelement::HTMLImageElement;
-use dom::htmlinputelement::HTMLInputElement;
+use dom::htmlinputelement::{HTMLInputElement, InputType};
 use dom::htmllabelelement::HTMLLabelElement;
 use dom::htmllegendelement::HTMLLegendElement;
 use dom::htmlobjectelement::HTMLObjectElement;
@@ -183,7 +183,7 @@ impl HTMLFormElementMethods for HTMLFormElement {
                             }
                             HTMLElementTypeId::HTMLInputElement => {
                                 let input_elem = elem.downcast::<HTMLInputElement>().unwrap();
-                                if input_elem.type_() == atom!("image") {
+                                if input_elem.input_type() == InputType::Image {
                                     return false;
                                 }
                                 input_elem.form_owner()

--- a/components/script/dom/radionodelist.rs
+++ b/components/script/dom/radionodelist.rs
@@ -10,7 +10,7 @@ use dom::bindings::inheritance::Castable;
 use dom::bindings::reflector::reflect_dom_object;
 use dom::bindings::root::{Dom, DomRoot};
 use dom::bindings::str::DOMString;
-use dom::htmlinputelement::HTMLInputElement;
+use dom::htmlinputelement::{HTMLInputElement, InputType};
 use dom::node::Node;
 use dom::nodelist::{NodeList, NodeListType};
 use dom::window::Window;
@@ -55,13 +55,12 @@ impl RadioNodeListMethods for RadioNodeList {
         self.upcast::<NodeList>().as_simple_list().iter().filter_map(|node| {
             // Step 1
             node.downcast::<HTMLInputElement>().and_then(|input| {
-                match input.type_() {
-                    atom!("radio") if input.Checked() => {
-                        // Step 3-4
-                        let value = input.Value();
-                        Some(if value.is_empty() { DOMString::from("on") } else { value })
-                    }
-                    _ => None
+                if input.input_type() == InputType::Radio && input.Checked() {
+                    // Step 3-4
+                    let value = input.Value();
+                    Some(if value.is_empty() { DOMString::from("on") } else { value })
+                } else {
+                    None
                 }
             })
         }).next()
@@ -74,8 +73,8 @@ impl RadioNodeListMethods for RadioNodeList {
         for node in self.upcast::<NodeList>().as_simple_list().iter() {
             // Step 1
             if let Some(input) = node.downcast::<HTMLInputElement>() {
-                match input.type_() {
-                    atom!("radio") if value == DOMString::from("on") => {
+                match input.input_type() {
+                    InputType::Radio if value == DOMString::from("on") => {
                         // Step 2
                         let val = input.Value();
                         if val.is_empty() || val == value {
@@ -83,7 +82,7 @@ impl RadioNodeListMethods for RadioNodeList {
                             return;
                         }
                     }
-                    atom!("radio") => {
+                    InputType::Radio => {
                         // Step 2
                         if input.Value() == value {
                             input.SetChecked(true);

--- a/tests/wpt/metadata/html/semantics/forms/the-input-element/clone.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-input-element/clone.html.ini
@@ -12,9 +12,6 @@
   [Radiobutton must retain unchecked state.]
     expected: FAIL
 
-  [Hidden field must retain changed value.]
-    expected: FAIL
-
   [Text field must retain changed value.]
     expected: FAIL
 


### PR DESCRIPTION
This came out of a conversation with nox in IRC:
https://mozilla.logbot.info/servo/20171201#c13946454-c13946594

The code I was working on which motivated this change is here:
https://github.com/servo/servo/pull/19461

Previously, InputType::Text was used to represent several different
values of the type attribute on an input element.

If an input element doesn't have a type attribute, or its type attribute
doesn't contain a recognised value, then the input's type defaults to
"text".

Before this change, there were a number of checks in the code which
directly looked at the type attribute. If those checks matched against
the value "text", then they were potentially buggy, since an input with
type=invalid should also behave like an input with type=text.

Rather than have every conditional which cares about the input type also
have to deal with invalid input types, we can convert the type attribute
to an InputType enum once, and then match against the enum.

A secondary benefit is that the compiler can tell us whether we've
missed branches in a match expression. While working on this I
discovered that the HTMLInputElement::value_mode() method misses a case
for inputs with type=hidden (this resulted in a failing WPT test
passing).

I've also implemented the Default trait for InputType, so we now only
have one place in the code which knows that InputType::Text is the
default, where previously there were several.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19471)
<!-- Reviewable:end -->
