### PR TITLE
style: Make GeckoElement::has_class faster.

### DIFF
--- a/components/style/gecko/snapshot_helpers.rs
+++ b/components/style/gecko/snapshot_helpers.rs
@@ -32,7 +32,14 @@ pub fn has_class<T>(
             1 => case_sensitivity.eq_atom(name, WeakAtom::new(class)),
             n => {
                 let classes = slice::from_raw_parts(list, n as usize);
-                classes.iter().any(|ptr| case_sensitivity.eq_atom(name, WeakAtom::new(*ptr)))
+                match case_sensitivity {
+                    CaseSensitivity::CaseSensitive => {
+                        classes.iter().any(|ptr| name == WeakAtom::new(*ptr))
+                    }
+                    CaseSensitivity::AsciiCaseInsensitive => {
+                        classes.iter().any(|ptr| name.eq_ignore_ascii_case(WeakAtom::new(*ptr)))
+                    }
+                }
             }
         }
     }

--- a/components/style/gecko/snapshot_helpers.rs
+++ b/components/style/gecko/snapshot_helpers.rs
@@ -34,7 +34,7 @@ pub fn has_class<T>(
                 let classes = slice::from_raw_parts(list, n as usize);
                 match case_sensitivity {
                     CaseSensitivity::CaseSensitive => {
-                        classes.iter().any(|ptr| name == WeakAtom::new(*ptr))
+                        classes.iter().any(|ptr| &**name == WeakAtom::new(*ptr))
                     }
                     CaseSensitivity::AsciiCaseInsensitive => {
                         classes.iter().any(|ptr| name.eq_ignore_ascii_case(WeakAtom::new(*ptr)))

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -2191,7 +2191,7 @@ impl<'le> ::selectors::Element for GeckoElement<'le> {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     fn has_class(&self, name: &Atom, case_sensitivity: CaseSensitivity) -> bool {
         if !self.may_have_class() {
             return false;


### PR DESCRIPTION
By force-inlining the fast path, and pulling out a branch that rust didn't manage to pull out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19787)
<!-- Reviewable:end -->
