### PR TITLE
Add a --date option to test-perf.

### DIFF
--- a/etc/ci/performance/gecko_driver.py
+++ b/etc/ci/performance/gecko_driver.py
@@ -71,7 +71,7 @@ def generate_placeholder(testcase):
         return [timings]
 
 
-def run_gecko_test(testcase, url, timeout, is_async):
+def run_gecko_test(testcase, url, date, timeout, is_async):
     with create_gecko_session() as driver:
         driver.set_page_load_timeout(timeout)
         try:

--- a/etc/ci/performance/test_all.sh
+++ b/etc/ci/performance/test_all.sh
@@ -14,6 +14,7 @@ set -o pipefail
 # https://groups.google.com/forum/#!topic/mozilla.dev.servo/JlAZoRgcnpA
 port="8123"
 base="http://localhost:${port}"
+date="$(date +%Y-%m-%d)"
 
 while (( "${#}" ))
 do
@@ -31,6 +32,10 @@ case "${1}" in
     ;;
   --base)
     base="${2}"
+    shift
+    ;;
+  --date)
+    date="${2}"
     shift
     ;;
   *)
@@ -56,11 +61,12 @@ trap 'kill $(jobs -pr)' SIGINT SIGTERM EXIT
 # MANIFEST="page_load_test/tp5n/20160509.manifest"
 MANIFEST="page_load_test/test.manifest" # A manifest that excludes
                                         # timeout test cases
-PERF_KEY="perf-$(uname -s)-$(uname -m)-$(date +%s).csv"
+PERF_KEY="perf-$(uname -s)-$(uname -m)-${date}.csv"
 PERF_FILE="output/${PERF_KEY}"
 
 echo "Running tests"
-python3 runner.py ${engine} --runs 4 --timeout "${timeout}" --base "${base}" \
+python3 runner.py ${engine} --runs 4 --timeout "${timeout}" \
+  --base "${base}" --date "${date}" \
   "${MANIFEST}" "${PERF_FILE}"
 
 if [[ "${submit:-}" ]];

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -171,9 +171,11 @@ class MachCommands(CommandBase):
              category='testing')
     @CommandArgument('--base', default=None,
                      help="the base URL for testcases")
+    @CommandArgument('--date', default=None,
+                     help="the datestamp for the data")
     @CommandArgument('--submit', '-a', default=False, action="store_true",
                      help="submit the data to perfherder")
-    def test_perf(self, base=None, submit=False):
+    def test_perf(self, base=None, date=None, submit=False):
         self.set_software_rendering_env(True)
 
         self.ensure_bootstrapped()
@@ -181,6 +183,8 @@ class MachCommands(CommandBase):
         cmd = ["bash", "test_perf.sh"]
         if base:
             cmd += ["--base", base]
+        if date:
+            cmd += ["--date", date]
         if submit:
             cmd += ["--submit"]
         return call(cmd,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

To generate old test-perf results, we need a way to set the date when running `./mach test-perf`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because they're test infrastructure

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19507)
<!-- Reviewable:end -->
