### PR TITLE
Fix mutation test in CI by passing env vars correctly

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -87,7 +87,7 @@ linux-rel-nogate:
   - ./mach clean-cargo-cache --keep 3 --force
   - ./mach build --release
   - python ./etc/ci/chaos_monkey_test.py
-  - RUSTFLAGS= bash ./etc/ci/mutation_test.sh
+  - env RUSTFLAGS= bash ./etc/ci/mutation_test.sh
 
 mac-rel-intermittent:
   - ./mach clean-nightlies --keep 3 --force


### PR DESCRIPTION
Originally, buildbot would try to directly execute `RUSTFLAGS=` as a binary
since it was the first token in the command string, which won't work.

Fix this by using the `env` command to set the environment variables,
as there is currently no support for setting per-step environment variables
in the `buildbot_steps.yml` file.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes should fix #19821 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they change the CI configuration

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19884)
<!-- Reviewable:end -->
