### PR TITLE
Implement Element::has_css_layout_box()

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -349,11 +349,12 @@ impl Element {
     }
 
     // https://drafts.csswg.org/cssom-view/#css-layout-box
-    // Elements that have a computed value of the display property
-    // that is table-column or table-column-group
-    // FIXME: Currently, it is assumed to be true always
+    //
+    // We'll have no content box if there's no fragment for the node, and we use
+    // bounding_content_box, for simplicity, to detect this (rather than making a more specific
+    // query to the layout thread).
     fn has_css_layout_box(&self) -> bool {
-        true
+        self.upcast::<Node>().bounding_content_box().is_some()
     }
 
     // https://drafts.csswg.org/cssom-view/#potentially-scrollable

--- a/tests/wpt/web-platform-tests/css/cssom-view/scroll-no-layout-box.html
+++ b/tests/wpt/web-platform-tests/css/cssom-view/scroll-no-layout-box.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>cssom-view - Scrolling element with no layout box</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scroll">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#css-layout-box">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div style="display: none">
+  <div id="elem"></div>
+</div>
+
+<script>
+test(() => {
+  const elem = document.getElementById('elem');
+  elem.scroll(1, 2);
+
+  assert_equals(elem.scrollTop, 0, "scrollTop should be unchanged");
+  assert_equals(elem.scrollLeft, 0, "scrollLeft should be unchanged");
+}, "scrolling an element with no CSS layout box should have no effect");
+</script>


### PR DESCRIPTION
r? emilio 

Here's my initial attempt to fix #19430. It seems surprisingly simple so I am wondering whether I have missed something! (Or maybe it just actually is quite simple...)

Some things I am unsure about:

1. The spec seems vague about what a [CSS layout box](https://drafts.csswg.org/cssom-view/#css-layout-box) actually is. Indeed it says: "The terms CSS layout box and SVG layout box are not currently defined by CSS or SVG."
2. One thing the spec *does* say explicitly is "For the purpose of the requirements in this specification, elements that have a computed value of the display property that is table-column or table-column-group must be considered to have an associated CSS layout box (the column or column group, respectively)." I am unclear about the relevance of this, since [overflow does not apply](https://drafts.csswg.org/css-overflow-3/#overflow-properties) to an [internal table element](https://drafts.csswg.org/css-display-3/#layout-specific-display). Therefore I haven't done anything about this explicitly, but maybe I'm missing some nuance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19803)
<!-- Reviewable:end -->
