### PR TITLE
Set CARGO_HOME for Windows builders.

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -189,6 +189,9 @@ arm64:
   - bash ./etc/ci/manifest_changed.sh
 
 windows-msvc-dev:
+  env:
+    CARGO_HOME: C:\buildbot\.cargo
+  commands:
   - mach.bat clean-cargo-cache --keep 3 --force
   - mach.bat clean-nightlies --keep 3 --force
   - mach.bat build --dev
@@ -198,6 +201,9 @@ windows-msvc-dev:
   - mach.bat test-stylo
 
 windows-msvc-nightly:
+  env:
+    CARGO_HOME: C:\buildbot\.cargo
+  commands:
   - mach.bat clean-cargo-cache --keep 3 --force
   - mach.bat clean-nightlies --keep 3 --force
   - mach.bat build --release


### PR DESCRIPTION
This is a temporary fix to allow reopening the tree. This value belongs in saltfs instead, but it's already late and I don't want to have to wait to deploy the changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20095)
<!-- Reviewable:end -->
