### PR TITLE
Add a --nightly | -n flag to mach run commands for linux

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -58,11 +58,13 @@ class PostBuildCommands(CommandBase):
                      help='Launch with software rendering')
     @CommandArgument('--bin', default=None,
                      help='Launch with specific binary')
+    @CommandArgument('--nightly', '-n', default=None,
+                     help='Specify a YYYY-MM-DD nightly build to run')
     @CommandArgument(
         'params', nargs='...',
         help="Command-line arguments to be passed through to Servo")
     def run(self, params, release=False, dev=False, android=None, debug=False, debugger=None,
-            headless=False, software=False, bin=None):
+            headless=False, software=False, bin=None, nightly=None):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
 
@@ -95,7 +97,7 @@ class PostBuildCommands(CommandBase):
             shell.communicate("\n".join(script) + "\n")
             return shell.wait()
 
-        args = [bin or self.get_binary_path(release, dev)]
+        args = [bin or self.get_nightly_binary_path(nightly) or self.get_binary_path(release, dev)]
 
         if headless:
             set_osmesa_env(args[0], env)
@@ -160,14 +162,17 @@ class PostBuildCommands(CommandBase):
                      help='Use dev build')
     @CommandArgument('--bin', default=None,
                      help='Launch with specific binary')
+    @CommandArgument('--nightly', '-n', default=None,
+                     help='Specify a YYYY-MM-DD nightly build to run')
     @CommandArgument(
         'params', nargs='...',
         help="Command-line arguments to be passed through to Servo")
-    def rr_record(self, release=False, dev=False, bin=None, params=[]):
+    def rr_record(self, release=False, dev=False, bin=None, nightly=None, params=[]):
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
 
-        servo_cmd = [bin or self.get_binary_path(release, dev)] + params
+        servo_cmd = [bin or self.get_nightly_binary_path(nightly) or
+                     self.get_binary_path(release, dev)] + params
         rr_cmd = ['rr', '--fatal-errors', 'record']
         try:
             check_call(rr_cmd + servo_cmd)


### PR DESCRIPTION
First tries to download and extract a specific nightly version to run mach commands against.

<!-- Please describe your changes on the following line: -->
I chose to split the Pull requests for each platform to avoid submitting a huge one, and to make sure I get the logic right.
I'm able to download / extract a nightly version, and I keep nightly versions in the target folder.
Windows and Mac OS support will be filed in separate PRs.
This is part of step two for #19505 

The mentor on the issue is jdm 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it is part of a ./mach command.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19947)
<!-- Reviewable:end -->
