### PR TITLE
Fix `mach build` for Servo in Firefox tree

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -131,12 +131,22 @@ def wpt_path(is_firefox, topdir, *paths):
     return os.path.join(topdir, rel, *paths)
 
 
-def wpt_harness_path(is_firefox, topdir, *paths):
+def wptrunner_path(is_firefox, topdir, *paths):
     wpt_root = wpt_path(is_firefox, topdir)
     if is_firefox:
         rel = os.path.join(wpt_root, "tests", "tools", "wptrunner")
     else:
         rel = os.path.join(wpt_root, "web-platform-tests", "tools", "wptrunner")
+
+    return os.path.join(topdir, rel, *paths)
+
+
+def wptserve_path(is_firefox, topdir, *paths):
+    wpt_root = wpt_path(is_firefox, topdir)
+    if is_firefox:
+        rel = os.path.join(wpt_root, "tests", "tools", "wptserve")
+    else:
+        rel = os.path.join(wpt_root, "web-platform-tests", "tools", "wptserve")
 
     return os.path.join(topdir, rel, *paths)
 
@@ -175,9 +185,9 @@ def _activate_virtualenv(topdir, is_firefox):
     # and it will check for conflicts.
     requirements_paths = [
         os.path.join("python", "requirements.txt"),
-        wpt_harness_path(is_firefox, topdir, "requirements.txt",),
-        wpt_harness_path(is_firefox, topdir, "requirements_firefox.txt"),
-        wpt_harness_path(is_firefox, topdir, "requirements_servo.txt"),
+        wptrunner_path(is_firefox, topdir, "requirements.txt",),
+        wptrunner_path(is_firefox, topdir, "requirements_firefox.txt"),
+        wptrunner_path(is_firefox, topdir, "requirements_servo.txt"),
     ]
 
     if need_pip_upgrade:
@@ -267,7 +277,8 @@ def bootstrap(topdir):
     sys.path[0:0] = [os.path.join(topdir, path) for path in SEARCH_PATHS]
 
     sys.path[0:0] = [wpt_path(is_firefox, topdir),
-                     wpt_harness_path(is_firefox, topdir)]
+                     wptrunner_path(is_firefox, topdir),
+                     wptserve_path(is_firefox, topdir)]
 
     import mach.main
     mach = mach.main.Mach(os.getcwd())

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -30,11 +30,14 @@ wpt = os.path.join(topdir, "tests", "wpt")
 def wpt_path(*args):
     return os.path.join(wpt, *args)
 
-sys.path.append(wpt_path("web-platform-tests", "tools", "wptrunner", "wptrunner"))
-from wptmanifest import parser, node
-
 CONFIG_FILE_PATH = os.path.join(".", "servo-tidy.toml")
 WPT_MANIFEST_PATH = wpt_path("include.ini")
+
+# Import wptmanifest only when we do have wpt in tree, i.e. we're not
+# inside a Firefox checkout.
+if os.path.isfile(WPT_MANIFEST_PATH):
+    sys.path.append(wpt_path("web-platform-tests", "tools", "wptrunner", "wptrunner"))
+    from wptmanifest import parser, node
 
 # Default configs
 config = {
@@ -1166,7 +1169,10 @@ def scan(only_changed_files=False, progress=True, stylo=False):
     # check config file for errors
     config_errors = check_config_file(CONFIG_FILE_PATH)
     # check ini directories exist
-    manifest_errors = check_manifest_dirs(WPT_MANIFEST_PATH)
+    if os.path.isfile(WPT_MANIFEST_PATH):
+        manifest_errors = check_manifest_dirs(WPT_MANIFEST_PATH)
+    else:
+        manifest_errors = ()
     # check directories contain expected files
     directory_errors = check_directory_files(config['check_ext'])
     # standard checks


### PR DESCRIPTION
Running `mach build` in servo directory in Firefox tree currently doesn't work due to several errors when importing modules.

First error:
```text
Traceback (most recent call last):
  File "mach", line 93, in <module>
    main(sys.argv)
  File "mach", line 23, in main
    mach = mach_bootstrap.bootstrap(topdir)
  File "servo/python/mach_bootstrap.py", line 280, in bootstrap
    mach.load_commands_from_file(os.path.join(topdir, path))
  File "servo/python/_virtualenv/Lib/site-packages/mach/main.py", line 265, in load_commands_from_file
    imp.load_source(module_name, path)
  File "servo/python/servo/testing_commands.py", line 42, in <module>
    from update import updatecommandline
  File "servo/../testing/web-platform/update/__init__.py", line 17, in <module>
    from wptrunner.update import setup_logging, WPTUpdate
  File "servo/../testing/web-platform/tests/tools/wptrunner/wptrunner/update/__init__.py", line 8, in <module>
    from update import WPTUpdate
  File "servo/../testing/web-platform/tests/tools/wptrunner/wptrunner/update/update.py", line 8, in <module>
    from .. import environment as env
  File "servo/../testing/web-platform/tests/tools/wptrunner/wptrunner/environment.py", line 12, in <module>
    from wptserve.handlers import StringHandler
ImportError: No module named wptserve.handlers
```

Second error:
```text
Traceback (most recent call last):
  File "mach", line 93, in <module>
    main(sys.argv)
  File "mach", line 23, in main
    mach = mach_bootstrap.bootstrap(topdir)
  File "servo/python/mach_bootstrap.py", line 291, in bootstrap
    mach.load_commands_from_file(os.path.join(topdir, path))
  File "servo/python/_virtualenv/Lib/site-packages/mach/main.py", line 265, in load_commands_from_file
    imp.load_source(module_name, path)
  File "servo/python/servo/testing_commands.py", line 43, in <module>
    from servo_tidy import tidy
  File "servo/python/tidy/servo_tidy/tidy.py", line 34, in <module>
    from wptmanifest import parser, node
ImportError: No module named wptmanifest
```

The two commits fix these two errors respectively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20227)
<!-- Reviewable:end -->
