### PR TITLE
hashglobe: Dump more information if out of memory while allocating a table

### DIFF
--- a/components/hashglobe/src/lib.rs
+++ b/components/hashglobe/src/lib.rs
@@ -29,12 +29,14 @@ trait Recover<Q: ?Sized> {
 #[derive(Debug)]
 pub struct FailedAllocationError {
     reason: &'static str,
+    /// The size we are allocating, if needed.
+    allocation_size: Option<usize>,
 }
 
 impl FailedAllocationError {
     #[inline]
     pub fn new(reason: &'static str) -> Self {
-        Self { reason }
+        Self { reason, allocation_size: None }
     }
 }
 
@@ -46,6 +48,9 @@ impl error::Error for FailedAllocationError {
 
 impl fmt::Display for FailedAllocationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.reason.fmt(f)
+        match self.allocation_size {
+            Some(size) => write!(f, "{}, allocation size: {}", self.reason, size),
+            None => self.reason.fmt(f),
+        }
     }
 }

--- a/components/hashglobe/src/table.rs
+++ b/components/hashglobe/src/table.rs
@@ -757,7 +757,7 @@ impl<K, V> RawTable<K, V> {
                                                                         align_of::<(K, V)>());
 
         if oflo {
-            return Err(FailedAllocationError { reason: "capacity overflow when allocating RawTable" });
+            return Err(FailedAllocationError::new("capacity overflow when allocating RawTable" ));
         }
 
         // One check for overflow that covers calculation and rounding of size.
@@ -767,21 +767,21 @@ impl<K, V> RawTable<K, V> {
 
         if let Some(cap_bytes) = cap_bytes {
             if size < cap_bytes {
-                return Err(FailedAllocationError { reason: "capacity overflow when allocating RawTable" });
+                return Err(FailedAllocationError::new("capacity overflow when allocating RawTable"));
             }
         } else {
-            
-            return Err(FailedAllocationError { reason: "capacity overflow when allocating RawTable" });
+            return Err(FailedAllocationError::new("capacity overflow when allocating RawTable"));
         }
-
 
 
         // FORK NOTE: Uses alloc shim instead of Heap.alloc
         let buffer = alloc(size, alignment);
-        
+
         if buffer.is_null() {
-            
-            return Err(FailedAllocationError { reason: "out of memory when allocating RawTable" });
+            return Err(FailedAllocationError {
+                reason: "out of memory when allocating RawTable",
+                allocation_size: Some(size),
+            });
         }
 
         let hashes = buffer.offset(hash_offset as isize) as *mut HashUint;


### PR DESCRIPTION
This is for Bug 1418806 and Bug 1416903. Sometimes, we got a crash message on stylo:

>  called `Result::unwrap()` on an `Err` value: FailedAllocationError {
>  reason: "out of memory when allocating RawTable" }

but this is not enough to debug, so let's add one more field in
FailedAllocationError, so we can know the size we are allocating.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19504)
<!-- Reviewable:end -->
