### PR TITLE
Regenerate all WebIDLs when one of them changes

### DIFF
--- a/components/script/CMakeLists.txt
+++ b/components/script/CMakeLists.txt
@@ -106,7 +106,7 @@ foreach(binding IN LISTS bindings)
                    .
                    Bindings/${binding}Binding
                    ${webidls_src}/${binding}.webidl
-    DEPENDS Bindings ${bindinggen_deps} ${webidls_src}/${binding}.webidl ParserResults
+    DEPENDS Bindings ${bindinggen_deps} ${webidls} ParserResults
     VERBATIM
     )
   add_custom_target(${binding} DEPENDS Bindings/${binding}Binding.rs)


### PR DESCRIPTION
WebIDL files have dependencies between each other, but cmake doesn't have any
information about them. This can cause it to not update all the changed bindings
when switching branches.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #20169

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it's a minor change in the build dependencies.
Switching between two of my branches was previously failing because a change in WebGL1 bindings didn't re-generate the WebGL2 bindings. I verified that it works with this patch.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20212)
<!-- Reviewable:end -->
