### PR TITLE
Paint worklets: Add pref for blocking sleep to be enabled for wpt tests

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -72459,7 +72459,7 @@
    "reftest"
   ],
   "mozilla/worklets/test_paint_worklet_timeout.js": [
-   "83cdbd59c905de898b72ba47d3ae10bb95d76301",
+   "3e4ff24fc85ad2956b741ff1785cecfb9641d792",
    "support"
   ],
   "mozilla/worklets/test_paint_worklet_timeout_ref.html": [

--- a/tests/wpt/mozilla/meta/mozilla/worklets/__dir__.ini
+++ b/tests/wpt/mozilla/meta/mozilla/worklets/__dir__.ini
@@ -1,1 +1,1 @@
-prefs: [dom.worklet.enabled:true]
+prefs: [dom.worklet.enabled:true,dom.worklet.blockingsleep.enabled:true]

--- a/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_timeout.js
+++ b/tests/wpt/mozilla/tests/mozilla/worklets/test_paint_worklet_timeout.js
@@ -1,7 +1,12 @@
 registerPaint("testgreen", class {
     paint(ctx, size) {
+        try {
+            sleep(30); // too long for a paintworklet to init
+        } catch (e) {
+            console.log("Problem sleeping: " + e);
+        }
+        // should fail if control reaches here before timeout
         ctx.fillStyle = 'green';
         ctx.fillRect(0, 0, size.width, size.height);
-        sleep(30); // too long for a paintworklet to init
     }
 });


### PR DESCRIPTION
In aa48a2c2e3c7699a167d9ffe791f4bb17e9b9f1c I added a timeout for paint
worklet threads. However, the test was broken. The blocking sleep
function that was implemented as part of that commit was guarded behind
the `dom.worklet.blockingsleep.enabled` pref, and while I ran the
wpt-tests with that pref enabled, the test runner for sure did not.
I tried running the test _without_ the pref enabled, and the tests still
pass. This is because even the reference in that reftest is that of
a broken image background, and *both* the paintworklet thread timing out
and `sleep()` not being in scope would render the same thing: a broken
image, which compares equal to the reference.

This patch makes sure that now the pref is enabled for wpt worklet
tests, and that such we can distinguish an actual timeout (test pass)
from an unexpected situation (when we should fail the test).

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #__ (github issue number if applicable). (*not applicable*)

<!-- Either: -->
- [] There are tests for these changes OR
- [X] These changes do not require tests because this patch fixes a broken test.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19630)
<!-- Reviewable:end -->
