### PR TITLE
stylo: Fix missing null terminator in error reporting code.

### DIFF
--- a/components/style/error_reporting.rs
+++ b/components/style/error_reporting.rs
@@ -13,6 +13,7 @@ use style_traits::ParseError;
 use stylesheets::UrlExtraData;
 
 /// Errors that can be encountered while parsing CSS.
+#[derive(Debug)]
 pub enum ContextualParseError<'a> {
     /// A property declaration was not recognized.
     UnsupportedPropertyDeclaration(&'a str, ParseError<'a>),

--- a/ports/geckolib/error_reporter.rs
+++ b/ports/geckolib/error_reporter.rs
@@ -66,6 +66,7 @@ impl<'a> ErrorString<'a> {
     }
 }
 
+#[derive(Debug)]
 enum Action {
     Nothing,
     Skip,
@@ -370,14 +371,14 @@ impl<'a> ErrorHelpers<'a> for ContextualParseError<'a> {
                         StyleParseErrorKind::ValueError(
                             ValueParseErrorKind::InvalidColor(..)
                         )
-                    ) => (b"PEColorNotColor", Action::Nothing),
+                    ) => (b"PEColorNotColor\0", Action::Nothing),
                     _ => {
                         // Not the best error message, since we weren't parsing
                         // a declaration, just a value. But we don't produce
                         // UnsupportedValue errors other than InvalidColors
                         // currently.
                         debug_assert!(false, "should use a more specific error message");
-                        (b"PEDeclDropped", Action::Nothing)
+                        (b"PEDeclDropped\0", Action::Nothing)
                     }
                 }
             }


### PR DESCRIPTION
This was causing the patch in bug 1420026 to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19915)
<!-- Reviewable:end -->
