### PR TITLE
style: Make Servo deal with CSS property prefs more correctly.

### DIFF
--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -164,9 +164,17 @@ macro_rules! css_properties(
     ( $([$getter:ident, $setter:ident, $id:expr],)* ) => (
         $(
             fn $getter(&self) -> DOMString {
+                debug_assert!(
+                    $id.enabled_for_all_content(),
+                    "Someone forgot a #[Pref] annotation"
+                );
                 self.get_property_value($id)
             }
             fn $setter(&self, value: DOMString) -> ErrorResult {
+                debug_assert!(
+                    $id.enabled_for_all_content(),
+                    "Someone forgot a #[Pref] annotation"
+                );
                 self.set_property($id, value, DOMString::new())
             }
         )*
@@ -236,6 +244,10 @@ impl CSSStyleDeclaration {
         // Step 1
         if self.readonly {
             return Err(Error::NoModificationAllowed);
+        }
+
+        if !id.enabled_for_all_content() {
+            return Ok(());
         }
 
         self.owner.mutate_associated_block(|pdb, changed| {

--- a/components/script/dom/webidls/CSSStyleDeclaration.webidl
+++ b/components/script/dom/webidls/CSSStyleDeclaration.webidl
@@ -244,8 +244,10 @@ partial interface CSSStyleDeclaration {
   [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString whiteSpace;
   [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString white-space;
 
-  [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString writingMode;
-  [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString writing-mode;
+  [Pref="layout.writing-mode.enabled", CEReactions, SetterThrows, TreatNullAs=EmptyString]
+  attribute DOMString writingMode;
+  [Pref="layout.writing-mode.enabled", CEReactions, SetterThrows, TreatNullAs=EmptyString]
+  attribute DOMString writing-mode;
 
   [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString letterSpacing;
   [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString letter-spacing;
@@ -385,13 +387,20 @@ partial interface CSSStyleDeclaration {
   [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString imageRendering;
   [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString image-rendering;
 
-  [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString columnCount;
-  [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString column-count;
-  [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString columnWidth;
-  [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString column-width;
-  [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString columns;
-  [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString columnGap;
-  [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString column-gap;
+  [Pref="layout.column-count.enabled", CEReactions, SetterThrows, TreatNullAs=EmptyString]
+  attribute DOMString columnCount;
+  [Pref="layout.column-count.enabled", CEReactions, SetterThrows, TreatNullAs=EmptyString]
+  attribute DOMString column-count;
+  [Pref="layout.column-width.enabled", CEReactions, SetterThrows, TreatNullAs=EmptyString]
+  attribute DOMString columnWidth;
+  [Pref="layout.column-width.enabled", CEReactions, SetterThrows, TreatNullAs=EmptyString]
+  attribute DOMString column-width;
+  [Pref="layout.columns.enabled", CEReactions, SetterThrows, TreatNullAs=EmptyString]
+  attribute DOMString columns;
+  [Pref="layout.column-gap.enabled", CEReactions, SetterThrows, TreatNullAs=EmptyString]
+  attribute DOMString columnGap;
+  [Pref="layout.column-gap.enabled", CEReactions, SetterThrows, TreatNullAs=EmptyString]
+  attribute DOMString column-gap;
 
   [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString transition;
   [CEReactions, SetterThrows, TreatNullAs=EmptyString] attribute DOMString transitionDuration;

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -61,7 +61,6 @@
   "layout.column-gap.enabled": false,
   "layout.column-width.enabled": false,
   "layout.columns.enabled": false,
-  "layout.text-orientation.enabled": false,
   "layout.viewport.enabled": false,
   "layout.writing-mode.enabled": false,
   "network.http-cache.disabled": false,


### PR DESCRIPTION
Right now you could still set preffed-off properties from CSSStyleDeclaration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20136)
<!-- Reviewable:end -->
