### PR TITLE
remove unused `self` in canvas_paint_thread

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -11,7 +11,7 @@ use azure::azure_hl::SurfacePattern;
 use canvas_traits::canvas::*;
 use cssparser::RGBA;
 use euclid::{Transform2D, Point2D, Vector2D, Rect, Size2D};
-use ipc_channel::ipc::{self, IpcSender, IpcReceiver};
+use ipc_channel::ipc::{IpcSender, IpcReceiver};
 use num_traits::ToPrimitive;
 use std::borrow::ToOwned;
 use std::mem;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
```
Compiling canvas v0.0.1 (file:///Users/tigercosmos/servo/components/canvas)
warning: unused import: `self`
  --> components/canvas/canvas_paint_thread.rs:14:24
   |
14 | use ipc_channel::ipc::{self, IpcSender, IpcReceiver};
   |                        ^^^^
   |
   = note: #[warn(unused_imports)] on by default
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19585)
<!-- Reviewable:end -->
