### PR TITLE
style: Cascade custom properties specially in a fast path.

### DIFF
--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -227,6 +227,8 @@ pub enum RestyleKind {
     /// We only need to recascade, for example, because only inherited
     /// properties in the parent changed.
     CascadeOnly,
+    /// We only need to recascade custom properties.
+    CascadeCustomProperties,
 }
 
 impl ElementData {
@@ -350,9 +352,16 @@ impl ElementData {
             return RestyleKind::CascadeWithReplacements(self.hint & RestyleHint::replacements());
         }
 
-        debug_assert!(self.hint.has_recascade_self(),
-                      "We definitely need to do something: {:?}!", self.hint);
-        return RestyleKind::CascadeOnly;
+        if self.hint.has_recascade_self() {
+            return RestyleKind::CascadeOnly;
+        }
+
+        debug_assert!(
+            self.hint.intersects(RestyleHint::RECASCADE_CUSTOM_PROPERTIES),
+            "We definitely need to do something: {:?}!",
+            self.hint
+        );
+        RestyleKind::CascadeCustomProperties
     }
 
     /// Returns the kind of restyling for animation-only restyle.

--- a/components/style/gecko/restyle_damage.rs
+++ b/components/style/gecko/restyle_damage.rs
@@ -57,6 +57,7 @@ impl GeckoRestyleDamage {
                 &mut reset_only,
             )
         };
+        let custom_properties_only = !any_style_changed;
         if reset_only &&
            old_style.custom_properties() != new_style.custom_properties() {
             // The Gecko_CalcStyleDifference call only checks the non-custom
@@ -68,7 +69,7 @@ impl GeckoRestyleDamage {
             reset_only = false;
         }
         let change = if any_style_changed {
-            StyleChange::Changed { reset_only }
+            StyleChange::Changed { reset_only, custom_properties_only }
         } else {
             StyleChange::Unchanged
         };

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -56,6 +56,9 @@ pub enum ChildCascadeRequirement {
     /// The same as `MustCascadeChildren`, but we only need to actually
     /// recascade if the child inherits any explicit reset style.
     MustCascadeChildrenIfInheritResetStyle,
+    /// Custom properties changed, so children need to get their styles updated,
+    /// but potentially only updating custom properties.
+    MustCascadeChildrenCustomProperties,
     /// Old and new computed values were different, so we must cascade the
     /// new values to children.
     MustCascadeChildren,
@@ -475,11 +478,15 @@ trait PrivateMatchMethods: TElement {
             StyleChange::Unchanged => {
                 return ChildCascadeRequirement::CanSkipCascade
             },
-            StyleChange::Changed { reset_only } => {
+            StyleChange::Changed { reset_only, custom_properties_only } => {
                 // If inherited properties changed, the best we can do is
                 // cascade the children.
                 if !reset_only {
-                    return ChildCascadeRequirement::MustCascadeChildren
+                    return if custom_properties_only {
+                        ChildCascadeRequirement::MustCascadeChildrenCustomProperties
+                    } else {
+                        ChildCascadeRequirement::MustCascadeChildren
+                    }
                 }
             }
         }

--- a/components/style/properties/computed_value_flags.rs
+++ b/components/style/properties/computed_value_flags.rs
@@ -57,16 +57,19 @@ bitflags! {
         /// Important because of the same reason.
         const INHERITS_CONTENT = 1 << 7;
 
+        /// Whether this style replaced any custom property reference.
+        const HAS_CUSTOM_PROPERTY_REFERENCES = 1 << 8;
+
         /// Whether the child explicitly inherits any reset property.
-        const INHERITS_RESET_STYLE = 1 << 8;
+        const INHERITS_RESET_STYLE = 1 << 9;
 
         /// A flag to mark a style which is a visited style.
-        const IS_STYLE_IF_VISITED = 1 << 9;
+        const IS_STYLE_IF_VISITED = 1 << 10;
 
         /// Whether the style or any of the ancestors has a multicol style.
         ///
         /// Only used in Servo.
-        const CAN_BE_FRAGMENTED = 1 << 10;
+        const CAN_BE_FRAGMENTED = 1 << 11;
     }
 }
 

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -395,7 +395,6 @@ where
     D: DomTraversal<E>,
     F: FnMut(E::ConcreteNode),
 {
-    use std::cmp;
     use traversal_flags::TraversalFlags;
 
     let flags = context.shared.traversal_flags;
@@ -420,12 +419,10 @@ where
             compute_style(traversal_data, context, element, data);
 
         if element.is_native_anonymous() {
-            // We must always cascade native anonymous subtrees, since they inherit
-            // styles from their first non-NAC ancestor.
-            child_cascade_requirement = cmp::max(
-                child_cascade_requirement,
-                ChildCascadeRequirement::MustCascadeChildren,
-            );
+            // We must always cascade native anonymous subtrees, since they
+            // inherit styles from their first non-NAC ancestor.
+            child_cascade_requirement =
+                ChildCascadeRequirement::MustCascadeDescendants;
         }
 
         // If we're restyling this element to display:none, throw away all style

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -636,7 +636,7 @@ where
 
             resolver.cascade_styles_with_default_parents(cascade_inputs)
         }
-        CascadeOnly => {
+        CascadeOnly | CascadeCustomProperties => {
             // Skipping full matching, load cascade inputs from previous values.
             let cascade_inputs =
                 ElementCascadeInputs::new_from_element_data(data);
@@ -783,6 +783,9 @@ where
                     if child_data.styles.primary().flags.contains(ComputedValueFlags::INHERITS_RESET_STYLE) {
                         child_hint |= RestyleHint::RECASCADE_SELF;
                     }
+                }
+                ChildCascadeRequirement::MustCascadeChildrenCustomProperties => {
+                    child_hint |= RestyleHint::RECASCADE_CUSTOM_PROPERTIES;
                 }
                 ChildCascadeRequirement::MustCascadeChildren => {
                     child_hint |= RestyleHint::RECASCADE_SELF;


### PR DESCRIPTION
When you change a custom property on an element, we need to restyle all children, given custom properties are inherited.

That's usually wasted work, if the element being restyled didn't use any custom property reference. This patch implements a fast path for that.

Do not merge yet, since it's unmeasured so far.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20151)
<!-- Reviewable:end -->
