### PR TITLE
style: Make GetFlattenedTreeParent more straight-forward.

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -504,8 +504,6 @@ extern "C" {
 } extern "C" {
  pub fn Gecko_IsInDocument ( node : RawGeckoNodeBorrowed , ) -> bool ; 
 } extern "C" {
- pub fn Gecko_FlattenedTreeParentIsParent ( node : RawGeckoNodeBorrowed , ) -> bool ; 
-} extern "C" {
  pub fn Gecko_IsSignificantChild ( node : RawGeckoNodeBorrowed , text_is_significant : bool , whitespace_is_significant : bool , ) -> bool ; 
 } extern "C" {
  pub fn Gecko_GetLastChild ( node : RawGeckoNodeBorrowed , ) -> RawGeckoNodeBorrowedOrNull ; 


### PR DESCRIPTION
Now that accessing nsIContent slots is not a blob of virtual function calls, we
should be able to unify logic here, and speed up the not-so-rare case for
chrome, while keeping the usual case fast.

Bug: 1427511
Reviewed-by: smaug
MozReview-Commit-ID: 87iY5Cbhx4T

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19673)
<!-- Reviewable:end -->
