### PR TITLE
style: Remove some unneeded indirection.

### DIFF
--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -398,22 +398,20 @@ pub trait ThreadSafeLayoutElement
                             &style_pseudo,
                             Some(data.styles.primary()),
                             CascadeFlags::empty(),
-                            &ServoMetricsProvider)
-                            .clone()
+                            &ServoMetricsProvider,
+                        )
                     }
                     PseudoElementCascadeType::Lazy => {
-                        context.stylist
-                               .lazily_compute_pseudo_element_style(
-                                   &context.guards,
-                                   unsafe { &self.unsafe_get() },
-                                   &style_pseudo,
-                                   RuleInclusion::All,
-                                   data.styles.primary(),
-                                   /* is_probe = */ false,
-                                   &ServoMetricsProvider,
-                                   /* matching_func = */ None)
-                               .unwrap()
-                               .clone()
+                        context.stylist.lazily_compute_pseudo_element_style(
+                           &context.guards,
+                           unsafe { self.unsafe_get() },
+                           &style_pseudo,
+                           RuleInclusion::All,
+                           data.styles.primary(),
+                           /* is_probe = */ false,
+                           &ServoMetricsProvider,
+                           /* matching_func = */ None,
+                        ).unwrap()
                     }
                 }
             }
@@ -424,7 +422,7 @@ pub trait ThreadSafeLayoutElement
     fn selected_style(&self) -> Arc<ComputedValues> {
         let data = self.style_data();
         data.styles.pseudos
-            .get(&PseudoElement::Selection).map(|s| s)
+            .get(&PseudoElement::Selection)
             .unwrap_or(data.styles.primary())
             .clone()
     }

--- a/components/style/selector_map.rs
+++ b/components/style/selector_map.rs
@@ -155,8 +155,8 @@ impl SelectorMap<Rule> {
     /// Sort the Rules at the end to maintain cascading order.
     pub fn get_all_matching_rules<E, F>(
         &self,
-        element: &E,
-        rule_hash_target: &E,
+        element: E,
+        rule_hash_target: E,
         matching_rules_list: &mut ApplicableDeclarationList,
         context: &mut MatchingContext<E::Impl>,
         quirks_mode: QuirksMode,
@@ -217,7 +217,7 @@ impl SelectorMap<Rule> {
 
     /// Adds rules in `rules` that match `element` to the `matching_rules` list.
     fn get_matching_rules<E, F>(
-        element: &E,
+        element: E,
         rules: &[Rule],
         matching_rules: &mut ApplicableDeclarationList,
         context: &mut MatchingContext<E::Impl>,
@@ -232,7 +232,7 @@ impl SelectorMap<Rule> {
             if matches_selector(&rule.selector,
                                 0,
                                 Some(&rule.hashes),
-                                element,
+                                &element,
                                 context,
                                 flags_setter) {
                 matching_rules.push(

--- a/components/style/style_resolver.rs
+++ b/components/style/style_resolver.rs
@@ -428,7 +428,7 @@ where
 
             // Compute the primary rule node.
             stylist.push_applicable_declarations(
-                &self.element,
+                self.element,
                 implemented_pseudo.as_ref(),
                 self.element.style_attribute(),
                 self.element.get_smil_override(),
@@ -502,7 +502,7 @@ where
         // NB: We handle animation rules for ::before and ::after when
         // traversing them.
         stylist.push_applicable_declarations(
-            &self.element,
+            self.element,
             Some(pseudo_element),
             None,
             None,

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -795,7 +795,7 @@ impl Stylist {
     pub fn lazily_compute_pseudo_element_style<E>(
         &self,
         guards: &StylesheetGuards,
-        element: &E,
+        element: E,
         pseudo: &PseudoElement,
         rule_inclusion: RuleInclusion,
         parent_style: &ComputedValues,
@@ -982,7 +982,7 @@ impl Stylist {
     fn lazy_pseudo_rules<E>(
         &self,
         guards: &StylesheetGuards,
-        element: &E,
+        element: E,
         parent_style: &ComputedValues,
         pseudo: &PseudoElement,
         is_probe: bool,
@@ -1203,7 +1203,7 @@ impl Stylist {
     /// This corresponds to `ElementRuleCollector` in WebKit.
     pub fn push_applicable_declarations<E, F>(
         &self,
-        element: &E,
+        element: E,
         pseudo_element: Option<&PseudoElement>,
         style_attribute: Option<ArcBorrow<Locked<PropertyDeclarationBlock>>>,
         smil_override: Option<ArcBorrow<Locked<PropertyDeclarationBlock>>>,
@@ -1238,7 +1238,7 @@ impl Stylist {
         if let Some(map) = self.cascade_data.user_agent.cascade_data.normal_rules(pseudo_element) {
             map.get_all_matching_rules(
                 element,
-                &rule_hash_target,
+                rule_hash_target,
                 applicable_declarations,
                 context,
                 self.quirks_mode,
@@ -1276,7 +1276,7 @@ impl Stylist {
             if let Some(map) = self.cascade_data.user.normal_rules(pseudo_element) {
                 map.get_all_matching_rules(
                     element,
-                    &rule_hash_target,
+                    rule_hash_target,
                     applicable_declarations,
                     context,
                     self.quirks_mode,
@@ -1307,7 +1307,7 @@ impl Stylist {
                     if let Some(map) = stylist.cascade_data.author.slotted_rules(pseudo_element) {
                         map.get_all_matching_rules(
                             element,
-                            &rule_hash_target,
+                            rule_hash_target,
                             applicable_declarations,
                             context,
                             self.quirks_mode,
@@ -1341,7 +1341,7 @@ impl Stylist {
 
                 map.get_all_matching_rules(
                     element,
-                    &rule_hash_target,
+                    rule_hash_target,
                     applicable_declarations,
                     &mut matching_context,
                     stylist.quirks_mode,
@@ -1358,7 +1358,7 @@ impl Stylist {
             if let Some(map) = self.cascade_data.author.normal_rules(pseudo_element) {
                 map.get_all_matching_rules(
                     element,
-                    &rule_hash_target,
+                    rule_hash_target,
                     applicable_declarations,
                     context,
                     self.quirks_mode,

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -2260,17 +2260,16 @@ fn get_pseudo_style(
             };
             let guards = StylesheetGuards::same(guard);
             let metrics = get_metrics_provider_for_product();
-            doc_data.stylist
-                .lazily_compute_pseudo_element_style(
-                    &guards,
-                    &element,
-                    &pseudo,
-                    rule_inclusion,
-                    base,
-                    is_probe,
-                    &metrics,
-                    matching_func,
-                )
+            doc_data.stylist.lazily_compute_pseudo_element_style(
+                &guards,
+                element,
+                &pseudo,
+                rule_inclusion,
+                base,
+                is_probe,
+                &metrics,
+                matching_func,
+            )
         },
     };
 


### PR DESCRIPTION
All TElement's implement Copy, and are just pointers, so the double indirection
is stupid.

I'm going to try to see if removing this double-indirection fixes some
selector-matching performance, and this is a trivial pre-requisite while I wait
for Talos results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19734)
<!-- Reviewable:end -->
