### PR TITLE
Remove text-is-significant param from Gecko_IsSignificantChild

### DIFF
--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -608,7 +608,6 @@ extern "C" {
 extern "C" {
     pub fn Gecko_IsSignificantChild(
         node: RawGeckoNodeBorrowed,
-        text_is_significant: bool,
         whitespace_is_significant: bool,
     ) -> bool;
 }

--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -256,7 +256,7 @@ impl<'ln> GeckoNode<'ln> {
 
     #[inline]
     fn contains_non_whitespace_content(&self) -> bool {
-        unsafe { Gecko_IsSignificantChild(self.0, true, false) }
+        unsafe { Gecko_IsSignificantChild(self.0, false) }
     }
 }
 
@@ -1933,7 +1933,7 @@ impl<'le> ::selectors::Element for GeckoElement<'le> {
 
     fn is_empty(&self) -> bool {
         !self.as_node().dom_children().any(|child| unsafe {
-            Gecko_IsSignificantChild(child.0, true, true)
+            Gecko_IsSignificantChild(child.0, true)
         })
     }
 


### PR DESCRIPTION
This is Servo side change of [bug 1441729](https://bugzilla.mozilla.org/show_bug.cgi?id=1441729).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20150)
<!-- Reviewable:end -->
