### PR TITLE
style: Update css-align to the spec (mostly)

### DIFF
--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -69,8 +69,8 @@ ${helpers.single_keyword("flex-wrap", "nowrap wrap wrap-reverse",
                              animation_value_type="discrete")}
 % else:
     ${helpers.predefined_type(name="justify-content",
-                              type="ContentDistribution",
-                              initial_value="specified::ContentDistribution::normal()",
+                              type="JustifyContent",
+                              initial_value="specified::JustifyContent(specified::ContentDistribution::normal())",
                               spec="https://drafts.csswg.org/css-align/#propdef-justify-content",
                               extra_prefixes="webkit",
                               animation_value_type="discrete")}
@@ -90,8 +90,8 @@ ${helpers.single_keyword("flex-wrap", "nowrap wrap wrap-reverse",
                              animation_value_type="discrete")}
 % else:
     ${helpers.predefined_type(name="align-content",
-                              type="ContentDistribution",
-                              initial_value="specified::ContentDistribution::normal()",
+                              type="AlignContent",
+                              initial_value="specified::AlignContent(specified::ContentDistribution::normal())",
                               spec="https://drafts.csswg.org/css-align/#propdef-align-content",
                               extra_prefixes="webkit",
                               animation_value_type="discrete")}

--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -138,15 +138,15 @@ ${helpers.predefined_type("flex-shrink", "NonNegativeNumber",
                              animation_value_type="discrete")}
 % else:
     ${helpers.predefined_type(name="align-self",
-                              type="SelfAlignment",
-                              initial_value="specified::SelfAlignment::auto()",
+                              type="AlignSelf",
+                              initial_value="specified::AlignSelf(specified::SelfAlignment::auto())",
                               spec="https://drafts.csswg.org/css-align/#align-self-property",
                               extra_prefixes="webkit",
                               animation_value_type="discrete")}
 
     ${helpers.predefined_type(name="justify-self",
-                              type="SelfAlignment",
-                              initial_value="specified::SelfAlignment::auto()",
+                              type="JustifySelf",
+                              initial_value="specified::JustifySelf(specified::SelfAlignment::auto())",
                               spec="https://drafts.csswg.org/css-align/#justify-self-property",
                               animation_value_type="discrete")}
 

--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -615,25 +615,17 @@
 <%helpers:shorthand name="place-content" sub_properties="align-content justify-content"
                     spec="https://drafts.csswg.org/css-align/#propdef-place-content"
                     products="gecko">
-    use values::specified::align::{AlignContent, JustifyContent, ContentDistribution, FallbackAllowed, AxisDirection};
+    use values::specified::align::{AlignContent, JustifyContent, ContentDistribution, AxisDirection};
 
     pub fn parse_value<'i, 't>(
         _: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Longhands, ParseError<'i>> {
         let align_content =
-            ContentDistribution::parse(
-                input,
-                FallbackAllowed::No,
-                AxisDirection::Inline,
-            )?;
+            ContentDistribution::parse(input, AxisDirection::Block)?;
 
         let justify_content = input.try(|input| {
-            ContentDistribution::parse(
-                input,
-                FallbackAllowed::No,
-                AxisDirection::Block,
-            )
+            ContentDistribution::parse(input, AxisDirection::Inline)
         });
 
         let justify_content = match justify_content {

--- a/components/style/properties/shorthand/position.mako.rs
+++ b/components/style/properties/shorthand/position.mako.rs
@@ -634,11 +634,19 @@
                 FallbackAllowed::No,
                 AxisDirection::Block,
             )
-        }).unwrap_or(align_content);
+        });
 
-        // NOTE(emilio): align-content parsing is more restrictive than
-        // justify-content parsing, so no need to do any extra check here for
-        // that.
+        let justify_content = match justify_content {
+            Ok(v) => v,
+            Err(err) => {
+                if !align_content.is_valid_on_both_axes() {
+                    return Err(err);
+                }
+
+                align_content
+            }
+        };
+
         if align_content.has_extra_flags() || justify_content.has_extra_flags() {
             return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
         }

--- a/components/style/values/computed/align.rs
+++ b/components/style/values/computed/align.rs
@@ -12,6 +12,7 @@ use values::computed::{Context, ToComputedValue};
 use values::specified;
 
 pub use super::specified::{AlignContent, JustifyContent, AlignItems, SelfAlignment};
+pub use super::specified::{AlignSelf, JustifySelf};
 
 /// The computed value for the `justify-items` property.
 ///

--- a/components/style/values/computed/align.rs
+++ b/components/style/values/computed/align.rs
@@ -11,7 +11,7 @@ use style_traits::{CssWriter, ToCss};
 use values::computed::{Context, ToComputedValue};
 use values::specified;
 
-pub use super::specified::{AlignItems, ContentDistribution, SelfAlignment};
+pub use super::specified::{AlignContent, JustifyContent, AlignItems, SelfAlignment};
 
 /// The computed value for the `justify-items` property.
 ///

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -33,6 +33,8 @@ pub use app_units::Au;
 pub use properties::animated_properties::TransitionProperty;
 #[cfg(feature = "gecko")]
 pub use self::align::{AlignItems, AlignContent, JustifyContent, SelfAlignment, JustifyItems};
+#[cfg(feature = "gecko")]
+pub use self::align::{AlignSelf, JustifySelf};
 pub use self::angle::Angle;
 pub use self::background::{BackgroundSize, BackgroundRepeat};
 pub use self::border::{BorderImageSlice, BorderImageWidth, BorderImageSideWidth};

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -32,7 +32,7 @@ use super::specified;
 pub use app_units::Au;
 pub use properties::animated_properties::TransitionProperty;
 #[cfg(feature = "gecko")]
-pub use self::align::{AlignItems, ContentDistribution, SelfAlignment, JustifyItems};
+pub use self::align::{AlignItems, AlignContent, JustifyContent, SelfAlignment, JustifyItems};
 pub use self::angle::Angle;
 pub use self::background::{BackgroundSize, BackgroundRepeat};
 pub use self::border::{BorderImageSlice, BorderImageWidth, BorderImageSideWidth};

--- a/components/style/values/specified/align.rs
+++ b/components/style/values/specified/align.rs
@@ -69,6 +69,14 @@ bitflags! {
     }
 }
 
+impl AlignFlags {
+    /// Returns the enumeration value stored in the lower 5 bits.
+    #[inline]
+    fn value(&self) -> Self {
+        *self & !AlignFlags::FLAG_BITS
+    }
+}
+
 impl ToCss for AlignFlags {
     fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
     where
@@ -81,7 +89,7 @@ impl ToCss for AlignFlags {
             _ => {}
         }
 
-        dest.write_str(match *self & !AlignFlags::FLAG_BITS {
+        dest.write_str(match self.value() {
             AlignFlags::AUTO => "auto",
             AlignFlags::NORMAL => "normal",
             AlignFlags::START => "start",
@@ -150,21 +158,17 @@ impl ContentDistribution {
 
     /// Returns whether this value is valid for both axis directions.
     pub fn is_valid_on_both_axes(&self) -> bool {
-        if self.primary.contains(AlignFlags::BASELINE) ||
-            self.primary.contains(AlignFlags::LAST_BASELINE)
-        {
+        match self.primary.value() {
             // <baseline-position> is only allowed on the block axis.
-            return false;
-        }
+            AlignFlags::BASELINE |
+            AlignFlags::LAST_BASELINE => false,
 
-        if self.primary.contains(AlignFlags::LEFT) ||
-            self.primary.contains(AlignFlags::RIGHT)
-        {
             // left | right are only allowed on the inline axis.
-            return false;
-        }
+            AlignFlags::LEFT |
+            AlignFlags::RIGHT => false,
 
-        true
+            _ => true,
+        }
     }
 
     /// The primary alignment
@@ -297,21 +301,17 @@ impl SelfAlignment {
 
     /// Returns whether this value is valid for both axis directions.
     pub fn is_valid_on_both_axes(&self) -> bool {
-        if self.0.contains(AlignFlags::BASELINE) ||
-            self.0.contains(AlignFlags::LAST_BASELINE)
-        {
+        match self.0.value() {
             // <baseline-position> is only allowed on the block axis.
-            return false;
-        }
+            AlignFlags::BASELINE |
+            AlignFlags::LAST_BASELINE => false,
 
-        if self.0.contains(AlignFlags::LEFT) ||
-            self.0.contains(AlignFlags::RIGHT)
-        {
             // left | right are only allowed on the inline axis.
-            return false;
-        }
+            AlignFlags::LEFT |
+            AlignFlags::RIGHT => false,
 
-        true
+            _ => true,
+        }
     }
 
     /// Whether this value has extra flags.

--- a/components/style/values/specified/align.rs
+++ b/components/style/values/specified/align.rs
@@ -75,7 +75,14 @@ impl ToCss for AlignFlags {
     where
         W: Write,
     {
-        let s = match *self & !AlignFlags::FLAG_BITS {
+        match *self & AlignFlags::FLAG_BITS {
+            AlignFlags::LEGACY => dest.write_str("legacy ")?,
+            AlignFlags::SAFE => dest.write_str("safe ")?,
+            // Don't serialize "unsafe", since it's the default.
+            _ => {}
+        }
+
+        dest.write_str(match *self & !AlignFlags::FLAG_BITS {
             AlignFlags::AUTO => "auto",
             AlignFlags::NORMAL => "normal",
             AlignFlags::START => "start",
@@ -94,16 +101,7 @@ impl ToCss for AlignFlags {
             AlignFlags::SPACE_AROUND => "space-around",
             AlignFlags::SPACE_EVENLY => "space-evenly",
             _ => unreachable!()
-        };
-        dest.write_str(s)?;
-
-        match *self & AlignFlags::FLAG_BITS {
-            AlignFlags::LEGACY => { dest.write_str(" legacy")?; }
-            AlignFlags::SAFE => { dest.write_str(" safe")?; }
-            AlignFlags::UNSAFE => { dest.write_str(" unsafe")?; }
-            _ => {}
-        }
-        Ok(())
+        })
     }
 }
 

--- a/components/style/values/specified/align.rs
+++ b/components/style/values/specified/align.rs
@@ -110,14 +110,14 @@ const ALIGN_ALL_BITS: u16 = structs::NS_STYLE_ALIGN_ALL_BITS as u16;
 /// Number of bits to shift a fallback alignment.
 const ALIGN_ALL_SHIFT: u32 = structs::NS_STYLE_ALIGN_ALL_SHIFT;
 
-/// Value of the `align-content` or `justify-content` property.
-///
-/// <https://drafts.csswg.org/css-align/#content-distribution>
-#[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq, ToComputedValue)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
-pub struct ContentDistribution {
-    primary: AlignFlags,
-    fallback: AlignFlags,
+/// An axis direction, either inline (for the `justify` properties) or block,
+/// (for the `align` properties).
+#[derive(Clone, Copy, PartialEq)]
+pub enum AxisDirection {
+    /// Block direction.
+    Block,
+    /// Inline direction.
+    Inline,
 }
 
 /// Whether fallback is allowed in align-content / justify-content parsing.
@@ -132,6 +132,16 @@ pub enum FallbackAllowed {
     Yes,
     /// Don't allow fallback alignment.
     No,
+}
+
+/// Shared value for the `align-content` and `justify-content` properties.
+///
+/// <https://drafts.csswg.org/css-align/#content-distribution>
+#[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq, ToComputedValue)]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+pub struct ContentDistribution {
+    primary: AlignFlags,
+    fallback: AlignFlags,
 }
 
 impl ContentDistribution {
@@ -155,6 +165,19 @@ impl ContentDistribution {
         Self { primary, fallback }
     }
 
+    fn from_bits(bits: u16) -> Self {
+        let primary =
+            AlignFlags::from_bits_truncate((bits & ALIGN_ALL_BITS) as u8);
+        let fallback =
+            AlignFlags::from_bits_truncate((bits >> ALIGN_ALL_SHIFT) as u8);
+        Self::with_fallback(primary, fallback)
+    }
+
+    fn as_bits(&self) -> u16 {
+        self.primary.bits() as u16 |
+        ((self.fallback.bits() as u16) << ALIGN_ALL_SHIFT)
+    }
+
     /// The primary alignment
     #[inline]
     pub fn primary(self) -> AlignFlags {
@@ -176,9 +199,10 @@ impl ContentDistribution {
 
     /// Parse a value for align-content / justify-content, optionally allowing
     /// fallback.
-    pub fn parse_with_fallback<'i, 't>(
+    pub fn parse<'i, 't>(
         input: &mut Parser<'i, 't>,
         fallback_allowed: FallbackAllowed,
+        _axis: AxisDirection,
     ) -> Result<Self, ParseError<'i>> {
         // normal | <baseline-position>
         if let Ok(value) = input.try(|input| parse_normal_or_baseline(input)) {
@@ -224,12 +248,69 @@ impl ToCss for ContentDistribution {
     }
 }
 
+/// Value for the `align-content` property.
+///
+/// <https://drafts.csswg.org/css-align/#propdef-align-content>
+#[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq, ToComputedValue, ToCss)]
+pub struct AlignContent(pub ContentDistribution);
 
-impl Parse for ContentDistribution {
-    // normal | <baseline-position> |
-    // [ <content-distribution> || [ <overflow-position>? && <content-position> ] ]
-    fn parse<'i, 't>(_: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
-        Self::parse_with_fallback(input, FallbackAllowed::Yes)
+impl Parse for AlignContent {
+    fn parse<'i, 't>(
+        _: &ParserContext,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self, ParseError<'i>> {
+        Ok(AlignContent(ContentDistribution::parse(
+            input,
+            FallbackAllowed::Yes,
+            AxisDirection::Block,
+        )?))
+    }
+}
+
+#[cfg(feature = "gecko")]
+impl From<u16> for AlignContent {
+    fn from(bits: u16) -> Self {
+        AlignContent(ContentDistribution::from_bits(bits))
+    }
+}
+
+#[cfg(feature = "gecko")]
+impl From<AlignContent> for u16 {
+    fn from(v: AlignContent) -> u16 {
+        v.0.as_bits()
+    }
+}
+
+/// Value for the `justify-content` property.
+///
+/// <https://drafts.csswg.org/css-align/#propdef-align-content>
+#[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq, ToComputedValue, ToCss)]
+pub struct JustifyContent(pub ContentDistribution);
+
+impl Parse for JustifyContent {
+    fn parse<'i, 't>(
+        _: &ParserContext,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self, ParseError<'i>> {
+        Ok(JustifyContent(ContentDistribution::parse(
+            input,
+            FallbackAllowed::Yes,
+            AxisDirection::Inline,
+        )?))
+    }
+}
+
+#[cfg(feature = "gecko")]
+impl From<u16> for JustifyContent {
+    fn from(bits: u16) -> Self {
+        JustifyContent(ContentDistribution::from_bits(bits))
+    }
+}
+
+#[cfg(feature = "gecko")]
+impl From<JustifyContent> for u16 {
+    fn from(v: JustifyContent) -> u16 {
+        v.0.as_bits()
     }
 }
 
@@ -346,25 +427,6 @@ impl Parse for JustifyItems {
         }
         // [ <overflow-position>? && <self-position> ]
         Ok(JustifyItems(parse_overflow_self_position(input)?))
-    }
-}
-
-#[cfg(feature = "gecko")]
-impl From<u16> for ContentDistribution {
-    fn from(bits: u16) -> ContentDistribution {
-        let primary =
-            AlignFlags::from_bits_truncate((bits & ALIGN_ALL_BITS) as u8);
-        let fallback =
-            AlignFlags::from_bits_truncate((bits >> ALIGN_ALL_SHIFT) as u8);
-        ContentDistribution::with_fallback(primary, fallback)
-    }
-}
-
-#[cfg(feature = "gecko")]
-impl From<ContentDistribution> for u16 {
-    fn from(v: ContentDistribution) -> u16 {
-        v.primary().bits() as u16 |
-        ((v.fallback().bits() as u16) << ALIGN_ALL_SHIFT)
     }
 }
 

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -26,7 +26,7 @@ use values::specified::calc::CalcNode;
 pub use properties::animated_properties::TransitionProperty;
 pub use self::angle::Angle;
 #[cfg(feature = "gecko")]
-pub use self::align::{AlignItems, ContentDistribution, SelfAlignment, JustifyItems};
+pub use self::align::{AlignContent, JustifyContent, AlignItems, ContentDistribution, SelfAlignment, JustifyItems};
 pub use self::background::{BackgroundRepeat, BackgroundSize};
 pub use self::border::{BorderCornerRadius, BorderImageSlice, BorderImageWidth};
 pub use self::border::{BorderImageSideWidth, BorderRadius, BorderSideWidth, BorderSpacing};

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -27,6 +27,8 @@ pub use properties::animated_properties::TransitionProperty;
 pub use self::angle::Angle;
 #[cfg(feature = "gecko")]
 pub use self::align::{AlignContent, JustifyContent, AlignItems, ContentDistribution, SelfAlignment, JustifyItems};
+#[cfg(feature = "gecko")]
+pub use self::align::{AlignSelf, JustifySelf};
 pub use self::background::{BackgroundRepeat, BackgroundSize};
 pub use self::border::{BorderCornerRadius, BorderImageSlice, BorderImageWidth};
 pub use self::border::{BorderImageSideWidth, BorderRadius, BorderSideWidth, BorderSpacing};


### PR DESCRIPTION
This is on top of #19850.

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1430817, and updates us
to the current version of the css-align spec.

The only remaining change is the justify-items: auto FIXME.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19851)
<!-- Reviewable:end -->
