### PR TITLE
Support zero rowspans

### DIFF
--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -30,7 +30,7 @@ use style::values::CSSFloat;
 use style::values::computed::LengthOrPercentageOrAuto;
 use table_cell::TableCellFlow;
 use table_row::{self, CellIntrinsicInlineSize, CollapsedBorder, CollapsedBorderProvenance};
-use table_row::TableRowFlow;
+use table_row::{TableRowFlow, TableRowSizeData};
 use table_wrapper::TableLayout;
 
 #[allow(unsafe_code)]
@@ -785,49 +785,51 @@ impl TableLikeFlow for BlockFlow {
         }
 
         if self.base.restyle_damage.contains(ServoRestyleDamage::REFLOW) {
-            // (size, cumulative_border_spacing)
-            let mut sizes = vec![(Au(0), Au(0))];
+            let mut sizes = vec![Default::default()];
             // The amount of border spacing up to and including this row,
             // but not including the spacing beneath it
-            let mut cumulative_border = Au(0);
+            let mut cumulative_border_spacing = Au(0);
             let mut incoming_rowspan_data = vec![];
+            let mut rowgroup_id = 0;
+            let mut first = true;
 
             // First pass: Compute block-direction border spacings
             // XXXManishearth this can be done in tandem with the second pass,
             // provided we never hit any rowspan cases
-            for kid in self.base.child_iter_mut()
-                           .filter(|k| k.is_table_row())
-                           .skip(1) {
-                cumulative_border +=
-                    border_spacing_for_row(&self.fragment, kid.as_table_row(),
-                                           block_direction_spacing);
-                // we haven't calculated sizes yet
-                sizes.push((Au(0), cumulative_border));
+            for kid in self.base.child_iter_mut() {
+                if kid.is_table_row() {
+                    // skip the first row, it is accounted for
+                    if first {
+                        first = false;
+                        continue;
+                    }
+                    cumulative_border_spacing +=
+                        border_spacing_for_row(&self.fragment, kid.as_table_row(),
+                                               block_direction_spacing);
+                    sizes.push(TableRowSizeData {
+                        // we haven't calculated sizes yet
+                        size: Au(0),
+                        cumulative_border_spacing,
+                        rowgroup_id
+                    });
+                } else if kid.is_table_rowgroup() && !first {
+                    rowgroup_id += 1;
+                }
             }
 
             // Second pass: Compute row block sizes
             // [expensive: iterates over cells]
             let mut i = 0;
-            let mut overflow = Au(0);
             for kid in self.base.child_iter_mut() {
                 if kid.is_table_row() {
-                    let (size, oflo) = kid.as_mut_table_row()
+                    let size = kid.as_mut_table_row()
                         .compute_block_size_table_row_base(layout_context,
                                                            &mut incoming_rowspan_data,
                                                            &sizes,
                                                            i);
-                    sizes[i].0 = size;
-                    overflow = oflo;
+                    sizes[i].size = size;
                     i += 1;
-                // new rowgroups stop rowspans
-                } else if kid.is_table_rowgroup() {
-                    if i > 0 {
-                        sizes[i - 1].0 = cmp::max(sizes[i - 1].0, overflow);
-                    }
                 }
-            }
-            if i > 0 {
-                sizes[i - 1].0 = cmp::max(sizes[i - 1].0, overflow);
             }
 
 

--- a/tests/wpt/mozilla/meta/css/table_rowspan_rowgroup_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/table_rowspan_rowgroup_a.html.ini
@@ -1,2 +1,0 @@
-[table_rowspan_rowgroup_a.html]
-  expected: FAIL


### PR DESCRIPTION
This makes rowspan=0 work by storing notes on which group of rows we're in
for tables containing both rowgroups and rows, and using that to respan
cells with overlarge or zero rowspans.

This also gets rid of the largest_leftover_incoming_size business, because
now spans will always be correct and we'll never have any left over.


Based on https://github.com/servo/servo/pull/20128


r? @mbrubeck

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20152)
<!-- Reviewable:end -->
