### PR TITLE
Revert canvas IPC changes

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -11,7 +11,7 @@ use azure::azure_hl::SurfacePattern;
 use canvas_traits::canvas::*;
 use cssparser::RGBA;
 use euclid::{Transform2D, Point2D, Vector2D, Rect, Size2D};
-use ipc_channel::ipc::{IpcSender, IpcReceiver};
+use ipc_channel::ipc::{self, IpcSender, IpcReceiver};
 use num_traits::ToPrimitive;
 use std::borrow::ToOwned;
 use std::mem;
@@ -118,8 +118,9 @@ impl<'a> CanvasPaintThread<'a> {
     /// communicate with it.
     pub fn start(size: Size2D<i32>,
                  webrender_api_sender: webrender_api::RenderApiSender,
-                 antialias: bool,
-                 receiver: IpcReceiver<CanvasMsg>) {
+                 antialias: bool)
+                 -> IpcSender<CanvasMsg> {
+        let (sender, receiver) = ipc::channel::<CanvasMsg>().unwrap();
         let antialias = if antialias {
             AntialiasMode::Default
         } else {
@@ -215,6 +216,8 @@ impl<'a> CanvasPaintThread<'a> {
                 }
             }
         }).expect("Thread spawning failed");
+
+        sender
     }
 
     fn save_context_state(&mut self) {

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -129,10 +129,11 @@ impl CanvasRenderingContext2D {
                          size: Size2D<i32>)
                          -> CanvasRenderingContext2D {
         debug!("Creating new canvas rendering context.");
-        let (ipc_renderer, receiver) = ipc::channel::<CanvasMsg>().unwrap();
+        let (sender, receiver) = ipc::channel().unwrap();
         let script_to_constellation_chan = global.script_to_constellation_chan();
         debug!("Asking constellation to create new canvas thread.");
-        script_to_constellation_chan.send(ScriptMsg::CreateCanvasPaintThread(size, receiver)).unwrap();
+        script_to_constellation_chan.send(ScriptMsg::CreateCanvasPaintThread(size, sender)).unwrap();
+        let ipc_renderer = receiver.recv().unwrap();
         debug!("Done.");
         CanvasRenderingContext2D {
             reflector_: Reflector::new(),

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -79,7 +79,7 @@ pub enum ScriptMsg {
     ChangeRunningAnimationsState(AnimationState),
     /// Requests that a new 2D canvas thread be created. (This is done in the constellation because
     /// 2D canvases may use the GPU and we don't want to give untrusted content access to the GPU.)
-    CreateCanvasPaintThread(Size2D<i32>, IpcReceiver<CanvasMsg>),
+    CreateCanvasPaintThread(Size2D<i32>, IpcSender<IpcSender<CanvasMsg>>),
     /// Notifies the constellation that this frame has received focus.
     Focus,
     /// Forward an event that was sent to the parent window.


### PR DESCRIPTION
https://github.com/servo/servo/pull/19547 is responsible for the surge of new intermittent timeouts in canvas-related tests. There's nothing wrong with the change, so I suspect an underlying problem in ipc-channel instead.

Fixes #19592. Fixes #19593. Fixes #19594. Fixes #19597.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19599)
<!-- Reviewable:end -->
