### PR TITLE
style: Use Python's True instead of string for arbitrary Python code in mako

### DIFF
--- a/components/style/properties/longhand/border.mako.rs
+++ b/components/style/properties/longhand/border.mako.rs
@@ -210,7 +210,7 @@ ${helpers.predefined_type("border-image-source", "ImageLayer",
     vector=False,
     animation_value_type="discrete",
     flags="APPLIES_TO_FIRST_LETTER",
-    boxed="True")}
+    boxed=True)}
 
 ${helpers.predefined_type("border-image-outset", "LengthOrNumberRect",
     parse_method="parse_non_negative",

--- a/components/style/properties/longhand/box.mako.rs
+++ b/components/style/properties/longhand/box.mako.rs
@@ -389,7 +389,7 @@ ${helpers.predefined_type("scroll-snap-destination",
                           "computed::Position::zero()",
                           products="gecko",
                           gecko_pref="layout.css.scroll-snap.enabled",
-                          boxed="True",
+                          boxed=True,
                           spec="Nonstandard (https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-destination)",
                           animation_value_type="discrete")}
 
@@ -505,7 +505,7 @@ ${helpers.predefined_type("perspective",
 ${helpers.predefined_type("perspective-origin",
                           "position::Position",
                           "computed::position::Position::center()",
-                          boxed="True",
+                          boxed=True,
                           extra_prefixes="moz webkit",
                           spec="https://drafts.csswg.org/css-transforms-2/#perspective-origin-property",
                           animation_value_type="ComputedValue")}
@@ -589,7 +589,7 @@ ${helpers.single_keyword("-moz-appearance",
 
 ${helpers.predefined_type("-moz-binding", "UrlOrNone", "Either::Second(None_)",
                           products="gecko",
-                          boxed="True" if product == "gecko" else "False",
+                          boxed= product == "gecko",
                           animation_value_type="none",
                           gecko_ffi_name="mBinding",
                           spec="Nonstandard (https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-binding)")}

--- a/components/style/properties/longhand/effects.mako.rs
+++ b/components/style/properties/longhand/effects.mako.rs
@@ -30,7 +30,7 @@ ${helpers.predefined_type("clip",
                           "ClipRectOrAuto",
                           "computed::ClipRectOrAuto::auto()",
                           animation_value_type="ComputedValue",
-                          boxed="True",
+                          boxed=True,
                           allow_quirks=True,
                           spec="https://drafts.fxtf.org/css-masking/#clip-property")}
 

--- a/components/style/properties/longhand/inherited_svg.mako.rs
+++ b/components/style/properties/longhand/inherited_svg.mako.rs
@@ -114,19 +114,19 @@ ${helpers.single_keyword("clip-rule", "nonzero evenodd",
 
 ${helpers.predefined_type("marker-start", "UrlOrNone", "Either::Second(None_)",
                           products="gecko",
-                          boxed="True" if product == "gecko" else "False",
+                          boxed= product == "gecko",
                           animation_value_type="discrete",
                           spec="https://www.w3.org/TR/SVG2/painting.html#VertexMarkerProperties")}
 
 ${helpers.predefined_type("marker-mid", "UrlOrNone", "Either::Second(None_)",
                           products="gecko",
-                          boxed="True" if product == "gecko" else "False",
+                          boxed= product == "gecko",
                           animation_value_type="discrete",
                           spec="https://www.w3.org/TR/SVG2/painting.html#VertexMarkerProperties")}
 
 ${helpers.predefined_type("marker-end", "UrlOrNone", "Either::Second(None_)",
                           products="gecko",
-                          boxed="True" if product == "gecko" else "False",
+                          boxed= product == "gecko",
                           animation_value_type="discrete",
                           spec="https://www.w3.org/TR/SVG2/painting.html#VertexMarkerProperties")}
 

--- a/components/style/properties/longhand/inherited_table.mako.rs
+++ b/components/style/properties/longhand/inherited_table.mako.rs
@@ -24,5 +24,5 @@ ${helpers.predefined_type("border-spacing",
                           "BorderSpacing",
                           "computed::BorderSpacing::zero()",
                           animation_value_type="BorderSpacing",
-                          boxed="True",
+                          boxed=True,
                           spec="https://drafts.csswg.org/css-tables/#propdef-border-spacing")}

--- a/components/style/properties/longhand/list.mako.rs
+++ b/components/style/properties/longhand/list.mako.rs
@@ -35,7 +35,7 @@ ${helpers.single_keyword("list-style-position", "outside inside", animation_valu
                               "computed::ListStyleType::disc()",
                               initial_specified_value="specified::ListStyleType::disc()",
                               animation_value_type="discrete",
-                              boxed="True",
+                              boxed=True,
                               spec="https://drafts.csswg.org/css-lists/#propdef-list-style-type")}
 % endif
 
@@ -58,5 +58,5 @@ ${helpers.predefined_type("-moz-image-region",
                           "computed::ClipRectOrAuto::auto()",
                           animation_value_type="ComputedValue",
                           products="gecko",
-                          boxed="True",
+                          boxed=True,
                           spec="Nonstandard (https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-image-region)")}

--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -247,7 +247,7 @@ ${helpers.predefined_type("object-position",
                           "Position",
                           "computed::Position::zero()",
                           products="gecko",
-                          boxed="True",
+                          boxed=True,
                           spec="https://drafts.csswg.org/css-images-3/#the-object-position",
                           animation_value_type="ComputedValue")}
 


### PR DESCRIPTION
As discussion in IRC with @nox and @gootorov , it's more correct to use Python's `True` for `${arbitrary Python code}` in mako.

Following is related IRC logs

```
15:39 nox
As I said, that's because there are 2 ways to invoke the things with Mako.

15:40 nox
${arbitrary Python code} vs <%named_helper ..>...</%named_helper>

15:40 nox
IIRC <%foo bar=True></%foo> is not valid Mako syntax,

15:40 nox
but with bar="True" it is.

15:42 cybai
gootorov: I did meet some issues when moving makos if I set "True" instead of Python's `True`. Thus, like nox mentioned above, it's related to how the code works

15:44 gootorov
nox: Alright, I got it now, thanks. There are a couple ${function} blocks that still use `boxed="True" though. They aren't <%named_helpers>, shouldn't they use Python's True too, then?

15:45 nox
gootorov: I think there is an issue because this specific attribute is also used as a string through other <%helpers>,

15:46 nox
gootorov: Seems like it's not an issue anymore because the boxed attribute is passed to arg_to_bool,

15:46 nox
which either returns the boolean as is or check whether it's a "True" or "False" string.

15:47 nox
gootorov: So indeed, you can probably make those use booleans now.

15:47 gootorov
nox: Okay, got it, thanks for the explanation :)
```

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19752)
<!-- Reviewable:end -->
