### PR TITLE
Remove reference to the Gecko pref svg.paint-order.enabled

### DIFF
--- a/components/style/properties/longhand/inherited_svg.mako.rs
+++ b/components/style/properties/longhand/inherited_svg.mako.rs
@@ -133,7 +133,6 @@ ${helpers.predefined_type("marker-end", "UrlOrNone", "Either::Second(None_)",
 ${helpers.predefined_type("paint-order", "SVGPaintOrder", "computed::SVGPaintOrder::normal()",
                           products="gecko",
                           animation_value_type="discrete",
-                          gecko_pref="svg.paint-order.enabled",
                           spec="https://www.w3.org/TR/SVG2/painting.html#PaintOrder")}
 
 ${helpers.predefined_type("-moz-context-properties",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This pref (to potentially disable support for a CSS property) is to be removed from Gecko, so we should also remove the reference to it in the Servo (stylo) code; the property will be always-supported, just like the majority of others.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).
        (See gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1437267.)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because ... it's just removing support for a pref that is never actually used (it has defaulted to true ever since it was introduced in Gecko).

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20016)
<!-- Reviewable:end -->
