### PR TITLE
deny warnings for all crates as default

### DIFF
--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
+
 //! Selecting the default global allocator for Servo
 
 #![cfg_attr(all(feature = "unstable", windows), feature(alloc_system, allocator_api))]

--- a/components/atoms/lib.rs
+++ b/components/atoms/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 extern crate string_cache;
 
 include!(concat!(env!("OUT_DIR"), "/atom.rs"));

--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 #[macro_use]
 extern crate bitflags;
 extern crate bluetooth_traits;

--- a/components/bluetooth_traits/lib.rs
+++ b/components/bluetooth_traits/lib.rs
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
+#![deny(warnings)]
 extern crate ipc_channel;
 extern crate regex;
 #[macro_use] extern crate serde;

--- a/components/canvas/lib.rs
+++ b/components/canvas/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 #![deny(unsafe_code)]
 
 extern crate azure;

--- a/components/canvas_traits/lib.rs
+++ b/components/canvas_traits/lib.rs
@@ -5,6 +5,7 @@
 #![crate_name = "canvas_traits"]
 #![crate_type = "rlib"]
 
+#![deny(warnings)]
 #![deny(unsafe_code)]
 
 extern crate cssparser;

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 #![deny(unsafe_code)]
 
 extern crate euclid;

--- a/components/config/lib.rs
+++ b/components/config/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 #![deny(unsafe_code)]
 
 #[cfg(target_os = "android")]

--- a/components/constellation/lib.rs
+++ b/components/constellation/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 #![deny(unsafe_code)]
 #![cfg_attr(feature = "unstable", feature(conservative_impl_trait))]
 #![feature(mpsc_select)]

--- a/components/debugger/lib.rs
+++ b/components/debugger/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 #[macro_use]
 extern crate log;
 extern crate ws;

--- a/components/deny_public_fields/lib.rs
+++ b/components/deny_public_fields/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 extern crate proc_macro;
 extern crate syn;
 extern crate synstructure;

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -12,6 +12,7 @@
 
 #![allow(non_snake_case)]
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 extern crate devtools_traits;
 extern crate hyper;

--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -11,6 +11,7 @@
 
 #![allow(non_snake_case)]
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 #[macro_use]
 extern crate bitflags;

--- a/components/dom_struct/lib.rs
+++ b/components/dom_struct/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 #![feature(proc_macro)]
 
 extern crate proc_macro;

--- a/components/domobject_derive/lib.rs
+++ b/components/domobject_derive/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 extern crate proc_macro;
 #[macro_use] extern crate quote;
 extern crate syn;

--- a/components/fallible/lib.rs
+++ b/components/fallible/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 extern crate hashglobe;
 extern crate smallvec;
 

--- a/components/geometry/lib.rs
+++ b/components/geometry/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 extern crate app_units;
 extern crate euclid;
 extern crate malloc_size_of;

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -5,6 +5,7 @@
 // For SIMD
 #![cfg_attr(feature = "unstable", feature(cfg_target_feature))]
 
+#![deny(warnings)]
 #![deny(unsafe_code)]
 
 extern crate app_units;

--- a/components/gfx_traits/lib.rs
+++ b/components/gfx_traits/lib.rs
@@ -6,6 +6,7 @@
 #![crate_type = "rlib"]
 
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 extern crate malloc_size_of;
 #[macro_use] extern crate malloc_size_of_derive;

--- a/components/hashglobe/src/lib.rs
+++ b/components/hashglobe/src/lib.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![deny(warnings)]
 pub mod alloc;
 pub mod hash_map;
 pub mod hash_set;

--- a/components/jstraceable_derive/lib.rs
+++ b/components/jstraceable_derive/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 extern crate proc_macro;
 #[macro_use] extern crate quote;
 extern crate syn;

--- a/components/layout/lib.rs
+++ b/components/layout/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 extern crate app_units;
 extern crate atomic_refcell;

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -5,6 +5,7 @@
 //! The layout thread. Performs layout on the DOM, builds display lists and sends them to be
 //! painted.
 
+#![deny(warnings)]
 #![feature(mpsc_select)]
 
 extern crate app_units;

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 extern crate gfx;
 extern crate ipc_channel;

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -43,6 +43,7 @@
 //!   measured as well as the thing it points to. E.g.
 //!   `<Box<_> as MallocSizeOf>::size_of(field, ops)`.
 
+#![deny(warnings)]
 extern crate app_units;
 extern crate cssparser;
 extern crate euclid;

--- a/components/malloc_size_of_derive/lib.rs
+++ b/components/malloc_size_of_derive/lib.rs
@@ -10,6 +10,7 @@
 
 //! A crate for deriving the MallocSizeOf trait.
 
+#![deny(warnings)]
 #[cfg(not(test))] extern crate proc_macro;
 #[macro_use] extern crate quote;
 extern crate syn;

--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 extern crate gfx;
 extern crate gfx_traits;
 extern crate ipc_channel;

--- a/components/msg/lib.rs
+++ b/components/msg/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 #![deny(unsafe_code)]
 
 #[macro_use]

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 extern crate base64;
 extern crate brotli;

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
+#![deny(warnings)]
 #![deny(unsafe_code)]
 
 extern crate cookie as cookie_rs;

--- a/components/nonzero/lib.rs
+++ b/components/nonzero/lib.rs
@@ -5,6 +5,7 @@
 //! `NonZero*` types that are either `core::nonzero::NonZero<_>`
 //! or some stable types with an equivalent API (but no memory layout optimization).
 
+#![deny(warnings)]
 #![cfg_attr(feature = "unstable", feature(nonzero))]
 #![cfg_attr(feature = "unstable", feature(const_fn))]
 #![cfg_attr(feature = "unstable", feature(const_nonzero_new))]

--- a/components/profile/lib.rs
+++ b/components/profile/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 #[allow(unused_extern_crates)]
 extern crate heartbeats_simple;

--- a/components/profile_traits/lib.rs
+++ b/components/profile_traits/lib.rs
@@ -7,6 +7,7 @@
 //! modules won't have to depend on `profile`.
 
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 extern crate ipc_channel;
 #[macro_use]

--- a/components/rand/lib.rs
+++ b/components/rand/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
+
 /// A random number generator which shares one instance of an `OsRng`.
 ///
 /// A problem with `OsRng`, which is inherited by `StdRng` and so

--- a/components/range/lib.rs
+++ b/components/range/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 extern crate malloc_size_of;
 #[macro_use] extern crate malloc_size_of_derive;

--- a/components/remutex/lib.rs
+++ b/components/remutex/lib.rs
@@ -10,6 +10,7 @@
 //! It provides the same interface as https://github.com/rust-lang/rust/blob/master/src/libstd/sys/common/remutex.rs
 //! so if those types are ever exported, we should be able to replace this implemtation.
 
+#![deny(warnings)]
 extern crate nonzero;
 #[macro_use] extern crate lazy_static;
 #[macro_use] extern crate log;

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -14,6 +14,7 @@
 #![feature(string_retain)]
 
 #![deny(unsafe_code)]
+#![deny(warnings)]
 #![allow(non_snake_case)]
 
 #![doc = "The script crate contains all matters DOM."]

--- a/components/script_layout_interface/lib.rs
+++ b/components/script_layout_interface/lib.rs
@@ -7,6 +7,7 @@
 //! to depend on script.
 
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 extern crate app_units;
 extern crate atomic_refcell;

--- a/components/script_plugins/lib.rs
+++ b/components/script_plugins/lib.rs
@@ -14,7 +14,7 @@
 //!                       Use this for structs that correspond to a DOM type
 
 
-
+#![deny(warnings)]
 #![deny(unsafe_code)]
 #![feature(macro_vis_matcher)]
 #![feature(plugin)]

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -8,6 +8,7 @@
 
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 extern crate bluetooth_traits;
 extern crate canvas_traits;

--- a/components/selectors/lib.rs
+++ b/components/selectors/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 // Make |cargo bench| work.
 #![cfg_attr(feature = "bench", feature(test))]
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -17,6 +17,7 @@
 //! `Servo` is fed events from a generic type that implements the
 //! `WindowMethods` trait.
 
+#![deny(warnings)]
 extern crate env_logger;
 #[cfg(all(not(target_os = "windows"), not(target_os = "ios")))]
 extern crate gaol;

--- a/components/servo_arc/lib.rs
+++ b/components/servo_arc/lib.rs
@@ -22,6 +22,7 @@
 // The semantics of Arc are alread documented in the Rust docs, so we don't
 // duplicate those here.
 #![allow(missing_docs)]
+#![deny(warnings)]
 
 extern crate nodrop;
 #[cfg(feature = "servo")] extern crate serde;

--- a/components/size_of_test/lib.rs
+++ b/components/size_of_test/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 #[macro_export]
 macro_rules! size_of_test {
     ($testname: ident, $t: ty, $expected_size: expr) => {

--- a/components/style_derive/lib.rs
+++ b/components/style_derive/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(warnings)]
 #![recursion_limit = "128"]
 
 #[macro_use] extern crate darling;

--- a/components/style_traits/lib.rs
+++ b/components/style_traits/lib.rs
@@ -8,7 +8,7 @@
 
 #![crate_name = "style_traits"]
 #![crate_type = "rlib"]
-
+#![deny(warnings)]
 #![deny(unsafe_code, missing_docs)]
 
 extern crate app_units;

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 #![crate_name = "servo_url"]
 #![crate_type = "rlib"]

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -6,6 +6,7 @@
 #![crate_type = "rlib"]
 
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 extern crate base64;
 extern crate cookie as cookie_rs;

--- a/components/webvr/lib.rs
+++ b/components/webvr/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 extern crate canvas_traits;
 extern crate euclid;

--- a/components/webvr_traits/lib.rs
+++ b/components/webvr_traits/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![deny(warnings)]
 
 extern crate ipc_channel;
 extern crate msg;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
deny warnings for all crates as default
r? emilio 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19572 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19573)
<!-- Reviewable:end -->
