### PR TITLE
(Do not merge) Introduce pins

### DIFF
--- a/components/script/dom/bindings/mod.rs
+++ b/components/script/dom/bindings/mod.rs
@@ -146,6 +146,7 @@ pub mod iterable;
 pub mod mozmap;
 pub mod namespace;
 pub mod num;
+pub mod pin;
 pub mod proxyhandler;
 pub mod refcounted;
 pub mod reflector;

--- a/components/script/dom/bindings/pin.rs
+++ b/components/script/dom/bindings/pin.rs
@@ -1,0 +1,297 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Pins, also known as immovable roots.
+
+use dom::bindings::reflector::DomObject;
+use dom::bindings::root::{Dom, DomRoot};
+use dom::bindings::trace::JSTraceable;
+use js::jsapi::JSTracer;
+use std::cell::{RefCell, UnsafeCell};
+use std::marker::PhantomData;
+use std::mem;
+use std::ops::{Deref, Drop};
+
+#[allow(unrooted_must_root)]
+#[allow_unrooted_interior]
+pub struct Pin<'this, T>
+where
+    T: JSTraceable + 'static,
+{
+    marker: PhantomData<&'this ()>,
+    cell: Option<PinCell<T>>,
+}
+
+impl<'this, T> Pin<'this, T>
+where
+    T: JSTraceable,
+{
+    #[inline]
+    pub unsafe fn new() -> Self {
+        Self { marker: PhantomData, cell: None }
+    }
+
+    pub fn pin<U>(&'this mut self, traced: U) -> Pinned<'this, T>
+    where
+        T: UntracedFrom<U>,
+    {
+        unsafe {
+            self.cell = Some(PinCell::new(T::untraced_from(traced)));
+            self.cell.as_mut().unwrap().pin()
+        }
+    }
+
+    pub fn pin_default(&'this mut self) -> Pinned<'this, T>
+    where
+        T: UntracedDefault,
+    {
+        unsafe {
+            self.cell = Some(PinCell::new(T::untraced_default()));
+            self.cell.as_mut().unwrap().pin()
+        }
+    }
+}
+
+#[allow_unrooted_interior]
+pub struct Pinned<'pin, T>
+where
+    T: 'static,
+{
+    value: &'pin T,
+}
+
+impl<'pin, T> Deref for Pinned<'pin, T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<'pin, T> Pinned<'pin, Mut<T>> {
+    /// FIXME(nox): Not exactly entirely sound given that `&mut T` most probably
+    /// wasn't acquired in a sound way, but when life gives you lemons…
+    pub fn swap(&mut self, other: &mut T) {
+        unsafe { mem::swap(self.as_mut(), other) }
+    }
+}
+
+impl<'pin, T> Pinned<'pin, Mut<T>>
+where
+    T: UntracedSink,
+{
+    #[inline]
+    pub fn clear(&mut self) {
+        unsafe { self.as_mut().clear() }
+    }
+
+    #[inline]
+    pub fn push<U>(&mut self, value: U)
+    where
+        <T as UntracedSink>::Item: UntracedFrom<U>,
+    {
+        unsafe {
+            let untraced = UntracedFrom::untraced_from(value);
+            self.as_mut().push(untraced);
+        }
+    }
+}
+
+impl<'pin, T, U> Extend<U> for Pinned<'pin, Mut<T>>
+where
+    T: UntracedSink,
+    <T as UntracedSink>::Item: UntracedFrom<U>,
+{
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = U>,
+    {
+        for value in iter {
+            self.push(value);
+        }
+    }
+}
+
+#[derive(JSTraceable)]
+pub struct Mut<T> {
+    value: UnsafeCell<T>,
+}
+
+impl<T> Mut<T> {
+    unsafe fn as_mut(&self) -> &mut T {
+        &mut *self.value.get()
+    }
+}
+
+impl<T> Deref for Mut<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.value.get() }
+    }
+}
+
+pub trait UntracedDefault: 'static {
+    unsafe fn untraced_default() -> Self;
+}
+
+impl<T> UntracedDefault for Mut<T>
+where
+    T: UntracedDefault
+{
+    #[inline]
+    unsafe fn untraced_default() -> Self {
+        Mut { value: UnsafeCell::new(T::untraced_default()) }
+    }
+}
+
+macro_rules! impl_untraceddefault_as_default {
+    (for<$($param:ident),*> $ty:ty) => {
+        impl<$($param),*> UntracedDefault for $ty
+        where
+            $($param: 'static),*
+        {
+            #[inline]
+            unsafe fn untraced_default() -> Self {
+                Default::default()
+            }
+        }
+    };
+}
+
+impl_untraceddefault_as_default!(for<T> Vec<T>);
+
+pub trait UntracedFrom<T>: 'static {
+    unsafe fn untraced_from(traced: T) -> Self;
+}
+
+impl<'a, T> UntracedFrom<&'a mut T> for T
+where
+    T: UntracedDefault + 'static,
+{
+    #[inline]
+    unsafe fn untraced_from(traced: &'a mut T) -> Self {
+        mem::replace(traced, T::untraced_default())
+    }
+}
+
+impl<'a, T> UntracedFrom<&'a T> for Dom<T>
+where
+    T: DomObject + 'static,
+{
+    #[allow(unrooted_must_root)]
+    #[inline]
+    unsafe fn untraced_from(traced: &'a T) -> Self {
+        Dom::from_ref(traced)
+    }
+}
+
+impl<'a, T> UntracedFrom<&'a Dom<T>> for Dom<T>
+where
+    T: DomObject + 'static,
+{
+    #[allow(unrooted_must_root)]
+    #[inline]
+    unsafe fn untraced_from(traced: &'a Dom<T>) -> Self {
+        Dom::from_ref(&**traced)
+    }
+}
+
+impl<T> UntracedFrom<DomRoot<T>> for Dom<T>
+where
+    T: DomObject + 'static,
+{
+    #[allow(unrooted_must_root)]
+    #[inline]
+    unsafe fn untraced_from(traced: DomRoot<T>) -> Self {
+        Dom::from_ref(&*traced)
+    }
+}
+
+pub unsafe trait UntracedSink {
+    type Item;
+
+    fn clear(&mut self);
+    fn push(&mut self, value: Self::Item);
+}
+
+unsafe impl<T> UntracedSink for Vec<T> {
+    type Item = T;
+
+    #[inline]
+    fn clear(&mut self) {
+        self.clear();
+    }
+
+    #[inline]
+    fn push(&mut self, value: Self::Item) {
+        self.push(value);
+    }
+}
+
+pub unsafe fn initialize() {
+    PINNED_TRACEABLES.with(|cell| {
+        let mut cell = cell.borrow_mut();
+        assert!(cell.is_none(), "pin list has already been initialized");
+        *cell = Some(None);
+    });
+}
+
+pub unsafe fn trace(tracer: *mut JSTracer) {
+    trace!("tracing stack-rooted pins");
+    PINNED_TRACEABLES.with(|ref cell| {
+        let cell = cell.borrow();
+        let mut head = cell.unwrap();
+        while let Some(current) = head {
+            (*current).value.trace(tracer);
+            head = (*current).prev;
+        }
+    });
+}
+
+thread_local! {
+    static PINNED_TRACEABLES: RefCell<Option<Option<*const PinCell<JSTraceable>>>> =
+        Default::default();
+}
+
+struct PinCell<T>
+where
+    T: JSTraceable + ?Sized + 'static,
+{
+    prev: Option<*const PinCell<JSTraceable>>,
+    value: T,
+}
+
+impl<T> PinCell<T>
+where
+    T: JSTraceable + 'static,
+{
+    unsafe fn new(untraced: T) -> Self {
+        Self { prev: None, value: untraced }
+    }
+
+    unsafe fn pin<'pin>(&'pin mut self) -> Pinned<'pin, T> {
+        let this = self as &PinCell<JSTraceable> as *const _;
+        PINNED_TRACEABLES.with(|cell| {
+            self.prev = mem::replace(
+                cell.borrow_mut().as_mut().unwrap(),
+                Some(this),
+            );
+        });
+        Pinned { value: &self.value }
+    }
+}
+
+impl<T> Drop for PinCell<T>
+where
+    T: JSTraceable + ?Sized + 'static,
+{
+    fn drop(&mut self) {
+        PINNED_TRACEABLES.with(|cell| {
+            *cell.borrow_mut().as_mut().unwrap() = self.prev;
+        });
+    }
+}

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -43,7 +43,6 @@ use dom::bindings::cell::DomRefCell;
 use dom::bindings::error::Error;
 use dom::bindings::refcounted::{Trusted, TrustedPromise};
 use dom::bindings::reflector::{DomObject, Reflector};
-use dom::bindings::root::{Dom, DomRoot};
 use dom::bindings::str::{DOMString, USVString};
 use dom::bindings::utils::WindowProxyHandler;
 use dom::document::PendingRestyle;
@@ -840,22 +839,6 @@ impl<'a, T: 'static + JSTraceable> RootedVec<'a, T> {
         unsafe {
             RootedTraceableSet::add(root);
         }
-        RootedVec {
-            root: root,
-        }
-    }
-}
-
-impl<'a, T: 'static + JSTraceable + DomObject> RootedVec<'a, Dom<T>> {
-    /// Create a vector of items of type Dom<T> that is rooted for
-    /// the lifetime of this struct
-    pub fn from_iter<I>(root: &'a mut RootableVec<Dom<T>>, iter: I) -> Self
-        where I: Iterator<Item = DomRoot<T>>
-    {
-        unsafe {
-            RootedTraceableSet::add(root);
-        }
-        root.v.extend(iter.map(|item| Dom::from_ref(&*item)));
         RootedVec {
             root: root,
         }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1176,10 +1176,10 @@ impl Document {
             }
         }
 
-        rooted_vec!(let mut target_touches);
+        pinned!(mut target_touches[Vec<_>]);
         let touches = {
             let touches = self.active_touch_points.borrow();
-            target_touches.extend(touches.iter().filter(|t| t.Target() == target).cloned());
+            target_touches.extend(touches.iter().filter(|t| t.Target() == target));
             TouchList::new(window, touches.r())
         };
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -97,7 +97,6 @@ use std::borrow::Cow;
 use std::cell::{Cell, Ref};
 use std::default::Default;
 use std::fmt;
-use std::mem;
 use std::rc::Rc;
 use std::str::FromStr;
 use style::CaseSensitivityExt;
@@ -338,10 +337,10 @@ impl Element {
     pub fn invoke_reactions(&self) {
         // TODO: This is not spec compliant, as this will allow some reactions to be processed
         // after clear_reaction_queue has been called.
-        rooted_vec!(let mut reactions);
+        pinned!(mut reactions[Vec<_>]);
         while !self.custom_element_reaction_queue.borrow().is_empty() {
-            mem::swap(&mut *reactions, &mut *self.custom_element_reaction_queue.borrow_mut());
-            for reaction in reactions.iter() {
+            reactions.swap(&mut *self.custom_element_reaction_queue.borrow_mut());
+            for reaction in &**reactions {
                 reaction.invoke(self);
             }
             reactions.clear();

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -132,18 +132,18 @@ impl Event {
 
         // Step 3. The "invoke" algorithm is only used on `target` separately,
         // so we don't put it in the path.
-        rooted_vec!(let mut event_path);
+        pinned!(mut event_path[Vec<Dom<_>>]);
 
         // Step 4.
         if let Some(target_node) = target.downcast::<Node>() {
             for ancestor in target_node.ancestors() {
-                event_path.push(Dom::from_ref(ancestor.upcast::<EventTarget>()));
+                event_path.push(ancestor.upcast::<EventTarget>());
             }
             let top_most_ancestor_or_target =
                 DomRoot::from_ref(event_path.r().last().cloned().unwrap_or(target));
             if let Some(document) = DomRoot::downcast::<Document>(top_most_ancestor_or_target) {
                 if self.type_() != atom!("load") && document.browsing_context().is_some() {
-                    event_path.push(Dom::from_ref(document.window().upcast()));
+                    event_path.push(document.window().upcast::<EventTarget>());
                 }
             }
         }

--- a/components/script/dom/gamepadbuttonlist.rs
+++ b/components/script/dom/gamepadbuttonlist.rs
@@ -28,8 +28,7 @@ impl GamepadButtonList {
     }
 
     pub fn new_from_vr(global: &GlobalScope, buttons: &[WebVRGamepadButton]) -> DomRoot<GamepadButtonList> {
-        rooted_vec!(let list <- buttons.iter()
-                                       .map(|btn| GamepadButton::new(&global, btn.pressed, btn.touched)));
+        pinned!(mut list[Vec<_>] <- buttons.iter().map(|btn| GamepadButton::new(&global, btn.pressed, btn.touched)));
 
         reflect_dom_object(Box::new(GamepadButtonList::new_inherited(list.r())),
                            global,

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1052,12 +1052,14 @@ impl VirtualMethods for HTMLFormElement {
 
         // Collect the controls to reset because reset_form_owner
         // will mutably borrow self.controls
-        rooted_vec!(let mut to_reset);
-        to_reset.extend(self.controls.borrow().iter()
-                        .filter(|c| !c.is_in_same_home_subtree(self))
-                        .map(|c| c.clone()));
+        pinned!(mut to_reset[Vec<Dom<_>>] <-
+            self.controls
+                .borrow()
+                .iter()
+                .filter(|c| !c.is_in_same_home_subtree(self))
+        );
 
-        for control in to_reset.iter() {
+        for control in &**to_reset {
             control.as_maybe_form_control()
                        .expect("Element must be a form control")
                        .reset_form_owner();

--- a/components/script/dom/mediaquerylist.rs
+++ b/components/script/dom/mediaquerylist.rs
@@ -134,16 +134,16 @@ impl WeakMediaQueryListVec {
     /// Evaluate media query lists and report changes
     /// <https://drafts.csswg.org/cssom-view/#evaluate-media-queries-and-report-changes>
     pub fn evaluate_and_report_changes(&self) {
-        rooted_vec!(let mut mql_list);
+        pinned!(mut mql_list[Vec<Dom<_>>]);
         self.cell.borrow_mut().update(|mql| {
             let mql = mql.root().unwrap();
             if let MediaQueryListMatchState::Changed(_) = mql.evaluate_changes() {
                 // Recording list of changed Media Queries
-                mql_list.push(Dom::from_ref(&*mql));
+                mql_list.push(mql);
             }
         });
         // Sending change events for all changed Media Queries
-        for mql in mql_list.iter() {
+        for mql in &**mql_list {
             let event = MediaQueryListEvent::new(&mql.global(),
                                                  atom!("change"),
                                                  false, false,

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1598,10 +1598,10 @@ impl Node {
                 parent.ranges.increase_above(parent, index, count);
             }
         }
-        rooted_vec!(let mut new_nodes);
+        pinned!(mut new_nodes[Vec<_>]);
         let new_nodes = if let NodeTypeId::DocumentFragment = node.type_id() {
             // Step 3.
-            new_nodes.extend(node.children().map(|kid| Dom::from_ref(&*kid)));
+            new_nodes.extend(node.children());
             // Step 4.
             for kid in new_nodes.r() {
                 Node::remove(*kid, node, SuppressObserver::Suppressed);
@@ -1671,12 +1671,12 @@ impl Node {
             Node::adopt(node, &*parent.owner_doc());
         }
         // Step 2.
-        rooted_vec!(let removed_nodes <- parent.children());
+        pinned!(mut removed_nodes[Vec<_>] <- parent.children());
         // Step 3.
-        rooted_vec!(let mut added_nodes);
+        pinned!(mut added_nodes[Vec<_>]);
         let added_nodes = if let Some(node) = node.as_ref() {
             if let NodeTypeId::DocumentFragment = node.type_id() {
-                added_nodes.extend(node.children().map(|child| Dom::from_ref(&*child)));
+                added_nodes.extend(node.children());
                 added_nodes.r()
             } else {
                 ref_slice(node)
@@ -2203,9 +2203,9 @@ impl NodeMethods for Node {
         };
 
         // Step 12.
-        rooted_vec!(let mut nodes);
+        pinned!(mut nodes[Vec<_>]);
         let nodes = if node.type_id() == NodeTypeId::DocumentFragment {
-            nodes.extend(node.children().map(|node| Dom::from_ref(&*node)));
+            nodes.extend(node.children());
             nodes.r()
         } else {
             ref_slice(&node)

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -269,8 +269,12 @@ impl PaintWorkletGlobalScope {
         // TODO: Step 10
         // Steps 11-12
         debug!("Invoking paint function {}.", name);
-        rooted_vec!(let arguments_values <- arguments.iter().cloned()
-                    .map(|argument| CSSStyleValue::new(self.upcast(), argument)));
+        pinned!(mut arguments_values[Vec<Dom<_>>] <-
+            arguments
+                .iter()
+                .cloned()
+                .map(|argument| CSSStyleValue::new(self.upcast(), argument))
+        );
         let arguments_value_vec: Vec<JSVal> = arguments_values.iter()
             .map(|argument| ObjectValue(argument.reflector().get_jsobject().get()))
             .collect();

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -14,7 +14,7 @@ use dom::bindings::error::{Error, ErrorResult, Fallible};
 use dom::bindings::inheritance::{CharacterDataTypeId, NodeTypeId};
 use dom::bindings::inheritance::Castable;
 use dom::bindings::reflector::{Reflector, reflect_dom_object};
-use dom::bindings::root::{Dom, DomRoot, MutDom, RootedReference};
+use dom::bindings::root::{DomRoot, MutDom, RootedReference};
 use dom::bindings::str::DOMString;
 use dom::bindings::trace::JSTraceable;
 use dom::bindings::weakref::{WeakRef, WeakRefVec};
@@ -765,7 +765,7 @@ impl RangeMethods for Range {
         }
 
         // Step 4.
-        rooted_vec!(let mut contained_children);
+        pinned!(mut contained_children[Vec<_>]);
         let ancestor = self.CommonAncestorContainer();
 
         let mut iter = start_node.following_nodes(&ancestor);
@@ -773,7 +773,7 @@ impl RangeMethods for Range {
         let mut next = iter.next();
         while let Some(child) = next {
             if self.contains(&child) {
-                contained_children.push(Dom::from_ref(&*child));
+                contained_children.push(child);
                 next = iter.next_skipping_children();
             } else {
                 next = iter.next();

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -6,6 +6,7 @@
 //! script thread, the dom, and the worker threads.
 
 use dom::bindings::codegen::Bindings::PromiseBinding::PromiseJobCallback;
+use dom::bindings::pin;
 use dom::bindings::refcounted::{LiveDOMReferences, trace_refcounted_objects};
 use dom::bindings::root::trace_roots;
 use dom::bindings::settings_stack;
@@ -143,6 +144,7 @@ pub unsafe fn new_rt_and_cx() -> Runtime {
     LiveDOMReferences::initialize();
     let runtime = RustRuntime::new().unwrap();
 
+    pin::initialize();
     JS_AddExtraGCRootsTracer(runtime.rt(), Some(trace_rust_roots), ptr::null_mut());
 
     // Needed for debug assertions about whether GC is running.
@@ -426,6 +428,7 @@ unsafe extern fn trace_rust_roots(tr: *mut JSTracer, _data: *mut os::raw::c_void
     }
     debug!("starting custom root handler");
     trace_thread(tr);
+    pin::trace(tr);
     trace_traceables(tr);
     trace_roots(tr);
     trace_refcounted_objects(tr);


### PR DESCRIPTION
Just pushing for people to take a look at it.

Things I want to do before we consider merging it:
 * document the stuff;
 * bikeshed the macro syntax;
 * use said macro in more places;
 * support non-`'static` types;
 * protect code against dropping `Pin` values out of order;
 * introduce an `UnpinnedDefault` trait;
 * introduce a `TracedVec` type that doesn't implement `drain`, moving iterators, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20063)
<!-- Reviewable:end -->
