### PR TITLE
Print url of recorded PWM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,6 +1780,7 @@ dependencies = [
  "profile_traits 0.0.1",
  "script_traits 0.0.1",
  "servo_config 0.0.1",
+ "servo_url 0.0.1",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1795,6 +1796,7 @@ dependencies = [
  "msg 0.0.1",
  "net_traits 0.0.1",
  "profile_traits 0.0.1",
+ "servo_url 0.0.1",
  "style 0.0.1",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -489,7 +489,8 @@ impl UnprivilegedPipelineContent {
         let paint_time_metrics = PaintTimeMetrics::new(self.id,
                                                        self.time_profiler_chan.clone(),
                                                        self.layout_to_constellation_chan.clone(),
-                                                       self.script_chan.clone());
+                                                       self.script_chan.clone(),
+                                                       self.load_data.url.clone());
         let layout_pair = STF::create(InitialScriptState {
             id: self.id,
             browsing_context_id: self.browsing_context_id,

--- a/components/metrics/Cargo.toml
+++ b/components/metrics/Cargo.toml
@@ -20,4 +20,5 @@ msg = {path = "../msg"}
 profile_traits = {path = "../profile_traits"}
 script_traits = {path = "../script_traits"}
 servo_config = {path = "../config"}
+servo_url = {path = "../url"}
 time = "0.1"

--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -14,6 +14,7 @@ extern crate msg;
 extern crate profile_traits;
 extern crate script_traits;
 extern crate servo_config;
+extern crate servo_url;
 extern crate time;
 
 use gfx::display_list::{DisplayItem, DisplayList};
@@ -24,6 +25,7 @@ use profile_traits::time::{ProfilerChan, ProfilerCategory, send_profile_data};
 use profile_traits::time::TimerMetadata;
 use script_traits::{ConstellationControlMsg, LayoutMsg, ProgressiveWebMetricType};
 use servo_config::opts;
+use servo_url::ServoUrl;
 use std::cell::{Cell, RefCell};
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -38,6 +40,7 @@ pub trait ProgressiveWebMetric {
     fn set_navigation_start(&mut self, time: u64);
     fn get_time_profiler_chan(&self) -> &ProfilerChan;
     fn send_queued_constellation_msg(&self, name: ProgressiveWebMetricType, time: u64);
+    fn get_url(&self) -> &ServoUrl;
 }
 
 /// TODO make this configurable
@@ -62,7 +65,8 @@ fn set_metric<U: ProgressiveWebMetric>(
     metric_type: ProgressiveWebMetricType,
     category: ProfilerCategory,
     attr: &Cell<Option<u64>>,
-    metric_time: Option<u64>)
+    metric_time: Option<u64>,
+    url: &ServoUrl)
 {
     let navigation_start = match pwm.get_navigation_start() {
         Some(time) => time,
@@ -95,7 +99,7 @@ fn set_metric<U: ProgressiveWebMetric>(
     // Print the metric to console if the print-pwm option was given.
     if opts::get().print_pwm {
         println!("Navigation start: {}", pwm.get_navigation_start().unwrap().to_ms());
-        println!("{:?} {:?}", metric_type, time.to_ms());
+        println!("{:?} {:?} {:?}", url, metric_type, time.to_ms());
     }
 
 }
@@ -117,6 +121,7 @@ pub struct InteractiveMetrics {
     time_to_interactive: Cell<Option<u64>>,
     #[ignore_malloc_size_of = "can't measure channels"]
     time_profiler_chan: ProfilerChan,
+    url: ServoUrl
 }
 
 #[derive(Clone, Copy, Debug, MallocSizeOf)]
@@ -157,13 +162,14 @@ pub enum InteractiveFlag {
 }
 
 impl InteractiveMetrics {
-    pub fn new(time_profiler_chan: ProfilerChan) -> InteractiveMetrics {
+    pub fn new(time_profiler_chan: ProfilerChan, url: ServoUrl) -> InteractiveMetrics {
         InteractiveMetrics {
             navigation_start: None,
             dom_content_loaded: Cell::new(None),
             main_thread_available: Cell::new(None),
             time_to_interactive: Cell::new(None),
             time_profiler_chan: time_profiler_chan,
+            url,
         }
     }
 
@@ -221,7 +227,9 @@ impl InteractiveMetrics {
             ProgressiveWebMetricType::TimeToInteractive,
             ProfilerCategory::TimeToInteractive,
             &self.time_to_interactive,
-            Some(metric_time));
+            Some(metric_time),
+            &self.url,
+        );
     }
 
     pub fn get_tti(&self) -> Option<u64> {
@@ -247,6 +255,10 @@ impl ProgressiveWebMetric for InteractiveMetrics {
     fn get_time_profiler_chan(&self) -> &ProfilerChan {
         &self.time_profiler_chan
     }
+
+    fn get_url(&self) -> &ServoUrl {
+        &self.url
+    }
 }
 
 pub struct PaintTimeMetrics {
@@ -258,6 +270,7 @@ pub struct PaintTimeMetrics {
     time_profiler_chan: ProfilerChan,
     constellation_chan: IpcSender<LayoutMsg>,
     script_chan: IpcSender<ConstellationControlMsg>,
+    url: ServoUrl,
 }
 
 impl PaintTimeMetrics {
@@ -265,7 +278,8 @@ impl PaintTimeMetrics {
         pipeline_id: PipelineId,
         time_profiler_chan: ProfilerChan,
         constellation_chan: IpcSender<LayoutMsg>,
-        script_chan: IpcSender<ConstellationControlMsg>)
+        script_chan: IpcSender<ConstellationControlMsg>,
+        url: ServoUrl)
             -> PaintTimeMetrics {
         PaintTimeMetrics {
             pending_metrics: RefCell::new(HashMap::new()),
@@ -276,6 +290,7 @@ impl PaintTimeMetrics {
             time_profiler_chan,
             constellation_chan,
             script_chan,
+            url,
         }
     }
 
@@ -294,6 +309,7 @@ impl PaintTimeMetrics {
             ProfilerCategory::TimeToFirstPaint,
             &self.first_paint,
             None,
+            &self.url,
         );
     }
 
@@ -354,6 +370,7 @@ impl PaintTimeMetrics {
                 ProfilerCategory::TimeToFirstPaint,
                 &self.first_paint,
                 Some(paint_time),
+                &self.url,
             );
 
             if pending_metric.1 {
@@ -364,6 +381,7 @@ impl PaintTimeMetrics {
                     ProfilerCategory::TimeToFirstContentfulPaint,
                     &self.first_contentful_paint,
                     Some(paint_time),
+                    &self.url,
                 );
             }
         }
@@ -396,5 +414,9 @@ impl ProgressiveWebMetric for PaintTimeMetrics {
 
     fn get_time_profiler_chan(&self) -> &ProfilerChan {
         &self.time_profiler_chan
+    }
+
+    fn get_url(&self) -> &ServoUrl {
+        &self.url
     }
 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2186,7 +2186,7 @@ impl Document {
             (DocumentReadyState::Complete, true)
         };
 
-        let interactive_time = InteractiveMetrics::new(window.time_profiler_chan().clone());
+        let interactive_time = InteractiveMetrics::new(window.time_profiler_chan().clone(), url.clone());
 
         Document {
             node: Node::new_document_node(),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1557,7 +1557,8 @@ impl ScriptThread {
             paint_time_metrics: PaintTimeMetrics::new(new_pipeline_id,
                                                       self.time_profiler_chan.clone(),
                                                       self.layout_to_constellation_chan.clone(),
-                                                      self.control_chan.clone()),
+                                                      self.control_chan.clone(),
+                                                      load_data.url.clone()),
         });
 
         // Pick a layout thread, any layout thread

--- a/tests/unit/metrics/Cargo.toml
+++ b/tests/unit/metrics/Cargo.toml
@@ -18,5 +18,6 @@ metrics = {path = "../../../components/metrics"}
 msg = {path = "../../../components/msg"}
 net_traits = {path = "../../../components/net_traits"}
 profile_traits = {path = "../../../components/profile_traits"}
+servo_url = {path = "../../../components/url"}
 style = {path = "../../../components/style"}
 time = "0.1.12"

--- a/tests/unit/metrics/interactive_time.rs
+++ b/tests/unit/metrics/interactive_time.rs
@@ -6,6 +6,7 @@ use ipc_channel::ipc;
 use metrics::{InteractiveMetrics, InteractiveFlag};
 use metrics::{ProfilerMetadataFactory, ProgressiveWebMetric};
 use profile_traits::time::{ProfilerChan, TimerMetadata};
+use servo_url::ServoUrl;
 use time;
 
 struct DummyProfilerMetadataFactory {}
@@ -19,7 +20,10 @@ impl ProfilerMetadataFactory for DummyProfilerMetadataFactory {
 fn test_interactive() -> InteractiveMetrics {
     let (sender, _) = ipc::channel().unwrap();
     let profiler_chan = ProfilerChan(sender);
-    let mut interactive = InteractiveMetrics::new(profiler_chan);
+    let mut interactive = InteractiveMetrics::new(
+        profiler_chan,
+        ServoUrl::parse("about:blank").unwrap(),
+    );
 
     assert_eq!((&interactive).get_navigation_start(), None);
     assert_eq!(interactive.get_tti(), None);

--- a/tests/unit/metrics/lib.rs
+++ b/tests/unit/metrics/lib.rs
@@ -12,6 +12,7 @@ extern crate metrics;
 extern crate msg;
 extern crate net_traits;
 extern crate profile_traits;
+extern crate servo_url;
 extern crate style;
 extern crate time;
 

--- a/tests/unit/metrics/paint_time.rs
+++ b/tests/unit/metrics/paint_time.rs
@@ -11,6 +11,7 @@ use metrics::{PaintTimeMetrics, ProfilerMetadataFactory, ProgressiveWebMetric};
 use msg::constellation_msg::TEST_PIPELINE_ID;
 use net_traits::image::base::PixelFormat;
 use profile_traits::time::{ProfilerChan, TimerMetadata};
+use servo_url::ServoUrl;
 use style::computed_values::image_rendering::T as ImageRendering;
 use time;
 
@@ -32,6 +33,7 @@ fn test_paint_metrics_construction() {
         profiler_chan,
         layout_sender,
         script_sender,
+        ServoUrl::parse("about:blank").unwrap(),
     );
     assert_eq!(
         (&paint_time_metrics).get_navigation_start(),
@@ -60,6 +62,7 @@ fn test_common(display_list: &DisplayList, epoch: Epoch) -> PaintTimeMetrics {
         profiler_chan,
         layout_sender,
         script_sender,
+        ServoUrl::parse("about:blank").unwrap(),
     );
     let dummy_profiler_metadata_factory = DummyProfilerMetadataFactory {};
 


### PR DESCRIPTION
This makes it a bit easier to compare results with other browsers.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19516)
<!-- Reviewable:end -->
