### PR TITLE
Add parsing support for the font-optical-sizing property

### DIFF
--- a/components/style/properties/data.py
+++ b/components/style/properties/data.py
@@ -19,7 +19,7 @@ SYSTEM_FONT_LONGHANDS = """font_family font_size font_style
                            font_size_adjust font_variant_alternates
                            font_variant_ligatures font_variant_east_asian
                            font_variant_numeric font_language_override
-                           font_feature_settings""".split()
+                           font_feature_settings font_optical_sizing""".split()
 
 
 def maybe_moz_logical_alias(product, side, prop):

--- a/components/style/properties/longhand/font.mako.rs
+++ b/components/style/properties/longhand/font.mako.rs
@@ -180,6 +180,16 @@ ${helpers.predefined_type("font-language-override",
                           flags="APPLIES_TO_FIRST_LETTER APPLIES_TO_FIRST_LINE APPLIES_TO_PLACEHOLDER",
                           spec="https://drafts.csswg.org/css-fonts-3/#propdef-font-language-override")}
 
+${helpers.single_keyword_system("font-optical-sizing",
+                                "auto none",
+                                products="gecko",
+                                gecko_pref="layout.css.font-variations.enabled",
+                                gecko_ffi_name="mFont.opticalSizing",
+                                gecko_constant_prefix="NS_FONT_OPTICAL_SIZING",
+                                animation_value_type="none",
+                                flags="APPLIES_TO_FIRST_LETTER APPLIES_TO_FIRST_LINE APPLIES_TO_PLACEHOLDER",
+                                spec="https://www.w3.org/TR/css-fonts-4/#font-optical-sizing-def")}
+
 ${helpers.predefined_type("-x-lang",
                           "XLang",
                           products="gecko",
@@ -278,9 +288,11 @@ ${helpers.predefined_type("-x-text-zoom",
                               -moz-list -moz-field""".split()
             kw_font_props = """font_style font_variant_caps font_stretch
                                font_kerning font_variant_position font_variant_ligatures
-                               font_variant_east_asian font_variant_numeric""".split()
+                               font_variant_east_asian font_variant_numeric
+                               font_optical_sizing""".split()
             kw_cast = """font_style font_variant_caps font_stretch
-                         font_kerning font_variant_position""".split()
+                         font_kerning font_variant_position
+                         font_optical_sizing""".split()
         %>
         #[derive(Clone, Copy, Debug, Eq, Hash, MallocSizeOf, PartialEq, ToCss)]
         pub enum SystemFont {

--- a/components/style/properties/shorthand/font.mako.rs
+++ b/components/style/properties/shorthand/font.mako.rs
@@ -10,6 +10,7 @@
                                     font-size line-height font-family
                                     ${'font-size-adjust' if product == 'gecko' else ''}
                                     ${'font-kerning' if product == 'gecko' else ''}
+                                    ${'font-optical-sizing' if product == 'gecko' else ''}
                                     ${'font-variant-alternates' if product == 'gecko' else ''}
                                     ${'font-variant-east-asian' if product == 'gecko' else ''}
                                     ${'font-variant-ligatures' if product == 'gecko' else ''}
@@ -30,7 +31,8 @@
         gecko_sub_properties = "kerning language_override size_adjust \
                                 variant_alternates variant_east_asian \
                                 variant_ligatures variant_numeric \
-                                variant_position feature_settings".split()
+                                variant_position feature_settings \
+                                optical_sizing".split()
     %>
     % if product == "gecko":
         % for prop in gecko_sub_properties:


### PR DESCRIPTION
See Gecko bug https://bugzilla.mozilla.org/show_bug.cgi?id=1435692.

<!-- Please describe your changes on the following line: -->
Adding a CSS property, see https://drafts.csswg.org/css-fonts-4/#font-optical-sizing-def. Rendering support in Gecko will be implemented in bug 1435692.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).
        This is part of https://bugzilla.mozilla.org/show_bug.cgi?id=1435692; note that it will not build successfully as part of stylo until the Gecko patches there are also landed.

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because tests will be added once the complete feature (both stylo and gecko sides of the code) is in place.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20032)
<!-- Reviewable:end -->
