### PR TITLE
Add a smoketest to Windows CI

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -201,6 +201,7 @@ windows-msvc-dev:
   - mach.bat package --dev
   - mach.bat build-geckolib
   - mach.bat test-stylo
+  - mach.bat smoketest
 
 windows-msvc-nightly:
   env:

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -898,3 +898,10 @@ testing/web-platform/mozilla/tests for Servo-only tests""" % reference_path)
         run_globals = {"__file__": run_file}
         execfile(run_file, run_globals)
         return run_globals["update_conformance"](version, dest_folder, None, patches_dir)
+
+    @Command('smoketest',
+             description='Load a simple page in Servo and ensure that it closes properly',
+             category='testing')
+    def smoketest(self):
+        return self.context.commands.dispatch(
+            'run', self.context, params=['tests/html/close-on-load.html'])

--- a/tests/html/close-on-load.html
+++ b/tests/html/close-on-load.html
@@ -1,0 +1,5 @@
+<script>
+  window.onload = function() {
+    window.close();
+  }
+</script>


### PR DESCRIPTION
This test runs Servo, then loads a page that waits until the onload event and closes the window. If anything crashes while this happens, the smoketest should be classified as a failure.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20217)
<!-- Reviewable:end -->
