### PR TITLE
style: move list-style-image out of mako

### DIFF
--- a/components/style/properties/longhand/list.mako.rs
+++ b/components/style/properties/longhand/list.mako.rs
@@ -95,45 +95,13 @@ ${helpers.single_keyword("list-style-position", "outside inside", animation_valu
     </%helpers:longhand>
 % endif
 
-<%helpers:longhand name="list-style-image" animation_value_type="discrete"
-                   boxed="${product == 'gecko'}"
-                   spec="https://drafts.csswg.org/css-lists/#propdef-list-style-image">
-    use values::specified::UrlOrNone;
-    pub use self::computed_value::T as SpecifiedValue;
-
-    pub mod computed_value {
-        use values::specified::UrlOrNone;
-
-        #[derive(Clone, Debug, MallocSizeOf, PartialEq, ToCss)]
-        pub struct T(pub UrlOrNone);
-
-        // FIXME(nox): This is wrong, there are different types for specified
-        // and computed URLs in Servo.
-        trivial_to_computed_value!(T);
-    }
-
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        computed_value::T(Either::Second(None_))
-    }
-    #[inline]
-    pub fn get_initial_specified_value() -> SpecifiedValue {
-        SpecifiedValue(Either::Second(None_))
-    }
-    pub fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
-                         -> Result<SpecifiedValue,ParseError<'i>> {
-        % if product == "gecko":
-        let mut value = input.try(|input| UrlOrNone::parse(context, input))?;
-        if let Either::First(ref mut url) = value {
-            url.build_image_value();
-        }
-        % else :
-        let value = input.try(|input| UrlOrNone::parse(context, input))?;
-        % endif
-
-        return Ok(SpecifiedValue(value));
-    }
-</%helpers:longhand>
+${helpers.predefined_type("list-style-image",
+                          "ListStyleImage",
+                          initial_value="specified::ListStyleImage::none()",
+                          initial_specified_value="specified::ListStyleImage::none()",
+                          animation_value_type="discrete",
+                          boxed=product == "gecko",
+                          spec="https://drafts.csswg.org/css-lists/#propdef-list-style-image")}
 
 ${helpers.predefined_type("quotes",
                           "Quotes",

--- a/components/style/values/computed/list.rs
+++ b/components/style/values/computed/list.rs
@@ -4,7 +4,7 @@
 
 //! `list` computed values.
 
-pub use values::specified::list::Quotes;
+pub use values::specified::list::{ListStyleImage, Quotes};
 
 impl Quotes {
     /// Initial value for `quotes`.

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -54,7 +54,7 @@ pub use super::specified::{BorderStyle, TextDecorationLine};
 pub use self::length::{CalcLengthOrPercentage, Length, LengthOrNone, LengthOrNumber, LengthOrPercentage};
 pub use self::length::{LengthOrPercentageOrAuto, LengthOrPercentageOrNone, MaxLength, MozLength};
 pub use self::length::{CSSPixelLength, NonNegativeLength, NonNegativeLengthOrPercentage};
-pub use self::list::Quotes;
+pub use self::list::{ListStyleImage, Quotes};
 pub use self::outline::OutlineStyle;
 pub use self::percentage::Percentage;
 pub use self::position::{Position, GridAutoFlow, GridTemplateAreas};

--- a/components/style/values/specified/list.rs
+++ b/components/style/values/specified/list.rs
@@ -8,6 +8,41 @@ use cssparser::{Parser, Token};
 use parser::{Parse, ParserContext};
 use std::fmt;
 use style_traits::{ParseError, StyleParseErrorKind, ToCss};
+use values::{Either, None_};
+use values::specified::UrlOrNone;
+
+/// Specified and computed `list-style-image` property.
+#[derive(Clone, Debug, MallocSizeOf, PartialEq, ToCss)]
+pub struct ListStyleImage(pub UrlOrNone);
+
+// FIXME(nox): This is wrong, there are different types for specified
+// and computed URLs in Servo.
+trivial_to_computed_value!(ListStyleImage);
+
+impl ListStyleImage {
+    /// Initial specified value for `list-style-image`.
+    #[inline]
+    pub fn none() -> ListStyleImage {
+        ListStyleImage(Either::Second(None_))
+    }
+}
+
+impl Parse for ListStyleImage {
+    fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
+                         -> Result<ListStyleImage, ParseError<'i>> {
+        #[allow(unused_mut)]
+        let mut value = input.try(|input| UrlOrNone::parse(context, input))?;
+
+        #[cfg(feature = "gecko")]
+        {
+            if let Either::First(ref mut url) = value {
+                url.build_image_value();
+            }
+        }
+
+        return Ok(ListStyleImage(value));
+    }
+}
 
 /// Specified and computed `quote` property.
 ///

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -49,7 +49,7 @@ pub use self::length::{LengthOrPercentage, LengthOrPercentageOrAuto};
 pub use self::length::{LengthOrPercentageOrNone, MaxLength, MozLength};
 pub use self::length::{NoCalcLength, ViewportPercentageLength};
 pub use self::length::NonNegativeLengthOrPercentage;
-pub use self::list::Quotes;
+pub use self::list::{ListStyleImage, Quotes};
 pub use self::outline::OutlineStyle;
 pub use self::rect::LengthOrNumberRect;
 pub use self::percentage::Percentage;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Moving `list-style-image` out of mako.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19557  (part of #19015 ).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because refactoring

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19570)
<!-- Reviewable:end -->
