### PR TITLE
Avoid `Window::GetComputedStyle` when checking for `display: none`

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -9,7 +9,6 @@ use canvas_traits::canvas::{RadialGradientStyle, RepetitionStyle, byte_swap_and_
 use cssparser::{Parser, ParserInput, RGBA};
 use cssparser::Color as CSSColor;
 use dom::bindings::cell::DomRefCell;
-use dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
 use dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding;
 use dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasFillRule;
 use dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasImageSource;
@@ -17,7 +16,6 @@ use dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasLin
 use dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasLineJoin;
 use dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasRenderingContext2DMethods;
 use dom::bindings::codegen::Bindings::ImageDataBinding::ImageDataMethods;
-use dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use dom::bindings::codegen::UnionTypes::StringOrCanvasGradientOrCanvasPattern;
 use dom::bindings::error::{Error, ErrorResult, Fallible};
 use dom::bindings::inheritance::Castable;
@@ -27,6 +25,7 @@ use dom::bindings::root::{Dom, DomRoot, LayoutDom};
 use dom::bindings::str::DOMString;
 use dom::canvasgradient::{CanvasGradient, CanvasGradientStyle, ToFillOrStrokeStyle};
 use dom::canvaspattern::CanvasPattern;
+use dom::element::Element;
 use dom::globalscope::GlobalScope;
 use dom::htmlcanvaselement::HTMLCanvasElement;
 use dom::imagedata::ImageData;
@@ -543,18 +542,11 @@ impl CanvasRenderingContext2D {
                         Some(ref canvas) => &**canvas,
                     };
 
-                    let window = window_from_node(canvas);
+                    let canvas_element = canvas.upcast::<Element>();
 
-                    let style = window.GetComputedStyle(canvas.upcast(), None);
-
-                    let element_not_rendered =
-                        !canvas.upcast::<Node>().is_in_doc() ||
-                        style.GetPropertyValue(DOMString::from("display")) == "none";
-
-                    if element_not_rendered {
-                        Ok(RGBA::new(0, 0, 0, 255))
-                    } else {
-                        self.parse_color(&style.GetPropertyValue(DOMString::from("color")))
+                    match canvas_element.style() {
+                        Some(ref s) if canvas_element.has_css_layout_box() => Ok(s.get_color().color),
+                        _ => Ok(RGBA::new(0, 0, 0, 255))
                     }
                 },
                 _ => Err(())

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -350,14 +350,14 @@ impl Element {
 
     /// style will be `None` for elements in a `display: none` subtree. otherwise, the element has a
     /// layout box iff it doesn't have `display: none`.
-    fn style(&self) -> Option<Arc<ComputedValues>> {
+    pub fn style(&self) -> Option<Arc<ComputedValues>> {
         window_from_node(self).style_query(
             self.upcast::<Node>().to_trusted_node_address()
         )
     }
 
     // https://drafts.csswg.org/cssom-view/#css-layout-box
-    fn has_css_layout_box(&self) -> bool {
+    pub fn has_css_layout_box(&self) -> bool {
         self.style()
             .map_or(false, |s| !s.get_box().clone_display().is_none())
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -25,7 +25,6 @@ use devtools_traits::{ScriptToDevtoolsControlMsg, WorkerId};
 use devtools_traits::CSSError;
 use document_loader::DocumentLoader;
 use dom::bindings::cell::DomRefCell;
-use dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
 use dom::bindings::codegen::Bindings::DocumentBinding::{DocumentMethods, DocumentReadyState};
 use dom::bindings::codegen::Bindings::EventBinding::EventInit;
 use dom::bindings::codegen::Bindings::TransitionEventBinding::TransitionEventInit;
@@ -1955,7 +1954,7 @@ impl ScriptThread {
         node.dirty(NodeDamage::NodeStyleDamaged);
 
         if let Some(el) = node.downcast::<Element>() {
-            if &*window.GetComputedStyle(el, None).Display() == "none" {
+            if !el.has_css_layout_box() {
                 return;
             }
         }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -72327,7 +72327,7 @@
    "testharness"
   ],
   "mozilla/transitionend_safety.html": [
-   "778e43b049aa421bad7f86eb03d0955576a84ce0",
+   "16d238e94b2cc2843c9aee4210db43d496bb3114",
    "testharness"
   ],
   "mozilla/union.html": [

--- a/tests/wpt/mozilla/tests/mozilla/transitionend_safety.html
+++ b/tests/wpt/mozilla/tests/mozilla/transitionend_safety.html
@@ -11,7 +11,6 @@
     elem.textContent = 'hi there';
     elem.style.transition = 'color 10ms';
     elem.style.color = 'black';
-    elem.ontransitionend = t.step_func_done();
 
     t.step_timeout(function() {
       elem.style.color = 'red';
@@ -20,6 +19,7 @@
         document.body.removeChild(elem);
         elem = null;
         window.gc();
+        t.step_timeout(t.step_func_done(), 100);
       }, 0);
     }, 0);
   }, 'Nodes cannot be GCed while a CSS transition is in effect.');


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Refactored Window::GetComputedStyle to use Element::Style.

Not sure which tests are relevant, but I've ran the dom, fetch & 2dcontext wpt tests. They don't seem to give errors.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #19885.

<!-- Either: -->
- [x] These changes do not require tests because it's a refactoring task

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20012)
<!-- Reviewable:end -->
