### PR TITLE
style: Derive ToCss for FontFamilyList.

### DIFF
--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -165,9 +165,10 @@ impl From<LengthOrPercentage> for FontSize {
 }
 
 /// Specifies a prioritized list of font family names or generic family names.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, ToCss)]
 pub enum FontFamily {
     /// List of `font-family`
+    #[css(iterable, comma)]
     Values(FontFamilyList),
     /// System font
     System(SystemFont),
@@ -241,26 +242,6 @@ impl MallocSizeOf for FontFamily {
                 }
             }
             FontFamily::System(_) => 0,
-        }
-    }
-}
-
-impl ToCss for FontFamily {
-    fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
-    where
-        W: Write,
-    {
-        match *self {
-            FontFamily::Values(ref v) => {
-                let mut iter = v.iter();
-                iter.next().unwrap().to_css(dest)?;
-                for family in iter {
-                    dest.write_str(", ")?;
-                    family.to_css(dest)?;
-                }
-                Ok(())
-            }
-            FontFamily::System(sys) => sys.to_css(dest),
         }
     }
 }

--- a/components/style_derive/to_css.rs
+++ b/components/style_derive/to_css.rs
@@ -44,7 +44,7 @@ pub fn derive(input: DeriveInput) -> Tokens {
                     #expr
 
                     for item in #binding.iter() {
-                        writer.item(item)?;
+                        writer.item(&item)?;
                     }
                 };
             } else {


### PR DESCRIPTION
The extra reference in to_css is needed because the family list iterator returns
by value in Gecko.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/19981)
<!-- Reviewable:end -->
