### PR TITLE
Re-enable sccache for Linux builds

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -96,40 +96,52 @@ mac-rel-intermittent:
   - ./etc/ci/check_intermittents.sh --log-raw intermittents.log
 
 linux-dev:
-  - ./mach clean-nightlies --keep 3 --force
-  - ./mach clean-cargo-cache --keep 3 --force
-  - ./mach test-tidy --no-progress --all
-  - ./mach test-tidy --no-progress --self-test
-  - ./mach build --dev
-  - ./mach test-unit
-  - ./mach package --dev
-  - ./mach build-cef
-  - ./mach build --dev --no-default-features --features default-except-unstable
-  - ./mach build-geckolib
-  - ./mach test-stylo
-  - bash ./etc/ci/lockfile_changed.sh
-  - bash ./etc/ci/manifest_changed.sh
-  - bash ./etc/ci/check_no_panic.sh
+  env:
+    CCACHE: sccache
+    RUSTC_WRAPPER: sccache
+  commands:
+    - ./mach clean-nightlies --keep 3 --force
+    - ./mach clean-cargo-cache --keep 3 --force
+    - ./mach test-tidy --no-progress --all
+    - ./mach test-tidy --no-progress --self-test
+    - ./mach build --dev
+    - ./mach test-unit
+    - ./mach package --dev
+    - ./mach build-cef
+    - ./mach build --dev --no-default-features --features default-except-unstable
+    - ./mach build-geckolib
+    - ./mach test-stylo
+    - bash ./etc/ci/lockfile_changed.sh
+    - bash ./etc/ci/manifest_changed.sh
+    - bash ./etc/ci/check_no_panic.sh
 
 linux-rel-wpt:
-  - ./mach clean-nightlies --keep 3 --force
-  - ./mach clean-cargo-cache --keep 3 --force
-  - ./mach build --release --with-debug-assertions
-  - ./mach test-wpt-failure
-  - ./mach test-wpt --release --processes 24 --total-chunks 2 --this-chunk 1 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
-  - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
-  - ./mach test-wpt --release --binary-arg=--multiprocess --processes 24 --log-raw test-wpt-mp.log --log-errorsummary wpt-mp-errorsummary.log eventsource
+  env:
+    CCACHE: sccache
+    RUSTC_WRAPPER: sccache
+  commands:
+    - ./mach clean-nightlies --keep 3 --force
+    - ./mach clean-cargo-cache --keep 3 --force
+    - ./mach build --release --with-debug-assertions
+    - ./mach test-wpt-failure
+    - ./mach test-wpt --release --processes 24 --total-chunks 2 --this-chunk 1 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
+    - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
+    - ./mach test-wpt --release --binary-arg=--multiprocess --processes 24 --log-raw test-wpt-mp.log --log-errorsummary wpt-mp-errorsummary.log eventsource
 
 linux-rel-css:
-  - ./mach clean-nightlies --keep 3 --force
-  - ./mach clean-cargo-cache --keep 3 --force
-  - ./mach build --release --with-debug-assertions
-  - ./mach test-wpt --release --processes 24 --total-chunks 2 --this-chunk 2 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
-  - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
-  - ./mach build-geckolib --release
-  - ./mach test-stylo --release
-  - bash ./etc/ci/lockfile_changed.sh
-  - bash ./etc/ci/manifest_changed.sh
+  env:
+    CCACHE: sccache
+    RUSTC_WRAPPER: sccache
+  commands:
+    - ./mach clean-nightlies --keep 3 --force
+    - ./mach clean-cargo-cache --keep 3 --force
+    - ./mach build --release --with-debug-assertions
+    - ./mach test-wpt --release --processes 24 --total-chunks 2 --this-chunk 2 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
+    - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
+    - ./mach build-geckolib --release
+    - ./mach test-stylo --release
+    - bash ./etc/ci/lockfile_changed.sh
+    - bash ./etc/ci/manifest_changed.sh
 
 linux-nightly:
   - ./mach clean-nightlies --keep 3 --force


### PR DESCRIPTION
As far as I know, sccache is working properly
on the non-cross-compiling Linux builders.
For safety, only enable it for the builders that run on PRs,
to avoid breaking our nightly generation and scheduled test runs.

This will also allow testing new versions of sccache more easily.
This implements my suggestion from https://github.com/servo/servo/pull/19858#issuecomment-360514782, and should also let us
handle testing a new sccache: https://github.com/rust-lang/rust/issues/42867#issuecomment-358692077 (our current version of sccache [seems to be 2018-01-09](https://github.com/servo/saltfs/blob/f50214b8fa012e03616ecae1ef2913e6fe9044da/servo-build-dependencies/ci-map.jinja#L5)).

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they change the CI configuration

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19883)
<!-- Reviewable:end -->
