### PR TITLE
Ensure matches_simple_selector is inlined

### DIFF
--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -541,8 +541,23 @@ where
     }
 }
 
+/// This function is for breaking the recursion in matches_simple_selector
+/// so that the compiler can inline that function.
+fn matches_simple_selector_helper<E, F>(
+    selector: &Component<E::Impl>,
+    element: &E,
+    context: &mut LocalMatchingContext<E::Impl>,
+    flags_setter: &mut F,
+) -> bool
+where
+    E: Element,
+    F: FnMut(&E, ElementSelectorFlags),
+{
+    matches_simple_selector(selector, element, context, flags_setter)
+}
+
 /// Determines whether the given element matches the given single selector.
-#[inline]
+#[inline(always)]
 fn matches_simple_selector<E, F>(
     selector: &Component<E::Impl>,
     element: &E,
@@ -710,7 +725,7 @@ where
         Component::Negation(ref negated) => {
             context.shared.nesting_level += 1;
             let result = !negated.iter().all(|ss| {
-                matches_simple_selector(
+                matches_simple_selector_helper(
                     ss,
                     element,
                     context,


### PR DESCRIPTION
For [bug 1430521](https://bugzilla.mozilla.org/show_bug.cgi?id=1430521).

This change shows significant improvement on the testcase mentioned in [bug 1414789 comment 6](https://bugzilla.mozilla.org/show_bug.cgi?id=1414789#c7), and it shows improvement on one subtest of dromaeo_css on at least one platform on talos, although it doesn't show anything significant on the overall score.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19774)
<!-- Reviewable:end -->
