### PR TITLE
Avoid debug serialization of PropertyDeclaration & co in release builds

### DIFF
--- a/components/style/font_metrics.rs
+++ b/components/style/font_metrics.rs
@@ -12,7 +12,6 @@ use context::SharedStyleContext;
 use logical_geometry::WritingMode;
 use media_queries::Device;
 use properties::style_structs::Font;
-use std::fmt;
 
 /// Represents the font metrics that style needs from a font to compute the
 /// value of certain CSS units like `ex`.
@@ -35,7 +34,7 @@ pub enum FontMetricsQueryResult {
 }
 
 /// A trait used to represent something capable of providing us font metrics.
-pub trait FontMetricsProvider: fmt::Debug {
+pub trait FontMetricsProvider {
     /// Obtain the metrics for given font family.
     ///
     /// TODO: We could make this take the full list, I guess, and save a few

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -1438,11 +1438,18 @@ macro_rules! impl_basic_rule_funcs_without_getter {
         debug: $debug:ident,
         to_css: $to_css:ident,
     } => {
+        #[cfg(debug_assertions)]
         #[no_mangle]
         pub extern "C" fn $debug(rule: &$raw_type, result: *mut nsACString) {
             read_locked_arc(rule, |rule: &$rule_type| {
                 write!(unsafe { result.as_mut().unwrap() }, "{:?}", *rule).unwrap();
             })
+        }
+
+        #[cfg(not(debug_assertions))]
+        #[no_mangle]
+        pub extern "C" fn $debug(_: &$raw_type, _: *mut nsACString) {
+            unreachable!()
         }
 
         #[no_mangle]


### PR DESCRIPTION
In total, this PR saves ~60k.

The conditional compilation on the _Debug FFI function eliminates one
of the ToCss variants, eliminating 54.4k, as well as a bunch of other
<1k functions. Removing the public trait implementation of Debug for the
font metrics provider eliminates the last Debug impl from stylo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19779)
<!-- Reviewable:end -->
