### PR TITLE
use entry global's origin in `is_origin_clean` check for canvas rendering

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -30,7 +30,7 @@ use dom::canvaspattern::CanvasPattern;
 use dom::globalscope::GlobalScope;
 use dom::htmlcanvaselement::HTMLCanvasElement;
 use dom::imagedata::ImageData;
-use dom::node::{document_from_node, Node, NodeDamage, window_from_node};
+use dom::node::{Node, NodeDamage, window_from_node};
 use dom_struct::dom_struct;
 use euclid::{Transform2D, Point2D, Vector2D, Rect, Size2D, vec2};
 use ipc_channel::ipc::{self, IpcSender};
@@ -249,13 +249,8 @@ impl CanvasRenderingContext2D {
             CanvasImageSource::CanvasRenderingContext2D(image) =>
                 image.origin_is_clean(),
             CanvasImageSource::HTMLImageElement(image) => {
-                let canvas = match self.canvas {
-                    Some(ref canvas) => canvas,
-                    None => return false,
-                };
                 let image_origin = image.get_origin().expect("Image's origin is missing");
-                let document = document_from_node(&**canvas);
-                document.url().clone().origin() == image_origin
+                image_origin.same_origin(GlobalScope::entry().origin())
             }
             CanvasImageSource::CSSStyleValue(_) => true,
         }


### PR DESCRIPTION

use entry global's origin in `is_origin_clean` check for canvas rendering

There is no change with:
```
./mach test-wpt tests/wpt/web-platform-tests/2dcontext
./mach test-wpt tests/wpt/web-platform-tests/html/semantics/embedded-content/the-canvas-element
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix  #19480 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19492)
<!-- Reviewable:end -->
