### PR TITLE
Allow warnings during mutation tests.

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -72,7 +72,7 @@ linux-rel-nogate:
   - ./mach clean-nightlies --keep 3 --force
   - env CC=gcc-5 CXX=g++-5 ./mach build --release
   - python ./etc/ci/chaos_monkey_test.py
-  - env CC=gcc-5 CXX=g++-5 bash ./etc/ci/mutation_test.sh
+  - env CC=gcc-5 CXX=g++-5 RUSTFLAGS= bash ./etc/ci/mutation_test.sh
 
 mac-rel-intermittent:
   - ./mach clean-nightlies --keep 3 --force


### PR DESCRIPTION
Sometimes mutations include removing the only use of a variable. When we deny warnings globally, we inhibit these mutations that trigger new warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19740)
<!-- Reviewable:end -->
