### PR TITLE
style: Simplify the skip item based display fixup adjustment.

### DIFF
--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -460,10 +460,6 @@ impl<'le> TElement for ServoLayoutElement<'le> {
         }
     }
 
-    fn skip_root_and_item_based_display_fixup(&self) -> bool {
-        false
-    }
-
     unsafe fn set_selector_flags(&self, flags: ElementSelectorFlags) {
         self.element.insert_selector_flags(flags);
     }

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -670,11 +670,6 @@ pub trait TElement
         self.get_data().map(|x| x.borrow_mut())
     }
 
-    /// Whether we should skip any root- or item-based display property
-    /// blockification on this element.  (This function exists so that Gecko
-    /// native anonymous content can opt out of this style fixup.)
-    fn skip_root_and_item_based_display_fixup(&self) -> bool;
-
     /// Sets selector flags, which indicate what kinds of selectors may have
     /// matched on this element and therefore what kind of work may need to
     /// be performed when DOM state changes.

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -1255,19 +1255,6 @@ impl<'le> TElement for GeckoElement<'le> {
         }
     }
 
-    #[inline]
-    fn skip_root_and_item_based_display_fixup(&self) -> bool {
-        if !self.is_native_anonymous() {
-            return false;
-        }
-
-        if let Some(p) = self.implemented_pseudo_element() {
-            return p.skip_item_based_display_fixup();
-        }
-
-        self.is_root_of_native_anonymous_subtree()
-    }
-
     unsafe fn set_selector_flags(&self, flags: ElementSelectorFlags) {
         debug_assert!(!flags.is_empty());
         self.set_flags(selector_flags_to_node_flags(flags));

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -3060,14 +3060,10 @@ bitflags! {
     pub struct CascadeFlags: u8 {
         /// Whether to inherit all styles from the parent. If this flag is not
         /// present, non-inherited styles are reset to their initial values.
-        const INHERIT_ALL = 1;
-
-        /// Whether to skip any display style fixup for root element, flex/grid
-        /// item, and ruby descendants.
-        const SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP = 1 << 1;
+        const INHERIT_ALL = 1 << 0;
 
         /// Whether to only cascade properties that are visited dependent.
-        const VISITED_DEPENDENT_ONLY = 1 << 2;
+        const VISITED_DEPENDENT_ONLY = 1 << 1;
 
         /// Whether the given element we're styling is the document element,
         /// that is, matches :root.
@@ -3077,15 +3073,15 @@ bitflags! {
         ///
         /// This affects some style adjustments, like blockification, and means
         /// that it may affect global state, like the Device's root font-size.
-        const IS_ROOT_ELEMENT = 1 << 3;
+        const IS_ROOT_ELEMENT = 1 << 2;
 
         /// Whether we're computing the style of a link, either visited or
         /// unvisited.
-        const IS_LINK = 1 << 4;
+        const IS_LINK = 1 << 3;
 
         /// Whether we're computing the style of a link element that happens to
         /// be visited.
-        const IS_VISITED_LINK = 1 << 5;
+        const IS_VISITED_LINK = 1 << 4;
     }
 }
 

--- a/components/style/style_resolver.rs
+++ b/components/style/style_resolver.rs
@@ -542,11 +542,6 @@ where
 
         let mut cascade_flags = CascadeFlags::empty();
 
-        if self.element.skip_root_and_item_based_display_fixup() ||
-           pseudo.map_or(false, |p| p.skip_item_based_display_fixup()) {
-            cascade_flags.insert(CascadeFlags::SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP);
-        }
-
         if pseudo.is_none() && self.element.is_link() {
             cascade_flags.insert(CascadeFlags::IS_LINK);
             if self.element.is_visited_link() &&

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -2019,12 +2019,11 @@ pub extern "C" fn Servo_ComputedValues_GetForAnonymousBox(parent_style_or_null: 
         page_decls,
     );
 
-    let cascade_flags = CascadeFlags::SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP;
     data.stylist.precomputed_values_for_pseudo_with_rule_node(
         &guards,
         &pseudo,
         parent_style_or_null.map(|x| &*x),
-        cascade_flags,
+        CascadeFlags::empty(),
         &metrics,
         rule_node
     ).into()
@@ -3620,10 +3619,17 @@ pub extern "C" fn Servo_ReparentStyle(
     let element = element.map(GeckoElement);
 
     let mut cascade_flags = CascadeFlags::empty();
-    if style_to_reparent.is_anon_box() {
-        cascade_flags.insert(CascadeFlags::SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP);
-    }
     if let Some(element) = element {
+        // NOTE(emilio): This relies on element.is_some() => pseudo.is_none(),
+        // which the caller guarantees, fortunately. But this doesn't handle the
+        // IS_ROOT_ELEMENT flag correctly!
+        //
+        // I think it's not possible to wrap a root element in a first-line
+        // frame (and reparenting only happens for ::first-line and its
+        // descendants), so this may be fine...
+        //
+        // We should just get rid of all these flags which pass element / pseudo
+        // state.
         if element.is_link() {
             cascade_flags.insert(CascadeFlags::IS_LINK);
             if element.is_visited_link() && doc_data.visited_styles_enabled() {


### PR DESCRIPTION
In practice the only NAC that possibly inherits from a grid or flex container
are pseudos.

In Gecko, if the root element is an item container, custom anon content would
also sometimes incorrectly inherit from that (see bug 1405635), but that's fixed
in Stylo.

We remove the IS_ROOT_ELEMENT blockification from the "skip display fixup"
check, since the root element is never NAC or anything like that, so there's no
need for the check.

This also fixes some reparenting fishiness related to pseudo-elements. We were
only skipping the fixup when reparenting anon boxes, not when reparenting normal
element styles, nor when reparenting other pseudo styles which are not anon
boxes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19666)
<!-- Reviewable:end -->
