### PR TITLE
style: Move border-image-repeat outside of mako.

### DIFF
--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -72,8 +72,8 @@ use style::values::generics::image::{Circle, Ellipse, EndingShape as GenericEndi
 use style::values::generics::image::{GradientItem as GenericGradientItem, GradientKind};
 use style::values::generics::image::{Image, ShapeExtent};
 use style::values::generics::image::PaintWorklet;
-use style::values::specified::background::RepeatKeyword as BackgroundRepeatKeyword;
-use style::values::specified::border::RepeatKeyword;
+use style::values::specified::background::BackgroundRepeatKeyword;
+use style::values::specified::border::BorderImageRepeatKeyword;
 use style::values::specified::position::{X, Y};
 use style_traits::CSSPixel;
 use style_traits::ToCss;
@@ -100,12 +100,12 @@ impl ResolvePercentage for NumberOrPercentage {
     }
 }
 
-fn convert_repeat_mode(from: RepeatKeyword) -> RepeatMode {
+fn convert_repeat_mode(from: BorderImageRepeatKeyword) -> RepeatMode {
     match from {
-        RepeatKeyword::Stretch => RepeatMode::Stretch,
-        RepeatKeyword::Repeat => RepeatMode::Repeat,
-        RepeatKeyword::Round => RepeatMode::Round,
-        RepeatKeyword::Space => RepeatMode::Space,
+        BorderImageRepeatKeyword::Stretch => RepeatMode::Stretch,
+        BorderImageRepeatKeyword::Repeat => RepeatMode::Repeat,
+        BorderImageRepeatKeyword::Round => RepeatMode::Round,
+        BorderImageRepeatKeyword::Space => RepeatMode::Space,
     }
 }
 

--- a/components/layout/display_list_builder.rs
+++ b/components/layout/display_list_builder.rs
@@ -59,7 +59,6 @@ use style::computed_values::visibility::T as Visibility;
 use style::logical_geometry::{LogicalMargin, LogicalPoint, LogicalRect, LogicalSize, WritingMode};
 use style::properties::ComputedValues;
 use style::properties::longhands::background_origin::single_value::computed_value::T as BackgroundOrigin;
-use style::properties::longhands::border_image_repeat::computed_value::RepeatKeyword;
 use style::properties::style_structs;
 use style::servo::restyle_damage::ServoRestyleDamage;
 use style::values::{Either, RGBA};
@@ -74,6 +73,7 @@ use style::values::generics::image::{GradientItem as GenericGradientItem, Gradie
 use style::values::generics::image::{Image, ShapeExtent};
 use style::values::generics::image::PaintWorklet;
 use style::values::specified::background::RepeatKeyword as BackgroundRepeatKeyword;
+use style::values::specified::border::RepeatKeyword;
 use style::values::specified::position::{X, Y};
 use style_traits::CSSPixel;
 use style_traits::ToCss;

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1788,13 +1788,13 @@ fn static_assert() {
     %>
 
     pub fn set_border_image_repeat(&mut self, v: values::computed::BorderImageRepeat) {
-        use values::specified::border::RepeatKeyword;
+        use values::specified::border::BorderImageRepeatKeyword;
         use gecko_bindings::structs::StyleBorderImageRepeat;
 
         % for i, side in enumerate(["H", "V"]):
             self.gecko.mBorderImageRepeat${side} = match v.${i} {
                 % for keyword in border_image_repeat_keywords:
-                RepeatKeyword::${keyword} => StyleBorderImageRepeat::${keyword},
+                BorderImageRepeatKeyword::${keyword} => StyleBorderImageRepeat::${keyword},
                 % endfor
             };
         % endfor
@@ -1810,13 +1810,13 @@ fn static_assert() {
     }
 
     pub fn clone_border_image_repeat(&self) -> values::computed::BorderImageRepeat {
-        use values::specified::border::RepeatKeyword;
+        use values::specified::border::BorderImageRepeatKeyword;
         use gecko_bindings::structs::StyleBorderImageRepeat;
 
         % for side in ["H", "V"]:
         let servo_${side.lower()} = match self.gecko.mBorderImageRepeat${side} {
             % for keyword in border_image_repeat_keywords:
-            StyleBorderImageRepeat::${keyword} => RepeatKeyword::${keyword},
+            StyleBorderImageRepeat::${keyword} => BorderImageRepeatKeyword::${keyword},
             % endfor
         };
         % endfor
@@ -3825,16 +3825,16 @@ fn static_assert() {
     %>
 
     <%self:simple_image_array_property name="repeat" shorthand="${shorthand}" field_name="mRepeat">
-        use values::specified::background::RepeatKeyword;
+        use values::specified::background::BackgroundRepeatKeyword;
         use gecko_bindings::structs::nsStyleImageLayers_Repeat;
         use gecko_bindings::structs::StyleImageLayerRepeat;
 
-        fn to_ns(repeat: RepeatKeyword) -> StyleImageLayerRepeat {
+        fn to_ns(repeat: BackgroundRepeatKeyword) -> StyleImageLayerRepeat {
             match repeat {
-                RepeatKeyword::Repeat => StyleImageLayerRepeat::Repeat,
-                RepeatKeyword::Space => StyleImageLayerRepeat::Space,
-                RepeatKeyword::Round => StyleImageLayerRepeat::Round,
-                RepeatKeyword::NoRepeat => StyleImageLayerRepeat::NoRepeat,
+                BackgroundRepeatKeyword::Repeat => StyleImageLayerRepeat::Repeat,
+                BackgroundRepeatKeyword::Space => StyleImageLayerRepeat::Space,
+                BackgroundRepeatKeyword::Round => StyleImageLayerRepeat::Round,
+                BackgroundRepeatKeyword::NoRepeat => StyleImageLayerRepeat::NoRepeat,
             }
         }
 
@@ -3848,15 +3848,15 @@ fn static_assert() {
 
     pub fn clone_${shorthand}_repeat(&self) -> longhands::${shorthand}_repeat::computed_value::T {
         use properties::longhands::${shorthand}_repeat::single_value::computed_value::T;
-        use values::specified::background::RepeatKeyword;
+        use values::specified::background::BackgroundRepeatKeyword;
         use gecko_bindings::structs::StyleImageLayerRepeat;
 
-        fn to_servo(repeat: StyleImageLayerRepeat) -> RepeatKeyword {
+        fn to_servo(repeat: StyleImageLayerRepeat) -> BackgroundRepeatKeyword {
             match repeat {
-                StyleImageLayerRepeat::Repeat => RepeatKeyword::Repeat,
-                StyleImageLayerRepeat::Space => RepeatKeyword::Space,
-                StyleImageLayerRepeat::Round => RepeatKeyword::Round,
-                StyleImageLayerRepeat::NoRepeat => RepeatKeyword::NoRepeat,
+                StyleImageLayerRepeat::Repeat => BackgroundRepeatKeyword::Repeat,
+                StyleImageLayerRepeat::Space => BackgroundRepeatKeyword::Space,
+                StyleImageLayerRepeat::Round => BackgroundRepeatKeyword::Round,
+                StyleImageLayerRepeat::NoRepeat => BackgroundRepeatKeyword::NoRepeat,
                 x => panic!("Found unexpected value in style struct for ${shorthand}_repeat property: {:?}", x),
             }
         }

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1787,8 +1787,8 @@ fn static_assert() {
     border_image_repeat_keywords = ["Stretch", "Repeat", "Round", "Space"]
     %>
 
-    pub fn set_border_image_repeat(&mut self, v: longhands::border_image_repeat::computed_value::T) {
-        use properties::longhands::border_image_repeat::computed_value::RepeatKeyword;
+    pub fn set_border_image_repeat(&mut self, v: values::computed::BorderImageRepeat) {
+        use values::specified::border::RepeatKeyword;
         use gecko_bindings::structs::StyleBorderImageRepeat;
 
         % for i, side in enumerate(["H", "V"]):
@@ -1809,8 +1809,8 @@ fn static_assert() {
         self.copy_border_image_repeat_from(other)
     }
 
-    pub fn clone_border_image_repeat(&self) -> longhands::border_image_repeat::computed_value::T {
-        use properties::longhands::border_image_repeat::computed_value::RepeatKeyword;
+    pub fn clone_border_image_repeat(&self) -> values::computed::BorderImageRepeat {
+        use values::specified::border::RepeatKeyword;
         use gecko_bindings::structs::StyleBorderImageRepeat;
 
         % for side in ["H", "V"]:

--- a/components/style/properties/longhand/border.mako.rs
+++ b/components/style/properties/longhand/border.mako.rs
@@ -221,57 +221,12 @@ ${helpers.predefined_type("border-image-outset", "LengthOrNumberRect",
     flags="APPLIES_TO_FIRST_LETTER",
     boxed=True)}
 
-<%helpers:longhand name="border-image-repeat" animation_value_type="discrete"
-                   flags="APPLIES_TO_FIRST_LETTER"
-                   spec="https://drafts.csswg.org/css-backgrounds/#border-image-repeat">
-    pub mod computed_value {
-        pub use super::RepeatKeyword;
-
-        #[derive(Clone, Debug, MallocSizeOf, PartialEq, ToCss)]
-        pub struct T(pub RepeatKeyword, pub RepeatKeyword);
-    }
-
-    #[derive(Clone, Debug, MallocSizeOf, PartialEq, ToCss)]
-    pub struct SpecifiedValue(pub RepeatKeyword,
-                              pub Option<RepeatKeyword>);
-
-    define_css_keyword_enum!(RepeatKeyword:
-                             "stretch" => Stretch,
-                             "repeat" => Repeat,
-                             "round" => Round,
-                             "space" => Space);
-
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        computed_value::T(RepeatKeyword::Stretch, RepeatKeyword::Stretch)
-    }
-
-    #[inline]
-    pub fn get_initial_specified_value() -> SpecifiedValue {
-        SpecifiedValue(RepeatKeyword::Stretch, None)
-    }
-
-    impl ToComputedValue for SpecifiedValue {
-        type ComputedValue = computed_value::T;
-
-        #[inline]
-        fn to_computed_value(&self, _context: &Context) -> computed_value::T {
-            computed_value::T(self.0, self.1.unwrap_or(self.0))
-        }
-        #[inline]
-        fn from_computed_value(computed: &computed_value::T) -> Self {
-            SpecifiedValue(computed.0, Some(computed.1))
-        }
-    }
-
-    pub fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
-                         -> Result<SpecifiedValue, ParseError<'i>> {
-        let first = RepeatKeyword::parse(input)?;
-        let second = input.try(RepeatKeyword::parse).ok();
-
-        Ok(SpecifiedValue(first, second))
-    }
-</%helpers:longhand>
+${helpers.predefined_type("border-image-repeat", "BorderImageRepeat",
+     initial_value="computed::BorderImageRepeat::repeat()",
+     initial_specified_value="specified::BorderImageRepeat::repeat()",
+     spec="https://drafts.csswg.org/css-backgrounds/#propdef-border-image-repeat",
+     animation_value_type="discrete",
+     flags="APPLIES_TO_FIRST_LETTER")}
 
 ${helpers.predefined_type("border-image-width", "BorderImageWidth",
     initial_value="computed::BorderImageWidth::all(computed::BorderImageSideWidth::one())",

--- a/components/style/values/computed/background.rs
+++ b/components/style/values/computed/background.rs
@@ -12,7 +12,7 @@ use values::animated::{ToAnimatedValue, ToAnimatedZero};
 use values::computed::{Context, ToComputedValue};
 use values::computed::length::LengthOrPercentageOrAuto;
 use values::generics::background::BackgroundSize as GenericBackgroundSize;
-use values::specified::background::{BackgroundRepeat as SpecifiedBackgroundRepeat, RepeatKeyword};
+use values::specified::background::{BackgroundRepeat as SpecifiedBackgroundRepeat, BackgroundRepeatKeyword};
 
 /// A computed value for the `background-size` property.
 pub type BackgroundSize = GenericBackgroundSize<LengthOrPercentageOrAuto>;
@@ -86,12 +86,12 @@ impl ToAnimatedValue for BackgroundSizeList {
 ///
 /// https://drafts.csswg.org/css-backgrounds/#the-background-repeat
 #[derive(Clone, Debug, MallocSizeOf, PartialEq)]
-pub struct BackgroundRepeat(pub RepeatKeyword, pub RepeatKeyword);
+pub struct BackgroundRepeat(pub BackgroundRepeatKeyword, pub BackgroundRepeatKeyword);
 
 impl BackgroundRepeat {
     /// Returns the `repeat repeat` value.
     pub fn repeat() -> Self {
-        BackgroundRepeat(RepeatKeyword::Repeat, RepeatKeyword::Repeat)
+        BackgroundRepeat(BackgroundRepeatKeyword::Repeat, BackgroundRepeatKeyword::Repeat)
     }
 }
 
@@ -101,8 +101,8 @@ impl ToCss for BackgroundRepeat {
         W: fmt::Write,
     {
         match (self.0, self.1) {
-            (RepeatKeyword::Repeat, RepeatKeyword::NoRepeat) => dest.write_str("repeat-x"),
-            (RepeatKeyword::NoRepeat, RepeatKeyword::Repeat) => dest.write_str("repeat-y"),
+            (BackgroundRepeatKeyword::Repeat, BackgroundRepeatKeyword::NoRepeat) => dest.write_str("repeat-x"),
+            (BackgroundRepeatKeyword::NoRepeat, BackgroundRepeatKeyword::Repeat) => dest.write_str("repeat-y"),
             (horizontal, vertical) => {
                 horizontal.to_css(dest)?;
                 if horizontal != vertical {
@@ -122,10 +122,10 @@ impl ToComputedValue for SpecifiedBackgroundRepeat {
     fn to_computed_value(&self, _: &Context) -> Self::ComputedValue {
         match *self {
             SpecifiedBackgroundRepeat::RepeatX => {
-                BackgroundRepeat(RepeatKeyword::Repeat, RepeatKeyword::NoRepeat)
+                BackgroundRepeat(BackgroundRepeatKeyword::Repeat, BackgroundRepeatKeyword::NoRepeat)
             }
             SpecifiedBackgroundRepeat::RepeatY => {
-                BackgroundRepeat(RepeatKeyword::NoRepeat, RepeatKeyword::Repeat)
+                BackgroundRepeat(BackgroundRepeatKeyword::NoRepeat, BackgroundRepeatKeyword::Repeat)
             }
             SpecifiedBackgroundRepeat::Keywords(horizontal, vertical) => {
                 BackgroundRepeat(horizontal, vertical.unwrap_or(horizontal))
@@ -138,10 +138,10 @@ impl ToComputedValue for SpecifiedBackgroundRepeat {
         // FIXME(emilio): Why can't this just be:
         //   SpecifiedBackgroundRepeat::Keywords(computed.0, computed.1)
         match (computed.0, computed.1) {
-            (RepeatKeyword::Repeat, RepeatKeyword::NoRepeat) => {
+            (BackgroundRepeatKeyword::Repeat, BackgroundRepeatKeyword::NoRepeat) => {
                 SpecifiedBackgroundRepeat::RepeatX
             }
-            (RepeatKeyword::NoRepeat, RepeatKeyword::Repeat) => {
+            (BackgroundRepeatKeyword::NoRepeat, BackgroundRepeatKeyword::Repeat) => {
                 SpecifiedBackgroundRepeat::RepeatY
             }
             (horizontal, vertical) => {

--- a/components/style/values/computed/border.rs
+++ b/components/style/values/computed/border.rs
@@ -6,7 +6,7 @@
 
 use app_units::Au;
 use values::animated::ToAnimatedZero;
-use values::computed::{Number, NumberOrPercentage};
+use values::computed::{Context, Number, NumberOrPercentage, ToComputedValue};
 use values::computed::length::{LengthOrPercentage, NonNegativeLength};
 use values::generics::border::BorderCornerRadius as GenericBorderCornerRadius;
 use values::generics::border::BorderImageSideWidth as GenericBorderImageSideWidth;
@@ -15,6 +15,7 @@ use values::generics::border::BorderRadius as GenericBorderRadius;
 use values::generics::border::BorderSpacing as GenericBorderSpacing;
 use values::generics::rect::Rect;
 use values::generics::size::Size;
+use values::specified::border::{BorderImageRepeat as SpecifiedBorderImageRepeat, RepeatKeyword};
 
 /// A computed value for the `border-image-width` property.
 pub type BorderImageWidth = Rect<BorderImageSideWidth>;
@@ -79,5 +80,32 @@ impl ToAnimatedZero for BorderCornerRadius {
     fn to_animated_zero(&self) -> Result<Self, ()> {
         // FIXME(nox): Why?
         Err(())
+    }
+}
+
+/// The computed value of the `border-image-repeat` property:
+///
+/// https://drafts.csswg.org/css-backgrounds/#propdef-border-image-repeat
+#[derive(Clone, Debug, MallocSizeOf, PartialEq, ToCss)]
+pub struct BorderImageRepeat(pub RepeatKeyword, pub RepeatKeyword);
+
+impl BorderImageRepeat {
+    /// Returns the `stretch stretch` value.
+    pub fn repeat() -> Self {
+        BorderImageRepeat(RepeatKeyword::Stretch, RepeatKeyword::Stretch)
+    }
+}
+
+impl ToComputedValue for SpecifiedBorderImageRepeat {
+    type ComputedValue = BorderImageRepeat;
+
+    #[inline]
+    fn to_computed_value(&self, _: &Context) -> Self::ComputedValue {
+        BorderImageRepeat(self.0, self.1.unwrap_or(self.0))
+    }
+
+    #[inline]
+    fn from_computed_value(computed: &Self::ComputedValue) -> Self {
+        SpecifiedBorderImageRepeat(computed.0, Some(computed.1))
     }
 }

--- a/components/style/values/computed/border.rs
+++ b/components/style/values/computed/border.rs
@@ -15,7 +15,7 @@ use values::generics::border::BorderRadius as GenericBorderRadius;
 use values::generics::border::BorderSpacing as GenericBorderSpacing;
 use values::generics::rect::Rect;
 use values::generics::size::Size;
-use values::specified::border::{BorderImageRepeat as SpecifiedBorderImageRepeat, RepeatKeyword};
+use values::specified::border::{BorderImageRepeat as SpecifiedBorderImageRepeat, BorderImageRepeatKeyword};
 
 /// A computed value for the `border-image-width` property.
 pub type BorderImageWidth = Rect<BorderImageSideWidth>;
@@ -87,12 +87,12 @@ impl ToAnimatedZero for BorderCornerRadius {
 ///
 /// https://drafts.csswg.org/css-backgrounds/#propdef-border-image-repeat
 #[derive(Clone, Debug, MallocSizeOf, PartialEq, ToCss)]
-pub struct BorderImageRepeat(pub RepeatKeyword, pub RepeatKeyword);
+pub struct BorderImageRepeat(pub BorderImageRepeatKeyword, pub BorderImageRepeatKeyword);
 
 impl BorderImageRepeat {
     /// Returns the `stretch stretch` value.
     pub fn repeat() -> Self {
-        BorderImageRepeat(RepeatKeyword::Stretch, RepeatKeyword::Stretch)
+        BorderImageRepeat(BorderImageRepeatKeyword::Stretch, BorderImageRepeatKeyword::Stretch)
     }
 }
 

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -34,7 +34,7 @@ pub use properties::animated_properties::TransitionProperty;
 pub use self::align::{AlignItems, AlignJustifyContent, AlignJustifySelf, JustifyItems};
 pub use self::angle::Angle;
 pub use self::background::{BackgroundSize, BackgroundRepeat};
-pub use self::border::{BorderImageSlice, BorderImageWidth, BorderImageSideWidth};
+pub use self::border::{BorderImageSlice, BorderImageWidth, BorderImageSideWidth, BorderImageRepeat};
 pub use self::border::{BorderRadius, BorderCornerRadius, BorderSpacing};
 pub use self::font::{FontSize, FontSizeAdjust, FontSynthesis, FontWeight, FontVariantAlternates};
 pub use self::font::{FontFamily, FontLanguageOverride, FontVariantSettings, FontVariantEastAsian};

--- a/components/style/values/specified/background.rs
+++ b/components/style/values/specified/background.rs
@@ -48,7 +48,7 @@ impl BackgroundSize {
 /// One of the keywords for `background-repeat`.
 #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, Parse, PartialEq, ToComputedValue, ToCss)]
 #[allow(missing_docs)]
-pub enum RepeatKeyword {
+pub enum BackgroundRepeatKeyword {
     Repeat,
     Space,
     Round,
@@ -65,14 +65,14 @@ pub enum BackgroundRepeat {
     /// `repeat-y`
     RepeatY,
     /// `[repeat | space | round | no-repeat]{1,2}`
-    Keywords(RepeatKeyword, Option<RepeatKeyword>),
+    Keywords(BackgroundRepeatKeyword, Option<BackgroundRepeatKeyword>),
 }
 
 impl BackgroundRepeat {
     /// Returns the `repeat` value.
     #[inline]
     pub fn repeat() -> Self {
-        BackgroundRepeat::Keywords(RepeatKeyword::Repeat, None)
+        BackgroundRepeat::Keywords(BackgroundRepeatKeyword::Repeat, None)
     }
 }
 
@@ -89,7 +89,7 @@ impl Parse for BackgroundRepeat {
             _ => {},
         }
 
-        let horizontal = match RepeatKeyword::from_ident(&ident) {
+        let horizontal = match BackgroundRepeatKeyword::from_ident(&ident) {
             Ok(h) => h,
             Err(()) => {
                 return Err(input.new_custom_error(
@@ -98,7 +98,7 @@ impl Parse for BackgroundRepeat {
             }
         };
 
-        let vertical = input.try(RepeatKeyword::parse).ok();
+        let vertical = input.try(BackgroundRepeatKeyword::parse).ok();
         Ok(BackgroundRepeat::Keywords(horizontal, vertical))
     }
 }

--- a/components/style/values/specified/border.rs
+++ b/components/style/values/specified/border.rs
@@ -175,7 +175,7 @@ impl Parse for BorderSpacing {
 /// One of the keywords for `border-image-repeat`.
 #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, Parse, PartialEq, ToComputedValue, ToCss)]
 #[allow(missing_docs)]
-pub enum RepeatKeyword {
+pub enum BorderImageRepeatKeyword {
     Stretch,
     Repeat,
     Round,
@@ -188,13 +188,13 @@ pub enum RepeatKeyword {
 ///
 /// `[ stretch | repeat | round | space ]{1,2}`
 #[derive(Clone, Debug, MallocSizeOf, PartialEq, ToCss)]
-pub struct BorderImageRepeat(pub RepeatKeyword, pub Option<RepeatKeyword>);
+pub struct BorderImageRepeat(pub BorderImageRepeatKeyword, pub Option<BorderImageRepeatKeyword>);
 
 impl BorderImageRepeat {
     /// Returns the `stretch` value.
     #[inline]
     pub fn repeat() -> Self {
-        BorderImageRepeat(RepeatKeyword::Stretch, None)
+        BorderImageRepeat(BorderImageRepeatKeyword::Stretch, None)
     }
 }
 
@@ -203,8 +203,8 @@ impl Parse for BorderImageRepeat {
         _context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        let first = RepeatKeyword::parse(input)?;
-        let second = input.try(RepeatKeyword::parse).ok();
+        let first = BorderImageRepeatKeyword::parse(input)?;
+        let second = input.try(BorderImageRepeatKeyword::parse).ok();
 
         Ok(BorderImageRepeat(first, second))
     }

--- a/components/style/values/specified/border.rs
+++ b/components/style/values/specified/border.rs
@@ -171,3 +171,41 @@ impl Parse for BorderSpacing {
         }).map(GenericBorderSpacing)
     }
 }
+
+/// One of the keywords for `border-image-repeat`.
+#[derive(Clone, Copy, Debug, Eq, MallocSizeOf, Parse, PartialEq, ToComputedValue, ToCss)]
+#[allow(missing_docs)]
+pub enum RepeatKeyword {
+    Stretch,
+    Repeat,
+    Round,
+    Space
+}
+
+/// The specified value for the `border-image-repeat` property.
+///
+/// https://drafts.csswg.org/css-backgrounds/#propdef-border-image-repeat
+///
+/// `[ stretch | repeat | round | space ]{1,2}`
+#[derive(Clone, Debug, MallocSizeOf, PartialEq, ToCss)]
+pub struct BorderImageRepeat(pub RepeatKeyword, pub Option<RepeatKeyword>);
+
+impl BorderImageRepeat {
+    /// Returns the `stretch` value.
+    #[inline]
+    pub fn repeat() -> Self {
+        BorderImageRepeat(RepeatKeyword::Stretch, None)
+    }
+}
+
+impl Parse for BorderImageRepeat {
+    fn parse<'i, 't>(
+        _context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self, ParseError<'i>> {
+        let first = RepeatKeyword::parse(input)?;
+        let second = input.try(RepeatKeyword::parse).ok();
+
+        Ok(BorderImageRepeat(first, second))
+    }
+}

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -28,7 +28,7 @@ pub use self::angle::Angle;
 #[cfg(feature = "gecko")]
 pub use self::align::{AlignItems, AlignJustifyContent, AlignJustifySelf, JustifyItems};
 pub use self::background::{BackgroundRepeat, BackgroundSize};
-pub use self::border::{BorderCornerRadius, BorderImageSlice, BorderImageWidth};
+pub use self::border::{BorderCornerRadius, BorderImageSlice, BorderImageWidth, BorderImageRepeat};
 pub use self::border::{BorderImageSideWidth, BorderRadius, BorderSideWidth, BorderSpacing};
 pub use self::font::{FontSize, FontSizeAdjust, FontSynthesis, FontWeight, FontVariantAlternates};
 pub use self::font::{FontFamily, FontLanguageOverride, FontVariantSettings, FontVariantEastAsian};


### PR DESCRIPTION
Part of #19015. 

r? emilio

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach build-geckolib` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19021
- [X] These changes do not require tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19668)
<!-- Reviewable:end -->
