### PR TITLE
Fire the pageshow event at the end of the page load

### DIFF
--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -47,6 +47,7 @@ none
 number
 onchange
 open
+pageshow
 password
 pause
 play

--- a/tests/wpt/web-platform-tests/html/syntax/parsing/the-end.html
+++ b/tests/wpt/web-platform-tests/html/syntax/parsing/the-end.html
@@ -29,12 +29,28 @@ async_test(function() {
 }, "load");
 
 async_test(function() {
-  var seen = false;
-  document.addEventListener("DOMContentLoaded", this.step_func(function() {
-    seen = true;
+  window.addEventListener("pageshow", this.step_func_done(function(e) {
+    assert_equals(e.type, "pageshow");
+    assert_false(e.bubbles, "bubbles should be false");
+    assert_false(e.cancelable, "cancelable should be false");
+    assert_equals(e.target, document, "target should be document");
+    assert_true(e.isTrusted, "isTrusted should be true");
+    assert_class_string(e, "PageTransitionEvent");
   }));
-  window.addEventListener("load", this.step_func_done(function() {
-    assert_true(seen, "DOMContentLoaded should be fired before load");
+}, "pageshow");
+
+async_test(function() {
+  var seen_dcl = false;
+  var seen_load = false;
+  document.addEventListener("DOMContentLoaded", this.step_func(function() {
+    seen_dcl = true;
+  }));
+  window.addEventListener("load", this.step_func(function() {
+    seen_load = true;
+    assert_true(seen_dcl, "DOMContentLoaded should be fired before load");
+  }));
+  window.addEventListener("pageshow", this.step_func_done(function() {
+    assert_true(seen_load, "load should be fired before pageshow")
   }));
 }, "order");
 </script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This implements step 8 of https://html.spec.whatwg.org/multipage/parsing.html#the-end

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because I could not find a wpt test for that, which is strange. I likely missed it :(

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20181)
<!-- Reviewable:end -->
