### PR TITLE
Use https github URL to clone servo-warc-tests repo

### DIFF
--- a/etc/ci/performance/test_perf.sh
+++ b/etc/ci/performance/test_perf.sh
@@ -26,8 +26,10 @@ else
     echo "Found existing test cases, skipping download and unzip."
 fi
 
+# We use the https URL for the repo so the clone works even if
+# github.com isn't in ssh's known hosts.
 WARC_DIR="./servo-warc-tests"
-WARC_REPO="git@github.com:servo/servo-warc-tests.git"
+WARC_REPO="https://github.com/servo/servo-warc-tests.git"
 
 # Clone the warc tests if they don't exist
 if [[ ! -d ${WARC_DIR} ]]; then


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fixes timeouts such as http://build.servo.org/builders/linux-nightly/builds/583/steps/test/logs/stdio caused by github.com not being in the ssh known hosts.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because this is test infrastructure

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19875)
<!-- Reviewable:end -->
