### PR TITLE
style: Fix interpolation of the gecko-size properties.

### DIFF
--- a/components/style/properties/longhand/position.mako.rs
+++ b/components/style/properties/longhand/position.mako.rs
@@ -171,7 +171,7 @@ ${helpers.predefined_type("order", "Integer", "0",
         "MozLength",
         "computed::MozLength::auto()",
         extra_prefixes="webkit",
-        animation_value_type="ComputedValue",
+        animation_value_type="MozLength",
         allow_quirks=True,
         spec="https://drafts.csswg.org/css-flexbox/#flex-basis-property"
     )}
@@ -208,7 +208,7 @@ ${helpers.predefined_type("order", "Integer", "0",
             logical=logical,
             allow_quirks=not logical,
             spec=spec % size,
-            animation_value_type="ComputedValues"
+            animation_value_type="MozLength"
         )}
         // min-width, min-height, min-block-size, min-inline-size,
         ${helpers.predefined_type(
@@ -219,7 +219,7 @@ ${helpers.predefined_type("order", "Integer", "0",
             logical=logical,
             allow_quirks=not logical,
             spec=spec % size,
-            animation_value_type="ComputedValue"
+            animation_value_type="MozLength"
         )}
         ${helpers.predefined_type(
             "max-%s" % size,
@@ -229,7 +229,7 @@ ${helpers.predefined_type("order", "Integer", "0",
             logical=logical,
             allow_quirks=not logical,
             spec=spec % size,
-            animation_value_type="ComputedValue",
+            animation_value_type="MaxLength",
         )}
     % else:
         // servo versions (no keyword support)


### PR DESCRIPTION
Followup to #19966 because, well...

The animation code should probably be more obvious.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19969)
<!-- Reviewable:end -->
