### PR TITLE
Restore the ability to disable incremental compilation

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -278,7 +278,7 @@ class CommandBase(object):
         self.config["build"].setdefault("debug-mozjs", False)
         self.config["build"].setdefault("ccache", "")
         self.config["build"].setdefault("rustflags", "")
-        self.config["build"].setdefault("incremental", False)
+        self.config["build"].setdefault("incremental", None)
         self.config["build"].setdefault("thinlto", False)
 
         self.config.setdefault("android", {})
@@ -439,6 +439,8 @@ class CommandBase(object):
 
         if self.config["build"]["incremental"]:
             env["CARGO_INCREMENTAL"] = "1"
+        elif self.config["build"]["incremental"] is not None:
+            env["CARGO_INCREMENTAL"] = "0"
 
         if extra_lib:
             if sys.platform == "darwin":

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -296,10 +296,6 @@ class CommandBase(object):
 
     def set_use_geckolib_toolchain(self, use_geckolib_toolchain=True):
         self._use_geckolib_toolchain = use_geckolib_toolchain
-        if use_geckolib_toolchain:
-            # We use Cargo Nightly 1.24 with Rust 1.22,
-            # it passes `-C incremental` to rustc, which is new in Rust 1.24.
-            self.config["build"]["incremental"] = False
 
     def toolchain(self):
         if self._use_geckolib_toolchain:

--- a/servobuild.example
+++ b/servobuild.example
@@ -1,6 +1,4 @@
 # Copy this file to .servobuild in the Servo root directory
-# Be sure to set the cache-dir correctly, otherwise extra
-# copies of the Rust compiler may get downloaded
 
 # Paths starting with "./" are relative to the repo root
 

--- a/servobuild.example
+++ b/servobuild.example
@@ -41,7 +41,10 @@ debug-mozjs = false
 #rustflags = ""
 
 # Enable or disable rustc’s incremental compilation
-# The default is enabled in debug mode only.
+# Cargo’s default is to enable it in debug mode but not in release mode.
+# Leaving this key unspecified makes mach keep Cargo’s default.
+# It can be set to true or false in order to always enable or always disable
+# incremental compilation.
 #incremental = false
 #incremental = true
 

--- a/servobuild.example
+++ b/servobuild.example
@@ -40,8 +40,10 @@ debug-mozjs = false
 # Any optional flags that will be added to $RUSTFLAGS
 #rustflags = ""
 
-# Enable rustc’s incremental compilation
+# Enable or disable rustc’s incremental compilation
+# The default is enabled in debug mode only.
 #incremental = false
+#incremental = true
 
 # Whether to use ThinLTO or not
 #thinlto = false


### PR DESCRIPTION
It became the default in debug mode in the last Rust/Cargo update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19763)
<!-- Reviewable:end -->
