### PR TITLE
Moved the test-perf http server to a different port.

### DIFF
--- a/etc/ci/performance/test_all.sh
+++ b/etc/ci/performance/test_all.sh
@@ -8,7 +8,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-base="http://localhost:8000"
+# We run the test-perf server on a port that WPT doesn't use,
+# to avoid WPT failures caused by picking up the wrong http server.
+# This was the root cause of a total test suite failure:
+# https://groups.google.com/forum/#!topic/mozilla.dev.servo/JlAZoRgcnpA
+port="8123"
+base="http://localhost:${port}"
 
 while (( "${#}" ))
 do
@@ -41,7 +46,7 @@ then echo "You didn't specify the engine to run: --servo or --gecko."; exit;
 fi
 
 echo "Starting the local server"
-python3 -m http.server > /dev/null 2>&1 &
+python3 -m http.server ${port} > /dev/null 2>&1 &
 
 # TODO: enable the full manifest when #11087 is fixed
 # https://github.com/servo/servo/issues/11087


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Run the test-perf http server on a different port than WPT uses.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because this is test infrastructure

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19484)
<!-- Reviewable:end -->
