### PR TITLE
Added default fall-back when CARGO_HOME is not set for clean-cargo-cache

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -189,7 +189,8 @@ class MachCommands(CommandBase):
         if os.environ.get("CARGO_HOME", ""):
             cargo_dir = os.environ.get("CARGO_HOME")
         else:
-            cargo_dir = path.join(self.context.topdir, ".cargo")
+            home_dir = os.path.expanduser("~")
+            cargo_dir = path.join(home_dir, ".cargo")
         if not os.path.isdir(cargo_dir):
             return
         cargo_file = open(path.join(self.context.topdir, "Cargo.lock"))


### PR DESCRIPTION
Added default fall-back when CARGO_HOME is not set.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19823 (github issue number if applicable).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19843)
<!-- Reviewable:end -->
