### PR TITLE
style: Don't guard the context opacity keywords with the svg in opentype pref.

### DIFF
--- a/components/style/values/specified/svg.rs
+++ b/components/style/values/specified/svg.rs
@@ -35,14 +35,16 @@ fn is_context_value_enabled() -> bool {
     false
 }
 
-fn parse_context_value<'i, 't, T>(input: &mut Parser<'i, 't>, value: T)
-                                  -> Result<T, ParseError<'i>> {
-    if is_context_value_enabled() {
-        if input.expect_ident_matching("context-value").is_ok() {
-            return Ok(value);
-        }
+fn parse_context_value<'i, 't, T>(
+    input: &mut Parser<'i, 't>,
+    value: T,
+) -> Result<T, ParseError<'i>> {
+    if !is_context_value_enabled() {
+        return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
     }
-    Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
+
+    input.expect_ident_matching("context-value")?;
+    Ok(value)
 }
 
 /// A value of <length> | <percentage> | <number> for stroke-dashoffset.
@@ -54,8 +56,10 @@ pub type SvgLengthOrPercentageOrNumber =
 pub type SVGLength = generic::SVGLength<SvgLengthOrPercentageOrNumber>;
 
 impl Parse for SVGLength {
-    fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
-                     -> Result<Self, ParseError<'i>> {
+    fn parse<'i, 't>(
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self, ParseError<'i>> {
         input.try(|i| SvgLengthOrPercentageOrNumber::parse(context, i))
              .map(Into::into)
              .or_else(|_| parse_context_value(input, generic::SVGLength::ContextValue))
@@ -77,8 +81,10 @@ pub type NonNegativeSvgLengthOrPercentageOrNumber =
 pub type SVGWidth = generic::SVGLength<NonNegativeSvgLengthOrPercentageOrNumber>;
 
 impl Parse for SVGWidth {
-    fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
-                     -> Result<Self, ParseError<'i>> {
+    fn parse<'i, 't>(
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self, ParseError<'i>> {
         input.try(|i| NonNegativeSvgLengthOrPercentageOrNumber::parse(context, i))
              .map(Into::into)
              .or_else(|_| parse_context_value(input, generic::SVGLength::ContextValue))
@@ -95,8 +101,10 @@ impl From<NonNegativeSvgLengthOrPercentageOrNumber> for SVGWidth {
 pub type SVGStrokeDashArray = generic::SVGStrokeDashArray<NonNegativeSvgLengthOrPercentageOrNumber>;
 
 impl Parse for SVGStrokeDashArray {
-    fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
-                     -> Result<Self, ParseError<'i>> {
+    fn parse<'i, 't>(
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self, ParseError<'i>> {
         if let Ok(values) = input.try(|i| CommaWithSpace::parse(i, |i| {
             NonNegativeSvgLengthOrPercentageOrNumber::parse(context, i)
         })) {

--- a/components/style/values/specified/svg.rs
+++ b/components/style/values/specified/svg.rs
@@ -113,17 +113,17 @@ impl Parse for SVGStrokeDashArray {
 pub type SVGOpacity = generic::SVGOpacity<Opacity>;
 
 impl Parse for SVGOpacity {
-    fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
-                     -> Result<Self, ParseError<'i>> {
+    fn parse<'i, 't>(
+        context: &ParserContext,
+        input: &mut Parser<'i, 't>,
+    ) -> Result<Self, ParseError<'i>> {
         if let Ok(opacity) = input.try(|i| Opacity::parse(context, i)) {
-            Ok(generic::SVGOpacity::Opacity(opacity))
-        } else if is_context_value_enabled() {
-            try_match_ident_ignore_ascii_case! { input,
-                "context-fill-opacity" => Ok(generic::SVGOpacity::ContextFillOpacity),
-                "context-stroke-opacity" => Ok(generic::SVGOpacity::ContextStrokeOpacity),
-            }
-        } else {
-            Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError))
+            return Ok(generic::SVGOpacity::Opacity(opacity));
+        }
+
+        try_match_ident_ignore_ascii_case! { input,
+            "context-fill-opacity" => Ok(generic::SVGOpacity::ContextFillOpacity),
+            "context-stroke-opacity" => Ok(generic::SVGOpacity::ContextStrokeOpacity),
         }
     }
 }


### PR DESCRIPTION
This is effectively the stylo version of the second patch for bug 1365926, and should fix bug 1442867.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20190)
<!-- Reviewable:end -->
