### PR TITLE
style: Fix special color keywords.

### DIFF
--- a/components/style/properties/longhand/color.mako.rs
+++ b/components/style/properties/longhand/color.mako.rs
@@ -63,7 +63,6 @@ pub mod system_colors {
                           IMESelectedConvertedTextBackground IMESelectedConvertedTextForeground
                           IMESelectedConvertedTextUnderline SpellCheckerUnderline""".split()
     %>
-    use cssparser::Parser;
     use gecko_bindings::bindings::Gecko_GetLookAndFeelSystemColor;
     use gecko_bindings::structs::root::mozilla::LookAndFeel_ColorID;
     use std::fmt::{self, Write};
@@ -109,7 +108,7 @@ pub mod system_colors {
     }
 
     impl SystemColor {
-        pub fn parse<'i, 't>(input: &mut Parser<'i, 't>,) -> Result<Self, ()> {
+        pub fn from_ident<'i, 't>(ident: &str) -> Result<Self, ()> {
             ascii_case_insensitive_phf_map! {
                 color_name -> SystemColor = {
                     % for color in system_colors:
@@ -118,7 +117,6 @@ pub mod system_colors {
                 }
             }
 
-            let ident = input.expect_ident().map_err(|_| ())?;
             color_name(ident).cloned().ok_or(())
         }
     }

--- a/components/style/values/specified/color.rs
+++ b/components/style/values/specified/color.rs
@@ -160,12 +160,14 @@ impl Parse for Color {
             Err(e) => {
                 #[cfg(feature = "gecko")]
                 {
-                    if let Ok(system) = input.try(SystemColor::parse) {
-                        return Ok(Color::System(system));
-                    }
+                    if let Ok(ident) = input.expect_ident() {
+                        if let Ok(system) = SystemColor::from_ident(ident) {
+                            return Ok(Color::System(system));
+                        }
 
-                    if let Ok(c) = gecko::SpecialColorKeyword::parse(input) {
-                        return Ok(Color::Special(c));
+                        if let Ok(c) = gecko::SpecialColorKeyword::from_ident(ident) {
+                            return Ok(Color::Special(c));
+                        }
                     }
                 }
 

--- a/components/style/values/specified/color.rs
+++ b/components/style/values/specified/color.rs
@@ -52,8 +52,8 @@ mod gecko {
         MozDefaultColor,
         MozDefaultBackgroundColor,
         MozHyperlinktext,
-        MozActiveHyperlinktext,
-        MozVisitedHyperlinktext,
+        MozActivehyperlinktext,
+        MozVisitedhyperlinktext,
     }
 }
 
@@ -368,8 +368,8 @@ impl Color {
                         Keyword::MozDefaultColor => pres_context.mDefaultColor,
                         Keyword::MozDefaultBackgroundColor => pres_context.mBackgroundColor,
                         Keyword::MozHyperlinktext => pres_context.mLinkColor,
-                        Keyword::MozActiveHyperlinktext => pres_context.mActiveLinkColor,
-                        Keyword::MozVisitedHyperlinktext => pres_context.mVisitedLinkColor,
+                        Keyword::MozActivehyperlinktext => pres_context.mActiveLinkColor,
+                        Keyword::MozVisitedhyperlinktext => pres_context.mVisitedLinkColor,
                     })
                 })
             }


### PR DESCRIPTION
They're -moz-activehyperlinktext and -moz-visitedhyperlinktext.

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1444059.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20240)
<!-- Reviewable:end -->
