### PR TITLE
implement range input sanitization

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1047,11 +1047,17 @@ impl HTMLInputElement {
             }
             InputType::Number => {
                 let mut textinput = self.textinput.borrow_mut();
-                if !textinput.single_line_content().is_valid_number_string() {
+                if !textinput.single_line_content().is_valid_floating_point_number_string() {
                     textinput.single_line_content_mut().clear();
                 }
             }
-            // TODO: Implement more value sanitization algorithms for different types of inputs
+            // https://html.spec.whatwg.org/multipage/#range-state-(type=range):value-sanitization-algorithm
+            InputType::Range => {
+                self.textinput
+                    .borrow_mut()
+                    .single_line_content_mut()
+                    .set_best_representation_of_the_floating_point_number();
+            }
             _ => ()
         }
     }

--- a/tests/wpt/metadata/html/semantics/forms/the-input-element/range-2.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-input-element/range-2.html.ini
@@ -9,6 +9,6 @@
   [range input value equals 100]
     expected: FAIL
 
-  [range input value equals 2]
+  [range input value set to an integer]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/forms/the-input-element/range.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-input-element/range.html.ini
@@ -21,9 +21,6 @@
   [default value when both min and max attributes are given, while min > max]
     expected: FAIL
 
-  [The default step scale factor is 1, unless min attribute has non-integer value]
-    expected: FAIL
-
   [Step scale factor behavior when min attribute has integer value but max attribute is non-integer ]
     expected: FAIL
 

--- a/tests/wpt/web-platform-tests/html/semantics/forms/the-input-element/range.html
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/the-input-element/range.html
@@ -34,6 +34,9 @@
       <input type="range" id="stepdown_beyond_min" min=3 max=11 value=6 step=3 />
       <input type="range" id="illegal_min_and_max" min="ab" max="f" />
       <input type="range" id="illegal_value_and_step" min=0 max=5 value="ppp" step="xyz" />
+      <input type="range" id="should_skip_whitespace" value=" 123"/>
+      <input type="range" id="exponent_value1" value=""/>
+      <input type="range" id="exponent_value2" value=""/>
     </div>
 
     <div id="log">
@@ -277,6 +280,35 @@
           assert_equals(e.value, "3")
         }, "Performing stepDown() beyond the value of the min attribute", {
           "help" : "https://html.spec.whatwg.org/multipage/#dom-input-stepdown"
+        }
+      );
+
+      test(
+        function() {
+          var e = document.getElementById('should_skip_whitespace');
+          assert_equals(e.value, "123")
+        }, "Skip ASCII whitespace within input", {
+          "help" : "https://html.spec.whatwg.org/multipage/#best-representation-of-the-number-as-a-floating-point-number"
+        }
+      );
+
+      test(
+        function() {
+          var e = document.getElementById('exponent_value1');
+          e.value = 1e2;
+          assert_equals(e.value, "100")
+        }, "Multiply value by ten raised to the exponentth power with `e`", {
+          "help" : "https://html.spec.whatwg.org/multipage/#best-representation-of-the-number-as-a-floating-point-number"
+        }
+      );
+
+      test(
+        function() {
+          var e = document.getElementById('exponent_value2');
+          e.value = 1E2;
+          assert_equals(e.value, "100")
+        }, "Multiply value by ten raised to the exponentth power with `E`", {
+          "help" : "https://html.spec.whatwg.org/multipage/#best-representation-of-the-number-as-a-floating-point-number"
         }
       );
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
implement range input sanitation. 
Since there is no `min`, `max`, `step` implementation currently, this should be continued in the future.

r? KiChjang 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19172 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19761)
<!-- Reviewable:end -->
