### PR TITLE
[Do not merge] WIP: Accept typed array arguments in codegen

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -563,6 +563,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
                                 isMember=False,
                                 isArgument=False,
                                 isAutoRooted=False,
+                                needsRootingInto=False,
                                 invalidEnumValueFatal=True,
                                 defaultValue=None,
                                 treatNullAs="Default",
@@ -871,7 +872,45 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         return handleOptional(templateBody, declType, handleDefaultNull("None"))
 
     if type.isSpiderMonkeyInterface():
-        raise TypeError("Can't handle SpiderMonkey interface arguments yet")
+        # Typed arrays can be constructed only with a prior rooted value
+        assert isArgument or isinstance(needsRootingInto, basestring)
+
+        if failureCode is None:
+            substitutions = {
+                "sourceDescription": sourceDescription,
+                "exceptionCode": exceptionCode,
+            }
+            unwrapFailureCode = string.Template(
+            'throw_type_error(cx, "${sourceDescription} is not a typed array.");\n'
+            '${exceptionCode}').substitute(substitutions)
+        else:
+            unwrapFailureCode = failureCode
+
+
+        templateBody = fill(
+            """
+            match typedarray::${ty}::from(cx, &mut ${stackRootName},
+                $${val}.get().to_object()) {
+                Ok(val) => val,
+                Err(()) => {
+                    $*{failureCode}
+                }
+            }
+            """,
+            ty=type.name,
+            stackRootName=needsRootingInto,
+            failureCode=unwrapFailureCode + "\n",
+        )
+
+        declType = CGGeneric("typedarray::%s" % type.name)
+        if type.nullable():
+            templateBody = "Some(%s)" % templateBody
+            declType = CGWrapper(declType, pre="Option<", post=">")
+
+        templateBody = wrapObjectTemplate(templateBody, "None",
+                                          isDefinitelyObject, type, failureCode)
+
+        return handleOptional(templateBody, declType, handleDefaultNull("None"))
 
     if type.isDOMString():
         nullBehavior = getConversionConfigForType(type, isEnforceRange, isClamp, treatNullAs)
@@ -1245,6 +1284,7 @@ class CGArgumentConverter(CGThing):
             isClamp=argument.clamp,
             isMember="Variadic" if argument.variadic else False,
             isAutoRooted=type_needs_auto_root(argument.type),
+            needsRootingInto="arg_root" if type_conversion_needs_root(argument.type) else False,
             allowTreatNonObjectAsNull=argument.allowTreatNonCallableAsNull())
         template = info.template
         default = info.default
@@ -1269,12 +1309,17 @@ class CGArgumentConverter(CGThing):
 
             arg = "arg%d" % index
 
-            self.converter = instantiateJSToNativeConversionTemplate(
-                template, replacementVariables, declType, arg)
+            converter = [instantiateJSToNativeConversionTemplate(
+                template, replacementVariables, declType, arg)]
+
+            if type_conversion_needs_root(argument.type):
+                converter.insert(0, CGGeneric("let mut arg_root = Rooted::new_unrooted();"))
 
             # The auto rooting is done only after the conversion is performed
             if type_needs_auto_root(argument.type):
-                self.converter.append(CGGeneric("auto_root!(in(cx) let %s = %s);" % (arg, arg)))
+                converter.append(CGGeneric("auto_root!(in(cx) let %s = %s);" % (arg, arg)))
+
+            self.converter = CGList(converter, "\n")
 
         else:
             assert argument.optional
@@ -5687,6 +5732,7 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'js::jsapi::MutableHandleValue',
         'js::jsapi::ObjectOpResult',
         'js::jsapi::PropertyDescriptor',
+        'js::jsapi::Rooted',
         'js::jsapi::RootedId',
         'js::jsapi::RootedObject',
         'js::jsapi::RootedString',
@@ -5718,6 +5764,7 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'js::rust::define_methods',
         'js::rust::define_properties',
         'js::rust::get_object_class',
+        'js::typedarray',
         'dom',
         'dom::bindings',
         'dom::bindings::codegen::InterfaceObjectMap',
@@ -6437,6 +6484,14 @@ def type_needs_tracing(t):
 
     assert False, (t, type(t))
 
+
+def type_conversion_needs_root(t):
+    assert isinstance(t, IDLObject), (t, type(t))
+
+    if t.isType():
+        return t.isSpiderMonkeyInterface()
+
+    assert False, (t, type(t))
 
 def type_needs_auto_root(t):
     """

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -881,11 +881,10 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
                 "exceptionCode": exceptionCode,
             }
             unwrapFailureCode = string.Template(
-            'throw_type_error(cx, "${sourceDescription} is not a typed array.");\n'
-            '${exceptionCode}').substitute(substitutions)
+                'throw_type_error(cx, "${sourceDescription} is not a typed array.");\n'
+                '${exceptionCode}').substitute(substitutions)
         else:
             unwrapFailureCode = failureCode
-
 
         templateBody = fill(
             """
@@ -6492,6 +6491,7 @@ def type_conversion_needs_root(t):
         return t.isSpiderMonkeyInterface()
 
     assert False, (t, type(t))
+
 
 def type_needs_auto_root(t):
     """

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -871,7 +871,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
 
         return handleOptional(templateBody, declType, handleDefaultNull("None"))
 
-    if type.isSpiderMonkeyInterface():
+    if type.isTypedArray() or type.isArrayBuffer() or type.isArrayBufferView() or type.isSharedArrayBuffer():
         # Typed arrays can be constructed only with a prior rooted value
         assert isArgument or isinstance(needsRootingInto, basestring)
 
@@ -910,6 +910,9 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
                                           isDefinitelyObject, type, failureCode)
 
         return handleOptional(templateBody, declType, handleDefaultNull("None"))
+
+    elif type.isSpiderMonkeyInterface():
+        raise TypeError("Can't handle SpiderMonkey interface arguments other than typed arrays yet")
 
     if type.isDOMString():
         nullBehavior = getConversionConfigForType(type, isEnforceRange, isClamp, treatNullAs)
@@ -6485,12 +6488,9 @@ def type_needs_tracing(t):
 
 
 def type_conversion_needs_root(t):
-    assert isinstance(t, IDLObject), (t, type(t))
+    assert isinstance(t, IDLType)
 
-    if t.isType():
-        return t.isSpiderMonkeyInterface()
-
-    assert False, (t, type(t))
+    return t.isSpiderMonkeyInterface()
 
 
 def type_needs_auto_root(t):

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -38,6 +38,7 @@ use js::jsapi::{HandleObject, HandleValue, Heap, JSContext, JSObject};
 use js::jsapi::{JS_NewPlainObject, JS_NewUint8ClampedArray};
 use js::jsval::{JSVal, NullValue};
 use js::rust::CustomAutoRooterGuard;
+use js::typedarray;
 use script_traits::MsDuration;
 use servo_config::prefs::PREFS;
 use std::borrow::ToOwned;
@@ -428,6 +429,9 @@ impl TestBindingMethods for TestBinding {
     fn PassByteString(&self, _: ByteString) {}
     fn PassEnum(&self, _: TestEnum) {}
     fn PassInterface(&self, _: &Blob) {}
+    fn PassTypedArray(&self, _: typedarray::Int8Array) {}
+    fn PassTypedArray2(&self, _: typedarray::ArrayBuffer) {}
+    fn PassTypedArray3(&self, _: typedarray::ArrayBufferView) {}
     fn PassUnion(&self, _: HTMLElementOrLong) {}
     fn PassUnion2(&self, _: EventOrString) {}
     fn PassUnion3(&self, _: BlobOrString) {}

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -246,6 +246,9 @@ interface TestBinding {
   void passByteString(ByteString arg);
   void passEnum(TestEnum arg);
   void passInterface(Blob arg);
+  void passTypedArray(Int8Array arg);
+  void passTypedArray2(ArrayBuffer arg);
+  void passTypedArray3(ArrayBufferView arg);
   void passUnion((HTMLElement or long) arg);
   void passUnion2((Event or DOMString) data);
   void passUnion3((Blob or DOMString) data);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Preliminary work for #5014.

Sorry for a long period of inactivity on the issue. I'd like to return to working on it, however this is more of an exploratory work and approach, rather that something I'm focused on landing.

Basically the changes are limited to generating correct conversion codegen using `typedarray` types from rust-mozjs, for function arguments.

I believe I need more guidance on how to implement the WebIDL typed array bindings in a more complete/correct way.
First of all, these changes do not support [`typedef (ArrayBufferView or ArrayBuffer) BufferSource;`](https://heycam.github.io/webidl/#BufferSource) (or any other union for that matter).

I believe that to use them inside regular union bindings code, this will more complete approach wrt rooting and possibly being stored on heap. Currently [`TypedArray`](https://github.com/servo/rust-mozjs/blob/master/src/typedarray.rs) types are only allowed on stack, since they internally hold a stack root guard. Is it possible and if so, how should such a type be stored on heap (in unions?)? Using `RootedTraceableBox`?

Secondly, this is the first argument that requires an outer stack root for the argument conversion. Should I add a `TypedArray::from_unrooted` (similar to [`TypedArray::from`](https://github.com/servo/rust-mozjs/blob/master/src/typedarray.rs#L77)) that returns an unrooted 'converted' value, which is only rooted later at the call time, removing the need for newly-added `needsRootingInto` param in codegen?

@jdm @KiChjang what do you think about this?

------------

For context, this is the generated code for `void passTypedArray(Int8Array arg);`:
```rust
// (...)
let mut arg_root = Rooted::new_unrooted();
let arg0: typedarray::Int8Array = if args.get(0).get().is_object() {
    match typedarray::Int8Array::from(cx, &mut arg_root,
        args.get(0).get().to_object()) {
        Ok(val) => val,
        Err(()) => {
            throw_type_error(cx, "value is not a typed array.");
            return false;

        }
    }

} else {
    throw_type_error(cx, "Value is not an object.");
    return false;

};
let result: () = this.PassTypedArray(arg0);
// (...)
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20205)
<!-- Reviewable:end -->
