### PR TITLE
CSS Paint API: Use a high timeout for worklet threads in tests

### DIFF
--- a/tests/wpt/mozilla/meta/mozilla/css-paint-api/__dir__.ini
+++ b/tests/wpt/mozilla/meta/mozilla/css-paint-api/__dir__.ini
@@ -1,1 +1,1 @@
-prefs: [dom.worklet.enabled:true]
+prefs: [dom.worklet.enabled:true, dom.worklet.timeout_ms:5000]


### PR DESCRIPTION
Fixes #19631

Since the addition of timeouts to paint worklets, CSS paint API threads
were failing intermittently because of the timeouts being fired. This is
because the timeouts are quite tight, to account for the 60fps
requirement. Bumping up the timeout threshold for these tests alone is
the easiest solution.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because this changes config for a test.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19702)
<!-- Reviewable:end -->
