### PR TITLE
Make FontTemplateData's Debug formatter more concise

### DIFF
--- a/components/gfx/platform/freetype/font_template.rs
+++ b/components/gfx/platform/freetype/font_template.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use servo_atoms::Atom;
+use std::fmt;
 use std::fs::File;
 use std::io::{Read, Error};
 use webrender_api::NativeFontHandle;
@@ -11,10 +12,21 @@ use webrender_api::NativeFontHandle;
 /// The identifier is an absolute path, and the bytes
 /// field is the loaded data that can be passed to
 /// freetype and azure directly.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct FontTemplateData {
+    // If you add members here, review the Debug impl below
+
     pub bytes: Vec<u8>,
     pub identifier: Atom,
+}
+
+impl fmt::Debug for FontTemplateData {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("FontTemplateData")
+           .field("bytes", &format!("[{} bytes]", self.bytes.len()))
+           .field("identifier", &self.identifier)
+           .finish()
+    }
 }
 
 impl FontTemplateData {

--- a/components/gfx/platform/macos/font_template.rs
+++ b/components/gfx/platform/macos/font_template.rs
@@ -24,8 +24,10 @@ use webrender_api::NativeFontHandle;
 /// The identifier is a PostScript font name. The
 /// CTFont object is cached here for use by the
 /// paint functions that create CGFont references.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct FontTemplateData {
+    // If you add members here, review the Debug impl below
+
     /// The `CTFont` object, if present. This is cached here so that we don't have to keep creating
     /// `CTFont` instances over and over. It can always be recreated from the `identifier` and/or
     /// `font_data` fields.
@@ -37,6 +39,21 @@ pub struct FontTemplateData {
 
     pub identifier: Atom,
     pub font_data: Option<Arc<Vec<u8>>>
+}
+
+impl fmt::Debug for FontTemplateData {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("FontTemplateData")
+           .field("ctfont", &self.ctfont)
+           .field("identifier", &self.identifier)
+           .field(
+               "font_data",
+               &self.font_data
+                    .as_ref()
+                    .map(|bytes| format!("[{} bytes]", bytes.len()))
+            )
+           .finish()
+    }
 }
 
 unsafe impl Send for FontTemplateData {}

--- a/components/gfx/platform/windows/font_template.rs
+++ b/components/gfx/platform/windows/font_template.rs
@@ -4,13 +4,30 @@
 
 use platform::windows::font_list::{descriptor_from_atom, font_from_atom};
 use servo_atoms::Atom;
+use std::fmt;
 use std::io;
 use webrender_api::NativeFontHandle;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct FontTemplateData {
+    // If you add members here, review the Debug impl below
+
     pub bytes: Option<Vec<u8>>,
     pub identifier: Atom,
+}
+
+impl fmt::Debug for FontTemplateData {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("FontTemplateData")
+           .field(
+               "bytes",
+               &self.bytes
+                    .as_ref()
+                    .map(|bytes| format!("[{} bytes]", bytes.len()))
+            )
+           .field("identifier", &self.identifier)
+           .finish()
+    }
 }
 
 impl FontTemplateData {


### PR DESCRIPTION
Otherwise the log gets spammed with all the individual bytes of the
underlying font file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20105)
<!-- Reviewable:end -->
