### PR TITLE
style: Remove needless and bogus bounds-check.

### DIFF
--- a/components/style/gecko_bindings/sugar/ns_style_auto_array.rs
+++ b/components/style/gecko_bindings/sugar/ns_style_auto_array.rs
@@ -15,9 +15,6 @@ use std::slice::{Iter, IterMut};
 impl<T> Index<usize> for nsStyleAutoArray<T> {
     type Output = T;
     fn index(&self, index: usize) -> &T {
-        if index > self.len() {
-            panic!("out of range")
-        }
         match index {
             0 => &self.mFirstElement,
             _ => &self.mOtherElements[index - 1],
@@ -27,9 +24,6 @@ impl<T> Index<usize> for nsStyleAutoArray<T> {
 
 impl<T> IndexMut<usize> for nsStyleAutoArray<T> {
     fn index_mut(&mut self, index: usize) -> &mut T {
-        if index > self.len() {
-            panic!("out of range")
-        }
         match index {
             0 => &mut self.mFirstElement,
             _ => &mut self.mOtherElements[index - 1],


### PR DESCRIPTION
The check should read index >= self.len(). But it doesn't matter anyway since
we're covered by Rust's bound checks by default anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19615)
<!-- Reviewable:end -->
