### PR TITLE
Add a topLevelDomComplete metric.

### DIFF
--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -141,6 +141,13 @@ impl DocumentLoader {
         !self.blocking_loads.is_empty()
     }
 
+    pub fn is_only_blocked_by_iframes(&self) -> bool {
+        self.blocking_loads.iter().all(|load| match *load {
+            LoadType::Subframe(_) => true,
+            _ => false
+        })
+    }
+
     pub fn inhibit_events(&mut self) {
         self.events_inhibited = true;
     }

--- a/components/script/dom/performancetiming.rs
+++ b/components/script/dom/performancetiming.rs
@@ -86,6 +86,12 @@ impl PerformanceTimingMethods for PerformanceTiming {
     fn LoadEventEnd(&self) -> u64 {
         self.document.get_load_event_end()
     }
+
+    // check-tidy: no specs after this line
+    // Servo-only timing for when top-level content (not iframes) is complete
+    fn TopLevelDomComplete(&self) -> u64 {
+        self.document.get_top_level_dom_complete()
+    }
 }
 
 

--- a/components/script/dom/webidls/PerformanceTiming.webidl
+++ b/components/script/dom/webidls/PerformanceTiming.webidl
@@ -29,4 +29,7 @@ interface PerformanceTiming {
   readonly attribute unsigned long long domComplete;
   readonly attribute unsigned long long loadEventStart;
   readonly attribute unsigned long long loadEventEnd;
+  /* Servo-onnly attribute for measuring when the top-level document (not iframes) is complete. */
+  [Pref="dom.testperf.enabled"]
+  readonly attribute unsigned long long topLevelDomComplete;
 };

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -40195,6 +40195,12 @@
      {}
     ]
    ],
+   "mozilla/window_performance_topLevelDomComplete.html": [
+    [
+     "/_mozilla/mozilla/window_performance_topLevelDomComplete.html",
+     {}
+    ]
+   ],
    "mozilla/window_requestAnimationFrame.html": [
     [
      "/_mozilla/mozilla/window_requestAnimationFrame.html",
@@ -72340,6 +72346,10 @@
   ],
   "mozilla/window_performance.html": [
    "f03283e68b82d972ad21f674243070643ef89489",
+   "testharness"
+  ],
+  "mozilla/window_performance_topLevelDomComplete.html": [
+   "4b953e63ffa6bf4ed1bc9a2baaea457d46502b9d",
    "testharness"
   ],
   "mozilla/window_requestAnimationFrame.html": [

--- a/tests/wpt/mozilla/meta/mozilla/window_performance_topLevelDomComplete.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/window_performance_topLevelDomComplete.html.ini
@@ -1,0 +1,3 @@
+[window_performance_topLevelDomComplete.html]
+  type: testharness
+  prefs: [dom.testperf.enabled:true]

--- a/tests/wpt/mozilla/tests/mozilla/window_performance_topLevelDomComplete.html
+++ b/tests/wpt/mozilla/tests/mozilla/window_performance_topLevelDomComplete.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+  <title>Performance toLevelDomComplete</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+async_test(function(t) {
+  window.onload = t.step_func(function() {
+    assert_true(performance.timing.domLoading <= performance.timing.topLevelDomComplete);
+    assert_true(performance.timing.topLevelDomComplete <= performance.timing.domComplete);
+    t.done();
+  });
+}, "performance.topLevelDomComplete");
+</script>
+</body>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Measure DOM completion without iframes. This is in support of measuring when the main document is loaded, ignoring secondary content, e.g. ads.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19561
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19569)
<!-- Reviewable:end -->
