### PR TITLE
style: make the try_match_ident_ignore_ascii_case macro actually return the error.

### DIFF
--- a/components/style/macros.rs
+++ b/components/style/macros.rs
@@ -53,19 +53,16 @@ macro_rules! trivial_to_computed_value {
 /// FIXME(emilio): The fact that `UnexpectedIdent` is a `SelectorParseError`
 /// doesn't make a lot of sense to me.
 macro_rules! try_match_ident_ignore_ascii_case {
-    ($input:expr, $( $match_body:tt )*) => {
+    ($input:expr, $( $match_body:tt )*) => {{
         let location = $input.current_source_location();
         let ident = $input.expect_ident_cloned()?;
-        (match_ignore_ascii_case! { &ident,
+        match_ignore_ascii_case! { &ident,
             $( $match_body )*
-            _ => Err(()),
-        })
-        .map_err(|()| {
-            location.new_custom_error(
+            _ => return Err(location.new_custom_error(
                 ::selectors::parser::SelectorParseErrorKind::UnexpectedIdent(ident.clone())
-            )
-        })
-    }
+            ))
+        }
+    }}
 }
 
 macro_rules! define_numbered_css_keyword_enum {

--- a/components/style/values/specified/text.rs
+++ b/components/style/values/specified/text.rs
@@ -293,8 +293,9 @@ impl Parse for TextDecorationLine {
         }
 
         loop {
-            let result: Result<_, ParseError> = input.try(|input| {
-                try_match_ident_ignore_ascii_case! { input,
+            let result = input.try(|input| {
+                let ident = input.expect_ident().map_err(|_| ())?;
+                match_ignore_ascii_case! { ident,
                     "underline" => {
                         if result.contains(TextDecorationLine::UNDERLINE) {
                             Err(())
@@ -327,6 +328,7 @@ impl Parse for TextDecorationLine {
                             Ok(())
                         }
                     }
+                    _ => Err(()),
                 }
             });
             if result.is_err() {


### PR DESCRIPTION
This allows it to be used as an expression, which I'd like to do very soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19854)
<!-- Reviewable:end -->
