### PR TITLE
Backed out changeset 39a71f4c9d94 for build bustages at make[4]: *** [force-cargo-library-build] Error 101 on a CLOSED TREE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.32.3"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cexpr 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -159,8 +159,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2950,7 +2949,7 @@ dependencies = [
  "app_units 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayvec 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bindgen 0.32.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bindgen 0.32.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3615,7 +3614,7 @@ dependencies = [
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum binary-space-partition 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88ceb0d16c4fd0e42876e298d7d3ce3780dd9ebdcbe4199816a32c77e08597ff"
 "checksum bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9a6301db0b49fb63551bc15b5ae348147101cdf323242b93ec7546d5002ff1af"
-"checksum bindgen 0.32.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b242e11a8f446f5fc7b76b37e81d737cabca562a927bd33766dac55b5f1177f"
+"checksum bindgen 0.32.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6ed9557522980fcdb4986097c2ea9d2504eafa7e5818f393110205b5325a52ce"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5cde24d1b2e2216a726368b2363a273739c91f4e3eb4e0dd12d672d396ad989"
 "checksum bitreader 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "80b13e2ab064ff3aa0bdbf1eff533f9822dc37899821f5f98c67f263eab51707"

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -78,7 +78,7 @@ kernel32-sys = "0.2"
 [build-dependencies]
 lazy_static = "1"
 log = "0.3"
-bindgen = { version = "0.32.3", optional = true }
+bindgen = { version = "0.32.2", optional = true }
 regex = {version = "0.2", optional = true}
 walkdir = "1.0"
 toml = {version = "0.2.1", optional = true, default-features = false}

--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -204,25 +204,15 @@ mod bindings {
 
             // Disable rust unions, because we replace some types inside of
             // them.
+            //
+            // FIXME(emilio, bug 1432153): Make the bindings rustfmt'd on
+            // automation.
             let mut builder = Builder::default()
+                .rustfmt_bindings(false)
                 .rust_target(RustTarget::Stable_1_0);
-            let rustfmt_path = env::var_os("MOZ_AUTOMATION").and_then(|_| {
-                env::var_os("TOOLTOOL_DIR")
-            }).map(PathBuf::from);
-
-            builder = match rustfmt_path {
-                Some(path) => {
-                    builder.with_rustfmt(path.join("rustc").join("bin").join("rustfmt"))
-                },
-                None => {
-                    builder.rustfmt_bindings(env::var_os("STYLO_RUSTFMT_BINDINGS").is_some())
-                }
-            };
-
             for dir in SEARCH_PATHS.iter() {
                 builder = builder.clang_arg("-I").clang_arg(dir.to_str().unwrap());
             }
-
             builder = builder.include(add_include("mozilla-config.h"));
 
             if env::var("CARGO_FEATURE_GECKO_DEBUG").is_ok() {


### PR DESCRIPTION
Backed out changeset 39a71f4c9d94 for build bustages at make[4]: *** [force-cargo-library-build] Error 101 on a CLOSED TREE

Backs out https://github.com/servo/servo/pull/20160

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20167)
<!-- Reviewable:end -->
