### PR TITLE
Revert #19666 since we do create NAC elements and expect them to be inline.

### DIFF
--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -460,6 +460,10 @@ impl<'le> TElement for ServoLayoutElement<'le> {
         }
     }
 
+    fn skip_root_and_item_based_display_fixup(&self) -> bool {
+        false
+    }
+
     unsafe fn set_selector_flags(&self, flags: ElementSelectorFlags) {
         self.element.insert_selector_flags(flags);
     }

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -670,6 +670,11 @@ pub trait TElement
         self.get_data().map(|x| x.borrow_mut())
     }
 
+    /// Whether we should skip any root- or item-based display property
+    /// blockification on this element.  (This function exists so that Gecko
+    /// native anonymous content can opt out of this style fixup.)
+    fn skip_root_and_item_based_display_fixup(&self) -> bool;
+
     /// Sets selector flags, which indicate what kinds of selectors may have
     /// matched on this element and therefore what kind of work may need to
     /// be performed when DOM state changes.

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -1256,6 +1256,19 @@ impl<'le> TElement for GeckoElement<'le> {
         }
     }
 
+    #[inline]
+    fn skip_root_and_item_based_display_fixup(&self) -> bool {
+        if !self.is_native_anonymous() {
+            return false;
+        }
+
+        if let Some(p) = self.implemented_pseudo_element() {
+            return p.skip_item_based_display_fixup();
+        }
+
+        self.is_root_of_native_anonymous_subtree()
+    }
+
     unsafe fn set_selector_flags(&self, flags: ElementSelectorFlags) {
         debug_assert!(!flags.is_empty());
         self.set_flags(selector_flags_to_node_flags(flags));

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -3060,10 +3060,14 @@ bitflags! {
     pub struct CascadeFlags: u8 {
         /// Whether to inherit all styles from the parent. If this flag is not
         /// present, non-inherited styles are reset to their initial values.
-        const INHERIT_ALL = 1 << 0;
+        const INHERIT_ALL = 1;
+
+        /// Whether to skip any display style fixup for root element, flex/grid
+        /// item, and ruby descendants.
+        const SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP = 1 << 1;
 
         /// Whether to only cascade properties that are visited dependent.
-        const VISITED_DEPENDENT_ONLY = 1 << 1;
+        const VISITED_DEPENDENT_ONLY = 1 << 2;
 
         /// Whether the given element we're styling is the document element,
         /// that is, matches :root.
@@ -3073,15 +3077,15 @@ bitflags! {
         ///
         /// This affects some style adjustments, like blockification, and means
         /// that it may affect global state, like the Device's root font-size.
-        const IS_ROOT_ELEMENT = 1 << 2;
+        const IS_ROOT_ELEMENT = 1 << 3;
 
         /// Whether we're computing the style of a link, either visited or
         /// unvisited.
-        const IS_LINK = 1 << 3;
+        const IS_LINK = 1 << 4;
 
         /// Whether we're computing the style of a link element that happens to
         /// be visited.
-        const IS_VISITED_LINK = 1 << 4;
+        const IS_VISITED_LINK = 1 << 5;
     }
 }
 

--- a/components/style/style_resolver.rs
+++ b/components/style/style_resolver.rs
@@ -542,6 +542,11 @@ where
 
         let mut cascade_flags = CascadeFlags::empty();
 
+        if self.element.skip_root_and_item_based_display_fixup() ||
+           pseudo.map_or(false, |p| p.skip_item_based_display_fixup()) {
+            cascade_flags.insert(CascadeFlags::SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP);
+        }
+
         if pseudo.is_none() && self.element.is_link() {
             cascade_flags.insert(CascadeFlags::IS_LINK);
             if self.element.is_visited_link() &&


### PR DESCRIPTION
This reverts commit 1970e82b0d310128eabe8466d39d42cc20e7ae4b, reversing
changes made to e882660ea694f9f12d9d2936012dbdf192f8aec8.

The reparenting logic is still bogus, but I'll figure out how to deal with that
in a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19667)
<!-- Reviewable:end -->
