### PR TITLE
Move the trap instruction in /etc/ci/performance/test_all.sh.

### DIFF
--- a/etc/ci/performance/test_all.sh
+++ b/etc/ci/performance/test_all.sh
@@ -43,6 +43,9 @@ fi
 echo "Starting the local server"
 python3 -m http.server > /dev/null 2>&1 &
 
+# Stop the local server no matter how we exit the script
+trap 'kill $(jobs -pr)' SIGINT SIGTERM EXIT
+
 # TODO: enable the full manifest when #11087 is fixed
 # https://github.com/servo/servo/issues/11087
 # MANIFEST="page_load_test/tp5n/20160509.manifest"
@@ -61,5 +64,3 @@ then
     python3 submit_to_s3.py "${PERF_FILE}" "${PERF_KEY}"
 fi
 
-echo "Stopping the local server"
-trap 'kill $(jobs -pr)' SIGINT SIGTERM EXIT


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

At the moment if the performance tests fail, the local server doesn't get killed, because the trap instruction is after the test run. This PR moves it to before.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because this is test infrastructure

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19474)
<!-- Reviewable:end -->
