### PR TITLE
Implement root element backgrounds

### DIFF
--- a/tests/wpt/web-platform-tests/css/css-backgrounds/background-root-1-ref.html
+++ b/tests/wpt/web-platform-tests/css/css-backgrounds/background-root-1-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>A nice Rainbow 🌈</title>
+<style>
+    html {
+        background-image: linear-gradient(
+            to right,
+            rgb(255, 0, 0) 0%,
+            rgb(255, 255, 0) 15%,
+            rgb(0, 255, 0) 30%,
+            rgb(0, 255, 255) 50%,
+            rgb(0, 0, 255) 65%,
+            rgb(255, 0, 255) 80%,
+            rgb(255, 0, 0) 100%);
+    }
+</style>
+<body>
+    <!-- intentionally left blank -->
+</body>

--- a/tests/wpt/web-platform-tests/css/css-backgrounds/background-root-1.html
+++ b/tests/wpt/web-platform-tests/css/css-backgrounds/background-root-1.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>A nice Rainbow 🌈</title>
+<link rel="match" href="background-root-1-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#body-background">
+<style>
+    body {
+        background-image: linear-gradient(
+            to right,
+            rgb(255, 0, 0) 0%,
+            rgb(255, 255, 0) 15%,
+            rgb(0, 255, 0) 30%,
+            rgb(0, 255, 255) 50%,
+            rgb(0, 0, 255) 65%,
+            rgb(255, 0, 255) 80%,
+            rgb(255, 0, 0) 100%);
+    }
+</style>
+<body>
+    <!-- intentionally left blank -->
+</body>

--- a/tests/wpt/web-platform-tests/css/css-backgrounds/background-root-2.html
+++ b/tests/wpt/web-platform-tests/css/css-backgrounds/background-root-2.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>A partially transparent (green) Background</title>
+<link rel="mismatch" href="reference/background-root-2-mismatch.html">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#body-background">
+<style>
+    html {
+        background-color: rgba(0, 255, 0, 0.5);
+    }
+</style>

--- a/tests/wpt/web-platform-tests/css/css-backgrounds/reference/background-root-2-mismatch.html
+++ b/tests/wpt/web-platform-tests/css/css-backgrounds/reference/background-root-2-mismatch.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>A partially transparent (green) Background</title>
+<style>
+    html {
+        background-color: rgba(0, 255, 0);
+    }
+</style>


### PR DESCRIPTION
Note: #19669 is visible with background images (and some gradients).

Note 2: Maybe the root background only needs to be propagated on REPAINT?

Note 3: I am not sure what the complete implications of not sending a background color to webrender are. But setting one gives wrong results with partially transparent background colors.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #19421
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19704)
<!-- Reviewable:end -->
