### PR TITLE
Avoid entraining various Debug impls in release builds

### DIFF
--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -746,18 +746,9 @@ pub trait TElement
     /// element-backed pseudo-element, in which case we return the originating
     /// element.
     fn rule_hash_target(&self) -> Self {
-        if let Some(pseudo) = self.implemented_pseudo_element() {
-            match self.closest_non_native_anonymous_ancestor() {
-                Some(e) => e,
-                None => {
-                    panic!(
-                        "Trying to collect rules for a detached pseudo-element: \
-                        {:?} {:?}",
-                        pseudo,
-                        self,
-                    )
-                }
-            }
+        if self.implemented_pseudo_element().is_some() {
+            self.closest_non_native_anonymous_ancestor()
+                .expect("Trying to collect rules for a detached pseudo-element")
         } else {
             *self
         }

--- a/components/style/gecko/conversions.rs
+++ b/components/style/gecko/conversions.rs
@@ -141,7 +141,7 @@ impl Angle {
             nsCSSUnit::eCSSUnit_Grad => Angle::Grad(value),
             nsCSSUnit::eCSSUnit_Radian => Angle::Rad(value),
             nsCSSUnit::eCSSUnit_Turn => Angle::Turn(value),
-            _ => panic!("Unexpected unit {:?} for angle", unit),
+            _ => panic!("Unexpected unit for angle"),
         }
     }
 }
@@ -415,7 +415,7 @@ impl nsStyleImage {
                 let atom = Gecko_GetImageElement(self);
                 Some(GenericImage::Element(Atom::from(atom)))
             },
-            x => panic!("Unexpected image type {:?}", x)
+            _ => panic!("Unexpected image type")
         }
     }
 
@@ -503,7 +503,7 @@ impl nsStyleImage {
                         // FIXME: We should support ShapeExtent::Contain and ShapeExtent::Cover.
                         // But we can't choose those yet since Gecko does not support both values.
                         // https://bugzilla.mozilla.org/show_bug.cgi?id=1217664
-                        x => panic!("Found unexpected gecko_size: {:?}", x),
+                        _ => panic!("Found unexpected gecko_size"),
                     }
                 };
 
@@ -539,7 +539,7 @@ impl nsStyleImage {
                         };
                         EndingShape::Ellipse(length_percentage_keyword)
                     },
-                    x => panic!("Found unexpected mShape: {:?}", x),
+                    _ => panic!("Found unexpected mShape"),
                 };
 
                 let position = match (horizontal_style, vertical_style) {
@@ -842,7 +842,7 @@ pub mod basic_shape {
                 FillBox => GeometryBox::FillBox,
                 StrokeBox => GeometryBox::StrokeBox,
                 ViewBox => GeometryBox::ViewBox,
-                other => panic!("Unexpected StyleGeometryBox::{:?} while converting to GeometryBox", other),
+                _ => panic!("Unexpected StyleGeometryBox while converting to GeometryBox"),
             }
         }
     }
@@ -855,7 +855,7 @@ pub mod basic_shape {
                 PaddingBox => ShapeBox::PaddingBox,
                 BorderBox => ShapeBox::BorderBox,
                 MarginBox => ShapeBox::MarginBox,
-                other => panic!("Unexpected StyleGeometryBox::{:?} while converting to ShapeBox", other),
+                _ => panic!("Unexpected StyleGeometryBox while converting to ShapeBox"),
             }
         }
     }
@@ -1010,7 +1010,7 @@ impl TextAlign {
             structs::NS_STYLE_TEXT_ALIGN_MOZ_CENTER => TextAlign::MozCenter,
             structs::NS_STYLE_TEXT_ALIGN_CHAR => TextAlign::Char,
             structs::NS_STYLE_TEXT_ALIGN_END => TextAlign::End,
-            x => panic!("Found unexpected value in style struct for text-align property: {:?}", x),
+            _ => panic!("Found unexpected value in style struct for text-align property"),
         }
     }
 }

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -901,7 +901,7 @@ impl structs::FontSizePrefs {
             structs::kGenericFont_monospace => self.mDefaultMonospaceSize,
             structs::kGenericFont_cursive => self.mDefaultCursiveSize,
             structs::kGenericFont_fantasy => self.mDefaultFantasySize,
-            x => unreachable!("Unknown generic ID {}", x),
+            _ => unreachable!("Unknown generic ID"),
         })
     }
 }

--- a/components/style/gecko_bindings/sugar/ns_css_value.rs
+++ b/components/style/gecko_bindings/sugar/ns_css_value.rs
@@ -114,7 +114,7 @@ impl nsCSSValue {
             nsCSSUnit::eCSSUnit_Calc => {
                 LengthOrPercentage::Calc(bindings::Gecko_CSSValue_GetCalc(self).into())
             },
-            x => panic!("The unit should not be {:?}", x),
+            _ => panic!("Unexpected unit"),
         }
     }
 
@@ -124,7 +124,7 @@ impl nsCSSValue {
             nsCSSUnit::eCSSUnit_Pixel => {
                 Length::new(bindings::Gecko_CSSValue_GetNumber(self))
             },
-            x => panic!("The unit should not be {:?}", x),
+            _ => panic!("Unexpected unit"),
         }
     }
 

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -437,7 +437,7 @@ def set_gecko_property(ffi_name, expr):
             ${keyword.casted_constant_name(value, cast_type)} => Keyword::${to_camel_case(value)},
             % endfor
             % if keyword.gecko_inexhaustive:
-            x => panic!("Found unexpected value in style struct for ${ident} property: {:?}", x),
+            _ => panic!("Found unexpected value in style struct for ${ident} property"),
             % endif
         }
         % else:
@@ -446,7 +446,7 @@ def set_gecko_property(ffi_name, expr):
             structs::${keyword.gecko_constant(value)} => Keyword::${to_camel_case(value)},
             % endfor
             % if keyword.gecko_inexhaustive:
-            x => panic!("Found unexpected value in style struct for ${ident} property: {:?}", x),
+            _ => panic!("Found unexpected value in style struct for ${ident} property"),
             % endif
         }
         % endif
@@ -598,8 +598,7 @@ def set_gecko_property(ffi_name, expr):
             CoordDataValue::Calc(calc) =>
                 SvgLengthOrPercentageOrNumber::LengthOrPercentage(
                     LengthOrPercentage::Calc(calc.into())),
-            _ => unreachable!("Unexpected coordinate {:?} in ${ident}",
-                              self.gecko.${gecko_ffi_name}.as_value()),
+            _ => unreachable!("Unexpected coordinate in ${ident}"),
         };
         SVGLength::Length(length.into())
     }
@@ -1257,7 +1256,7 @@ fn clone_single_transform_function(
             % for servo, gecko, format in transform_functions:
                 ${computed_operation_arm(servo, gecko, format)}
             % endfor
-            _ => panic!("{:?} is not an acceptable transform function", transform_function),
+            _ => panic!("unacceptable transform function"),
         }
     }
 }
@@ -2377,7 +2376,7 @@ fn static_assert() {
             % endfor
             structs::${border_style_keyword.gecko_constant('auto')} => OutlineStyle::Auto,
             % if border_style_keyword.gecko_inexhaustive:
-            x => panic!("Found unexpected value in style struct for outline_style property: {:?}", x),
+            _ => panic!("Found unexpected value in style struct for outline_style property"),
             % endif
         }
     }
@@ -2900,8 +2899,8 @@ fn static_assert() {
                         ${value}_list.push(CustomIdent(ident));
                     },
                 % endfor
-                x => {
-                    panic!("Found unexpected value for font-variant-alternates: {:?}", x);
+                _ => {
+                    panic!("Found unexpected value for font-variant-alternates");
                 }
             }
         }
@@ -3078,7 +3077,7 @@ fn static_assert() {
             % for value in keyword.gecko_values():
                 structs::${keyword.gecko_constant(value)} => Keyword::${to_camel_case(value)},
             % endfor
-            x => panic!("Found unexpected value for animation-${ident}: {:?}", x),
+            _ => panic!("Found unexpected value for animation-${ident}"),
         }
     }
     ${impl_animation_count(ident, gecko_ffi_name)}
@@ -3812,7 +3811,7 @@ fn static_assert() {
                         % endif
                             => Keyword::${to_camel_case(value)},
                         % endfor
-                        x => panic!("Found unexpected value in style struct for ${ident} property: {:?}", x),
+                        _ => panic!("Found unexpected value in style struct for ${ident} property"),
                     }
                 }).collect()
         )
@@ -3862,7 +3861,7 @@ fn static_assert() {
                 StyleImageLayerRepeat::Space => RepeatKeyword::Space,
                 StyleImageLayerRepeat::Round => RepeatKeyword::Round,
                 StyleImageLayerRepeat::NoRepeat => RepeatKeyword::NoRepeat,
-                x => panic!("Found unexpected value in style struct for ${shorthand}_repeat property: {:?}", x),
+                _ => panic!("Found unexpected value in style struct for ${shorthand}_repeat property"),
             }
         }
 
@@ -4839,7 +4838,7 @@ fn static_assert() {
                 structs::NS_STYLE_TEXT_EMPHASIS_STYLE_DOUBLE_CIRCLE => ShapeKeyword::DoubleCircle,
                 structs::NS_STYLE_TEXT_EMPHASIS_STYLE_TRIANGLE => ShapeKeyword::Triangle,
                 structs::NS_STYLE_TEXT_EMPHASIS_STYLE_SESAME => ShapeKeyword::Sesame,
-                x => panic!("Unexpected value in style struct for text-emphasis-style property: {:?}", x)
+                _ => panic!("Unexpected value in style struct for text-emphasis-style property")
             };
 
         T::Keyword(KeywordValue {
@@ -4947,7 +4946,7 @@ fn static_assert() {
                 structs::NS_STYLE_TEXT_OVERFLOW_ELLIPSIS => TextOverflowSide::Ellipsis,
                 structs::NS_STYLE_TEXT_OVERFLOW_STRING =>
                     TextOverflowSide::String(side.mString.to_string().into_boxed_str()),
-                x => panic!("Found unexpected value in style struct for text_overflow property: {:?}", x),
+                _ => panic!("Found unexpected value in style struct for text_overflow property"),
             }
         }
 
@@ -5430,7 +5429,7 @@ clip-path
             structs::NS_STYLE_CURSOR_ALL_SCROLL => Keyword::Cursor(Cursor::AllScroll),
             structs::NS_STYLE_CURSOR_ZOOM_IN => Keyword::Cursor(Cursor::ZoomIn),
             structs::NS_STYLE_CURSOR_ZOOM_OUT => Keyword::Cursor(Cursor::ZoomOut),
-            x => panic!("Found unexpected value in style struct for cursor property: {:?}", x),
+            _ => panic!("Found unexpected value in style struct for cursor property"),
         };
 
         let images = self.gecko.mCursorImages.iter().map(|gecko_cursor_image| {
@@ -5693,7 +5692,7 @@ clip-path
                             )
                         }
                     },
-                    x => panic!("Found unexpected value in style struct for content property: {:?}", x),
+                    _ => panic!("Found unexpected value in style struct for content property"),
                 }
             }).collect()
         )

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -558,7 +558,7 @@
                 % for value in values:
                     ${to_rust_ident(value).upper()} => ${type}::${to_camel_case(value)},
                 % endfor
-                x => panic!("Found unexpected value in style struct for ${keyword.name} property: {:?}", x),
+                _ => panic!("Found unexpected value in style struct for ${keyword.name} property"),
             }
         }
     }

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -178,7 +178,7 @@ impl From<nsCSSPropertyID> for TransitionProperty {
             % endfor
             nsCSSPropertyID::eCSSPropertyExtra_all_properties => TransitionProperty::All,
             _ => {
-                panic!("non-convertible nsCSSPropertyID::{:?}", property)
+                panic!("non-convertible nsCSSPropertyID")
             }
         }
     }
@@ -552,7 +552,7 @@ impl Animate for AnimationValue {
             % endif
             % endfor
             _ => {
-                panic!("Unexpected AnimationValue::animate call, got: {:?}, {:?}", self, other);
+                panic!("Unexpected AnimationValue::animate call");
             }
         };
         Ok(value)
@@ -582,11 +582,7 @@ impl ComputeSquaredDistance for AnimationValue {
             % endif
             % endfor
             _ => {
-                panic!(
-                    "computed values should be of the same property, got: {:?}, {:?}",
-                    self,
-                    other
-                );
+                panic!("computed values should be of the same property");
             },
         }
     }

--- a/components/style/values/computed/font.rs
+++ b/components/style/values/computed/font.rs
@@ -482,7 +482,7 @@ impl SingleFontFamily {
                 name: (&*family.mName).into(),
                 syntax: FamilyNameSyntax::Quoted,
             }),
-            x => panic!("Found unexpected font FontFamilyType: {:?}", x),
+            _ => panic!("Found unexpected font FontFamilyType"),
         }
     }
 }

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -3029,7 +3029,7 @@ macro_rules! get_longhand_from_id {
         match PropertyId::from_nscsspropertyid($id) {
             Ok(PropertyId::Longhand(long)) => long,
             _ => {
-                panic!("stylo: unknown presentation property with id {:?}", $id);
+                panic!("stylo: unknown presentation property with id");
             }
         }
     };
@@ -3042,7 +3042,7 @@ macro_rules! match_wrap_declared {
                 LonghandId::$property => PropertyDeclaration::$property($inner),
             )*
             _ => {
-                panic!("stylo: Don't know how to handle presentation property {:?}", $longhand);
+                panic!("stylo: Don't know how to handle presentation property");
             }
         }
     )
@@ -3226,7 +3226,7 @@ pub extern "C" fn Servo_DeclarationBlock_SetLengthValue(
         structs::nsCSSUnit::eCSSUnit_Point => NoCalcLength::Absolute(AbsoluteLength::Pt(value)),
         structs::nsCSSUnit::eCSSUnit_Pica => NoCalcLength::Absolute(AbsoluteLength::Pc(value)),
         structs::nsCSSUnit::eCSSUnit_Quarter => NoCalcLength::Absolute(AbsoluteLength::Q(value)),
-        _ => unreachable!("Unknown unit {:?} passed to SetLengthValue", unit)
+        _ => unreachable!("Unknown unit passed to SetLengthValue")
     };
 
     let prop = match_wrap_declared! { long,


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1351737#c29

This patch saves more than 80k of code size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19756)
<!-- Reviewable:end -->
