### PR TITLE
Use more WebRender types in gfx/display_list.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2959,6 +2959,7 @@ dependencies = [
  "euclid 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "malloc_size_of 0.0.1",
  "malloc_size_of_derive 0.0.1",
+ "webrender_api 0.56.1 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,6 @@ dependencies = [
 name = "metrics_tests"
 version = "0.0.1"
 dependencies = [
- "euclid 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.0.1",
  "gfx_traits 0.0.1",
  "ipc-channel 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1788,8 +1787,8 @@ dependencies = [
  "net_traits 0.0.1",
  "profile_traits 0.0.1",
  "servo_url 0.0.1",
- "style 0.0.1",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webrender_api 0.56.1 (git+https://github.com/servo/webrender)",
 ]
 
 [[package]]

--- a/components/geometry/Cargo.toml
+++ b/components/geometry/Cargo.toml
@@ -14,3 +14,4 @@ app_units = "0.6"
 euclid = "0.16"
 malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = { path = "../malloc_size_of_derive" }
+webrender_api = { git = "https://github.com/servo/webrender" }

--- a/components/geometry/lib.rs
+++ b/components/geometry/lib.rs
@@ -6,9 +6,12 @@ extern crate app_units;
 extern crate euclid;
 extern crate malloc_size_of;
 #[macro_use] extern crate malloc_size_of_derive;
+extern crate webrender_api;
 
 use app_units::{Au, MAX_AU, MIN_AU};
 use euclid::{Point2D, Rect, Size2D};
+use std::f32;
+use webrender_api::{LayoutPoint, LayoutRect, LayoutSize};
 
 // Units for use with euclid::length and euclid::scale_factor.
 
@@ -32,9 +35,27 @@ pub enum DeviceIndependentPixel {}
 // originally proposed in 2002 as a standard unit of measure in Gecko.
 // See https://bugzilla.mozilla.org/show_bug.cgi?id=177805 for more info.
 
-#[inline(always)]
-pub fn max_rect() -> Rect<Au> {
-    Rect::new(Point2D::new(MIN_AU / 2, MIN_AU / 2), Size2D::new(MAX_AU, MAX_AU))
+pub trait MaxRect {
+    #[inline(always)]
+    fn max_rect() -> Self;
+}
+
+impl MaxRect for Rect<Au> {
+    fn max_rect() -> Rect<Au> {
+        Rect::new(
+            Point2D::new(MIN_AU / 2, MIN_AU / 2),
+            Size2D::new(MAX_AU, MAX_AU)
+        )
+    }
+}
+
+impl MaxRect for LayoutRect {
+    fn max_rect() -> LayoutRect {
+        LayoutRect::new(
+            LayoutPoint::new(f32::MIN / 2.0, f32::MIN / 2.0),
+            LayoutSize::new(f32::MAX, f32::MAX),
+        )
+    }
 }
 
 /// A helper function to convert a rect of `f32` pixels to a rect of app units.

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -26,15 +26,17 @@ use range::Range;
 use servo_geometry::max_rect;
 use std::cmp::{self, Ordering};
 use std::collections::HashMap;
+use std::f32;
 use std::fmt;
 use std::sync::Arc;
-use style::computed_values::{border_style, image_rendering};
 use style::values::computed::Filter;
 use style_traits::cursor::Cursor;
 use text::TextRun;
 use text::glyph::ByteIndex;
-use webrender_api::{self, BoxShadowClipMode, ClipId, ColorF, GradientStop, LocalClip, MixBlendMode};
-use webrender_api::{ScrollPolicy, ScrollSensitivity, StickyOffsetBounds, TransformStyle};
+use webrender_api::{BoxShadowClipMode, ClipId, ColorF, ExtendMode, GradientStop, ImageKey};
+use webrender_api::{ImageRendering, LayoutPoint, LayoutRect, LayoutSize, LayoutVector2D};
+use webrender_api::{LineStyle, LocalClip, MixBlendMode, NormalBorder, RepeatMode, ScrollPolicy};
+use webrender_api::{ScrollSensitivity, StickyOffsetBounds, TransformStyle};
 
 pub use style::dom::OpaqueNode;
 
@@ -442,7 +444,11 @@ impl BaseDisplayItem {
                 node: OpaqueNode(0),
                 pointing: None,
             },
-            local_clip: LocalClip::from(max_rect().to_rectf()),
+            // Create a rectangle of maximal size.
+            local_clip: LocalClip::from(LayoutRect::new(
+                LayoutPoint::new(f32::MIN / 2.0, f32::MIN / 2.0),
+                LayoutSize::new(f32::MAX, f32::MAX),
+            )),
             section: DisplayListSection::Content,
             stacking_context_id: StackingContextId::root(),
             clipping_and_scrolling: ClippingAndScrolling::simple(ClipScrollNodeIndex(0)),
@@ -699,15 +705,15 @@ pub struct ImageDisplayItem {
     /// The dimensions to which the image display item should be stretched. If this is smaller than
     /// the bounds of this display item, then the image will be repeated in the appropriate
     /// direction to tile the entire bounds.
-    pub stretch_size: Size2D<Au>,
+    pub stretch_size: LayoutSize,
 
     /// The amount of space to add to the right and bottom part of each tile, when the image
     /// is tiled.
-    pub tile_spacing: Size2D<Au>,
+    pub tile_spacing: LayoutSize,
 
     /// The algorithm we should use to stretch the image. See `image_rendering` in CSS-IMAGES-3 §
     /// 5.3.
-    pub image_rendering: image_rendering::T,
+    pub image_rendering: ImageRendering,
 }
 /// Paints an iframe.
 #[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
@@ -720,16 +726,16 @@ pub struct IframeDisplayItem {
 #[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
 pub struct Gradient {
     /// The start point of the gradient (computed during display list construction).
-    pub start_point: Point2D<Au>,
+    pub start_point: LayoutPoint,
 
     /// The end point of the gradient (computed during display list construction).
-    pub end_point: Point2D<Au>,
+    pub end_point: LayoutPoint,
 
     /// A list of color stops.
     pub stops: Vec<GradientStop>,
 
-    /// True if gradient repeats infinitly.
-    pub repeating: bool,
+    /// Whether the gradient is repeated or clamped.
+    pub extend_mode: ExtendMode,
 }
 
 #[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
@@ -747,24 +753,24 @@ pub struct GradientDisplayItem {
     /// the same gradient.
     ///
     /// Without tiles, the tile will be the same size as the background.
-    pub tile: Size2D<Au>,
-    pub tile_spacing: Size2D<Au>,
+    pub tile: LayoutSize,
+    pub tile_spacing: LayoutSize,
 }
 
 /// Paints a radial gradient.
 #[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
 pub struct RadialGradient {
     /// The center point of the gradient.
-    pub center: Point2D<Au>,
+    pub center: LayoutPoint,
 
     /// The radius of the gradient with an x and an y component.
-    pub radius: Size2D<Au>,
+    pub radius: LayoutSize,
 
     /// A list of color stops.
     pub stops: Vec<GradientStop>,
 
-    /// True if gradient repeats infinitly.
-    pub repeating: bool,
+    /// Whether the gradient is repeated or clamped.
+    pub extend_mode: ExtendMode,
 }
 
 #[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
@@ -782,21 +788,8 @@ pub struct RadialGradientDisplayItem {
     /// the same gradient.
     ///
     /// Without tiles, the tile will be the same size as the background.
-    pub tile: Size2D<Au>,
-    pub tile_spacing: Size2D<Au>,
-}
-
-/// A normal border, supporting CSS border styles.
-#[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
-pub struct NormalBorder {
-    /// Border colors.
-    pub color: SideOffsets2D<ColorF>,
-
-    /// Border styles.
-    pub style: SideOffsets2D<border_style::T>,
-
-    /// Border radii.
-    pub radius: BorderRadii<Au>,
+    pub tile: LayoutSize,
+    pub tile_spacing: LayoutSize,
 }
 
 /// A border that is made of image segments.
@@ -815,10 +808,10 @@ pub struct ImageBorder {
     pub fill: bool,
 
     /// How to repeat or stretch horizontal edges (border-image-repeat).
-    pub repeat_horizontal: webrender_api::RepeatMode,
+    pub repeat_horizontal: RepeatMode,
 
     /// How to repeat or stretch vertical edges (border-image-repeat).
-    pub repeat_vertical: webrender_api::RepeatMode,
+    pub repeat_vertical: RepeatMode,
 }
 
 /// A border that is made of linear gradient
@@ -934,8 +927,7 @@ pub struct LineDisplayItem {
     pub color: ColorF,
 
     /// The line segment style.
-    #[ignore_malloc_size_of = "enum type in webrender"]
-    pub style: webrender_api::LineStyle,
+    pub style: LineStyle,
 }
 
 /// Paints a box shadow per CSS-BACKGROUNDS.
@@ -945,25 +937,24 @@ pub struct BoxShadowDisplayItem {
     pub base: BaseDisplayItem,
 
     /// The dimensions of the box that we're placing a shadow around.
-    pub box_bounds: Rect<Au>,
+    pub box_bounds: LayoutRect,
 
     /// The offset of this shadow from the box.
-    pub offset: Vector2D<Au>,
+    pub offset: LayoutVector2D,
 
     /// The color of this shadow.
     pub color: ColorF,
 
     /// The blur radius for this shadow.
-    pub blur_radius: Au,
+    pub blur_radius: f32,
 
     /// The spread radius of this shadow.
-    pub spread_radius: Au,
+    pub spread_radius: f32,
 
     /// The border radius of this shadow.
     pub border_radius: BorderRadii<Au>,
 
     /// How we should clip the result.
-    #[ignore_malloc_size_of = "enum type in webrender"]
     pub clip_mode: BoxShadowClipMode,
 }
 
@@ -974,13 +965,13 @@ pub struct PushTextShadowDisplayItem {
     pub base: BaseDisplayItem,
 
     /// The offset of this shadow from the text.
-    pub offset: Vector2D<Au>,
+    pub offset: LayoutVector2D,
 
     /// The color of this shadow.
     pub color: ColorF,
 
     /// The blur radius for this shadow.
-    pub blur_radius: Au,
+    pub blur_radius: f32,
 }
 
 /// Defines a text shadow that affects all items until the next PopTextShadow.
@@ -1118,7 +1109,7 @@ pub struct WebRenderImageInfo {
     pub width: u32,
     pub height: u32,
     pub format: PixelFormat,
-    pub key: Option<webrender_api::ImageKey>,
+    pub key: Option<ImageKey>,
 }
 
 impl WebRenderImageInfo {
@@ -1152,28 +1143,3 @@ impl SimpleMatrixDetection for Transform3D<f32> {
     }
 }
 
-trait ToPointF {
-    fn to_pointf(&self) -> webrender_api::LayoutPoint;
-}
-
-impl ToPointF for Point2D<Au> {
-    fn to_pointf(&self) -> webrender_api::LayoutPoint {
-        webrender_api::LayoutPoint::new(self.x.to_f32_px(), self.y.to_f32_px())
-    }
-}
-
-trait ToRectF {
-    fn to_rectf(&self) -> webrender_api::LayoutRect;
-}
-
-impl ToRectF for Rect<Au> {
-    fn to_rectf(&self) -> webrender_api::LayoutRect {
-        let x = self.origin.x.to_f32_px();
-        let y = self.origin.y.to_f32_px();
-        let w = self.size.width.to_f32_px();
-        let h = self.size.height.to_f32_px();
-        let point = webrender_api::LayoutPoint::new(x, y);
-        let size = webrender_api::LayoutSize::new(w, h);
-        webrender_api::LayoutRect::new(point, size)
-    }
-}

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -23,7 +23,7 @@ use ipc_channel::ipc::IpcSharedMemory;
 use msg::constellation_msg::PipelineId;
 use net_traits::image::base::{Image, PixelFormat};
 use range::Range;
-use servo_geometry::max_rect;
+use servo_geometry::MaxRect;
 use std::cmp::{self, Ordering};
 use std::collections::HashMap;
 use std::f32;
@@ -445,10 +445,7 @@ impl BaseDisplayItem {
                 pointing: None,
             },
             // Create a rectangle of maximal size.
-            local_clip: LocalClip::from(LayoutRect::new(
-                LayoutPoint::new(f32::MIN / 2.0, f32::MIN / 2.0),
-                LayoutSize::new(f32::MAX, f32::MAX),
-            )),
+            local_clip: LocalClip::from(LayoutRect::max_rect()),
             section: DisplayListSection::Content,
             stacking_context_id: StackingContextId::root(),
             clipping_and_scrolling: ClippingAndScrolling::simple(ClipScrollNodeIndex(0)),
@@ -495,7 +492,7 @@ impl ClippingRegion {
     #[inline]
     pub fn max() -> ClippingRegion {
         ClippingRegion {
-            main: max_rect(),
+            main: Rect::max_rect(),
             complex: Vec::new(),
         }
     }
@@ -606,7 +603,7 @@ impl ClippingRegion {
 
     #[inline]
     pub fn is_max(&self) -> bool {
-        self.main == max_rect() && self.complex.is_empty()
+        self.main == Rect::max_rect() && self.complex.is_empty()
     }
 }
 
@@ -616,7 +613,7 @@ impl fmt::Debug for ClippingRegion {
             write!(f, "ClippingRegion::Max")
         } else if *self == ClippingRegion::empty() {
             write!(f, "ClippingRegion::Empty")
-        } else if self.main == max_rect() {
+        } else if self.main == Rect::max_rect() {
             write!(f, "ClippingRegion(Complex={:?})", self.complex)
         } else {
             write!(f, "ClippingRegion(Rect={:?}, Complex={:?})", self.main, self.complex)

--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -44,7 +44,7 @@ use layout_debug;
 use model::{AdjoiningMargins, CollapsibleMargins, IntrinsicISizes, MarginCollapseInfo, MaybeAuto};
 use sequential;
 use serde::{Serialize, Serializer};
-use servo_geometry::max_rect;
+use servo_geometry::MaxRect;
 use std::cmp::{max, min};
 use std::fmt;
 use std::sync::Arc;
@@ -1955,7 +1955,7 @@ impl Flow for BlockFlow {
         let container_size = Size2D::new(self.base.block_container_inline_size, Au(0));
 
         if self.is_root() {
-            self.base.clip = max_rect();
+            self.base.clip = Rect::max_rect();
         }
 
         if self.base.flags.contains(FlowFlags::IS_ABSOLUTELY_POSITIONED) {

--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -23,7 +23,7 @@ use style::values::generics::image::EndingShape as GenericEndingShape;
 use style::values::generics::image::GradientItem as GenericGradientItem;
 use style::values::specified::background::RepeatKeyword;
 use style::values::specified::position::{X, Y};
-use webrender_api::GradientStop;
+use webrender_api::{ExtendMode, GradientStop};
 
 /// A helper data structure for gradients.
 #[derive(Clone, Copy)]
@@ -370,6 +370,14 @@ fn convert_gradient_stops(gradient_items: &[GradientItem], total_length: Au) -> 
     stops
 }
 
+fn as_gradient_extend_mode(repeating: bool) -> ExtendMode {
+    if repeating {
+        ExtendMode::Repeat
+    } else {
+        ExtendMode::Clamp
+    }
+}
+
 pub fn convert_linear_gradient(
     size: Size2D<Au>,
     stops: &[GradientItem],
@@ -431,10 +439,10 @@ pub fn convert_linear_gradient(
     let center = Point2D::new(size.width / 2, size.height / 2);
 
     display_list::Gradient {
-        start_point: center - delta,
-        end_point: center + delta,
+        start_point: (center - delta).to_layout(),
+        end_point: (center + delta).to_layout(),
         stops: stops,
-        repeating: repeating,
+        extend_mode: as_gradient_extend_mode(repeating),
     }
 }
 
@@ -473,10 +481,10 @@ pub fn convert_radial_gradient(
     }
 
     display_list::RadialGradient {
-        center: center,
-        radius: radius,
+        center: center.to_layout(),
+        radius: radius.to_layout(),
         stops: stops,
-        repeating: repeating,
+        extend_mode: as_gradient_extend_mode(repeating),
     }
 }
 

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -46,7 +46,7 @@ use net_traits::image::base::PixelFormat;
 use net_traits::image_cache::UsePlaceholder;
 use range::Range;
 use servo_config::opts;
-use servo_geometry::max_rect;
+use servo_geometry::MaxRect;
 use std::{cmp, f32};
 use std::default::Default;
 use std::mem;
@@ -2381,7 +2381,7 @@ impl SavedStackingContextCollectionState {
             .containing_block_clip_stack
             .last()
             .cloned()
-            .unwrap_or_else(max_rect);
+            .unwrap_or_else(MaxRect::max_rect);
         state.clip_stack.push(clip);
         self.clips_pushed += 1;
     }
@@ -2447,7 +2447,7 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
 
         let origin = &border_box.origin;
         let transform_clip = |clip: &Rect<Au>| {
-            if *clip == max_rect() {
+            if *clip == Rect::max_rect() {
                 return *clip;
             }
 
@@ -2458,7 +2458,7 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
                     // clip region. Here we don't have enough information to detect when that is
                     // happening. For the moment we just punt on trying to optimize the display
                     // list for those cases.
-                    max_rect()
+                    Rect::max_rect()
                 },
                 Some(transform) => {
                     let clip = Rect::new(
@@ -2573,7 +2573,7 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
                 state.containing_block_clipping_and_scrolling
             },
             StylePosition::Fixed => {
-                preserved_state.push_clip(state, &max_rect(), StylePosition::Fixed);
+                preserved_state.push_clip(state, &Rect::max_rect(), StylePosition::Fixed);
                 state.current_clipping_and_scrolling
             },
             _ => state.current_clipping_and_scrolling,
@@ -2599,7 +2599,11 @@ impl BlockFlowDisplayListBuilding for BlockFlow {
                 &stacking_relative_border_box,
             );
         }
-        self.base.clip = state.clip_stack.last().cloned().unwrap_or_else(max_rect);
+        self.base.clip = state
+            .clip_stack
+            .last()
+            .cloned()
+            .unwrap_or_else(Rect::max_rect);
 
         // We keep track of our position so that any stickily positioned elements can
         // properly determine the extent of their movement relative to scrolling containers.
@@ -2969,7 +2973,11 @@ impl InlineFlowDisplayListBuilding for InlineFlow {
     fn collect_stacking_contexts_for_inline(&mut self, state: &mut StackingContextCollectionState) {
         self.base.stacking_context_id = state.current_stacking_context_id;
         self.base.clipping_and_scrolling = Some(state.current_clipping_and_scrolling);
-        self.base.clip = state.clip_stack.last().cloned().unwrap_or_else(max_rect);
+        self.base.clip = state
+            .clip_stack
+            .last()
+            .cloned()
+            .unwrap_or_else(Rect::max_rect);
 
         for fragment in self.fragments.fragments.iter_mut() {
             let previous_cb_clipping_and_scrolling = state.containing_block_clipping_and_scrolling;

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -31,7 +31,7 @@ use gfx::display_list::{BorderRadii, BoxShadowDisplayItem, ClipScrollNode};
 use gfx::display_list::{ClipScrollNodeIndex, ClipScrollNodeType, ClippingAndScrolling};
 use gfx::display_list::{ClippingRegion, DisplayItem, DisplayItemMetadata, DisplayList};
 use gfx::display_list::{DisplayListSection, GradientDisplayItem, IframeDisplayItem, ImageBorder};
-use gfx::display_list::{ImageDisplayItem, LineDisplayItem, NormalBorder, OpaqueNode};
+use gfx::display_list::{ImageDisplayItem, LineDisplayItem, OpaqueNode};
 use gfx::display_list::{PopAllTextShadowsDisplayItem, PushTextShadowDisplayItem};
 use gfx::display_list::{RadialGradientDisplayItem, SolidColorDisplayItem, StackingContext};
 use gfx::display_list::{StackingContextType, StickyFrameData, TextDisplayItem, TextOrientation};
@@ -56,14 +56,12 @@ use style::computed_values::background_clip::single_value::T as BackgroundClip;
 use style::computed_values::background_origin::single_value::T as BackgroundOrigin;
 use style::computed_values::border_style::T as BorderStyle;
 use style::computed_values::cursor;
-use style::computed_values::image_rendering::T as ImageRendering;
 use style::computed_values::overflow_x::T as StyleOverflow;
 use style::computed_values::pointer_events::T as PointerEvents;
 use style::computed_values::position::T as StylePosition;
 use style::computed_values::visibility::T as Visibility;
 use style::logical_geometry::{LogicalMargin, LogicalPoint, LogicalRect, LogicalSize, WritingMode};
 use style::properties::ComputedValues;
-use style::properties::longhands::border_image_repeat::computed_value::RepeatKeyword;
 use style::properties::style_structs;
 use style::servo::restyle_damage::ServoRestyleDamage;
 use style::values::{Either, RGBA};
@@ -76,8 +74,9 @@ use style_traits::CSSPixel;
 use style_traits::ToCss;
 use style_traits::cursor::Cursor;
 use table_cell::CollapsedBordersForCell;
-use webrender_api::{BoxShadowClipMode, ClipId, ClipMode, ColorF, ComplexClipRegion, LineStyle};
-use webrender_api::{LocalClip, RepeatMode, ScrollPolicy, ScrollSensitivity, StickyOffsetBounds};
+use webrender_api::{self, BoxShadowClipMode, ClipId, ClipMode, ColorF, ComplexClipRegion};
+use webrender_api::{ImageRendering, LayoutSize, LayoutVector2D, LineStyle};
+use webrender_api::{LocalClip, NormalBorder, ScrollPolicy, ScrollSensitivity, StickyOffsetBounds};
 
 trait ResolvePercentage {
     fn resolve(&self, length: u32) -> u32;
@@ -89,15 +88,6 @@ impl ResolvePercentage for NumberOrPercentage {
             NumberOrPercentage::Percentage(p) => (p.0 * length as f32).round() as u32,
             NumberOrPercentage::Number(n) => n.round() as u32,
         }
-    }
-}
-
-fn convert_repeat_mode(from: RepeatKeyword) -> RepeatMode {
-    match from {
-        RepeatKeyword::Stretch => RepeatMode::Stretch,
-        RepeatKeyword::Repeat => RepeatMode::Repeat,
-        RepeatKeyword::Round => RepeatMode::Round,
-        RepeatKeyword::Space => RepeatMode::Space,
     }
 }
 
@@ -825,6 +815,17 @@ fn calculate_inner_bounds(mut bounds: Rect<Au>, offsets: SideOffsets2D<Au>) -> R
     bounds
 }
 
+fn simple_normal_border(color: ColorF, style: webrender_api::BorderStyle) -> NormalBorder {
+    let side = webrender_api::BorderSide { color, style };
+    NormalBorder {
+        left: side,
+        right: side,
+        top: side,
+        bottom: side,
+        radius: webrender_api::BorderRadius::zero(),
+    }
+}
+
 fn calculate_inner_border_radii(
     mut radii: BorderRadii<Au>,
     offsets: SideOffsets2D<Au>,
@@ -1129,9 +1130,9 @@ impl FragmentDisplayListBuilding for Fragment {
             base: base,
             webrender_image: webrender_image,
             image_data: None,
-            stretch_size: placement.tile_size,
-            tile_spacing: placement.tile_spacing,
-            image_rendering: style.get_inheritedbox().image_rendering.clone(),
+            stretch_size: placement.tile_size.to_layout(),
+            tile_spacing: placement.tile_spacing.to_layout(),
+            image_rendering: style.get_inheritedbox().image_rendering.to_layout(),
         })));
     }
 
@@ -1227,8 +1228,8 @@ impl FragmentDisplayListBuilding for Fragment {
                 DisplayItem::Gradient(Box::new(GradientDisplayItem {
                     base: base,
                     gradient: gradient,
-                    tile: placement.tile_size,
-                    tile_spacing: placement.tile_spacing,
+                    tile: placement.tile_size.to_layout(),
+                    tile_spacing: placement.tile_spacing.to_layout(),
                 }))
             },
             GradientKind::Radial(shape, center, _angle) => {
@@ -1242,8 +1243,8 @@ impl FragmentDisplayListBuilding for Fragment {
                 DisplayItem::RadialGradient(Box::new(RadialGradientDisplayItem {
                     base: base,
                     gradient: gradient,
-                    tile: placement.tile_size,
-                    tile_spacing: placement.tile_spacing,
+                    tile: placement.tile_size.to_layout(),
+                    tile_spacing: placement.tile_spacing.to_layout(),
                 }))
             },
         };
@@ -1279,18 +1280,18 @@ impl FragmentDisplayListBuilding for Fragment {
             let border_radius = build_border_radius(absolute_bounds, style.get_border());
             state.add_display_item(DisplayItem::BoxShadow(Box::new(BoxShadowDisplayItem {
                 base: base,
-                box_bounds: *absolute_bounds,
+                box_bounds: absolute_bounds.to_layout(),
                 color: box_shadow
                     .base
                     .color
                     .unwrap_or(style.get_color().color)
                     .to_layout(),
-                offset: Vector2D::new(
-                    Au::from(box_shadow.base.horizontal),
-                    Au::from(box_shadow.base.vertical),
+                offset: LayoutVector2D::new(
+                    box_shadow.base.horizontal.px(),
+                    box_shadow.base.vertical.px(),
                 ),
-                blur_radius: Au::from(box_shadow.base.blur),
-                spread_radius: Au::from(box_shadow.spread),
+                blur_radius: box_shadow.base.blur.px(),
+                spread_radius: box_shadow.spread.px(),
                 border_radius,
                 clip_mode: if box_shadow.inset {
                     BoxShadowClipMode::Inset
@@ -1373,20 +1374,31 @@ impl FragmentDisplayListBuilding for Fragment {
             display_list_section,
         );
 
+        let border_radius = build_border_radius(&bounds, border_style_struct);
+
         match border_style_struct.border_image_source {
             Either::First(_) => {
                 state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
                     base: base,
                     border_widths: border.to_physical(style.writing_mode),
                     details: BorderDetails::Normal(NormalBorder {
-                        color: SideOffsets2D::new(
-                            colors.top.to_layout(),
-                            colors.right.to_layout(),
-                            colors.bottom.to_layout(),
-                            colors.left.to_layout(),
-                        ),
-                        style: border_style,
-                        radius: build_border_radius(&bounds, border_style_struct),
+                        left: webrender_api::BorderSide {
+                            color: colors.left.to_layout(),
+                            style: border_style.left.to_layout(),
+                        },
+                        right: webrender_api::BorderSide {
+                            color: colors.right.to_layout(),
+                            style: border_style.right.to_layout(),
+                        },
+                        top: webrender_api::BorderSide {
+                            color: colors.top.to_layout(),
+                            style: border_style.top.to_layout(),
+                        },
+                        bottom: webrender_api::BorderSide {
+                            color: colors.bottom.to_layout(),
+                            style: border_style.bottom.to_layout(),
+                        },
+                        radius: border_radius.to_border_radius(),
                     }),
                 })));
             },
@@ -1432,6 +1444,7 @@ impl FragmentDisplayListBuilding for Fragment {
                     self.get_webrender_image_for_paint_worklet(state, style, paint_worklet, size);
                 if let Some(webrender_image) = webrender_image {
                     let corners = &border_style_struct.border_image_slice.offsets;
+                    let border_image_repeat = &border_style_struct.border_image_repeat;
 
                     state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
                         base: base,
@@ -1447,12 +1460,8 @@ impl FragmentDisplayListBuilding for Fragment {
                             ),
                             // TODO(gw): Support border-image-outset
                             outset: SideOffsets2D::zero(),
-                            repeat_horizontal: convert_repeat_mode(
-                                border_style_struct.border_image_repeat.0,
-                            ),
-                            repeat_vertical: convert_repeat_mode(
-                                border_style_struct.border_image_repeat.1,
-                            ),
+                            repeat_horizontal: border_image_repeat.0.to_layout(),
+                            repeat_vertical: border_image_repeat.1.to_layout(),
                         }),
                     })));
                 }
@@ -1472,6 +1481,7 @@ impl FragmentDisplayListBuilding for Fragment {
                     );
                     if let Some(webrender_image) = webrender_image {
                         let corners = &border_style_struct.border_image_slice.offsets;
+                        let border_image_repeat = &border_style_struct.border_image_repeat;
 
                         state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
                             base: base,
@@ -1487,12 +1497,8 @@ impl FragmentDisplayListBuilding for Fragment {
                                 ),
                                 // TODO(gw): Support border-image-outset
                                 outset: SideOffsets2D::zero(),
-                                repeat_horizontal: convert_repeat_mode(
-                                    border_style_struct.border_image_repeat.0,
-                                ),
-                                repeat_vertical: convert_repeat_mode(
-                                    border_style_struct.border_image_repeat.1,
-                                ),
+                                repeat_horizontal: border_image_repeat.0.to_layout(),
+                                repeat_vertical: border_image_repeat.1.to_layout(),
                             }),
                         })));
                     }
@@ -1544,11 +1550,7 @@ impl FragmentDisplayListBuilding for Fragment {
         state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(width),
-            details: BorderDetails::Normal(NormalBorder {
-                color: SideOffsets2D::new_all_same(color),
-                style: SideOffsets2D::new_all_same(outline_style),
-                radius: Default::default(),
-            }),
+            details: BorderDetails::Normal(simple_normal_border(color, outline_style.to_layout())),
         })));
     }
 
@@ -1575,11 +1577,10 @@ impl FragmentDisplayListBuilding for Fragment {
         state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(1)),
-            details: BorderDetails::Normal(NormalBorder {
-                color: SideOffsets2D::new_all_same(ColorF::rgb(0, 0, 200)),
-                style: SideOffsets2D::new_all_same(BorderStyle::Solid),
-                radius: Default::default(),
-            }),
+            details: BorderDetails::Normal(simple_normal_border(
+                ColorF::rgb(0, 0, 200),
+                webrender_api::BorderStyle::Solid,
+            )),
         })));
 
         // Draw a rectangle representing the baselines.
@@ -1623,11 +1624,10 @@ impl FragmentDisplayListBuilding for Fragment {
         state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(1)),
-            details: BorderDetails::Normal(NormalBorder {
-                color: SideOffsets2D::new_all_same(ColorF::rgb(0, 0, 200)),
-                style: SideOffsets2D::new_all_same(BorderStyle::Solid),
-                radius: Default::default(),
-            }),
+            details: BorderDetails::Normal(simple_normal_border(
+                ColorF::rgb(0, 0, 200),
+                webrender_api::BorderStyle::Solid,
+            )),
         })));
     }
 
@@ -1996,9 +1996,9 @@ impl FragmentDisplayListBuilding for Fragment {
                         base: base,
                         webrender_image: WebRenderImageInfo::from_image(image),
                         image_data: Some(Arc::new(image.bytes.clone())),
-                        stretch_size: stacking_relative_content_box.size,
-                        tile_spacing: Size2D::zero(),
-                        image_rendering: self.style.get_inheritedbox().image_rendering.clone(),
+                        stretch_size: stacking_relative_content_box.size.to_layout(),
+                        tile_spacing: LayoutSize::zero(),
+                        image_rendering: self.style.get_inheritedbox().image_rendering.to_layout(),
                     })));
                 }
             },
@@ -2037,8 +2037,8 @@ impl FragmentDisplayListBuilding for Fragment {
                         key: Some(image_key),
                     },
                     image_data: None,
-                    stretch_size: stacking_relative_content_box.size,
-                    tile_spacing: Size2D::zero(),
+                    stretch_size: stacking_relative_content_box.size.to_layout(),
+                    tile_spacing: LayoutSize::zero(),
                     image_rendering: ImageRendering::Auto,
                 }));
 
@@ -2160,8 +2160,8 @@ impl FragmentDisplayListBuilding for Fragment {
             state.add_display_item(DisplayItem::PushTextShadow(Box::new(
                 PushTextShadowDisplayItem {
                     base: base.clone(),
-                    blur_radius: Au::from(shadow.blur),
-                    offset: Vector2D::new(Au::from(shadow.horizontal), Au::from(shadow.vertical)),
+                    blur_radius: shadow.blur.px(),
+                    offset: LayoutVector2D::new(shadow.horizontal.px(), shadow.vertical.px()),
                     color: shadow
                         .color
                         .unwrap_or(self.style().get_color().color)
@@ -3141,11 +3141,10 @@ impl BaseFlowDisplayListBuilding for BaseFlow {
         state.add_display_item(DisplayItem::Border(Box::new(BorderDisplayItem {
             base: base,
             border_widths: SideOffsets2D::new_all_same(Au::from_px(2)),
-            details: BorderDetails::Normal(NormalBorder {
-                color: SideOffsets2D::new_all_same(color),
-                style: SideOffsets2D::new_all_same(BorderStyle::Solid),
-                radius: BorderRadii::all_same(Au(0)),
-            }),
+            details: BorderDetails::Normal(simple_normal_border(
+                color,
+                webrender_api::BorderStyle::Solid,
+            )),
         })));
     }
 }

--- a/components/layout/display_list/conversions.rs
+++ b/components/layout/display_list/conversions.rs
@@ -7,6 +7,7 @@ use euclid::{Point2D, Rect, SideOffsets2D, Size2D, Vector2D};
 use style::computed_values::image_rendering::T as ImageRendering;
 use style::computed_values::mix_blend_mode::T as MixBlendMode;
 use style::computed_values::transform_style::T as TransformStyle;
+use style::properties::longhands::border_image_repeat::RepeatKeyword;
 use style::values::RGBA;
 use style::values::computed::{BorderStyle, Filter};
 use style::values::generics::effects::Filter as GenericFilter;
@@ -148,5 +149,17 @@ impl ToLayout for Vector2D<Au> {
     type Type = wr::LayoutVector2D;
     fn to_layout(&self) -> Self::Type {
         wr::LayoutVector2D::new(self.x.to_f32_px(), self.y.to_f32_px())
+    }
+}
+
+impl ToLayout for RepeatKeyword {
+    type Type = wr::RepeatMode;
+    fn to_layout(&self) -> Self::Type {
+        match *self {
+            RepeatKeyword::Stretch => wr::RepeatMode::Stretch,
+            RepeatKeyword::Repeat => wr::RepeatMode::Repeat,
+            RepeatKeyword::Round => wr::RepeatMode::Round,
+            RepeatKeyword::Space => wr::RepeatMode::Space,
+        }
     }
 }

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -43,7 +43,7 @@ use model::{CollapsibleMargins, IntrinsicISizes, MarginCollapseInfo};
 use multicol::MulticolFlow;
 use parallel::FlowParallelInfo;
 use serde::ser::{Serialize, SerializeStruct, Serializer};
-use servo_geometry::{au_rect_to_f32_rect, f32_rect_to_au_rect, max_rect};
+use servo_geometry::{au_rect_to_f32_rect, f32_rect_to_au_rect, MaxRect};
 use std::fmt;
 use std::iter::Zip;
 use std::slice::IterMut;
@@ -1062,7 +1062,7 @@ impl BaseFlow {
             absolute_cb: ContainingBlockLink::new(),
             early_absolute_position_info: EarlyAbsolutePositionInfo::new(writing_mode),
             late_absolute_position_info: LateAbsolutePositionInfo::new(),
-            clip: max_rect(),
+            clip: MaxRect::max_rect(),
             flags: flags,
             writing_mode: writing_mode,
             thread_id: 0,

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -108,7 +108,7 @@ use servo_atoms::Atom;
 use servo_config::opts;
 use servo_config::prefs::PREFS;
 use servo_config::resource_files::read_resource_file;
-use servo_geometry::max_rect;
+use servo_geometry::MaxRect;
 use servo_url::ServoUrl;
 use std::borrow::ToOwned;
 use std::cell::{Cell, RefCell};
@@ -1467,7 +1467,7 @@ impl LayoutThread {
 
         if let Some(mut root_flow) = self.root_flow.borrow().clone() {
             let reflow_info = Reflow {
-                page_clip_rect: max_rect(),
+                page_clip_rect: Rect::max_rect(),
             };
 
             // Unwrap here should not panic since self.root_flow is only ever set to Some(_)

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -716,19 +716,31 @@ impl MallocSizeOf for url::Host {
 }
 
 #[cfg(feature = "servo")]
+malloc_size_of_is_0!(webrender_api::BorderStyle);
+#[cfg(feature = "servo")]
+malloc_size_of_is_0!(webrender_api::BoxShadowClipMode);
+#[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::ClipAndScrollInfo);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::ClipId);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::ColorF);
 #[cfg(feature = "servo")]
+malloc_size_of_is_0!(webrender_api::ExtendMode);
+#[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::GradientStop);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::ImageKey);
 #[cfg(feature = "servo")]
+malloc_size_of_is_0!(webrender_api::ImageRendering);
+#[cfg(feature = "servo")]
+malloc_size_of_is_0!(webrender_api::LineStyle);
+#[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::LocalClip);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::MixBlendMode);
+#[cfg(feature = "servo")]
+malloc_size_of_is_0!(webrender_api::NormalBorder);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::RepeatMode);
 #[cfg(feature = "servo")]

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -84,7 +84,7 @@ use script_traits::webdriver_msg::{WebDriverJSError, WebDriverJSResult};
 use selectors::attr::CaseSensitivity;
 use servo_config::opts;
 use servo_config::prefs::PREFS;
-use servo_geometry::{f32_rect_to_au_rect, max_rect};
+use servo_geometry::{f32_rect_to_au_rect, MaxRect};
 use servo_url::{Host, MutableOrigin, ImmutableOrigin, ServoUrl};
 use std::borrow::ToOwned;
 use std::cell::Cell;
@@ -1606,7 +1606,7 @@ impl Window {
             return false;
         }
 
-        let had_clip_rect = clip_rect != max_rect();
+        let had_clip_rect = clip_rect != MaxRect::max_rect();
         if had_clip_rect && !should_move_clip_rect(clip_rect, viewport) {
             return false;
         }
@@ -1614,7 +1614,7 @@ impl Window {
         self.page_clip_rect.set(proposed_clip_rect);
 
         // If we didn't have a clip rect, the previous display doesn't need rebuilding
-        // because it was built for infinite clip (max_rect()).
+        // because it was built for infinite clip (MaxRect::amax_rect()).
         had_clip_rect
     }
 
@@ -1835,7 +1835,7 @@ impl Window {
             js_runtime: DomRefCell::new(Some(runtime.clone())),
             bluetooth_thread,
             bluetooth_extra_permission_data: BluetoothExtraPermissionData::new(),
-            page_clip_rect: Cell::new(max_rect()),
+            page_clip_rect: Cell::new(MaxRect::max_rect()),
             resize_event: Default::default(),
             layout_chan,
             layout_rpc,

--- a/tests/unit/metrics/Cargo.toml
+++ b/tests/unit/metrics/Cargo.toml
@@ -10,7 +10,6 @@ path = "lib.rs"
 doctest = false
 
 [dependencies]
-euclid = "0.16"
 gfx = {path = "../../../components/gfx"}
 gfx_traits = {path = "../../../components/gfx_traits"}
 ipc-channel = "0.9"
@@ -19,5 +18,5 @@ msg = {path = "../../../components/msg"}
 net_traits = {path = "../../../components/net_traits"}
 profile_traits = {path = "../../../components/profile_traits"}
 servo_url = {path = "../../../components/url"}
-style = {path = "../../../components/style"}
 time = "0.1.12"
+webrender_api = {git = "https://github.com/servo/webrender"}

--- a/tests/unit/metrics/lib.rs
+++ b/tests/unit/metrics/lib.rs
@@ -4,7 +4,6 @@
 
 #![cfg(test)]
 
-extern crate euclid;
 extern crate gfx;
 extern crate gfx_traits;
 extern crate ipc_channel;
@@ -13,8 +12,8 @@ extern crate msg;
 extern crate net_traits;
 extern crate profile_traits;
 extern crate servo_url;
-extern crate style;
 extern crate time;
+extern crate webrender_api;
 
 mod interactive_time;
 mod paint_time;

--- a/tests/unit/metrics/paint_time.rs
+++ b/tests/unit/metrics/paint_time.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use euclid::Size2D;
 use gfx::display_list::{BaseDisplayItem, WebRenderImageInfo};
 use gfx::display_list::{DisplayItem, DisplayList, ImageDisplayItem};
 use gfx_traits::Epoch;
@@ -12,8 +11,8 @@ use msg::constellation_msg::TEST_PIPELINE_ID;
 use net_traits::image::base::PixelFormat;
 use profile_traits::time::{ProfilerChan, TimerMetadata};
 use servo_url::ServoUrl;
-use style::computed_values::image_rendering::T as ImageRendering;
 use time;
+use webrender_api::{ImageRendering, LayoutSize};
 
 struct DummyProfilerMetadataFactory {}
 impl ProfilerMetadataFactory for DummyProfilerMetadataFactory {
@@ -128,8 +127,8 @@ fn test_first_contentful_paint_setter() {
             key: None,
         },
         image_data: None,
-        stretch_size: Size2D::zero(),
-        tile_spacing: Size2D::zero(),
+        stretch_size: LayoutSize::zero(),
+        tile_spacing: LayoutSize::zero(),
         image_rendering: ImageRendering::Auto,
     }));
     let display_list = DisplayList {


### PR DESCRIPTION
Use more WebRender types in gfx/display_list.
This uses floating-point (Layout) coordinates in where possible.
Replace NormalBorder struct with WebRender equivalent.
Remove ToPointF and ToRectF traits.
Convert border RepeatKeyword with ToLayout.
Add some definitions to malloc_size_of for WebRender types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19782)
<!-- Reviewable:end -->
