### PR TITLE
Use a false value that is valid Python, not just JSON.

### DIFF
--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servo.py
@@ -54,7 +54,7 @@ def env_extras(**kwargs):
 def env_options():
     return {"host": "127.0.0.1",
             "external_host": "web-platform.test",
-            "bind_hostname": "false",
+            "bind_hostname": False,
             "testharnessreport": "testharnessreport-servo.js",
             "supports_debugger": True}
 


### PR DESCRIPTION
https://github.com/w3c/web-platform-tests/commit/cb2d75fd13182ab3bdd7189dafe2ff7bbf4acd56 makes this dictionary be interpreted as Python values, not interpolated via JSON.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20076)
<!-- Reviewable:end -->
