### PR TITLE
Implement correct corner clipping for background color

### DIFF
--- a/tests/wpt/web-platform-tests/css/css-backgrounds/background-clip/clip-rounded-corner-ref.html
+++ b/tests/wpt/web-platform-tests/css/css-backgrounds/background-clip/clip-rounded-corner-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Filled Background with Rounded Corner</title>
+<style>
+    #a {
+        width: 100px;
+        height: 80px;
+        border: 20px blue solid;
+        border-top-right-radius: 20px;
+        background-color: green;
+        background-clip: border-box;
+    }
+    #shield {
+        position: absolute;
+        width: 30px;
+        height: 30px;
+        left: 120px;
+        top: 5px;
+        background-color: black;
+    }
+</style>
+<body>
+    <div id="a"></div>
+    <!-- Hide the curved outside border to deal with imprecise rendering. -->
+    <div id="shield"></div>
+</body>

--- a/tests/wpt/web-platform-tests/css/css-backgrounds/background-clip/clip-rounded-corner.html
+++ b/tests/wpt/web-platform-tests/css/css-backgrounds/background-clip/clip-rounded-corner.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Filled Background with Rounded Corner</title>
+<link rel="match" href="clip-rounded-corner-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#corner-clipping">
+<style>
+    #b {
+        width: 100px;
+        height: 80px;
+        border: 20px blue solid;
+        border-top-right-radius: 20px;
+        background-color: green;
+        background-clip: content-box;
+    }
+    #shield {
+        position: absolute;
+        width: 30px;
+        height: 30px;
+        left: 120px;
+        top: 5px;
+        background-color: black;
+    }
+</style>
+<body>
+    <div id="b"></div>
+    <!-- Hide the curved outside border to deal with imprecise rendering. -->
+    <div id="shield"></div>
+</body>


### PR DESCRIPTION
Add one regression ref test.

See also #19649

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19675)
<!-- Reviewable:end -->
