### PR TITLE
Added extra bool in Window object to know about its Mutation Observers

### DIFF
--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -9,7 +9,7 @@ use dom::bindings::codegen::Bindings::MutationObserverBinding::MutationCallback;
 use dom::bindings::codegen::Bindings::MutationObserverBinding::MutationObserverBinding::MutationObserverMethods;
 use dom::bindings::codegen::Bindings::MutationObserverBinding::MutationObserverInit;
 use dom::bindings::error::{Error, Fallible};
-use dom::bindings::reflector::{Reflector, reflect_dom_object};
+use dom::bindings::reflector::{Reflector, reflect_dom_object, DomObject};
 use dom::bindings::root::DomRoot;
 use dom::bindings::str::DOMString;
 use dom::mutationrecord::MutationRecord;
@@ -67,6 +67,7 @@ impl MutationObserver {
     }
 
     pub fn Constructor(global: &Window, callback: Rc<MutationCallback>) -> Fallible<DomRoot<MutationObserver>> {
+        global.set_exists_mut_observer();
         let observer = MutationObserver::new(global, callback);
         ScriptThread::add_mutation_observer(&*observer);
         Ok(observer)
@@ -105,6 +106,9 @@ impl MutationObserver {
 
     /// <https://dom.spec.whatwg.org/#queueing-a-mutation-record>
     pub fn queue_a_mutation_record(target: &Node, attr_type: Mutation) {
+        if !target.global().as_window().get_exists_mut_observer() {
+            return;
+        }
         // Step 1
         let mut interestedObservers: Vec<(DomRoot<MutationObserver>, Option<DOMString>)> = vec![];
         // Step 2 & 3

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -285,9 +285,20 @@ pub struct Window {
     /// The Webrender Document id associated with this window.
     #[ignore_malloc_size_of = "defined in webrender_api"]
     webrender_document: DocumentId,
+
+    /// Flag to identify whether mutation observers are present(true)/absent(false)
+    exists_mut_observer: Cell<bool>,
 }
 
 impl Window {
+    pub fn get_exists_mut_observer(&self) -> bool {
+        self.exists_mut_observer.get()
+    }
+
+    pub fn set_exists_mut_observer(&self) {
+        self.exists_mut_observer.set(true);
+    }
+
     #[allow(unsafe_code)]
     pub fn clear_js_runtime_for_script_deallocation(&self) {
         unsafe {
@@ -1814,6 +1825,7 @@ impl Window {
             test_worklet: Default::default(),
             paint_worklet: Default::default(),
             webrender_document,
+            exists_mut_observer: Cell::new(false),
         });
 
         unsafe {

--- a/tests/html/mut_observer_perf.html
+++ b/tests/html/mut_observer_perf.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset='utf-8'>
+</head>
+<body>
+<script>
+window.onload = function(){
+
+    var script = document.createElement("script");
+    script.setAttribute("attr", "val");
+
+    var start_test = function(targetNode,attr) {
+        var start = performance.now();
+        for( val = 1; val <= 1000; val++) {
+            targetNode.setAttribute(attr, val);
+        }
+        var stop = performance.now();
+        console.log('Time taken:'+ (stop - start)/1000.0);
+    };
+
+    var config = { attributes: true, childList: true };
+    console.log('Mutation Observer Algorithm performance testing...');
+
+    console.log('\nMutation performed without observer ->');
+    start_test(script,"attr");
+
+    console.log('\nMutation performed with observer ->');
+    var callback = function(mutationsList) {
+        for(var mutation of mutationsList) {
+            if (mutation.type == 'childList') {
+                // Uncomment below line to see changes
+                // console.log('A child node has been added or removed.');
+            }
+            else if (mutation.type == 'attributes') {
+                // Uncomment below line to see changes
+                // console.log('The ' + mutation.attributeName + ' attribute was modified.');
+            }
+        }
+    };
+    var observer = new MutationObserver(callback);
+    observer.observe(script, config);
+    start_test(script,"attr");
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
- Added Cell<bool> type variable in Window object to know whether its mutation observers are present/absent
- Added get and set functions for this variable
- Added supporting test files to check for performance

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #16936.

<!-- Either: -->
- [x] There are tests for these changes, but these are manual tests for checking correctness of added code

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20041)
<!-- Reviewable:end -->
