### PR TITLE
Integrate font-variation-settings descriptor with stylo

### DIFF
--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -26,7 +26,7 @@ use style_traits::{Comma, CssWriter, OneOrMoreSeparated, ParseError};
 use style_traits::{StyleParseErrorKind, ToCss};
 use values::computed::font::FamilyName;
 #[cfg(feature = "gecko")]
-use values::specified::font::SpecifiedFontFeatureSettings;
+use values::specified::font::{SpecifiedFontFeatureSettings, FontVariationSettings};
 use values::specified::url::SpecifiedUrl;
 
 /// A source for a font-face rule.
@@ -235,6 +235,12 @@ macro_rules! is_descriptor_enabled {
             mozilla::StylePrefs_sFontDisplayEnabled
         }
     };
+    ("font-variation-settings") => {
+        unsafe {
+            use gecko_bindings::structs::mozilla;
+            mozilla::StylePrefs_sFontVariationsEnabled
+        }
+    };
     ($name: tt) => { true }
 }
 
@@ -245,7 +251,7 @@ macro_rules! font_face_descriptors_common {
         /// Data inside a `@font-face` rule.
         ///
         /// <https://drafts.csswg.org/css-fonts/#font-face-rule>
-        #[derive(Clone, Debug, Eq, PartialEq)]
+        #[derive(Clone, Debug, PartialEq)]
         pub struct FontFaceRuleData {
             $(
                 #[$doc]
@@ -403,6 +409,11 @@ font_face_descriptors! {
         /// The feature settings of this font face.
         "font-feature-settings" feature_settings / mFontFeatureSettings: SpecifiedFontFeatureSettings = {
             font_feature_settings::SpecifiedValue::normal()
+        },
+
+        /// The variation settings of this font face.
+        "font-variation-settings" variation_settings / mFontVariationSettings: FontVariationSettings = {
+            font_variation_settings::SpecifiedValue::normal()
         },
 
         /// The language override of this font face.

--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -1472,6 +1472,9 @@ extern "C" {
     pub fn Gecko_CSSValue_SetInt(css_value: nsCSSValueBorrowedMut, integer: i32, unit: nsCSSUnit);
 }
 extern "C" {
+    pub fn Gecko_CSSValue_SetFloat(css_value: nsCSSValueBorrowedMut, value: f32, unit: nsCSSUnit);
+}
+extern "C" {
     pub fn Gecko_CSSValue_SetPair(
         css_value: nsCSSValueBorrowedMut,
         xvalue: nsCSSValueBorrowed,

--- a/components/style/gecko/generated/structs.rs
+++ b/components/style/gecko/generated/structs.rs
@@ -10231,6 +10231,10 @@ pub mod root {
             pub static mut StylePrefs_sGridTemplateSubgridValueEnabled: bool;
         }
         extern "C" {
+            #[link_name = "\u{1}_ZN7mozilla10StylePrefs22sFontVariationsEnabledE"]
+            pub static mut StylePrefs_sFontVariationsEnabled: bool;
+        }
+        extern "C" {
             #[link_name = "\u{1}_ZN7mozilla10StylePrefs22sEmulateMozBoxWithFlexE"]
             pub static mut StylePrefs_sEmulateMozBoxWithFlex: bool;
         }
@@ -11885,6 +11889,7 @@ pub mod root {
             pub mSrc: root::nsCSSValue,
             pub mUnicodeRange: root::nsCSSValue,
             pub mFontFeatureSettings: root::nsCSSValue,
+            pub mFontVariationSettings: root::nsCSSValue,
             pub mFontLanguageOverride: root::nsCSSValue,
             pub mDisplay: root::nsCSSValue,
         }
@@ -11896,7 +11901,7 @@ pub mod root {
         fn bindgen_test_layout_CSSFontFaceDescriptors() {
             assert_eq!(
                 ::std::mem::size_of::<CSSFontFaceDescriptors>(),
-                144usize,
+                160usize,
                 concat!("Size of: ", stringify!(CSSFontFaceDescriptors))
             );
             assert_eq!(
@@ -11992,10 +11997,23 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<CSSFontFaceDescriptors>())).mFontLanguageOverride
+                    &(*(::std::ptr::null::<CSSFontFaceDescriptors>())).mFontVariationSettings
                         as *const _ as usize
                 },
                 112usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(CSSFontFaceDescriptors),
+                    "::",
+                    stringify!(mFontVariationSettings)
+                )
+            );
+            assert_eq!(
+                unsafe {
+                    &(*(::std::ptr::null::<CSSFontFaceDescriptors>())).mFontLanguageOverride
+                        as *const _ as usize
+                },
+                128usize,
                 concat!(
                     "Offset of field: ",
                     stringify!(CSSFontFaceDescriptors),
@@ -12007,7 +12025,7 @@ pub mod root {
                 unsafe {
                     &(*(::std::ptr::null::<CSSFontFaceDescriptors>())).mDisplay as *const _ as usize
                 },
-                128usize,
+                144usize,
                 concat!(
                     "Offset of field: ",
                     stringify!(CSSFontFaceDescriptors),
@@ -21749,9 +21767,10 @@ pub mod root {
         eCSSFontDesc_Src = 4,
         eCSSFontDesc_UnicodeRange = 5,
         eCSSFontDesc_FontFeatureSettings = 6,
-        eCSSFontDesc_FontLanguageOverride = 7,
-        eCSSFontDesc_Display = 8,
-        eCSSFontDesc_COUNT = 9,
+        eCSSFontDesc_FontVariationSettings = 7,
+        eCSSFontDesc_FontLanguageOverride = 8,
+        eCSSFontDesc_Display = 9,
+        eCSSFontDesc_COUNT = 10,
     }
     #[repr(i32)]
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -37537,7 +37556,7 @@ pub mod root {
     fn bindgen_test_layout_nsCSSFontFaceStyleDecl() {
         assert_eq!(
             ::std::mem::size_of::<nsCSSFontFaceStyleDecl>(),
-            176usize,
+            192usize,
             concat!("Size of: ", stringify!(nsCSSFontFaceStyleDecl))
         );
         assert_eq!(
@@ -37599,7 +37618,7 @@ pub mod root {
     fn bindgen_test_layout_nsCSSFontFaceRule() {
         assert_eq!(
             ::std::mem::size_of::<nsCSSFontFaceRule>(),
-            240usize,
+            256usize,
             concat!("Size of: ", stringify!(nsCSSFontFaceRule))
         );
         assert_eq!(

--- a/components/style/gecko_bindings/sugar/ns_css_value.rs
+++ b/components/style/gecko_bindings/sugar/ns_css_value.rs
@@ -205,6 +205,11 @@ impl nsCSSValue {
         self.set_int_internal(value.into(), nsCSSUnit::eCSSUnit_Enumerated);
     }
 
+    /// Set to a number value
+    pub fn set_number(&mut self, number: f32) {
+        unsafe { bindings::Gecko_CSSValue_SetFloat(self, number, nsCSSUnit::eCSSUnit_Number) }
+    }
+
     /// Set to a url value
     pub fn set_url(&mut self, url: &SpecifiedUrl) {
         unsafe { bindings::Gecko_CSSValue_SetURL(self, url.for_ffi()) }
@@ -407,4 +412,12 @@ impl IndexMut<usize> for nsCSSValue_Array {
 pub trait ToNsCssValue {
     /// Convert
     fn convert(self, nscssvalue: &mut nsCSSValue);
+}
+
+impl<T: ToNsCssValue> From<T> for nsCSSValue {
+    fn from(value: T) -> nsCSSValue {
+        let mut result = nsCSSValue::null();
+        value.convert(&mut result);
+        result
+    }
 }

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -4746,7 +4746,7 @@ pub extern "C" fn Servo_ParseFontDescriptor(
     use style::font_face::{FontDisplay, FontWeight, Source};
     use style::properties::longhands::font_language_override;
     use style::values::computed::font::FamilyName;
-    use style::values::specified::font::SpecifiedFontFeatureSettings;
+    use style::values::specified::font::{SpecifiedFontFeatureSettings, FontVariationSettings};
 
     let string = unsafe { (*value).to_string() };
     let mut input = ParserInput::new(&string);
@@ -4796,6 +4796,7 @@ pub extern "C" fn Servo_ParseFontDescriptor(
             eCSSFontDesc_Src / Vec<Source>,
             eCSSFontDesc_UnicodeRange / Vec<UnicodeRange>,
             eCSSFontDesc_FontFeatureSettings / SpecifiedFontFeatureSettings,
+            eCSSFontDesc_FontVariationSettings / FontVariationSettings,
             eCSSFontDesc_FontLanguageOverride / font_language_override::SpecifiedValue,
             eCSSFontDesc_Display / FontDisplay,
         ]


### PR DESCRIPTION
This is the Servo side change for [bug 1435984](https://bugzilla.mozilla.org/show_bug.cgi?id=1435984).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20042)
<!-- Reviewable:end -->
