### PR TITLE
Remove #![deny(warnings)]

### DIFF
--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -23,7 +23,6 @@
 //! [cssparser]: ../cssparser/index.html
 //! [selectors]: ../selectors/index.html
 
-#![deny(warnings)]
 #![deny(missing_docs)]
 
 #![recursion_limit = "500"]  // For define_css_keyword_enum! in -moz-appearance

--- a/ports/geckolib/lib.rs
+++ b/ports/geckolib/lib.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![deny(warnings)]
 
 extern crate cssparser;
 extern crate env_logger;

--- a/support/gecko/nsstring/src/lib.rs
+++ b/support/gecko/nsstring/src/lib.rs
@@ -113,7 +113,6 @@
 //! which invoke their member's destructors through C++ code.
 
 #![allow(non_camel_case_types)]
-#![deny(warnings)]
 
 #[macro_use]
 extern crate bitflags;


### PR DESCRIPTION
We already have https://github.com/servo/servo/pull/19612 to deny warnings at the time of landing into master. But it’s not useful to break the build when later compiler with a more recent Rust version that has introduced new warnings:

https://bugzilla.mozilla.org/show_bug.cgi?id=1434619

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19914)
<!-- Reviewable:end -->
