### PR TITLE
Fix license metadata for servo_arc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
  "nsstring 0.1.0",
  "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.19.0",
- "servo_arc 0.1.0",
+ "servo_arc 0.1.1",
  "smallvec 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
@@ -1004,7 +1004,7 @@ dependencies = [
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-fontconfig 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_allocator 0.0.1",
- "servo_arc 0.1.0",
+ "servo_arc 0.1.1",
  "servo_atoms 0.0.1",
  "servo_geometry 0.0.1",
  "servo_url 0.0.1",
@@ -1369,7 +1369,7 @@ dependencies = [
  "selectors 0.19.0",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "servo_arc 0.1.0",
+ "servo_arc 0.1.1",
  "servo_atoms 0.0.1",
  "servo_config 0.0.1",
  "servo_geometry 0.0.1",
@@ -1415,7 +1415,7 @@ dependencies = [
  "selectors 0.19.0",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_allocator 0.0.1",
- "servo_arc 0.1.0",
+ "servo_arc 0.1.1",
  "servo_atoms 0.0.1",
  "servo_config 0.0.1",
  "servo_geometry 0.0.1",
@@ -1568,7 +1568,7 @@ dependencies = [
  "hashglobe 0.1.0",
  "mozjs 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.19.0",
- "servo_arc 0.1.0",
+ "servo_arc 0.1.1",
  "smallbitvec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1592,7 +1592,7 @@ name = "malloc_size_of_tests"
 version = "0.0.1"
 dependencies = [
  "malloc_size_of 0.0.1",
- "servo_arc 0.1.0",
+ "servo_arc 0.1.1",
 ]
 
 [[package]]
@@ -2415,7 +2415,7 @@ dependencies = [
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_allocator 0.0.1",
- "servo_arc 0.1.0",
+ "servo_arc 0.1.1",
  "servo_atoms 0.0.1",
  "servo_config 0.0.1",
  "servo_geometry 0.0.1",
@@ -2459,7 +2459,7 @@ dependencies = [
  "range 0.0.1",
  "script_traits 0.0.1",
  "selectors 0.19.0",
- "servo_arc 0.1.0",
+ "servo_arc 0.1.1",
  "servo_atoms 0.0.1",
  "servo_url 0.0.1",
  "style 0.0.1",
@@ -2530,7 +2530,7 @@ dependencies = [
  "phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "servo_arc 0.1.0",
+ "servo_arc 0.1.1",
  "smallvec 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "servo_arc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2928,7 +2928,7 @@ dependencies = [
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.19.0",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "servo_arc 0.1.0",
+ "servo_arc 0.1.1",
  "servo_atoms 0.0.1",
  "servo_config 0.0.1",
  "servo_url 0.0.1",
@@ -2969,7 +2969,7 @@ dependencies = [
  "rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.19.0",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "servo_arc 0.1.0",
+ "servo_arc 0.1.1",
  "servo_atoms 0.0.1",
  "servo_config 0.0.1",
  "servo_url 0.0.1",
@@ -2990,7 +2990,7 @@ dependencies = [
  "malloc_size_of_derive 0.0.1",
  "selectors 0.19.0",
  "serde 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "servo_arc 0.1.0",
+ "servo_arc 0.1.1",
  "servo_atoms 0.0.1",
  "webrender_api 0.57.0 (git+https://github.com/servo/webrender)",
 ]

--- a/components/servo_arc/Cargo.toml
+++ b/components/servo_arc/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "servo_arc"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The Servo Project Developers"]
-license = "MPL-2.0"
+license = "MIT/Apache-2.0"
 repository = "https://github.com/servo/servo"
 description = "A fork of std::sync::Arc with some extra functionality and without weak references"
 


### PR DESCRIPTION
The header in lib.rs states that this library is MIT / Apache-2.0, since it is forked from the Rust standard library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20088)
<!-- Reviewable:end -->
