### PR TITLE
style: Add infrastructure to have a standalone author stylesheet collection

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -105,7 +105,7 @@ use style::media_queries::MediaList;
 use style::properties::PropertyDeclarationBlock;
 use style::selector_parser::{PseudoElement, Snapshot};
 use style::shared_lock::{SharedRwLock as StyleSharedRwLock, Locked as StyleLocked};
-use style::stylesheet_set::StylesheetSet;
+use style::stylesheet_set::DocumentStylesheetSet;
 use style::stylesheets::{CssRules, FontFaceRule, KeyframesRule, MediaRule, Stylesheet};
 use style::stylesheets::{NamespaceRule, StyleRule, ImportRule, SupportsRule, ViewportRule};
 use style::stylesheets::keyframes_rule::Keyframe;
@@ -659,7 +659,7 @@ unsafe impl JSTraceable for StyleLocked<MediaList> {
     }
 }
 
-unsafe impl<S> JSTraceable for StylesheetSet<S>
+unsafe impl<S> JSTraceable for DocumentStylesheetSet<S>
 where
     S: JSTraceable + ::style::stylesheets::StylesheetInDocument + PartialEq + 'static,
 {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -135,7 +135,7 @@ use style::media_queries::{Device, MediaList, MediaType};
 use style::selector_parser::{RestyleDamage, Snapshot};
 use style::shared_lock::{SharedRwLock as StyleSharedRwLock, SharedRwLockReadGuard};
 use style::str::{HTML_SPACE_CHARACTERS, split_html_space_chars, str_join};
-use style::stylesheet_set::StylesheetSet;
+use style::stylesheet_set::DocumentStylesheetSet;
 use style::stylesheets::{Stylesheet, StylesheetContents, Origin, OriginSet};
 use task_source::TaskSource;
 use time;
@@ -262,7 +262,7 @@ pub struct Document {
     /// Can be acquired once for accessing many objects.
     style_shared_lock: StyleSharedRwLock,
     /// List of stylesheets associated with nodes in this document. |None| if the list needs to be refreshed.
-    stylesheets: DomRefCell<StylesheetSet<StyleSheetInDocument>>,
+    stylesheets: DomRefCell<DocumentStylesheetSet<StyleSheetInDocument>>,
     stylesheet_list: MutNullableDom<StyleSheetList>,
     ready_state: Cell<DocumentReadyState>,
     /// Whether the DOMContentLoaded event has already been dispatched.
@@ -1466,7 +1466,7 @@ impl Document {
 
         // Mark the document element dirty so a reflow will be performed.
         //
-        // FIXME(emilio): Use the StylesheetSet invalidation stuff.
+        // FIXME(emilio): Use the DocumentStylesheetSet invalidation stuff.
         if let Some(element) = self.GetDocumentElement() {
             element.upcast::<Node>().dirty(NodeDamage::NodeStyleDamaged);
         }
@@ -2264,7 +2264,7 @@ impl Document {
                 PER_PROCESS_AUTHOR_SHARED_LOCK.clone()
                 //StyleSharedRwLock::new()
             },
-            stylesheets: DomRefCell::new(StylesheetSet::new()),
+            stylesheets: DomRefCell::new(DocumentStylesheetSet::new()),
             stylesheet_list: MutNullableDom::new(None),
             ready_state: Cell::new(ready_state),
             domcontentloaded_dispatched: Cell::new(domcontentloaded_dispatched),
@@ -3807,7 +3807,7 @@ impl DocumentMethods for Document {
         self.scripts.set(None);
         self.anchors.set(None);
         self.applets.set(None);
-        *self.stylesheets.borrow_mut() = StylesheetSet::new();
+        *self.stylesheets.borrow_mut() = DocumentStylesheetSet::new();
         self.animation_frame_ident.set(0);
         self.animation_frame_list.borrow_mut().clear();
         self.pending_restyles.borrow_mut().clear();

--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -2130,9 +2130,14 @@ extern "C" {
     );
 }
 extern "C" {
-    pub fn Servo_StyleSet_NoteStyleSheetsChanged(
+    pub fn Servo_StyleSet_SetAuthorStyleDisabled(
         set: RawServoStyleSetBorrowed,
         author_style_disabled: bool,
+    );
+}
+extern "C" {
+    pub fn Servo_StyleSet_NoteStyleSheetsChanged(
+        set: RawServoStyleSetBorrowed,
         changed_origins: OriginFlags,
     );
 }

--- a/components/style/stylesheet_set.rs
+++ b/components/style/stylesheet_set.rs
@@ -587,3 +587,29 @@ where
         }
     }
 }
+
+/// The set of stylesheets effective for a given XBL binding or Shadow Root.
+pub struct AuthorStylesheetSet<S>
+where
+    S: StylesheetInDocument + PartialEq + 'static,
+{
+    /// The actual style sheets.
+    collection: SheetCollection<S>,
+    /// The set of invalidations scheduled for this collection.
+    invalidations: StylesheetInvalidationSet,
+}
+
+impl<S> AuthorStylesheetSet<S>
+where
+    S: StylesheetInDocument + PartialEq + 'static,
+{
+    fn collection_for(
+        &mut self,
+        _sheet: &S,
+        _guard: &SharedRwLockReadGuard,
+    ) -> &mut SheetCollection<S> {
+        &mut self.collection
+    }
+
+    sheet_set_methods!("AuthorStylesheetSet");
+}

--- a/components/style/stylesheet_set.rs
+++ b/components/style/stylesheet_set.rs
@@ -367,6 +367,9 @@ where
 
     fn set_data_validity_at_least(&mut self, validity: OriginValidity) {
         use std::cmp;
+
+        debug_assert_ne!(validity, OriginValidity::Valid);
+
         self.dirty = true;
         self.data_validity = cmp::max(validity, self.data_validity);
     }

--- a/components/style/stylesheet_set.rs
+++ b/components/style/stylesheet_set.rs
@@ -370,7 +370,7 @@ where
 
 /// The set of stylesheets effective for a given document.
 #[cfg_attr(feature = "servo", derive(MallocSizeOf))]
-pub struct StylesheetSet<S>
+pub struct DocumentStylesheetSet<S>
 where
     S: StylesheetInDocument + PartialEq + 'static,
 {
@@ -387,13 +387,13 @@ where
     author_style_disabled: bool,
 }
 
-impl<S> StylesheetSet<S>
+impl<S> DocumentStylesheetSet<S>
 where
     S: StylesheetInDocument + PartialEq + 'static,
 {
     /// Create a new empty StylesheetSet.
     pub fn new() -> Self {
-        StylesheetSet {
+        Self {
             collections: Default::default(),
             invalidations: StylesheetInvalidationSet::new(),
             origins_dirty: OriginSet::empty(),
@@ -438,7 +438,7 @@ where
         sheet: S,
         guard: &SharedRwLockReadGuard
     ) {
-        debug!("StylesheetSet::append_stylesheet");
+        debug!("DocumentStylesheetSet::append_stylesheet");
         self.collect_invalidations_for(device, &sheet, guard);
         let origin = sheet.contents(guard).origin;
         self.collections.borrow_mut_for_origin(&origin).append(sheet);
@@ -451,7 +451,7 @@ where
         sheet: S,
         guard: &SharedRwLockReadGuard
     ) {
-        debug!("StylesheetSet::prepend_stylesheet");
+        debug!("DocumentStylesheetSet::prepend_stylesheet");
         self.collect_invalidations_for(device, &sheet, guard);
 
         let origin = sheet.contents(guard).origin;
@@ -466,7 +466,7 @@ where
         before_sheet: S,
         guard: &SharedRwLockReadGuard,
     ) {
-        debug!("StylesheetSet::insert_stylesheet_before");
+        debug!("DocumentStylesheetSet::insert_stylesheet_before");
         self.collect_invalidations_for(device, &sheet, guard);
 
         let origin = sheet.contents(guard).origin;
@@ -491,7 +491,7 @@ where
 
     /// Notes that the author style has been disabled for this document.
     pub fn set_author_style_disabled(&mut self, disabled: bool) {
-        debug!("StylesheetSet::set_author_style_disabled");
+        debug!("DocumentStylesheetSet::set_author_style_disabled");
         if self.author_style_disabled == disabled {
             return;
         }
@@ -517,7 +517,7 @@ where
     {
         use std::mem;
 
-        debug!("StylesheetSet::flush");
+        debug!("DocumentStylesheetSet::flush");
 
         let had_invalidations =
             self.invalidations.flush(document_element, snapshots);
@@ -546,7 +546,7 @@ where
     pub fn flush_without_invalidation(&mut self) -> OriginSet {
         use std::mem;
 
-        debug!("StylesheetSet::flush_without_invalidation");
+        debug!("DocumentStylesheetSet::flush_without_invalidation");
 
         self.invalidations.clear();
         mem::replace(&mut self.origins_dirty, OriginSet::empty())

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -41,7 +41,7 @@ use smallvec::SmallVec;
 use std::ops;
 use std::sync::Mutex;
 use style_traits::viewport::ViewportConstraints;
-use stylesheet_set::{OriginValidity, SheetRebuildKind, DocumentStylesheetSet, StylesheetFlusher};
+use stylesheet_set::{DataValidity, SheetRebuildKind, DocumentStylesheetSet, StylesheetFlusher};
 #[cfg(feature = "gecko")]
 use stylesheets::{CounterStyleRule, FontFaceRule, FontFeatureValuesRule, PageRule};
 use stylesheets::{CssRule, Origin, OriginSet, PerOrigin, PerOriginIter};
@@ -240,12 +240,12 @@ impl DocumentCascadeData {
     {
         debug_assert_ne!(origin, Origin::UserAgent);
 
-        let validity = flusher.origin_validity(origin);
+        let validity = flusher.data_validity(origin);
 
         match validity {
-            OriginValidity::Valid => {},
-            OriginValidity::CascadeInvalid => cascade_data.clear_cascade_data(),
-            OriginValidity::FullyInvalid => cascade_data.clear(),
+            DataValidity::Valid => {},
+            DataValidity::CascadeInvalid => cascade_data.clear_cascade_data(),
+            DataValidity::FullyInvalid => cascade_data.clear(),
         }
 
         let guard = guards.for_origin(origin);

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -41,7 +41,7 @@ use smallvec::SmallVec;
 use std::ops;
 use std::sync::Mutex;
 use style_traits::viewport::ViewportConstraints;
-use stylesheet_set::{DataValidity, SheetRebuildKind, DocumentStylesheetSet, StylesheetFlusher};
+use stylesheet_set::{AuthorStylesEnabled, DataValidity, SheetRebuildKind, DocumentStylesheetSet, StylesheetFlusher};
 #[cfg(feature = "gecko")]
 use stylesheets::{CounterStyleRule, FontFaceRule, FontFeatureValuesRule, PageRule};
 use stylesheets::{CssRule, Origin, OriginSet, PerOrigin, PerOriginIter};
@@ -592,8 +592,8 @@ impl Stylist {
     }
 
     /// Sets whether author style is enabled or not.
-    pub fn set_author_style_disabled(&mut self, disabled: bool) {
-        self.stylesheets.set_author_style_disabled(disabled);
+    pub fn set_author_styles_enabled(&mut self, enabled: AuthorStylesEnabled) {
+        self.stylesheets.set_author_styles_enabled(enabled);
     }
 
     /// Returns whether we've recorded any stylesheet change so far.

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -240,6 +240,10 @@ impl DocumentCascadeData {
     {
         debug_assert_ne!(origin, Origin::UserAgent);
 
+        if !flusher.origin_dirty(origin) {
+            return Ok(());
+        }
+
         let validity = flusher.data_validity(origin);
 
         match validity {

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -41,7 +41,7 @@ use smallvec::SmallVec;
 use std::ops;
 use std::sync::Mutex;
 use style_traits::viewport::ViewportConstraints;
-use stylesheet_set::{OriginValidity, SheetRebuildKind, StylesheetSet, StylesheetFlusher};
+use stylesheet_set::{OriginValidity, SheetRebuildKind, DocumentStylesheetSet, StylesheetFlusher};
 #[cfg(feature = "gecko")]
 use stylesheets::{CounterStyleRule, FontFaceRule, FontFeatureValuesRule, PageRule};
 use stylesheets::{CssRule, Origin, OriginSet, PerOrigin, PerOriginIter};
@@ -328,21 +328,21 @@ impl DocumentCascadeData {
     }
 }
 
-/// A wrapper over a StylesheetSet that can be `Sync`, since it's only used and
-/// exposed via mutable methods in the `Stylist`.
+/// A wrapper over a DocumentStylesheetSet that can be `Sync`, since it's only
+/// used and exposed via mutable methods in the `Stylist`.
 #[cfg_attr(feature = "servo", derive(MallocSizeOf))]
-struct StylistStylesheetSet(StylesheetSet<StylistSheet>);
+struct StylistStylesheetSet(DocumentStylesheetSet<StylistSheet>);
 // Read above to see why this is fine.
 unsafe impl Sync for StylistStylesheetSet {}
 
 impl StylistStylesheetSet {
     fn new() -> Self {
-        StylistStylesheetSet(StylesheetSet::new())
+        StylistStylesheetSet(DocumentStylesheetSet::new())
     }
 }
 
 impl ops::Deref for StylistStylesheetSet {
-    type Target = StylesheetSet<StylistSheet>;
+    type Target = DocumentStylesheetSet<StylistSheet>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -135,7 +135,6 @@ use style::selector_parser::{PseudoElementCascadeType, SelectorImpl};
 use style::shared_lock::{SharedRwLockReadGuard, StylesheetGuards, ToCssWithGuard, Locked};
 use style::string_cache::{Atom, WeakAtom};
 use style::style_adjuster::StyleAdjuster;
-use style::stylesheet_set::AuthorStylesEnabled;
 use style::stylesheets::{CssRule, CssRules, CssRuleType, CssRulesHelpers, DocumentRule};
 use style::stylesheets::{FontFeatureValuesRule, ImportRule, KeyframesRule, MediaRule};
 use style::stylesheets::{NamespaceRule, Origin, OriginSet, PageRule, StyleRule};
@@ -143,7 +142,7 @@ use style::stylesheets::{StylesheetContents, SupportsRule};
 use style::stylesheets::StylesheetLoader as StyleStylesheetLoader;
 use style::stylesheets::keyframes_rule::{Keyframe, KeyframeSelector, KeyframesStepValue};
 use style::stylesheets::supports_rule::parse_condition_or_declaration;
-use style::stylist::{add_size_of_ua_cache, RuleInclusion, Stylist};
+use style::stylist::{add_size_of_ua_cache, AuthorStylesEnabled, RuleInclusion, Stylist};
 use style::thread_state;
 use style::timer::Timer;
 use style::traversal::DomTraversal;
@@ -1248,11 +1247,18 @@ pub unsafe extern "C" fn Servo_StyleSet_FlushStyleSheets(
 #[no_mangle]
 pub extern "C" fn Servo_StyleSet_NoteStyleSheetsChanged(
     raw_data: RawServoStyleSetBorrowed,
-    author_style_disabled: bool,
     changed_origins: OriginFlags,
 ) {
     let mut data = PerDocumentStyleData::from_ffi(raw_data).borrow_mut();
     data.stylist.force_stylesheet_origins_dirty(OriginSet::from(changed_origins));
+}
+
+#[no_mangle]
+pub extern "C" fn Servo_StyleSet_SetAuthorStyleDisabled(
+    raw_data: RawServoStyleSetBorrowed,
+    author_style_disabled: bool,
+) {
+    let mut data = PerDocumentStyleData::from_ffi(raw_data).borrow_mut();
     let enabled =
         if author_style_disabled {
             AuthorStylesEnabled::No

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -135,6 +135,7 @@ use style::selector_parser::{PseudoElementCascadeType, SelectorImpl};
 use style::shared_lock::{SharedRwLockReadGuard, StylesheetGuards, ToCssWithGuard, Locked};
 use style::string_cache::{Atom, WeakAtom};
 use style::style_adjuster::StyleAdjuster;
+use style::stylesheet_set::AuthorStylesEnabled;
 use style::stylesheets::{CssRule, CssRules, CssRuleType, CssRulesHelpers, DocumentRule};
 use style::stylesheets::{FontFeatureValuesRule, ImportRule, KeyframesRule, MediaRule};
 use style::stylesheets::{NamespaceRule, Origin, OriginSet, PageRule, StyleRule};
@@ -1252,7 +1253,13 @@ pub extern "C" fn Servo_StyleSet_NoteStyleSheetsChanged(
 ) {
     let mut data = PerDocumentStyleData::from_ffi(raw_data).borrow_mut();
     data.stylist.force_stylesheet_origins_dirty(OriginSet::from(changed_origins));
-    data.stylist.set_author_style_disabled(author_style_disabled);
+    let enabled =
+        if author_style_disabled {
+            AuthorStylesEnabled::No
+        } else {
+            AuthorStylesEnabled::Yes
+        };
+    data.stylist.set_author_styles_enabled(enabled);
 }
 
 #[no_mangle]


### PR DESCRIPTION
Right now Gecko uses a whole `Stylist` for stuff like XBL / Shadow DOM.

That's not great, because it has tons of unrelated logic, and also eats up a lot of memory. Also, it prevents us to optimize style changes in shadow hosts the same way we do for the document.

These patches mostly rejigger stuff around so that you can define a `DocumentStylesheetSet` and then an `AuthorStylesheetSet`, which would contain just the Shadow DOM sheets / XBL resource sheets.

It still doesn't introduce any use for the later, but that will come later.

There's a patch in this PR that requires Gecko changes, posted in https://bugzilla.mozilla.org/show_bug.cgi?id=1436798.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20004)
<!-- Reviewable:end -->
