### PR TITLE
Add a --bin flag to the |mach run and rr-record commands

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -59,11 +59,13 @@ class PostBuildCommands(CommandBase):
                      help='Launch in headless mode')
     @CommandArgument('--software', '-s', action='store_true',
                      help='Launch with software rendering')
+    @CommandArgument('--bin', default=None,
+                     help='Launch with specific binary')
     @CommandArgument(
         'params', nargs='...',
         help="Command-line arguments to be passed through to Servo")
     def run(self, params, release=False, dev=False, android=None, debug=False, debugger=None, browserhtml=False,
-            headless=False, software=False):
+            headless=False, software=False, bin=None):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
 
@@ -96,7 +98,7 @@ class PostBuildCommands(CommandBase):
             shell.communicate("\n".join(script) + "\n")
             return shell.wait()
 
-        args = [self.get_binary_path(release, dev)]
+        args = [bin or self.get_binary_path(release, dev)]
 
         if browserhtml:
             browserhtml_path = get_browserhtml_path(args[0])
@@ -173,14 +175,16 @@ class PostBuildCommands(CommandBase):
                      help='Use release build')
     @CommandArgument('--dev', '-d', action='store_true',
                      help='Use dev build')
+    @CommandArgument('--bin', default=None,
+                     help='Launch with specific binary')
     @CommandArgument(
         'params', nargs='...',
         help="Command-line arguments to be passed through to Servo")
-    def rr_record(self, release=False, dev=False, params=[]):
+    def rr_record(self, release=False, dev=False, bin=None, params=[]):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
 
-        servo_cmd = [self.get_binary_path(release, dev)] + params
+        servo_cmd = [bin or self.get_binary_path(release, dev)] + params
         rr_cmd = ['rr', '--fatal-errors', 'record']
         try:
             check_call(rr_cmd + servo_cmd)


### PR DESCRIPTION
Add a --bin flag to the |mach run and rr-record commands to specify which servo binary to run

<!-- Please describe your changes on the following line: -->

Step 1 for #19505.
This flag allows to specify a downloaded servo binary for the ./mach run and ./mach rr-record commands.
The base issue is mentored by @jdm

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because | I would love to write tests on this, but I'm not really sure I can, since it's on ./mach commands

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19944)
<!-- Reviewable:end -->
