### PR TITLE
Root sequence<any> params using CustomAutoRooter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
  "cssparser 0.23.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashglobe 0.1.0",
- "mozjs 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mozjs 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_arc 0.0.1",
  "smallbitvec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1862,7 +1862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mozjs"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2586,7 +2586,7 @@ dependencies = [
  "mime 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mitochondria 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "mozjs 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mozjs 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
  "nonzero 0.0.1",
@@ -3896,7 +3896,7 @@ dependencies = [
 "checksum mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9e965267d4d58496fc4f740e9861118367f13570cadf66316ed2c3f2f14d87c7"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum mitochondria 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9de3eca27871df31c33b807f834b94ef7d000956f57aa25c5aed9c5f0aae8f6f"
-"checksum mozjs 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9935bada5ea5d70291f21cce7b1bbad507edea12590ebe9cfb6b665fb716480"
+"checksum mozjs 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2cd8370617e9a151ed9e7b49f38092075d0ae80bdf9f1dcd807a60cc9c3b7151"
 "checksum mozjs_sys 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef1e24df9f76502cd4459919098ec1ac3af75ce694ec5b8837aa91f69f2ad0eb"
 "checksum mp3-metadata 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ab5f1d2693586420208d1200ce5a51cd44726f055b635176188137aff42c7de"
 "checksum mp4parse 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f821e3799bc0fd16d9b861fb02fa7ee1b5fba29f45ad591dade105c48ca9a1a0"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -65,7 +65,7 @@ metrics = {path = "../metrics"}
 mitochondria = "1.1.2"
 mime = "0.2.1"
 mime_guess = "1.8.0"
-mozjs = { version = "0.1.9", features = ["promises"]}
+mozjs = { version = "0.1.10", features = ["promises"]}
 msg = {path = "../msg"}
 net_traits = {path = "../net_traits"}
 nonzero = {path = "../nonzero"}

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -38,6 +38,7 @@ use dom_struct::dom_struct;
 use js::jsapi::{HandleObject, HandleValue, Heap, JSContext, JSObject};
 use js::jsapi::{JS_NewPlainObject, JS_NewUint8ClampedArray};
 use js::jsval::{JSVal, NullValue};
+use js::rust::CustomAutoRooterGuard;
 use script_traits::MsDuration;
 use servo_config::prefs::PREFS;
 use std::borrow::ToOwned;
@@ -449,6 +450,14 @@ impl TestBindingMethods for TestBinding {
     fn PassCallbackFunction(&self, _: Rc<Function>) {}
     fn PassCallbackInterface(&self, _: Rc<EventListener>) {}
     fn PassSequence(&self, _: Vec<i32>) {}
+    #[allow(unsafe_code)]
+    unsafe fn PassAnySequence(&self, _: *mut JSContext, _: CustomAutoRooterGuard<Vec<JSVal>>) {}
+    #[allow(unsafe_code)]
+    unsafe fn AnySequencePassthrough(&self, _: *mut JSContext, seq: CustomAutoRooterGuard<Vec<JSVal>>) -> Vec<JSVal> {
+        (*seq).clone()
+    }
+    #[allow(unsafe_code)]
+    unsafe fn PassObjectSequence(&self, _: *mut JSContext, _: CustomAutoRooterGuard<Vec<*mut JSObject>>) {}
     fn PassStringSequence(&self, _: Vec<DOMString>) {}
     fn PassInterfaceSequence(&self, _: Vec<DomRoot<Blob>>) {}
 

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -263,6 +263,9 @@ interface TestBinding {
   void passCallbackFunction(Function fun);
   void passCallbackInterface(EventListener listener);
   void passSequence(sequence<long> seq);
+  void passAnySequence(sequence<any> seq);
+  sequence<any> anySequencePassthrough(sequence<any> seq);
+  void passObjectSequence(sequence<object> seq);
   void passStringSequence(sequence<DOMString> seq);
   void passInterfaceSequence(sequence<Blob> seq);
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -32845,6 +32845,12 @@
      {}
     ]
    ],
+   "mozilla/custom_auto_rooter.html": [
+    [
+     "/_mozilla/mozilla/custom_auto_rooter.html",
+     {}
+    ]
+   ],
    "mozilla/deep_serialization_succeeds.html": [
     [
      "/_mozilla/mozilla/deep_serialization_succeeds.html",
@@ -66035,6 +66041,10 @@
   "mozilla/css-paint-api/valid-image-before-load.html": [
    "67d8cdd3e3a1656ba315fcbf6dae7236680bac16",
    "reftest"
+  ],
+  "mozilla/custom_auto_rooter.html": [
+   "3466095fb0846b848c948dd1596764fff456fa9b",
+   "testharness"
   ],
   "mozilla/deep_serialization_succeeds.html": [
    "cb3d201d577c17d19babf1f6c04ba882fa42048e",

--- a/tests/wpt/mozilla/meta/mozilla/custom_auto_rooter.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/custom_auto_rooter.html.ini
@@ -1,0 +1,3 @@
+[custom_auto_rooter.html]
+  type: testharness
+  prefs: [dom.testbinding.enabled:true]

--- a/tests/wpt/mozilla/tests/mozilla/custom_auto_rooter.html
+++ b/tests/wpt/mozilla/tests/mozilla/custom_auto_rooter.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<meta charset="utf-8">
+<title>Types using Custom Auto Rooter work correctly</title>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<script>
+test(function() {
+  var t = new TestBinding;
+
+  var seq = [5, "str", { key: "val" }, undefined];
+  assert_array_equals(seq, t.anySequencePassthrough(seq), "Returned simple array is the same");
+
+  var seq = new Array(null, {'inner': 1, 'a': 'as'}, {'inner': 2}, null, undefined);
+  assert_array_equals(seq, t.anySequencePassthrough(seq), "Returned array using new Array is the same");
+
+  var seq = new Array(null, {'inner': 1, 'a': 'as', 'toString': function() { seq = null; return Object.prototype.toString(this); }}, {'inner': 2}, null, undefined);
+  assert_array_equals(seq, t.anySequencePassthrough(seq), "Returned array with closure member is the same");
+}, "sequence<any> conversion did not lose any values");
+</script>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Attempt at https://github.com/servo/servo/issues/16678. At the moment this pulls an external [remove-handle-conv](https://github.com/Xanewok/rust-mozjs/tree/remove-handle-conv) branch for rust-mozjs (removing `FromJSValConvertible` implementation for `HandleValue` and adding one for `*mut JSObject`)

In short, this roots the `sequence<any>` and `sequence<object>` function arguments using `CustomAutoRooter` (introduced in https://github.com/servo/rust-mozjs/pull/382).

As per https://github.com/servo/servo/issues/16678#issuecomment-302224110 the underlying vector contains raw gc thing pointers instead of handles. To do that, this introduces new possible `isMember = "AutoRoot"` value in CodegenRust.py.
The rooted argument is passed to a function wrapped in a `CustomAutoRooterGuard` [RAII root guard](https://github.com/servo/rust-mozjs/blob/ed5e37a288b5738d9b571b8100b4a22a2c00f075/src/rust.rs#L586-L588) (e.g. as `CustomAutoRooterGuard<Vec<JSVal>>`)

I felt quite out of my depth when trying to adapt CodegenRust.py code, so I'd appreciate any help with how can be done better/in a more clean manner.
Also the name `CustomAutoRooterGuard` is quite lengthy, so I'm also open to changing it (`AutoRoot`? `AutoRootGuard`?)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [x] These changes fix #16678  (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19644)
<!-- Reviewable:end -->
