### PR TITLE
Allow floats to impact list item marker position

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -3887,6 +3887,18 @@
      {}
     ]
    ],
+   "css/list_item_marker_around_float.html": [
+    [
+     "/_mozilla/css/list_item_marker_around_float.html",
+     [
+      [
+       "/_mozilla/css/list_item_marker_around_float_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "css/list_item_overflow.html": [
     [
      "/_mozilla/css/list_item_overflow.html",
@@ -9534,6 +9546,11 @@
     ]
    ],
    "css/link_style_order_ref.html": [
+    [
+     {}
+    ]
+   ],
+   "css/list_item_marker_around_float_ref.html": [
     [
      {}
     ]
@@ -63571,6 +63588,14 @@
   ],
   "css/link_style_order_ref.html": [
    "958f9315c950502cdadb2297e1ab77e197774113",
+   "support"
+  ],
+  "css/list_item_marker_around_float.html": [
+   "1023fced99e1181fadce849978c4e111da8ad4aa",
+   "reftest"
+  ],
+  "css/list_item_marker_around_float_ref.html": [
+   "1c13844df9055d73a8421ca3f8398cb4c289c44e",
    "support"
   ],
   "css/list_item_overflow.html": [

--- a/tests/wpt/mozilla/tests/css/list_item_marker_around_float.html
+++ b/tests/wpt/mozilla/tests/css/list_item_marker_around_float.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="match" href="list_item_marker_around_float_ref.html">
+
+<style>
+#float {
+  float: left;
+  height: 50px;
+  width: 200px;
+}
+</style>
+
+<div id="float">
+</div>
+
+<ul>
+  <li>One</li>
+  <li>Two</li>
+  <li>Three</li>
+  <li>Four</li>
+  <li>Five</li>
+</ul>

--- a/tests/wpt/mozilla/tests/css/list_item_marker_around_float_ref.html
+++ b/tests/wpt/mozilla/tests/css/list_item_marker_around_float_ref.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta charset="utf-8">
+
+<style>
+#float {
+  float: left;
+  height: 50px;
+  width: 200px;
+}
+
+li {
+  list-style-type: none;
+}
+
+.wrap {
+  display: inline-block;
+  position: relative;
+}
+
+.marker {
+  position: absolute;
+  right: 100%;
+}
+</style>
+
+<div id="float">
+</div>
+
+<ul>
+  <li><div class="wrap"><span class="marker">•&nbsp;</span>One</div></li>
+  <li><div class="wrap"><span class="marker">•&nbsp;</span>Two</div></li>
+  <li><div class="wrap"><span class="marker">•&nbsp;</span>Three</div></li>
+  <li><div class="wrap"><span class="marker">•&nbsp;</span>Four</div></li>
+  <li><div class="wrap"><span class="marker">•&nbsp;</span>Five</div></li>
+</ul>


### PR DESCRIPTION
Although not required by the specification, this matches the rendering
of Gecko and Blink.

Fixes #19796.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19852)
<!-- Reviewable:end -->
