### PR TITLE
remove unused `Auto` in test of serialization

### DIFF
--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -6,7 +6,7 @@ use properties::{parse, parse_input};
 use style::computed_values::display::T as Display;
 use style::properties::{PropertyDeclaration, Importance};
 use style::properties::parse_property_declaration_list;
-use style::values::{CustomIdent, RGBA, Auto};
+use style::values::{CustomIdent, RGBA};
 use style::values::generics::flex::FlexBasis;
 use style::values::specified::{BorderStyle, BorderSideWidth, Color};
 use style::values::specified::{Length, LengthOrPercentage, LengthOrPercentageOrAuto};


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
```
warning: unused import: `Auto`
 --> /Users/tigercosmos/servo/tests/unit/style/properties/serialization.rs:9:40
  |
9 | use style::values::{CustomIdent, RGBA, Auto};
  |                                        ^^^^
  |
  = note: #[warn(unused_imports)] on by default
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19589)
<!-- Reviewable:end -->
