### PR TITLE
style: Simplify ::-moz-fieldset-content special-casing.

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -3084,9 +3084,6 @@ bitflags! {
         /// content.
         const PROHIBIT_DISPLAY_CONTENTS = 1 << 4;
 
-        /// Whether we're styling the ::-moz-fieldset-content anonymous box.
-        const IS_FIELDSET_CONTENT = 1 << 5;
-
         /// Whether we're computing the style of a link, either visited or
         /// unvisited.
         const IS_LINK = 1 << 6;

--- a/components/style/style_adjuster.rs
+++ b/components/style/style_adjuster.rs
@@ -343,12 +343,12 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
     fn adjust_for_fieldset_content(
         &mut self,
         layout_parent_style: &ComputedValues,
-        flags: CascadeFlags,
     ) {
-        use properties::CascadeFlags;
-        if !flags.contains(CascadeFlags::IS_FIELDSET_CONTENT) {
-            return;
+        match self.style.pseudo {
+            Some(ref p) if p.is_fieldset_content() => {},
+            _ => return,
         }
+
         debug_assert_eq!(self.style.get_box().clone_display(), Display::Block);
         // TODO We actually want style from parent rather than layout
         // parent, so that this fixup doesn't happen incorrectly when
@@ -570,7 +570,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
         #[cfg(feature = "gecko")]
         {
             self.adjust_for_prohibited_display_contents(flags);
-            self.adjust_for_fieldset_content(layout_parent_style, flags);
+            self.adjust_for_fieldset_content(layout_parent_style);
         }
         self.adjust_for_top_layer();
         self.blockify_if_necessary(layout_parent_style, flags);

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1987,10 +1987,6 @@ pub extern "C" fn Servo_ComputedValues_GetForAnonymousBox(parent_style_or_null: 
     let pseudo = PseudoElement::from_anon_box_atom(&atom)
         .expect("Not an anon box pseudo?");
 
-    let mut cascade_flags = CascadeFlags::SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP;
-    if pseudo.is_fieldset_content() {
-        cascade_flags.insert(CascadeFlags::IS_FIELDSET_CONTENT);
-    }
     let metrics = get_metrics_provider_for_product();
 
     // If the pseudo element is PageContent, we should append the precomputed
@@ -2023,6 +2019,7 @@ pub extern "C" fn Servo_ComputedValues_GetForAnonymousBox(parent_style_or_null: 
         page_decls,
     );
 
+    let cascade_flags = CascadeFlags::SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP;
     data.stylist.precomputed_values_for_pseudo_with_rule_node(
         &guards,
         &pseudo,
@@ -3639,11 +3636,8 @@ pub extern "C" fn Servo_ReparentStyle(
             cascade_flags.insert(CascadeFlags::PROHIBIT_DISPLAY_CONTENTS);
         }
     }
-    if let Some(pseudo) = pseudo.as_ref() {
+    if pseudo.is_some() {
         cascade_flags.insert(CascadeFlags::PROHIBIT_DISPLAY_CONTENTS);
-        if pseudo.is_fieldset_content() {
-            cascade_flags.insert(CascadeFlags::IS_FIELDSET_CONTENT);
-        }
     }
 
     doc_data.stylist.compute_style_with_inputs(


### PR DESCRIPTION
The style adjuster knows about the pseudo, so there's no reason to thread that
info down.

There are more simplifications that can be done in followups, cleaning a bit the
cascade flags too, those will come later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19661)
<!-- Reviewable:end -->
