### PR TITLE
style: Make Contain::parse simpler

### DIFF
--- a/components/style/values/specified/box.rs
+++ b/components/style/values/specified/box.rs
@@ -553,18 +553,8 @@ impl Parse for Contain {
                 "layout" => Some(Contain::LAYOUT),
                 "style" => Some(Contain::STYLE),
                 "paint" => Some(Contain::PAINT),
-                "strict" => {
-                    if result.is_empty() {
-                        return Ok(Contain::STRICT | Contain::STRICT_BITS)
-                    }
-                    None
-                },
-                "none" => {
-                    if result.is_empty() {
-                        return Ok(result)
-                    }
-                    None
-                },
+                "strict" if result.is_empty() => return Ok(Contain::STRICT | Contain::STRICT_BITS),
+                "none" if result.is_empty() => return Ok(result),
                 _ => None
             };
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
---
Makes Contain::parse slightly simpler, as discussed in #19682

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19682 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because refactoring

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19692)
<!-- Reviewable:end -->

