### PR TITLE
Use more WebRender types in gfx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,6 @@ dependencies = [
  "simd 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
- "style_traits 0.0.1",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "truetype 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -40,7 +40,6 @@ servo_geometry = {path = "../geometry"}
 servo_url = {path = "../url"}
 smallvec = "0.6"
 style = {path = "../style"}
-style_traits = {path = "../style_traits"}
 time = "0.1.12"
 unicode-bidi = {version = "0.3", features = ["with_serde"]}
 unicode-script = {version = "0.1", features = ["harfbuzz"]}

--- a/components/gfx/lib.rs
+++ b/components/gfx/lib.rs
@@ -58,7 +58,6 @@ extern crate servo_url;
 extern crate simd;
 extern crate smallvec;
 extern crate style;
-extern crate style_traits;
 extern crate time;
 extern crate unicode_bidi;
 extern crate unicode_script;

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -714,9 +714,12 @@ impl MallocSizeOf for url::Host {
         }
     }
 }
-
+#[cfg(feature = "servo")]
+malloc_size_of_is_0!(webrender_api::BorderRadius);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::BorderStyle);
+#[cfg(feature = "servo")]
+malloc_size_of_is_0!(webrender_api::BorderWidths);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::BoxShadowClipMode);
 #[cfg(feature = "servo")]
@@ -728,7 +731,11 @@ malloc_size_of_is_0!(webrender_api::ColorF);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::ExtendMode);
 #[cfg(feature = "servo")]
+malloc_size_of_is_0!(webrender_api::FilterOp);
+#[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::GradientStop);
+#[cfg(feature = "servo")]
+malloc_size_of_is_0!(webrender_api::ImageBorder);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::ImageKey);
 #[cfg(feature = "servo")]


### PR DESCRIPTION
Removes ImageBorder details from gfx.
Use WebRender BorderRadius in BoxShadow.
Stores cursors as integer.
Use FilterOp, BorderWidths from WebRender.
Store content_rect as LayoutRect.

This amends #19782.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19824)
<!-- Reviewable:end -->
