### PR TITLE
Fix some innerText getter WPTs

### DIFF
--- a/tests/wpt/metadata/innerText/getter.html.ini
+++ b/tests/wpt/metadata/innerText/getter.html.ini
@@ -32,12 +32,6 @@
   [visibility:visible child rendered ("<div style='visibility:hidden'>123<span style='visibility:visible'>abc")]
     expected: FAIL
 
-  [visibility:collapse row-group with visible cell ("<table><tbody style='visibility:collapse'><tr><td style='visibility:visible'>abc")]
-    expected: FAIL
-
-  [visibility:collapse row with visible cell ("<table><tr style='visibility:collapse'><td style='visibility:visible'>abc")]
-    expected: FAIL
-
   [visibility:collapse honored on flex item ("<div style='display:flex'><span style='visibility:collapse'>1</span><span>2</span></div>")]
     expected: FAIL
 
@@ -134,12 +128,6 @@
   [soft hyphen preserved ("<div style='width:0'>abc&shy;def")]
     expected: FAIL
 
-  [Ignoring non-rendered table whitespace ("<div><table style='white-space:pre'>  <td>abc</td>  </table>")]
-    expected: FAIL
-
-  [Tab-separated table cells ("<div><table><tr><td>abc<td>def</table>")]
-    expected: FAIL
-
   [Tab-separated table cells including empty cells ("<div><table><tr><td>abc<td><td>def</table>")]
     expected: FAIL
 
@@ -152,19 +140,10 @@
   [Newlines around table ("<div>abc<table><td>def</table>ghi")]
     expected: FAIL
 
-  [Tab-separated table cells in a border-collapse table ("<div><table style='border-collapse:collapse'><tr><td>abc<td>def</table>")]
-    expected: FAIL
-
   [ ("<table><tfoot><tr><td>footer</tfoot><thead><tr><td style='visibility:collapse'>thead</thead><tbody><tr><td>tbody</tbody></table>")]
     expected: FAIL
 
-  [Newline between cells and caption ("<div><table><tr><td>abc<caption>def</caption></table>")]
-    expected: FAIL
-
   [Tab-separated table cells ("<div><div class='table'><span class='cell'>abc</span>\\n<span class='cell'>def</span></div>")]
-    expected: FAIL
-
-  [Newline-separated table rows ("<div><div class='table'><span class='row'><span class='cell'>abc</span></span>\\n<span class='row'><span class='cell'>def</span></span></div>")]
     expected: FAIL
 
   [Newlines around table ("<div>abc<div class='table'><span class='cell'>def</span></div>ghi")]

--- a/tests/wpt/metadata/innerText/getter.html.ini
+++ b/tests/wpt/metadata/innerText/getter.html.ini
@@ -137,16 +137,10 @@
   [Newline-separated table rows ("<div><table><tr><td>abc<tr><td>def</table>")]
     expected: FAIL
 
-  [Newlines around table ("<div>abc<table><td>def</table>ghi")]
-    expected: FAIL
-
   [ ("<table><tfoot><tr><td>footer</tfoot><thead><tr><td style='visibility:collapse'>thead</thead><tbody><tr><td>tbody</tbody></table>")]
     expected: FAIL
 
   [Tab-separated table cells ("<div><div class='table'><span class='cell'>abc</span>\\n<span class='cell'>def</span></div>")]
-    expected: FAIL
-
-  [Newlines around table ("<div>abc<div class='table'><span class='cell'>def</span></div>ghi")]
     expected: FAIL
 
   [Tab-separated table cells ("<div><div class='itable'><span class='cell'>abc</span>\\n<span class='cell'>def</span></div>")]
@@ -188,9 +182,6 @@
   [<rt> and no <rp> ("<div><ruby>abc<rt>def</rt></ruby>")]
     expected: FAIL
 
-  [<rp> ("<div><ruby>abc<rp>(</rp><rt>def</rt><rp>)</rp></ruby>")]
-    expected: FAIL
-
   [visibility:collapse row-group ("<table><tbody style='visibility:collapse'><tr><td>abc")]
     expected: FAIL
 
@@ -219,5 +210,11 @@
     expected: FAIL
 
   [innerText getter test]
+    expected: FAIL
+
+  [empty <option> in <select> ("<div>a<select><option></select>bc")]
+    expected: FAIL
+
+  [Invisible <p> doesn't induce extra line breaks ("<div style='visibility:hidden'><p><span style='visibility:visible'>abc</span></p>\\n<div style='visibility:visible'>def</div>")]
     expected: FAIL
 


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are WPTs for these changes.

This completes steps 6 and 7 from the [inner text collection steps](https://html.spec.whatwg.org/multipage/dom.html#inner-text-collection-steps). Unfortunately, it does not seem to fix the failing tests related to tables mentioned in #20060.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20125)
<!-- Reviewable:end -->
