### PR TITLE
style: Remove new function added to the build from bindings.rs

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -1152,8 +1152,6 @@ extern "C" {
 } extern "C" {
  pub fn Servo_Element_IsPrimaryStyleReusedViaRuleNode ( element : RawGeckoElementBorrowed , ) -> bool ; 
 } extern "C" {
- pub fn Servo_InvalidateStyleForDocStateChanges ( root : RawGeckoElementBorrowed , sets : * const nsTArray < RawServoStyleSetBorrowed > , aStatesChanged : u64 , ) ; 
-} extern "C" {
  pub fn Servo_StyleSheet_FromUTF8Bytes ( loader : * mut Loader , gecko_stylesheet : * mut ServoStyleSheet , data : * const u8 , data_len : usize , parsing_mode : SheetParsingMode , extra_data : * mut RawGeckoURLExtraData , line_number_offset : u32 , quirks_mode : nsCompatibility , reusable_sheets : * mut LoaderReusableStyleSheets , ) -> RawServoStyleSheetContentsStrong ; 
 } extern "C" {
  pub fn Servo_StyleSheet_Empty ( parsing_mode : SheetParsingMode , ) -> RawServoStyleSheetContentsStrong ; 


### PR DESCRIPTION
Since it was removed from gecko, and this confuses a lot to
ports/geckolib/tests/build.rs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19799)
<!-- Reviewable:end -->
