### PR TITLE
Decouple metrics and gfx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,6 @@ dependencies = [
 name = "metrics"
 version = "0.0.1"
 dependencies = [
- "gfx 0.0.1",
  "gfx_traits 0.0.1",
  "ipc-channel 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -17,7 +17,7 @@
 use app_units::Au;
 use euclid::{Transform3D, Point2D, Vector2D, Rect, Size2D, TypedRect, SideOffsets2D};
 use euclid::num::{One, Zero};
-use gfx_traits::StackingContextId;
+use gfx_traits::{self, StackingContextId};
 use gfx_traits::print_tree::PrintTree;
 use ipc_channel::ipc::IpcSharedMemory;
 use msg::constellation_msg::PipelineId;
@@ -143,6 +143,25 @@ impl DisplayList {
             );
         }
         print_tree.end_level();
+    }
+}
+
+impl gfx_traits::DisplayList for DisplayList {
+    /// Analyze the display list to figure out if this may be the first
+    /// contentful paint (i.e. the display list contains items of type text,
+    /// image, non-white canvas or SVG). Used by metrics.
+    fn is_contentful(&self) -> bool {
+        for item in &self.list {
+            match item {
+                &DisplayItem::Text(_) |
+                &DisplayItem::Image(_) => {
+                    return true
+                }
+                _ => (),
+            }
+        }
+
+        false
     }
 }
 

--- a/components/gfx_traits/lib.rs
+++ b/components/gfx_traits/lib.rs
@@ -105,3 +105,8 @@ pub fn node_id_from_clip_id(id: usize) -> Option<usize> {
     }
     None
 }
+
+pub trait DisplayList {
+    /// Returns true if this display list contains meaningful content.
+    fn is_contentful(&self) -> bool;
+}

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1042,7 +1042,7 @@ impl LayoutThread {
             // Observe notifications about rendered frames if needed right before
             // sending the display list to WebRender in order to set time related
             // Progressive Web Metrics.
-            self.paint_time_metrics.maybe_observe_paint_time(self, epoch, &display_list);
+            self.paint_time_metrics.maybe_observe_paint_time(self, epoch, &*display_list);
 
             self.webrender_api.set_display_list(
                 self.webrender_document,

--- a/components/metrics/Cargo.toml
+++ b/components/metrics/Cargo.toml
@@ -10,7 +10,6 @@ name = "metrics"
 path = "lib.rs"
 
 [dependencies]
-gfx = {path = "../gfx"}
 gfx_traits = {path = "../gfx_traits"}
 ipc-channel = "0.9"
 log = "0.3.5"

--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate gfx;
 extern crate gfx_traits;
 extern crate ipc_channel;
 #[macro_use]
@@ -17,8 +16,7 @@ extern crate servo_config;
 extern crate servo_url;
 extern crate time;
 
-use gfx::display_list::{DisplayItem, DisplayList};
-use gfx_traits::Epoch;
+use gfx_traits::{Epoch, DisplayList};
 use ipc_channel::ipc::IpcSender;
 use msg::constellation_msg::PipelineId;
 use profile_traits::time::{ProfilerChan, ProfilerCategory, send_profile_data};
@@ -324,24 +322,9 @@ impl PaintTimeMetrics {
             return;
         }
 
-        let mut is_contentful = false;
-        // Analyze the display list to figure out if this may be the first
-        // contentful paint (i.e. the display list contains items of type text,
-        // image, non-white canvas or SVG).
-        for item in &display_list.list {
-            match item {
-                &DisplayItem::Text(_) |
-                &DisplayItem::Image(_) => {
-                    is_contentful = true;
-                    break;
-                }
-                _ => (),
-            }
-        }
-
         self.pending_metrics.borrow_mut().insert(epoch, (
             profiler_metadata_factory.new_metadata(),
-            is_contentful,
+            display_list.is_contentful(),
         ));
 
         // Send the pending metric information to the compositor thread.

--- a/tests/unit/metrics/paint_time.rs
+++ b/tests/unit/metrics/paint_time.rs
@@ -69,7 +69,7 @@ fn test_common(display_list: &DisplayList, epoch: Epoch) -> PaintTimeMetrics {
     paint_time_metrics.maybe_observe_paint_time(
         &dummy_profiler_metadata_factory,
         epoch,
-        &display_list,
+        &*display_list,
     );
 
     // Should not set any metric until navigation start is set.


### PR DESCRIPTION
Added gfx_traits::DisplayList so metrics doesn't depend on the gfx crate for gfx::display_list::DisplayList.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19422 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because succesful compilation should be enough

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19755)
<!-- Reviewable:end -->
