### PR TITLE
style: Adjust the writing-mode fixup to call set_adjusted_display on Servo.

### DIFF
--- a/components/style/style_adjuster.rs
+++ b/components/style/style_adjuster.rs
@@ -193,7 +193,16 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
 
         if our_writing_mode != parent_writing_mode &&
            self.style.get_box().clone_display() == Display::Inline {
-            self.style.mutate_box().set_display(Display::InlineBlock);
+            // TODO(emilio): Figure out if we can just set the adjusted display
+            // on Gecko too and unify this code path.
+            if cfg!(feature = "servo") {
+                self.style.mutate_box().set_adjusted_display(
+                    Display::InlineBlock,
+                    false,
+                );
+            } else {
+                self.style.mutate_box().set_display(Display::InlineBlock);
+            }
         }
     }
 


### PR DESCRIPTION
This is functionally equivalent right now (set_adjusted_display will just do
set_display), but won't be after #19709.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19758)
<!-- Reviewable:end -->
