### PR TITLE
Remove support for <input type=datetime>

### DIFF
--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -15,7 +15,6 @@ color
 controllerchange
 cursive
 date
-datetime
 datetime-local
 dir
 email

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -68,7 +68,6 @@ pub enum InputType {
     Checkbox,
     Color,
     Date,
-    Datetime,
     DatetimeLocal,
     Email,
     File,
@@ -95,11 +94,11 @@ impl InputType {
     // than the underlying value.
     fn is_textual(&self) -> bool {
         match *self {
-            InputType::Color | InputType::Date | InputType::Datetime
-            | InputType::DatetimeLocal | InputType::Email | InputType::Hidden
-            | InputType::Month | InputType::Number | InputType::Range
-            | InputType::Search | InputType::Tel | InputType::Text
-            | InputType::Time | InputType::Url | InputType::Week => {
+            InputType::Color | InputType::Date | InputType::DatetimeLocal
+            | InputType::Email | InputType::Hidden | InputType::Month
+            | InputType::Number | InputType::Range | InputType::Search
+            | InputType::Tel | InputType::Text | InputType::Time
+            | InputType::Url | InputType::Week => {
                 true
             }
 
@@ -117,7 +116,6 @@ impl InputType {
             InputType::Checkbox => "checkbox",
             InputType::Color => "color",
             InputType::Date => "date",
-            InputType::Datetime => "datetime",
             InputType::DatetimeLocal => "datetime-local",
             InputType::Email => "email",
             InputType::File => "file",
@@ -147,7 +145,6 @@ impl<'a> From<&'a Atom> for InputType {
             atom!("checkbox") => InputType::Checkbox,
             atom!("color") => InputType::Color,
             atom!("date") => InputType::Date,
-            atom!("datetime") => InputType::Datetime,
             atom!("datetime-local") => InputType::DatetimeLocal,
             atom!("email") => InputType::Email,
             atom!("file") => InputType::File,
@@ -286,11 +283,11 @@ impl HTMLInputElement {
                 ValueMode::DefaultOn
             },
 
-            InputType::Color | InputType::Date | InputType::Datetime
-            | InputType::DatetimeLocal | InputType::Email | InputType::Month
-            | InputType::Number | InputType::Password | InputType::Range
-            | InputType::Search | InputType::Tel | InputType::Text
-            | InputType::Time | InputType::Url | InputType::Week => {
+            InputType::Color | InputType::Date | InputType::DatetimeLocal
+            | InputType::Email | InputType::Month | InputType::Number
+            | InputType::Password | InputType::Range | InputType::Search
+            | InputType::Tel | InputType::Text | InputType::Time
+            | InputType::Url | InputType::Week => {
                 ValueMode::Value
             }
 
@@ -1532,8 +1529,8 @@ impl Activatable for HTMLInputElement {
                     .filter(|input| {
                         input.form_owner() == owner && match input.input_type() {
                             InputType::Text | InputType::Search | InputType::Url | InputType::Tel
-                            | InputType::Email | InputType::Password | InputType::Datetime
-                            | InputType::Date | InputType::Month | InputType::Week | InputType::Time
+                            | InputType::Email | InputType::Password | InputType::Date
+                            | InputType::Month | InputType::Week | InputType::Time
                             | InputType::DatetimeLocal | InputType::Number
                               => true,
                             _ => false

--- a/tests/wpt/metadata/html/semantics/forms/historical.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/historical.html.ini
@@ -1,8 +1,5 @@
 [historical.html]
   type: testharness
-  [<input type=datetime> should not be supported]
-    expected: FAIL
-
   [<input name=isindex> should not be supported]
     expected: FAIL
 


### PR DESCRIPTION
It has been removed from the spec: https://github.com/whatwg/html/issues/336

See also https://github.com/servo/servo/pull/19471#pullrequestreview-80711878

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19509)
<!-- Reviewable:end -->
