### PR TITLE
style: Cascade pres hints after normal user rules.

### DIFF
--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -472,22 +472,28 @@ impl RuleTree {
 /// where it likely did not result from a rigorous performance analysis.)
 const RULE_TREE_GC_INTERVAL: usize = 300;
 
-/// The cascade level these rules are relevant at, as per[1].
+/// The cascade level these rules are relevant at, as per[1][2][3].
+///
+/// Presentational hints for SVG and HTML are in the "author-level
+/// zero-specificity" level, that is, right after user rules, and before author
+/// rules.
 ///
 /// The order of variants declared here is significant, and must be in
 /// _ascending_ order of precedence.
 ///
 /// [1]: https://drafts.csswg.org/css-cascade/#cascade-origin
+/// [2]: https://drafts.csswg.org/css-cascade/#preshint
+/// [3]: https://html.spec.whatwg.org/multipage/#presentational-hints
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "servo", derive(MallocSizeOf))]
 pub enum CascadeLevel {
     /// Normal User-Agent rules.
     UANormal = 0,
-    /// Presentational hints.
-    PresHints,
     /// User normal rules.
     UserNormal,
+    /// Presentational hints.
+    PresHints,
     /// Author normal rules.
     AuthorNormal,
     /// Style attribute normal rules.


### PR DESCRIPTION
Per https://drafts.csswg.org/css-cascade/#preshint and
https://html.spec.whatwg.org/#presentational-hints.

This was causing failures in the link color reftests with the preferences sheet
as a User sheet.

Bug: 1436782
Reviewed-by: bholley
MozReview-Commit-ID: 9iwEqPBw4CF

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20010)
<!-- Reviewable:end -->
