### PR TITLE
Include non-upstream metadata changes in WPT sync.

### DIFF
--- a/etc/ci/update-wpt-checkout
+++ b/etc/ci/update-wpt-checkout
@@ -67,12 +67,10 @@ function unsafe_run_tests() {
 # last commit with the new results.
 function unsafe_update_metadata() {
     ./mach update-wpt "${1}" || return 1
-    # Ignore any metadata changes to files that weren't modified by this sync.
-    git checkout -- tests/wpt/mozilla/meta || return 2
     # Ensure any new directories or ini files are included in these changes.
-    git add tests/wpt/metadata || return 3
+    git add tests/wpt/ || return 2
     # Merge all changes with the existing commit.
-    git commit -a --amend --no-edit || return 4
+    git commit -a --amend --no-edit || return 3
 }
 
 # Push the branch to a remote branch, then open a PR for the branch

--- a/etc/ci/update-wpt-checkout
+++ b/etc/ci/update-wpt-checkout
@@ -68,7 +68,7 @@ function unsafe_run_tests() {
 function unsafe_update_metadata() {
     ./mach update-wpt "${1}" || return 1
     # Ensure any new directories or ini files are included in these changes.
-    git add tests/wpt/ || return 2
+    git add tests/wpt/metadata tests/wpt/mozilla/meta || return 2
     # Merge all changes with the existing commit.
     git commit -a --amend --no-edit || return 3
 }


### PR DESCRIPTION
The original sync work excluded changes to metadata files under tests/wpt/mozilla under the assumption that any change in test results indicated an existing intermittent issue. This is incorrect, because these tests rely on shared infrastructure with upstream, so the results can be influenced by syncing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20112)
<!-- Reviewable:end -->
