### PR TITLE
Use default sccache timeout.

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -3,7 +3,7 @@ env:
   CARGO_INCREMENTAL: "0"
   CCACHE: sccache
   RUSTC_WRAPPER: sccache
-  SCCACHE_IDLE_TIMEOUT: 600
+  SCCACHE_IDLE_TIMEOUT: "600"
 
 mac-rel-wpt1:
   - ./mach clean-nightlies --keep 3 --force

--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -3,6 +3,7 @@ env:
   CARGO_INCREMENTAL: "0"
   CCACHE: sccache
   RUSTC_WRAPPER: sccache
+  SCCACHE_IDLE_TIMEOUT: 600
 
 mac-rel-wpt1:
   - ./mach clean-nightlies --keep 3 --force


### PR DESCRIPTION
Try to resolve the ongoing issues on cross builders where the sccache server takes up 50% of available memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19856)
<!-- Reviewable:end -->
