### PR TITLE
Propagate error code from fetching WPT changes.

### DIFF
--- a/etc/ci/update-wpt-checkout
+++ b/etc/ci/update-wpt-checkout
@@ -116,7 +116,7 @@ EOF
     curl -H "Authorization: token ${WPT_SYNC_TOKEN}" \
          -H "Content-Type: application/json" \
          --data @prdata.json \
-         https://api.github.com/repos/servo/servo/pulls || return 4
+         https://api.github.com/repos/servo/servo/pulls || return 5
 }
 
 function pull_from_upstream() {

--- a/etc/ci/update-wpt-checkout
+++ b/etc/ci/update-wpt-checkout
@@ -164,6 +164,8 @@ function main() {
         if [[ "${code}" == "255" ]]; then
             echo "No changes to sync."
             return 0
+        elif [[ "${code}" != "" ]]; then
+            return "${code}"
         fi
     fi
 


### PR DESCRIPTION
http://build.servo.org/builders/mac-nightly/builds/606 shows a completely error-free run, despite encountering an error early on in `./etc/ci/update-wpt-checkout fetch-and-update-expectations`. We were swallowing the nonzero error code in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20024)
<!-- Reviewable:end -->
