### PR TITLE
hashglobe: Dump the requested aligment if out of memory while allocating a table

### DIFF
--- a/components/hashglobe/src/lib.rs
+++ b/components/hashglobe/src/lib.rs
@@ -27,16 +27,24 @@ trait Recover<Q: ?Sized> {
 }
 
 #[derive(Debug)]
+pub struct AllocationInfo {
+    /// The size we are requesting.
+    size: usize,
+    /// The alignment we are requesting.
+    alignment: usize,
+}
+
+#[derive(Debug)]
 pub struct FailedAllocationError {
     reason: &'static str,
-    /// The size we are allocating, if needed.
-    allocation_size: Option<usize>,
+    /// The allocation info we are requesting, if needed.
+    allocation_info: Option<AllocationInfo>,
 }
 
 impl FailedAllocationError {
     #[inline]
     pub fn new(reason: &'static str) -> Self {
-        Self { reason, allocation_size: None }
+        Self { reason, allocation_info: None }
     }
 }
 
@@ -48,8 +56,10 @@ impl error::Error for FailedAllocationError {
 
 impl fmt::Display for FailedAllocationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.allocation_size {
-            Some(size) => write!(f, "{}, allocation size: {}", self.reason, size),
+        match self.allocation_info {
+            Some(ref info) => {
+                write!(f, "{}, allocation: (size: {}, alignment: {})", self.reason, info.size, info.alignment)
+            },
             None => self.reason.fmt(f),
         }
     }

--- a/components/hashglobe/src/table.rs
+++ b/components/hashglobe/src/table.rs
@@ -778,9 +778,10 @@ impl<K, V> RawTable<K, V> {
         let buffer = alloc(size, alignment);
 
         if buffer.is_null() {
+            use AllocationInfo;
             return Err(FailedAllocationError {
                 reason: "out of memory when allocating RawTable",
-                allocation_size: Some(size),
+                allocation_info: Some(AllocationInfo { size, alignment }),
             });
         }
 


### PR DESCRIPTION
This is for Bug 1418806 and Bug 1416903. We need not only the requested size
but also the requested alignment for debugging.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19607)
<!-- Reviewable:end -->
