### PR TITLE
Defend against bugs in SelectorFlagsMap

### DIFF
--- a/components/style/context.rs
+++ b/components/style/context.rs
@@ -553,8 +553,9 @@ impl<E: TElement> SelectorFlagsMap<E> {
     }
 
     /// Applies the flags. Must be called on the main thread.
-    pub fn apply_flags(&mut self) {
+    fn apply_flags(&mut self) {
         debug_assert!(thread_state::get() == ThreadState::LAYOUT);
+        self.cache.evict_all();
         for (el, flags) in self.map.drain() {
             unsafe { el.set_selector_flags(flags); }
         }


### PR DESCRIPTION
Some defensive programming:

* Make `SelectorFlagsMap::apply_flags` private so it's easier to ensure it is called from the correct thread.

* Clear the cache and the map at the same time; otherwise `apply_flags` leaves `SelectorFlagsMap` in an inconsistent state.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19517)
<!-- Reviewable:end -->
