### PR TITLE
style: remove unused AsciiExt imports.

### DIFF
--- a/components/style/attr.rs
+++ b/components/style/attr.rs
@@ -16,7 +16,6 @@ use selectors::attr::AttrSelectorOperation;
 use servo_arc::Arc;
 use servo_url::ServoUrl;
 use shared_lock::Locked;
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::str::FromStr;
 use str::{HTML_SPACE_CHARACTERS, read_exponent, read_fraction};
 use str::{read_numbers, split_commas, split_html_space_chars};

--- a/components/style/counter_style/mod.rs
+++ b/components/style/counter_style/mod.rs
@@ -15,7 +15,6 @@ use error_reporting::{ContextualParseError, ParseErrorReporter};
 use parser::{ParserContext, ParserErrorContext, Parse};
 use selectors::parser::SelectorParseErrorKind;
 use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::fmt::{self, Write};
 use std::ops::Range;

--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -15,7 +15,6 @@ use selector_map::{PrecomputedHashSet, PrecomputedHashMap};
 use selectors::parser::SelectorParseErrorKind;
 use servo_arc::Arc;
 use smallvec::SmallVec;
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::borrow::{Borrow, Cow};
 use std::cmp;
 use std::fmt::{self, Write};

--- a/components/style/gecko/generated/pseudo_element_definition.rs
+++ b/components/style/gecko/generated/pseudo_element_definition.rs
@@ -1596,7 +1596,6 @@ impl PseudoElement {
     /// Returns `None` if the pseudo-element is not recognized.
     #[inline]
     pub fn tree_pseudo_element(name: &str, args: Box<[Atom]>) -> Option<Self> {
-        #[allow(unused_imports)] use std::ascii::AsciiExt;
         debug_assert!(name.starts_with("-moz-tree-"));
         let tree_part = &name[10..];
             if tree_part.eq_ignore_ascii_case("column") {

--- a/components/style/gecko/pseudo_element_definition.mako.rs
+++ b/components/style/gecko/pseudo_element_definition.mako.rs
@@ -252,7 +252,6 @@ impl PseudoElement {
     /// Returns `None` if the pseudo-element is not recognized.
     #[inline]
     pub fn tree_pseudo_element(name: &str, args: Box<[Atom]>) -> Option<Self> {
-        #[allow(unused_imports)] use std::ascii::AsciiExt;
         debug_assert!(name.starts_with("-moz-tree-"));
         let tree_part = &name[10..];
         % for pseudo in TREE_PSEUDOS:

--- a/components/style/gecko_string_cache/mod.rs
+++ b/components/style/gecko_string_cache/mod.rs
@@ -14,7 +14,6 @@ use gecko_bindings::structs::{nsAtom, nsAtom_AtomKind, nsStaticAtom};
 use nsstring::{nsAString, nsStr};
 use precomputed_hash::PrecomputedHash;
 use std::{mem, slice, str};
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::borrow::{Cow, Borrow};
 use std::char::{self, DecodeUtf16};
 use std::fmt::{self, Write};

--- a/components/style/str.rs
+++ b/components/style/str.rs
@@ -7,7 +7,6 @@
 #![deny(missing_docs)]
 
 use num_traits::ToPrimitive;
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::convert::AsRef;
 use std::fmt::{self, Write};

--- a/components/style/stylesheets/supports_rule.rs
+++ b/components/style/stylesheets/supports_rule.rs
@@ -13,7 +13,6 @@ use properties::{PropertyId, PropertyDeclaration, SourcePropertyDeclaration};
 use selectors::parser::SelectorParseErrorKind;
 use servo_arc::Arc;
 use shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked, SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::ffi::{CStr, CString};
 use std::fmt::{self, Write};
 use std::str;

--- a/components/style/stylesheets/viewport_rule.rs
+++ b/components/style/stylesheets/viewport_rule.rs
@@ -20,7 +20,6 @@ use properties::StyleBuilder;
 use rule_cache::RuleCacheConditions;
 use selectors::parser::SelectorParseErrorKind;
 use shared_lock::{SharedRwLockReadGuard, StylesheetGuards, ToCssWithGuard};
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fmt::{self, Write};

--- a/components/style/values/mod.rs
+++ b/components/style/values/mod.rs
@@ -12,7 +12,6 @@ use Atom;
 pub use cssparser::{RGBA, Token, Parser, serialize_identifier, CowRcStr, SourceLocation};
 use parser::{Parse, ParserContext};
 use selectors::parser::SelectorParseErrorKind;
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt::{self, Debug, Write};
 use std::hash;
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};

--- a/components/style/values/specified/align.rs
+++ b/components/style/values/specified/align.rs
@@ -10,7 +10,6 @@ use cssparser::Parser;
 use gecko_bindings::structs;
 use parser::{Parse, ParserContext};
 use selectors::parser::SelectorParseErrorKind;
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
 

--- a/components/style/values/specified/angle.rs
+++ b/components/style/values/specified/angle.rs
@@ -6,7 +6,6 @@
 
 use cssparser::{Parser, Token};
 use parser::{ParserContext, Parse};
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, ToCss};
 use values::CSSFloat;

--- a/components/style/values/specified/calc.rs
+++ b/components/style/values/specified/calc.rs
@@ -8,7 +8,6 @@
 
 use cssparser::{Parser, Token, NumberOrPercentage, AngleOrNumber};
 use parser::ParserContext;
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
 use style_traits::values::specified::AllowedNumericType;

--- a/components/style/values/specified/color.rs
+++ b/components/style/values/specified/color.rs
@@ -71,7 +71,6 @@ impl<'a, 'b: 'a, 'i: 'a> ::cssparser::ColorComponentParser<'i> for ColorComponen
         &self,
         input: &mut Parser<'i, 't>,
     ) -> Result<AngleOrNumber, ParseError<'i>> {
-        #[allow(unused_imports)] use std::ascii::AsciiExt;
         use values::specified::Angle;
 
         let location = input.current_source_location();
@@ -123,8 +122,6 @@ impl<'a, 'b: 'a, 'i: 'a> ::cssparser::ColorComponentParser<'i> for ColorComponen
         &self,
         input: &mut Parser<'i, 't>,
     ) -> Result<NumberOrPercentage, ParseError<'i>> {
-        #[allow(unused_imports)] use std::ascii::AsciiExt;
-
         let location = input.current_source_location();
 
         match input.next()?.clone() {
@@ -142,8 +139,6 @@ impl<'a, 'b: 'a, 'i: 'a> ::cssparser::ColorComponentParser<'i> for ColorComponen
 
 impl Parse for Color {
     fn parse<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
-        #[allow(unused_imports)] use std::ascii::AsciiExt;
-
         // Currently we only store authored value for color keywords,
         // because all browsers serialize those values as keywords for
         // specified value.

--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -14,8 +14,6 @@ use gecko_bindings::bindings;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use parser::{Parse, ParserContext};
 use properties::longhands::system_font::SystemFont;
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
 use values::CustomIdent;
@@ -1855,7 +1853,6 @@ impl ToComputedValue for FontLanguageOverride {
 
     #[inline]
     fn to_computed_value(&self, _context: &Context) -> computed::FontLanguageOverride {
-        #[allow(unused_imports)] use std::ascii::AsciiExt;
         match *self {
             FontLanguageOverride::Normal => computed::FontLanguageOverride(0),
             FontLanguageOverride::Override(ref lang) => {

--- a/components/style/values/specified/grid.rs
+++ b/components/style/values/specified/grid.rs
@@ -7,7 +7,6 @@
 
 use cssparser::{Parser, Token, ParseError as CssParseError};
 use parser::{Parse, ParserContext};
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::mem;
 use style_traits::{ParseError, StyleParseErrorKind};
 use values::{CSSFloat, CustomIdent};

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -12,7 +12,6 @@ use euclid::Size2D;
 use font_metrics::FontMetricsQueryResult;
 use parser::{Parse, ParserContext};
 use std::cmp;
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::ops::{Add, Mul};
 use style_traits::{ParseError, StyleParseErrorKind};
 use style_traits::values::specified::AllowedNumericType;

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -12,7 +12,6 @@ use cssparser::{Parser, Token, serialize_identifier};
 use num_traits::One;
 use parser::{ParserContext, Parse};
 use self::url::SpecifiedUrl;
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::f32;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};

--- a/components/style/values/specified/percentage.rs
+++ b/components/style/values/specified/percentage.rs
@@ -6,7 +6,6 @@
 
 use cssparser::{Parser, Token};
 use parser::{Parse, ParserContext};
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, ToCss};
 use style_traits::values::specified::AllowedNumericType;

--- a/components/style/values/specified/text.rs
+++ b/components/style/values/specified/text.rs
@@ -7,7 +7,6 @@
 use cssparser::{Parser, Token};
 use parser::{Parse, ParserContext};
 use selectors::parser::SelectorParseErrorKind;
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
 use values::computed::{Context, ToComputedValue};

--- a/components/style/values/specified/time.rs
+++ b/components/style/values/specified/time.rs
@@ -6,7 +6,6 @@
 
 use cssparser::{Parser, Token};
 use parser::{ParserContext, Parse};
-#[allow(unused_imports)] use std::ascii::AsciiExt;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
 use style_traits::values::specified::AllowedNumericType;


### PR DESCRIPTION
eq_ignore_ascii_case is not in AsciiExt since rustc 1.23.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20194)
<!-- Reviewable:end -->
