### PR TITLE
style: Handle quirks-mode changes correctly.

### DIFF
--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -77,6 +77,9 @@ impl UserAgentCascadeDataCache {
         }
     }
 
+    // FIXME(emilio): This may need to be keyed on quirks-mode too, though there
+    // aren't class / id selectors on those sheets, usually, so it's probably
+    // ok...
     fn lookup<'a, I, S>(
         &'a mut self,
         sheets: I,
@@ -1146,13 +1149,11 @@ impl Stylist {
 
     /// Sets the quirks mode of the document.
     pub fn set_quirks_mode(&mut self, quirks_mode: QuirksMode) {
-        // FIXME(emilio): We don't seem to change the quirks mode dynamically
-        // during multiple layout passes, but this is totally bogus, in the
-        // sense that it's updated asynchronously.
-        //
-        // This should probably be an argument to `update`, and use the quirks
-        // mode info in the `SharedLayoutContext`.
+        if self.quirks_mode == quirks_mode {
+            return;
+        }
         self.quirks_mode = quirks_mode;
+        self.force_stylesheet_origins_dirty(OriginSet::all());
     }
 
     /// Returns the applicable CSS declarations for the given element.

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -2450,19 +2450,12 @@ pub extern "C" fn Servo_StyleSet_Drop(data: RawServoStyleSetOwned) {
     let _ = data.into_box::<PerDocumentStyleData>();
 }
 
-
-/// Updating the stylesheets and redoing selector matching is always happens
-/// before the document element is inserted. Therefore we don't need to call
-/// `force_dirty` here.
 #[no_mangle]
-pub extern "C" fn Servo_StyleSet_CompatModeChanged(raw_data: RawServoStyleSetBorrowed) {
+pub unsafe extern "C" fn Servo_StyleSet_CompatModeChanged(raw_data: RawServoStyleSetBorrowed) {
     let mut data = PerDocumentStyleData::from_ffi(raw_data).borrow_mut();
-    let quirks_mode = unsafe {
-        (*data.stylist.device().pres_context().mDocument.raw::<nsIDocument>())
-            .mCompatMode
-    };
-
-    data.stylist.set_quirks_mode(quirks_mode.into());
+    let doc =
+        &*data.stylist.device().pres_context().mDocument.raw::<nsIDocument>();
+    data.stylist.set_quirks_mode(QuirksMode::from(doc.mCompatMode));
 }
 
 fn parse_property_into<R>(


### PR DESCRIPTION
The reason why bug 1355721 regressed this is because in non-e10s we definitely
flush before parsing the standards quirks-mode. And bug 1355721 introduced an
unconditional UpdateStylistIfNeeded, unless the counter style / font
equivalents.

That means that the stylist wouldn't remain on its initial state after the first
flush, which itself means that when the compat mode changed, the UA and user
rules were already on the stylist with the quirks mode keys. That makes
class-names be keyed in ascii lowercase.

After that no user style changed, so no rebuild happens for the cascade data in
the user origin, so we keep looking at the wrong keys indefinitely.

We should try to avoid the flush there and ensure that by the time we create a
pres shell the quirks mode is already up-to-date...

Bug: 1394233
Reviewed-by: xidorn
MozReview-Commit-ID: 25dD2bca3tN

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20018)
<!-- Reviewable:end -->
