### PR TITLE
Stop using LocalClip::RoundedRect

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -3109,11 +3109,3 @@ impl ISizeAndMarginsComputer for InlineFlexItem {
                                      fragment.margin.inline_end)
     }
 }
-
-/// A stacking context, a pseudo-stacking context, or a non-stacking context.
-#[derive(Clone, Copy, PartialEq)]
-pub enum BlockStackingContextType {
-    NonstackingContext,
-    PseudoStackingContext,
-    StackingContext,
-}


### PR DESCRIPTION
We would like to remove this functionality from WebRender, so convert
its use to clip scroll nodes. This change also removes the redundant
BlocBlockStackingContextType in favor of Option<StackingContextType>,
which is just as expressive. This simplifies the code a bit.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20214)
<!-- Reviewable:end -->
