### PR TITLE
selectors: Manually inline any(..) in matches_selector_list.

### DIFF
--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -72,14 +72,24 @@ pub fn matches_selector_list<E>(
 where
     E: Element
 {
-    selector_list.0.iter().any(|selector| {
-        matches_selector(selector,
-                         0,
-                         None,
-                         element,
-                         context,
-                         &mut |_, _| {})
-    })
+    // This is pretty much any(..) but manually inlined because the compiler
+    // refuses to do so from querySelector / querySelectorAll.
+    for selector in &selector_list.0 {
+        let matches = matches_selector(
+            selector,
+            0,
+            None,
+            element,
+            context,
+            &mut |_, _| {},
+        );
+
+        if matches {
+            return true;
+        }
+    }
+
+    false
 }
 
 #[inline(always)]


### PR DESCRIPTION
Since the compiler refuses to inline the inner closure even with -O3, which is
sad :(.

Sad try run:

  https://treeherder.mozilla.org/perf.html#/compare?originalProject=try&originalRevision=c2724c47e98f990826327da05220cd83b772d144&newProject=try&newRevision=52ac88b40a08a5ef6a629bd681f2e5a444b75f54&framework=1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19558)
<!-- Reviewable:end -->
