### PR TITLE
Update README.md to fix font requirements for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ sudo zypper install libX11-devel libexpat-devel libbz2-devel Mesa-libEGL-devel M
 #### On Arch Linux
 
 ``` sh
-sudo pacman -S --needed base-devel git python2 python2-virtualenv python2-pip mesa cmake bzip2 libxmu glu pkg-config
+sudo pacman -S --needed base-devel git python2 python2-virtualenv python2-pip mesa cmake bzip2 libxmu glu pkg-config ttf-fira-sans
 ```
 #### On Gentoo Linux
 


### PR DESCRIPTION
The current specifications for installation of Servo in Arch Linux fails to run due to requirement of fonts.

The fix is just to include the required package in the required dependencies list in README.md.

<!-- Please describe your changes on the following line: -->

I added the required font package for Arch Linux in the README file. This is in accordance with the comments on the bug #12107, which deals with similar requirements for Gentoo
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because - The changes are in README file

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19867)
<!-- Reviewable:end -->
