### PR TITLE
Use typed coordinates more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2807,6 +2807,7 @@ dependencies = [
  "euclid 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "malloc_size_of 0.0.1",
  "malloc_size_of_derive 0.0.1",
+ "style_traits 0.0.1",
  "webrender_api 0.57.0 (git+https://github.com/servo/webrender)",
 ]
 

--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -6,7 +6,6 @@
 
 use SendableFrameTree;
 use compositor::CompositingReason;
-use euclid::{TypedPoint2D, TypedSize2D};
 use gfx_traits::Epoch;
 use ipc_channel::ipc::IpcSender;
 use msg::constellation_msg::{Key, KeyModifiers, KeyState, PipelineId, TopLevelBrowsingContextId};
@@ -17,11 +16,10 @@ use script_traits::{AnimationState, ConstellationMsg, EventResult, LoadData};
 use servo_url::ServoUrl;
 use std::fmt::{Debug, Error, Formatter};
 use std::sync::mpsc::{Receiver, Sender};
-use style_traits::DevicePixel;
 use style_traits::cursor::CursorKind;
 use style_traits::viewport::ViewportConstraints;
 use webrender;
-use webrender_api;
+use webrender_api::{self, DeviceIntPoint, DeviceUintSize};
 
 
 /// Used to wake up the event loop, provided by the servo port/embedder.
@@ -120,16 +118,16 @@ pub enum EmbedderMsg {
     /// Alerts the embedder that the current page has changed its title.
     ChangePageTitle(TopLevelBrowsingContextId, Option<String>),
     /// Move the window to a point
-    MoveTo(TopLevelBrowsingContextId, TypedPoint2D<i32, DevicePixel>),
+    MoveTo(TopLevelBrowsingContextId, DeviceIntPoint),
     /// Resize the window to size
-    ResizeTo(TopLevelBrowsingContextId, TypedSize2D<u32, DevicePixel>),
+    ResizeTo(TopLevelBrowsingContextId, DeviceUintSize),
     /// Get Window Informations size and position
     GetClientWindow(TopLevelBrowsingContextId,
-                    IpcSender<(TypedSize2D<u32, DevicePixel>, TypedPoint2D<i32, DevicePixel>)>),
+                    IpcSender<(DeviceUintSize, DeviceIntPoint)>),
     /// Get screen size (pixel)
-    GetScreenSize(TopLevelBrowsingContextId, IpcSender<(TypedSize2D<u32, DevicePixel>)>),
+    GetScreenSize(TopLevelBrowsingContextId, IpcSender<(DeviceUintSize)>),
     /// Get screen available size (pixel)
-    GetScreenAvailSize(TopLevelBrowsingContextId, IpcSender<(TypedSize2D<u32, DevicePixel>)>),
+    GetScreenAvailSize(TopLevelBrowsingContextId, IpcSender<(DeviceUintSize)>),
     /// Wether or not to follow a link
     AllowNavigation(TopLevelBrowsingContextId, ServoUrl, IpcSender<bool>),
     /// Sends an unconsumed key event back to the embedder.

--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -6,7 +6,7 @@
 
 use SendableFrameTree;
 use compositor::CompositingReason;
-use euclid::{Point2D, Size2D};
+use euclid::{TypedPoint2D, TypedSize2D};
 use gfx_traits::Epoch;
 use ipc_channel::ipc::IpcSender;
 use msg::constellation_msg::{Key, KeyModifiers, KeyState, PipelineId, TopLevelBrowsingContextId};
@@ -17,6 +17,7 @@ use script_traits::{AnimationState, ConstellationMsg, EventResult, LoadData};
 use servo_url::ServoUrl;
 use std::fmt::{Debug, Error, Formatter};
 use std::sync::mpsc::{Receiver, Sender};
+use style_traits::DevicePixel;
 use style_traits::cursor::CursorKind;
 use style_traits::viewport::ViewportConstraints;
 use webrender;
@@ -119,15 +120,16 @@ pub enum EmbedderMsg {
     /// Alerts the embedder that the current page has changed its title.
     ChangePageTitle(TopLevelBrowsingContextId, Option<String>),
     /// Move the window to a point
-    MoveTo(TopLevelBrowsingContextId, Point2D<i32>),
+    MoveTo(TopLevelBrowsingContextId, TypedPoint2D<i32, DevicePixel>),
     /// Resize the window to size
-    ResizeTo(TopLevelBrowsingContextId, Size2D<u32>),
+    ResizeTo(TopLevelBrowsingContextId, TypedSize2D<u32, DevicePixel>),
     /// Get Window Informations size and position
-    GetClientWindow(TopLevelBrowsingContextId, IpcSender<(Size2D<u32>, Point2D<i32>)>),
+    GetClientWindow(TopLevelBrowsingContextId,
+                    IpcSender<(TypedSize2D<u32, DevicePixel>, TypedPoint2D<i32, DevicePixel>)>),
     /// Get screen size (pixel)
-    GetScreenSize(TopLevelBrowsingContextId, IpcSender<(Size2D<u32>)>),
+    GetScreenSize(TopLevelBrowsingContextId, IpcSender<(TypedSize2D<u32, DevicePixel>)>),
     /// Get screen available size (pixel)
-    GetScreenAvailSize(TopLevelBrowsingContextId, IpcSender<(Size2D<u32>)>),
+    GetScreenAvailSize(TopLevelBrowsingContextId, IpcSender<(TypedSize2D<u32, DevicePixel>)>),
     /// Wether or not to follow a link
     AllowNavigation(TopLevelBrowsingContextId, ServoUrl, IpcSender<bool>),
     /// Sends an unconsumed key event back to the embedder.

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -5,25 +5,25 @@
 //! Abstract windowing methods. The concrete implementations of these can be found in `platform/`.
 
 use compositor_thread::EventLoopWaker;
-use euclid::{Length, TypedScale, TypedPoint2D, TypedSize2D};
+use euclid::TypedScale;
 use gleam::gl;
 use ipc_channel::ipc::IpcSender;
 use msg::constellation_msg::{Key, KeyModifiers, KeyState, TopLevelBrowsingContextId, TraversalDirection};
 use net_traits::net_error_list::NetError;
 use script_traits::{LoadData, MouseButton, TouchEventType, TouchId};
-use servo_geometry::DeviceIndependentPixel;
+use servo_geometry::{DeviceIndependentPixel, DeviceUintLength};
 use servo_url::ServoUrl;
 use std::fmt::{Debug, Error, Formatter};
 use std::rc::Rc;
 use style_traits::DevicePixel;
 use style_traits::cursor::CursorKind;
-use webrender_api::{DeviceUintSize, DeviceUintRect, ScrollLocation};
+use webrender_api::{DeviceIntPoint, DeviceSize, DevicePoint, DeviceUintSize, DeviceUintRect, ScrollLocation};
 
 #[derive(Clone)]
 pub enum MouseWindowEvent {
-    Click(MouseButton, TypedPoint2D<f32, DevicePixel>),
-    MouseDown(MouseButton, TypedPoint2D<f32, DevicePixel>),
-    MouseUp(MouseButton, TypedPoint2D<f32, DevicePixel>),
+    Click(MouseButton, DevicePoint),
+    MouseDown(MouseButton, DevicePoint),
+    MouseUp(MouseButton, DevicePoint),
 }
 
 /// Various debug and profiling flags that WebRender supports.
@@ -54,12 +54,12 @@ pub enum WindowEvent {
     /// Sent when a mouse hit test is to be performed.
     MouseWindowEventClass(MouseWindowEvent),
     /// Sent when a mouse move.
-    MouseWindowMoveEventClass(TypedPoint2D<f32, DevicePixel>),
+    MouseWindowMoveEventClass(DevicePoint),
     /// Touch event: type, identifier, point
-    Touch(TouchEventType, TouchId, TypedPoint2D<f32, DevicePixel>),
+    Touch(TouchEventType, TouchId, DevicePoint),
     /// Sent when the user scrolls. The first point is the delta and the second point is the
     /// origin.
-    Scroll(ScrollLocation, TypedPoint2D<i32, DevicePixel>, TouchEventType),
+    Scroll(ScrollLocation, DeviceIntPoint, TouchEventType),
     /// Sent when the user zooms.
     Zoom(f32),
     /// Simulated "pinch zoom" gesture for non-touch platforms (e.g. ctrl-scrollwheel).
@@ -123,21 +123,20 @@ pub trait WindowMethods {
     /// Returns the position and size of the window within the rendering area.
     fn window_rect(&self) -> DeviceUintRect;
     /// Returns the size of the window.
-    fn size(&self) -> TypedSize2D<f32, DevicePixel>;
+    fn size(&self) -> DeviceSize;
     /// Presents the window to the screen (perhaps by page flipping).
     fn present(&self);
 
     /// Return the size of the window with head and borders and position of the window values
-    fn client_window(&self, ctx: TopLevelBrowsingContextId) ->
-        (TypedSize2D<u32, DevicePixel>, TypedPoint2D<i32, DevicePixel>);
+    fn client_window(&self, ctx: TopLevelBrowsingContextId) -> (DeviceUintSize, DeviceIntPoint);
     /// Return the size of the screen.
-    fn screen_size(&self, ctx: TopLevelBrowsingContextId) -> TypedSize2D<u32, DevicePixel>;
+    fn screen_size(&self, ctx: TopLevelBrowsingContextId) -> DeviceUintSize;
     /// Return the available size of the screen.
-    fn screen_avail_size(&self, ctx: TopLevelBrowsingContextId) -> TypedSize2D<u32, DevicePixel>;
+    fn screen_avail_size(&self, ctx: TopLevelBrowsingContextId) -> DeviceUintSize;
     /// Set the size inside of borders and head
-    fn set_inner_size(&self, ctx: TopLevelBrowsingContextId, size: TypedSize2D<u32, DevicePixel>);
+    fn set_inner_size(&self, ctx: TopLevelBrowsingContextId, size: DeviceUintSize);
     /// Set the window position
-    fn set_position(&self, ctx: TopLevelBrowsingContextId, point: TypedPoint2D<i32, DevicePixel>);
+    fn set_position(&self, ctx: TopLevelBrowsingContextId, point: DeviceIntPoint);
     /// Set fullscreen state
     fn set_fullscreen_state(&self, ctx: TopLevelBrowsingContextId, state: bool);
 
@@ -167,7 +166,7 @@ pub trait WindowMethods {
     /// Requests that the window system prepare a composite. Typically this will involve making
     /// some type of platform-specific graphics context current. Returns true if the composite may
     /// proceed and false if it should not.
-    fn prepare_for_composite(&self, width: Length<u32, DevicePixel>, height: Length<u32, DevicePixel>) -> bool;
+    fn prepare_for_composite(&self, width: DeviceUintLength, height: DeviceUintLength) -> bool;
 
     /// Sets the cursor to be used in the window.
     fn set_cursor(&self, cursor: CursorKind);

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -17,7 +17,7 @@ use std::fmt::{Debug, Error, Formatter};
 use std::rc::Rc;
 use style_traits::DevicePixel;
 use style_traits::cursor::CursorKind;
-use webrender_api::{DeviceIntPoint, DeviceSize, DevicePoint, DeviceUintSize, DeviceUintRect, ScrollLocation};
+use webrender_api::{DeviceIntPoint, DevicePoint, DeviceUintSize, DeviceUintRect, ScrollLocation};
 
 #[derive(Clone)]
 pub enum MouseWindowEvent {
@@ -122,8 +122,6 @@ pub trait WindowMethods {
     fn framebuffer_size(&self) -> DeviceUintSize;
     /// Returns the position and size of the window within the rendering area.
     fn window_rect(&self) -> DeviceUintRect;
-    /// Returns the size of the window.
-    fn size(&self) -> DeviceSize;
     /// Presents the window to the screen (perhaps by page flipping).
     fn present(&self);
 

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -5,8 +5,7 @@
 //! Abstract windowing methods. The concrete implementations of these can be found in `platform/`.
 
 use compositor_thread::EventLoopWaker;
-use euclid::{Point2D, Size2D};
-use euclid::{TypedScale, TypedPoint2D, TypedSize2D};
+use euclid::{Length, TypedScale, TypedPoint2D, TypedSize2D};
 use gleam::gl;
 use ipc_channel::ipc::IpcSender;
 use msg::constellation_msg::{Key, KeyModifiers, KeyState, TopLevelBrowsingContextId, TraversalDirection};
@@ -123,21 +122,22 @@ pub trait WindowMethods {
     fn framebuffer_size(&self) -> DeviceUintSize;
     /// Returns the position and size of the window within the rendering area.
     fn window_rect(&self) -> DeviceUintRect;
-    /// Returns the size of the window in density-independent "px" units.
-    fn size(&self) -> TypedSize2D<f32, DeviceIndependentPixel>;
+    /// Returns the size of the window.
+    fn size(&self) -> TypedSize2D<f32, DevicePixel>;
     /// Presents the window to the screen (perhaps by page flipping).
     fn present(&self);
 
     /// Return the size of the window with head and borders and position of the window values
-    fn client_window(&self, ctx: TopLevelBrowsingContextId) -> (Size2D<u32>, Point2D<i32>);
-    /// Return the size of the screen (pixel)
-    fn screen_size(&self, ctx: TopLevelBrowsingContextId) -> Size2D<u32>;
-    /// Return the available size of the screen (pixel)
-    fn screen_avail_size(&self, ctx: TopLevelBrowsingContextId) -> Size2D<u32>;
+    fn client_window(&self, ctx: TopLevelBrowsingContextId) ->
+        (TypedSize2D<u32, DevicePixel>, TypedPoint2D<i32, DevicePixel>);
+    /// Return the size of the screen.
+    fn screen_size(&self, ctx: TopLevelBrowsingContextId) -> TypedSize2D<u32, DevicePixel>;
+    /// Return the available size of the screen.
+    fn screen_avail_size(&self, ctx: TopLevelBrowsingContextId) -> TypedSize2D<u32, DevicePixel>;
     /// Set the size inside of borders and head
-    fn set_inner_size(&self, ctx: TopLevelBrowsingContextId, size: Size2D<u32>);
+    fn set_inner_size(&self, ctx: TopLevelBrowsingContextId, size: TypedSize2D<u32, DevicePixel>);
     /// Set the window position
-    fn set_position(&self, ctx: TopLevelBrowsingContextId, point: Point2D<i32>);
+    fn set_position(&self, ctx: TopLevelBrowsingContextId, point: TypedPoint2D<i32, DevicePixel>);
     /// Set fullscreen state
     fn set_fullscreen_state(&self, ctx: TopLevelBrowsingContextId, state: bool);
 
@@ -167,7 +167,7 @@ pub trait WindowMethods {
     /// Requests that the window system prepare a composite. Typically this will involve making
     /// some type of platform-specific graphics context current. Returns true if the composite may
     /// proceed and false if it should not.
-    fn prepare_for_composite(&self, width: usize, height: usize) -> bool;
+    fn prepare_for_composite(&self, width: Length<u32, DevicePixel>, height: Length<u32, DevicePixel>) -> bool;
 
     /// Sets the cursor to be used in the window.
     fn set_cursor(&self, cursor: CursorKind);

--- a/components/geometry/Cargo.toml
+++ b/components/geometry/Cargo.toml
@@ -14,4 +14,5 @@ app_units = "0.6"
 euclid = "0.17"
 malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = { path = "../malloc_size_of_derive" }
+style_traits = { path = "../style_traits" }
 webrender_api = { git = "https://github.com/servo/webrender" }

--- a/components/geometry/lib.rs
+++ b/components/geometry/lib.rs
@@ -5,15 +5,19 @@
 extern crate app_units;
 extern crate euclid;
 extern crate malloc_size_of;
+extern crate style_traits;
 #[macro_use] extern crate malloc_size_of_derive;
 extern crate webrender_api;
 
 use app_units::{Au, MAX_AU, MIN_AU};
-use euclid::{Point2D, Rect, Size2D};
+use euclid::{Length, Point2D, Rect, Size2D};
 use std::f32;
+use style_traits::DevicePixel;
 use webrender_api::{LayoutPoint, LayoutRect, LayoutSize};
 
 // Units for use with euclid::length and euclid::scale_factor.
+
+pub type DeviceUintLength = Length<u32, DevicePixel>;
 
 /// A normalized "pixel" at the default resolution for the display.
 ///

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -11,9 +11,10 @@ use dom::bindings::root::{Dom, DomRoot};
 use dom::globalscope::GlobalScope;
 use dom::window::Window;
 use dom_struct::dom_struct;
-use euclid::Size2D;
+use euclid::TypedSize2D;
 use ipc_channel::ipc;
 use script_traits::ScriptMsg;
+use style_traits::{CSSPixel, DevicePixel};
 
 #[dom_struct]
 pub struct Screen {
@@ -35,18 +36,22 @@ impl Screen {
                            ScreenBinding::Wrap)
     }
 
-    fn screen_size(&self) -> Size2D<u32> {
-        let (send, recv) = ipc::channel::<(Size2D<u32>)>().unwrap();
+    fn screen_size(&self) -> TypedSize2D<u32, CSSPixel> {
+        let (send, recv) = ipc::channel::<(TypedSize2D<u32, DevicePixel>)>().unwrap();
         self.window.upcast::<GlobalScope>()
             .script_to_constellation_chan().send(ScriptMsg::GetScreenSize(send)).unwrap();
-        recv.recv().unwrap_or(Size2D::zero())
+        let dpr = self.window.device_pixel_ratio();
+        let screen = recv.recv().unwrap_or(TypedSize2D::zero());
+        (screen.to_f32() / dpr).to_u32()
     }
 
-    fn screen_avail_size(&self) -> Size2D<u32> {
-        let (send, recv) = ipc::channel::<(Size2D<u32>)>().unwrap();
+    fn screen_avail_size(&self) -> TypedSize2D<u32, CSSPixel> {
+        let (send, recv) = ipc::channel::<(TypedSize2D<u32, DevicePixel>)>().unwrap();
         self.window.upcast::<GlobalScope>()
             .script_to_constellation_chan().send(ScriptMsg::GetScreenAvailSize(send)).unwrap();
-        recv.recv().unwrap_or(Size2D::zero())
+        let dpr = self.window.device_pixel_ratio();
+        let screen = recv.recv().unwrap_or(TypedSize2D::zero());
+        (screen.to_f32() / dpr).to_u32()
     }
 }
 

--- a/components/script/dom/screen.rs
+++ b/components/script/dom/screen.rs
@@ -14,7 +14,8 @@ use dom_struct::dom_struct;
 use euclid::TypedSize2D;
 use ipc_channel::ipc;
 use script_traits::ScriptMsg;
-use style_traits::{CSSPixel, DevicePixel};
+use style_traits::CSSPixel;
+use webrender_api::DeviceUintSize;
 
 #[dom_struct]
 pub struct Screen {
@@ -37,7 +38,7 @@ impl Screen {
     }
 
     fn screen_size(&self) -> TypedSize2D<u32, CSSPixel> {
-        let (send, recv) = ipc::channel::<(TypedSize2D<u32, DevicePixel>)>().unwrap();
+        let (send, recv) = ipc::channel::<DeviceUintSize>().unwrap();
         self.window.upcast::<GlobalScope>()
             .script_to_constellation_chan().send(ScriptMsg::GetScreenSize(send)).unwrap();
         let dpr = self.window.device_pixel_ratio();
@@ -46,7 +47,7 @@ impl Screen {
     }
 
     fn screen_avail_size(&self) -> TypedSize2D<u32, CSSPixel> {
-        let (send, recv) = ipc::channel::<(TypedSize2D<u32, DevicePixel>)>().unwrap();
+        let (send, recv) = ipc::channel::<DeviceUintSize>().unwrap();
         self.window.upcast::<GlobalScope>()
             .script_to_constellation_chan().send(ScriptMsg::GetScreenAvailSize(send)).unwrap();
         let dpr = self.window.device_pixel_ratio();

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -48,7 +48,7 @@ use dom::windowproxy::WindowProxy;
 use dom::worklet::Worklet;
 use dom::workletglobalscope::WorkletGlobalScopeType;
 use dom_struct::dom_struct;
-use euclid::{Point2D, Vector2D, Rect, Size2D};
+use euclid::{Point2D, Vector2D, Rect, Size2D, TypedPoint2D, TypedScale, TypedSize2D};
 use fetch;
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
@@ -102,7 +102,7 @@ use style::properties::{ComputedValues, PropertyId};
 use style::selector_parser::PseudoElement;
 use style::str::HTML_SPACE_CHARACTERS;
 use style::stylesheets::CssRuleType;
-use style_traits::ParsingMode;
+use style_traits::{CSSPixel, DevicePixel, ParsingMode};
 use task::TaskCanceller;
 use task_source::dom_manipulation::DOMManipulationTaskSource;
 use task_source::file_reading::FileReadingTaskSource;
@@ -930,11 +930,12 @@ impl WindowMethods for Window {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-window-resizeto
-    fn ResizeTo(&self, x: i32, y: i32) {
+    fn ResizeTo(&self, width: i32, height: i32) {
         // Step 1
         //TODO determine if this operation is allowed
-        let size = Size2D::new(x.to_u32().unwrap_or(1), y.to_u32().unwrap_or(1));
-        self.send_to_constellation(ScriptMsg::ResizeTo(size));
+        let dpr = self.device_pixel_ratio();
+        let size = TypedSize2D::new(width, height).to_f32() * dpr;
+        self.send_to_constellation(ScriptMsg::ResizeTo(size.to_u32()));
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-window-resizeby
@@ -948,8 +949,9 @@ impl WindowMethods for Window {
     fn MoveTo(&self, x: i32, y: i32) {
         // Step 1
         //TODO determine if this operation is allowed
-        let point = Point2D::new(x, y);
-        self.send_to_constellation(ScriptMsg::MoveTo(point));
+        let dpr = self.device_pixel_ratio();
+        let point = TypedPoint2D::new(x, y).to_f32() * dpr;
+        self.send_to_constellation(ScriptMsg::MoveTo(point.to_i32()));
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-window-moveby
@@ -985,8 +987,7 @@ impl WindowMethods for Window {
 
     // https://drafts.csswg.org/cssom-view/#dom-window-devicepixelratio
     fn DevicePixelRatio(&self) -> Finite<f64> {
-        let dpr = self.window_size.get().map_or(1.0f32, |data| data.device_pixel_ratio.get());
-        Finite::wrap(dpr as f64)
+        Finite::wrap(self.device_pixel_ratio().get() as f64)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-window-status
@@ -1174,10 +1175,16 @@ impl Window {
         self.current_viewport.set(new_viewport)
     }
 
-    pub fn client_window(&self) -> (Size2D<u32>, Point2D<i32>) {
-        let (send, recv) = ipc::channel::<(Size2D<u32>, Point2D<i32>)>().unwrap();
+    pub fn device_pixel_ratio(&self) -> TypedScale<f32, CSSPixel, DevicePixel> {
+        self.window_size.get().map_or(TypedScale::new(1.0), |data| data.device_pixel_ratio)
+    }
+
+    fn client_window(&self) -> (TypedSize2D<u32, CSSPixel>, TypedPoint2D<i32, CSSPixel>) {
+        let (send, recv) = ipc::channel::<(TypedSize2D<u32, DevicePixel>, TypedPoint2D<i32, DevicePixel>)>().unwrap();
         self.send_to_constellation(ScriptMsg::GetClientWindow(send));
-        recv.recv().unwrap_or((Size2D::zero(), Point2D::zero()))
+        let (size, point) = recv.recv().unwrap_or((TypedSize2D::zero(), TypedPoint2D::zero()));
+        let dpr = self.device_pixel_ratio();
+        ((size.to_f32() / dpr).to_u32(), (point.to_f32() / dpr).to_i32())
     }
 
     /// Advances the layout animation clock by `delta` milliseconds, and then

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -116,7 +116,7 @@ use timers::{IsInterval, TimerCallback};
 use tinyfiledialogs::{self, MessageBoxIcon};
 use url::Position;
 use webdriver_handlers::jsval_to_webdriver;
-use webrender_api::{ExternalScrollId, DocumentId};
+use webrender_api::{ExternalScrollId, DeviceIntPoint, DeviceUintSize, DocumentId};
 use webvr_traits::WebVRMsg;
 
 /// Current state of the window object
@@ -1180,7 +1180,7 @@ impl Window {
     }
 
     fn client_window(&self) -> (TypedSize2D<u32, CSSPixel>, TypedPoint2D<i32, CSSPixel>) {
-        let (send, recv) = ipc::channel::<(TypedSize2D<u32, DevicePixel>, TypedPoint2D<i32, DevicePixel>)>().unwrap();
+        let (send, recv) = ipc::channel::<(DeviceUintSize, DeviceIntPoint)>().unwrap();
         self.send_to_constellation(ScriptMsg::GetClientWindow(send));
         let (size, point) = recv.recv().unwrap_or((TypedSize2D::zero(), TypedPoint2D::zero()));
         let dpr = self.device_pixel_ratio();

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -41,7 +41,7 @@ pub mod webdriver_msg;
 use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::WebGLPipeline;
 use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, WorkerId};
-use euclid::{Size2D, Length, Point2D, Vector2D, Rect, TypedScale, TypedSize2D};
+use euclid::{Length, Point2D, Vector2D, Rect, TypedSize2D, TypedScale};
 use gfx_traits::Epoch;
 use hyper::header::Headers;
 use hyper::method::Method;
@@ -650,7 +650,7 @@ pub enum WebDriverCommandMsg {
     /// Act as if keys were pressed in the browsing context with the given ID.
     SendKeys(BrowsingContextId, Vec<(Key, KeyModifiers, KeyState)>),
     /// Set the window size.
-    SetWindowSize(TopLevelBrowsingContextId, Size2D<u32>, IpcSender<WindowSizeData>),
+    SetWindowSize(TopLevelBrowsingContextId, TypedSize2D<u32, DevicePixel>, IpcSender<WindowSizeData>),
     /// Take a screenshot of the window.
     TakeScreenshot(TopLevelBrowsingContextId, IpcSender<Option<Image>>),
 }

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -69,7 +69,7 @@ use style_traits::CSSPixel;
 use style_traits::SpeculativePainter;
 use style_traits::cursor::CursorKind;
 use webdriver_msg::{LoadStatus, WebDriverScriptCommand};
-use webrender_api::{ExternalScrollId, DevicePixel, DocumentId, ImageKey};
+use webrender_api::{ExternalScrollId, DevicePixel, DeviceUintSize, DocumentId, ImageKey};
 use webvr_traits::{WebVREvent, WebVRMsg};
 
 pub use script_msg::{LayoutMsg, ScriptMsg, EventResult, LogEntry};
@@ -650,7 +650,7 @@ pub enum WebDriverCommandMsg {
     /// Act as if keys were pressed in the browsing context with the given ID.
     SendKeys(BrowsingContextId, Vec<(Key, KeyModifiers, KeyState)>),
     /// Set the window size.
-    SetWindowSize(TopLevelBrowsingContextId, TypedSize2D<u32, DevicePixel>, IpcSender<WindowSizeData>),
+    SetWindowSize(TopLevelBrowsingContextId, DeviceUintSize, IpcSender<WindowSizeData>),
     /// Take a screenshot of the window.
     TakeScreenshot(TopLevelBrowsingContextId, IpcSender<Option<Image>>),
 }

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -13,7 +13,7 @@ use WorkerGlobalScopeInit;
 use WorkerScriptLoadOrigin;
 use canvas_traits::canvas::CanvasMsg;
 use devtools_traits::{ScriptToDevtoolsControlMsg, WorkerId};
-use euclid::{Size2D, TypedPoint2D, TypedSize2D};
+use euclid::{Size2D, TypedSize2D};
 use gfx_traits::Epoch;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use msg::constellation_msg::{BrowsingContextId, PipelineId, TraversalDirection};
@@ -23,9 +23,10 @@ use net_traits::request::RequestInit;
 use net_traits::storage_thread::StorageType;
 use servo_url::ImmutableOrigin;
 use servo_url::ServoUrl;
-use style_traits::{DevicePixel, CSSPixel};
+use style_traits::CSSPixel;
 use style_traits::cursor::CursorKind;
 use style_traits::viewport::ViewportConstraints;
+use webrender_api::{DeviceIntPoint, DeviceUintSize};
 
 /// Messages from the layout to the constellation.
 #[derive(Deserialize, Serialize)]
@@ -136,11 +137,11 @@ pub enum ScriptMsg {
     /// Send a key event
     SendKeyEvent(Option<char>, Key, KeyState, KeyModifiers),
     /// Get Window Informations size and position
-    GetClientWindow(IpcSender<(TypedSize2D<u32, DevicePixel>, TypedPoint2D<i32, DevicePixel>)>),
+    GetClientWindow(IpcSender<(DeviceUintSize, DeviceIntPoint)>),
     /// Move the window to a point
-    MoveTo(TypedPoint2D<i32, DevicePixel>),
+    MoveTo(DeviceIntPoint),
     /// Resize the window to size
-    ResizeTo(TypedSize2D<u32, DevicePixel>),
+    ResizeTo(DeviceUintSize),
     /// Script has handled a touch event, and either prevented or allowed default actions.
     TouchEventProcessed(EventResult),
     /// A log entry, with the top-level browsing context id and thread name
@@ -155,9 +156,9 @@ pub enum ScriptMsg {
     /// Enter or exit fullscreen
     SetFullscreenState(bool),
     /// Get the screen size (pixel)
-    GetScreenSize(IpcSender<(TypedSize2D<u32, DevicePixel>)>),
+    GetScreenSize(IpcSender<(DeviceUintSize)>),
     /// Get the available screen size (pixel)
-    GetScreenAvailSize(IpcSender<(TypedSize2D<u32, DevicePixel>)>),
+    GetScreenAvailSize(IpcSender<(DeviceUintSize)>),
     /// Requests that the compositor shut down.
     Exit,
 }

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -13,7 +13,7 @@ use WorkerGlobalScopeInit;
 use WorkerScriptLoadOrigin;
 use canvas_traits::canvas::CanvasMsg;
 use devtools_traits::{ScriptToDevtoolsControlMsg, WorkerId};
-use euclid::{Point2D, Size2D, TypedSize2D};
+use euclid::{Size2D, TypedPoint2D, TypedSize2D};
 use gfx_traits::Epoch;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use msg::constellation_msg::{BrowsingContextId, PipelineId, TraversalDirection};
@@ -23,7 +23,7 @@ use net_traits::request::RequestInit;
 use net_traits::storage_thread::StorageType;
 use servo_url::ImmutableOrigin;
 use servo_url::ServoUrl;
-use style_traits::CSSPixel;
+use style_traits::{DevicePixel, CSSPixel};
 use style_traits::cursor::CursorKind;
 use style_traits::viewport::ViewportConstraints;
 
@@ -136,11 +136,11 @@ pub enum ScriptMsg {
     /// Send a key event
     SendKeyEvent(Option<char>, Key, KeyState, KeyModifiers),
     /// Get Window Informations size and position
-    GetClientWindow(IpcSender<(Size2D<u32>, Point2D<i32>)>),
+    GetClientWindow(IpcSender<(TypedSize2D<u32, DevicePixel>, TypedPoint2D<i32, DevicePixel>)>),
     /// Move the window to a point
-    MoveTo(Point2D<i32>),
+    MoveTo(TypedPoint2D<i32, DevicePixel>),
     /// Resize the window to size
-    ResizeTo(Size2D<u32>),
+    ResizeTo(TypedSize2D<u32, DevicePixel>),
     /// Script has handled a touch event, and either prevented or allowed default actions.
     TouchEventProcessed(EventResult),
     /// A log entry, with the top-level browsing context id and thread name
@@ -155,9 +155,9 @@ pub enum ScriptMsg {
     /// Enter or exit fullscreen
     SetFullscreenState(bool),
     /// Get the screen size (pixel)
-    GetScreenSize(IpcSender<(Size2D<u32>)>),
+    GetScreenSize(IpcSender<(TypedSize2D<u32, DevicePixel>)>),
     /// Get the available screen size (pixel)
-    GetScreenAvailSize(IpcSender<(Size2D<u32>)>),
+    GetScreenAvailSize(IpcSender<(TypedSize2D<u32, DevicePixel>)>),
     /// Requests that the compositor shut down.
     Exit,
 }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -81,6 +81,7 @@ use constellation::{FromCompositorLogger, FromScriptLogger};
 #[cfg(all(not(target_os = "windows"), not(target_os = "ios")))]
 use constellation::content_process_sandbox_profile;
 use env_logger::Logger as EnvLogger;
+use euclid::Length;
 #[cfg(all(not(target_os = "windows"), not(target_os = "ios")))]
 use gaol::sandbox::{ChildSandbox, ChildSandboxMethods};
 use gfx::font_cache_thread::FontCacheThread;
@@ -133,7 +134,7 @@ impl<Window> Servo<Window> where Window: WindowMethods + 'static {
         let opts = opts::get();
 
         // Make sure the gl context is made current.
-        window.prepare_for_composite(0, 0);
+        window.prepare_for_composite(Length::new(0), Length::new(0));
 
         // Get both endpoints of a special channel for communication between
         // the client window and the compositor. This channel is unique because

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -27,7 +27,7 @@ extern crate webdriver;
 
 mod keys;
 
-use euclid::Size2D;
+use euclid::TypedSize2D;
 use hyper::method::Method::{self, Post};
 use image::{DynamicImage, ImageFormat, RgbImage};
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
@@ -418,7 +418,7 @@ impl Handler {
             Nullable::Value(v) => v,
             Nullable::Null => 0,
         };
-        let size = Size2D::new(width as u32, height as u32);
+        let size = TypedSize2D::new(width as u32, height as u32);
         let top_level_browsing_context_id = self.session()?.top_level_browsing_context_id;
         let cmd_msg = WebDriverCommandMsg::SetWindowSize(top_level_browsing_context_id, size, sender.clone());
 

--- a/ports/servo/glutin_app/window.rs
+++ b/ports/servo/glutin_app/window.rs
@@ -40,7 +40,7 @@ use style_traits::cursor::CursorKind;
 use tinyfiledialogs;
 #[cfg(target_os = "windows")]
 use user32;
-use webrender_api::{DeviceUintRect, DeviceUintSize, ScrollLocation};
+use webrender_api::{DeviceIntPoint, DeviceUintRect, DeviceUintSize, ScrollLocation};
 #[cfg(target_os = "windows")]
 use winapi;
 use winit;
@@ -222,8 +222,7 @@ impl Window {
 
     pub fn new(is_foreground: bool,
                window_size: TypedSize2D<u32, DeviceIndependentPixel>) -> Rc<Window> {
-        let win_size: TypedSize2D<u32, DevicePixel> =
-            (window_size.to_f32() * window_creation_scale_factor()).to_u32();
+        let win_size: DeviceUintSize = (window_size.to_f32() * window_creation_scale_factor()).to_u32();
         let width = win_size.to_untyped().width;
         let height = win_size.to_untyped().height;
 
@@ -882,7 +881,7 @@ impl WindowMethods for Window {
         self.inner_size.get().to_f32() * self.hidpi_factor()
     }
 
-    fn client_window(&self, _: BrowserId) -> (TypedSize2D<u32, DevicePixel>, TypedPoint2D<i32, DevicePixel>) {
+    fn client_window(&self, _: BrowserId) -> (DeviceUintSize, DeviceIntPoint) {
         let (size, point) = match self.kind {
             WindowKind::Window(ref window, ..) => {
                 // TODO(ajeffrey): can this fail?
@@ -903,11 +902,11 @@ impl WindowMethods for Window {
         ((size * dpr).to_u32(), (point * dpr).to_i32())
     }
 
-    fn screen_size(&self, _: BrowserId) -> TypedSize2D<u32, DevicePixel> {
+    fn screen_size(&self, _: BrowserId) -> DeviceUintSize {
         (self.screen_size.to_f32() * self.hidpi_factor()).to_u32()
     }
 
-    fn screen_avail_size(&self, browser_id: BrowserId) -> TypedSize2D<u32, DevicePixel> {
+    fn screen_avail_size(&self, browser_id: BrowserId) -> DeviceUintSize {
         // FIXME: Glutin doesn't have API for available size. Fallback to screen size
         self.screen_size(browser_id)
     }
@@ -916,7 +915,7 @@ impl WindowMethods for Window {
         self.animation_state.set(state);
     }
 
-    fn set_inner_size(&self, _: BrowserId, size: TypedSize2D<u32, DevicePixel>) {
+    fn set_inner_size(&self, _: BrowserId, size: DeviceUintSize) {
         match self.kind {
             WindowKind::Window(ref window, ..) => {
                 let size = size.to_f32() / self.hidpi_factor();
@@ -926,7 +925,7 @@ impl WindowMethods for Window {
         }
     }
 
-    fn set_position(&self, _: BrowserId, point: TypedPoint2D<i32, DevicePixel>) {
+    fn set_position(&self, _: BrowserId, point: DeviceIntPoint) {
         match self.kind {
             WindowKind::Window(ref window, ..) => {
                 let point = point.to_f32() / self.hidpi_factor();

--- a/ports/servo/glutin_app/window.rs
+++ b/ports/servo/glutin_app/window.rs
@@ -868,17 +868,13 @@ impl WindowMethods for Window {
     }
 
     fn framebuffer_size(&self) -> DeviceUintSize {
-        self.size().to_u32()
+        (self.inner_size.get().to_f32() * self.hidpi_factor()).to_u32()
     }
 
     fn window_rect(&self) -> DeviceUintRect {
         let size = self.framebuffer_size();
         let origin = TypedPoint2D::zero();
         DeviceUintRect::new(origin, size)
-    }
-
-    fn size(&self) -> TypedSize2D<f32, DevicePixel> {
-        self.inner_size.get().to_f32() * self.hidpi_factor()
     }
 
     fn client_window(&self, _: BrowserId) -> (DeviceUintSize, DeviceIntPoint) {

--- a/ports/servo/glutin_app/window.rs
+++ b/ports/servo/glutin_app/window.rs
@@ -7,7 +7,7 @@
 use compositing::compositor_thread::EventLoopWaker;
 use compositing::windowing::{AnimationState, MouseWindowEvent, WindowEvent};
 use compositing::windowing::{WebRenderDebugOption, WindowMethods};
-use euclid::{Point2D, Size2D, TypedPoint2D, TypedVector2D, TypedScale, TypedSize2D};
+use euclid::{Length, TypedPoint2D, TypedVector2D, TypedScale, TypedSize2D};
 #[cfg(target_os = "windows")]
 use gdi32;
 use gleam::gl;
@@ -177,18 +177,18 @@ enum WindowKind {
 /// The type of a window.
 pub struct Window {
     kind: WindowKind,
-    screen_size: Size2D<u32>,
+    screen_size: TypedSize2D<u32, DeviceIndependentPixel>,
     inner_size: Cell<TypedSize2D<u32, DeviceIndependentPixel>>,
 
     mouse_down_button: Cell<Option<winit::MouseButton>>,
-    mouse_down_point: Cell<Point2D<i32>>,
+    mouse_down_point: Cell<TypedPoint2D<i32, DeviceIndependentPixel>>,
     event_queue: RefCell<Vec<WindowEvent>>,
 
     /// id of the top level browsing context. It is unique as tabs
     /// are not supported yet. None until created.
     browser_id: Cell<Option<BrowserId>>,
 
-    mouse_pos: Cell<Point2D<i32>>,
+    mouse_pos: Cell<TypedPoint2D<i32, DeviceIndependentPixel>>,
     key_modifiers: Cell<GlutinKeyModifiers>,
     current_url: RefCell<Option<ServoUrl>>,
 
@@ -223,8 +223,7 @@ impl Window {
     pub fn new(is_foreground: bool,
                window_size: TypedSize2D<u32, DeviceIndependentPixel>) -> Rc<Window> {
         let win_size: TypedSize2D<u32, DevicePixel> =
-            (window_size.to_f32() * window_creation_scale_factor())
-                .to_usize().cast().expect("Window size should fit in u32");
+            (window_size.to_f32() * window_creation_scale_factor()).to_u32();
         let width = win_size.to_untyped().width;
         let height = win_size.to_untyped().height;
 
@@ -237,7 +236,7 @@ impl Window {
         let screen_size;
         let inner_size;
         let window_kind = if opts::get().headless {
-            screen_size = Size2D::new(width, height);
+            screen_size = TypedSize2D::new(width, height);
             inner_size = TypedSize2D::new(width, height);
             WindowKind::Headless(HeadlessContext::new(width, height))
         } else {
@@ -268,7 +267,7 @@ impl Window {
             }
 
             let (screen_width, screen_height) = events_loop.get_primary_monitor().get_dimensions();
-            screen_size = Size2D::new(screen_width, screen_height);
+            screen_size = TypedSize2D::new(screen_width, screen_height);
             // TODO(ajeffrey): can this fail?
             let (width, height) = glutin_window.get_inner_size().expect("Failed to get window inner size.");
             inner_size = TypedSize2D::new(width, height);
@@ -316,11 +315,11 @@ impl Window {
             kind: window_kind,
             event_queue: RefCell::new(vec!()),
             mouse_down_button: Cell::new(None),
-            mouse_down_point: Cell::new(Point2D::new(0, 0)),
+            mouse_down_point: Cell::new(TypedPoint2D::new(0, 0)),
 
             browser_id: Cell::new(None),
 
-            mouse_pos: Cell::new(Point2D::new(0, 0)),
+            mouse_pos: Cell::new(TypedPoint2D::new(0, 0)),
             key_modifiers: Cell::new(GlutinKeyModifiers::empty()),
             current_url: RefCell::new(None),
 
@@ -422,8 +421,7 @@ impl Window {
                 }, ..
             } => {
                 if button == MouseButton::Left || button == MouseButton::Right {
-                    let mouse_pos = self.mouse_pos.get();
-                    self.handle_mouse(button, state, mouse_pos.x, mouse_pos.y);
+                    self.handle_mouse(button, state, self.mouse_pos.get());
                 }
             },
             Event::WindowEvent {
@@ -433,7 +431,7 @@ impl Window {
                 },
                 ..
             } => {
-                self.mouse_pos.set(Point2D::new(x as i32, y as i32));
+                self.mouse_pos.set(TypedPoint2D::new(x as i32, y as i32));
                 self.event_queue.borrow_mut().push(
                     WindowEvent::MouseWindowMoveEventClass(TypedPoint2D::new(x as f32, y as f32)));
             }
@@ -481,7 +479,7 @@ impl Window {
                 }
                 // window.set_inner_size() takes DeviceIndependentPixel.
                 let new_size = TypedSize2D::new(width as f32, height as f32);
-                let new_size = (new_size / self.hidpi_factor()).cast().expect("Window size should fit in u32");
+                let new_size = (new_size / self.hidpi_factor()).to_u32();
                 if self.inner_size.get() != new_size {
                     self.inner_size.set(new_size);
                     self.event_queue.borrow_mut().push(WindowEvent::Resize);
@@ -518,37 +516,37 @@ impl Window {
             }
         }
 
-        let mouse_pos = self.mouse_pos.get();
-        let event = WindowEvent::Scroll(scroll_location,
-                                        TypedPoint2D::new(mouse_pos.x as i32, mouse_pos.y as i32),
-                                        phase);
+        let pos = self.mouse_pos.get().to_f32() * self.hidpi_factor();
+        let event = WindowEvent::Scroll(scroll_location, pos.to_i32(), phase);
         self.event_queue.borrow_mut().push(event);
     }
 
     /// Helper function to handle a click
-    fn handle_mouse(&self, button: winit::MouseButton, action: winit::ElementState, x: i32, y: i32) {
+    fn handle_mouse(&self, button: winit::MouseButton,
+                    action: winit::ElementState,
+                    coords: TypedPoint2D<i32, DeviceIndependentPixel>) {
         use script_traits::MouseButton;
 
         // FIXME(tkuehn): max pixel dist should be based on pixel density
         let max_pixel_dist = 10f64;
+        let scaled_coords = coords.to_f32() * self.hidpi_factor();
         let event = match action {
             ElementState::Pressed => {
-                self.mouse_down_point.set(Point2D::new(x, y));
+                self.mouse_down_point.set(coords);
                 self.mouse_down_button.set(Some(button));
-                MouseWindowEvent::MouseDown(MouseButton::Left, TypedPoint2D::new(x as f32, y as f32))
+                MouseWindowEvent::MouseDown(MouseButton::Left, scaled_coords)
             }
             ElementState::Released => {
-                let mouse_up_event = MouseWindowEvent::MouseUp(MouseButton::Left,
-                                                               TypedPoint2D::new(x as f32, y as f32));
+                let mouse_up_event = MouseWindowEvent::MouseUp(MouseButton::Left, scaled_coords);
                 match self.mouse_down_button.get() {
                     None => mouse_up_event,
                     Some(but) if button == but => {
-                        let pixel_dist = self.mouse_down_point.get() - Point2D::new(x, y);
+                        let pixel_dist = self.mouse_down_point.get() - coords;
                         let pixel_dist = ((pixel_dist.x * pixel_dist.x +
                                            pixel_dist.y * pixel_dist.y) as f64).sqrt();
                         if pixel_dist < max_pixel_dist {
                             self.event_queue.borrow_mut().push(WindowEvent::MouseWindowEventClass(mouse_up_event));
-                            MouseWindowEvent::Click(MouseButton::Left, TypedPoint2D::new(x as f32, y as f32))
+                            MouseWindowEvent::Click(MouseButton::Left, scaled_coords)
                         } else {
                             mouse_up_event
                         }
@@ -871,7 +869,7 @@ impl WindowMethods for Window {
     }
 
     fn framebuffer_size(&self) -> DeviceUintSize {
-        (self.inner_size.get().to_f32() * self.hidpi_factor()).to_usize().cast().expect("Window size should fit in u32")
+        self.size().to_u32()
     }
 
     fn window_rect(&self) -> DeviceUintRect {
@@ -880,34 +878,36 @@ impl WindowMethods for Window {
         DeviceUintRect::new(origin, size)
     }
 
-    fn size(&self) -> TypedSize2D<f32, DeviceIndependentPixel> {
-        self.inner_size.get().to_f32()
+    fn size(&self) -> TypedSize2D<f32, DevicePixel> {
+        self.inner_size.get().to_f32() * self.hidpi_factor()
     }
 
-    fn client_window(&self, _: BrowserId) -> (Size2D<u32>, Point2D<i32>) {
-        match self.kind {
+    fn client_window(&self, _: BrowserId) -> (TypedSize2D<u32, DevicePixel>, TypedPoint2D<i32, DevicePixel>) {
+        let (size, point) = match self.kind {
             WindowKind::Window(ref window, ..) => {
                 // TODO(ajeffrey): can this fail?
                 let (width, height) = window.get_outer_size().expect("Failed to get window outer size.");
-                let size = Size2D::new(width, height);
+                let size = TypedSize2D::new(width as f32, height as f32);
                 // TODO(ajeffrey): can this fail?
                 let (x, y) = window.get_position().expect("Failed to get window position.");
-                let origin = Point2D::new(x as i32, y as i32);
+                let origin = TypedPoint2D::new(x as f32, y as f32);
                 (size, origin)
             }
             WindowKind::Headless(ref context) => {
-                let size = TypedSize2D::new(context.width, context.height);
-                (size, Point2D::zero())
+                let size = TypedSize2D::new(context.width as f32, context.height as f32);
+                let origin = TypedPoint2D::zero();
+                (size, origin)
             }
-        }
-
+        };
+        let dpr = self.hidpi_factor();
+        ((size * dpr).to_u32(), (point * dpr).to_i32())
     }
 
-    fn screen_size(&self, _: BrowserId) -> Size2D<u32> {
-        self.screen_size
+    fn screen_size(&self, _: BrowserId) -> TypedSize2D<u32, DevicePixel> {
+        (self.screen_size.to_f32() * self.hidpi_factor()).to_u32()
     }
 
-    fn screen_avail_size(&self, browser_id: BrowserId) -> Size2D<u32> {
+    fn screen_avail_size(&self, browser_id: BrowserId) -> TypedSize2D<u32, DevicePixel> {
         // FIXME: Glutin doesn't have API for available size. Fallback to screen size
         self.screen_size(browser_id)
     }
@@ -916,19 +916,21 @@ impl WindowMethods for Window {
         self.animation_state.set(state);
     }
 
-    fn set_inner_size(&self, _: BrowserId, size: Size2D<u32>) {
+    fn set_inner_size(&self, _: BrowserId, size: TypedSize2D<u32, DevicePixel>) {
         match self.kind {
             WindowKind::Window(ref window, ..) => {
+                let size = size.to_f32() / self.hidpi_factor();
                 window.set_inner_size(size.width as u32, size.height as u32)
             }
             WindowKind::Headless(..) => {}
         }
     }
 
-    fn set_position(&self, _: BrowserId, point: Point2D<i32>) {
+    fn set_position(&self, _: BrowserId, point: TypedPoint2D<i32, DevicePixel>) {
         match self.kind {
             WindowKind::Window(ref window, ..) => {
-                window.set_position(point.x, point.y)
+                let point = point.to_f32() / self.hidpi_factor();
+                window.set_position(point.x as i32, point.y as i32)
             }
             WindowKind::Headless(..) => {}
         }
@@ -1112,7 +1114,7 @@ impl WindowMethods for Window {
     fn set_favicon(&self, _: BrowserId, _: ServoUrl) {
     }
 
-    fn prepare_for_composite(&self, _width: usize, _height: usize) -> bool {
+    fn prepare_for_composite(&self, _width: Length<u32, DevicePixel>, _height: Length<u32, DevicePixel>) -> bool {
         true
     }
 


### PR DESCRIPTION
Requires https://github.com/servo/servo/pull/19895

We use Size2D and Point2D across compositing, constellation and script, loosing the type of pixels we use (DevicePixel, DeviceIndepententPixel or CSSPixel) along the way, which might lead to bugs like `window.outerHeight` not taking into account the page zoom (using DeviceIndepententPixel instead of CSSPixel).

This should make the situation a bit better.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because we can't zoom in a test

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20071)
<!-- Reviewable:end -->
