### PR TITLE
Improve disk usage of doc builds.

### DIFF
--- a/etc/ci/upload_docs.sh
+++ b/etc/ci/upload_docs.sh
@@ -14,6 +14,9 @@ set -o pipefail
 
 cd "$(dirname ${0})/../.."
 
+# Clean up any traces of previous doc builds.
+./etc/ci/clean_build_artifacts.sh
+
 env CC=gcc-5 CXX=g++-5 ./mach doc
 # etc/doc.servo.org/index.html overwrites $(mach rust-root)/doc/index.html
 # Use recursive copy here to avoid `cp` returning an error code
@@ -34,6 +37,9 @@ echo "Copying apis.html."
 cp apis.html ../../target/doc/servo/
 echo "Copied apis.html."
 cd ../..
+
+# Clean up the traces of the current doc build.
+./etc/ci/clean_build_artifacts.sh
 
 echo "Starting ghp-import."
 ghp-import -n target/doc


### PR DESCRIPTION
Continuing the war on disk space usage, I noticed the doc builder on servo-linux4 was growing over time without bound.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20168)
<!-- Reviewable:end -->
