### PR TITLE
#20174 removed the option and unwrap

### DIFF
--- a/components/config/basedir.rs
+++ b/components/config/basedir.rs
@@ -17,19 +17,18 @@ use std::path::PathBuf;
 use xdg;
 
 #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
-pub fn default_config_dir() -> Option<PathBuf> {
+pub fn default_config_dir() -> PathBuf {
     let xdg_dirs = xdg::BaseDirectories::with_profile("servo", "default").unwrap();
-    let config_dir = xdg_dirs.get_config_home();
-    Some(config_dir)
+    xdg_dirs.get_config_home()
 }
 
 #[cfg(target_os = "android")]
 #[allow(unsafe_code)]
-pub fn default_config_dir() -> Option<PathBuf> {
+pub fn default_config_dir() -> PathBuf {
     let dir = unsafe {
         CStr::from_ptr((*android_injected_glue::get_app().activity).externalDataPath)
     };
-    Some(PathBuf::from(dir.to_str().unwrap()))
+    PathBuf::from(dir.to_str().unwrap())
 }
 
 #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
@@ -67,16 +66,16 @@ pub fn default_cache_dir() -> Option<PathBuf> {
 }
 
 #[cfg(target_os = "macos")]
-pub fn default_config_dir() -> Option<PathBuf> {
+pub fn default_config_dir() -> PathBuf {
     let mut config_dir = env::home_dir().unwrap();
     config_dir.push("Library");
     config_dir.push("Application Support");
     config_dir.push("Servo");
-    Some(config_dir)
+    config_dir
 }
 
 #[cfg(target_os = "windows")]
-pub fn default_config_dir() -> Option<PathBuf> {
+pub fn default_config_dir() -> PathBuf {
     let mut config_dir = match env::var_os("APPDATA") {
         Some(appdata_path) => PathBuf::from(appdata_path),
         None => {
@@ -87,5 +86,5 @@ pub fn default_config_dir() -> Option<PathBuf> {
         }
     };
     config_dir.push("Servo");
-    Some(config_dir)
+    config_dir
 }

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -184,7 +184,7 @@ pub fn add_user_prefs() {
             init_user_prefs(&mut path);
         }
         None => {
-            let mut path = default_config_dir().unwrap();
+            let mut path = default_config_dir();
             if path.join("prefs.json").exists() {
                 init_user_prefs(&mut path);
             }

--- a/components/config/tests/prefs.rs
+++ b/components/config/tests/prefs.rs
@@ -56,7 +56,7 @@ fn test_default_config_dir_create_read_write() {
   \"shell.homepage\": \"https://google.com\"\
 }";
     let mut expected_json = String::new();
-    let config_path = basedir::default_config_dir().unwrap();
+    let config_path = basedir::default_config_dir();
 
     if !config_path.exists() {
       fs::create_dir_all(&config_path).unwrap();

--- a/ports/servo/main.rs
+++ b/ports/servo/main.rs
@@ -258,7 +258,7 @@ fn args() -> Vec<String> {
     use std::fs::File;
     use std::io::{BufRead, BufReader};
 
-    let mut params_file = config::basedir::default_config_dir().unwrap();
+    let mut params_file = config::basedir::default_config_dir();
     params_file.push("android_params");
     match File::open(params_file.to_str().unwrap()) {
         Ok(f) => {


### PR DESCRIPTION
I removed the useless option and the need for unwrap from default_config_dir

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #20174 (github issue number if applicable).
- [X] These changes do not require tests because they are used at build time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20175)
<!-- Reviewable:end -->
