### PR TITLE
style: Ruby style adjustments shouldn't reset mOriginalDisplay.

### DIFF
--- a/components/style/style_adjuster.rs
+++ b/components/style/style_adjuster.rs
@@ -470,7 +470,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
             if !flags.contains(CascadeFlags::SKIP_ROOT_AND_ITEM_BASED_DISPLAY_FIXUP) {
                 let inline_display = self_display.inlinify();
                 if self_display != inline_display {
-                    self.style.mutate_box().set_display(inline_display);
+                    self.style.mutate_box().set_adjusted_display(inline_display, false);
                 }
             }
         }


### PR DESCRIPTION
This matches what Gecko does:

  https://searchfox.org/mozilla-central/rev/7476b71e0010ab3277b77cc0ae4d998c4b1d2b64/layout/style/GeckoStyleContext.cpp#992

And it's conceptually more right, since we ideally shouldn't mutate
mOriginalDisplay from StyleAdjuster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19760)
<!-- Reviewable:end -->
