### PR TITLE
style_derive: Support parse-time aliases.

### DIFF
--- a/components/style_derive/lib.rs
+++ b/components/style_derive/lib.rs
@@ -39,7 +39,7 @@ pub fn derive_to_animated_value(stream: TokenStream) -> TokenStream {
     to_animated_value::derive(input).to_string().parse().unwrap()
 }
 
-#[proc_macro_derive(Parse)]
+#[proc_macro_derive(Parse, attributes(parse))]
 pub fn derive_parse(stream: TokenStream) -> TokenStream {
     let input = syn::parse_derive_input(&stream.to_string()).unwrap();
     parse::derive(input).to_string().parse().unwrap()


### PR DESCRIPTION
This will allow #19659 to use derive on display using:

    #[parse(aliases = "-webkit-flex")]
    Flex,
    #[parse(aliases = "-webkit-inline-flex")]
    InlineFlex,

And such.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19665)
<!-- Reviewable:end -->
