### PR TITLE
Optimize selector matching for some common cases

### DIFF
--- a/components/style/invalidation/element/invalidator.rs
+++ b/components/style/invalidation/element/invalidator.rs
@@ -9,7 +9,7 @@ use context::StackLimitChecker;
 use dom::{TElement, TNode};
 use selector_parser::SelectorImpl;
 use selectors::matching::{CompoundSelectorMatchingResult, MatchingContext};
-use selectors::matching::matches_compound_selector;
+use selectors::matching::matches_compound_selector_from;
 use selectors::parser::{Combinator, Component, Selector};
 use smallvec::SmallVec;
 use std::fmt;
@@ -691,7 +691,7 @@ where
         debug!("TreeStyleInvalidator::process_invalidation({:?}, {:?}, {:?})",
                self.element, invalidation, invalidation_kind);
 
-        let matching_result = matches_compound_selector(
+        let matching_result = matches_compound_selector_from(
             &invalidation.selector,
             invalidation.offset,
             self.processor.matching_context(),


### PR DESCRIPTION
This is the "better way" I mentioned in #19774, which seems to actually improve the score of dromaeo_css on talos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19781)
<!-- Reviewable:end -->
