### PR TITLE
Update WebRender

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,7 +3309,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.57.0"
-source = "git+https://github.com/servo/webrender#c956e149f23a9088758338990fd65f0250638352"
+source = "git+https://github.com/servo/webrender#47f5afa5c011080ee787c1170038de1e5fc28155"
 dependencies = [
  "app_units 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "webrender_api"
 version = "0.57.0"
-source = "git+https://github.com/servo/webrender#c956e149f23a9088758338990fd65f0250638352"
+source = "git+https://github.com/servo/webrender#47f5afa5c011080ee787c1170038de1e5fc28155"
 dependencies = [
  "app_units 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1171,19 +1171,15 @@ impl<Window: WindowMethods> IOCompositor<Window> {
     fn send_viewport_rects(&self) {
         let mut scroll_states_per_pipeline = HashMap::new();
         for scroll_layer_state in self.webrender_api.get_scroll_node_state(self.webrender_document) {
-            if scroll_layer_state.id.external_id().is_none() &&
-               !scroll_layer_state.id.is_root_scroll_node() {
-                continue;
-            }
-
             let scroll_state = ScrollState {
-                scroll_root_id: scroll_layer_state.id,
+                scroll_id: scroll_layer_state.id,
                 scroll_offset: scroll_layer_state.scroll_offset.to_untyped(),
             };
 
-            scroll_states_per_pipeline.entry(scroll_layer_state.id.pipeline_id())
-                                     .or_insert(vec![])
-                                     .push(scroll_state);
+            scroll_states_per_pipeline
+                .entry(scroll_layer_state.id.pipeline_id())
+                .or_insert(vec![])
+                .push(scroll_state);
         }
 
         for (pipeline_id, scroll_states) in scroll_states_per_pipeline {

--- a/components/gfx/display_list/mod.rs
+++ b/components/gfx/display_list/mod.rs
@@ -31,11 +31,11 @@ use std::fmt;
 use std::sync::Arc;
 use text::TextRun;
 use text::glyph::ByteIndex;
-use webrender_api::{BorderRadius, BorderWidths, BoxShadowClipMode, ClipId, ColorF, ExtendMode};
-use webrender_api::{FilterOp, GradientStop, ImageBorder, ImageKey, ImageRendering, LayoutPoint};
-use webrender_api::{LayoutRect, LayoutSize, LayoutVector2D, LineStyle, LocalClip, MixBlendMode};
-use webrender_api::{NormalBorder, ScrollPolicy, ScrollSensitivity, StickyOffsetBounds};
-use webrender_api::TransformStyle;
+use webrender_api::{BorderRadius, BorderWidths, BoxShadowClipMode, ColorF, ExtendMode};
+use webrender_api::{ExternalScrollId, FilterOp, GradientStop, ImageBorder, ImageKey};
+use webrender_api::{ImageRendering, LayoutPoint, LayoutRect, LayoutSize, LayoutVector2D};
+use webrender_api::{LineStyle, LocalClip, MixBlendMode, NormalBorder, ScrollPolicy};
+use webrender_api::{ScrollSensitivity, StickyOffsetBounds, TransformStyle};
 
 pub use style::dom::OpaqueNode;
 
@@ -350,7 +350,7 @@ pub struct StickyFrameData {
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub enum ClipScrollNodeType {
-    ScrollFrame(ScrollSensitivity),
+    ScrollFrame(ScrollSensitivity, ExternalScrollId),
     StickyFrame(StickyFrameData),
     Clip,
 }
@@ -358,10 +358,6 @@ pub enum ClipScrollNodeType {
 /// Defines a clip scroll node.
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct ClipScrollNode {
-    /// The WebRender clip id of this scroll root based on the source of this clip
-    /// and information about the fragment.
-    pub id: Option<ClipId>,
-
     /// The index of the parent of this ClipScrollNode.
     pub parent_index: ClipScrollNodeIndex,
 
@@ -1099,7 +1095,7 @@ impl WebRenderImageInfo {
 }
 
 /// The type of the scroll offset list. This is only populated if WebRender is in use.
-pub type ScrollOffsetMap = HashMap<ClipId, Vector2D<f32>>;
+pub type ScrollOffsetMap = HashMap<ExternalScrollId, Vector2D<f32>>;
 
 
 pub trait SimpleMatrixDetection {

--- a/components/gfx_traits/lib.rs
+++ b/components/gfx_traits/lib.rs
@@ -56,10 +56,10 @@ int_range_index! {
     struct ByteIndex(isize)
 }
 
-/// The type of fragment that a stacking context represents.
+/// The type of fragment that a scroll root is created for.
 ///
 /// This can only ever grow to maximum 4 entries. That's because we cram the value of this enum
-/// into the lower 2 bits of the `StackingContextId`, which otherwise contains a 32-bit-aligned
+/// into the lower 2 bits of the `ScrollRootId`, which otherwise contains a 32-bit-aligned
 /// heap address.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub enum FragmentType {
@@ -71,23 +71,20 @@ pub enum FragmentType {
     AfterPseudoContent,
 }
 
-/// The next ID that will be used for a special stacking context.
+/// The next ID that will be used for a special scroll root id.
 ///
-/// A special stacking context is a stacking context that is one of (a) the outer stacking context
-/// of an element with `overflow: scroll`; (b) generated content; (c) both (a) and (b).
-static NEXT_SPECIAL_STACKING_CONTEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+/// A special scroll root is a scroll root that is created for generated content.
+static NEXT_SPECIAL_SCROLL_ROOT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 
-/// If none of the bits outside this mask are set, the stacking context is a special stacking
-/// context.
-///
+/// If none of the bits outside this mask are set, the scroll root is a special scroll root.
 /// Note that we assume that the top 16 bits of the address space are unused on the platform.
-const SPECIAL_STACKING_CONTEXT_ID_MASK: usize = 0xffff;
+const SPECIAL_SCROLL_ROOT_ID_MASK: usize = 0xffff;
 
-/// Returns a new stacking context ID for a special stacking context.
+/// Returns a new scroll root ID for a scroll root.
 fn next_special_id() -> usize {
     // We shift this left by 2 to make room for the fragment type ID.
-    ((NEXT_SPECIAL_STACKING_CONTEXT_ID.fetch_add(1, Ordering::SeqCst) + 1) << 2) &
-        SPECIAL_STACKING_CONTEXT_ID_MASK
+    ((NEXT_SPECIAL_SCROLL_ROOT_ID.fetch_add(1, Ordering::SeqCst) + 1) << 2) &
+        SPECIAL_SCROLL_ROOT_ID_MASK
 }
 
 pub fn combine_id_with_fragment_type(id: usize, fragment_type: FragmentType) ->  usize {
@@ -99,8 +96,8 @@ pub fn combine_id_with_fragment_type(id: usize, fragment_type: FragmentType) -> 
     }
 }
 
-pub fn node_id_from_clip_id(id: usize) -> Option<usize> {
-    if (id & !SPECIAL_STACKING_CONTEXT_ID_MASK) != 0 {
+pub fn node_id_from_scroll_id(id: usize) -> Option<usize> {
+    if (id & !SPECIAL_SCROLL_ROOT_ID_MASK) != 0 {
         return Some((id & !3) as usize);
     }
     None

--- a/components/layout/display_list/webrender_helpers.rs
+++ b/components/layout/display_list/webrender_helpers.rs
@@ -296,16 +296,15 @@ impl WebRenderDisplayItemConverter for DisplayItem {
 
                 let webrender_id = match node.node_type {
                     ClipScrollNodeType::Clip => builder.define_clip_with_parent(
-                        node.id,
                         parent_id,
                         item_rect,
                         node.clip.get_complex_clips(),
                         None,
                     ),
-                    ClipScrollNodeType::ScrollFrame(scroll_sensitivity) => builder
+                    ClipScrollNodeType::ScrollFrame(scroll_sensitivity, external_id) => builder
                         .define_scroll_frame_with_parent(
-                            node.id,
                             parent_id,
+                            Some(external_id),
                             node.content_rect,
                             node.clip.main.to_layout(),
                             node.clip.get_complex_clips(),
@@ -316,7 +315,6 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                         // TODO: Add define_sticky_frame_with_parent to WebRender.
                         builder.push_clip_id(parent_id);
                         let id = builder.define_sticky_frame(
-                            node.id,
                             item_rect,
                             sticky_data.margins,
                             sticky_data.vertical_offset_bounds,
@@ -328,7 +326,6 @@ impl WebRenderDisplayItemConverter for DisplayItem {
                     },
                 };
 
-                debug_assert!(node.id.is_none() || node.id == Some(webrender_id));
                 clip_ids[item.node_index.0] = Some(webrender_id);
             },
         }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -16,7 +16,7 @@ use ipc_channel::ipc::IpcSender;
 use msg::constellation_msg::PipelineId;
 use opaque_node::OpaqueNodeMethods;
 use script_layout_interface::rpc::{ContentBoxResponse, ContentBoxesResponse, LayoutRPC};
-use script_layout_interface::rpc::{NodeGeometryResponse, NodeScrollRootIdResponse};
+use script_layout_interface::rpc::{NodeGeometryResponse, NodeScrollIdResponse};
 use script_layout_interface::rpc::{OffsetParentResponse, ResolvedStyleResponse, StyleResponse};
 use script_layout_interface::rpc::TextIndexResponse;
 use script_layout_interface::wrapper_traits::{LayoutNode, ThreadSafeLayoutElement, ThreadSafeLayoutNode};
@@ -34,7 +34,7 @@ use style::logical_geometry::{WritingMode, BlockFlowDirection, InlineBaseDirecti
 use style::properties::{style_structs, PropertyId, PropertyDeclarationId, LonghandId};
 use style::selector_parser::PseudoElement;
 use style_traits::ToCss;
-use webrender_api::ClipId;
+use webrender_api::ExternalScrollId;
 use wrapper::LayoutNodeLayoutData;
 
 /// Mutable data belonging to the LayoutThread.
@@ -56,8 +56,8 @@ pub struct LayoutThreadData {
     /// A queued response for the client {top, left, width, height} of a node in pixels.
     pub client_rect_response: Rect<i32>,
 
-    /// A queued response for the scroll root id for a given node.
-    pub scroll_root_id_response: Option<ClipId>,
+    /// A queued response for the scroll id for a given node.
+    pub scroll_id_response: Option<ExternalScrollId>,
 
     /// A queued response for the scroll {top, left, width, height} of a node in pixels.
     pub scroll_area_response: Rect<i32>,
@@ -131,10 +131,10 @@ impl LayoutRPC for LayoutRPCImpl {
         }
     }
 
-    fn node_scroll_root_id(&self) -> NodeScrollRootIdResponse {
-        NodeScrollRootIdResponse(self.0.lock()
-                                       .unwrap().scroll_root_id_response
-                                       .expect("scroll_root_id is not correctly fetched"))
+    fn node_scroll_id(&self) -> NodeScrollIdResponse {
+        NodeScrollIdResponse(self.0.lock()
+                             .unwrap().scroll_id_response
+                             .expect("scroll id is not correctly fetched"))
     }
 
     /// Retrieves the resolved value for a CSS style property.
@@ -611,11 +611,12 @@ pub fn process_node_geometry_request<N: LayoutNode>(requested_node: N, layout_ro
     iterator.client_rect
 }
 
-pub fn process_node_scroll_root_id_request<N: LayoutNode>(id: PipelineId,
-                                                          requested_node: N)
-                                                          -> ClipId {
+pub fn process_node_scroll_id_request<N: LayoutNode>(
+    id: PipelineId,
+    requested_node: N
+) -> ExternalScrollId {
     let layout_node = requested_node.to_threadsafe();
-    layout_node.generate_scroll_root_id(id)
+    layout_node.generate_scroll_id(id)
 }
 
 pub fn process_node_scroll_area_request< N: LayoutNode>(requested_node: N, layout_root: &mut Flow)

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -823,13 +823,13 @@ malloc_size_of_is_0!(webrender_api::BoxShadowClipMode);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::ClipAndScrollInfo);
 #[cfg(feature = "servo")]
-malloc_size_of_is_0!(webrender_api::ClipId);
-#[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::ColorF);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::ExtendMode);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::FilterOp);
+#[cfg(feature = "servo")]
+malloc_size_of_is_0!(webrender_api::ExternalScrollId);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(webrender_api::GradientStop);
 #[cfg(feature = "servo")]

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -261,6 +261,10 @@ impl PipelineId {
         webrender_api::ClipId::root_scroll_node(self.to_webrender())
     }
 
+    pub fn root_scroll_id(&self) -> webrender_api::ExternalScrollId {
+        webrender_api::ExternalScrollId(0, self.to_webrender())
+    }
+
     pub fn root_clip_and_scroll_info(&self) -> webrender_api::ClipAndScrollInfo {
         webrender_api::ClipAndScrollInfo::simple(self.root_scroll_node())
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -141,7 +141,6 @@ use time;
 use timers::OneshotTimerCallback;
 use url::Host;
 use url::percent_encoding::percent_decode;
-use webrender_api::ClipId;
 
 /// The number of times we are allowed to see spurious `requestAnimationFrame()` calls before
 /// falling back to fake ones.
@@ -730,11 +729,10 @@ impl Document {
         if let Some((x, y)) = point {
             // Step 3
             let global_scope = self.window.upcast::<GlobalScope>();
-            let webrender_pipeline_id = global_scope.pipeline_id().to_webrender();
             self.window.update_viewport_for_scroll(x, y);
             self.window.perform_a_scroll(x,
                                          y,
-                                         ClipId::root_scroll_node(webrender_pipeline_id),
+                                         global_scope.pipeline_id().root_scroll_id(),
                                          ScrollBehavior::Instant,
                                          target.r());
         }

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -113,7 +113,7 @@ pub enum ReflowGoal {
     TickAnimations,
     ContentBoxQuery(TrustedNodeAddress),
     ContentBoxesQuery(TrustedNodeAddress),
-    NodeScrollRootIdQuery(TrustedNodeAddress),
+    NodeScrollIdQuery(TrustedNodeAddress),
     NodeGeometryQuery(TrustedNodeAddress),
     NodeScrollGeometryQuery(TrustedNodeAddress),
     ResolvedStyleQuery(TrustedNodeAddress, Option<PseudoElement>, PropertyId),
@@ -132,7 +132,7 @@ impl ReflowGoal {
             ReflowGoal::TickAnimations | ReflowGoal::Full => true,
             ReflowGoal::ContentBoxQuery(_) | ReflowGoal::ContentBoxesQuery(_) |
             ReflowGoal::NodeGeometryQuery(_) | ReflowGoal::NodeScrollGeometryQuery(_) |
-            ReflowGoal::NodeScrollRootIdQuery(_) |
+            ReflowGoal::NodeScrollIdQuery(_) |
             ReflowGoal::ResolvedStyleQuery(..) | ReflowGoal::OffsetParentQuery(_) |
             ReflowGoal::StyleQuery(_)  => false,
         }
@@ -145,8 +145,7 @@ impl ReflowGoal {
             ReflowGoal::StyleQuery(_)  | ReflowGoal::TextIndexQuery(..) |
             ReflowGoal::ContentBoxQuery(_) | ReflowGoal::ContentBoxesQuery(_) |
             ReflowGoal::NodeGeometryQuery(_) | ReflowGoal::NodeScrollGeometryQuery(_) |
-            ReflowGoal::NodeScrollRootIdQuery(_) |
-            ReflowGoal::ResolvedStyleQuery(..) |
+            ReflowGoal::NodeScrollIdQuery(_) | ReflowGoal::ResolvedStyleQuery(..) |
             ReflowGoal::OffsetParentQuery(_) => false,
             ReflowGoal::NodesFromPointQuery(..) | ReflowGoal::Full |
             ReflowGoal::TickAnimations => true,

--- a/components/script_layout_interface/rpc.rs
+++ b/components/script_layout_interface/rpc.rs
@@ -8,7 +8,7 @@ use script_traits::UntrustedNodeAddress;
 use servo_arc::Arc;
 use style::properties::ComputedValues;
 use style::properties::longhands::overflow_x;
-use webrender_api::ClipId;
+use webrender_api::ExternalScrollId;
 
 /// Synchronous messages that script can send to layout.
 ///
@@ -27,8 +27,8 @@ pub trait LayoutRPC {
     fn node_geometry(&self) -> NodeGeometryResponse;
     /// Requests the scroll geometry of this node. Used by APIs such as `scrollTop`.
     fn node_scroll_area(&self) -> NodeGeometryResponse;
-    /// Requests the scroll root id of this node. Used by APIs such as `scrollTop`
-    fn node_scroll_root_id(&self) -> NodeScrollRootIdResponse;
+    /// Requests the scroll id of this node. Used by APIs such as `scrollTop`
+    fn node_scroll_id(&self) -> NodeScrollIdResponse;
     /// Query layout for the resolved value of a given CSS property
     fn resolved_style(&self) -> ResolvedStyleResponse;
     fn offset_parent(&self) -> OffsetParentResponse;
@@ -51,7 +51,7 @@ pub struct NodeGeometryResponse {
 
 pub struct NodeOverflowResponse(pub Option<Point2D<overflow_x::computed_value::T>>);
 
-pub struct NodeScrollRootIdResponse(pub ClipId);
+pub struct NodeScrollIdResponse(pub ExternalScrollId);
 
 pub struct ResolvedStyleResponse(pub String);
 

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -25,7 +25,7 @@ use style::font_metrics::ServoMetricsProvider;
 use style::properties::ComputedValues;
 use style::selector_parser::{PseudoElement, PseudoElementCascadeType, SelectorImpl};
 use style::stylist::RuleInclusion;
-use webrender_api::ClipId;
+use webrender_api::ExternalScrollId;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PseudoElementType {
@@ -269,9 +269,9 @@ pub trait ThreadSafeLayoutNode: Clone + Copy + Debug + GetLayoutData + NodeInfo 
         self.get_pseudo_element_type().fragment_type()
     }
 
-    fn generate_scroll_root_id(&self, pipeline_id: PipelineId) -> ClipId {
+    fn generate_scroll_id(&self, pipeline_id: PipelineId) -> ExternalScrollId {
         let id = combine_id_with_fragment_type(self.opaque().id(), self.fragment_type());
-        ClipId::new(id as u64, pipeline_id.to_webrender())
+        ExternalScrollId(id as u64, pipeline_id.to_webrender())
     }
 }
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -70,7 +70,7 @@ use style_traits::CSSPixel;
 use style_traits::SpeculativePainter;
 use style_traits::cursor::CursorKind;
 use webdriver_msg::{LoadStatus, WebDriverScriptCommand};
-use webrender_api::{ClipId, DevicePixel, DocumentId, ImageKey};
+use webrender_api::{ExternalScrollId, DevicePixel, DocumentId, ImageKey};
 use webvr_traits::{WebVREvent, WebVRMsg};
 
 pub use script_msg::{LayoutMsg, ScriptMsg, EventResult, LogEntry};
@@ -719,7 +719,7 @@ pub enum AnimationTickType {
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct ScrollState {
     /// The ID of the scroll root.
-    pub scroll_root_id: ClipId,
+    pub scroll_id: ExternalScrollId,
     /// The scrolling offset of this stacking context.
     pub scroll_offset: Vector2D<f32>,
 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -7517,6 +7517,18 @@
      {}
     ]
    ],
+   "mozilla/duplicated_scroll_ids.html": [
+    [
+     "/_mozilla/mozilla/duplicated_scroll_ids.html",
+     [
+      [
+       "/_mozilla/mozilla/duplicated_scroll_ids_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "mozilla/iframe/resize_after_load.html": [
     [
      "/_mozilla/mozilla/iframe/resize_after_load.html",
@@ -11036,6 +11048,11 @@
     ]
    ],
    "mozilla/details_ui_opened_ref.html": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/duplicated_scroll_ids_ref.html": [
     [
      {}
     ]
@@ -66228,6 +66245,14 @@
   "mozilla/double_focus.html": [
    "614fb3a1e9d775f07bf1d5b9a846ca48729f7805",
    "testharness"
+  ],
+  "mozilla/duplicated_scroll_ids.html": [
+   "3a10b783d1f411d7afdb3132b8eb43532c39c683",
+   "reftest"
+  ],
+  "mozilla/duplicated_scroll_ids_ref.html": [
+   "b2627acdddf71cf3b2a91d99f6db456397f71032",
+   "support"
   ],
   "mozilla/element_attribute.html": [
    "35625bedf3b323f8538174058c755cbccd25157c",

--- a/tests/wpt/mozilla/tests/mozilla/duplicated_scroll_ids.html
+++ b/tests/wpt/mozilla/tests/mozilla/duplicated_scroll_ids.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <link rel="match" href="duplicated_scroll_ids_ref.html">
+        <title>Ensure that content which produces duplicate scroll ids does not panic</title>
+    </head>
+    <body>
+        <div style="width: 100px; height: 100px; background: green"></div>
+        <details open style="overflow: auto">
+    </body>
+</html>
+

--- a/tests/wpt/mozilla/tests/mozilla/duplicated_scroll_ids_ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/duplicated_scroll_ids_ref.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Ensure that content which produces duplicate scroll ids does not panic</title>
+    </head>
+    <body>
+        <div style="width: 100px; height: 100px; background: green"></div>
+    </body>
+</html>
+


### PR DESCRIPTION
This allows servo to use the ExternalScrollId API from WebRender fixing
some issues related to duplicate scroll root ids.

Fixes #17176.
Fixes #19287.
Fixes #19648.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #17176, #19287, and #19648.

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19933)
<!-- Reviewable:end -->
