### PR TITLE
Do not leave space below baseline when it is not needed (i.e.there is…

### DIFF
--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -1143,7 +1143,11 @@ impl InlineFlow {
         let font_style = style.clone_font();
         let font_metrics = text::font_metrics_for_style(font_context, font_style);
         let line_height = text::line_height_from_style(style, &font_metrics);
-        let inline_metrics = InlineMetrics::from_font_metrics(&font_metrics, line_height);
+        let inline_metrics = if fragments.iter().any(Fragment::is_text_or_replaced) {
+            InlineMetrics::from_font_metrics(&font_metrics, line_height)
+        } else {
+            InlineMetrics::new(Au(0), Au(0), Au(0))
+        };
 
         let mut line_metrics = LineMetrics::new(Au(0), MIN_AU);
         let mut largest_block_size_for_top_fragments = Au(0);

--- a/tests/wpt/metadata/css/CSS2/fonts/font-variant-applies-to-005.xht.ini
+++ b/tests/wpt/metadata/css/CSS2/fonts/font-variant-applies-to-005.xht.ini
@@ -1,3 +1,0 @@
-[font-variant-applies-to-005.xht]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata/css/CSS2/lists/list-style-applies-to-012.xht.ini
+++ b/tests/wpt/metadata/css/CSS2/lists/list-style-applies-to-012.xht.ini
@@ -1,3 +1,0 @@
-[list-style-applies-to-012.xht]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata/css/CSS2/lists/list-style-type-applies-to-012.xht.ini
+++ b/tests/wpt/metadata/css/CSS2/lists/list-style-type-applies-to-012.xht.ini
@@ -1,3 +1,0 @@
-[list-style-type-applies-to-012.xht]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata/css/css-flexbox/flexbox_inline.html.ini
+++ b/tests/wpt/metadata/css/css-flexbox/flexbox_inline.html.ini
@@ -1,0 +1,2 @@
+[flexbox_inline.html]
+  expected: FAIL


### PR DESCRIPTION
… no text)

This is my first layout fix and a naive approach to fix #18831.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #18831

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19789)
<!-- Reviewable:end -->
