### PR TITLE
selectors: Never match ::slotted on <slot>s.

### DIFF
--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -784,6 +784,13 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
         }
     }
 
+    fn is_html_slot_element(&self) -> bool {
+        unsafe {
+            self.element.is_html_element() &&
+            self.get_local_name() == &local_name!("slot")
+        }
+    }
+
     fn is_html_element_in_html_document(&self) -> bool {
         unsafe {
             if !self.element.is_html_element() {
@@ -1174,6 +1181,10 @@ impl<'le> ::selectors::Element for ServoThreadSafeLayoutElement<'le> {
     fn next_sibling_element(&self) -> Option<Self> {
         warn!("ServoThreadSafeLayoutElement::next_sibling_element called");
         None
+    }
+
+    fn is_html_slot_element(&self) -> bool {
+        self.element.is_html_slot_element()
     }
 
     fn is_html_element_in_html_document(&self) -> bool {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -916,8 +916,12 @@ impl LayoutElementHelpers for LayoutDom<Element> {
 }
 
 impl Element {
+    pub fn is_html_element(&self) -> bool {
+        self.namespace == ns!(html)
+    }
+
     pub fn html_element_in_html_document(&self) -> bool {
-        self.namespace == ns!(html) && self.upcast::<Node>().is_in_html_doc()
+        self.is_html_element() && self.upcast::<Node>().is_in_html_doc()
     }
 
     pub fn local_name(&self) -> &LocalName {
@@ -2712,6 +2716,10 @@ impl<'a> SelectorsElement for DomRoot<Element> {
 
     fn is_html_element_in_html_document(&self) -> bool {
         self.html_element_in_html_document()
+    }
+
+    fn is_html_slot_element(&self) -> bool {
+        self.is_html_element() && self.local_name() == &local_name!("slot")
     }
 }
 

--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -416,6 +416,7 @@ where
             element.parent_element()
         }
         Combinator::SlotAssignment => {
+            debug_assert!(element.assigned_slot().map_or(true, |s| s.is_html_slot_element()));
             element.assigned_slot()
         }
         Combinator::PseudoElement => {
@@ -631,6 +632,8 @@ where
         Component::Combinator(_) => unreachable!(),
         Component::Slotted(ref selector) => {
             context.shared.nest(|context| {
+                // <slots> are never flattened tree slottables.
+                !element.is_html_slot_element() &&
                 element.assigned_slot().is_some() &&
                 matches_complex_selector(
                     selector.iter(),

--- a/components/selectors/tree.rs
+++ b/components/selectors/tree.rs
@@ -82,6 +82,9 @@ pub trait Element: Sized + Clone + Debug {
     /// Whether this element is a `link`.
     fn is_link(&self) -> bool;
 
+    /// Returns whether the element is an HTML <slot> element.
+    fn is_html_slot_element(&self) -> bool;
+
     /// Returns the assigned <slot> element this element is assigned to.
     ///
     /// Necessary for the `::slotted` pseudo-class.

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -419,12 +419,6 @@ pub trait TElement
     /// Return whether this element is an element in the HTML namespace.
     fn is_html_element(&self) -> bool;
 
-    /// Returns whether this element is a <html:slot> element.
-    fn is_html_slot_element(&self) -> bool {
-        self.get_local_name() == &*local_name!("slot") &&
-        self.is_html_element()
-    }
-
     /// Return the list of slotted nodes of this node.
     fn slotted_nodes(&self) -> &[Self::ConcreteNode] {
         &[]

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -2206,6 +2206,12 @@ impl<'le> ::selectors::Element for GeckoElement<'le> {
     }
 
     #[inline]
+    fn is_html_slot_element(&self) -> bool {
+        self.is_html_element() &&
+        self.get_local_name().as_ptr() == local_name!("slot").as_ptr()
+    }
+
+    #[inline]
     fn ignores_nth_child_selectors(&self) -> bool {
         self.is_root_of_anonymous_subtree()
     }

--- a/components/style/invalidation/element/element_wrapper.rs
+++ b/components/style/invalidation/element/element_wrapper.rs
@@ -295,6 +295,10 @@ impl<'a, E> Element for ElementWrapper<'a, E>
         self.element.is_html_element_in_html_document()
     }
 
+    fn is_html_slot_element(&self) -> bool {
+        self.element.is_html_slot_element()
+    }
+
     fn get_local_name(&self) -> &<Self::Impl as ::selectors::SelectorImpl>::BorrowedLocalName {
         self.element.get_local_name()
     }


### PR DESCRIPTION
This fixes the test from https://github.com/w3c/web-platform-tests/pull/9212 in
Gecko.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19878)
<!-- Reviewable:end -->
