### PR TITLE
script: Move `style` as Element method

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -82,7 +82,6 @@ use std::mem;
 use std::ops::Range;
 use style::context::QuirksMode;
 use style::dom::OpaqueNode;
-use style::properties::ComputedValues;
 use style::selector_parser::{SelectorImpl, SelectorParser};
 use style::stylesheets::Stylesheet;
 use style::thread_state;
@@ -618,10 +617,6 @@ impl Node {
 
     pub fn client_rect(&self) -> Rect<i32> {
         window_from_node(self).client_rect_query(self.to_trusted_node_address())
-    }
-
-    pub fn style(&self) -> Option<Arc<ComputedValues>> {
-        window_from_node(self).style_query(self.to_trusted_node_address())
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth


### PR DESCRIPTION
r? emilio 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #19886 
- [x] These changes do not require tests because it should not break anything

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19889)
<!-- Reviewable:end -->
