### PR TITLE
Filter out failed test-perf runs.

### DIFF
--- a/etc/ci/performance/runner.py
+++ b/etc/ci/performance/runner.py
@@ -281,10 +281,12 @@ def save_result_csv(results, filename, manifest, expected_runs, base):
         'unloadEventStart',
     ]
 
+    successes = [r for r in results if r['domComplete'] != -1]
+
     with open(filename, 'w', encoding='utf-8') as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames)
         writer.writeheader()
-        writer.writerows(results)
+        writer.writerows(successes)
 
 
 def format_result_summary(results):


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Google Data Studio is a lot happier if the data that's driving it is already filtered. This PR filters out any failed test runs from the CSV file generated by test-perf.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because this is test infrastructure

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19523)
<!-- Reviewable:end -->
