### PR TITLE
Update Arch Linux setup to include clang

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ sudo zypper install libX11-devel libexpat-devel libbz2-devel Mesa-libEGL-devel M
 #### On Arch Linux
 
 ``` sh
-sudo pacman -S --needed base-devel git python2 python2-virtualenv python2-pip mesa cmake bzip2 libxmu glu pkg-config
+sudo pacman -S --needed base-devel git python2 python2-virtualenv python2-pip mesa cmake bzip2 libxmu glu pkg-config clang
 ```
 #### On Gentoo Linux
 
@@ -138,9 +138,9 @@ list of installed components. It is not on by default. Visual Studio 2017 MUST i
 > If you encountered errors with the environment above, do the following for a workaround:
 > 1.  Download and install [Build Tools for Visual Studio 2017](https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15)
 > 2.  Install `python2.7 x86-x64` and `virtualenv`
-> 3.  Run `mach.bat build -d`. 
+> 3.  Run `mach.bat build -d`.
 
->If you have troubles with `x64 type` prompt as `mach.bat` set by default:  
+>If you have troubles with `x64 type` prompt as `mach.bat` set by default:
 > 1. you may need to choose and launch the type manually, such as `x86_x64 Cross Tools Command Prompt for VS 2017` in the Windows menu.)
 > 2. `cd to/the/path/servo`
 > 3. `python mach build -d`


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`clang` is needed to compile servo, but isn't listed as one of the dependencies needed for arch and isn't part of the `base-devel` group.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X]  no applicable github issue

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's a README change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19701)
<!-- Reviewable:end -->
