### PR TITLE
Rowspan support for tables

### DIFF
--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -840,26 +840,18 @@ impl TableLikeFlow for BlockFlow {
             // [expensive: iterates over cells]
             // At this point, `current_block_offset` is at the content edge of our box. Now iterate
             // over children.
-            let mut effects_rows = 0;
             let mut i = 0;
             for kid in self.base.child_iter_mut() {
                 if kid.is_table_row() {
                     has_rows = true;
                     let row = kid.as_mut_table_row();
-                    if row.mut_base().restyle_damage.contains(ServoRestyleDamage::REFLOW) ||
-                       effects_rows != 0 {
-                        row.assign_block_size_to_self_and_children(&sizes, i, &mut effects_rows);
-                        row.mut_base().restyle_damage
-                            .remove(ServoRestyleDamage::REFLOW_OUT_OF_FLOW |
-                                    ServoRestyleDamage::REFLOW);
-                    }
+                    row.assign_block_size_to_self_and_children(&sizes, i);
+                    row.mut_base().restyle_damage
+                        .remove(ServoRestyleDamage::REFLOW_OUT_OF_FLOW |
+                                ServoRestyleDamage::REFLOW);
                     current_block_offset = current_block_offset +
                         border_spacing_for_row(&self.fragment, row,
                                                block_direction_spacing);
-                    // may happen for empty rows
-                    if effects_rows != 0 {
-                        effects_rows -= 1;
-                    }
                     i += 1;
                 }
 

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -784,14 +784,14 @@ impl TableLikeFlow for BlockFlow {
 
         if self.base.restyle_damage.contains(ServoRestyleDamage::REFLOW) {
             let mut sizes = vec![];
+            let mut incoming_rowspan_data = vec![];
 
             for kid in self.base.child_iter_mut() {
                 if kid.is_table_row() {
                     sizes.push(kid.as_mut_table_row()
-                        .compute_block_size_table_row_base(layout_context))
+                        .compute_block_size_table_row_base(layout_context, &mut incoming_rowspan_data))
                 }
             }
-
             let mut effects_rows = 0;
             let mut i = 0;
             for kid in self.base.child_iter_mut() {

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -567,13 +567,6 @@ impl Flow for TableFlow {
 }
 
 #[derive(Debug)]
-// XXXManishearth We might be able to avoid the Arc<T>s if
-// the table is structured such that the columns always come
-// first in the flow tree, at which point we can
-// reuse the iterator that we use for colgroups
-// for rows (and have no borrowing issues between
-// holding on to both ColumnStyle<'table> and
-// the rows)
 struct ColumnStyle<'table> {
     span: u32,
     colgroup_style: Option<&'table ComputedValues>,

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -148,6 +148,17 @@ impl TableCellFlow {
             }
         }
     }
+
+    // Total block size of child
+    //
+    // Call after block size calculation
+    pub fn total_block_size(&mut self) -> Au {
+        // TODO: Percentage block-size
+        let specified = MaybeAuto::from_style(self.fragment().style()
+                                                  .content_block_size(),
+                                              Au(0)).specified_or_zero();
+        specified + self.fragment().border_padding.block_start_end()
+    }
 }
 
 impl Flow for TableCellFlow {

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -150,11 +150,10 @@ impl TableRowFlow {
                                              incoming_rowspan_data, &mut max_block_size,
                                              &mut largest_leftover_incoming_size);
             kid.place_float_if_applicable();
-            if !kid.base().flags.is_float() {
-                kid.assign_block_size_for_inorder_child_if_necessary(layout_context,
-                                                                     thread_id,
-                                                                     content_box);
-            }
+            debug_assert!(!kid.base().flags.is_float(), "table cells should never float");
+            kid.assign_block_size_for_inorder_child_if_necessary(layout_context,
+                                                                 thread_id,
+                                                                 content_box);
 
             let row_span;
             let column_span;

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -115,8 +115,6 @@ impl TableRowFlow {
                                                  incoming_rowspan_data: &mut Vec<Au>,
                                                  border_info: &[(Au, Au)], // (_, cumulative_border_size)
                                                  row_index: usize) -> (Au, Au) {
-        // XXXManishearth skip this when the REFLOW flag is unset if it is not affected by other
-        // rows
         fn include_sizes_from_previous_rows(col: &mut usize,
                                             incoming_rowspan: &[u32],
                                             incoming_rowspan_data: &mut Vec<Au>,
@@ -208,13 +206,12 @@ impl TableRowFlow {
         (block_size, largest_leftover_incoming_size)
     }
 
-    pub fn assign_block_size_to_self_and_children(&mut self, sizes: &[(Au, Au)], index: usize, effects_rows: &mut u32) {
+    pub fn assign_block_size_to_self_and_children(&mut self, sizes: &[(Au, Au)], index: usize) {
         // Assign the block-size of kid fragments, which is the same value as own block-size.
         let block_size = sizes[index].0;
         for kid in self.block_flow.base.child_iter_mut() {
             let child_table_cell = kid.as_mut_table_cell();
             let block_size = if child_table_cell.row_span > 1 {
-                 *effects_rows = max(*effects_rows, child_table_cell.row_span);
                 let row_sizes = sizes[index..].iter()
                                               .take(child_table_cell.row_span as usize)
                                               .fold(Au(0), |accum, size| accum + size.0);

--- a/components/layout/table_row.rs
+++ b/components/layout/table_row.rs
@@ -114,7 +114,9 @@ impl TableRowFlow {
     /// methods
     #[inline(always)]
     pub fn compute_block_size_table_row_base<'a>(&'a mut self, layout_context: &LayoutContext,
-                                                 incoming_rowspan_data: &mut Vec<Au>) -> Au {
+                                                 incoming_rowspan_data: &mut Vec<Au>,
+                                                 border_info: &[(Au, Au)],
+                                                 row_index: usize) -> Au {
         // XXXManishearth skip this when the REFLOW flag is unset if it is not affected by other
         // rows
         fn include_sizes_from_previous_rows(col: &mut usize,
@@ -185,16 +187,16 @@ impl TableRowFlow {
         block_size
     }
 
-    pub fn assign_block_size_to_self_and_children(&mut self, sizes: &[Au], index: usize, effects_rows: &mut u32) {
+    pub fn assign_block_size_to_self_and_children(&mut self, sizes: &[(Au, Au)], index: usize, effects_rows: &mut u32) {
         // Assign the block-size of kid fragments, which is the same value as own block-size.
-        let block_size = sizes[index];
+        let block_size = sizes[index].0;
         for kid in self.block_flow.base.child_iter_mut() {
             let child_table_cell = kid.as_mut_table_cell();
             let block_size = if child_table_cell.row_span > 1 {
                  *effects_rows = max(*effects_rows, child_table_cell.row_span);
                  // XXXManishearth support border spacing and such
                  sizes[index..].iter().take(child_table_cell.row_span as usize)
-                               .fold(Au(0), |accum, size| accum + *size)
+                               .fold(Au(0), |accum, size| accum + size.0)
             } else {
                 block_size
             };

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -159,9 +159,9 @@ impl Flow for TableRowGroupFlow {
         });
     }
 
-    fn assign_block_size(&mut self, _: &LayoutContext) {
+    fn assign_block_size(&mut self, lc: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for table_rowgroup");
-        self.block_flow.assign_block_size_for_table_like_flow(self.spacing.vertical());
+        self.block_flow.assign_block_size_for_table_like_flow(self.spacing.vertical(), lc);
     }
 
     fn compute_stacking_relative_position(&mut self, layout_context: &LayoutContext) {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -5837,6 +5837,18 @@
      {}
     ]
    ],
+   "css/table_rowspan_notequal_a.html": [
+    [
+     "/_mozilla/css/table_rowspan_notequal_a.html",
+     [
+      [
+       "/_mozilla/css/table_rowspan_notequal_ref.html",
+       "!="
+      ]
+     ],
+     {}
+    ]
+   ],
    "css/table_rowspan_rowgroup_a.html": [
     [
      "/_mozilla/css/table_rowspan_rowgroup_a.html",
@@ -9752,6 +9764,11 @@
     ]
    ],
    "css/table_row_direction_ref.html": [
+    [
+     {}
+    ]
+   ],
+   "css/table_rowspan_notequal_ref.html": [
     [
      {}
     ]
@@ -63930,6 +63947,14 @@
   ],
   "css/table_row_direction_ref.html": [
    "e045db1f738850e516079b66f915ba314b54ed99",
+   "support"
+  ],
+  "css/table_rowspan_notequal_a.html": [
+   "ec7ab6318a498f6b88369f097af53a0626c6fb1d",
+   "reftest"
+  ],
+  "css/table_rowspan_notequal_ref.html": [
+   "2a07facbd9f417264b46f6419ab00593051dae56",
    "support"
   ],
   "css/table_rowspan_rowgroup_a.html": [

--- a/tests/wpt/mozilla/meta/css/table_rowspan_rowgroup_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/table_rowspan_rowgroup_a.html.ini
@@ -1,0 +1,2 @@
+[table_rowspan_rowgroup_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/tests/css/table_rowspan_notequal_a.html
+++ b/tests/wpt/mozilla/tests/css/table_rowspan_notequal_a.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="UTF-8">
+  <link rel="mismatch" href="table_rowspan_notequal_ref.html">
+  <style>
+    td {
+      width: 100px;
+      border: 1px solid purple;
+    }
+  </style>
+  <body>
+    <table style="border: 1px solid purple">
+      <tr><td rowspan="2">&nbsp;</td><td>&nbsp;</td></tr>
+      <tr><td>&nbsp;</td></tr>
+    </table>
+  </body>
+</html>
+

--- a/tests/wpt/mozilla/tests/css/table_rowspan_notequal_ref.html
+++ b/tests/wpt/mozilla/tests/css/table_rowspan_notequal_ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <meta charset="UTF-8">
+  <style>
+    td {
+      width: 100px;
+      border: 1px solid purple;
+    }
+  </style>
+  <body>
+    <table style="border: 1px solid purple">
+      <tr><td>&nbsp;</td><td>&nbsp;</td></tr>
+      <tr><td>&nbsp;</td></tr>
+    </table>
+  </body>
+</html>
+


### PR DESCRIPTION
fixes #20092


This just contains the first steps.

We apply a naive algorithm: Spanning cells apply a pressure equal to `block_size / rowspan` on each row they are in. We move table row block size computation into the tables, and make it two pass. In the first pass we compute the sizes of each row, and in the
second pass we assign them, adding them up for any involved cells.


This is missing:

 - [x] Accounting for border sizes
 - [x] Applying pressure to rows that are not the row containing the cell
 - [ ] Reducing pressure on future rows if the current row is able to accomodate more of the cell
 - [x] For tables containing both rows and rowgroups, reset the rowspan info when we hit a rowgroup
 - [x] Correctly handle overflowing rowspans

cc @mbrubeck @pcwalton

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20128)
<!-- Reviewable:end -->
