### PR TITLE
let mutation testing display diff if compilation fails

### DIFF
--- a/python/servo/mutation/test.py
+++ b/python/servo/mutation/test.py
@@ -42,8 +42,11 @@ def mutation_test(file_name, tests):
             if mutated_line != -1:
                 logging.info("Mutated {0} at line {1}".format(file_name, mutated_line))
                 logging.info("compiling mutant {0}:{1}".format(file_name, mutated_line))
-                if subprocess.call('python mach build --release', shell=True, stdout=DEVNULL):
+                test_command = "python mach build --release"
+                if subprocess.call(test_command, shell=True, stdout=DEVNULL):
                     logging.error("Compilation Failed: Unexpected error")
+                    logging.error("Failed: while running `{0}`".format(test_command))
+                    subprocess.call('git --no-pager diff {0}'.format(file_name), shell=True)
                     status = Status.UNEXPECTED
                 else:
                     for test in tests:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

let mutation testing display diff if compilation fails

r? @jdm

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19566 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19586)
<!-- Reviewable:end -->
