### PR TITLE
Do not throw if PerformanceObserver.observe gets an empty sequence

### DIFF
--- a/components/script/dom/performanceobserver.rs
+++ b/components/script/dom/performanceobserver.rs
@@ -9,7 +9,7 @@ use dom::bindings::codegen::Bindings::PerformanceObserverBinding;
 use dom::bindings::codegen::Bindings::PerformanceObserverBinding::PerformanceObserverCallback;
 use dom::bindings::codegen::Bindings::PerformanceObserverBinding::PerformanceObserverInit;
 use dom::bindings::codegen::Bindings::PerformanceObserverBinding::PerformanceObserverMethods;
-use dom::bindings::error::{Error, Fallible};
+use dom::bindings::error::Fallible;
 use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
 use dom::bindings::root::DomRoot;
 use dom::bindings::str::DOMString;
@@ -97,19 +97,20 @@ impl PerformanceObserver {
 impl PerformanceObserverMethods for PerformanceObserver {
     // https://w3c.github.io/performance-timeline/#dom-performanceobserver-observe()
     fn Observe(&self, options: &PerformanceObserverInit) -> Fallible<()> {
-        // step 1
+        // steps 1-2
         // Make sure the client is asking to observe events from allowed entry types.
         let entry_types = options.entryTypes.iter()
                                             .filter(|e| VALID_ENTRY_TYPES.contains(&e.as_ref()))
                                             .map(|e| e.clone())
                                             .collect::<Vec<DOMString>>();
-        // step 2
-        // There must be at least one valid entry type.
+        // step 3
         if entry_types.is_empty() {
-            return Err(Error::Type("entryTypes cannot be empty".to_string()));
+            // TODO This warning should actually go to the dev console.
+            warn!("Cannot observe an empty sequence of entry types");
+            return Ok(());
         }
 
-        // step 3-4-5
+        // step 4-5-6
         self.global().performance().add_observer(self, entry_types, options.buffered);
 
         Ok(())

--- a/tests/wpt/metadata/navigation-timing/nav2_test_attributes_exist.html.ini
+++ b/tests/wpt/metadata/navigation-timing/nav2_test_attributes_exist.html.ini
@@ -1,5 +1,6 @@
 [nav2_test_attributes_exist.html]
   type: testharness
+  expected: TIMEOUT
   [Performance navigation timing entries are observable.]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/navigation-timing/nav2_test_attributes_values.html.ini
+++ b/tests/wpt/metadata/navigation-timing/nav2_test_attributes_values.html.ini
@@ -1,5 +1,6 @@
 [nav2_test_attributes_values.html]
   type: testharness
+  expected: TIMEOUT
   [Performance navigation timing instance's value is reasonable.]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/navigation-timing/nav2_test_instance_accessors.html.ini
+++ b/tests/wpt/metadata/navigation-timing/nav2_test_instance_accessors.html.ini
@@ -1,5 +1,6 @@
 [nav2_test_instance_accessors.html]
   type: testharness
+  expected: TIMEOUT
   [Performance navigation timing entries are accessible through three different accessors.]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/navigation-timing/nav2_test_navigation_type_backforward.html.ini
+++ b/tests/wpt/metadata/navigation-timing/nav2_test_navigation_type_backforward.html.ini
@@ -1,5 +1,6 @@
 [nav2_test_navigation_type_backforward.html]
   type: testharness
+  expected: TIMEOUT
   [Navigation Timing 2 WPT]
     expected: FAIL
 

--- a/tests/wpt/metadata/navigation-timing/nav2_test_navigation_type_navigate.html.ini
+++ b/tests/wpt/metadata/navigation-timing/nav2_test_navigation_type_navigate.html.ini
@@ -1,5 +1,6 @@
 [nav2_test_navigation_type_navigate.html]
   type: testharness
+  expected: TIMEOUT
   [Navigation type to be navigate.]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/navigation-timing/nav2_test_navigation_type_reload.html.ini
+++ b/tests/wpt/metadata/navigation-timing/nav2_test_navigation_type_reload.html.ini
@@ -1,5 +1,6 @@
 [nav2_test_navigation_type_reload.html]
   type: testharness
+  expected: TIMEOUT
   [Navigation Timing 2 WPT]
     expected: FAIL
 

--- a/tests/wpt/metadata/navigation-timing/nav2_test_redirect_none.html.ini
+++ b/tests/wpt/metadata/navigation-timing/nav2_test_redirect_none.html.ini
@@ -1,5 +1,6 @@
 [nav2_test_redirect_none.html]
   type: testharness
+  expected: TIMEOUT
   [Naivation without redirects.]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/navigation-timing/nav2_test_redirect_xserver_opt_in.html.ini
+++ b/tests/wpt/metadata/navigation-timing/nav2_test_redirect_xserver_opt_in.html.ini
@@ -1,5 +1,6 @@
 [nav2_test_redirect_xserver_opt_in.html]
   type: testharness
+  expected: TIMEOUT
   [Navigation Timing 2 WPT]
     expected: FAIL
 

--- a/tests/wpt/metadata/navigation-timing/nav2_test_unique_nav_instances.html.ini
+++ b/tests/wpt/metadata/navigation-timing/nav2_test_unique_nav_instances.html.ini
@@ -1,5 +1,6 @@
 [nav2_test_unique_nav_instances.html]
   type: testharness
+  expected: TIMEOUT
   [Each window has a unique nav timing 2 instance.]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/navigation-timing/nav2_test_unloadEvents_no_previous_document.html.ini
+++ b/tests/wpt/metadata/navigation-timing/nav2_test_unloadEvents_no_previous_document.html.ini
@@ -1,5 +1,6 @@
 [nav2_test_unloadEvents_no_previous_document.html]
   type: testharness
+  expected: TIMEOUT
   [Navigation Timing 2 WPT]
     expected: FAIL
 

--- a/tests/wpt/metadata/navigation-timing/nav2_test_unloadEvents_with_cross_origin_redirects.html.ini
+++ b/tests/wpt/metadata/navigation-timing/nav2_test_unloadEvents_with_cross_origin_redirects.html.ini
@@ -1,5 +1,6 @@
 [nav2_test_unloadEvents_with_cross_origin_redirects.html]
   type: testharness
+  expected: TIMEOUT
   [Navigation Timing 2 WPT]
     expected: FAIL
 

--- a/tests/wpt/metadata/navigation-timing/test_document_open.html.ini
+++ b/tests/wpt/metadata/navigation-timing/test_document_open.html.ini
@@ -1,0 +1,2 @@
+[test_document_open.html]
+  expected: TIMEOUT

--- a/tests/wpt/metadata/navigation-timing/test_navigation_type_backforward.html.ini
+++ b/tests/wpt/metadata/navigation-timing/test_navigation_type_backforward.html.ini
@@ -1,6 +1,6 @@
 [test_navigation_type_backforward.html]
   type: testharness
-  expected: ERROR
+  expected: TIMEOUT
   [window.performance.navigation is defined]
     expected: FAIL
 

--- a/tests/wpt/metadata/navigation-timing/test_navigation_type_reload.html.ini
+++ b/tests/wpt/metadata/navigation-timing/test_navigation_type_reload.html.ini
@@ -1,6 +1,6 @@
 [test_navigation_type_reload.html]
   type: testharness
-  expected: ERROR
+  expected: TIMEOUT
   [window.performance.navigation is defined]
     expected: FAIL
 

--- a/tests/wpt/metadata/navigation-timing/test_no_previous_document.html.ini
+++ b/tests/wpt/metadata/navigation-timing/test_no_previous_document.html.ini
@@ -1,6 +1,6 @@
 [test_no_previous_document.html]
   type: testharness
-  expected: ERROR
+  expected: TIMEOUT
   [window.performance.navigation is defined]
     expected: FAIL
 

--- a/tests/wpt/metadata/navigation-timing/test_timing_reload.html.ini
+++ b/tests/wpt/metadata/navigation-timing/test_timing_reload.html.ini
@@ -1,6 +1,6 @@
 [test_timing_reload.html]
   type: testharness
-  expected: ERROR
+  expected: TIMEOUT
   [window.performance.navigation is defined]
     expected: FAIL
 

--- a/tests/wpt/metadata/performance-timeline/po-navigation.html.ini
+++ b/tests/wpt/metadata/performance-timeline/po-navigation.html.ini
@@ -1,5 +1,6 @@
 [po-navigation.html]
   type: testharness
+  expected: TIMEOUT
   [navigation entry is observable]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/performance-timeline/po-observe.any.js.ini
+++ b/tests/wpt/metadata/performance-timeline/po-observe.any.js.ini
@@ -1,23 +1,17 @@
 [po-observe.any.worker.html]
   type: testharness
-  [Empty sequence entryTypes is a no-op]
-    expected: FAIL
-
-  [Unknown entryTypes are no-op]
-    expected: FAIL
-
   [Check observer callback parameter and this values]
+    expected: FAIL
+
+  [entryTypes must be a sequence or throw a TypeError]
     expected: FAIL
 
 
 [po-observe.any.html]
   type: testharness
-  [Empty sequence entryTypes is a no-op]
-    expected: FAIL
-
-  [Unknown entryTypes are no-op]
-    expected: FAIL
-
   [Check observer callback parameter and this values]
+    expected: FAIL
+
+  [entryTypes must be a sequence or throw a TypeError]
     expected: FAIL
 

--- a/tests/wpt/metadata/performance-timeline/po-resource.html.ini
+++ b/tests/wpt/metadata/performance-timeline/po-resource.html.ini
@@ -1,5 +1,6 @@
 [po-resource.html]
   type: testharness
+  expected: TIMEOUT
   [resource entries are observable]
-    expected: FAIL
+    expected: TIMEOUT
 


### PR DESCRIPTION
Apply this spec change: https://github.com/w3c/performance-timeline/pull/88

Some tests change from FAIL to TIMEOUT, which is expected as we still don't support the Resource or the Navigation Timing APIs. And the "entryTypes must be a sequence or throw a TypeError" fails because of #19776.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19777)
<!-- Reviewable:end -->
