### PR TITLE
Enable css-fonts WPT tests

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -23,6 +23,8 @@ skip: true
     skip: false
   [css-flexbox]
     skip: false
+  [css-fonts]
+    skip: false
   [css-images]
     skip: false
   [css-style-attr]

--- a/tests/wpt/metadata/css/css-fonts/first-available-font-003.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/first-available-font-003.html.ini
@@ -1,0 +1,2 @@
+[first-available-font-003.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/first-available-font-004.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/first-available-font-004.html.ini
@@ -1,0 +1,2 @@
+[first-available-font-004.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/first-available-font-005.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/first-available-font-005.html.ini
@@ -1,0 +1,2 @@
+[first-available-font-005.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/first-available-font-006.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/first-available-font-006.html.ini
@@ -1,0 +1,2 @@
+[first-available-font-006.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/first-available-font-007.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/first-available-font-007.html.ini
@@ -1,0 +1,2 @@
+[first-available-font-007.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-default-04.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-default-04.html.ini
@@ -1,0 +1,2 @@
+[font-default-04.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-display/font-display-change.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-display/font-display-change.html.ini
@@ -1,0 +1,2 @@
+[font-display-change.html]
+  expected: TIMEOUT

--- a/tests/wpt/metadata/css/css-fonts/font-display/font-display-failure-fallback.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-display/font-display-failure-fallback.html.ini
@@ -1,0 +1,4 @@
+[font-display-failure-fallback.html]
+  [Fallback for font failure period]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-fonts/font-display/font-display.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-display/font-display.html.ini
@@ -1,0 +1,2 @@
+[font-display.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-feature-settings-serialization-001.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-feature-settings-serialization-001.html.ini
@@ -1,0 +1,4 @@
+[font-feature-settings-serialization-001.html]
+  [font-feature-settings should have its feature tag serialized with double quotes]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-fonts/font-features-across-space-1.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-features-across-space-1.html.ini
@@ -1,0 +1,2 @@
+[font-features-across-space-1.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-features-across-space-2.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-features-across-space-2.html.ini
@@ -1,0 +1,2 @@
+[font-features-across-space-2.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-features-across-space-3.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-features-across-space-3.html.ini
@@ -1,0 +1,2 @@
+[font-features-across-space-3.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-kerning-01.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-kerning-01.html.ini
@@ -1,0 +1,2 @@
+[font-kerning-01.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-kerning-03.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-kerning-03.html.ini
@@ -1,0 +1,2 @@
+[font-kerning-03.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-kerning-04.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-kerning-04.html.ini
@@ -1,0 +1,2 @@
+[font-kerning-04.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-kerning-05.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-kerning-05.html.ini
@@ -1,0 +1,2 @@
+[font-kerning-05.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-size-adjust-005.xht.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-size-adjust-005.xht.ini
@@ -1,0 +1,2 @@
+[font-size-adjust-005.xht]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-stretch-01.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-stretch-01.html.ini
@@ -1,0 +1,2 @@
+[font-stretch-01.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-stretch-02.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-stretch-02.html.ini
@@ -1,0 +1,2 @@
+[font-stretch-02.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-stretch-03.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-stretch-03.html.ini
@@ -1,0 +1,2 @@
+[font-stretch-03.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-stretch-04.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-stretch-04.html.ini
@@ -1,0 +1,2 @@
+[font-stretch-04.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-stretch-05.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-stretch-05.html.ini
@@ -1,0 +1,2 @@
+[font-stretch-05.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-stretch-06.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-stretch-06.html.ini
@@ -1,0 +1,2 @@
+[font-stretch-06.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-stretch-07.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-stretch-07.html.ini
@@ -1,0 +1,2 @@
+[font-stretch-07.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-stretch-08.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-stretch-08.html.ini
@@ -1,0 +1,2 @@
+[font-stretch-08.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-stretch-09.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-stretch-09.html.ini
@@ -1,0 +1,2 @@
+[font-stretch-09.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-stretch-10.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-stretch-10.html.ini
@@ -1,0 +1,2 @@
+[font-stretch-10.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-stretch-11.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-stretch-11.html.ini
@@ -1,0 +1,2 @@
+[font-stretch-11.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-synthesis-01.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-synthesis-01.html.ini
@@ -1,0 +1,2 @@
+[font-synthesis-01.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-synthesis-02.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-synthesis-02.html.ini
@@ -1,0 +1,2 @@
+[font-synthesis-02.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-synthesis-03.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-synthesis-03.html.ini
@@ -1,0 +1,2 @@
+[font-synthesis-03.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-synthesis-04.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-synthesis-04.html.ini
@@ -1,0 +1,2 @@
+[font-synthesis-04.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-synthesis-05.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-synthesis-05.html.ini
@@ -1,0 +1,2 @@
+[font-synthesis-05.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-01.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-01.html.ini
@@ -1,0 +1,2 @@
+[font-variant-01.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-02.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-02.html.ini
@@ -1,0 +1,2 @@
+[font-variant-02.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-03.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-03.html.ini
@@ -1,0 +1,2 @@
+[font-variant-03.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-04.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-04.html.ini
@@ -1,0 +1,2 @@
+[font-variant-04.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-02.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-02.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-02.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-03.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-03.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-03.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-04.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-04.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-04.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-05.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-05.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-05.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-06.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-06.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-06.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-07.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-07.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-07.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-08.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-08.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-08.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-09.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-09.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-09.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-10.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-10.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-10.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-11.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-11.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-11.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-12.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-12.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-12.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-13.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-13.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-13.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-14.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-14.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-14.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-15.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-15.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-15.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-16.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-16.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-16.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-17.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-17.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-17.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-18.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-18.html.ini
@@ -1,0 +1,2 @@
+[font-variant-alternates-18.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-alternates-parsing.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-alternates-parsing.html.ini
@@ -1,0 +1,4 @@
+[font-variant-alternates-parsing.html]
+  [CSS Test:  font-variant-alternates: historical-forms; parses case-insensitively]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-fonts/font-variant-caps-02.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-caps-02.html.ini
@@ -1,0 +1,2 @@
+[font-variant-caps-02.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-caps-03.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-caps-03.html.ini
@@ -1,0 +1,2 @@
+[font-variant-caps-03.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-caps-04.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-caps-04.html.ini
@@ -1,0 +1,2 @@
+[font-variant-caps-04.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-caps-05.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-caps-05.html.ini
@@ -1,0 +1,2 @@
+[font-variant-caps-05.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-caps-06.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-caps-06.html.ini
@@ -1,0 +1,2 @@
+[font-variant-caps-06.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-caps-07.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-caps-07.html.ini
@@ -1,0 +1,2 @@
+[font-variant-caps-07.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-caps.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-caps.html.ini
@@ -1,0 +1,2 @@
+[font-variant-caps.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-02.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-02.html.ini
@@ -1,0 +1,2 @@
+[font-variant-east-asian-02.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-03.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-03.html.ini
@@ -1,0 +1,2 @@
+[font-variant-east-asian-03.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-04.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-04.html.ini
@@ -1,0 +1,2 @@
+[font-variant-east-asian-04.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-05.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-05.html.ini
@@ -1,0 +1,2 @@
+[font-variant-east-asian-05.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-06.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-06.html.ini
@@ -1,0 +1,2 @@
+[font-variant-east-asian-06.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-07.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-07.html.ini
@@ -1,0 +1,2 @@
+[font-variant-east-asian-07.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-08.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-08.html.ini
@@ -1,0 +1,2 @@
+[font-variant-east-asian-08.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-09.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-09.html.ini
@@ -1,0 +1,2 @@
+[font-variant-east-asian-09.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-10.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-east-asian-10.html.ini
@@ -1,0 +1,2 @@
+[font-variant-east-asian-10.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-east-asian.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-east-asian.html.ini
@@ -1,0 +1,2 @@
+[font-variant-east-asian.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-ligatures-02.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-ligatures-02.html.ini
@@ -1,0 +1,2 @@
+[font-variant-ligatures-02.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-ligatures-04.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-ligatures-04.html.ini
@@ -1,0 +1,2 @@
+[font-variant-ligatures-04.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-ligatures-05.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-ligatures-05.html.ini
@@ -1,0 +1,2 @@
+[font-variant-ligatures-05.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-ligatures-07.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-ligatures-07.html.ini
@@ -1,0 +1,2 @@
+[font-variant-ligatures-07.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-ligatures-10.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-ligatures-10.html.ini
@@ -1,0 +1,2 @@
+[font-variant-ligatures-10.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-ligatures-11.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-ligatures-11.html.ini
@@ -1,0 +1,2 @@
+[font-variant-ligatures-11.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-ligatures.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-ligatures.html.ini
@@ -1,0 +1,2 @@
+[font-variant-ligatures.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-numeric-02.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-numeric-02.html.ini
@@ -1,0 +1,2 @@
+[font-variant-numeric-02.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-numeric-03.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-numeric-03.html.ini
@@ -1,0 +1,2 @@
+[font-variant-numeric-03.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-numeric-04.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-numeric-04.html.ini
@@ -1,0 +1,2 @@
+[font-variant-numeric-04.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-numeric-05.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-numeric-05.html.ini
@@ -1,0 +1,2 @@
+[font-variant-numeric-05.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-numeric-06.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-numeric-06.html.ini
@@ -1,0 +1,2 @@
+[font-variant-numeric-06.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-numeric-07.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-numeric-07.html.ini
@@ -1,0 +1,2 @@
+[font-variant-numeric-07.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-numeric-08.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-numeric-08.html.ini
@@ -1,0 +1,2 @@
+[font-variant-numeric-08.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-numeric-09.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-numeric-09.html.ini
@@ -1,0 +1,2 @@
+[font-variant-numeric-09.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-numeric.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-numeric.html.ini
@@ -1,0 +1,2 @@
+[font-variant-numeric.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-position-01.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-position-01.html.ini
@@ -1,0 +1,2 @@
+[font-variant-position-01.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/font-variant-position.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/font-variant-position.html.ini
@@ -1,0 +1,2 @@
+[font-variant-position.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/matching/fixed-stretch-style-over-weight.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/matching/fixed-stretch-style-over-weight.html.ini
@@ -1,0 +1,2 @@
+[fixed-stretch-style-over-weight.html]
+  expected: TIMEOUT

--- a/tests/wpt/metadata/css/css-fonts/matching/stretch-distance-over-weight-distance.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/matching/stretch-distance-over-weight-distance.html.ini
@@ -1,0 +1,2 @@
+[stretch-distance-over-weight-distance.html]
+  expected: TIMEOUT

--- a/tests/wpt/metadata/css/css-fonts/matching/style-ranges-over-weight-direction.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/matching/style-ranges-over-weight-direction.html.ini
@@ -1,0 +1,2 @@
+[style-ranges-over-weight-direction.html]
+  expected: TIMEOUT

--- a/tests/wpt/metadata/css/css-fonts/test_datafont_same_origin.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/test_datafont_same_origin.html.ini
@@ -1,0 +1,4 @@
+[test_datafont_same_origin.html]
+  [Test if data:font would be treated same origin.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-fonts/test_font_feature_values_parsing.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/test_font_feature_values_parsing.html.ini
@@ -1,0 +1,319 @@
+[test_font_feature_values_parsing.html]
+  [basic parse tests - @font-feature-values bongo {  }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { ; }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { ,; }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { ;, }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { ,;, }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset; }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset,; }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset abc; }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { ;;abc } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc;; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc: } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc,: } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc:, } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc:,; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { a,b } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { a;b } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { a:;b: } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { a:,;b: } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { a:1,;b: } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc 1 2 3 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc:, 1 2 3 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc:; 1 2 3 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3a } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3, def: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @blah @styleset { abc: 1 2 3; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @blah } @styleset { abc: 1 2 3; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @blah , @styleset { abc: 1 2 3; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3; }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3 }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3;]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { abc: 1 2 3]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { ok-1: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @annotation { ok-1: 3; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @stylistic { blah: 3; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { \n@styleset\n  { blah: 3; super-blah: 4 5;\n  more-blah: 5 6 7;\n } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { \n@styleset\n  {\n blah:\n 3\n;\n super-blah:\n 4\n 5\n;\n  more-blah:\n 5 6\n 7;\n } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @stylistic { blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: 1 2 3 4; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @character-variant { blah: 1 2; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @swash { blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @ornaments { blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @annotation { blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: 0; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: 120 124; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @character-variant { blah: 0; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @character-variant { blah: 111; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @character-variant { blah: 111 13; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { styleset { blah: 1 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { stylistic { blah: 1 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { character-variant { blah: 1 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { swash { blah: 1 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { ornaments { blah: 1 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { annotation { blah: 1 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @bongo { blah: 1 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @bongo { blah: 1 2 3 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @bongo { blah: 1 2 3; burp: 1;;; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: -1 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: 1 -1 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: 1.5 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: 15px } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: red } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: (1) } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah:(1) } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah:, 1 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: <1> } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: 1! } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: 1,, } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: 1 1 1 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @stylistic { blah: 1 2 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @character-variant { blah: 1 2 3 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @swash { blah: 1 2 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @ornaments { blah: 1 2 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @annotation { blah: 1 2 } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values "bongo" { @styleset { blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values 'bongo' { @styleset { blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values \\62 ongo { @styleset { blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo, super bongo, bongo the supreme { @styleset { blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values 'serif', 'sans-serif' { @styleset { blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo, "super bongo", 'bongo the supreme' { @styleset { blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values 毎日カレーを食べたい！ { @styleset { blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values 毎日カレーを食べたい！, 納豆嫌い { @styleset { blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: 1; blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { blah: 1; de-blah: 1; blah: 2; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { \\tra-la: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { b\\lah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { \\62 lah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { \\:blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { \\;blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { complex\\20 blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { complex\\ blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { Håkon: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { Åквариум: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { \\1f449\\1f4a9\\1f448: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { 魅力: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { 毎日カレーを食べたい！: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { TECHNICIÄNS\\ ÖF\\ SPÅCE\\ SHIP\\ EÅRTH\\ THIS\\ IS\\ YÖÜR\\ CÄPTÅIN\\ SPEÄKING\\ YÖÜR\\ ØÅPTÅIN\\ IS\\ DEA̋D: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { 123blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { :123blah 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { :123blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { ?123blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { "blah": 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { complex blah: 1; } }]
+    expected: FAIL
+
+  [basic parse tests - @font-feature-values bongo { @styleset { complex\\  blah: 1; } }]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-fonts/variations/font-parse-numeric-stretch-style-weight.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/variations/font-parse-numeric-stretch-style-weight.html.ini
@@ -1,0 +1,190 @@
+[font-parse-numeric-stretch-style-weight.html]
+  [Valid value 850 for font property weight used for styling.]
+    expected: FAIL
+
+  [Valid value 850.3 for font property weight used for styling.]
+    expected: FAIL
+
+  [Valid value calc(100 + 300) for font property weight used for styling.]
+    expected: FAIL
+
+  [Valid value calc(0.2 + 205.5) for font property weight used for styling.]
+    expected: FAIL
+
+  [Valid value 51% for font property stretch used for styling.]
+    expected: FAIL
+
+  [Valid value 199% for font property stretch used for styling.]
+    expected: FAIL
+
+  [Valid value calc(10% + 20%) for font property stretch used for styling.]
+    expected: FAIL
+
+  [Valid value oblique 50deg for font property style used for styling.]
+    expected: FAIL
+
+  [Valid value oblique -90deg for font property style used for styling.]
+    expected: FAIL
+
+  [Valid value oblique 90deg for font property style used for styling.]
+    expected: FAIL
+
+  [Valid value oblique calc(30deg + 20deg) for font property style used for styling.]
+    expected: FAIL
+
+  [Valid value 100 matches 100 for weight in @font-face.]
+    expected: FAIL
+
+  [Valid value 700 matches 700 for weight in @font-face.]
+    expected: FAIL
+
+  [Valid value 900 matches 900 for weight in @font-face.]
+    expected: FAIL
+
+  [Valid value bold matches bold for weight in @font-face.]
+    expected: FAIL
+
+  [Valid value normal matches normal for weight in @font-face.]
+    expected: FAIL
+
+  [Valid value 100 400 matches 100 400 for weight in @font-face.]
+    expected: FAIL
+
+  [Valid value 100 101.5 matches 100 101.5 for weight in @font-face.]
+    expected: FAIL
+
+  [Valid value 999.8 999.9 matches 999.8 999.9 for weight in @font-face.]
+    expected: FAIL
+
+  [Valid value 100% matches 100% for stretch in @font-face.]
+    expected: FAIL
+
+  [Valid value 110% matches 110% for stretch in @font-face.]
+    expected: FAIL
+
+  [Valid value 111.5% matches 111.5% for stretch in @font-face.]
+    expected: FAIL
+
+  [Valid value 50% 200% matches 50% 200% for stretch in @font-face.]
+    expected: FAIL
+
+  [Valid value 0.1% 1% matches 0.1% 1% for stretch in @font-face.]
+    expected: FAIL
+
+  [Valid value 900% 901% matches 900% 901% for stretch in @font-face.]
+    expected: FAIL
+
+  [Valid value ultra-condensed matches ultra-condensed for stretch in @font-face.]
+    expected: FAIL
+
+  [Valid value ultra-expanded matches ultra-expanded for stretch in @font-face.]
+    expected: FAIL
+
+  [Valid value normal matches normal for style in @font-face.]
+    expected: FAIL
+
+  [Valid value italic matches italic for style in @font-face.]
+    expected: FAIL
+
+  [Valid value oblique matches oblique for style in @font-face.]
+    expected: FAIL
+
+  [Valid value oblique 10deg matches oblique 10deg for style in @font-face.]
+    expected: FAIL
+
+  [Valid value oblique 10deg 20deg matches oblique 10deg 20deg for style in @font-face.]
+    expected: FAIL
+
+  [Value 0 must not be accepted as weight in @font-face.]
+    expected: FAIL
+
+  [Value 0.9 must not be accepted as weight in @font-face.]
+    expected: FAIL
+
+  [Value -100 200 must not be accepted as weight in @font-face.]
+    expected: FAIL
+
+  [Value 100 -200 must not be accepted as weight in @font-face.]
+    expected: FAIL
+
+  [Value 500 400 must not be accepted as weight in @font-face.]
+    expected: FAIL
+
+  [Value 100 1001 must not be accepted as weight in @font-face.]
+    expected: FAIL
+
+  [Value 1001 must not be accepted as weight in @font-face.]
+    expected: FAIL
+
+  [Value 1000.5 must not be accepted as weight in @font-face.]
+    expected: FAIL
+
+  [Value 100 200 300 must not be accepted as weight in @font-face.]
+    expected: FAIL
+
+  [Value a must not be accepted as weight in @font-face.]
+    expected: FAIL
+
+  [Value a b c must not be accepted as weight in @font-face.]
+    expected: FAIL
+
+  [Value -0.5% must not be accepted as stretch in @font-face.]
+    expected: FAIL
+
+  [Value -1% must not be accepted as stretch in @font-face.]
+    expected: FAIL
+
+  [Value 0% must not be accepted as stretch in @font-face.]
+    expected: FAIL
+
+  [Value calc(0% - 10%) must not be accepted as stretch in @font-face.]
+    expected: FAIL
+
+  [Value 60% 70% 80% must not be accepted as stretch in @font-face.]
+    expected: FAIL
+
+  [Value a% must not be accepted as stretch in @font-face.]
+    expected: FAIL
+
+  [Value a b c must not be accepted as stretch in @font-face.]
+    expected: FAIL
+
+  [Value 0.1 must not be accepted as stretch in @font-face.]
+    expected: FAIL
+
+  [Value -60% 80% must not be accepted as stretch in @font-face.]
+    expected: FAIL
+
+  [Value ultra-expannnned must not be accepted as stretch in @font-face.]
+    expected: FAIL
+
+  [Value 50% 0 must not be accepted as stretch in @font-face.]
+    expected: FAIL
+
+  [Value oblique 100deg must not be accepted as style in @font-face.]
+    expected: FAIL
+
+  [Value oblique italic must not be accepted as style in @font-face.]
+    expected: FAIL
+
+  [Value oblique -91deg must not be accepted as style in @font-face.]
+    expected: FAIL
+
+  [Value oblique 0 must not be accepted as style in @font-face.]
+    expected: FAIL
+
+  [Value oblique 10 must not be accepted as style in @font-face.]
+    expected: FAIL
+
+  [Value iiitalic must not be accepted as style in @font-face.]
+    expected: FAIL
+
+  [Value 90deg must not be accepted as style in @font-face.]
+    expected: FAIL
+
+  [Value 11 must not be accepted as style in @font-face.]
+    expected: FAIL
+
+  [Value italic 90deg must not be accepted as style in @font-face.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-fonts/variations/variable-box-font.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/variations/variable-box-font.html.ini
@@ -1,0 +1,2 @@
+[variable-box-font.html]
+  expected: TIMEOUT

--- a/tests/wpt/metadata/css/css-fonts/variations/variable-gpos-m2b.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/variations/variable-gpos-m2b.html.ini
@@ -1,0 +1,2 @@
+[variable-gpos-m2b.html]
+  expected: TIMEOUT

--- a/tests/wpt/metadata/css/css-fonts/variations/variable-gsub.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/variations/variable-gsub.html.ini
@@ -1,0 +1,2 @@
+[variable-gsub.html]
+  expected: TIMEOUT


### PR DESCRIPTION
See https://github.com/servo/servo/pull/19928#issuecomment-362354270

Note that some of these tests require you to install the fonts found in
tests/wpt/web-platform-tests/css/fonts.

r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19930)
<!-- Reviewable:end -->
