### PR TITLE
Try to reduce instances of intermittent failures in wpt sync.

### DIFF
--- a/etc/ci/update-wpt-checkout
+++ b/etc/ci/update-wpt-checkout
@@ -59,7 +59,7 @@ function cleanup() {
 # Build Servo and run the full WPT testsuite, saving the results to a log file.
 function unsafe_run_tests() {
     # Run the full testsuite and record the new test results.
-    ./mach test-wpt --release --processes 12 --log-raw "${1}" \
+    ./mach test-wpt --release --processes 6 --log-raw "${1}" \
            --always-succeed || return 1
 }
 


### PR DESCRIPTION
Making the job take longer in favour of reducing the variability of test results makes sense to me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20006)
<!-- Reviewable:end -->
