### PR TITLE
style: Don't adjust :visited styles.

### DIFF
--- a/components/style/style_adjuster.rs
+++ b/components/style/style_adjuster.rs
@@ -557,6 +557,15 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
         layout_parent_style: &ComputedValues,
         flags: CascadeFlags,
     ) {
+        // Don't adjust visited styles, visited-dependent properties aren't
+        // affected by these adjustments and it'd be just wasted work anyway.
+        //
+        // It also doesn't make much sense to adjust them, since we don't
+        // cascade most properties anyway, and they wouldn't be looked up.
+        if flags.contains(CascadeFlags::VISITED_DEPENDENT_ONLY) {
+            return;
+        }
+
         self.adjust_for_visited(flags);
         #[cfg(feature = "gecko")]
         {


### PR DESCRIPTION
As the comment says those are not interesting, and it matches what we do for
text and placeholders in Servo_ComputedValues_Inherit.

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1425893

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19601)
<!-- Reviewable:end -->
