### PR TITLE
Turn flow::base and friends into methods

### DIFF
--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -5,7 +5,7 @@
 //! CSS transitions and animations.
 
 use context::LayoutContext;
-use flow::{self, Flow};
+use flow::{Flow, GetBaseFlow};
 use fnv::FnvHashMap;
 use gfx::display_list::OpaqueNode;
 use ipc_channel::ipc::IpcSender;
@@ -170,7 +170,7 @@ pub fn recalc_style_for_animations(context: &LayoutContext,
         }
     });
 
-    let base = flow::mut_base(flow);
+    let base = flow.mut_base();
     base.restyle_damage.insert(damage);
     for kid in base.children.iter_mut() {
         recalc_style_for_animations(context, kid, animations)

--- a/components/layout/flex.rs
+++ b/components/layout/flex.rs
@@ -13,8 +13,7 @@ use display_list_builder::{DisplayListBuildState, FlexFlowDisplayListBuilding};
 use display_list_builder::StackingContextCollectionState;
 use euclid::Point2D;
 use floats::FloatKind;
-use flow;
-use flow::{Flow, FlowClass, ImmutableFlowUtils, OpaqueFlow, FlowFlags};
+use flow::{Flow, FlowClass, GetBaseFlow, ImmutableFlowUtils, OpaqueFlow, FlowFlags};
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
 use layout_debug;
 use model::{AdjoiningMargins, CollapsibleMargins};
@@ -451,7 +450,7 @@ impl FlexFlow {
         let mut computation = self.block_flow.fragment.compute_intrinsic_inline_sizes();
         if !fixed_width {
             for kid in self.block_flow.base.children.iter_mut() {
-                let base = flow::mut_base(kid);
+                let base = kid.mut_base();
                 let is_absolutely_positioned = base.flags.contains(FlowFlags::IS_ABSOLUTELY_POSITIONED);
                 if !is_absolutely_positioned {
                     let flex_item_inline_sizes = IntrinsicISizes {
@@ -477,7 +476,7 @@ impl FlexFlow {
         let mut computation = self.block_flow.fragment.compute_intrinsic_inline_sizes();
         if !fixed_width {
             for kid in self.block_flow.base.children.iter_mut() {
-                let base = flow::mut_base(kid);
+                let base = kid.mut_base();
                 let is_absolutely_positioned = base.flags.contains(FlowFlags::IS_ABSOLUTELY_POSITIONED);
                 if !is_absolutely_positioned {
                     computation.content_intrinsic_sizes.minimum_inline_size =
@@ -519,7 +518,7 @@ impl FlexFlow {
 
         let mut children = self.block_flow.base.children.random_access_mut();
         for kid in &mut self.items {
-            let kid_base = flow::mut_base(children.get(kid.index));
+            let kid_base = children.get(kid.index).mut_base();
             kid_base.block_container_explicit_block_size = container_block_size;
             if kid_base.flags.contains(FlowFlags::INLINE_POSITION_IS_STATIC) {
                 // The inline-start margin edge of the child flow is at our inline-start content
@@ -667,7 +666,7 @@ impl FlexFlow {
 
         let mut children = self.block_flow.base.children.random_access_mut();
         for item in &mut self.items {
-            let base = flow::mut_base(children.get(item.index));
+            let base = children.get(item.index).mut_base();
             if !self.main_reverse {
                 base.position.start.b = cur_b;
                 cur_b = cur_b + base.position.size.block;

--- a/components/layout/floats.rs
+++ b/components/layout/floats.rs
@@ -4,7 +4,7 @@
 
 use app_units::{Au, MAX_AU};
 use block::FormattingContextType;
-use flow::{self, Flow, FlowFlags, ImmutableFlowUtils};
+use flow::{Flow, FlowFlags, GetBaseFlow, ImmutableFlowUtils};
 use persistent_list::PersistentList;
 use std::cmp::{max, min};
 use std::fmt;
@@ -458,7 +458,7 @@ impl SpeculatedFloatPlacement {
     /// Given the speculated inline size of the floats out for the inorder predecessor of this
     /// flow, computes the speculated inline size of the floats flowing in.
     pub fn compute_floats_in(&mut self, flow: &mut Flow) {
-        let base_flow = flow::base(flow);
+        let base_flow = flow.base();
         if base_flow.flags.contains(FlowFlags::CLEARS_LEFT) {
             self.left = Au(0)
         }
@@ -491,7 +491,7 @@ impl SpeculatedFloatPlacement {
             }
         }
 
-        let base_flow = flow::base(flow);
+        let base_flow = flow.base();
         if !base_flow.flags.is_float() {
             return
         }
@@ -522,7 +522,7 @@ impl SpeculatedFloatPlacement {
     /// Given a flow, computes the speculated inline size of the floats in of its first child.
     pub fn compute_floats_in_for_first_child(parent_flow: &mut Flow) -> SpeculatedFloatPlacement {
         if !parent_flow.is_block_like() {
-            return flow::base(parent_flow).speculated_float_placement_in
+            return parent_flow.base().speculated_float_placement_in
         }
 
         let parent_block_flow = parent_flow.as_block();

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -12,7 +12,7 @@ use canvas_traits::canvas::CanvasMsg;
 use context::{LayoutContext, with_thread_local_font_context};
 use euclid::{Transform3D, Point2D, Vector2D, Rect, Size2D};
 use floats::ClearType;
-use flow::{self, ImmutableFlowUtils};
+use flow::{GetBaseFlow, ImmutableFlowUtils};
 use flow_ref::FlowRef;
 use gfx;
 use gfx::display_list::{BLUR_INFLATION_FACTOR, OpaqueNode};
@@ -232,7 +232,7 @@ impl SpecificFragmentInfo {
                 SpecificFragmentInfo::InlineBlock(ref info) => &info.flow_ref,
             };
 
-        flow::base(&**flow).restyle_damage
+        flow.base().restyle_damage
     }
 
     pub fn get_type(&self) -> &'static str {
@@ -2612,11 +2612,11 @@ impl Fragment {
         match self.specific {
             SpecificFragmentInfo::InlineBlock(ref info) => {
                 let block_flow = info.flow_ref.as_block();
-                overflow.union(&flow::base(block_flow).overflow);
+                overflow.union(&block_flow.base().overflow);
             }
             SpecificFragmentInfo::InlineAbsolute(ref info) => {
                 let block_flow = info.flow_ref.as_block();
-                overflow.union(&flow::base(block_flow).overflow);
+                overflow.union(&block_flow.base().overflow);
             }
             _ => (),
         }

--- a/components/layout/generated_content.rs
+++ b/components/layout/generated_content.rs
@@ -9,7 +9,7 @@
 //! as possible.
 
 use context::{LayoutContext, with_thread_local_font_context};
-use flow::{self, Flow, FlowFlags, ImmutableFlowUtils};
+use flow::{Flow, FlowFlags, GetBaseFlow, ImmutableFlowUtils};
 use fragment::{Fragment, GeneratedContentInfo, SpecificFragmentInfo, UnscannedTextFragmentInfo};
 use gfx::display_list::OpaqueNode;
 use script_layout_interface::wrapper_traits::PseudoElementType;
@@ -132,8 +132,8 @@ impl<'a> InorderFlowTraversal for ResolveGeneratedContent<'a> {
 
     #[inline]
     fn should_process_subtree(&mut self, flow: &mut Flow) -> bool {
-        flow::base(flow).restyle_damage.intersects(ServoRestyleDamage::RESOLVE_GENERATED_CONTENT) ||
-            flow::base(flow).flags.intersects(FlowFlags::AFFECTS_COUNTERS | FlowFlags::HAS_COUNTER_AFFECTING_CHILDREN)
+        flow.base().restyle_damage.intersects(ServoRestyleDamage::RESOLVE_GENERATED_CONTENT) ||
+            flow.base().flags.intersects(FlowFlags::AFFECTS_COUNTERS | FlowFlags::HAS_COUNTER_AFFECTING_CHILDREN)
     }
 }
 

--- a/components/layout/incremental.rs
+++ b/components/layout/incremental.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use flow::{self, FlowFlags, Flow};
+use flow::{FlowFlags, Flow, GetBaseFlow};
 use style::computed_values::float::T as Float;
 use style::selector_parser::RestyleDamage;
 use style::servo::restyle_damage::ServoRestyleDamage;
@@ -30,20 +30,20 @@ pub trait LayoutDamageComputation {
 impl<'a> LayoutDamageComputation for &'a mut Flow {
     fn compute_layout_damage(self) -> SpecialRestyleDamage {
         let mut special_damage = SpecialRestyleDamage::empty();
-        let is_absolutely_positioned = flow::base(self).flags.contains(FlowFlags::IS_ABSOLUTELY_POSITIONED);
+        let is_absolutely_positioned = self.base().flags.contains(FlowFlags::IS_ABSOLUTELY_POSITIONED);
 
         // In addition to damage, we use this phase to compute whether nodes affect CSS counters.
         let mut has_counter_affecting_children = false;
 
         {
-            let self_base = flow::mut_base(self);
+            let self_base = self.mut_base();
             // Take a snapshot of the parent damage before updating it with damage from children.
             let parent_damage = self_base.restyle_damage;
 
             for kid in self_base.children.iter_mut() {
                 let child_is_absolutely_positioned =
-                    flow::base(kid).flags.contains(FlowFlags::IS_ABSOLUTELY_POSITIONED);
-                flow::mut_base(kid).restyle_damage.insert(
+                    kid.base().flags.contains(FlowFlags::IS_ABSOLUTELY_POSITIONED);
+                kid.mut_base().restyle_damage.insert(
                     parent_damage.damage_for_child(is_absolutely_positioned,
                                                    child_is_absolutely_positioned));
                 {
@@ -51,16 +51,16 @@ impl<'a> LayoutDamageComputation for &'a mut Flow {
                     special_damage.insert(kid.compute_layout_damage());
                 }
                 self_base.restyle_damage
-                         .insert(flow::base(kid).restyle_damage.damage_for_parent(
+                         .insert(kid.base().restyle_damage.damage_for_parent(
                                  child_is_absolutely_positioned));
 
                 has_counter_affecting_children = has_counter_affecting_children ||
-                    flow::base(kid).flags.intersects(FlowFlags::AFFECTS_COUNTERS |
+                    kid.base().flags.intersects(FlowFlags::AFFECTS_COUNTERS |
                                                      FlowFlags::HAS_COUNTER_AFFECTING_CHILDREN);
             }
         }
 
-        let self_base = flow::mut_base(self);
+        let self_base = self.mut_base();
         if self_base.flags.float_kind() != Float::None &&
                 self_base.restyle_damage.intersects(ServoRestyleDamage::REFLOW) {
             special_damage.insert(SpecialRestyleDamage::REFLOW_ENTIRE_DOCUMENT);
@@ -76,7 +76,7 @@ impl<'a> LayoutDamageComputation for &'a mut Flow {
     }
 
     fn reflow_entire_document(self) {
-        let self_base = flow::mut_base(self);
+        let self_base = self.mut_base();
         self_base.restyle_damage.insert(RestyleDamage::rebuild_and_reflow());
         self_base.restyle_damage.remove(ServoRestyleDamage::RECONSTRUCT_FLOW);
         for kid in self_base.children.iter_mut() {

--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -12,8 +12,8 @@ use display_list_builder::{DisplayListBuildState, InlineFlowDisplayListBuilding}
 use display_list_builder::StackingContextCollectionState;
 use euclid::{Point2D, Size2D};
 use floats::{FloatKind, Floats, PlacementInfo};
-use flow::{self, BaseFlow, Flow, FlowClass, ForceNonfloatedFlag};
-use flow::{FlowFlags, EarlyAbsolutePositionInfo, OpaqueFlow};
+use flow::{BaseFlow, Flow, FlowClass, ForceNonfloatedFlag};
+use flow::{FlowFlags, EarlyAbsolutePositionInfo, GetBaseFlow, OpaqueFlow};
 use flow_ref::FlowRef;
 use fragment::{CoordinateSystem, Fragment, FragmentBorderBoxIterator, Overflow};
 use fragment::FragmentFlags;
@@ -1315,7 +1315,7 @@ impl Flow for InlineFlow {
 
         let writing_mode = self.base.writing_mode;
         for kid in self.base.child_iter_mut() {
-            flow::mut_base(kid).floats = Floats::new(writing_mode);
+            kid.mut_base().floats = Floats::new(writing_mode);
         }
 
         self.base.flags.remove(FlowFlags::CONTAINS_TEXT_OR_REPLACED_FRAGMENTS);
@@ -1423,7 +1423,7 @@ impl Flow for InlineFlow {
         // sizes down to them.
         let block_container_explicit_block_size = self.base.block_container_explicit_block_size;
         for kid in self.base.child_iter_mut() {
-            let kid_base = flow::mut_base(kid);
+            let kid_base = kid.mut_base();
 
             kid_base.block_container_inline_size = inline_size;
             kid_base.block_container_writing_mode = container_mode;
@@ -1524,14 +1524,14 @@ impl Flow for InlineFlow {
             match f.specific {
                 SpecificFragmentInfo::InlineBlock(ref mut info) => {
                     let block = FlowRef::deref_mut(&mut info.flow_ref);
-                    flow::mut_base(block).early_absolute_position_info = EarlyAbsolutePositionInfo {
+                    block.mut_base().early_absolute_position_info = EarlyAbsolutePositionInfo {
                         relative_containing_block_size: containing_block_size,
                         relative_containing_block_mode: writing_mode,
                     };
                 }
                 SpecificFragmentInfo::InlineAbsolute(ref mut info) => {
                     let block = FlowRef::deref_mut(&mut info.flow_ref);
-                    flow::mut_base(block).early_absolute_position_info = EarlyAbsolutePositionInfo {
+                    block.mut_base().early_absolute_position_info = EarlyAbsolutePositionInfo {
                         relative_containing_block_size: containing_block_size,
                         relative_containing_block_mode: writing_mode,
                     };
@@ -1757,7 +1757,7 @@ impl fmt::Debug for InlineFlow {
                "{:?}({:x}) {:?}",
                self.class(),
                self.base.debug_id(),
-               flow::base(self))
+               self.base())
     }
 }
 

--- a/components/layout/layout_debug.rs
+++ b/components/layout/layout_debug.rs
@@ -5,7 +5,7 @@
 //! Supports writing a trace file created during each layout scope
 //! that can be viewed by an external tool to make layout debugging easier.
 
-use flow;
+use flow::GetBaseFlow;
 use flow_ref::FlowRef;
 use serde_json::{to_string, to_value, Value};
 use std::borrow::ToOwned;
@@ -63,7 +63,7 @@ impl Scope {
     pub fn new(name: String) -> Scope {
         STATE_KEY.with(|ref r| {
             if let Some(ref mut state) = *r.borrow_mut() {
-                let flow_trace = to_value(&flow::base(&*state.flow_root)).unwrap();
+                let flow_trace = to_value(&state.flow_root.base()).unwrap();
                 let data = Box::new(ScopeData::new(name.clone(), flow_trace));
                 state.scope_stack.push(data);
             }
@@ -78,7 +78,7 @@ impl Drop for Scope {
         STATE_KEY.with(|ref r| {
             if let Some(ref mut state) = *r.borrow_mut() {
                 let mut current_scope = state.scope_stack.pop().unwrap();
-                current_scope.post = to_value(&flow::base(&*state.flow_root)).unwrap();
+                current_scope.post = to_value(&state.flow_root.base()).unwrap();
                 let previous_scope = state.scope_stack.last_mut().unwrap();
                 previous_scope.children.push(current_scope);
             }
@@ -100,7 +100,7 @@ pub fn begin_trace(flow_root: FlowRef) {
     assert!(STATE_KEY.with(|ref r| r.borrow().is_none()));
 
     STATE_KEY.with(|ref r| {
-        let flow_trace = to_value(&flow::base(&*flow_root)).unwrap();
+        let flow_trace = to_value(&flow_root.base()).unwrap();
         let state = State {
             scope_stack: vec![Box::new(ScopeData::new("root".to_owned(), flow_trace))],
             flow_root: flow_root.clone(),
@@ -116,7 +116,7 @@ pub fn end_trace(generation: u32) {
     let mut thread_state = STATE_KEY.with(|ref r| r.borrow_mut().take().unwrap());
     assert!(thread_state.scope_stack.len() == 1);
     let mut root_scope = thread_state.scope_stack.pop().unwrap();
-    root_scope.post = to_value(&flow::base(&*thread_state.flow_root)).unwrap();
+    root_scope.post = to_value(&thread_state.flow_root.base()).unwrap();
 
     let result = to_string(&root_scope).unwrap();
     let mut file = File::create(format!("layout_trace-{}.json", generation)).unwrap();

--- a/components/layout/multicol.rs
+++ b/components/layout/multicol.rs
@@ -13,7 +13,7 @@ use context::LayoutContext;
 use display_list_builder::{DisplayListBuildState, StackingContextCollectionState};
 use euclid::{Point2D, Vector2D};
 use floats::FloatKind;
-use flow::{Flow, FlowClass, OpaqueFlow, mut_base, FragmentationContext};
+use flow::{Flow, FlowClass, OpaqueFlow, FragmentationContext, GetBaseFlow};
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
 use gfx_traits::print_tree::PrintTree;
 use std::cmp::{min, max};
@@ -180,7 +180,7 @@ impl Flow for MulticolFlow {
         let pitch = LogicalSize::new(self.block_flow.base.writing_mode, self.column_pitch, Au(0));
         let pitch = pitch.to_physical(self.block_flow.base.writing_mode);
         for (i, child) in self.block_flow.base.children.iter_mut().enumerate() {
-            let point = &mut mut_base(child).stacking_relative_position;
+            let point = &mut child.mut_base().stacking_relative_position;
             *point = *point + Vector2D::new(pitch.width * i as i32, pitch.height * i as i32);
         }
     }

--- a/components/layout/parallel.rs
+++ b/components/layout/parallel.rs
@@ -10,7 +10,7 @@
 
 use block::BlockFlow;
 use context::LayoutContext;
-use flow::{self, Flow};
+use flow::{Flow, GetBaseFlow};
 use flow_ref::FlowRef;
 use profile_traits::time::{self, TimerMetadata, profile};
 use rayon;
@@ -84,7 +84,7 @@ fn bottom_up_flow(mut unsafe_flow: UnsafeFlow,
         }
 
 
-        let base = flow::mut_base(flow);
+        let base = flow.mut_base();
 
         // Reset the count of children for the next layout traversal.
         base.parallel.children_count.store(base.children.len() as isize,
@@ -103,7 +103,7 @@ fn bottom_up_flow(mut unsafe_flow: UnsafeFlow,
         let parent: &mut Flow = unsafe {
             &mut *(unsafe_parent.0 as *mut Flow)
         };
-        let parent_base = flow::mut_base(parent);
+        let parent_base = parent.mut_base();
         if parent_base.parallel.children_count.fetch_sub(1, Ordering::Relaxed) == 1 {
             // We were the last child of our parent. Reflow our parent.
             unsafe_flow = unsafe_parent
@@ -127,7 +127,7 @@ fn top_down_flow<'scope>(unsafe_flows: &[UnsafeFlow],
         unsafe {
             // Get a real flow.
             let flow: &mut Flow = mem::transmute(*unsafe_flow);
-            flow::mut_base(flow).thread_id =
+            flow.mut_base().thread_id =
                 pool.current_thread_index().unwrap() as u8;
 
             if assign_isize_traversal.should_process(flow) {
@@ -136,7 +136,7 @@ fn top_down_flow<'scope>(unsafe_flows: &[UnsafeFlow],
             }
 
             // Possibly enqueue the children.
-            for kid in flow::child_iter_mut(flow) {
+            for kid in flow.mut_base().child_iter_mut() {
                 had_children = true;
                 discovered_child_flows.push(UnsafeFlow(kid));
             }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -8,7 +8,7 @@ use app_units::Au;
 use construct::ConstructionResult;
 use context::LayoutContext;
 use euclid::{Point2D, Vector2D, Rect, Size2D};
-use flow::{self, Flow};
+use flow::{Flow, GetBaseFlow};
 use fragment::{Fragment, FragmentBorderBoxIterator, SpecificFragmentInfo};
 use gfx::display_list::{DisplayList, OpaqueNode, ScrollOffsetMap};
 use inline::InlineFragmentNodeFlags;
@@ -774,7 +774,7 @@ where
         let position = maybe_data.map_or(Point2D::zero(), |data| {
             match (*data).flow_construction_result {
                 ConstructionResult::Flow(ref flow_ref, _) =>
-                    flow::base(flow_ref.deref()).stacking_relative_position.to_point(),
+                    flow_ref.deref().base().stacking_relative_position.to_point(),
                 // TODO(dzbarsky) search parents until we find node with a flow ref.
                 // https://github.com/servo/servo/issues/8307
                 _ => Point2D::zero()

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -13,8 +13,7 @@ use context::LayoutContext;
 use display_list_builder::{BlockFlowDisplayListBuilding, BorderPaintingMode};
 use display_list_builder::{DisplayListBuildState, StackingContextCollectionFlags, StackingContextCollectionState};
 use euclid::Point2D;
-use flow;
-use flow::{BaseFlow, EarlyAbsolutePositionInfo, Flow, FlowClass, ImmutableFlowUtils, OpaqueFlow};
+use flow::{BaseFlow, EarlyAbsolutePositionInfo, Flow, FlowClass, ImmutableFlowUtils, GetBaseFlow, OpaqueFlow};
 use flow_list::MutFlowListIterator;
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
 use gfx_traits::print_tree::PrintTree;
@@ -752,12 +751,12 @@ impl TableLikeFlow for BlockFlow {
                 }
 
                 // At this point, `current_block_offset` is at the border edge of the child.
-                flow::mut_base(kid).position.start.b = current_block_offset;
+                kid.mut_base().position.start.b = current_block_offset;
 
                 // Move past the child's border box. Do not use the `translate_including_floats`
                 // function here because the child has already translated floats past its border
                 // box.
-                let kid_base = flow::mut_base(kid);
+                let kid_base = kid.mut_base();
                 current_block_offset = current_block_offset + kid_base.position.size.block;
             }
 
@@ -796,7 +795,7 @@ impl TableLikeFlow for BlockFlow {
             // Write in the size of the relative containing block for children. (This information
             // is also needed to handle RTL.)
             for kid in self.base.child_iter_mut() {
-                flow::mut_base(kid).early_absolute_position_info = EarlyAbsolutePositionInfo {
+                kid.mut_base().early_absolute_position_info = EarlyAbsolutePositionInfo {
                     relative_containing_block_size: self.fragment.content_box().size,
                     relative_containing_block_mode: self.fragment.style().writing_mode,
                 };
@@ -856,7 +855,7 @@ impl<'a> Iterator for TableRowIterator<'a> {
         match self.kids.next() {
             Some(kid) => {
                 if kid.is_table_rowgroup() {
-                    self.grandkids = Some(flow::mut_base(kid).child_iter_mut());
+                    self.grandkids = Some(kid.mut_base().child_iter_mut());
                     self.next()
                 } else if kid.is_table_row() {
                     Some(kid.as_mut_table_row())

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -13,7 +13,7 @@ use display_list_builder::{BlockFlowDisplayListBuilding, BorderPaintingMode};
 use display_list_builder::{DisplayListBuildState, StackingContextCollectionFlags};
 use display_list_builder::StackingContextCollectionState;
 use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
-use flow::{self, Flow, FlowClass, FlowFlags, OpaqueFlow};
+use flow::{Flow, FlowClass, FlowFlags, GetBaseFlow, OpaqueFlow};
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
 use gfx_traits::print_tree::PrintTree;
 use layout_debug;
@@ -101,8 +101,8 @@ impl TableCellFlow {
         // Note to the reader: this code has been tested with negative margins.
         // We end up with a "end" that's before the "start," but the math still works out.
         let mut extents = None;
-        for kid in flow::base(self).children.iter() {
-            let kid_base = flow::base(kid);
+        for kid in self.base().children.iter() {
+            let kid_base = kid.base();
             if kid_base.flags.contains(FlowFlags::IS_ABSOLUTELY_POSITIONED) {
                 continue
             }
@@ -128,7 +128,7 @@ impl TableCellFlow {
         };
 
         let kids_size = last_end - first_start;
-        let self_size = flow::base(self).position.size.block -
+        let self_size = self.base().position.size.block -
             self.block_flow.fragment.border_padding.block_start_end();
         let kids_self_gap = self_size - kids_size;
 
@@ -143,8 +143,8 @@ impl TableCellFlow {
             return
         }
 
-        for kid in flow::mut_base(self).children.iter_mut() {
-            let kid_base = flow::mut_base(kid);
+        for kid in self.mut_base().children.iter_mut() {
+            let kid_base = kid.mut_base();
             if !kid_base.flags.contains(FlowFlags::IS_ABSOLUTELY_POSITIONED) {
                 kid_base.position.start.b += offset
             }

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -13,7 +13,7 @@ use display_list_builder::{BlockFlowDisplayListBuilding, BorderPaintingMode};
 use display_list_builder::{DisplayListBuildState, StackingContextCollectionFlags};
 use display_list_builder::StackingContextCollectionState;
 use euclid::Point2D;
-use flow::{self, EarlyAbsolutePositionInfo, Flow, FlowClass, ImmutableFlowUtils, OpaqueFlow};
+use flow::{EarlyAbsolutePositionInfo, Flow, FlowClass, ImmutableFlowUtils, GetBaseFlow, OpaqueFlow};
 use flow_list::MutFlowListIterator;
 use fragment::{Fragment, FragmentBorderBoxIterator, Overflow};
 use gfx_traits::print_tree::PrintTree;
@@ -126,7 +126,7 @@ impl TableRowFlow {
                 - self.block_flow.fragment.margin;
             for kid in self.block_flow.base.child_iter_mut() {
                 kid.place_float_if_applicable();
-                if !flow::base(kid).flags.is_float() {
+                if !kid.base().flags.is_float() {
                     kid.assign_block_size_for_inorder_child_if_necessary(layout_context,
                                                                          thread_id,
                                                                          content_box);
@@ -143,7 +143,7 @@ impl TableRowFlow {
                             child_specified_block_size +
                             child_fragment.border_padding.block_start_end());
                 }
-                let child_node = flow::mut_base(kid);
+                let child_node = kid.mut_base();
                 child_node.position.start.b = Au(0);
                 max_block_size = max(max_block_size, child_node.position.size.block);
             }
@@ -301,7 +301,7 @@ impl Flow for TableRowFlow {
 
                 // Collect minimum and preferred inline-sizes of the cell for automatic table layout
                 // calculation.
-                let child_base = flow::mut_base(kid);
+                let child_base = kid.mut_base();
                 let child_column_inline_size = ColumnIntrinsicInlineSize {
                     minimum_length: match child_specified_inline_size {
                         LengthOrPercentageOrAuto::Auto |


### PR DESCRIPTION
This feels more idiomatic in modern Rust, and replaces code like this:

`flow::base(&**root_flow).restyle_damage`

with this:

`root_flow.base().restyle_damage`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are refactoring only

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19565)
<!-- Reviewable:end -->
