### PR TITLE
Remove border_collapse field in InternalTable

### DIFF
--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -364,9 +364,7 @@ impl Flow for TableFlow {
             }
         }
 
-        let inline_size_computer = InternalTable {
-            border_collapse: self.block_flow.fragment.style.get_inheritedtable().border_collapse,
-        };
+        let inline_size_computer = InternalTable;
         inline_size_computer.compute_used_inline_size(&mut self.block_flow,
                                                       shared_context,
                                                       containing_block_inline_size);
@@ -541,22 +539,18 @@ impl fmt::Debug for TableFlow {
 
 /// Table, TableRowGroup, TableRow, TableCell types.
 /// Their inline-sizes are calculated in the same way and do not have margins.
-pub struct InternalTable {
-    pub border_collapse: border_collapse::T,
-}
+pub struct InternalTable;
 
 impl ISizeAndMarginsComputer for InternalTable {
-    fn compute_border_and_padding(&self, block: &mut BlockFlow, containing_block_inline_size: Au) {
-        block.fragment.compute_border_and_padding(containing_block_inline_size)
-    }
-
     /// Compute the used value of inline-size, taking care of min-inline-size and max-inline-size.
     ///
     /// CSS Section 10.4: Minimum and Maximum inline-sizes
-    fn compute_used_inline_size(&self,
-                                block: &mut BlockFlow,
-                                shared_context: &SharedStyleContext,
-                                parent_flow_inline_size: Au) {
+    fn compute_used_inline_size(
+        &self,
+        block: &mut BlockFlow,
+        shared_context: &SharedStyleContext,
+        parent_flow_inline_size: Au
+    ) {
         let mut input = self.compute_inline_size_constraint_inputs(block,
                                                                    parent_flow_inline_size,
                                                                    shared_context);

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -208,9 +208,7 @@ impl Flow for TableCellFlow {
         // The position was set to the column inline-size by the parent flow, table row flow.
         let containing_block_inline_size = self.block_flow.base.block_container_inline_size;
 
-        let inline_size_computer = InternalTable {
-            border_collapse: self.block_flow.fragment.style.get_inheritedtable().border_collapse,
-        };
+        let inline_size_computer = InternalTable;
         inline_size_computer.compute_used_inline_size(&mut self.block_flow,
                                                       shared_context,
                                                       containing_block_inline_size);

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -353,9 +353,7 @@ impl Flow for TableRowFlow {
         let inline_start_content_edge = Au(0);
         let inline_end_content_edge = Au(0);
 
-        let inline_size_computer = InternalTable {
-            border_collapse: self.block_flow.fragment.style.get_inheritedtable().border_collapse,
-        };
+        let inline_size_computer = InternalTable;
         inline_size_computer.compute_used_inline_size(&mut self.block_flow,
                                                       shared_context,
                                                       containing_block_inline_size);

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -131,9 +131,7 @@ impl Flow for TableRowGroupFlow {
         let content_inline_size = containing_block_inline_size;
 
         let border_collapse = self.block_flow.fragment.style.get_inheritedtable().border_collapse;
-        let inline_size_computer = InternalTable {
-            border_collapse: border_collapse,
-        };
+        let inline_size_computer = InternalTable;
         inline_size_computer.compute_used_inline_size(&mut self.block_flow,
                                                       shared_context,
                                                       containing_block_inline_size);


### PR DESCRIPTION
This field doesn't seem to serve a purpose after #18252.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19522)
<!-- Reviewable:end -->
