### PR TITLE
Fix division by zero in gradient stop calculation

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -798,6 +798,7 @@ fn convert_gradient_stops(gradient_items: &[GradientItem],
                 position_to_offset(position, total_length)
             }
         };
+        assert!(offset.is_finite());
         stops.push(GradientStop {
             offset: offset,
             color: stop.color.to_gfx_color()
@@ -3271,6 +3272,9 @@ struct StopRun {
 }
 
 fn position_to_offset(position: LengthOrPercentage, total_length: Au) -> f32 {
+    if total_length == Au(0) {
+        return 0.0
+    }
     match position {
         LengthOrPercentage::Length(l) => l.to_i32_au() as f32 / total_length.0 as f32,
         LengthOrPercentage::Percentage(percentage) => percentage.0 as f32,

--- a/tests/wpt/web-platform-tests/css/css-images/gradient-crash-ref.html
+++ b/tests/wpt/web-platform-tests/css/css-images/gradient-crash-ref.html
@@ -1,0 +1,1 @@
+<!--intentionally blank-->

--- a/tests/wpt/web-platform-tests/css/css-images/gradient-crash.html
+++ b/tests/wpt/web-platform-tests/css/css-images/gradient-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Does this gradient crash the browser?</title>
+<link rel="match" href="gradient-crash-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-images-3/#color-stop-syntax">
+<meta name="assert" content="Gradients with total length zero and absolute positioned stops do not crash.">
+<style>
+  div {
+    background: linear-gradient(black 0,white);
+  }
+</style>
+<div></div>


### PR DESCRIPTION
Check if total_length is zero and return 0.0 instead
of NaN in this case.

Closes #18435

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #18435 (github issue number if applicable).

<!-- Either: -->
- [x] There are tests for these changes OR
- [x] These changes do not require tests because simple bugfix/no idea for good test

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19652)
<!-- Reviewable:end -->
