### PR TITLE
style: Move will-change outside of mako

### DIFF
--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -3619,11 +3619,11 @@ fn static_assert() {
         if self.gecko.mWillChange.len() == 0 {
             T::Auto
         } else {
-            T::AnimateableFeatures(
-                self.gecko.mWillChange.iter().map(|gecko_atom| {
-                    CustomIdent((gecko_atom.mRawPtr as *mut nsAtom).into())
-                }).collect()
-            )
+            let custom_idents: Vec<CustomIdent> = self.gecko.mWillChange.iter().map(|gecko_atom| {
+                CustomIdent((gecko_atom.mRawPtr as *mut nsAtom).into())
+            }).collect();
+
+            T::AnimateableFeatures(custom_idents.into_boxed_slice())
         }
     }
 

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -881,62 +881,14 @@ ${helpers.single_keyword("-moz-orient",
                           spec="Nonstandard (https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-orient)",
                           animation_value_type="discrete")}
 
-<%helpers:longhand name="will-change" products="gecko" animation_value_type="discrete"
-                   spec="https://drafts.csswg.org/css-will-change/#will-change">
-    use std::fmt;
-    use style_traits::ToCss;
-    use values::CustomIdent;
-
-    pub mod computed_value {
-        pub use super::SpecifiedValue as T;
-    }
-
-    #[derive(Clone, Debug, MallocSizeOf, PartialEq, ToComputedValue)]
-    pub enum SpecifiedValue {
-        Auto,
-        AnimateableFeatures(Vec<CustomIdent>),
-    }
-
-    impl ToCss for SpecifiedValue {
-        fn to_css<W>(&self, dest: &mut W) -> fmt::Result where W: fmt::Write {
-            match *self {
-                SpecifiedValue::Auto => dest.write_str("auto"),
-                SpecifiedValue::AnimateableFeatures(ref features) => {
-                    let (first, rest) = features.split_first().unwrap();
-                    first.to_css(dest)?;
-                    for feature in rest {
-                        dest.write_str(", ")?;
-                        feature.to_css(dest)?;
-                    }
-                    Ok(())
-                }
-            }
-        }
-    }
-
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        computed_value::T::Auto
-    }
-
-    /// auto | <animateable-feature>#
-    pub fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
-                         -> Result<SpecifiedValue, ParseError<'i>> {
-        if input.try(|input| input.expect_ident_matching("auto")).is_ok() {
-            Ok(computed_value::T::Auto)
-        } else {
-            input.parse_comma_separated(|i| {
-                let location = i.current_source_location();
-                CustomIdent::from_ident(location, i.expect_ident()?, &[
-                    "will-change",
-                    "none",
-                    "all",
-                    "auto",
-                ])
-            }).map(SpecifiedValue::AnimateableFeatures)
-        }
-    }
-</%helpers:longhand>
+${helpers.predefined_type(
+    "will-change",
+    "WillChange",
+    "computed::WillChange::auto()",
+    products="gecko",
+    animation_value_type="discrete",
+    spec="https://drafts.csswg.org/css-will-change/#will-change"
+)}
 
 ${helpers.predefined_type(
     "shape-image-threshold", "Opacity", "0.0",

--- a/components/style/values/computed/box.rs
+++ b/components/style/values/computed/box.rs
@@ -9,7 +9,8 @@ use values::computed::length::LengthOrPercentage;
 use values::generics::box_::AnimationIterationCount as GenericAnimationIterationCount;
 use values::generics::box_::VerticalAlign as GenericVerticalAlign;
 
-pub use values::specified::box_::{AnimationName, OverflowClipBox, OverscrollBehavior, ScrollSnapType};
+pub use values::specified::box_::{AnimationName, OverflowClipBox, OverscrollBehavior};
+pub use values::specified::box_::{ScrollSnapType, WillChange};
 
 /// A computed value for the `vertical-align` property.
 pub type VerticalAlign = GenericVerticalAlign<LengthOrPercentage>;

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -41,7 +41,7 @@ pub use self::font::{FontFamily, FontLanguageOverride, FontVariantSettings, Font
 pub use self::font::{FontVariantLigatures, FontVariantNumeric, FontFeatureSettings};
 pub use self::font::{MozScriptLevel, MozScriptMinSize, MozScriptSizeMultiplier, XTextZoom, XLang};
 pub use self::box_::{AnimationIterationCount, AnimationName, OverscrollBehavior};
-pub use self::box_::{OverflowClipBox, ScrollSnapType, VerticalAlign};
+pub use self::box_::{OverflowClipBox, ScrollSnapType, VerticalAlign, WillChange};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};
 pub use self::flex::FlexBasis;

--- a/components/style/values/specified/box.rs
+++ b/components/style/values/specified/box.rs
@@ -9,6 +9,7 @@ use cssparser::Parser;
 use parser::{Parse, ParserContext};
 use std::fmt;
 use style_traits::{ParseError, ToCss};
+use values::CustomIdent;
 use values::KeyframesName;
 use values::generics::box_::AnimationIterationCount as GenericAnimationIterationCount;
 use values::generics::box_::VerticalAlign as GenericVerticalAlign;
@@ -130,3 +131,49 @@ define_css_keyword_enum! { OverflowClipBox:
     "content-box" => ContentBox,
 }
 add_impls_for_keyword_enum!(OverflowClipBox);
+
+#[derive(Clone, Debug, MallocSizeOf, PartialEq, ToComputedValue, ToCss)]
+/// Provides a rendering hint to the user agent,
+/// stating what kinds of changes the author expects
+/// to perform on the element
+///
+/// <https://drafts.csswg.org/css-will-change/#will-change>
+pub enum WillChange {
+    /// Expresses no particular intent
+    Auto,
+    #[css(comma, iterable)]
+    /// <custom-ident>
+    AnimateableFeatures(Box<[CustomIdent]>),
+}
+
+impl WillChange {
+    #[inline]
+    /// Get default value of `will-change` as `auto`
+    pub fn auto() -> WillChange {
+        WillChange::Auto
+    }
+}
+
+impl Parse for WillChange {
+    /// auto | <animateable-feature>#
+    fn parse<'i, 't>(
+        _context: &ParserContext,
+        input: &mut Parser<'i, 't>
+    ) -> Result<WillChange, ParseError<'i>> {
+        if input.try(|input| input.expect_ident_matching("auto")).is_ok() {
+            return Ok(WillChange::Auto);
+        }
+
+        let custom_idents = input.parse_comma_separated(|i| {
+            let location = i.current_source_location();
+            CustomIdent::from_ident(location, i.expect_ident()?, &[
+                "will-change",
+                "none",
+                "all",
+                "auto",
+            ])
+        })?;
+
+        Ok(WillChange::AnimateableFeatures(custom_idents.into_boxed_slice()))
+    }
+}

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -35,7 +35,7 @@ pub use self::font::{FontFamily, FontLanguageOverride, FontVariantSettings, Font
 pub use self::font::{FontVariantLigatures, FontVariantNumeric, FontFeatureSettings};
 pub use self::font::{MozScriptLevel, MozScriptMinSize, MozScriptSizeMultiplier, XTextZoom, XLang};
 pub use self::box_::{AnimationIterationCount, AnimationName, OverscrollBehavior};
-pub use self::box_::{OverflowClipBox, ScrollSnapType, VerticalAlign};
+pub use self::box_::{OverflowClipBox, ScrollSnapType, VerticalAlign, WillChange};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};
 pub use self::effects::{BoxShadow, Filter, SimpleShadow};
 pub use self::flex::FlexBasis;

--- a/components/style_derive/to_css.rs
+++ b/components/style_derive/to_css.rs
@@ -27,7 +27,7 @@ pub fn derive(input: DeriveInput) -> Tokens {
 
         let mut expr = if !bindings.is_empty() {
             let mut expr = quote! {};
-            if variant_attrs.function && variant_attrs.iterable {
+            if variant_attrs.iterable {
                 assert_eq!(bindings.len(), 1);
                 let binding = &bindings[0];
                 expr = quote! {


### PR DESCRIPTION
This is a sub-PR of #19015 
r? emilio 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #19582 
- [x] These changes do not require tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19583)
<!-- Reviewable:end -->
