### PR TITLE
style: Move border-image-repeat outside of mako. 

### DIFF
--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -21,7 +21,7 @@ use style::values::generics::background::BackgroundSize;
 use style::values::generics::image::{Circle, Ellipse, ShapeExtent};
 use style::values::generics::image::EndingShape as GenericEndingShape;
 use style::values::generics::image::GradientItem as GenericGradientItem;
-use style::values::specified::background::RepeatKeyword;
+use style::values::specified::background::BackgroundRepeatKeyword;
 use style::values::specified::position::{X, Y};
 use webrender_api::{ExtendMode, GradientStop};
 
@@ -176,7 +176,7 @@ fn tile_image(position: &mut Au, size: &mut Au, absolute_anchor_origin: Au, imag
 ///
 /// This is done separately for both axes because the repeat keywords may differ.
 pub fn tile_image_axis(
-    repeat: RepeatKeyword,
+    repeat: BackgroundRepeatKeyword,
     position: &mut Au,
     size: &mut Au,
     tile_size: &mut Au,
@@ -187,16 +187,16 @@ pub fn tile_image_axis(
 ) {
     let absolute_anchor_origin = *position + offset;
     match repeat {
-        RepeatKeyword::NoRepeat => {
+        BackgroundRepeatKeyword::NoRepeat => {
             *position += offset;
             *size = *tile_size;
         },
-        RepeatKeyword::Repeat => {
+        BackgroundRepeatKeyword::Repeat => {
             *position = clip_origin;
             *size = clip_size;
             tile_image(position, size, absolute_anchor_origin, *tile_size);
         },
-        RepeatKeyword::Space => {
+        BackgroundRepeatKeyword::Space => {
             tile_image_spaced(
                 position,
                 size,
@@ -209,7 +209,7 @@ pub fn tile_image_axis(
             *size = clip_size;
             tile_image(position, size, absolute_anchor_origin, combined_tile_size);
         },
-        RepeatKeyword::Round => {
+        BackgroundRepeatKeyword::Round => {
             tile_image_round(position, size, absolute_anchor_origin, tile_size);
             *position = clip_origin;
             *size = clip_size;

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -69,6 +69,7 @@ use style::values::computed::effects::SimpleShadow;
 use style::values::computed::pointing::Cursor;
 use style::values::generics::background::BackgroundSize;
 use style::values::generics::image::{GradientKind, Image, PaintWorklet};
+use style::values::specified::border::RepeatKeyword;
 use style_traits::CSSPixel;
 use style_traits::ToCss;
 use style_traits::cursor::CursorKind;

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -69,7 +69,6 @@ use style::values::computed::effects::SimpleShadow;
 use style::values::computed::pointing::Cursor;
 use style::values::generics::background::BackgroundSize;
 use style::values::generics::image::{GradientKind, Image, PaintWorklet};
-use style::values::specified::border::RepeatKeyword;
 use style_traits::CSSPixel;
 use style_traits::ToCss;
 use style_traits::cursor::CursorKind;

--- a/components/layout/display_list/conversions.rs
+++ b/components/layout/display_list/conversions.rs
@@ -7,10 +7,10 @@ use euclid::{Point2D, Rect, SideOffsets2D, Size2D, Vector2D};
 use style::computed_values::image_rendering::T as ImageRendering;
 use style::computed_values::mix_blend_mode::T as MixBlendMode;
 use style::computed_values::transform_style::T as TransformStyle;
-use style::properties::longhands::border_image_repeat::RepeatKeyword;
 use style::values::RGBA;
 use style::values::computed::{BorderStyle, Filter};
 use style::values::generics::effects::Filter as GenericFilter;
+use style::values::specified::border::BorderImageRepeatKeyword;
 use webrender_api as wr;
 
 pub trait ToLayout {
@@ -152,14 +152,15 @@ impl ToLayout for Vector2D<Au> {
     }
 }
 
-impl ToLayout for RepeatKeyword {
+impl ToLayout for BorderImageRepeatKeyword {
     type Type = wr::RepeatMode;
+
     fn to_layout(&self) -> Self::Type {
         match *self {
-            RepeatKeyword::Stretch => wr::RepeatMode::Stretch,
-            RepeatKeyword::Repeat => wr::RepeatMode::Repeat,
-            RepeatKeyword::Round => wr::RepeatMode::Round,
-            RepeatKeyword::Space => wr::RepeatMode::Space,
+            BorderImageRepeatKeyword::Stretch => wr::RepeatMode::Stretch,
+            BorderImageRepeatKeyword::Repeat => wr::RepeatMode::Repeat,
+            BorderImageRepeatKeyword::Round => wr::RepeatMode::Round,
+            BorderImageRepeatKeyword::Space => wr::RepeatMode::Space,
         }
     }
 }

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1713,13 +1713,13 @@ fn static_assert() {
     %>
 
     pub fn set_border_image_repeat(&mut self, v: longhands::border_image_repeat::computed_value::T) {
-        use values::specified::border::RepeatKeyword;
+        use values::specified::border::BorderImageRepeatKeyword;
         use gecko_bindings::structs::StyleBorderImageRepeat;
 
         % for i, side in enumerate(["H", "V"]):
             self.gecko.mBorderImageRepeat${side} = match v.${i} {
                 % for keyword in border_image_repeat_keywords:
-                RepeatKeyword::${keyword} => StyleBorderImageRepeat::${keyword},
+                BorderImageRepeatKeyword::${keyword} => StyleBorderImageRepeat::${keyword},
                 % endfor
             };
         % endfor
@@ -1735,13 +1735,13 @@ fn static_assert() {
     }
 
     pub fn clone_border_image_repeat(&self) -> longhands::border_image_repeat::computed_value::T {
-        use values::specified::border::RepeatKeyword;
+        use values::specified::border::BorderImageRepeatKeyword;
         use gecko_bindings::structs::StyleBorderImageRepeat;
 
         % for side in ["H", "V"]:
         let servo_${side.lower()} = match self.gecko.mBorderImageRepeat${side} {
             % for keyword in border_image_repeat_keywords:
-            StyleBorderImageRepeat::${keyword} => RepeatKeyword::${keyword},
+            StyleBorderImageRepeat::${keyword} => BorderImageRepeatKeyword::${keyword},
             % endfor
         };
         % endfor
@@ -3816,16 +3816,16 @@ fn static_assert() {
     %>
 
     <%self:simple_image_array_property name="repeat" shorthand="${shorthand}" field_name="mRepeat">
-        use values::specified::background::RepeatKeyword;
+        use values::specified::background::BackgroundRepeatKeyword;
         use gecko_bindings::structs::nsStyleImageLayers_Repeat;
         use gecko_bindings::structs::StyleImageLayerRepeat;
 
-        fn to_ns(repeat: RepeatKeyword) -> StyleImageLayerRepeat {
+        fn to_ns(repeat: BackgroundRepeatKeyword) -> StyleImageLayerRepeat {
             match repeat {
-                RepeatKeyword::Repeat => StyleImageLayerRepeat::Repeat,
-                RepeatKeyword::Space => StyleImageLayerRepeat::Space,
-                RepeatKeyword::Round => StyleImageLayerRepeat::Round,
-                RepeatKeyword::NoRepeat => StyleImageLayerRepeat::NoRepeat,
+                BackgroundRepeatKeyword::Repeat => StyleImageLayerRepeat::Repeat,
+                BackgroundRepeatKeyword::Space => StyleImageLayerRepeat::Space,
+                BackgroundRepeatKeyword::Round => StyleImageLayerRepeat::Round,
+                BackgroundRepeatKeyword::NoRepeat => StyleImageLayerRepeat::NoRepeat,
             }
         }
 
@@ -3839,15 +3839,15 @@ fn static_assert() {
 
     pub fn clone_${shorthand}_repeat(&self) -> longhands::${shorthand}_repeat::computed_value::T {
         use properties::longhands::${shorthand}_repeat::single_value::computed_value::T;
-        use values::specified::background::RepeatKeyword;
+        use values::specified::background::BackgroundRepeatKeyword;
         use gecko_bindings::structs::StyleImageLayerRepeat;
 
-        fn to_servo(repeat: StyleImageLayerRepeat) -> RepeatKeyword {
+        fn to_servo(repeat: StyleImageLayerRepeat) -> BackgroundRepeatKeyword {
             match repeat {
-                StyleImageLayerRepeat::Repeat => RepeatKeyword::Repeat,
-                StyleImageLayerRepeat::Space => RepeatKeyword::Space,
-                StyleImageLayerRepeat::Round => RepeatKeyword::Round,
-                StyleImageLayerRepeat::NoRepeat => RepeatKeyword::NoRepeat,
+                StyleImageLayerRepeat::Repeat => BackgroundRepeatKeyword::Repeat,
+                StyleImageLayerRepeat::Space => BackgroundRepeatKeyword::Space,
+                StyleImageLayerRepeat::Round => BackgroundRepeatKeyword::Round,
+                StyleImageLayerRepeat::NoRepeat => BackgroundRepeatKeyword::NoRepeat,
                 _ => panic!("Found unexpected value in style struct for ${shorthand}_repeat property"),
             }
         }

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -1713,7 +1713,7 @@ fn static_assert() {
     %>
 
     pub fn set_border_image_repeat(&mut self, v: longhands::border_image_repeat::computed_value::T) {
-        use properties::longhands::border_image_repeat::computed_value::RepeatKeyword;
+        use values::specified::border::RepeatKeyword;
         use gecko_bindings::structs::StyleBorderImageRepeat;
 
         % for i, side in enumerate(["H", "V"]):
@@ -1735,7 +1735,7 @@ fn static_assert() {
     }
 
     pub fn clone_border_image_repeat(&self) -> longhands::border_image_repeat::computed_value::T {
-        use properties::longhands::border_image_repeat::computed_value::RepeatKeyword;
+        use values::specified::border::RepeatKeyword;
         use gecko_bindings::structs::StyleBorderImageRepeat;
 
         % for side in ["H", "V"]:

--- a/components/style/properties/longhand/border.mako.rs
+++ b/components/style/properties/longhand/border.mako.rs
@@ -101,60 +101,15 @@ ${helpers.predefined_type("border-image-outset", "LengthOrNumberRect",
     flags="APPLIES_TO_FIRST_LETTER",
     boxed=True)}
 
-<%helpers:longhand name="border-image-repeat" animation_value_type="discrete"
-                   flags="APPLIES_TO_FIRST_LETTER"
-                   spec="https://drafts.csswg.org/css-backgrounds/#border-image-repeat">
-    pub mod computed_value {
-        pub use super::RepeatKeyword;
-
-        #[derive(Clone, Debug, MallocSizeOf, PartialEq, ToCss)]
-        pub struct T(pub RepeatKeyword, pub RepeatKeyword);
-    }
-
-    #[derive(Clone, Debug, MallocSizeOf, PartialEq, ToCss)]
-    pub struct SpecifiedValue(pub RepeatKeyword,
-                              pub Option<RepeatKeyword>);
-
-    #[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
-    #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, Parse, PartialEq, ToCss)]
-    pub enum RepeatKeyword {
-        Stretch,
-        Repeat,
-        Round,
-        Space,
-    }
-
-    #[inline]
-    pub fn get_initial_value() -> computed_value::T {
-        computed_value::T(RepeatKeyword::Stretch, RepeatKeyword::Stretch)
-    }
-
-    #[inline]
-    pub fn get_initial_specified_value() -> SpecifiedValue {
-        SpecifiedValue(RepeatKeyword::Stretch, None)
-    }
-
-    impl ToComputedValue for SpecifiedValue {
-        type ComputedValue = computed_value::T;
-
-        #[inline]
-        fn to_computed_value(&self, _context: &Context) -> computed_value::T {
-            computed_value::T(self.0, self.1.unwrap_or(self.0))
-        }
-        #[inline]
-        fn from_computed_value(computed: &computed_value::T) -> Self {
-            SpecifiedValue(computed.0, Some(computed.1))
-        }
-    }
-
-    pub fn parse<'i, 't>(_context: &ParserContext, input: &mut Parser<'i, 't>)
-                         -> Result<SpecifiedValue, ParseError<'i>> {
-        let first = RepeatKeyword::parse(input)?;
-        let second = input.try(RepeatKeyword::parse).ok();
-
-        Ok(SpecifiedValue(first, second))
-    }
-</%helpers:longhand>
+${helpers.predefined_type(
+    "border-image-repeat",
+    "BorderImageRepeat",
+    "computed::BorderImageRepeat::stretch()",
+    initial_specified_value="specified::BorderImageRepeat::stretch()",
+    animation_value_type="discrete",
+    spec="https://drafts.csswg.org/css-backgrounds/#the-border-image-repeat",
+    flags="APPLIES_TO_FIRST_LETTER",
+)}
 
 ${helpers.predefined_type("border-image-width", "BorderImageWidth",
     initial_value="computed::BorderImageWidth::all(computed::BorderImageSideWidth::one())",

--- a/components/style/values/computed/background.rs
+++ b/components/style/values/computed/background.rs
@@ -12,7 +12,7 @@ use values::animated::{ToAnimatedValue, ToAnimatedZero};
 use values::computed::{Context, ToComputedValue};
 use values::computed::length::LengthOrPercentageOrAuto;
 use values::generics::background::BackgroundSize as GenericBackgroundSize;
-use values::specified::background::{BackgroundRepeat as SpecifiedBackgroundRepeat, RepeatKeyword};
+use values::specified::background::{BackgroundRepeat as SpecifiedBackgroundRepeat, BackgroundRepeatKeyword};
 
 /// A computed value for the `background-size` property.
 pub type BackgroundSize = GenericBackgroundSize<LengthOrPercentageOrAuto>;
@@ -86,12 +86,12 @@ impl ToAnimatedValue for BackgroundSizeList {
 ///
 /// https://drafts.csswg.org/css-backgrounds/#the-background-repeat
 #[derive(Clone, Debug, MallocSizeOf, PartialEq)]
-pub struct BackgroundRepeat(pub RepeatKeyword, pub RepeatKeyword);
+pub struct BackgroundRepeat(pub BackgroundRepeatKeyword, pub BackgroundRepeatKeyword);
 
 impl BackgroundRepeat {
     /// Returns the `repeat repeat` value.
     pub fn repeat() -> Self {
-        BackgroundRepeat(RepeatKeyword::Repeat, RepeatKeyword::Repeat)
+        BackgroundRepeat(BackgroundRepeatKeyword::Repeat, BackgroundRepeatKeyword::Repeat)
     }
 }
 
@@ -101,8 +101,12 @@ impl ToCss for BackgroundRepeat {
         W: Write,
     {
         match (self.0, self.1) {
-            (RepeatKeyword::Repeat, RepeatKeyword::NoRepeat) => dest.write_str("repeat-x"),
-            (RepeatKeyword::NoRepeat, RepeatKeyword::Repeat) => dest.write_str("repeat-y"),
+            (BackgroundRepeatKeyword::Repeat, BackgroundRepeatKeyword::NoRepeat) => {
+                dest.write_str("repeat-x")
+            },
+            (BackgroundRepeatKeyword::NoRepeat, BackgroundRepeatKeyword::Repeat) => {
+                dest.write_str("repeat-y")
+            },
             (horizontal, vertical) => {
                 horizontal.to_css(dest)?;
                 if horizontal != vertical {
@@ -122,10 +126,10 @@ impl ToComputedValue for SpecifiedBackgroundRepeat {
     fn to_computed_value(&self, _: &Context) -> Self::ComputedValue {
         match *self {
             SpecifiedBackgroundRepeat::RepeatX => {
-                BackgroundRepeat(RepeatKeyword::Repeat, RepeatKeyword::NoRepeat)
+                BackgroundRepeat(BackgroundRepeatKeyword::Repeat, BackgroundRepeatKeyword::NoRepeat)
             }
             SpecifiedBackgroundRepeat::RepeatY => {
-                BackgroundRepeat(RepeatKeyword::NoRepeat, RepeatKeyword::Repeat)
+                BackgroundRepeat(BackgroundRepeatKeyword::NoRepeat, BackgroundRepeatKeyword::Repeat)
             }
             SpecifiedBackgroundRepeat::Keywords(horizontal, vertical) => {
                 BackgroundRepeat(horizontal, vertical.unwrap_or(horizontal))
@@ -138,10 +142,10 @@ impl ToComputedValue for SpecifiedBackgroundRepeat {
         // FIXME(emilio): Why can't this just be:
         //   SpecifiedBackgroundRepeat::Keywords(computed.0, computed.1)
         match (computed.0, computed.1) {
-            (RepeatKeyword::Repeat, RepeatKeyword::NoRepeat) => {
+            (BackgroundRepeatKeyword::Repeat, BackgroundRepeatKeyword::NoRepeat) => {
                 SpecifiedBackgroundRepeat::RepeatX
             }
-            (RepeatKeyword::NoRepeat, RepeatKeyword::Repeat) => {
+            (BackgroundRepeatKeyword::NoRepeat, BackgroundRepeatKeyword::Repeat) => {
                 SpecifiedBackgroundRepeat::RepeatY
             }
             (horizontal, vertical) => {

--- a/components/style/values/computed/border.rs
+++ b/components/style/values/computed/border.rs
@@ -5,8 +5,10 @@
 //! Computed types for CSS values related to borders.
 
 use app_units::Au;
+use std::fmt::{self, Write};
+use style_traits::{ToCss, CssWriter};
 use values::animated::ToAnimatedZero;
-use values::computed::{Number, NumberOrPercentage};
+use values::computed::{Context, Number, NumberOrPercentage, ToComputedValue};
 use values::computed::length::{LengthOrPercentage, NonNegativeLength};
 use values::generics::border::BorderCornerRadius as GenericBorderCornerRadius;
 use values::generics::border::BorderImageSideWidth as GenericBorderImageSideWidth;
@@ -15,6 +17,7 @@ use values::generics::border::BorderRadius as GenericBorderRadius;
 use values::generics::border::BorderSpacing as GenericBorderSpacing;
 use values::generics::rect::Rect;
 use values::generics::size::Size;
+use values::specified::border::{BorderImageRepeat as SpecifiedBorderImageRepeat, RepeatKeyword};
 
 /// A computed value for the `border-image-width` property.
 pub type BorderImageWidth = Rect<BorderImageSideWidth>;
@@ -79,5 +82,46 @@ impl ToAnimatedZero for BorderCornerRadius {
     fn to_animated_zero(&self) -> Result<Self, ()> {
         // FIXME(nox): Why?
         Err(())
+    }
+}
+
+/// The computed value of the `border-image-repeat` property:
+///
+/// https://drafts.csswg.org/css-backgrounds/#the-border-image-repeat
+#[derive(Clone, Debug, MallocSizeOf, PartialEq)]
+pub struct BorderImageRepeat(pub RepeatKeyword, pub RepeatKeyword);
+
+impl BorderImageRepeat {
+    /// Returns the `stretch` value.
+    pub fn stretch() -> Self {
+        BorderImageRepeat(RepeatKeyword::Stretch, RepeatKeyword::Stretch)
+    }
+}
+
+impl ToCss for BorderImageRepeat {
+    fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
+    where
+        W: Write,
+    {
+        self.0.to_css(dest)?;
+        if self.0 != self.1 {
+            dest.write_str(" ")?;
+            self.1.to_css(dest)?;
+        }
+        Ok(())
+    }
+}
+
+impl ToComputedValue for SpecifiedBorderImageRepeat {
+    type ComputedValue = BorderImageRepeat;
+
+    #[inline]
+    fn to_computed_value(&self, _: &Context) -> Self::ComputedValue {
+        BorderImageRepeat(self.0, self.1.unwrap_or(self.0))
+    }
+
+    #[inline]
+    fn from_computed_value(computed: &Self::ComputedValue) -> Self {
+        SpecifiedBorderImageRepeat(computed.0, Some(computed.1))
     }
 }

--- a/components/style/values/computed/border.rs
+++ b/components/style/values/computed/border.rs
@@ -17,7 +17,7 @@ use values::generics::border::BorderRadius as GenericBorderRadius;
 use values::generics::border::BorderSpacing as GenericBorderSpacing;
 use values::generics::rect::Rect;
 use values::generics::size::Size;
-use values::specified::border::{BorderImageRepeat as SpecifiedBorderImageRepeat, RepeatKeyword};
+use values::specified::border::{BorderImageRepeat as SpecifiedBorderImageRepeat, BorderImageRepeatKeyword};
 
 /// A computed value for the `border-image-width` property.
 pub type BorderImageWidth = Rect<BorderImageSideWidth>;
@@ -89,12 +89,12 @@ impl ToAnimatedZero for BorderCornerRadius {
 ///
 /// https://drafts.csswg.org/css-backgrounds/#the-border-image-repeat
 #[derive(Clone, Debug, MallocSizeOf, PartialEq)]
-pub struct BorderImageRepeat(pub RepeatKeyword, pub RepeatKeyword);
+pub struct BorderImageRepeat(pub BorderImageRepeatKeyword, pub BorderImageRepeatKeyword);
 
 impl BorderImageRepeat {
     /// Returns the `stretch` value.
     pub fn stretch() -> Self {
-        BorderImageRepeat(RepeatKeyword::Stretch, RepeatKeyword::Stretch)
+        BorderImageRepeat(BorderImageRepeatKeyword::Stretch, BorderImageRepeatKeyword::Stretch)
     }
 }
 

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -37,7 +37,7 @@ pub use self::align::{AlignItems, AlignContent, JustifyContent, SelfAlignment, J
 pub use self::align::{AlignSelf, JustifySelf};
 pub use self::angle::Angle;
 pub use self::background::{BackgroundSize, BackgroundRepeat};
-pub use self::border::{BorderImageSlice, BorderImageWidth, BorderImageSideWidth};
+pub use self::border::{BorderImageRepeat, BorderImageSlice, BorderImageWidth, BorderImageSideWidth};
 pub use self::border::{BorderRadius, BorderCornerRadius, BorderSpacing};
 pub use self::font::{FontSize, FontSizeAdjust, FontSynthesis, FontWeight, FontVariantAlternates};
 pub use self::font::{FontFamily, FontLanguageOverride, FontVariantSettings, FontVariantEastAsian};

--- a/components/style/values/specified/background.rs
+++ b/components/style/values/specified/background.rs
@@ -48,7 +48,7 @@ impl BackgroundSize {
 /// One of the keywords for `background-repeat`.
 #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, Parse, PartialEq, ToComputedValue, ToCss)]
 #[allow(missing_docs)]
-pub enum RepeatKeyword {
+pub enum BackgroundRepeatKeyword {
     Repeat,
     Space,
     Round,
@@ -65,14 +65,14 @@ pub enum BackgroundRepeat {
     /// `repeat-y`
     RepeatY,
     /// `[repeat | space | round | no-repeat]{1,2}`
-    Keywords(RepeatKeyword, Option<RepeatKeyword>),
+    Keywords(BackgroundRepeatKeyword, Option<BackgroundRepeatKeyword>),
 }
 
 impl BackgroundRepeat {
     /// Returns the `repeat` value.
     #[inline]
     pub fn repeat() -> Self {
-        BackgroundRepeat::Keywords(RepeatKeyword::Repeat, None)
+        BackgroundRepeat::Keywords(BackgroundRepeatKeyword::Repeat, None)
     }
 }
 
@@ -89,7 +89,7 @@ impl Parse for BackgroundRepeat {
             _ => {},
         }
 
-        let horizontal = match RepeatKeyword::from_ident(&ident) {
+        let horizontal = match BackgroundRepeatKeyword::from_ident(&ident) {
             Ok(h) => h,
             Err(()) => {
                 return Err(input.new_custom_error(
@@ -98,7 +98,7 @@ impl Parse for BackgroundRepeat {
             }
         };
 
-        let vertical = input.try(RepeatKeyword::parse).ok();
+        let vertical = input.try(BackgroundRepeatKeyword::parse).ok();
         Ok(BackgroundRepeat::Keywords(horizontal, vertical))
     }
 }

--- a/components/style/values/specified/border.rs
+++ b/components/style/values/specified/border.rs
@@ -176,7 +176,7 @@ impl Parse for BorderSpacing {
 #[allow(missing_docs)]
 #[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, Parse, PartialEq, ToCss)]
-pub enum RepeatKeyword {
+pub enum BorderImageRepeatKeyword {
     Stretch,
     Repeat,
     Round,
@@ -187,13 +187,13 @@ pub enum RepeatKeyword {
 ///
 /// https://drafts.csswg.org/css-backgrounds/#the-border-image-repeat
 #[derive(Clone, Debug, MallocSizeOf, PartialEq, ToCss)]
-pub struct BorderImageRepeat(pub RepeatKeyword, pub Option<RepeatKeyword>);
+pub struct BorderImageRepeat(pub BorderImageRepeatKeyword, pub Option<BorderImageRepeatKeyword>);
 
 impl BorderImageRepeat {
     /// Returns the `stretch` value.
     #[inline]
     pub fn stretch() -> Self {
-        BorderImageRepeat(RepeatKeyword::Stretch, None)
+        BorderImageRepeat(BorderImageRepeatKeyword::Stretch, None)
     }
 }
 
@@ -202,8 +202,8 @@ impl Parse for BorderImageRepeat {
         _context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        let horizontal = RepeatKeyword::parse(input)?;
-        let vertical = input.try(RepeatKeyword::parse).ok();
+        let horizontal = BorderImageRepeatKeyword::parse(input)?;
+        let vertical = input.try(BorderImageRepeatKeyword::parse).ok();
         Ok(BorderImageRepeat(horizontal, vertical))
     }
 }

--- a/components/style/values/specified/border.rs
+++ b/components/style/values/specified/border.rs
@@ -171,3 +171,39 @@ impl Parse for BorderSpacing {
         }).map(GenericBorderSpacing)
     }
 }
+
+/// A single border-image-repeat keyword.
+#[allow(missing_docs)]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Eq, MallocSizeOf, Parse, PartialEq, ToCss)]
+pub enum RepeatKeyword {
+    Stretch,
+    Repeat,
+    Round,
+    Space,
+}
+
+/// The specified value for the `border-image-repeat` property.
+///
+/// https://drafts.csswg.org/css-backgrounds/#the-border-image-repeat
+#[derive(Clone, Debug, MallocSizeOf, PartialEq, ToCss)]
+pub struct BorderImageRepeat(pub RepeatKeyword, pub Option<RepeatKeyword>);
+
+impl BorderImageRepeat {
+    /// Returns the `stretch` value.
+    #[inline]
+    pub fn stretch() -> Self {
+        BorderImageRepeat(RepeatKeyword::Stretch, None)
+    }
+}
+
+impl Parse for BorderImageRepeat {
+    fn parse<'i, 't>(
+        _context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self, ParseError<'i>> {
+        let horizontal = RepeatKeyword::parse(input)?;
+        let vertical = input.try(RepeatKeyword::parse).ok();
+        Ok(BorderImageRepeat(horizontal, vertical))
+    }
+}

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -31,7 +31,7 @@ pub use self::align::{AlignContent, JustifyContent, AlignItems, ContentDistribut
 pub use self::align::{AlignSelf, JustifySelf};
 pub use self::background::{BackgroundRepeat, BackgroundSize};
 pub use self::border::{BorderCornerRadius, BorderImageSlice, BorderImageWidth};
-pub use self::border::{BorderImageSideWidth, BorderRadius, BorderSideWidth, BorderSpacing};
+pub use self::border::{BorderImageRepeat, BorderImageSideWidth, BorderRadius, BorderSideWidth, BorderSpacing};
 pub use self::font::{FontSize, FontSizeAdjust, FontSynthesis, FontWeight, FontVariantAlternates};
 pub use self::font::{FontFamily, FontLanguageOverride, FontVariantSettings, FontVariantEastAsian};
 pub use self::font::{FontVariantLigatures, FontVariantNumeric, FontFeatureSettings};


### PR DESCRIPTION
This is a rebased / nitpick-addressed / bug-fixed version of #19210, and with a commit from #19668 renaming the two `RepeatKeyword`s to different names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19924)
<!-- Reviewable:end -->
