### PR TITLE
Supress output from git push in WPT sync.

### DIFF
--- a/etc/ci/update-wpt-checkout
+++ b/etc/ci/update-wpt-checkout
@@ -94,7 +94,7 @@ function unsafe_open_pull_request() {
     AUTH="${WPT_SYNC_USER}:${WPT_SYNC_TOKEN}"
     UPSTREAM="https://${AUTH}@github.com/${WPT_SYNC_USER}/servo.git"
     git remote add "${REMOTE_NAME}" "${UPSTREAM}" || return 2
-    git push -f "${REMOTE_NAME}" "${BRANCH_NAME}" || return 3
+    git push -f "${REMOTE_NAME}" "${BRANCH_NAME}" &>/dev/null || return 3
 
     # Prepare the pull request metadata.
     BODY="Automated downstream sync of changes from upstream as of "

--- a/etc/ci/upload_docs.sh
+++ b/etc/ci/upload_docs.sh
@@ -36,4 +36,4 @@ cd ../..
 ghp-import -n target/doc
 git push -qf \
     "https://${TOKEN}@github.com/servo/doc.servo.org.git" gh-pages \
-    >/dev/null 2>&1
+    &>/dev/null


### PR DESCRIPTION
Pushing to the remote exposes sensitive data in the logs of the job. The old token has been revoked as a consequence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19920)
<!-- Reviewable:end -->
