### PR TITLE
Ensure default paths are set when updating WPT metadata.

### DIFF
--- a/tests/wpt/update/updatecommandline.py
+++ b/tests/wpt/update/updatecommandline.py
@@ -20,6 +20,7 @@ def check_args(kwargs):
     from wptrunner import wptcommandline
 
     wptcommandline.set_from_config(kwargs)
+    wptcommandline.check_paths(kwargs)
     kwargs["upstream"] = kwargs["upstream"] if kwargs["upstream"] is not None else kwargs["sync"]
 
     if kwargs["upstream"]:


### PR DESCRIPTION
This fixes https://github.com/w3c/web-platform-tests/issues/9819 and will allow our nightly upstream sync to complete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20206)
<!-- Reviewable:end -->
