### PR TITLE
Remove js.mem.gc.refresh_frame_slices.enabled pref

### DIFF
--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -260,7 +260,6 @@ pub unsafe fn new_rt_and_cx() -> Runtime {
     if let Some(val) = PREFS.get("js.mem.gc.dynamic_mark_slice.enabled").as_boolean() {
         JS_SetGCParameter(runtime.rt(), JSGCParamKey::JSGC_DYNAMIC_MARK_SLICE, val as u32);
     }
-    // TODO: handle js.mem.gc.refresh_frame_slices.enabled
     if let Some(val) = PREFS.get("js.mem.gc.dynamic_heap_growth.enabled").as_boolean() {
         JS_SetGCParameter(runtime.rt(), JSGCParamKey::JSGC_DYNAMIC_HEAP_GROWTH, val as u32);
     }

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -45,7 +45,6 @@
   "js.mem.gc.incremental.slice_ms": 10,
   "js.mem.gc.low_frequency_heap_growth": 150,
   "js.mem.gc.per_compartment.enabled": true,
-  "js.mem.gc.refresh_frame_slices.enabled": true,
   "js.mem.gc.zeal.frequency": 100,
   "js.mem.gc.zeal.level": 0,
   "js.mem.high_water_mark": 128,


### PR DESCRIPTION
Clean up after gecko [bug 1421358](https://bugzilla.mozilla.org/show_bug.cgi?id=1421358), which removed the pref entirely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19722)
<!-- Reviewable:end -->
