### PR TITLE
Generate some PropertyDeclaration methods by hand 🐉🐲

### DIFF
--- a/components/style/properties/data.py
+++ b/components/style/properties/data.py
@@ -149,6 +149,7 @@ class Longhand(object):
                  predefined_type=None, servo_pref=None, gecko_pref=None,
                  enabled_in="content", need_index=False,
                  gecko_ffi_name=None,
+                 is_gecko_size_type_hack=False,
                  allowed_in_keyframe_block=True, cast_type='u8',
                  logical=False, alias=None, extra_prefixes=None, boxed=False,
                  flags=None, allowed_in_page_rule=False, allow_quirks=False, ignored_when_colors_disabled=False,
@@ -185,6 +186,7 @@ class Longhand(object):
         self.allow_quirks = allow_quirks
         self.ignored_when_colors_disabled = ignored_when_colors_disabled
         self.is_vector = vector
+        self.is_gecko_size_type_hack = is_gecko_size_type_hack
 
         # https://drafts.csswg.org/css-animations/#keyframes
         # > The <declaration-list> inside of <keyframe-block> accepts any CSS property

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -302,9 +302,9 @@
                 PropertyDeclaration::${property.camel_case}(ref value) => {
                     DeclaredValue::Value(value)
                 },
-                PropertyDeclaration::CSSWideKeyword(id, value) => {
-                    debug_assert!(id == LonghandId::${property.camel_case});
-                    DeclaredValue::CSSWideKeyword(value)
+                PropertyDeclaration::CSSWideKeyword(ref declaration) => {
+                    debug_assert!(declaration.id == LonghandId::${property.camel_case});
+                    DeclaredValue::CSSWideKeyword(declaration.keyword)
                 },
                 PropertyDeclaration::WithVariables(..) => {
                     panic!("variables should already have been substituted")
@@ -903,6 +903,7 @@
     <%call expr="longhand(name,
                           predefined_type=length_type,
                           logical=logical,
+                          is_gecko_size_type_hack=True,
                           **kwargs)">
         % if not logical:
             use values::specified::AllowQuirks;

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -435,14 +435,14 @@ impl AnimationValue {
             },
             % endif
             % endfor
-            PropertyDeclaration::CSSWideKeyword(id, keyword) => {
-                match id {
+            PropertyDeclaration::CSSWideKeyword(ref declaration) => {
+                match declaration.id {
                     // We put all the animatable properties first in the hopes
                     // that it might increase match locality.
                     % for prop in data.longhands:
                     % if prop.animatable:
                     LonghandId::${prop.camel_case} => {
-                        let style_struct = match keyword {
+                        let style_struct = match declaration.keyword {
                             % if not prop.style_struct.inherited:
                                 CSSWideKeyword::Unset |
                             % endif
@@ -472,15 +472,15 @@ impl AnimationValue {
                     % endfor
                 }
             },
-            PropertyDeclaration::WithVariables(id, ref unparsed) => {
+            PropertyDeclaration::WithVariables(ref declaration) => {
                 let substituted = {
                     let custom_properties =
                         extra_custom_properties.or_else(|| context.style().custom_properties());
 
-                    unparsed.substitute_variables(
-                        id,
+                    declaration.value.substitute_variables(
+                        declaration.id,
                         custom_properties,
-                        context.quirks_mode
+                        context.quirks_mode,
                     )
                 };
                 return AnimationValue::from_declaration(

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -314,6 +314,24 @@ impl Clone for PropertyDeclaration {
     }
 }
 
+impl PropertyDeclaration {
+    /// Like the method on ToCss, but without the type parameter to avoid
+    /// accidentally monomorphizing this large function multiple times for
+    /// different writers.
+    pub fn to_css(&self, dest: &mut CssStringWriter) -> fmt::Result {
+        use self::PropertyDeclaration::*;
+
+        let mut dest = CssWriter::new(dest);
+        match *self {
+            % for ty, variants in groups.iteritems():
+            ${" | ".join("{}(ref value)".format(v) for v in variants)} => {
+                value.to_css(&mut dest)
+            }
+            % endfor
+        }
+    }
+}
+
 /// A longhand or shorthand porperty
 #[derive(Clone, Copy, Debug)]
 pub struct NonCustomPropertyId(usize);
@@ -1563,6 +1581,15 @@ pub struct WideKeywordDeclaration {
     keyword: CSSWideKeyword,
 }
 
+impl ToCss for WideKeywordDeclaration {
+    fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
+    where
+        W: fmt::Write,
+    {
+        self.keyword.to_css(dest)
+    }
+}
+
 /// An unparsed declaration that contains `var()` functions.
 #[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
 #[derive(Clone, PartialEq)]
@@ -1570,6 +1597,29 @@ pub struct VariableDeclaration {
     id: LonghandId,
     #[cfg_attr(feature = "gecko", ignore_malloc_size_of = "XXX: how to handle this?")]
     value: Arc<UnparsedValue>,
+}
+
+impl ToCss for VariableDeclaration {
+    fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
+    where
+        W: fmt::Write,
+    {
+        // https://drafts.csswg.org/css-variables/#variables-in-shorthands
+        match self.value.from_shorthand {
+            // Normally, we shouldn't be printing variables here if they came from
+            // shorthands. But we should allow properties that came from shorthand
+            // aliases. That also matches with the Gecko behavior.
+            // FIXME(emilio): This is just a hack for `-moz-transform`.
+            Some(shorthand) if shorthand.flags().contains(PropertyFlags::SHORTHAND_ALIAS_PROPERTY) => {
+                dest.write_str(&*self.value.css)?
+            }
+            None => {
+                dest.write_str(&*self.value.css)?
+            }
+            _ => {},
+        }
+        Ok(())
+    }
 }
 
 /// A custom property declaration with the property name and the declared value.
@@ -1583,6 +1633,15 @@ pub struct CustomDeclaration {
     pub value: DeclaredValueOwned<Arc<::custom_properties::SpecifiedValue>>,
 }
 
+impl ToCss for CustomDeclaration {
+    fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
+    where
+        W: fmt::Write,
+    {
+        self.value.borrow().to_css(dest)
+    }
+}
+
 impl fmt::Debug for PropertyDeclaration {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.id().to_css(&mut CssWriter::new(f))?;
@@ -1594,40 +1653,6 @@ impl fmt::Debug for PropertyDeclaration {
         let mut s = CssString::new();
         self.to_css(&mut s)?;
         write!(f, "{}", s)
-    }
-}
-
-impl PropertyDeclaration {
-    /// Like the method on ToCss, but without the type parameter to avoid
-    /// accidentally monomorphizing this large function multiple times for
-    /// different writers.
-    pub fn to_css(&self, dest: &mut CssStringWriter) -> fmt::Result {
-        match *self {
-            % for property in data.longhands:
-            PropertyDeclaration::${property.camel_case}(ref value) => {
-                value.to_css(&mut CssWriter::new(dest))
-            }
-            % endfor
-            PropertyDeclaration::CSSWideKeyword(ref declaration) => {
-                declaration.keyword.to_css(&mut CssWriter::new(dest))
-            },
-            PropertyDeclaration::WithVariables(ref declaration) => {
-                // https://drafts.csswg.org/css-variables/#variables-in-shorthands
-                match declaration.value.from_shorthand {
-                    // Normally, we shouldn't be printing variables here if they came from
-                    // shorthands. But we should allow properties that came from shorthand
-                    // aliases. That also matches with the Gecko behavior.
-                    Some(shorthand) if shorthand.flags().contains(PropertyFlags::SHORTHAND_ALIAS_PROPERTY) =>
-                        dest.write_str(&*declaration.value.css)?,
-                    None => dest.write_str(&*declaration.value.css)?,
-                    _ => {},
-                }
-                Ok(())
-            },
-            PropertyDeclaration::Custom(ref declaration) => {
-                declaration.value.borrow().to_css(&mut CssWriter::new(dest))
-            },
-        }
     }
 }
 

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1658,29 +1658,9 @@ impl PropertyDeclaration {
     /// Returns true if this property declaration is for one of the animatable
     /// properties.
     pub fn is_animatable(&self) -> bool {
-        match *self {
-            % for property in data.longhands:
-            PropertyDeclaration::${property.camel_case}(_) => {
-                % if property.animatable:
-                    true
-                % else:
-                    false
-                % endif
-            }
-            % endfor
-            PropertyDeclaration::CSSWideKeyword(id, _) |
-            PropertyDeclaration::WithVariables(id, _) => match id {
-                % for property in data.longhands:
-                LonghandId::${property.camel_case} => {
-                    % if property.animatable:
-                        true
-                    % else:
-                        false
-                    % endif
-                }
-                % endfor
-            },
-            PropertyDeclaration::Custom(..) => false,
+        match self.id() {
+            PropertyDeclarationId::Longhand(id) => id.is_animatable(),
+            PropertyDeclarationId::Custom(..) => false,
         }
     }
 

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -1443,12 +1443,16 @@ impl PropertyId {
 #[derive(Clone, PartialEq)]
 pub enum PropertyDeclaration {
     % for property in data.longhands:
-        /// ${property.name}
-        % if property.boxed:
-            ${property.camel_case}(Box<longhands::${property.ident}::SpecifiedValue>),
-        % else:
-            ${property.camel_case}(longhands::${property.ident}::SpecifiedValue),
-        % endif
+    /// ${property.name}
+    <%
+        if property.predefined_type and not property.is_vector:
+            ty = "::values::specified::{}".format(property.predefined_type)
+        else:
+            ty = "longhands::{}::SpecifiedValue".format(property.ident)
+        if property.boxed:
+            ty = "Box<{}>".format(ty)
+    %>
+    ${property.camel_case}(${ty}),
     % endfor
     /// A css-wide keyword.
     CSSWideKeyword(LonghandId, CSSWideKeyword),

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -202,6 +202,96 @@ pub mod animated_properties {
     <%include file="/helpers/animated_properties.mako.rs" />
 }
 
+<%
+    variants = []
+    for property in data.longhands:
+        if property.predefined_type and not property.is_vector and not property.is_gecko_size_type_hack:
+            ty = "::values::specified::{}".format(property.predefined_type)
+        else:
+            ty = "longhands::{}::SpecifiedValue".format(property.ident)
+        if property.boxed:
+            ty = "Box<{}>".format(ty)
+        variants.append({
+            "name": property.camel_case,
+            "type": ty,
+            "doc": "`" + property.name + "`",
+        })
+    variants += [
+        {
+            "name": "CSSWideKeyword",
+            "type": "WideKeywordDeclaration",
+            "doc": "A CSS-wide keyword.",
+        },
+        {
+            "name": "WithVariables",
+            "type": "VariableDeclaration",
+            "doc": "An unparsed declaration.",
+        },
+        {
+            "name": "Custom",
+            "type": "CustomDeclaration",
+            "doc": "A custom property declaration.",
+        },
+    ]
+%>
+
+/// Servo's representation for a property declaration.
+#[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
+#[derive(PartialEq)]
+#[repr(u16)]
+pub enum PropertyDeclaration {
+    % for variant in variants:
+    /// ${variant["doc"]}
+    ${variant["name"]}(${variant["type"]}),
+    % endfor
+}
+
+<%
+    from itertools import groupby
+
+    groups = {}
+    keyfunc = lambda x: x["type"]
+    for ty, group in groupby(sorted(variants, key=keyfunc), keyfunc):
+        groups[ty] = list(group)
+%>
+
+impl Clone for PropertyDeclaration {
+    #[inline]
+    fn clone(&self) -> Self {
+        use self::PropertyDeclaration::*;
+
+        #[repr(C)]
+        struct VariantRepr<T> {
+            tag: u16,
+            value: T
+        }
+
+        match *self {
+            % for ty, variants in groups.iteritems():
+            % if len(variants) == 1:
+            ${variants[0]["name"]}(ref value) => {
+                ${variants[0]["name"]}(value.clone())
+            }
+            % else:
+            ${" | ".join("{}(ref value)".format(v["name"]) for v in variants)} => {
+                unsafe {
+                    let mut out = ManuallyDrop::new(mem::uninitialized());
+                    ptr::write(
+                        &mut out as *mut _ as *mut VariantRepr<${ty}>,
+                        VariantRepr {
+                            tag: *(self as *const _ as *const u16),
+                            value: value.clone(),
+                        },
+                    );
+                    ManuallyDrop::into_inner(out)
+                }
+            }
+            % endif
+            % endfor
+        }
+    }
+}
+
 /// A longhand or shorthand porperty
 #[derive(Clone, Copy, Debug)]
 pub struct NonCustomPropertyId(usize);
@@ -1439,96 +1529,6 @@ impl PropertyId {
         }
 
         false
-    }
-}
-
-<%
-    variants = []
-    for property in data.longhands:
-        if property.predefined_type and not property.is_vector and not property.is_gecko_size_type_hack:
-            ty = "::values::specified::{}".format(property.predefined_type)
-        else:
-            ty = "longhands::{}::SpecifiedValue".format(property.ident)
-        if property.boxed:
-            ty = "Box<{}>".format(ty)
-        variants.append({
-            "name": property.camel_case,
-            "type": ty,
-            "doc": "`" + property.name + "`",
-        })
-    variants += [
-        {
-            "name": "CSSWideKeyword",
-            "type": "WideKeywordDeclaration",
-            "doc": "A CSS-wide keyword.",
-        },
-        {
-            "name": "WithVariables",
-            "type": "VariableDeclaration",
-            "doc": "An unparsed declaration.",
-        },
-        {
-            "name": "Custom",
-            "type": "CustomDeclaration",
-            "doc": "A custom property declaration.",
-        },
-    ]
-%>
-
-/// Servo's representation for a property declaration.
-#[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
-#[derive(PartialEq)]
-#[repr(u16)]
-pub enum PropertyDeclaration {
-    % for variant in variants:
-    /// ${variant["doc"]}
-    ${variant["name"]}(${variant["type"]}),
-    % endfor
-}
-
-<%
-    from itertools import groupby
-
-    groups = {}
-    keyfunc = lambda x: x["type"]
-    for ty, group in groupby(sorted(variants, key=keyfunc), keyfunc):
-        groups[ty] = list(group)
-%>
-
-impl Clone for PropertyDeclaration {
-    #[inline]
-    fn clone(&self) -> Self {
-        use self::PropertyDeclaration::*;
-
-        #[repr(C)]
-        struct VariantRepr<T> {
-            tag: u16,
-            value: T
-        }
-
-        match *self {
-            % for ty, variants in groups.iteritems():
-            % if len(variants) == 1:
-            ${variants[0]["name"]}(ref value) => {
-                ${variants[0]["name"]}(value.clone())
-            }
-            % else:
-            ${" | ".join("{}(ref value)".format(v["name"]) for v in variants)} => {
-                unsafe {
-                    let mut out = ManuallyDrop::new(mem::uninitialized());
-                    ptr::write(
-                        &mut out as *mut _ as *mut VariantRepr<${ty}>,
-                        VariantRepr {
-                            tag: *(self as *const _ as *const u16),
-                            value: value.clone(),
-                        },
-                    );
-                    ManuallyDrop::into_inner(out)
-                }
-            }
-            % endif
-            % endfor
-        }
     }
 }
 

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -203,6 +203,8 @@ pub mod animated_properties {
 }
 
 <%
+    from itertools import groupby
+
     variants = []
     for property in data.longhands:
         if property.predefined_type and not property.is_vector and not property.is_gecko_size_type_hack:
@@ -216,7 +218,33 @@ pub mod animated_properties {
             "type": ty,
             "doc": "`" + property.name + "`",
         })
-    variants += [
+
+    groups = {}
+    keyfunc = lambda x: x["type"]
+    sortkeys = {}
+    for ty, group in groupby(sorted(variants, key=keyfunc), keyfunc):
+        group = [v["name"] for v in group]
+        groups[ty] = group
+        for v in group:
+            if len(group) == 1:
+                sortkeys[v] = (1, v, "")
+            else:
+                sortkeys[v] = (len(group), ty, v)
+    variants.sort(key=lambda x: sortkeys[x["name"]])
+
+    # It is extremely important to sort the `data.longhands` array here so
+    # that it is in the same order as `variants`, for `LonghandId` and
+    # `PropertyDeclarationId` to coincide.
+    data.longhands.sort(key=lambda x: sortkeys[x.camel_case])
+%>
+
+// WARNING: It is *really* important for the variants of `LonghandId`
+// and `PropertyDeclaration` to be defined in the exact same order,
+// with the exception of `CSSWideKeyword`, `WithVariables` and `Custom`,
+// which don't exist in `LonghandId`.
+
+<%
+    extra = [
         {
             "name": "CSSWideKeyword",
             "type": "WideKeywordDeclaration",
@@ -233,6 +261,9 @@ pub mod animated_properties {
             "doc": "A custom property declaration.",
         },
     ]
+    for v in extra:
+        variants.append(v)
+        groups[v["type"]] = [v["name"]]
 %>
 
 /// Servo's representation for a property declaration.
@@ -245,15 +276,6 @@ pub enum PropertyDeclaration {
     ${variant["name"]}(${variant["type"]}),
     % endfor
 }
-
-<%
-    from itertools import groupby
-
-    groups = {}
-    keyfunc = lambda x: x["type"]
-    for ty, group in groupby(sorted(variants, key=keyfunc), keyfunc):
-        groups[ty] = list(group)
-%>
 
 impl Clone for PropertyDeclaration {
     #[inline]
@@ -269,11 +291,11 @@ impl Clone for PropertyDeclaration {
         match *self {
             % for ty, variants in groups.iteritems():
             % if len(variants) == 1:
-            ${variants[0]["name"]}(ref value) => {
-                ${variants[0]["name"]}(value.clone())
+            ${variants[0]}(ref value) => {
+                ${variants[0]}(value.clone())
             }
             % else:
-            ${" | ".join("{}(ref value)".format(v["name"]) for v in variants)} => {
+            ${" | ".join("{}(ref value)".format(v) for v in variants)} => {
                 unsafe {
                     let mut out = ManuallyDrop::new(mem::uninitialized());
                     ptr::write(
@@ -376,7 +398,7 @@ impl<'a> Iterator for LonghandIdSetIterator<'a> {
                 return None;
             }
 
-            let id: LonghandId = unsafe { mem::transmute(self.cur as ${"u16" if product == "gecko" else "u8"}) };
+            let id: LonghandId = unsafe { mem::transmute(self.cur as u16) };
             self.cur += 1;
 
             if self.longhands.contains(id) {
@@ -583,6 +605,7 @@ bitflags! {
 
 /// An identifier for a given longhand property.
 #[derive(Clone, Copy, Eq, Hash, MallocSizeOf, PartialEq)]
+#[repr(u16)]
 pub enum LonghandId {
     % for i, property in enumerate(data.longhands):
         /// ${property.name}
@@ -1623,23 +1646,16 @@ impl PropertyDeclaration {
             }
             _ => {}
         }
-        let longhand_id = match *self {
+        // This is just fine because PropertyDeclarationId and LonghandId
+        // have corresponding discriminants.
+        let id = unsafe { *(self as *const _ as *const LonghandId) };
+        debug_assert_eq!(id, match *self {
             % for property in data.longhands:
-                PropertyDeclaration::${property.camel_case}(..) => {
-                    LonghandId::${property.camel_case}
-                }
+            PropertyDeclaration::${property.camel_case}(..) => LonghandId::${property.camel_case},
             % endfor
-            PropertyDeclaration::CSSWideKeyword(..) |
-            PropertyDeclaration::WithVariables(..) |
-            PropertyDeclaration::Custom(..) => {
-                debug_assert!(false, "unreachable");
-                // This value is never used, but having an expression of the same "shape"
-                // as for other variants helps the optimizer compile this `match` expression
-                // to a lookup table.
-                LonghandId::BackgroundColor
-            }
-        };
-        PropertyDeclarationId::Longhand(longhand_id)
+            _ => id,
+        });
+        PropertyDeclarationId::Longhand(id)
     }
 
     fn with_variables_from_shorthand(&self, shorthand: ShorthandId) -> Option< &str> {

--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -17,9 +17,10 @@ use custom_properties::CustomPropertiesBuilder;
 use servo_arc::{Arc, UniqueArc};
 use smallbitvec::SmallBitVec;
 use std::borrow::Cow;
-use std::{mem, ops};
+use std::{ops, ptr};
 use std::cell::RefCell;
 use std::fmt::{self, Write};
+use std::mem::{self, ManuallyDrop};
 
 #[cfg(feature = "servo")] use cssparser::RGBA;
 use cssparser::{CowRcStr, Parser, TokenSerializationType, serialize_identifier};
@@ -1441,28 +1442,94 @@ impl PropertyId {
     }
 }
 
-/// Servo's representation for a property declaration.
-#[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
-#[derive(Clone, PartialEq)]
-pub enum PropertyDeclaration {
-    % for property in data.longhands:
-    <%
+<%
+    variants = []
+    for property in data.longhands:
         if property.predefined_type and not property.is_vector and not property.is_gecko_size_type_hack:
             ty = "::values::specified::{}".format(property.predefined_type)
         else:
             ty = "longhands::{}::SpecifiedValue".format(property.ident)
         if property.boxed:
             ty = "Box<{}>".format(ty)
-    %>
-    /// ${property.name}
-    ${property.camel_case}(${ty}),
+        variants.append({
+            "name": property.camel_case,
+            "type": ty,
+            "doc": "`" + property.name + "`",
+        })
+    variants += [
+        {
+            "name": "CSSWideKeyword",
+            "type": "WideKeywordDeclaration",
+            "doc": "A CSS-wide keyword.",
+        },
+        {
+            "name": "WithVariables",
+            "type": "VariableDeclaration",
+            "doc": "An unparsed declaration.",
+        },
+        {
+            "name": "Custom",
+            "type": "CustomDeclaration",
+            "doc": "A custom property declaration.",
+        },
+    ]
+%>
+
+/// Servo's representation for a property declaration.
+#[cfg_attr(feature = "gecko", derive(MallocSizeOf))]
+#[derive(PartialEq)]
+#[repr(u16)]
+pub enum PropertyDeclaration {
+    % for variant in variants:
+    /// ${variant["doc"]}
+    ${variant["name"]}(${variant["type"]}),
     % endfor
-    /// A css-wide keyword.
-    CSSWideKeyword(WideKeywordDeclaration),
-    /// An unparsed declaration.
-    WithVariables(VariableDeclaration),
-    /// A custom property declaration.
-    Custom(CustomDeclaration),
+}
+
+<%
+    from itertools import groupby
+
+    groups = {}
+    keyfunc = lambda x: x["type"]
+    for ty, group in groupby(sorted(variants, key=keyfunc), keyfunc):
+        groups[ty] = list(group)
+%>
+
+impl Clone for PropertyDeclaration {
+    #[inline]
+    fn clone(&self) -> Self {
+        use self::PropertyDeclaration::*;
+
+        #[repr(C)]
+        struct VariantRepr<T> {
+            tag: u16,
+            value: T
+        }
+
+        match *self {
+            % for ty, variants in groups.iteritems():
+            % if len(variants) == 1:
+            ${variants[0]["name"]}(ref value) => {
+                ${variants[0]["name"]}(value.clone())
+            }
+            % else:
+            ${" | ".join("{}(ref value)".format(v["name"]) for v in variants)} => {
+                unsafe {
+                    let mut out = ManuallyDrop::new(mem::uninitialized());
+                    ptr::write(
+                        &mut out as *mut _ as *mut VariantRepr<${ty}>,
+                        VariantRepr {
+                            tag: *(self as *const _ as *const u16),
+                            value: value.clone(),
+                        },
+                    );
+                    ManuallyDrop::into_inner(out)
+                }
+            }
+            % endif
+            % endfor
+        }
+    }
 }
 
 /// A declaration using a CSS-wide keyword.

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -18,9 +18,9 @@ use std::sync::atomic::AtomicBool;
 use style::context::QuirksMode;
 use style::error_reporting::{ParseErrorReporter, ContextualParseError};
 use style::media_queries::MediaList;
-use style::properties::Importance;
-use style::properties::{CSSWideKeyword, DeclaredValueOwned, PropertyDeclaration, PropertyDeclarationBlock};
-use style::properties::DeclarationSource;
+use style::properties::{CSSWideKeyword, CustomDeclaration, DeclarationSource};
+use style::properties::{DeclaredValueOwned, Importance};
+use style::properties::{PropertyDeclaration, PropertyDeclarationBlock};
 use style::properties::longhands::{self, animation_timing_function};
 use style::shared_lock::SharedRwLock;
 use style::stylesheets::{Origin, Namespaces};
@@ -108,11 +108,17 @@ fn test_parse_stylesheet() {
                         ), (0 << 20) + (1 << 10) + (1 << 0))
                     )),
                     block: Arc::new(stylesheet.shared_lock.wrap(block_from(vec![
-                        (PropertyDeclaration::Display(longhands::display::SpecifiedValue::None),
-                         Importance::Important),
-                        (PropertyDeclaration::Custom(Atom::from("a"),
-                         DeclaredValueOwned::CSSWideKeyword(CSSWideKeyword::Inherit)),
-                         Importance::Important),
+                        (
+                            PropertyDeclaration::Display(longhands::display::SpecifiedValue::None),
+                            Importance::Important,
+                        ),
+                        (
+                            PropertyDeclaration::Custom(CustomDeclaration {
+                                name: Atom::from("a"),
+                                value: DeclaredValueOwned::CSSWideKeyword(CSSWideKeyword::Inherit),
+                            }),
+                            Importance::Important,
+                        ),
                     ]))),
                     source_location: SourceLocation {
                         line: 3,


### PR DESCRIPTION
We rely on https://github.com/rust-lang/rfcs/pull/2195 to make some enums share the same discriminants by definition.

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1428285.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19956)
<!-- Reviewable:end -->
