### PR TITLE
pretty print tree

### DIFF
--- a/components/gfx_traits/print_tree.rs
+++ b/components/gfx_traits/print_tree.rs
@@ -22,12 +22,21 @@ impl PrintTree {
         }
     }
 
-    /// Descend one level in the tree with the given title.
-    pub fn new_level(&mut self, title: String) {
+    /// Descend one level in the tree with the given title string.
+    pub fn new_level(&mut self, queued_title: String) {
         self.flush_queued_item("\u{251C}\u{2500}");
 
         self.print_level_prefix();
-        println!("\u{251C}\u{2500} {}", title);
+
+        let items: Vec<&str> = queued_title.split("\n").collect();
+        println!("\u{251C}\u{2500} {}", items[0]);
+        for i in 1..items.len() {
+            self.print_level_child_indentation();
+            print!("{}", items[i]);
+            if i < items.len() {
+                print!("\n");
+            }
+        }
 
         self.level = self.level + 1;
     }
@@ -35,7 +44,7 @@ impl PrintTree {
     /// Ascend one level in the tree.
     pub fn end_level(&mut self) {
         self.flush_queued_item("\u{2514}\u{2500}");
-        self.level = self.level - 1;
+        self.level -= 1;
     }
 
     /// Add an item to the current level in the tree.
@@ -50,10 +59,25 @@ impl PrintTree {
         }
     }
 
+    fn print_level_child_indentation(&self) {
+        for _ in 0..(self.level + 1) {
+            print!("\u{2502}  ");
+        }
+        print!("{}", " ".repeat(7));
+    }
+
     fn flush_queued_item(&mut self, prefix: &str) {
         if let Some(queued_item) = self.queued_item.take() {
             self.print_level_prefix();
-            println!("{} {}", prefix, queued_item);
+            let items: Vec<&str> = queued_item.split("\n").collect();
+            println!("{} {}", prefix, items[0]);
+            for i in 1..items.len() {
+                self.print_level_child_indentation();
+                print!("{}", items[i]);
+                if i < items.len() {
+                    print!("\n");
+                }
+            }
         }
     }
 }

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -2191,7 +2191,7 @@ impl Flow for BlockFlow {
     }
 
     fn print_extra_flow_children(&self, print_tree: &mut PrintTree) {
-        print_tree.add_item(format!("↑↑ Fragment for block: {:?}", self.fragment));
+        print_tree.add_item(format!("↑↑ Fragment for block:{:?}", self.fragment));
     }
 }
 

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -925,26 +925,29 @@ impl fmt::Debug for BaseFlow {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let child_count = self.parallel.children_count.load(Ordering::SeqCst);
         let child_count_string = if child_count > 0 {
-            format!(" children={}", child_count)
+            format!("\nchildren={}", child_count)
         } else {
             "".to_owned()
         };
 
         let absolute_descendants_string = if self.abs_descendants.len() > 0 {
-            format!(" abs-descendents={}", self.abs_descendants.len())
+            format!("\nabs-descendents={}", self.abs_descendants.len())
         } else {
             "".to_owned()
         };
 
         let damage_string = if self.restyle_damage != RestyleDamage::empty() {
-            format!(" damage={:?}", self.restyle_damage)
+            format!("\ndamage={:?}", self.restyle_damage)
         } else {
             "".to_owned()
         };
 
         write!(f,
-               "sc={:?} pos={:?}, {}{} floatspec-in={:?}, floatspec-out={:?}, \
-                overflow={:?}{}{}{}",
+               "\nsc={:?}\
+                \npos={:?}{}{}\
+                \nfloatspec-in={:?}\
+                \nfloatspec-out={:?}\
+                \noverflow={:?}{}{}{}",
                self.stacking_context_id,
                self.position,
                if self.flags.contains(FlowFlags::FLOATS_LEFT) { "FL" } else { "" },

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -2958,24 +2958,24 @@ impl Fragment {
 impl fmt::Debug for Fragment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let border_padding_string = if !self.border_padding.is_zero() {
-            format!(" border_padding={:?}", self.border_padding)
+            format!("\nborder_padding={:?}", self.border_padding)
         } else {
             "".to_owned()
         };
 
         let margin_string = if !self.margin.is_zero() {
-            format!(" margin={:?}", self.margin)
+            format!("\nmargin={:?}", self.margin)
         } else {
             "".to_owned()
         };
 
         let damage_string = if self.restyle_damage != RestyleDamage::empty() {
-            format!(" damage={:?}", self.restyle_damage)
+            format!("\ndamage={:?}", self.restyle_damage)
         } else {
             "".to_owned()
         };
 
-        write!(f, "{}({}) [{:?}] border_box={:?}{}{}{}",
+        write!(f, "\n{}({}) [{:?}]\nborder_box={:?}{}{}{}",
             self.specific.get_type(),
             self.debug_id,
             self.specific,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
```
│  │  │  │  │  │  │         floatspec-out=L 0px R 0px 
│  │  │  │  │  │  │         overflow=Overflow { scroll: TypedRect(0px×0px at (0px,0px)), paint: TypedRect(0px×0px at (0px,0px)) }
│  │  │  │  │  │  │         damage=BUBBLE_ISIZES
│  │  │  │  │  │  │  └─ ↑↑ Fragment for block:
│  │  │  │  │  │  │  │         SpecificFragmentInfo::Table(2671) []
│  │  │  │  │  │  │  │         border_box=LogicalRect(H LTR, i0px×b0px, @ (i0px,b0px))
│  │  │  │  │  │  │  │         damage=REPOSITION | STORE_OVERFLOW | BUBBLE_ISIZES | REFLOW_OUT_OF_FLOW | REFLOW
│  │  │  │  ├─ Block(1268a9710) 
│  │  │  │  │         sc=StackingContextId(0)
│  │  │  │  │         pos=LogicalRect(H LTR, i720px×b36px, @ (i152px,b2636.883333333333px))
│  │  │  │  │         floatspec-in=L 0px R 0px
│  │  │  │  │         floatspec-out=L 0px R 0px 
│  │  │  │  │         overflow=Overflow { scroll: TypedRect(750px×36px at (-15px,0px)), paint: TypedRect(750px×36px at (-15px,0px)) }
│  │  │  │  │         children=1
│  │  │  │  │         damage=BUBBLE_ISIZES
│  │  │  │  │  ├─ ↑↑ Fragment for block:
│  │  │  │  │  │         SpecificFragmentInfo::Generic(2673) []
│  │  │  │  │  │         border_box=LogicalRect(H LTR, i720px×b36px, @ (i0px,b0px))
│  │  │  │  │  │         border_padding=LogicalMargin(H LTR, i:0px..0px b:6px..0px)
│  │  │  │  │  │         damage=REPOSITION | STORE_OVERFLOW
│  │  │  │  │  ├─ Block(128554f10) 
│  │  │  │  │  │         sc=StackingContextId(0)
│  │  │  │  │  │         pos=LogicalRect(H LTR, i750px×b30px, @ (i0px,b6px))
│  │  │  │  │  │         floatspec-in=L 0px R 0px
│  │  │  │  │  │         floatspec-out=L 0px R 0px 
│  │  │  │  │  │         overflow=Overflow { scroll: TypedRect(750px×30px at (-15px,0px)), paint: TypedRect(750px×30px at (-15px,0px)) }
│  │  │  │  │  │         children=6
│  │  │  │  │  │         damage=BUBBLE_ISIZES
│  │  │  │  │  │  ├─ ↑↑ Fragment for block:
│  │  │  │  │  │  │         SpecificFragmentInfo::Generic(2361) []
│  │  │  │  │  │  │         border_box=LogicalRect(H LTR, i750px×b30px, @ (i-15px,b0px))
│  │  │  │  │  │  │         margin=LogicalMargin(H LTR, i:-15px..-15px b:0px..0px)
│  │  │  │  │  │  │         damage=REPOSITION | STORE_OVERFLOW
│  │  │  │  │  │  ├─ TableWrapperFlow: Block(128555410) 
│  │  │  │  │  │  │         sc=StackingContextId(0)
│  │  │  │  │  │  │         pos=LogicalRect(H LTR, i750px×b0px, @ (i-15px,b0px))
│  │  │  │  │  │  │         floatspec-in=L 0px R 0px
│  │  │  │  │  │  │         floatspec-out=L 0px R 0px 
│  │  │  │  │  │  │         overflow=Overflow { scroll: TypedRect(0px×0px at (0px,0px)), paint: TypedRect(0px×0px at (0px,0px)) }
│  │  │  │  │  │  │         children=1
│  │  │  │  │  │  │         damage=BUBBLE_ISIZES
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12675 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19622)
<!-- Reviewable:end -->
