### PR TITLE
Dockerfile to build container used by TaskCluster

### DIFF
--- a/etc/ci/Dockerfile
+++ b/etc/ci/Dockerfile
@@ -1,0 +1,44 @@
+FROM debian:jessie
+MAINTAINER Servo Dockerfile Maintainers <servo-dockerfile-maintainers@mozilla.com>
+
+# Rust installation from https://hub.docker.com/r/jimmycuadra/rust/
+ENV USER root
+ENV RUST_VERSION=1.18.0
+
+RUN apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    libssl-dev \
+    pkg-config && \
+  curl -sO https://static.rust-lang.org/dist/rust-$RUST_VERSION-x86_64-unknown-linux-gnu.tar.gz && \
+  tar -xzf rust-$RUST_VERSION-x86_64-unknown-linux-gnu.tar.gz && \
+  ./rust-$RUST_VERSION-x86_64-unknown-linux-gnu/install.sh --without=rust-docs && \
+  DEBIAN_FRONTEND=noninteractive apt-get remove --purge -y curl && \
+  DEBIAN_FRONTEND=noninteractive apt-get autoremove -y && \
+  rm -rf \
+    rust-$RUST_VERSION-x86_64-unknown-linux-gnu \
+    rust-$RUST_VERSION-x86_64-unknown-linux-gnu.tar.gz \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/* && \
+  mkdir /source
+
+# Servo's requirements
+RUN apt-get update && apt-get install -y \
+  xvfb \
+  python \
+  python3 \
+  python-pip
+
+RUN pip install virtualenv
+RUN useradd servo
+
+# TODO: RUN wget https://raw.githubusercontent.com/servo/saltfs/master/xvfb/xvfb.conf /etc/init/xvfb.conf
+# TODO: cross: Servo's servo-build-depenencies salt state
+# TODO: cross: Servo's servo-build-dependencies.android
+# TODO: cross: Servo's servo-build-dependencies.arm
+# TODO: builder-specific config from saltfs/buildbot/master/files/config/environments.py
+


### PR DESCRIPTION
TC pulls the container from  https://hub.docker.com/r/servobrowser/servo-linux-dev/

Perms to upload there are managed with other infra secrets

This is as the Dockerfile stood when I last uploaded; future work includes
automating the build and push upon Dockerfile changes landing in this repo.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [X] These changes address the issue that edunham is embarrassed to send a "we're changing a thing" email without the "and you can change it too" step, which requires the Dockerfile that generated the container that TaskCluster pulls from to live in a sensible public place

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____
- [X] these changes are prerequisite to adding more better tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

r? @aneeshusa

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19694)
<!-- Reviewable:end -->
