### PR TITLE
style: Make XBL / Shadow DOM use something more light-weight than a Stylist.

### DIFF
--- a/components/style/author_styles.rs
+++ b/components/style/author_styles.rs
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! A set of author stylesheets and their computed representation, such as the
+//! ones used for ShadowRoot and XBL.
+
+use context::QuirksMode;
+use dom::TElement;
+#[cfg(feature = "gecko")]
+use gecko_bindings::sugar::ownership::{HasBoxFFI, HasFFI, HasSimpleFFI};
+use invalidation::media_queries::ToMediaListKey;
+use media_queries::Device;
+use shared_lock::SharedRwLockReadGuard;
+use stylesheet_set::AuthorStylesheetSet;
+use stylesheets::StylesheetInDocument;
+use stylist::CascadeData;
+
+
+/// A set of author stylesheets and their computed representation, such as the
+/// ones used for ShadowRoot and XBL.
+pub struct AuthorStyles<S>
+where
+    S: StylesheetInDocument + PartialEq + 'static,
+{
+    /// The sheet collection, which holds the sheet pointers, the invalidations,
+    /// and all that stuff.
+    pub stylesheets: AuthorStylesheetSet<S>,
+    /// The actual cascade data computed from the stylesheets.
+    pub data: CascadeData,
+    /// The quirks mode of the last stylesheet flush, used because XBL sucks and
+    /// we should really fix it, see bug 1406875.
+    pub quirks_mode: QuirksMode,
+}
+
+impl<S> AuthorStyles<S>
+where
+    S: StylesheetInDocument + PartialEq + 'static,
+{
+    /// Create an empty AuthorStyles.
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            stylesheets: AuthorStylesheetSet::new(),
+            data: CascadeData::new(),
+            quirks_mode: QuirksMode::NoQuirks,
+        }
+    }
+
+    /// Flush the pending sheet changes, updating `data` as appropriate.
+    ///
+    /// TODO(emilio): Need a host element and a snapshot map to do invalidation
+    /// properly.
+    #[inline]
+    pub fn flush<E>(
+        &mut self,
+        device: &Device,
+        quirks_mode: QuirksMode,
+        guard: &SharedRwLockReadGuard,
+    )
+    where
+        E: TElement,
+        S: ToMediaListKey,
+    {
+        let flusher = self.stylesheets.flush::<E>(
+            /* host = */ None,
+            /* snapshot_map = */ None,
+        );
+
+        if flusher.sheets.dirty() {
+            self.quirks_mode = quirks_mode;
+        }
+
+        // Ignore OOM.
+        let _ = self.data.rebuild(
+            device,
+            quirks_mode,
+            flusher.sheets,
+            guard,
+        );
+    }
+}
+
+#[cfg(feature = "gecko")]
+unsafe impl HasFFI for AuthorStyles<::gecko::data::GeckoStyleSheet> {
+    type FFIType = ::gecko_bindings::bindings::RawServoAuthorStyles;
+}
+#[cfg(feature = "gecko")]
+unsafe impl HasSimpleFFI for AuthorStyles<::gecko::data::GeckoStyleSheet> {}
+#[cfg(feature = "gecko")]
+unsafe impl HasBoxFFI for AuthorStyles<::gecko::data::GeckoStyleSheet> {}

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -754,7 +754,7 @@ pub trait TElement
     fn each_xbl_cascade_data<'a, F>(&self, _: F) -> bool
     where
         Self: 'a,
-        F: FnMut(AtomicRef<'a, CascadeData>, QuirksMode),
+        F: FnMut(&'a CascadeData, QuirksMode),
     {
         false
     }
@@ -766,7 +766,7 @@ pub trait TElement
     fn each_applicable_non_document_style_rule_data<'a, F>(&self, mut f: F) -> bool
     where
         Self: 'a,
-        F: FnMut(AtomicRef<'a, CascadeData>, QuirksMode),
+        F: FnMut(&'a CascadeData, QuirksMode),
     {
         let cut_off_inheritance = self.each_xbl_cascade_data(&mut f);
 

--- a/components/style/gecko/generated/atom_macro.rs
+++ b/components/style/gecko/generated/atom_macro.rs
@@ -884,6 +884,8 @@ cfg_if! {
             pub static nsGkAtoms_figcaption: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms6figureE"]
             pub static nsGkAtoms_figure: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms7findbarE"]
+            pub static nsGkAtoms_findbar: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms5fixedE"]
             pub static nsGkAtoms_fixed: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms5flagsE"]
@@ -964,12 +966,20 @@ cfg_if! {
             pub static nsGkAtoms_glyphchar: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms7glyphidE"]
             pub static nsGkAtoms_glyphid: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms16graphicsDocumentE"]
+            pub static nsGkAtoms_graphicsDocument: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms14graphicsObjectE"]
+            pub static nsGkAtoms_graphicsObject: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms14graphicsSymbolE"]
+            pub static nsGkAtoms_graphicsSymbol: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms4gridE"]
             pub static nsGkAtoms_grid: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms6grippyE"]
             pub static nsGkAtoms_grippy: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms5groupE"]
             pub static nsGkAtoms_group: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms8groupboxE"]
+            pub static nsGkAtoms_groupbox: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms17groupingSeparatorE"]
             pub static nsGkAtoms_groupingSeparator: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms12groupingSizeE"]
@@ -1328,6 +1338,8 @@ cfg_if! {
             pub static nsGkAtoms_menubutton: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms10menuButtonE"]
             pub static nsGkAtoms_menuButton: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms11menucaptionE"]
+            pub static nsGkAtoms_menucaption: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms9menugroupE"]
             pub static nsGkAtoms_menugroup: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms8menuitemE"]
@@ -1482,6 +1494,8 @@ cfg_if! {
             pub static nsGkAtoms_noscript: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms7noshadeE"]
             pub static nsGkAtoms_noshade: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms12notificationE"]
+            pub static nsGkAtoms_notification: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms10novalidateE"]
             pub static nsGkAtoms_novalidate: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms4_notE"]
@@ -4418,6 +4432,26 @@ cfg_if! {
             pub static nsGkAtoms_windows_theme_zune: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms21windows_theme_genericE"]
             pub static nsGkAtoms_windows_theme_generic: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms4aeroE"]
+            pub static nsGkAtoms_aero: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms9aero_liteE"]
+            pub static nsGkAtoms_aero_lite: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms9luna_blueE"]
+            pub static nsGkAtoms_luna_blue: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms10luna_oliveE"]
+            pub static nsGkAtoms_luna_olive: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms11luna_silverE"]
+            pub static nsGkAtoms_luna_silver: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms6royaleE"]
+            pub static nsGkAtoms_royale: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms4zuneE"]
+            pub static nsGkAtoms_zune: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms12windows_win7E"]
+            pub static nsGkAtoms_windows_win7: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms12windows_win8E"]
+            pub static nsGkAtoms_windows_win8: *mut nsStaticAtom;
+            #[link_name = "_ZN9nsGkAtoms13windows_win10E"]
+            pub static nsGkAtoms_windows_win10: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms29_moz_scrollbar_start_backwardE"]
             pub static nsGkAtoms__moz_scrollbar_start_backward: *mut nsStaticAtom;
             #[link_name = "_ZN9nsGkAtoms28_moz_scrollbar_start_forwardE"]
@@ -6055,6 +6089,8 @@ cfg_if! {
             pub static nsGkAtoms_figcaption: *mut nsStaticAtom;
             #[link_name = "?figure@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
             pub static nsGkAtoms_figure: *mut nsStaticAtom;
+            #[link_name = "?findbar@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_findbar: *mut nsStaticAtom;
             #[link_name = "?fixed@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
             pub static nsGkAtoms_fixed: *mut nsStaticAtom;
             #[link_name = "?flags@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
@@ -6135,12 +6171,20 @@ cfg_if! {
             pub static nsGkAtoms_glyphchar: *mut nsStaticAtom;
             #[link_name = "?glyphid@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
             pub static nsGkAtoms_glyphid: *mut nsStaticAtom;
+            #[link_name = "?graphicsDocument@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_graphicsDocument: *mut nsStaticAtom;
+            #[link_name = "?graphicsObject@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_graphicsObject: *mut nsStaticAtom;
+            #[link_name = "?graphicsSymbol@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_graphicsSymbol: *mut nsStaticAtom;
             #[link_name = "?grid@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
             pub static nsGkAtoms_grid: *mut nsStaticAtom;
             #[link_name = "?grippy@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
             pub static nsGkAtoms_grippy: *mut nsStaticAtom;
             #[link_name = "?group@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
             pub static nsGkAtoms_group: *mut nsStaticAtom;
+            #[link_name = "?groupbox@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_groupbox: *mut nsStaticAtom;
             #[link_name = "?groupingSeparator@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
             pub static nsGkAtoms_groupingSeparator: *mut nsStaticAtom;
             #[link_name = "?groupingSize@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
@@ -6499,6 +6543,8 @@ cfg_if! {
             pub static nsGkAtoms_menubutton: *mut nsStaticAtom;
             #[link_name = "?menuButton@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
             pub static nsGkAtoms_menuButton: *mut nsStaticAtom;
+            #[link_name = "?menucaption@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_menucaption: *mut nsStaticAtom;
             #[link_name = "?menugroup@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
             pub static nsGkAtoms_menugroup: *mut nsStaticAtom;
             #[link_name = "?menuitem@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
@@ -6653,6 +6699,8 @@ cfg_if! {
             pub static nsGkAtoms_noscript: *mut nsStaticAtom;
             #[link_name = "?noshade@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
             pub static nsGkAtoms_noshade: *mut nsStaticAtom;
+            #[link_name = "?notification@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_notification: *mut nsStaticAtom;
             #[link_name = "?novalidate@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
             pub static nsGkAtoms_novalidate: *mut nsStaticAtom;
             #[link_name = "?_not@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
@@ -9589,6 +9637,26 @@ cfg_if! {
             pub static nsGkAtoms_windows_theme_zune: *mut nsStaticAtom;
             #[link_name = "?windows_theme_generic@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
             pub static nsGkAtoms_windows_theme_generic: *mut nsStaticAtom;
+            #[link_name = "?aero@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_aero: *mut nsStaticAtom;
+            #[link_name = "?aero_lite@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_aero_lite: *mut nsStaticAtom;
+            #[link_name = "?luna_blue@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_luna_blue: *mut nsStaticAtom;
+            #[link_name = "?luna_olive@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_luna_olive: *mut nsStaticAtom;
+            #[link_name = "?luna_silver@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_luna_silver: *mut nsStaticAtom;
+            #[link_name = "?royale@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_royale: *mut nsStaticAtom;
+            #[link_name = "?zune@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_zune: *mut nsStaticAtom;
+            #[link_name = "?windows_win7@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_windows_win7: *mut nsStaticAtom;
+            #[link_name = "?windows_win8@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_windows_win8: *mut nsStaticAtom;
+            #[link_name = "?windows_win10@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
+            pub static nsGkAtoms_windows_win10: *mut nsStaticAtom;
             #[link_name = "?_moz_scrollbar_start_backward@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
             pub static nsGkAtoms__moz_scrollbar_start_backward: *mut nsStaticAtom;
             #[link_name = "?_moz_scrollbar_start_forward@nsGkAtoms@@2PEAVnsStaticAtom@@EA"]
@@ -11226,6 +11294,8 @@ cfg_if! {
             pub static nsGkAtoms_figcaption: *mut nsStaticAtom;
             #[link_name = "\x01?figure@nsGkAtoms@@2PAVnsStaticAtom@@A"]
             pub static nsGkAtoms_figure: *mut nsStaticAtom;
+            #[link_name = "\x01?findbar@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_findbar: *mut nsStaticAtom;
             #[link_name = "\x01?fixed@nsGkAtoms@@2PAVnsStaticAtom@@A"]
             pub static nsGkAtoms_fixed: *mut nsStaticAtom;
             #[link_name = "\x01?flags@nsGkAtoms@@2PAVnsStaticAtom@@A"]
@@ -11306,12 +11376,20 @@ cfg_if! {
             pub static nsGkAtoms_glyphchar: *mut nsStaticAtom;
             #[link_name = "\x01?glyphid@nsGkAtoms@@2PAVnsStaticAtom@@A"]
             pub static nsGkAtoms_glyphid: *mut nsStaticAtom;
+            #[link_name = "\x01?graphicsDocument@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_graphicsDocument: *mut nsStaticAtom;
+            #[link_name = "\x01?graphicsObject@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_graphicsObject: *mut nsStaticAtom;
+            #[link_name = "\x01?graphicsSymbol@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_graphicsSymbol: *mut nsStaticAtom;
             #[link_name = "\x01?grid@nsGkAtoms@@2PAVnsStaticAtom@@A"]
             pub static nsGkAtoms_grid: *mut nsStaticAtom;
             #[link_name = "\x01?grippy@nsGkAtoms@@2PAVnsStaticAtom@@A"]
             pub static nsGkAtoms_grippy: *mut nsStaticAtom;
             #[link_name = "\x01?group@nsGkAtoms@@2PAVnsStaticAtom@@A"]
             pub static nsGkAtoms_group: *mut nsStaticAtom;
+            #[link_name = "\x01?groupbox@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_groupbox: *mut nsStaticAtom;
             #[link_name = "\x01?groupingSeparator@nsGkAtoms@@2PAVnsStaticAtom@@A"]
             pub static nsGkAtoms_groupingSeparator: *mut nsStaticAtom;
             #[link_name = "\x01?groupingSize@nsGkAtoms@@2PAVnsStaticAtom@@A"]
@@ -11670,6 +11748,8 @@ cfg_if! {
             pub static nsGkAtoms_menubutton: *mut nsStaticAtom;
             #[link_name = "\x01?menuButton@nsGkAtoms@@2PAVnsStaticAtom@@A"]
             pub static nsGkAtoms_menuButton: *mut nsStaticAtom;
+            #[link_name = "\x01?menucaption@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_menucaption: *mut nsStaticAtom;
             #[link_name = "\x01?menugroup@nsGkAtoms@@2PAVnsStaticAtom@@A"]
             pub static nsGkAtoms_menugroup: *mut nsStaticAtom;
             #[link_name = "\x01?menuitem@nsGkAtoms@@2PAVnsStaticAtom@@A"]
@@ -11824,6 +11904,8 @@ cfg_if! {
             pub static nsGkAtoms_noscript: *mut nsStaticAtom;
             #[link_name = "\x01?noshade@nsGkAtoms@@2PAVnsStaticAtom@@A"]
             pub static nsGkAtoms_noshade: *mut nsStaticAtom;
+            #[link_name = "\x01?notification@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_notification: *mut nsStaticAtom;
             #[link_name = "\x01?novalidate@nsGkAtoms@@2PAVnsStaticAtom@@A"]
             pub static nsGkAtoms_novalidate: *mut nsStaticAtom;
             #[link_name = "\x01?_not@nsGkAtoms@@2PAVnsStaticAtom@@A"]
@@ -14760,6 +14842,26 @@ cfg_if! {
             pub static nsGkAtoms_windows_theme_zune: *mut nsStaticAtom;
             #[link_name = "\x01?windows_theme_generic@nsGkAtoms@@2PAVnsStaticAtom@@A"]
             pub static nsGkAtoms_windows_theme_generic: *mut nsStaticAtom;
+            #[link_name = "\x01?aero@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_aero: *mut nsStaticAtom;
+            #[link_name = "\x01?aero_lite@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_aero_lite: *mut nsStaticAtom;
+            #[link_name = "\x01?luna_blue@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_luna_blue: *mut nsStaticAtom;
+            #[link_name = "\x01?luna_olive@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_luna_olive: *mut nsStaticAtom;
+            #[link_name = "\x01?luna_silver@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_luna_silver: *mut nsStaticAtom;
+            #[link_name = "\x01?royale@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_royale: *mut nsStaticAtom;
+            #[link_name = "\x01?zune@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_zune: *mut nsStaticAtom;
+            #[link_name = "\x01?windows_win7@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_windows_win7: *mut nsStaticAtom;
+            #[link_name = "\x01?windows_win8@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_windows_win8: *mut nsStaticAtom;
+            #[link_name = "\x01?windows_win10@nsGkAtoms@@2PAVnsStaticAtom@@A"]
+            pub static nsGkAtoms_windows_win10: *mut nsStaticAtom;
             #[link_name = "\x01?_moz_scrollbar_start_backward@nsGkAtoms@@2PAVnsStaticAtom@@A"]
             pub static nsGkAtoms__moz_scrollbar_start_backward: *mut nsStaticAtom;
             #[link_name = "\x01?_moz_scrollbar_start_forward@nsGkAtoms@@2PAVnsStaticAtom@@A"]
@@ -16400,6 +16502,8 @@ macro_rules! atom {
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_figcaption as *mut _) } }};
 ("figure") =>
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_figure as *mut _) } }};
+("findbar") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_findbar as *mut _) } }};
 ("fixed") =>
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_fixed as *mut _) } }};
 ("flags") =>
@@ -16480,12 +16584,20 @@ macro_rules! atom {
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_glyphchar as *mut _) } }};
 ("glyphid") =>
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_glyphid as *mut _) } }};
+("graphics-document") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_graphicsDocument as *mut _) } }};
+("graphics-object") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_graphicsObject as *mut _) } }};
+("graphics-symbol") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_graphicsSymbol as *mut _) } }};
 ("grid") =>
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_grid as *mut _) } }};
 ("grippy") =>
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_grippy as *mut _) } }};
 ("group") =>
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_group as *mut _) } }};
+("groupbox") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_groupbox as *mut _) } }};
 ("grouping-separator") =>
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_groupingSeparator as *mut _) } }};
 ("grouping-size") =>
@@ -16844,6 +16956,8 @@ macro_rules! atom {
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_menubutton as *mut _) } }};
 ("menu-button") =>
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_menuButton as *mut _) } }};
+("menucaption") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_menucaption as *mut _) } }};
 ("menugroup") =>
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_menugroup as *mut _) } }};
 ("menuitem") =>
@@ -16998,6 +17112,8 @@ macro_rules! atom {
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_noscript as *mut _) } }};
 ("noshade") =>
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_noshade as *mut _) } }};
+("notification") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_notification as *mut _) } }};
 ("novalidate") =>
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_novalidate as *mut _) } }};
 ("not") =>
@@ -19934,6 +20050,26 @@ macro_rules! atom {
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_windows_theme_zune as *mut _) } }};
 ("windows-theme-generic") =>
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_windows_theme_generic as *mut _) } }};
+("aero") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_aero as *mut _) } }};
+("aero-lite") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_aero_lite as *mut _) } }};
+("luna-blue") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_luna_blue as *mut _) } }};
+("luna-olive") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_luna_olive as *mut _) } }};
+("luna-silver") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_luna_silver as *mut _) } }};
+("royale") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_royale as *mut _) } }};
+("zune") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_zune as *mut _) } }};
+("windows-win7") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_windows_win7 as *mut _) } }};
+("windows-win8") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_windows_win8 as *mut _) } }};
+("windows-win10") =>
+  {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms_windows_win10 as *mut _) } }};
 ("-moz-scrollbar-start-backward") =>
   {{ #[allow(unsafe_code)] #[allow(unused_unsafe)]unsafe { $crate::string_cache::atom_macro::atom_from_static($crate::string_cache::atom_macro::nsGkAtoms__moz_scrollbar_start_backward as *mut _) } }};
 ("-moz-scrollbar-start-forward") =>

--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -18,7 +18,6 @@ use gecko_bindings::structs::mozilla::dom::CallerType;
 use gecko_bindings::structs::mozilla::AnonymousCounterStyle;
 use gecko_bindings::structs::mozilla::AtomArray;
 use gecko_bindings::structs::mozilla::MallocSizeOf;
-use gecko_bindings::structs::mozilla::ServoStyleSet;
 use gecko_bindings::structs::mozilla::OriginFlags;
 use gecko_bindings::structs::mozilla::UniquePtr;
 use gecko_bindings::structs::ServoRawOffsetArc;
@@ -255,38 +254,60 @@ use gecko_bindings::structs::FontFamilyName;
 use gecko_bindings::structs::mozilla::SharedFontList;
 pub type nsTArrayBorrowed_uintptr_t<'a> = &'a mut ::gecko_bindings::structs::nsTArray<usize>;
 pub type RawServoStyleSetOwned = ::gecko_bindings::sugar::ownership::Owned<RawServoStyleSet>;
-pub type RawServoStyleSetOwnedOrNull = ::gecko_bindings::sugar::ownership::OwnedOrNull<RawServoStyleSet>;
+pub type RawServoStyleSetOwnedOrNull =
+    ::gecko_bindings::sugar::ownership::OwnedOrNull<RawServoStyleSet>;
 pub type RawServoStyleSetBorrowed<'a> = &'a RawServoStyleSet;
 pub type RawServoStyleSetBorrowedOrNull<'a> = Option<&'a RawServoStyleSet>;
 pub type RawServoStyleSetBorrowedMut<'a> = &'a mut RawServoStyleSet;
 pub type RawServoStyleSetBorrowedMutOrNull<'a> = Option<&'a mut RawServoStyleSet>;
-enum RawServoStyleSetVoid { }
+enum RawServoStyleSetVoid {
+}
 pub struct RawServoStyleSet(RawServoStyleSetVoid);
-pub type RawServoSelectorListOwned = ::gecko_bindings::sugar::ownership::Owned<RawServoSelectorList>;
-pub type RawServoSelectorListOwnedOrNull = ::gecko_bindings::sugar::ownership::OwnedOrNull<RawServoSelectorList>;
+pub type RawServoAuthorStylesOwned =
+    ::gecko_bindings::sugar::ownership::Owned<RawServoAuthorStyles>;
+pub type RawServoAuthorStylesOwnedOrNull =
+    ::gecko_bindings::sugar::ownership::OwnedOrNull<RawServoAuthorStyles>;
+pub type RawServoAuthorStylesBorrowed<'a> = &'a RawServoAuthorStyles;
+pub type RawServoAuthorStylesBorrowedOrNull<'a> = Option<&'a RawServoAuthorStyles>;
+pub type RawServoAuthorStylesBorrowedMut<'a> = &'a mut RawServoAuthorStyles;
+pub type RawServoAuthorStylesBorrowedMutOrNull<'a> = Option<&'a mut RawServoAuthorStyles>;
+enum RawServoAuthorStylesVoid {
+}
+pub struct RawServoAuthorStyles(RawServoAuthorStylesVoid);
+pub type RawServoSelectorListOwned =
+    ::gecko_bindings::sugar::ownership::Owned<RawServoSelectorList>;
+pub type RawServoSelectorListOwnedOrNull =
+    ::gecko_bindings::sugar::ownership::OwnedOrNull<RawServoSelectorList>;
 pub type RawServoSelectorListBorrowed<'a> = &'a RawServoSelectorList;
 pub type RawServoSelectorListBorrowedOrNull<'a> = Option<&'a RawServoSelectorList>;
 pub type RawServoSelectorListBorrowedMut<'a> = &'a mut RawServoSelectorList;
 pub type RawServoSelectorListBorrowedMutOrNull<'a> = Option<&'a mut RawServoSelectorList>;
-pub type RawServoSourceSizeListOwned = ::gecko_bindings::sugar::ownership::Owned<RawServoSourceSizeList>;
-pub type RawServoSourceSizeListOwnedOrNull = ::gecko_bindings::sugar::ownership::OwnedOrNull<RawServoSourceSizeList>;
+pub type RawServoSourceSizeListOwned =
+    ::gecko_bindings::sugar::ownership::Owned<RawServoSourceSizeList>;
+pub type RawServoSourceSizeListOwnedOrNull =
+    ::gecko_bindings::sugar::ownership::OwnedOrNull<RawServoSourceSizeList>;
 pub type RawServoSourceSizeListBorrowed<'a> = &'a RawServoSourceSizeList;
 pub type RawServoSourceSizeListBorrowedOrNull<'a> = Option<&'a RawServoSourceSizeList>;
 pub type RawServoSourceSizeListBorrowedMut<'a> = &'a mut RawServoSourceSizeList;
 pub type RawServoSourceSizeListBorrowedMutOrNull<'a> = Option<&'a mut RawServoSourceSizeList>;
-pub type ServoElementSnapshotOwned = ::gecko_bindings::sugar::ownership::Owned<ServoElementSnapshot>;
-pub type ServoElementSnapshotOwnedOrNull = ::gecko_bindings::sugar::ownership::OwnedOrNull<ServoElementSnapshot>;
+pub type ServoElementSnapshotOwned =
+    ::gecko_bindings::sugar::ownership::Owned<ServoElementSnapshot>;
+pub type ServoElementSnapshotOwnedOrNull =
+    ::gecko_bindings::sugar::ownership::OwnedOrNull<ServoElementSnapshot>;
 pub type ServoElementSnapshotBorrowed<'a> = &'a ServoElementSnapshot;
 pub type ServoElementSnapshotBorrowedOrNull<'a> = Option<&'a ServoElementSnapshot>;
 pub type ServoElementSnapshotBorrowedMut<'a> = &'a mut ServoElementSnapshot;
 pub type ServoElementSnapshotBorrowedMutOrNull<'a> = Option<&'a mut ServoElementSnapshot>;
-pub type RawServoAnimationValueMapOwned = ::gecko_bindings::sugar::ownership::Owned<RawServoAnimationValueMap>;
-pub type RawServoAnimationValueMapOwnedOrNull = ::gecko_bindings::sugar::ownership::OwnedOrNull<RawServoAnimationValueMap>;
+pub type RawServoAnimationValueMapOwned =
+    ::gecko_bindings::sugar::ownership::Owned<RawServoAnimationValueMap>;
+pub type RawServoAnimationValueMapOwnedOrNull =
+    ::gecko_bindings::sugar::ownership::OwnedOrNull<RawServoAnimationValueMap>;
 pub type RawServoAnimationValueMapBorrowed<'a> = &'a RawServoAnimationValueMap;
 pub type RawServoAnimationValueMapBorrowedOrNull<'a> = Option<&'a RawServoAnimationValueMap>;
 pub type RawServoAnimationValueMapBorrowedMut<'a> = &'a mut RawServoAnimationValueMap;
 pub type RawServoAnimationValueMapBorrowedMutOrNull<'a> = Option<&'a mut RawServoAnimationValueMap>;
-enum RawServoAnimationValueMapVoid { }
+enum RawServoAnimationValueMapVoid {
+}
 pub struct RawServoAnimationValueMap(RawServoAnimationValueMapVoid);
 pub type RawGeckoNodeBorrowed<'a> = &'a RawGeckoNode;
 pub type RawGeckoNodeBorrowedOrNull<'a> = Option<&'a RawGeckoNode>;
@@ -295,7 +316,8 @@ pub type RawGeckoElementBorrowedOrNull<'a> = Option<&'a RawGeckoElement>;
 pub type RawGeckoDocumentBorrowed<'a> = &'a RawGeckoDocument;
 pub type RawGeckoDocumentBorrowedOrNull<'a> = Option<&'a RawGeckoDocument>;
 pub type RawServoDeclarationBlockStrongBorrowed<'a> = &'a RawServoDeclarationBlockStrong;
-pub type RawServoDeclarationBlockStrongBorrowedOrNull<'a> = Option<&'a RawServoDeclarationBlockStrong>;
+pub type RawServoDeclarationBlockStrongBorrowedOrNull<'a> =
+    Option<&'a RawServoDeclarationBlockStrong>;
 pub type RawGeckoPresContextBorrowed<'a> = &'a RawGeckoPresContext;
 pub type RawGeckoPresContextBorrowedOrNull<'a> = Option<&'a RawGeckoPresContext>;
 pub type RawGeckoXBLBindingBorrowed<'a> = &'a RawGeckoXBLBinding;
@@ -313,9 +335,11 @@ pub type nsTimingFunctionBorrowedOrNull<'a> = Option<&'a nsTimingFunction>;
 pub type nsTimingFunctionBorrowedMut<'a> = &'a mut nsTimingFunction;
 pub type nsTimingFunctionBorrowedMutOrNull<'a> = Option<&'a mut nsTimingFunction>;
 pub type RawGeckoAnimationPropertySegmentBorrowed<'a> = &'a RawGeckoAnimationPropertySegment;
-pub type RawGeckoAnimationPropertySegmentBorrowedOrNull<'a> = Option<&'a RawGeckoAnimationPropertySegment>;
+pub type RawGeckoAnimationPropertySegmentBorrowedOrNull<'a> =
+    Option<&'a RawGeckoAnimationPropertySegment>;
 pub type RawGeckoAnimationPropertySegmentBorrowedMut<'a> = &'a mut RawGeckoAnimationPropertySegment;
-pub type RawGeckoAnimationPropertySegmentBorrowedMutOrNull<'a> = Option<&'a mut RawGeckoAnimationPropertySegment>;
+pub type RawGeckoAnimationPropertySegmentBorrowedMutOrNull<'a> =
+    Option<&'a mut RawGeckoAnimationPropertySegment>;
 pub type RawGeckoComputedTimingBorrowed<'a> = &'a RawGeckoComputedTiming;
 pub type RawGeckoComputedTimingBorrowedOrNull<'a> = Option<&'a RawGeckoComputedTiming>;
 pub type RawGeckoComputedTimingBorrowedMut<'a> = &'a mut RawGeckoComputedTiming;
@@ -329,13 +353,18 @@ pub type RawGeckoKeyframeListBorrowedOrNull<'a> = Option<&'a RawGeckoKeyframeLis
 pub type RawGeckoKeyframeListBorrowedMut<'a> = &'a mut RawGeckoKeyframeList;
 pub type RawGeckoKeyframeListBorrowedMutOrNull<'a> = Option<&'a mut RawGeckoKeyframeList>;
 pub type RawGeckoPropertyValuePairListBorrowed<'a> = &'a RawGeckoPropertyValuePairList;
-pub type RawGeckoPropertyValuePairListBorrowedOrNull<'a> = Option<&'a RawGeckoPropertyValuePairList>;
+pub type RawGeckoPropertyValuePairListBorrowedOrNull<'a> =
+    Option<&'a RawGeckoPropertyValuePairList>;
 pub type RawGeckoPropertyValuePairListBorrowedMut<'a> = &'a mut RawGeckoPropertyValuePairList;
-pub type RawGeckoPropertyValuePairListBorrowedMutOrNull<'a> = Option<&'a mut RawGeckoPropertyValuePairList>;
+pub type RawGeckoPropertyValuePairListBorrowedMutOrNull<'a> =
+    Option<&'a mut RawGeckoPropertyValuePairList>;
 pub type RawGeckoComputedKeyframeValuesListBorrowed<'a> = &'a RawGeckoComputedKeyframeValuesList;
-pub type RawGeckoComputedKeyframeValuesListBorrowedOrNull<'a> = Option<&'a RawGeckoComputedKeyframeValuesList>;
-pub type RawGeckoComputedKeyframeValuesListBorrowedMut<'a> = &'a mut RawGeckoComputedKeyframeValuesList;
-pub type RawGeckoComputedKeyframeValuesListBorrowedMutOrNull<'a> = Option<&'a mut RawGeckoComputedKeyframeValuesList>;
+pub type RawGeckoComputedKeyframeValuesListBorrowedOrNull<'a> =
+    Option<&'a RawGeckoComputedKeyframeValuesList>;
+pub type RawGeckoComputedKeyframeValuesListBorrowedMut<'a> =
+    &'a mut RawGeckoComputedKeyframeValuesList;
+pub type RawGeckoComputedKeyframeValuesListBorrowedMutOrNull<'a> =
+    Option<&'a mut RawGeckoComputedKeyframeValuesList>;
 pub type RawGeckoFontFaceRuleListBorrowed<'a> = &'a RawGeckoFontFaceRuleList;
 pub type RawGeckoFontFaceRuleListBorrowedOrNull<'a> = Option<&'a RawGeckoFontFaceRuleList>;
 pub type RawGeckoFontFaceRuleListBorrowedMut<'a> = &'a mut RawGeckoFontFaceRuleList;
@@ -343,28 +372,37 @@ pub type RawGeckoFontFaceRuleListBorrowedMutOrNull<'a> = Option<&'a mut RawGecko
 pub type RawGeckoServoStyleRuleListBorrowed<'a> = &'a RawGeckoServoStyleRuleList;
 pub type RawGeckoServoStyleRuleListBorrowedOrNull<'a> = Option<&'a RawGeckoServoStyleRuleList>;
 pub type RawGeckoServoStyleRuleListBorrowedMut<'a> = &'a mut RawGeckoServoStyleRuleList;
-pub type RawGeckoServoStyleRuleListBorrowedMutOrNull<'a> = Option<&'a mut RawGeckoServoStyleRuleList>;
+pub type RawGeckoServoStyleRuleListBorrowedMutOrNull<'a> =
+    Option<&'a mut RawGeckoServoStyleRuleList>;
 pub type RawGeckoServoAnimationValueListBorrowed<'a> = &'a RawGeckoServoAnimationValueList;
-pub type RawGeckoServoAnimationValueListBorrowedOrNull<'a> = Option<&'a RawGeckoServoAnimationValueList>;
+pub type RawGeckoServoAnimationValueListBorrowedOrNull<'a> =
+    Option<&'a RawGeckoServoAnimationValueList>;
 pub type RawGeckoServoAnimationValueListBorrowedMut<'a> = &'a mut RawGeckoServoAnimationValueList;
-pub type RawGeckoServoAnimationValueListBorrowedMutOrNull<'a> = Option<&'a mut RawGeckoServoAnimationValueList>;
+pub type RawGeckoServoAnimationValueListBorrowedMutOrNull<'a> =
+    Option<&'a mut RawGeckoServoAnimationValueList>;
 pub type RawGeckoStyleAnimationListBorrowed<'a> = &'a RawGeckoStyleAnimationList;
 pub type RawGeckoStyleAnimationListBorrowedOrNull<'a> = Option<&'a RawGeckoStyleAnimationList>;
 pub type RawGeckoStyleAnimationListBorrowedMut<'a> = &'a mut RawGeckoStyleAnimationList;
-pub type RawGeckoStyleAnimationListBorrowedMutOrNull<'a> = Option<&'a mut RawGeckoStyleAnimationList>;
+pub type RawGeckoStyleAnimationListBorrowedMutOrNull<'a> =
+    Option<&'a mut RawGeckoStyleAnimationList>;
 pub type RawGeckoStyleChildrenIteratorBorrowed<'a> = &'a RawGeckoStyleChildrenIterator;
-pub type RawGeckoStyleChildrenIteratorBorrowedOrNull<'a> = Option<&'a RawGeckoStyleChildrenIterator>;
+pub type RawGeckoStyleChildrenIteratorBorrowedOrNull<'a> =
+    Option<&'a RawGeckoStyleChildrenIterator>;
 pub type RawGeckoStyleChildrenIteratorBorrowedMut<'a> = &'a mut RawGeckoStyleChildrenIterator;
-pub type RawGeckoStyleChildrenIteratorBorrowedMutOrNull<'a> = Option<&'a mut RawGeckoStyleChildrenIterator>;
+pub type RawGeckoStyleChildrenIteratorBorrowedMutOrNull<'a> =
+    Option<&'a mut RawGeckoStyleChildrenIterator>;
 pub type ServoCssRulesStrong = ::gecko_bindings::sugar::ownership::Strong<ServoCssRules>;
 pub type ServoCssRulesBorrowed<'a> = &'a ServoCssRules;
 pub type ServoCssRulesBorrowedOrNull<'a> = Option<&'a ServoCssRules>;
-enum ServoCssRulesVoid { }
+enum ServoCssRulesVoid {
+}
 pub struct ServoCssRules(ServoCssRulesVoid);
-pub type RawServoStyleSheetContentsStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoStyleSheetContents>;
+pub type RawServoStyleSheetContentsStrong =
+    ::gecko_bindings::sugar::ownership::Strong<RawServoStyleSheetContents>;
 pub type RawServoStyleSheetContentsBorrowed<'a> = &'a RawServoStyleSheetContents;
 pub type RawServoStyleSheetContentsBorrowedOrNull<'a> = Option<&'a RawServoStyleSheetContents>;
-pub type RawServoDeclarationBlockStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoDeclarationBlock>;
+pub type RawServoDeclarationBlockStrong =
+    ::gecko_bindings::sugar::ownership::Strong<RawServoDeclarationBlock>;
 pub type RawServoDeclarationBlockBorrowed<'a> = &'a RawServoDeclarationBlock;
 pub type RawServoDeclarationBlockBorrowedOrNull<'a> = Option<&'a RawServoDeclarationBlock>;
 pub type RawServoStyleRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoStyleRule>;
@@ -373,20 +411,25 @@ pub type RawServoStyleRuleBorrowedOrNull<'a> = Option<&'a RawServoStyleRule>;
 pub type RawServoImportRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoImportRule>;
 pub type RawServoImportRuleBorrowed<'a> = &'a RawServoImportRule;
 pub type RawServoImportRuleBorrowedOrNull<'a> = Option<&'a RawServoImportRule>;
-enum RawServoImportRuleVoid { }
+enum RawServoImportRuleVoid {
+}
 pub struct RawServoImportRule(RawServoImportRuleVoid);
-pub type RawServoAnimationValueStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoAnimationValue>;
+pub type RawServoAnimationValueStrong =
+    ::gecko_bindings::sugar::ownership::Strong<RawServoAnimationValue>;
 pub type RawServoAnimationValueBorrowed<'a> = &'a RawServoAnimationValue;
 pub type RawServoAnimationValueBorrowedOrNull<'a> = Option<&'a RawServoAnimationValue>;
 pub type RawServoKeyframeStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoKeyframe>;
 pub type RawServoKeyframeBorrowed<'a> = &'a RawServoKeyframe;
 pub type RawServoKeyframeBorrowedOrNull<'a> = Option<&'a RawServoKeyframe>;
-enum RawServoKeyframeVoid { }
+enum RawServoKeyframeVoid {
+}
 pub struct RawServoKeyframe(RawServoKeyframeVoid);
-pub type RawServoKeyframesRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoKeyframesRule>;
+pub type RawServoKeyframesRuleStrong =
+    ::gecko_bindings::sugar::ownership::Strong<RawServoKeyframesRule>;
 pub type RawServoKeyframesRuleBorrowed<'a> = &'a RawServoKeyframesRule;
 pub type RawServoKeyframesRuleBorrowedOrNull<'a> = Option<&'a RawServoKeyframesRule>;
-enum RawServoKeyframesRuleVoid { }
+enum RawServoKeyframesRuleVoid {
+}
 pub struct RawServoKeyframesRule(RawServoKeyframesRuleVoid);
 pub type RawServoMediaListStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoMediaList>;
 pub type RawServoMediaListBorrowed<'a> = &'a RawServoMediaList;
@@ -394,37 +437,49 @@ pub type RawServoMediaListBorrowedOrNull<'a> = Option<&'a RawServoMediaList>;
 pub type RawServoMediaRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoMediaRule>;
 pub type RawServoMediaRuleBorrowed<'a> = &'a RawServoMediaRule;
 pub type RawServoMediaRuleBorrowedOrNull<'a> = Option<&'a RawServoMediaRule>;
-enum RawServoMediaRuleVoid { }
+enum RawServoMediaRuleVoid {
+}
 pub struct RawServoMediaRule(RawServoMediaRuleVoid);
-pub type RawServoNamespaceRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoNamespaceRule>;
+pub type RawServoNamespaceRuleStrong =
+    ::gecko_bindings::sugar::ownership::Strong<RawServoNamespaceRule>;
 pub type RawServoNamespaceRuleBorrowed<'a> = &'a RawServoNamespaceRule;
 pub type RawServoNamespaceRuleBorrowedOrNull<'a> = Option<&'a RawServoNamespaceRule>;
-enum RawServoNamespaceRuleVoid { }
+enum RawServoNamespaceRuleVoid {
+}
 pub struct RawServoNamespaceRule(RawServoNamespaceRuleVoid);
 pub type RawServoPageRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoPageRule>;
 pub type RawServoPageRuleBorrowed<'a> = &'a RawServoPageRule;
 pub type RawServoPageRuleBorrowedOrNull<'a> = Option<&'a RawServoPageRule>;
-enum RawServoPageRuleVoid { }
+enum RawServoPageRuleVoid {
+}
 pub struct RawServoPageRule(RawServoPageRuleVoid);
-pub type RawServoSupportsRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoSupportsRule>;
+pub type RawServoSupportsRuleStrong =
+    ::gecko_bindings::sugar::ownership::Strong<RawServoSupportsRule>;
 pub type RawServoSupportsRuleBorrowed<'a> = &'a RawServoSupportsRule;
 pub type RawServoSupportsRuleBorrowedOrNull<'a> = Option<&'a RawServoSupportsRule>;
-enum RawServoSupportsRuleVoid { }
+enum RawServoSupportsRuleVoid {
+}
 pub struct RawServoSupportsRule(RawServoSupportsRuleVoid);
-pub type RawServoDocumentRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoDocumentRule>;
+pub type RawServoDocumentRuleStrong =
+    ::gecko_bindings::sugar::ownership::Strong<RawServoDocumentRule>;
 pub type RawServoDocumentRuleBorrowed<'a> = &'a RawServoDocumentRule;
 pub type RawServoDocumentRuleBorrowedOrNull<'a> = Option<&'a RawServoDocumentRule>;
-enum RawServoDocumentRuleVoid { }
+enum RawServoDocumentRuleVoid {
+}
 pub struct RawServoDocumentRule(RawServoDocumentRuleVoid);
-pub type RawServoFontFeatureValuesRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoFontFeatureValuesRule>;
+pub type RawServoFontFeatureValuesRuleStrong =
+    ::gecko_bindings::sugar::ownership::Strong<RawServoFontFeatureValuesRule>;
 pub type RawServoFontFeatureValuesRuleBorrowed<'a> = &'a RawServoFontFeatureValuesRule;
-pub type RawServoFontFeatureValuesRuleBorrowedOrNull<'a> = Option<&'a RawServoFontFeatureValuesRule>;
-enum RawServoFontFeatureValuesRuleVoid { }
+pub type RawServoFontFeatureValuesRuleBorrowedOrNull<'a> =
+    Option<&'a RawServoFontFeatureValuesRule>;
+enum RawServoFontFeatureValuesRuleVoid {
+}
 pub struct RawServoFontFeatureValuesRule(RawServoFontFeatureValuesRuleVoid);
 pub type RawServoRuleNodeStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoRuleNode>;
 pub type RawServoRuleNodeBorrowed<'a> = &'a RawServoRuleNode;
 pub type RawServoRuleNodeBorrowedOrNull<'a> = Option<&'a RawServoRuleNode>;
-enum RawServoRuleNodeVoid { }
+enum RawServoRuleNodeVoid {
+}
 pub struct RawServoRuleNode(RawServoRuleNodeVoid);
 
 extern "C" {
@@ -541,10 +596,23 @@ extern "C" {
     pub fn Servo_StyleSet_Drop(ptr: RawServoStyleSetOwned);
 }
 extern "C" {
+    pub fn Servo_AuthorStyles_Drop(ptr: RawServoAuthorStylesOwned);
+}
+extern "C" {
     pub fn Servo_SelectorList_Drop(ptr: RawServoSelectorListOwned);
 }
 extern "C" {
     pub fn Servo_SourceSizeList_Drop(ptr: RawServoSourceSizeListOwned);
+}
+extern "C" {
+    pub fn Gecko_RecordTraversalStatistics(
+        total: u32,
+        parallel: u32,
+        total_t: u32,
+        parallel_t: u32,
+        total_s: u32,
+        parallel_s: u32,
+    );
 }
 extern "C" {
     pub fn Gecko_IsSignificantChild(
@@ -1538,9 +1606,9 @@ extern "C" {
     ) -> RawGeckoXBLBindingBorrowedOrNull;
 }
 extern "C" {
-    pub fn Gecko_XBLBinding_GetRawServoStyleSet(
+    pub fn Gecko_XBLBinding_GetRawServoStyles(
         aXBLBinding: RawGeckoXBLBindingBorrowed,
-    ) -> RawServoStyleSetBorrowedOrNull;
+    ) -> RawServoAuthorStylesBorrowedOrNull;
 }
 extern "C" {
     pub fn Gecko_XBLBinding_InheritsStyle(aXBLBinding: RawGeckoXBLBindingBorrowed) -> bool;
@@ -2026,7 +2094,8 @@ extern "C" {
 extern "C" {
     pub fn Servo_InvalidateStyleForDocStateChanges(
         root: RawGeckoElementBorrowed,
-        sets: *const nsTArray<RawServoStyleSetBorrowed>,
+        doc_styles: RawServoStyleSetBorrowed,
+        non_document_styles: *const nsTArray<RawServoAuthorStylesBorrowed>,
         aStatesChanged: u64,
     );
 }
@@ -2093,7 +2162,7 @@ extern "C" {
 extern "C" {
     pub fn Servo_StyleSet_MediumFeaturesChanged(
         document_set: RawServoStyleSetBorrowed,
-        non_document_sets: *const nsTArray<*mut ServoStyleSet>,
+        non_document_sets: *mut nsTArray<RawServoAuthorStylesBorrowedMut>,
         may_affect_default_style: bool,
     ) -> MediumFeaturesChangedResult;
 }
@@ -2228,6 +2297,24 @@ extern "C" {
         malloc_size_of: MallocSizeOf,
         malloc_enclosing_size_of: MallocSizeOf,
         sizes: *mut ServoStyleSetSizes,
+    );
+}
+extern "C" {
+    pub fn Servo_AuthorStyles_Create() -> *mut RawServoAuthorStyles;
+}
+extern "C" {
+    pub fn Servo_AuthorStyles_AppendStyleSheet(
+        self_: RawServoAuthorStylesBorrowedMut,
+        gecko_sheet: *const ServoStyleSheet,
+    );
+}
+extern "C" {
+    pub fn Servo_AuthorStyles_ForceDirty(self_: RawServoAuthorStylesBorrowedMut);
+}
+extern "C" {
+    pub fn Servo_AuthorStyles_Flush(
+        self_: RawServoAuthorStylesBorrowedMut,
+        document_styles: RawServoStyleSetBorrowed,
     );
 }
 extern "C" {

--- a/components/style/gecko/generated/pseudo_element_definition.rs
+++ b/components/style/gecko/generated/pseudo_element_definition.rs
@@ -1728,7 +1728,7 @@ impl ToCss for PseudoElement {
                 dest.write_char('(')?;
                 let mut iter = args.iter();
                 if let Some(first) = iter.next() {
-                    serialize_atom_identifier(first, dest)?;
+                    serialize_atom_identifier(&first, dest)?;
                     for item in iter {
                         dest.write_str(", ")?;
                         serialize_atom_identifier(item, dest)?;

--- a/components/style/gecko/generated/structs.rs
+++ b/components/style/gecko/generated/structs.rs
@@ -1207,6 +1207,7 @@ pub mod root {
                 pub mStrings: root::mozilla::css::URLValueData_RustOrGeckoString,
                 pub mUsingRustString: bool,
                 pub mLoadedImage: bool,
+                pub mCORSMode: root::mozilla::CORSMode,
             }
             pub type URLValueData_HasThreadSafeRefCnt = root::mozilla::TrueType;
             #[repr(C)]
@@ -1374,6 +1375,18 @@ pub mod root {
                         stringify!(URLValueData),
                         "::",
                         stringify!(mLoadedImage)
+                    )
+                );
+                assert_eq!(
+                    unsafe {
+                        &(*(::std::ptr::null::<URLValueData>())).mCORSMode as *const _ as usize
+                    },
+                    58usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(URLValueData),
+                        "::",
+                        stringify!(mCORSMode)
                     )
                 );
             }
@@ -2390,9 +2403,93 @@ pub mod root {
                 }
             }
             #[repr(C)]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, Copy)]
+            pub struct UserData {
+                pub _bindgen_opaque_blob: [u64; 2usize],
+            }
+            pub type UserData_destroyFunc = u64;
+            #[repr(C)]
+            #[derive(Debug, Copy)]
+            pub struct UserData_Entry {
+                pub _bindgen_opaque_blob: [u64; 3usize],
+            }
+            #[test]
+            fn bindgen_test_layout_UserData_Entry() {
+                assert_eq!(
+                    ::std::mem::size_of::<UserData_Entry>(),
+                    24usize,
+                    concat!("Size of: ", stringify!(UserData_Entry))
+                );
+                assert_eq!(
+                    ::std::mem::align_of::<UserData_Entry>(),
+                    8usize,
+                    concat!("Alignment of ", stringify!(UserData_Entry))
+                );
+            }
+            impl Clone for UserData_Entry {
+                fn clone(&self) -> Self {
+                    *self
+                }
+            }
+            #[test]
+            fn bindgen_test_layout_UserData() {
+                assert_eq!(
+                    ::std::mem::size_of::<UserData>(),
+                    16usize,
+                    concat!("Size of: ", stringify!(UserData))
+                );
+                assert_eq!(
+                    ::std::mem::align_of::<UserData>(),
+                    8usize,
+                    concat!("Alignment of ", stringify!(UserData))
+                );
+            }
+            impl Clone for UserData {
+                fn clone(&self) -> Self {
+                    *self
+                }
+            }
+            #[repr(C)]
+            pub struct SourceSurface__bindgen_vtable(::std::os::raw::c_void);
+            /// This is the base class for source surfaces. These objects are surfaces
+            /// which may be used as a source in a SurfacePattern or a DrawSurface call.
+            /// They cannot be drawn to directly.
+            ///
+            /// Although SourceSurface has thread-safe refcount, some SourceSurface cannot
+            /// be used on random threads at the same time. Only DataSourceSurface can be
+            /// used on random threads now. This will be fixed in the future. Eventually
+            /// all SourceSurface should be thread-safe.
+            #[repr(C)]
+            #[derive(Debug)]
             pub struct SourceSurface {
-                _unused: [u8; 0],
+                pub vtable_: *const SourceSurface__bindgen_vtable,
+                pub _base: u64,
+                pub mUserData: root::mozilla::gfx::UserData,
+            }
+            #[test]
+            fn bindgen_test_layout_SourceSurface() {
+                assert_eq!(
+                    ::std::mem::size_of::<SourceSurface>(),
+                    32usize,
+                    concat!("Size of: ", stringify!(SourceSurface))
+                );
+                assert_eq!(
+                    ::std::mem::align_of::<SourceSurface>(),
+                    8usize,
+                    concat!("Alignment of ", stringify!(SourceSurface))
+                );
+                assert_eq!(
+                    unsafe {
+                        &(*(::std::ptr::null::<SourceSurface>())).mUserData as *const _ as usize
+                    },
+                    16usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(SourceSurface),
+                        "::",
+                        stringify!(mUserData)
+                    )
+                );
             }
         }
         pub mod layers {
@@ -5160,6 +5257,20 @@ pub mod root {
                 *self
             }
         }
+        pub mod external {
+            #[allow(unused_imports)]
+            use self::super::super::super::root;
+            /// AtomicRefCounted<T> is like RefCounted<T>, with an atomically updated
+            /// reference counter.
+            ///
+            /// NOTE: Please do not use this class, use NS_INLINE_DECL_THREADSAFE_REFCOUNTING
+            /// instead.
+            #[repr(C)]
+            #[derive(Debug, Copy, Clone)]
+            pub struct AtomicRefCounted {
+                pub _address: u8,
+            }
+        }
         #[repr(C)]
         #[derive(Debug, Copy, Clone)]
         pub struct SupportsWeakPtr {
@@ -5644,6 +5755,10 @@ pub mod root {
         pub const StyleBackendType_Gecko: root::mozilla::StyleBackendType = 1;
         pub const StyleBackendType_Servo: root::mozilla::StyleBackendType = 2;
         pub type StyleBackendType = u8;
+        pub mod profiler {
+            #[allow(unused_imports)]
+            use self::super::super::super::root;
+        }
         pub type TimeStampValue = u64;
         /// Instances of this class represent the length of an interval of time.
         /// Negative durations are allowed, meaning the end is before the start.
@@ -6572,6 +6687,25 @@ pub mod root {
             root::nsTArray<root::mozilla::PropertyStyleAnimationValuePair>;
         #[test]
         fn __bindgen_test_layout_DefaultDelete_open0_RawServoStyleSet_close0_instantiation() {
+            assert_eq!(
+                ::std::mem::size_of::<root::mozilla::DefaultDelete>(),
+                1usize,
+                concat!(
+                    "Size of template specialization: ",
+                    stringify!(root::mozilla::DefaultDelete)
+                )
+            );
+            assert_eq!(
+                ::std::mem::align_of::<root::mozilla::DefaultDelete>(),
+                1usize,
+                concat!(
+                    "Alignment of template specialization: ",
+                    stringify!(root::mozilla::DefaultDelete)
+                )
+            );
+        }
+        #[test]
+        fn __bindgen_test_layout_DefaultDelete_open0_RawServoAuthorStyles_close0_instantiation() {
             assert_eq!(
                 ::std::mem::size_of::<root::mozilla::DefaultDelete>(),
                 1usize,
@@ -8052,7 +8186,7 @@ pub mod root {
         pub const SERVO_PREF_ENABLED_page_break_after: bool = false;
         pub const SERVO_PREF_ENABLED_page_break_before: bool = false;
         pub const SERVO_PREF_ENABLED_page_break_inside: bool = false;
-        pub const SERVO_PREF_ENABLED_paint_order: bool = true;
+        pub const SERVO_PREF_ENABLED_paint_order: bool = false;
         pub const SERVO_PREF_ENABLED_perspective: bool = false;
         pub const SERVO_PREF_ENABLED_perspective_origin: bool = false;
         pub const SERVO_PREF_ENABLED_place_content: bool = false;
@@ -11313,90 +11447,11 @@ pub mod root {
                 )
             );
         }
-        /// A PostTraversalTask is a task to be performed immediately after a Servo
-        /// traversal.  There are just a few tasks we need to perform, so we use this
-        /// class rather than Runnables, to avoid virtual calls and some allocations.
-        ///
-        /// A PostTraversalTask is only safe to run immediately after the Servo
-        /// traversal, since it can hold raw pointers to DOM objects.
-        #[repr(C)]
-        #[derive(Debug, Copy)]
-        pub struct PostTraversalTask {
-            pub mType: root::mozilla::PostTraversalTask_Type,
-            pub mTarget: *mut ::std::os::raw::c_void,
-            pub mResult: root::nsresult,
-        }
-        pub const PostTraversalTask_Type_ResolveFontFaceLoadedPromise:
-            root::mozilla::PostTraversalTask_Type = 0;
-        pub const PostTraversalTask_Type_RejectFontFaceLoadedPromise:
-            root::mozilla::PostTraversalTask_Type = 1;
-        pub const PostTraversalTask_Type_DispatchLoadingEventAndReplaceReadyPromise:
-            root::mozilla::PostTraversalTask_Type = 2;
-        pub const PostTraversalTask_Type_DispatchFontFaceSetCheckLoadingFinishedAfterDelay:
-            root::mozilla::PostTraversalTask_Type = 3;
-        pub const PostTraversalTask_Type_LoadFontEntry: root::mozilla::PostTraversalTask_Type = 4;
-        pub type PostTraversalTask_Type = i32;
-        #[test]
-        fn bindgen_test_layout_PostTraversalTask() {
-            assert_eq!(
-                ::std::mem::size_of::<PostTraversalTask>(),
-                24usize,
-                concat!("Size of: ", stringify!(PostTraversalTask))
-            );
-            assert_eq!(
-                ::std::mem::align_of::<PostTraversalTask>(),
-                8usize,
-                concat!("Alignment of ", stringify!(PostTraversalTask))
-            );
-            assert_eq!(
-                unsafe { &(*(::std::ptr::null::<PostTraversalTask>())).mType as *const _ as usize },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(PostTraversalTask),
-                    "::",
-                    stringify!(mType)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<PostTraversalTask>())).mTarget as *const _ as usize
-                },
-                8usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(PostTraversalTask),
-                    "::",
-                    stringify!(mTarget)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<PostTraversalTask>())).mResult as *const _ as usize
-                },
-                16usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(PostTraversalTask),
-                    "::",
-                    stringify!(mResult)
-                )
-            );
-        }
-        impl Clone for PostTraversalTask {
-            fn clone(&self) -> Self {
-                *self
-            }
-        }
         #[repr(C)]
         #[derive(Debug, Copy, Clone)]
         pub struct ServoStyleRuleMap {
             _unused: [u8; 0],
         }
-        pub const StylistState_NotDirty: root::mozilla::StylistState = 0;
-        pub const StylistState_StyleSheetsDirty: root::mozilla::StylistState = 1;
-        pub const StylistState_XBLStyleSheetsDirty: root::mozilla::StylistState = 2;
-        pub type StylistState = u8;
         pub const OriginFlags_UserAgent: root::mozilla::OriginFlags = root::mozilla::OriginFlags(1);
         pub const OriginFlags_User: root::mozilla::OriginFlags = root::mozilla::OriginFlags(2);
         pub const OriginFlags_Author: root::mozilla::OriginFlags = root::mozilla::OriginFlags(4);
@@ -11430,183 +11485,6 @@ pub mod root {
         #[repr(C)]
         #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
         pub struct OriginFlags(pub u8);
-        /// The set of style sheets that apply to a document, backed by a Servo
-        /// Stylist.  A ServoStyleSet contains ServoStyleSheets.
-        #[repr(C)]
-        #[derive(Debug)]
-        pub struct ServoStyleSet {
-            pub mKind: root::mozilla::ServoStyleSet_Kind,
-            pub mDocument: *mut root::nsIDocument,
-            pub mRawSet: root::mozilla::UniquePtr<root::RawServoStyleSet>,
-            pub mSheets: [u64; 9usize],
-            pub mAuthorStyleDisabled: bool,
-            pub mStylistState: root::mozilla::StylistState,
-            pub mUserFontSetUpdateGeneration: u64,
-            pub mUserFontCacheUpdateGeneration: u32,
-            pub mNeedsRestyleAfterEnsureUniqueInner: bool,
-            pub mNonInheritingStyleContexts: [u64; 7usize],
-            pub mPostTraversalTasks: root::nsTArray<root::mozilla::PostTraversalTask>,
-            pub mStyleRuleMap: root::mozilla::UniquePtr<root::mozilla::ServoStyleRuleMap>,
-        }
-        pub type ServoStyleSet_SnapshotTable = root::mozilla::ServoElementSnapshotTable;
-        pub const ServoStyleSet_Kind_Master: root::mozilla::ServoStyleSet_Kind = 0;
-        pub const ServoStyleSet_Kind_ForXBL: root::mozilla::ServoStyleSet_Kind = 1;
-        pub type ServoStyleSet_Kind = u8;
-        #[test]
-        fn bindgen_test_layout_ServoStyleSet() {
-            assert_eq!(
-                ::std::mem::size_of::<ServoStyleSet>(),
-                192usize,
-                concat!("Size of: ", stringify!(ServoStyleSet))
-            );
-            assert_eq!(
-                ::std::mem::align_of::<ServoStyleSet>(),
-                8usize,
-                concat!("Alignment of ", stringify!(ServoStyleSet))
-            );
-            assert_eq!(
-                unsafe { &(*(::std::ptr::null::<ServoStyleSet>())).mKind as *const _ as usize },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ServoStyleSet),
-                    "::",
-                    stringify!(mKind)
-                )
-            );
-            assert_eq!(
-                unsafe { &(*(::std::ptr::null::<ServoStyleSet>())).mDocument as *const _ as usize },
-                8usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ServoStyleSet),
-                    "::",
-                    stringify!(mDocument)
-                )
-            );
-            assert_eq!(
-                unsafe { &(*(::std::ptr::null::<ServoStyleSet>())).mRawSet as *const _ as usize },
-                16usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ServoStyleSet),
-                    "::",
-                    stringify!(mRawSet)
-                )
-            );
-            assert_eq!(
-                unsafe { &(*(::std::ptr::null::<ServoStyleSet>())).mSheets as *const _ as usize },
-                24usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ServoStyleSet),
-                    "::",
-                    stringify!(mSheets)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<ServoStyleSet>())).mAuthorStyleDisabled as *const _
-                        as usize
-                },
-                96usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ServoStyleSet),
-                    "::",
-                    stringify!(mAuthorStyleDisabled)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<ServoStyleSet>())).mStylistState as *const _ as usize
-                },
-                97usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ServoStyleSet),
-                    "::",
-                    stringify!(mStylistState)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<ServoStyleSet>())).mUserFontSetUpdateGeneration
-                        as *const _ as usize
-                },
-                104usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ServoStyleSet),
-                    "::",
-                    stringify!(mUserFontSetUpdateGeneration)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<ServoStyleSet>())).mUserFontCacheUpdateGeneration
-                        as *const _ as usize
-                },
-                112usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ServoStyleSet),
-                    "::",
-                    stringify!(mUserFontCacheUpdateGeneration)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<ServoStyleSet>())).mNeedsRestyleAfterEnsureUniqueInner
-                        as *const _ as usize
-                },
-                116usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ServoStyleSet),
-                    "::",
-                    stringify!(mNeedsRestyleAfterEnsureUniqueInner)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<ServoStyleSet>())).mNonInheritingStyleContexts
-                        as *const _ as usize
-                },
-                120usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ServoStyleSet),
-                    "::",
-                    stringify!(mNonInheritingStyleContexts)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<ServoStyleSet>())).mPostTraversalTasks as *const _
-                        as usize
-                },
-                176usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ServoStyleSet),
-                    "::",
-                    stringify!(mPostTraversalTasks)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<ServoStyleSet>())).mStyleRuleMap as *const _ as usize
-                },
-                184usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ServoStyleSet),
-                    "::",
-                    stringify!(mStyleRuleMap)
-                )
-            );
-        }
         #[repr(C)]
         #[derive(Debug)]
         pub struct CachedInheritingStyles {
@@ -12638,6 +12516,7 @@ pub mod root {
         NS_SUCCESS_UNORM_NOTFOUND = 7864337,
         NS_ERROR_NOT_IN_TREE = 2155348006,
         NS_OK_NO_NAME_CLAUSE_HANDLED = 7864354,
+        NS_ERROR_BLOCKED_BY_POLICY = 2155347971,
     }
     pub type nsrefcnt = root::MozRefCountType;
     #[repr(C)]
@@ -13232,11 +13111,6 @@ pub mod root {
     pub struct RefPtr_ConstRemovingRefPtrTraits {
         pub _address: u8,
     }
-    #[repr(C)]
-    #[derive(Debug, Copy, Clone)]
-    pub struct JSContext {
-        _unused: [u8; 0],
-    }
     pub mod JS {
         #[allow(unused_imports)]
         use self::super::super::root;
@@ -13721,6 +13595,11 @@ pub mod root {
                 *self
             }
         }
+    }
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone)]
+    pub struct JSContext {
+        _unused: [u8; 0],
     }
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]
@@ -15648,8 +15527,10 @@ pub mod root {
         root::nsChangeHint(536870912);
     pub const nsChangeHint_nsChangeHint_UpdateTableCellSpans: root::nsChangeHint =
         root::nsChangeHint(1073741824);
+    pub const nsChangeHint_nsChangeHint_VisibilityChange: root::nsChangeHint =
+        root::nsChangeHint(2147483648);
     pub const nsChangeHint_nsChangeHint_AllHints: root::nsChangeHint =
-        root::nsChangeHint(2147483647);
+        root::nsChangeHint(4294967295);
     impl ::std::ops::BitOr<root::nsChangeHint> for root::nsChangeHint {
         type Output = Self;
         #[inline]
@@ -16089,6 +15970,40 @@ pub mod root {
             )
         );
     }
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone)]
+    pub struct ProfilerBacktrace {
+        _unused: [u8; 0],
+    }
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone)]
+    pub struct ProfilerMarkerPayload {
+        _unused: [u8; 0],
+    }
+    #[repr(C)]
+    #[derive(Debug, Copy)]
+    pub struct ProfilerBacktraceDestructor {
+        pub _address: u8,
+    }
+    #[test]
+    fn bindgen_test_layout_ProfilerBacktraceDestructor() {
+        assert_eq!(
+            ::std::mem::size_of::<ProfilerBacktraceDestructor>(),
+            1usize,
+            concat!("Size of: ", stringify!(ProfilerBacktraceDestructor))
+        );
+        assert_eq!(
+            ::std::mem::align_of::<ProfilerBacktraceDestructor>(),
+            1usize,
+            concat!("Alignment of ", stringify!(ProfilerBacktraceDestructor))
+        );
+    }
+    impl Clone for ProfilerBacktraceDestructor {
+        fn clone(&self) -> Self {
+            *self
+        }
+    }
+    pub type UniqueProfilerBacktrace = root::mozilla::UniquePtr<root::ProfilerBacktrace>;
     pub const JSValueTag_JSVAL_TAG_MAX_DOUBLE: root::JSValueTag = 131056;
     pub const JSValueTag_JSVAL_TAG_INT32: root::JSValueTag = 131057;
     pub const JSValueTag_JSVAL_TAG_UNDEFINED: root::JSValueTag = 131059;
@@ -16992,40 +16907,6 @@ pub mod root {
             )
         );
     }
-    #[repr(C)]
-    #[derive(Debug, Copy, Clone)]
-    pub struct ProfilerBacktrace {
-        _unused: [u8; 0],
-    }
-    #[repr(C)]
-    #[derive(Debug, Copy, Clone)]
-    pub struct ProfilerMarkerPayload {
-        _unused: [u8; 0],
-    }
-    #[repr(C)]
-    #[derive(Debug, Copy)]
-    pub struct ProfilerBacktraceDestructor {
-        pub _address: u8,
-    }
-    #[test]
-    fn bindgen_test_layout_ProfilerBacktraceDestructor() {
-        assert_eq!(
-            ::std::mem::size_of::<ProfilerBacktraceDestructor>(),
-            1usize,
-            concat!("Size of: ", stringify!(ProfilerBacktraceDestructor))
-        );
-        assert_eq!(
-            ::std::mem::align_of::<ProfilerBacktraceDestructor>(),
-            1usize,
-            concat!("Alignment of ", stringify!(ProfilerBacktraceDestructor))
-        );
-    }
-    impl Clone for ProfilerBacktraceDestructor {
-        fn clone(&self) -> Self {
-            *self
-        }
-    }
-    pub type UniqueProfilerBacktrace = root::mozilla::UniquePtr<root::ProfilerBacktrace>;
     pub type gfxSize = [u64; 2usize];
     #[repr(C)]
     #[derive(Debug, Copy)]
@@ -21788,6 +21669,11 @@ pub mod root {
     }
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]
+    pub struct RawServoAuthorStyles {
+        _unused: [u8; 0],
+    }
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone)]
     pub struct RawServoStyleSet {
         _unused: [u8; 0],
     }
@@ -22013,7 +21899,7 @@ pub mod root {
         pub mStateObjectContainer: root::nsCOMPtr,
         pub mStateObjectCached: root::nsCOMPtr,
         pub mInSyncOperationCount: u32,
-        pub mXPathEvaluator: root::RefPtr<root::mozilla::dom::XPathEvaluator>,
+        pub mXPathEvaluator: root::mozilla::UniquePtr<root::mozilla::dom::XPathEvaluator>,
         pub mAnonymousContents: root::nsTArray<root::RefPtr<root::mozilla::dom::AnonymousContent>>,
         pub mBlockDOMContentLoaded: u32,
         pub mDOMMediaQueryLists: root::mozilla::LinkedList,
@@ -25049,74 +24935,63 @@ pub mod root {
             }
         }
         #[inline]
-        pub fn mFireAfterPaintEvents(&self) -> ::std::os::raw::c_uint {
+        pub fn mIsChrome(&self) -> ::std::os::raw::c_uint {
             unsafe { ::std::mem::transmute(self._bitfield_1.get(33usize, 1u8) as u32) }
         }
         #[inline]
-        pub fn set_mFireAfterPaintEvents(&mut self, val: ::std::os::raw::c_uint) {
+        pub fn set_mIsChrome(&mut self, val: ::std::os::raw::c_uint) {
             unsafe {
                 let val: u32 = ::std::mem::transmute(val);
                 self._bitfield_1.set(33usize, 1u8, val as u64)
             }
         }
         #[inline]
-        pub fn mIsChrome(&self) -> ::std::os::raw::c_uint {
+        pub fn mIsChromeOriginImage(&self) -> ::std::os::raw::c_uint {
             unsafe { ::std::mem::transmute(self._bitfield_1.get(34usize, 1u8) as u32) }
         }
         #[inline]
-        pub fn set_mIsChrome(&mut self, val: ::std::os::raw::c_uint) {
+        pub fn set_mIsChromeOriginImage(&mut self, val: ::std::os::raw::c_uint) {
             unsafe {
                 let val: u32 = ::std::mem::transmute(val);
                 self._bitfield_1.set(34usize, 1u8, val as u64)
             }
         }
         #[inline]
-        pub fn mIsChromeOriginImage(&self) -> ::std::os::raw::c_uint {
+        pub fn mPaintFlashing(&self) -> ::std::os::raw::c_uint {
             unsafe { ::std::mem::transmute(self._bitfield_1.get(35usize, 1u8) as u32) }
         }
         #[inline]
-        pub fn set_mIsChromeOriginImage(&mut self, val: ::std::os::raw::c_uint) {
+        pub fn set_mPaintFlashing(&mut self, val: ::std::os::raw::c_uint) {
             unsafe {
                 let val: u32 = ::std::mem::transmute(val);
                 self._bitfield_1.set(35usize, 1u8, val as u64)
             }
         }
         #[inline]
-        pub fn mPaintFlashing(&self) -> ::std::os::raw::c_uint {
+        pub fn mPaintFlashingInitialized(&self) -> ::std::os::raw::c_uint {
             unsafe { ::std::mem::transmute(self._bitfield_1.get(36usize, 1u8) as u32) }
         }
         #[inline]
-        pub fn set_mPaintFlashing(&mut self, val: ::std::os::raw::c_uint) {
+        pub fn set_mPaintFlashingInitialized(&mut self, val: ::std::os::raw::c_uint) {
             unsafe {
                 let val: u32 = ::std::mem::transmute(val);
                 self._bitfield_1.set(36usize, 1u8, val as u64)
             }
         }
         #[inline]
-        pub fn mPaintFlashingInitialized(&self) -> ::std::os::raw::c_uint {
+        pub fn mHasWarnedAboutPositionedTableParts(&self) -> ::std::os::raw::c_uint {
             unsafe { ::std::mem::transmute(self._bitfield_1.get(37usize, 1u8) as u32) }
         }
         #[inline]
-        pub fn set_mPaintFlashingInitialized(&mut self, val: ::std::os::raw::c_uint) {
+        pub fn set_mHasWarnedAboutPositionedTableParts(&mut self, val: ::std::os::raw::c_uint) {
             unsafe {
                 let val: u32 = ::std::mem::transmute(val);
                 self._bitfield_1.set(37usize, 1u8, val as u64)
             }
         }
         #[inline]
-        pub fn mHasWarnedAboutPositionedTableParts(&self) -> ::std::os::raw::c_uint {
-            unsafe { ::std::mem::transmute(self._bitfield_1.get(38usize, 1u8) as u32) }
-        }
-        #[inline]
-        pub fn set_mHasWarnedAboutPositionedTableParts(&mut self, val: ::std::os::raw::c_uint) {
-            unsafe {
-                let val: u32 = ::std::mem::transmute(val);
-                self._bitfield_1.set(38usize, 1u8, val as u64)
-            }
-        }
-        #[inline]
         pub fn mHasWarnedAboutTooLargeDashedOrDottedRadius(&self) -> ::std::os::raw::c_uint {
-            unsafe { ::std::mem::transmute(self._bitfield_1.get(39usize, 1u8) as u32) }
+            unsafe { ::std::mem::transmute(self._bitfield_1.get(38usize, 1u8) as u32) }
         }
         #[inline]
         pub fn set_mHasWarnedAboutTooLargeDashedOrDottedRadius(
@@ -25125,40 +25000,40 @@ pub mod root {
         ) {
             unsafe {
                 let val: u32 = ::std::mem::transmute(val);
-                self._bitfield_1.set(39usize, 1u8, val as u64)
+                self._bitfield_1.set(38usize, 1u8, val as u64)
             }
         }
         #[inline]
         pub fn mQuirkSheetAdded(&self) -> ::std::os::raw::c_uint {
-            unsafe { ::std::mem::transmute(self._bitfield_1.get(40usize, 1u8) as u32) }
+            unsafe { ::std::mem::transmute(self._bitfield_1.get(39usize, 1u8) as u32) }
         }
         #[inline]
         pub fn set_mQuirkSheetAdded(&mut self, val: ::std::os::raw::c_uint) {
+            unsafe {
+                let val: u32 = ::std::mem::transmute(val);
+                self._bitfield_1.set(39usize, 1u8, val as u64)
+            }
+        }
+        #[inline]
+        pub fn mNeedsPrefUpdate(&self) -> ::std::os::raw::c_uint {
+            unsafe { ::std::mem::transmute(self._bitfield_1.get(40usize, 1u8) as u32) }
+        }
+        #[inline]
+        pub fn set_mNeedsPrefUpdate(&mut self, val: ::std::os::raw::c_uint) {
             unsafe {
                 let val: u32 = ::std::mem::transmute(val);
                 self._bitfield_1.set(40usize, 1u8, val as u64)
             }
         }
         #[inline]
-        pub fn mNeedsPrefUpdate(&self) -> ::std::os::raw::c_uint {
-            unsafe { ::std::mem::transmute(self._bitfield_1.get(41usize, 1u8) as u32) }
-        }
-        #[inline]
-        pub fn set_mNeedsPrefUpdate(&mut self, val: ::std::os::raw::c_uint) {
-            unsafe {
-                let val: u32 = ::std::mem::transmute(val);
-                self._bitfield_1.set(41usize, 1u8, val as u64)
-            }
-        }
-        #[inline]
         pub fn mHadNonBlankPaint(&self) -> ::std::os::raw::c_uint {
-            unsafe { ::std::mem::transmute(self._bitfield_1.get(42usize, 1u8) as u32) }
+            unsafe { ::std::mem::transmute(self._bitfield_1.get(41usize, 1u8) as u32) }
         }
         #[inline]
         pub fn set_mHadNonBlankPaint(&mut self, val: ::std::os::raw::c_uint) {
             unsafe {
                 let val: u32 = ::std::mem::transmute(val);
-                self._bitfield_1.set(42usize, 1u8, val as u64)
+                self._bitfield_1.set(41usize, 1u8, val as u64)
             }
         }
         #[inline]
@@ -25195,7 +25070,6 @@ pub mod root {
             mFontFeatureValuesDirty: ::std::os::raw::c_uint,
             mSuppressResizeReflow: ::std::os::raw::c_uint,
             mIsVisual: ::std::os::raw::c_uint,
-            mFireAfterPaintEvents: ::std::os::raw::c_uint,
             mIsChrome: ::std::os::raw::c_uint,
             mIsChromeOriginImage: ::std::os::raw::c_uint,
             mPaintFlashing: ::std::os::raw::c_uint,
@@ -25355,47 +25229,42 @@ pub mod root {
                 mIsVisual as u64
             });
             __bindgen_bitfield_unit.set(33usize, 1u8, {
-                let mFireAfterPaintEvents: u32 =
-                    unsafe { ::std::mem::transmute(mFireAfterPaintEvents) };
-                mFireAfterPaintEvents as u64
-            });
-            __bindgen_bitfield_unit.set(34usize, 1u8, {
                 let mIsChrome: u32 = unsafe { ::std::mem::transmute(mIsChrome) };
                 mIsChrome as u64
             });
-            __bindgen_bitfield_unit.set(35usize, 1u8, {
+            __bindgen_bitfield_unit.set(34usize, 1u8, {
                 let mIsChromeOriginImage: u32 =
                     unsafe { ::std::mem::transmute(mIsChromeOriginImage) };
                 mIsChromeOriginImage as u64
             });
-            __bindgen_bitfield_unit.set(36usize, 1u8, {
+            __bindgen_bitfield_unit.set(35usize, 1u8, {
                 let mPaintFlashing: u32 = unsafe { ::std::mem::transmute(mPaintFlashing) };
                 mPaintFlashing as u64
             });
-            __bindgen_bitfield_unit.set(37usize, 1u8, {
+            __bindgen_bitfield_unit.set(36usize, 1u8, {
                 let mPaintFlashingInitialized: u32 =
                     unsafe { ::std::mem::transmute(mPaintFlashingInitialized) };
                 mPaintFlashingInitialized as u64
             });
-            __bindgen_bitfield_unit.set(38usize, 1u8, {
+            __bindgen_bitfield_unit.set(37usize, 1u8, {
                 let mHasWarnedAboutPositionedTableParts: u32 =
                     unsafe { ::std::mem::transmute(mHasWarnedAboutPositionedTableParts) };
                 mHasWarnedAboutPositionedTableParts as u64
             });
-            __bindgen_bitfield_unit.set(39usize, 1u8, {
+            __bindgen_bitfield_unit.set(38usize, 1u8, {
                 let mHasWarnedAboutTooLargeDashedOrDottedRadius: u32 =
                     unsafe { ::std::mem::transmute(mHasWarnedAboutTooLargeDashedOrDottedRadius) };
                 mHasWarnedAboutTooLargeDashedOrDottedRadius as u64
             });
-            __bindgen_bitfield_unit.set(40usize, 1u8, {
+            __bindgen_bitfield_unit.set(39usize, 1u8, {
                 let mQuirkSheetAdded: u32 = unsafe { ::std::mem::transmute(mQuirkSheetAdded) };
                 mQuirkSheetAdded as u64
             });
-            __bindgen_bitfield_unit.set(41usize, 1u8, {
+            __bindgen_bitfield_unit.set(40usize, 1u8, {
                 let mNeedsPrefUpdate: u32 = unsafe { ::std::mem::transmute(mNeedsPrefUpdate) };
                 mNeedsPrefUpdate as u64
             });
-            __bindgen_bitfield_unit.set(42usize, 1u8, {
+            __bindgen_bitfield_unit.set(41usize, 1u8, {
                 let mHadNonBlankPaint: u32 = unsafe { ::std::mem::transmute(mHadNonBlankPaint) };
                 mHadNonBlankPaint as u64
             });
@@ -28694,8 +28563,8 @@ pub mod root {
         pub mLoadFlags: root::nsLoadFlags,
         pub mLockCount: u32,
         pub mAnimationConsumers: u32,
-        pub _bitfield_1: root::__BindgenBitfieldUnit<[u8; 1usize], u8>,
-        pub __bindgen_padding_0: [u8; 3usize],
+        pub _bitfield_1: root::__BindgenBitfieldUnit<[u8; 2usize], u8>,
+        pub __bindgen_padding_0: u16,
     }
     pub type imgRequestProxy_Image = root::mozilla::image::Image;
     pub type imgRequestProxy_ImageURL = root::mozilla::image::ImageURL;
@@ -28820,36 +28689,47 @@ pub mod root {
             }
         }
         #[inline]
-        pub fn mDeferNotifications(&self) -> bool {
+        pub fn mPendingNotify(&self) -> bool {
             unsafe { ::std::mem::transmute(self._bitfield_1.get(5usize, 1u8) as u8) }
         }
         #[inline]
-        pub fn set_mDeferNotifications(&mut self, val: bool) {
+        pub fn set_mPendingNotify(&mut self, val: bool) {
             unsafe {
                 let val: u8 = ::std::mem::transmute(val);
                 self._bitfield_1.set(5usize, 1u8, val as u64)
             }
         }
         #[inline]
-        pub fn mHadListener(&self) -> bool {
+        pub fn mValidating(&self) -> bool {
             unsafe { ::std::mem::transmute(self._bitfield_1.get(6usize, 1u8) as u8) }
         }
         #[inline]
-        pub fn set_mHadListener(&mut self, val: bool) {
+        pub fn set_mValidating(&mut self, val: bool) {
             unsafe {
                 let val: u8 = ::std::mem::transmute(val);
                 self._bitfield_1.set(6usize, 1u8, val as u64)
             }
         }
         #[inline]
-        pub fn mHadDispatch(&self) -> bool {
+        pub fn mHadListener(&self) -> bool {
             unsafe { ::std::mem::transmute(self._bitfield_1.get(7usize, 1u8) as u8) }
+        }
+        #[inline]
+        pub fn set_mHadListener(&mut self, val: bool) {
+            unsafe {
+                let val: u8 = ::std::mem::transmute(val);
+                self._bitfield_1.set(7usize, 1u8, val as u64)
+            }
+        }
+        #[inline]
+        pub fn mHadDispatch(&self) -> bool {
+            unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 1u8) as u8) }
         }
         #[inline]
         pub fn set_mHadDispatch(&mut self, val: bool) {
             unsafe {
                 let val: u8 = ::std::mem::transmute(val);
-                self._bitfield_1.set(7usize, 1u8, val as u64)
+                self._bitfield_1.set(8usize, 1u8, val as u64)
             }
         }
         #[inline]
@@ -28859,12 +28739,13 @@ pub mod root {
             mForceDispatchLoadGroup: bool,
             mListenerIsStrongRef: bool,
             mDecodeRequested: bool,
-            mDeferNotifications: bool,
+            mPendingNotify: bool,
+            mValidating: bool,
             mHadListener: bool,
             mHadDispatch: bool,
-        ) -> root::__BindgenBitfieldUnit<[u8; 1usize], u8> {
+        ) -> root::__BindgenBitfieldUnit<[u8; 2usize], u8> {
             let mut __bindgen_bitfield_unit: root::__BindgenBitfieldUnit<
-                [u8; 1usize],
+                [u8; 2usize],
                 u8,
             > = Default::default();
             __bindgen_bitfield_unit.set(0usize, 1u8, {
@@ -28890,14 +28771,18 @@ pub mod root {
                 mDecodeRequested as u64
             });
             __bindgen_bitfield_unit.set(5usize, 1u8, {
-                let mDeferNotifications: u8 = unsafe { ::std::mem::transmute(mDeferNotifications) };
-                mDeferNotifications as u64
+                let mPendingNotify: u8 = unsafe { ::std::mem::transmute(mPendingNotify) };
+                mPendingNotify as u64
             });
             __bindgen_bitfield_unit.set(6usize, 1u8, {
+                let mValidating: u8 = unsafe { ::std::mem::transmute(mValidating) };
+                mValidating as u64
+            });
+            __bindgen_bitfield_unit.set(7usize, 1u8, {
                 let mHadListener: u8 = unsafe { ::std::mem::transmute(mHadListener) };
                 mHadListener as u64
             });
-            __bindgen_bitfield_unit.set(7usize, 1u8, {
+            __bindgen_bitfield_unit.set(8usize, 1u8, {
                 let mHadDispatch: u8 = unsafe { ::std::mem::transmute(mHadDispatch) };
                 mHadDispatch as u64
             });
@@ -37181,18 +37066,6 @@ pub mod root {
     pub const SERVO_CSS_PSEUDO_ELEMENT_FLAGS_mozPlaceholder: u32 = 8;
     pub const SERVO_CSS_PSEUDO_ELEMENT_FLAGS_placeholder: u32 = 8;
     pub const SERVO_CSS_PSEUDO_ELEMENT_FLAGS_mozColorSwatch: u32 = 12;
-    pub type nsCSSAnonBoxes_NonInheritingBase = u8;
-    pub const nsCSSAnonBoxes_NonInheriting_oofPlaceholder: root::nsCSSAnonBoxes_NonInheriting = 0;
-    pub const nsCSSAnonBoxes_NonInheriting_horizontalFramesetBorder:
-        root::nsCSSAnonBoxes_NonInheriting = 1;
-    pub const nsCSSAnonBoxes_NonInheriting_verticalFramesetBorder:
-        root::nsCSSAnonBoxes_NonInheriting = 2;
-    pub const nsCSSAnonBoxes_NonInheriting_framesetBlank: root::nsCSSAnonBoxes_NonInheriting = 3;
-    pub const nsCSSAnonBoxes_NonInheriting_tableColGroup: root::nsCSSAnonBoxes_NonInheriting = 4;
-    pub const nsCSSAnonBoxes_NonInheriting_tableCol: root::nsCSSAnonBoxes_NonInheriting = 5;
-    pub const nsCSSAnonBoxes_NonInheriting_pageBreak: root::nsCSSAnonBoxes_NonInheriting = 6;
-    pub const nsCSSAnonBoxes_NonInheriting__Count: root::nsCSSAnonBoxes_NonInheriting = 7;
-    pub type nsCSSAnonBoxes_NonInheriting = u8;
     /// templated hashtable class maps keys to interface pointers.
     /// See nsBaseHashtable for complete declaration.
     /// @param KeyClass a wrapper-class for the hashtable key, see nsHashKeys.h
@@ -38701,6 +38574,26 @@ pub mod root {
         );
     }
     #[test]
+    fn __bindgen_test_layout_UniquePtr_open0_ProfilerBacktrace_ProfilerBacktraceDestructor_close0_instantiation(
+) {
+        assert_eq!(
+            ::std::mem::size_of::<root::mozilla::UniquePtr<root::ProfilerBacktrace>>(),
+            8usize,
+            concat!(
+                "Size of template specialization: ",
+                stringify!(root::mozilla::UniquePtr<root::ProfilerBacktrace>)
+            )
+        );
+        assert_eq!(
+            ::std::mem::align_of::<root::mozilla::UniquePtr<root::ProfilerBacktrace>>(),
+            8usize,
+            concat!(
+                "Alignment of template specialization: ",
+                stringify!(root::mozilla::UniquePtr<root::ProfilerBacktrace>)
+            )
+        );
+    }
+    #[test]
     fn __bindgen_test_layout_BaseTimeDuration_open0_TimeDurationValueCalculator_close0_instantiation(
 ) {
         assert_eq!(
@@ -39125,26 +39018,6 @@ pub mod root {
             concat!(
                 "Alignment of template specialization: ",
                 stringify!(root::nsTArray<root::mozilla::StyleSetHandle>)
-            )
-        );
-    }
-    #[test]
-    fn __bindgen_test_layout_UniquePtr_open0_ProfilerBacktrace_ProfilerBacktraceDestructor_close0_instantiation(
-) {
-        assert_eq!(
-            ::std::mem::size_of::<root::mozilla::UniquePtr<root::ProfilerBacktrace>>(),
-            8usize,
-            concat!(
-                "Size of template specialization: ",
-                stringify!(root::mozilla::UniquePtr<root::ProfilerBacktrace>)
-            )
-        );
-        assert_eq!(
-            ::std::mem::align_of::<root::mozilla::UniquePtr<root::ProfilerBacktrace>>(),
-            8usize,
-            concat!(
-                "Alignment of template specialization: ",
-                stringify!(root::mozilla::UniquePtr<root::ProfilerBacktrace>)
             )
         );
     }
@@ -41182,21 +41055,41 @@ pub mod root {
         );
     }
     #[test]
-    fn __bindgen_test_layout_RefPtr_open0_XPathEvaluator_close0_instantiation() {
+    fn __bindgen_test_layout_UniquePtr_open0_XPathEvaluator_DefaultDelete_open1_XPathEvaluator_close1_close0_instantiation(
+) {
         assert_eq!(
-            ::std::mem::size_of::<root::RefPtr<root::mozilla::dom::XPathEvaluator>>(),
+            ::std::mem::size_of::<root::mozilla::UniquePtr<root::mozilla::dom::XPathEvaluator>>(),
             8usize,
             concat!(
                 "Size of template specialization: ",
-                stringify!(root::RefPtr<root::mozilla::dom::XPathEvaluator>)
+                stringify!(root::mozilla::UniquePtr<root::mozilla::dom::XPathEvaluator>)
             )
         );
         assert_eq!(
-            ::std::mem::align_of::<root::RefPtr<root::mozilla::dom::XPathEvaluator>>(),
+            ::std::mem::align_of::<root::mozilla::UniquePtr<root::mozilla::dom::XPathEvaluator>>(),
             8usize,
             concat!(
                 "Alignment of template specialization: ",
-                stringify!(root::RefPtr<root::mozilla::dom::XPathEvaluator>)
+                stringify!(root::mozilla::UniquePtr<root::mozilla::dom::XPathEvaluator>)
+            )
+        );
+    }
+    #[test]
+    fn __bindgen_test_layout_DefaultDelete_open0_XPathEvaluator_close0_instantiation() {
+        assert_eq!(
+            ::std::mem::size_of::<root::mozilla::DefaultDelete>(),
+            1usize,
+            concat!(
+                "Size of template specialization: ",
+                stringify!(root::mozilla::DefaultDelete)
+            )
+        );
+        assert_eq!(
+            ::std::mem::align_of::<root::mozilla::DefaultDelete>(),
+            1usize,
+            concat!(
+                "Alignment of template specialization: ",
+                stringify!(root::mozilla::DefaultDelete)
             )
         );
     }
@@ -41451,6 +41344,25 @@ pub mod root {
             concat!(
                 "Alignment of template specialization: ",
                 stringify!(root::nsAutoPtr<root::mozilla::LangGroupFontPrefs>)
+            )
+        );
+    }
+    #[test]
+    fn __bindgen_test_layout_nsTArray_open0_nsRect_close0_instantiation() {
+        assert_eq!(
+            ::std::mem::size_of::<root::nsTArray<root::nsRect>>(),
+            8usize,
+            concat!(
+                "Size of template specialization: ",
+                stringify!(root::nsTArray<root::nsRect>)
+            )
+        );
+        assert_eq!(
+            ::std::mem::align_of::<root::nsTArray<root::nsRect>>(),
+            8usize,
+            concat!(
+                "Alignment of template specialization: ",
+                stringify!(root::nsTArray<root::nsRect>)
             )
         );
     }
@@ -41794,25 +41706,6 @@ pub mod root {
             concat!(
                 "Alignment of template specialization: ",
                 stringify!(root::mozilla::DefaultDelete)
-            )
-        );
-    }
-    #[test]
-    fn __bindgen_test_layout_nsTArray_open0_nsRect_close0_instantiation() {
-        assert_eq!(
-            ::std::mem::size_of::<root::nsTArray<root::nsRect>>(),
-            8usize,
-            concat!(
-                "Size of template specialization: ",
-                stringify!(root::nsTArray<root::nsRect>)
-            )
-        );
-        assert_eq!(
-            ::std::mem::align_of::<root::nsTArray<root::nsRect>>(),
-            8usize,
-            concat!(
-                "Alignment of template specialization: ",
-                stringify!(root::nsTArray<root::nsRect>)
             )
         );
     }
@@ -45244,64 +45137,6 @@ pub mod root {
         );
     }
     #[test]
-    fn __bindgen_test_layout_nsTArray_open0_RefPtr_open1_ServoStyleSheet_close1_close0_instantiation(
-) {
-        assert_eq!(
-            ::std::mem::size_of::<root::nsTArray<root::RefPtr<root::mozilla::ServoStyleSheet>>>(),
-            8usize,
-            concat!(
-                "Size of template specialization: ",
-                stringify!(root::nsTArray<root::RefPtr<root::mozilla::ServoStyleSheet>>)
-            )
-        );
-        assert_eq!(
-            ::std::mem::align_of::<root::nsTArray<root::RefPtr<root::mozilla::ServoStyleSheet>>>(),
-            8usize,
-            concat!(
-                "Alignment of template specialization: ",
-                stringify!(root::nsTArray<root::RefPtr<root::mozilla::ServoStyleSheet>>)
-            )
-        );
-    }
-    #[test]
-    fn __bindgen_test_layout_RefPtr_open0_ServoStyleContext_close0_instantiation() {
-        assert_eq!(
-            ::std::mem::size_of::<root::RefPtr<root::mozilla::ServoStyleContext>>(),
-            8usize,
-            concat!(
-                "Size of template specialization: ",
-                stringify!(root::RefPtr<root::mozilla::ServoStyleContext>)
-            )
-        );
-        assert_eq!(
-            ::std::mem::align_of::<root::RefPtr<root::mozilla::ServoStyleContext>>(),
-            8usize,
-            concat!(
-                "Alignment of template specialization: ",
-                stringify!(root::RefPtr<root::mozilla::ServoStyleContext>)
-            )
-        );
-    }
-    #[test]
-    fn __bindgen_test_layout_nsTArray_open0_PostTraversalTask_close0_instantiation() {
-        assert_eq!(
-            ::std::mem::size_of::<root::nsTArray<root::mozilla::PostTraversalTask>>(),
-            8usize,
-            concat!(
-                "Size of template specialization: ",
-                stringify!(root::nsTArray<root::mozilla::PostTraversalTask>)
-            )
-        );
-        assert_eq!(
-            ::std::mem::align_of::<root::nsTArray<root::mozilla::PostTraversalTask>>(),
-            8usize,
-            concat!(
-                "Alignment of template specialization: ",
-                stringify!(root::nsTArray<root::mozilla::PostTraversalTask>)
-            )
-        );
-    }
-    #[test]
     fn __bindgen_test_layout_UniquePtr_open0_ServoStyleRuleMap_DefaultDelete_open1_ServoStyleRuleMap_close1_close0_instantiation(
 ) {
         assert_eq!(
@@ -45494,7 +45329,7 @@ pub mod root {
         );
     }
     #[test]
-    fn __bindgen_test_layout_RefPtr_open0_ServoStyleContext_close0_instantiation_1() {
+    fn __bindgen_test_layout_RefPtr_open0_ServoStyleContext_close0_instantiation() {
         assert_eq!(
             ::std::mem::size_of::<root::RefPtr<root::mozilla::ServoStyleContext>>(),
             8usize,

--- a/components/style/gecko_bindings/sugar/ns_t_array.rs
+++ b/components/style/gecko_bindings/sugar/ns_t_array.rs
@@ -36,6 +36,7 @@ impl<T> nsTArray<T> {
         debug_assert!(!self.mBuffer.is_null());
         unsafe { mem::transmute(self.mBuffer) }
     }
+
     // unsafe, since header may be in shared static or something
     unsafe fn header_mut<'a>(&'a mut self) -> &'a mut nsTArrayHeader {
         debug_assert!(!self.mBuffer.is_null());

--- a/components/style/invalidation/element/state_and_attributes.rs
+++ b/components/style/invalidation/element/state_and_attributes.rs
@@ -6,7 +6,6 @@
 //! changes.
 
 use Atom;
-use atomic_refcell::AtomicRef;
 use context::{QuirksMode, SharedStyleContext};
 use data::ElementData;
 use dom::TElement;
@@ -57,7 +56,7 @@ where
 /// changes.
 pub struct StateAndAttrInvalidationProcessor<'a, 'b: 'a, E: TElement> {
     shared_context: &'a SharedStyleContext<'b>,
-    shadow_rule_datas: &'a [(AtomicRef<'b, CascadeData>, QuirksMode)],
+    shadow_rule_datas: &'a [(&'b CascadeData, QuirksMode)],
     cut_off_inheritance: bool,
     element: E,
     data: &'a mut ElementData,
@@ -68,7 +67,7 @@ impl<'a, 'b: 'a, E: TElement> StateAndAttrInvalidationProcessor<'a, 'b, E> {
     /// Creates a new StateAndAttrInvalidationProcessor.
     pub fn new(
         shared_context: &'a SharedStyleContext<'b>,
-        shadow_rule_datas: &'a [(AtomicRef<'b, CascadeData>, QuirksMode)],
+        shadow_rule_datas: &'a [(&'b CascadeData, QuirksMode)],
         cut_off_inheritance: bool,
         element: E,
         data: &'a mut ElementData,

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -87,6 +87,7 @@ mod macros;
 pub mod applicable_declarations;
 #[allow(missing_docs)] // TODO.
 #[cfg(feature = "servo")] pub mod attr;
+pub mod author_styles;
 pub mod bezier;
 pub mod bloom;
 pub mod context;

--- a/components/style/stylesheet_set.rs
+++ b/components/style/stylesheet_set.rs
@@ -583,6 +583,20 @@ impl<S> AuthorStylesheetSet<S>
 where
     S: StylesheetInDocument + PartialEq + 'static,
 {
+    /// Create a new empty AuthorStylesheetSet.
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            collection: Default::default(),
+            invalidations: StylesheetInvalidationSet::new(),
+        }
+    }
+
+    /// Whether anything has changed since the last time this was flushed.
+    pub fn dirty(&self) -> bool {
+        self.collection.dirty
+    }
+
     fn collection_for(
         &mut self,
         _sheet: &S,
@@ -592,6 +606,17 @@ where
     }
 
     sheet_set_methods!("AuthorStylesheetSet");
+
+    /// Iterate over the list of stylesheets.
+    pub fn iter(&self) -> StylesheetCollectionIterator<S> {
+        self.collection.iter()
+    }
+
+    /// Mark the sheet set dirty, as appropriate.
+    pub fn force_dirty(&mut self) {
+        self.invalidations.invalidate_fully();
+        self.collection.set_data_validity_at_least(DataValidity::FullyInvalid);
+    }
 
     /// Flush the stylesheets for this author set.
     ///

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -1983,7 +1983,8 @@ pub struct CascadeData {
 }
 
 impl CascadeData {
-    fn new() -> Self {
+    /// Creates an empty `CascadeData`.
+    pub fn new() -> Self {
         Self {
             normal_rules: ElementAndPseudoRules::default(),
             slotted_rules: None,
@@ -2005,7 +2006,7 @@ impl CascadeData {
 
     /// Rebuild the cascade data from a given SheetCollection, incrementally if
     /// possible.
-    fn rebuild<'a, S>(
+    pub fn rebuild<'a, S>(
         &mut self,
         device: &Device,
         quirks_mode: QuirksMode,
@@ -2281,7 +2282,7 @@ impl CascadeData {
 
     /// Returns whether all the media-feature affected values matched before and
     /// match now in the given stylesheet.
-    fn media_feature_affected_matches<S>(
+    pub fn media_feature_affected_matches<S>(
         &self,
         stylesheet: &S,
         guard: &SharedRwLockReadGuard,

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -36,6 +36,8 @@ use style::gecko::wrapper::{GeckoElement, GeckoNode};
 use style::gecko_bindings::bindings;
 use style::gecko_bindings::bindings::{RawGeckoElementBorrowed, RawGeckoElementBorrowedOrNull, RawGeckoNodeBorrowed};
 use style::gecko_bindings::bindings::{RawGeckoKeyframeListBorrowed, RawGeckoKeyframeListBorrowedMut};
+use style::gecko_bindings::bindings::{RawServoAuthorStyles, RawServoAuthorStylesBorrowed};
+use style::gecko_bindings::bindings::{RawServoAuthorStylesBorrowedMut, RawServoAuthorStylesOwned};
 use style::gecko_bindings::bindings::{RawServoDeclarationBlockBorrowed, RawServoDeclarationBlockStrong};
 use style::gecko_bindings::bindings::{RawServoDocumentRule, RawServoDocumentRuleBorrowed};
 use style::gecko_bindings::bindings::{RawServoFontFeatureValuesRule, RawServoFontFeatureValuesRuleBorrowed};
@@ -52,8 +54,6 @@ use style::gecko_bindings::bindings::{RawServoStyleSetBorrowed, RawServoStyleSet
 use style::gecko_bindings::bindings::{RawServoStyleSheetContentsBorrowed, ServoComputedDataBorrowed};
 use style::gecko_bindings::bindings::{RawServoStyleSheetContentsStrong, ServoStyleContextBorrowed};
 use style::gecko_bindings::bindings::{RawServoSupportsRule, RawServoSupportsRuleBorrowed};
-use style::gecko_bindings::bindings::{RawServoAuthorStyles, RawServoAuthorStylesBorrowed};
-use style::gecko_bindings::bindings::{RawServoAuthorStylesBorrowedMut, RawServoAuthorStylesOwned};
 use style::gecko_bindings::bindings::{ServoCssRulesBorrowed, ServoCssRulesStrong};
 use style::gecko_bindings::bindings::{nsACString, nsAString, nsCSSPropertyIDSetBorrowedMut};
 use style::gecko_bindings::bindings::Gecko_AddPropertyToSet;

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -17,6 +17,7 @@ use std::iter;
 use std::mem;
 use std::ptr;
 use style::applicable_declarations::ApplicableDeclarationBlock;
+use style::author_styles::AuthorStyles;
 use style::context::{CascadeInputs, QuirksMode, SharedStyleContext, StyleContext};
 use style::context::ThreadLocalStyleContext;
 use style::counter_style;
@@ -51,6 +52,8 @@ use style::gecko_bindings::bindings::{RawServoStyleSetBorrowed, RawServoStyleSet
 use style::gecko_bindings::bindings::{RawServoStyleSheetContentsBorrowed, ServoComputedDataBorrowed};
 use style::gecko_bindings::bindings::{RawServoStyleSheetContentsStrong, ServoStyleContextBorrowed};
 use style::gecko_bindings::bindings::{RawServoSupportsRule, RawServoSupportsRuleBorrowed};
+use style::gecko_bindings::bindings::{RawServoAuthorStyles, RawServoAuthorStylesBorrowed};
+use style::gecko_bindings::bindings::{RawServoAuthorStylesBorrowedMut, RawServoAuthorStylesOwned};
 use style::gecko_bindings::bindings::{ServoCssRulesBorrowed, ServoCssRulesStrong};
 use style::gecko_bindings::bindings::{nsACString, nsAString, nsCSSPropertyIDSetBorrowedMut};
 use style::gecko_bindings::bindings::Gecko_AddPropertyToSet;
@@ -1121,9 +1124,70 @@ pub extern "C" fn Servo_StyleSet_AppendStyleSheet(
 }
 
 #[no_mangle]
+pub extern "C" fn Servo_AuthorStyles_Create() -> *mut RawServoAuthorStyles {
+    Box::into_raw(Box::new(AuthorStyles::<GeckoStyleSheet>::new())) as *mut _
+}
+
+#[no_mangle]
+pub extern "C" fn Servo_AuthorStyles_Drop(
+    styles: RawServoAuthorStylesOwned,
+) {
+    let _ = styles.into_box::<AuthorStyles<_>>();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Servo_AuthorStyles_AppendStyleSheet(
+    styles: RawServoAuthorStylesBorrowedMut,
+    sheet: *const ServoStyleSheet,
+) {
+    let styles = AuthorStyles::<GeckoStyleSheet>::from_ffi_mut(styles);
+
+    let global_style_data = &*GLOBAL_STYLE_DATA;
+    let guard = global_style_data.shared_lock.read();
+    let sheet = GeckoStyleSheet::new(sheet);
+    styles.stylesheets.append_stylesheet(None, sheet, &guard);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Servo_AuthorStyles_ForceDirty(
+    styles: RawServoAuthorStylesBorrowedMut,
+) {
+    let styles = AuthorStyles::<GeckoStyleSheet>::from_ffi_mut(styles);
+    styles.stylesheets.force_dirty();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn Servo_AuthorStyles_Flush(
+    styles: RawServoAuthorStylesBorrowedMut,
+    document_set: RawServoStyleSetBorrowed,
+) {
+    let styles = AuthorStyles::<GeckoStyleSheet>::from_ffi_mut(styles);
+    // Try to avoid the atomic borrow below if possible.
+    if !styles.stylesheets.dirty() {
+        return;
+    }
+
+    let global_style_data = &*GLOBAL_STYLE_DATA;
+    let guard = global_style_data.shared_lock.read();
+
+    let document_data =
+        PerDocumentStyleData::from_ffi(document_set).borrow();
+
+    let stylist = &document_data.stylist;
+
+    // TODO(emilio): This is going to need an element or something to do proper
+    // invalidation in Shadow roots.
+    styles.flush::<GeckoElement>(
+        stylist.device(),
+        stylist.quirks_mode(),
+        &guard,
+    );
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn Servo_StyleSet_MediumFeaturesChanged(
     document_set: RawServoStyleSetBorrowed,
-    non_document_sets: *const nsTArray<*mut structs::ServoStyleSet>,
+    non_document_styles: *mut nsTArray<RawServoAuthorStylesBorrowedMut>,
     may_affect_default_style: bool,
 ) -> structs::MediumFeaturesChangedResult {
     let global_style_data = &*GLOBAL_STYLE_DATA;
@@ -1156,27 +1220,20 @@ pub unsafe extern "C" fn Servo_StyleSet_MediumFeaturesChanged(
     }
 
     let mut affects_non_document_rules = false;
-    for non_document_style_set in &**non_document_sets {
-        let non_document_data = &*(**non_document_style_set).mRawSet.mPtr;
-        let non_document_data =
-            mem::transmute::<&structs::RawServoStyleSet, &bindings::RawServoStyleSet>(non_document_data);
-        let mut non_document_data =
-            PerDocumentStyleData::from_ffi(non_document_data).borrow_mut();
-
-        let origins_changed =
-            non_document_data.stylist.media_features_change_changed_style(
-                &guards,
+    for author_styles in &mut **non_document_styles {
+        let author_styles =
+            AuthorStyles::<GeckoStyleSheet>::from_ffi_mut(&mut *author_styles);
+        let affected_style = author_styles.stylesheets.iter().any(|sheet| {
+            !author_styles.data.media_feature_affected_matches(
+                sheet,
+                &guards.author,
                 document_data.stylist.device(),
-            );
-        if !origins_changed.is_empty() {
+                document_data.stylist.quirks_mode(),
+            )
+        });
+        if affected_style {
             affects_non_document_rules = true;
-            // XBL stylesets are rebuilt entirely, so we need to mark them
-            // dirty from here instead of going through the stylist
-            // force_origin_dirty stuff, which would be useless.
-            //
-            // FIXME(emilio, bug 1436059): This is super-hacky, make XBL /
-            // Shadow DOM not use a style set at all.
-            (**non_document_style_set).mStylistState = structs::StylistState_StyleSheetsDirty;
+            author_styles.stylesheets.force_dirty();
         }
     }
 
@@ -4930,19 +4987,25 @@ pub extern "C" fn Servo_ParseCounterStyleName(
 #[no_mangle]
 pub unsafe extern "C" fn Servo_InvalidateStyleForDocStateChanges(
     root: RawGeckoElementBorrowed,
-    raw_style_sets: *const nsTArray<RawServoStyleSetBorrowed>,
+    document_style: RawServoStyleSetBorrowed,
+    non_document_styles: *const nsTArray<RawServoAuthorStylesBorrowed>,
     states_changed: u64,
 ) {
     use style::invalidation::element::document_state::DocumentStateInvalidationProcessor;
     use style::invalidation::element::invalidator::TreeStyleInvalidator;
 
-    let mut borrows = SmallVec::<[_; 20]>::with_capacity((*raw_style_sets).len());
-    for style_set in &**raw_style_sets {
-        borrows.push(PerDocumentStyleData::from_ffi(*style_set).borrow());
-    }
+    let document_data = PerDocumentStyleData::from_ffi(document_style).borrow();
+
+    let iter =
+        document_data.stylist.iter_origins().map(|(data, _origin)| data)
+        .chain((*non_document_styles).iter().map(|author_styles| {
+            let styles: &_ = AuthorStyles::<GeckoStyleSheet>::from_ffi(author_styles);
+            &styles.data
+        }));
+
     let root = GeckoElement(root);
     let mut processor = DocumentStateInvalidationProcessor::new(
-        borrows.iter().flat_map(|b| b.stylist.iter_origins().map(|(data, _origin)| data)),
+        iter,
         DocumentState::from_bits_truncate(states_changed),
         root.as_node().owner_doc().quirks_mode(),
     );


### PR DESCRIPTION
Introduce AuthorStyles, which is just a struct aggregating stylesheets +
CascadeData, with a quirks_mode parameter because XBL sucks so bad.

Bug: 1436059
Reviewed-by: xidorn
MozReview-Commit-ID: 7q99tSNXo0K

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20061)
<!-- Reviewable:end -->
