### PR TITLE
Add note to Gentoo setup to set LIBCLANG_PATH envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ sudo emerge net-misc/curl media-libs/freeglut \
     dev-python/virtualenv dev-python/pip dev-libs/openssl \
     x11-libs/libXmu media-libs/glu x11-base/xorg-server sys-devel/clang
 ```
+with the following environment variable set:
+```sh
+export LIBCLANG_PATH="/usr/lib64/llvm/*/lib64"
+```
 #### On Windows (MSVC)
 
 1. Install Python for Windows (https://www.python.org/downloads/release/python-2714/). The Windows x86-64 MSI installer is fine.


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Without `LIBCLANG_PATH` environment variable set the build for `gecko-media` fails as in https://github.com/servo/servo/issues/19351 for Gentoo Linux. This patch adds a note to the README to set the environment variable.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it is a documentation fix

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19739)
<!-- Reviewable:end -->
