### PR TITLE
Fix float conversion of paint timing metrics

### DIFF
--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -46,6 +46,15 @@ pub const MAX_TASK_NS: u64 = 50000000;
 /// 10 second window (in ns)
 const INTERACTIVE_WINDOW_SECONDS_IN_NS: u64 = 10000000000;
 
+pub trait ToMs<T> {
+    fn to_ms(&self) -> T;
+}
+
+impl ToMs<f64> for u64 {
+    fn to_ms(&self) -> f64 {
+        *self as f64 / 1000000.
+    }
+}
 
 fn set_metric<U: ProgressiveWebMetric>(
     pwm: &U,
@@ -85,8 +94,8 @@ fn set_metric<U: ProgressiveWebMetric>(
 
     // Print the metric to console if the print-pwm option was given.
     if opts::get().print_pwm {
-        println!("Navigation start: {}", pwm.get_navigation_start().unwrap());
-        println!("{:?} {:?}", metric_type, time);
+        println!("Navigation start: {}", pwm.get_navigation_start().unwrap().to_ms());
+        println!("{:?} {:?}", metric_type, time.to_ms());
     }
 
 }

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -20,6 +20,7 @@ use dom::performanceobserver::PerformanceObserver as DOMPerformanceObserver;
 use dom::performancetiming::PerformanceTiming;
 use dom::window::Window;
 use dom_struct::dom_struct;
+use metrics::ToMs;
 use std::cell::Cell;
 use std::cmp::Ordering;
 use time;
@@ -260,7 +261,7 @@ impl Performance {
             Some(ref timing) => timing.navigation_start_precise(),
             None => self.navigation_start_precise,
         };
-        (time::precise_time_ns() - nav_start) as f64 / 1000000.
+        (time::precise_time_ns() - nav_start).to_ms()
     }
 }
 

--- a/components/script/dom/performancepainttiming.rs
+++ b/components/script/dom/performancepainttiming.rs
@@ -9,6 +9,7 @@ use dom::bindings::str::DOMString;
 use dom::globalscope::GlobalScope;
 use dom::performanceentry::PerformanceEntry;
 use dom_struct::dom_struct;
+use metrics::ToMs;
 use script_traits::ProgressiveWebMetricType;
 
 #[dom_struct]
@@ -26,7 +27,7 @@ impl PerformancePaintTiming {
         PerformancePaintTiming {
             entry: PerformanceEntry::new_inherited(name,
                                                    DOMString::from("paint"),
-                                                   start_time as f64,
+                                                   start_time.to_ms(),
                                                    0.)
         }
     }


### PR DESCRIPTION
This is a follow up of #19077

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19498)
<!-- Reviewable:end -->
