### PR TITLE
Unconditionally derive ToComputedValue as Clone for non-generic types

### DIFF
--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -289,7 +289,10 @@ impl<'a, 'cx, 'cx_a: 'cx, S: ToComputedValue + 'a> Iterator for ComputedVecIter<
 /// This trait is derivable with `#[derive(ToComputedValue)]`. The derived
 /// implementation just calls `ToComputedValue::to_computed_value` on each field
 /// of the passed value, or `Clone::clone` if the field is annotated with
-/// `#[compute(clone)]`.
+/// `#[compute(clone)]`. The deriving code assumes that if the type isn't
+/// generic, then the trait can be implemented as simple `Clone::clone` calls,
+/// this means that a manual implementation with `ComputedValue = Self` is bogus
+/// if it returns anything else than a clone.
 pub trait ToComputedValue {
     /// The computed value type we're going to be converted to.
     type ComputedValue;

--- a/components/style_derive/to_computed_value.rs
+++ b/components/style_derive/to_computed_value.rs
@@ -13,6 +13,29 @@ pub fn derive(input: DeriveInput) -> Tokens {
     let (impl_generics, ty_generics, mut where_clause, computed_value_type) =
         cg::fmap_trait_parts(&input, &trait_path, Ident::from("ComputedValue"));
 
+    if input.generics.params.is_empty() {
+        return quote! {
+            impl #impl_generics ::values::computed::ToComputedValue for #name #ty_generics
+            #where_clause
+            {
+                type ComputedValue = #computed_value_type;
+
+                #[inline]
+                fn to_computed_value(
+                    &self,
+                    _context: &::values::computed::Context,
+                ) -> Self::ComputedValue {
+                    ::std::clone::Clone::clone(self)
+                }
+
+                #[inline]
+                fn from_computed_value(computed: &Self::ComputedValue) -> Self {
+                    ::std::clone::Clone::clone(computed)
+                }
+            }
+        }
+    }
+
     let to_body = cg::fmap_match(&input, BindStyle::Ref, |binding| {
         let attrs = cg::parse_field_attrs::<ComputedValueAttrs>(&binding.ast());
         if attrs.clone {


### PR DESCRIPTION
We assume that types such as `<Self as ToComputedValue>::ToComputedValue == Self`
just construct a new value that is just a clone of the original one without any
additional code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20183)
<!-- Reviewable:end -->
