### PR TITLE
style: Don't serialize default values of the font shorthand.

### DIFF
--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -2670,12 +2670,11 @@ pub extern "C" fn Servo_DeclarationBlock_SerializeOneValue(
 }
 
 #[no_mangle]
-pub extern "C" fn Servo_SerializeFontValueForCanvas(
+pub unsafe extern "C" fn Servo_SerializeFontValueForCanvas(
     declarations: RawServoDeclarationBlockBorrowed,
     buffer: *mut nsAString,
 ) {
     use style::properties::shorthands::font;
-
     read_locked_arc(declarations, |decls: &PropertyDeclarationBlock| {
         let longhands = match font::LonghandsToSerialize::from_iter(decls.declarations().iter()) {
             Ok(l) => l,
@@ -2685,12 +2684,8 @@ pub extern "C" fn Servo_SerializeFontValueForCanvas(
             }
         };
 
-        let mut string = String::new();
-        let rv = longhands.to_css_for_canvas(&mut CssWriter::new(&mut string));
+        let rv = longhands.to_css(&mut CssWriter::new(&mut *buffer));
         debug_assert!(rv.is_ok());
-
-        let buffer = unsafe { buffer.as_mut().unwrap() };
-        buffer.assign_utf8(&string);
     })
 }
 


### PR DESCRIPTION
This makes us consistent with the old style system and Blink / WebKit.

Not adding a test because shorthands serialization is a mess... :(

Anyway, nothing like fixing bugs by removing code.

Bug: 1436031

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19964)
<!-- Reviewable:end -->
