### PR TITLE
Add layout RPC query for getting an element's style

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -154,12 +154,13 @@ pub fn handle_get_layout(documents: &Documents,
 }
 
 fn determine_auto_margins(window: &Window, node: &Node) -> AutoMargins {
-    let margin = window.margin_style_query(node.to_trusted_node_address());
+    let style = window.style_query(node.to_trusted_node_address()).unwrap();
+    let margin = style.get_margin();
     AutoMargins {
-        top: margin.top == margin_top::computed_value::T::Auto,
-        right: margin.right == margin_right::computed_value::T::Auto,
-        bottom: margin.bottom == margin_bottom::computed_value::T::Auto,
-        left: margin.left == margin_left::computed_value::T::Auto,
+        top: margin.margin_top == margin_top::computed_value::T::Auto,
+        right: margin.margin_right == margin_right::computed_value::T::Auto,
+        bottom: margin.margin_bottom == margin_bottom::computed_value::T::Auto,
+        left: margin.margin_left == margin_left::computed_value::T::Auto,
     }
 }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -348,27 +348,24 @@ impl Element {
     }
 
     // https://drafts.csswg.org/cssom-view/#css-layout-box
-    //
-    // We'll have no content box if there's no fragment for the node, and we use
-    // bounding_content_box, for simplicity, to detect this (rather than making a more specific
-    // query to the layout thread).
     fn has_css_layout_box(&self) -> bool {
-        self.upcast::<Node>().bounding_content_box().is_some()
+        let style = self.upcast::<Node>().style();
+
+        // style will be None for elements in a display: none subtree. otherwise, the element has a
+        // layout box iff it doesn't have display: none.
+        style.map_or(false, |s| !s.get_box().clone_display().is_none())
     }
 
     // https://drafts.csswg.org/cssom-view/#potentially-scrollable
     fn potentially_scrollable(&self) -> bool {
-        self.has_css_layout_box() &&
-        !self.overflow_x_is_visible() &&
-        !self.overflow_y_is_visible()
+        self.has_css_layout_box() && !self.has_any_visible_overflow()
     }
 
     // https://drafts.csswg.org/cssom-view/#scrolling-box
     fn has_scrolling_box(&self) -> bool {
         // TODO: scrolling mechanism, such as scrollbar (We don't have scrollbar yet)
         //       self.has_scrolling_mechanism()
-        self.overflow_x_is_hidden() ||
-        self.overflow_y_is_hidden()
+        self.has_any_hidden_overflow()
     }
 
     fn has_overflow(&self) -> bool {
@@ -376,32 +373,33 @@ impl Element {
         self.ScrollWidth() > self.ClientWidth()
     }
 
-    // used value of overflow-x is "visible"
-    fn overflow_x_is_visible(&self) -> bool {
-        let window = window_from_node(self);
-        let overflow_pair = window.overflow_query(self.upcast::<Node>().to_trusted_node_address());
-        overflow_pair.x == overflow_x::computed_value::T::Visible
+    // TODO: Once #19183 is closed (overflow-x/y types moved out of mako), then we could implement
+    //       a more generic `fn has_some_overflow(&self, overflow: Overflow)` rather than have
+    //       these two `has_any_{visible,hidden}_overflow` methods which are very structurally
+    //       similar.
+
+    /// Computed value of overflow-x or overflow-y is "visible"
+    fn has_any_visible_overflow(&self) -> bool {
+        let style = self.upcast::<Node>().style();
+
+        style.map_or(false, |s| {
+            let box_ = s.get_box();
+
+            box_.clone_overflow_x() == overflow_x::computed_value::T::Visible ||
+                box_.clone_overflow_y() == overflow_y::computed_value::T::Visible
+        })
     }
 
-    // used value of overflow-y is "visible"
-    fn overflow_y_is_visible(&self) -> bool {
-        let window = window_from_node(self);
-        let overflow_pair = window.overflow_query(self.upcast::<Node>().to_trusted_node_address());
-        overflow_pair.y == overflow_y::computed_value::T::Visible
-    }
+    /// Computed value of overflow-x or overflow-y is "hidden"
+    fn has_any_hidden_overflow(&self) -> bool {
+        let style = self.upcast::<Node>().style();
 
-    // used value of overflow-x is "hidden"
-    fn overflow_x_is_hidden(&self) -> bool {
-        let window = window_from_node(self);
-        let overflow_pair = window.overflow_query(self.upcast::<Node>().to_trusted_node_address());
-        overflow_pair.x == overflow_x::computed_value::T::Hidden
-    }
+        style.map_or(false, |s| {
+            let box_ = s.get_box();
 
-    // used value of overflow-y is "hidden"
-    fn overflow_y_is_hidden(&self) -> bool {
-        let window = window_from_node(self);
-        let overflow_pair = window.overflow_query(self.upcast::<Node>().to_trusted_node_address());
-        overflow_pair.y == overflow_y::computed_value::T::Hidden
+            box_.clone_overflow_x() == overflow_x::computed_value::T::Hidden ||
+                box_.clone_overflow_y() == overflow_y::computed_value::T::Hidden
+        })
     }
 }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -82,6 +82,7 @@ use std::mem;
 use std::ops::Range;
 use style::context::QuirksMode;
 use style::dom::OpaqueNode;
+use style::properties::ComputedValues;
 use style::selector_parser::{SelectorImpl, SelectorParser};
 use style::stylesheets::Stylesheet;
 use style::thread_state;
@@ -617,6 +618,10 @@ impl Node {
 
     pub fn client_rect(&self) -> Rect<i32> {
         window_from_node(self).client_rect_query(self.to_trusted_node_address())
+    }
+
+    pub fn style(&self) -> Option<Arc<ComputedValues>> {
+        window_from_node(self).style_query(self.to_trusted_node_address())
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -113,13 +113,12 @@ pub enum ReflowGoal {
     TickAnimations,
     ContentBoxQuery(TrustedNodeAddress),
     ContentBoxesQuery(TrustedNodeAddress),
-    NodeOverflowQuery(TrustedNodeAddress),
     NodeScrollRootIdQuery(TrustedNodeAddress),
     NodeGeometryQuery(TrustedNodeAddress),
     NodeScrollGeometryQuery(TrustedNodeAddress),
     ResolvedStyleQuery(TrustedNodeAddress, Option<PseudoElement>, PropertyId),
     OffsetParentQuery(TrustedNodeAddress),
-    MarginStyleQuery(TrustedNodeAddress),
+    StyleQuery(TrustedNodeAddress),
     TextIndexQuery(TrustedNodeAddress, Point2D<f32>),
     NodesFromPointQuery(Point2D<f32>, NodesFromPointQueryType),
 }
@@ -133,9 +132,9 @@ impl ReflowGoal {
             ReflowGoal::TickAnimations | ReflowGoal::Full => true,
             ReflowGoal::ContentBoxQuery(_) | ReflowGoal::ContentBoxesQuery(_) |
             ReflowGoal::NodeGeometryQuery(_) | ReflowGoal::NodeScrollGeometryQuery(_) |
-            ReflowGoal::NodeOverflowQuery(_) | ReflowGoal::NodeScrollRootIdQuery(_) |
+            ReflowGoal::NodeScrollRootIdQuery(_) |
             ReflowGoal::ResolvedStyleQuery(..) | ReflowGoal::OffsetParentQuery(_) |
-            ReflowGoal::MarginStyleQuery(_)  => false,
+            ReflowGoal::StyleQuery(_)  => false,
         }
     }
 
@@ -143,10 +142,10 @@ impl ReflowGoal {
     /// false if a layout_thread display list is sufficient.
     pub fn needs_display(&self) -> bool {
         match *self {
-            ReflowGoal::MarginStyleQuery(_)  | ReflowGoal::TextIndexQuery(..) |
+            ReflowGoal::StyleQuery(_)  | ReflowGoal::TextIndexQuery(..) |
             ReflowGoal::ContentBoxQuery(_) | ReflowGoal::ContentBoxesQuery(_) |
             ReflowGoal::NodeGeometryQuery(_) | ReflowGoal::NodeScrollGeometryQuery(_) |
-            ReflowGoal::NodeOverflowQuery(_) | ReflowGoal::NodeScrollRootIdQuery(_) |
+            ReflowGoal::NodeScrollRootIdQuery(_) |
             ReflowGoal::ResolvedStyleQuery(..) |
             ReflowGoal::OffsetParentQuery(_) => false,
             ReflowGoal::NodesFromPointQuery(..) | ReflowGoal::Full |

--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -11,7 +11,6 @@ use invalidation::element::restyle_hints::RestyleHint;
 #[cfg(feature = "gecko")]
 use malloc_size_of::MallocSizeOfOps;
 use properties::ComputedValues;
-use properties::longhands::display::computed_value::T as Display;
 use rule_tree::StrongRuleNode;
 use selector_parser::{EAGER_PSEUDO_COUNT, PseudoElement, RestyleDamage};
 use selectors::NthIndexCache;
@@ -169,7 +168,7 @@ impl ElementStyles {
 
     /// Whether this element `display` value is `none`.
     pub fn is_display_none(&self) -> bool {
-        self.primary().get_box().clone_display() == Display::None
+        self.primary().get_box().clone_display().is_none()
     }
 
     #[cfg(feature = "gecko")]

--- a/components/style/values/specified/box.rs
+++ b/components/style/values/specified/box.rs
@@ -216,6 +216,12 @@ impl Display {
             other => other,
         }
     }
+
+    /// Returns true if the value is `None`
+    #[inline]
+    pub fn is_none(&self) -> bool {
+        *self == Display::None
+    }
 }
 
 /// A specified value for the `vertical-align` property.


### PR DESCRIPTION
This enables us to implement Element::has_css_layout_box() in a more
direct way, and also enables us to remove some of the existing more
specific queries.

Fixes #19811.

r? @emilio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19881)
<!-- Reviewable:end -->
