### PR TITLE
Remove solved FIXMEs about border radii

### DIFF
--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -775,8 +775,6 @@ pub struct NormalBorder {
     pub style: SideOffsets2D<border_style::T>,
 
     /// Border radii.
-    ///
-    /// TODO(pcwalton): Elliptical radii.
     pub radius: BorderRadii<Au>,
 }
 
@@ -845,8 +843,6 @@ pub struct BorderDisplayItem {
 }
 
 /// Information about the border radii.
-///
-/// TODO(pcwalton): Elliptical radii.
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub struct BorderRadii<T> {
     pub top_left: Size2D<T>,

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -1544,7 +1544,6 @@ impl FragmentDisplayListBuilding for Fragment {
                 Au::from(box_shadow.spread),
             );
 
-            // TODO(pcwalton): Multiple border radii; elliptical border radii.
             let base = state.create_base_display_item(&bounds,
                                                       LocalClip::from(clip.to_rectf()),
                                                       self.node,


### PR DESCRIPTION
 cc pcwalton 

cgaebel: Is this [comment] still accurate?

    // TODO(cgaebel): Support border radii even in the case of multiple border widths.
    // This is an extension of supporting elliptical radii. For now, all percentage
    // radii will be relative to the width.

[comment]: https://github.com/servo/servo/blob/446536b9c34b331f5466bfb212be8cb1faa2dee8/components/layout/display_list_builder.rs#L659-L661

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19655)
<!-- Reviewable:end -->
