### PR TITLE
Don't clean the cargo cache on Windows.

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -191,10 +191,7 @@ arm64:
   - bash ./etc/ci/manifest_changed.sh
 
 windows-msvc-dev:
-  env:
-    CARGO_HOME: C:\buildbot\.cargo
   commands:
-  - mach.bat clean-cargo-cache --keep 3 --force
   - mach.bat clean-nightlies --keep 3 --force
   - mach.bat build --dev
   - mach.bat test-unit
@@ -203,10 +200,7 @@ windows-msvc-dev:
   - mach.bat test-stylo
 
 windows-msvc-nightly:
-  env:
-    CARGO_HOME: C:\buildbot\.cargo
   commands:
-  - mach.bat clean-cargo-cache --keep 3 --force
   - mach.bat clean-nightlies --keep 3 --force
   - mach.bat build --release
   - mach.bat package --release


### PR DESCRIPTION
I previously added the CARGO_HOME for Windows builders because I thought there might be a permissions problem with the default location that was causing the errors when cloning repositories. I suspect that cleaning the cache is to blame for those somehow, since as far as I recall the problems started after #19713. Let's take it out and see if they go away!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20233)
<!-- Reviewable:end -->
