### PR TITLE
Added --progress flag to test-perf git commands

### DIFF
--- a/etc/ci/performance/test_perf.sh
+++ b/etc/ci/performance/test_perf.sh
@@ -31,11 +31,11 @@ WARC_REPO="git@github.com:servo/servo-warc-tests.git"
 
 # Clone the warc tests if they don't exist
 if [[ ! -d ${WARC_DIR} ]]; then
-    git clone ${WARC_REPO}
+    git clone --progress ${WARC_REPO}
 fi
 
 # Make sure we're running with an up-to-date warc test repo
-git -C ${WARC_DIR} pull
+git -C ${WARC_DIR} pull --progress
 
 virtualenv venv --python="$(which python3)"
 PS1="" source venv/bin/activate


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Adding a `--progress` flag to git commands in test-perf to try to avoid the timeouts we're seeing at http://build.servo.org/builders/linux-nightly/builds/581/steps/test/logs/stdio
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because this is test infrastructure

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19855)
<!-- Reviewable:end -->
