### PR TITLE
Make layout depend on style/servo feature

### DIFF
--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -41,7 +41,7 @@ serde_json = "1.0"
 servo_config = {path = "../config"}
 servo_url = {path = "../url"}
 smallvec = "0.6"
-style = {path = "../style"}
+style = {path = "../style", features = ["servo"]}
 style_traits = {path = "../style_traits"}
 unicode-bidi = {version = "0.3", features = ["with_serde"]}
 unicode-script = {version = "0.1", features = ["harfbuzz"]}


### PR DESCRIPTION
This fixes an error when running commands like `./mach check -p layout`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they change build metadata only

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19562)
<!-- Reviewable:end -->
