### PR TITLE
Ensure readonly files can be removed on Windows.

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -16,6 +16,7 @@ import os.path as path
 import re
 import subprocess
 import sys
+import traceback
 import urllib2
 import glob
 
@@ -318,6 +319,7 @@ class MachCommands(CommandBase):
                                         try:
                                             delete(crate_path)
                                         except:
+                                            print(traceback.format_exc())
                                             print("Delete %s failed!" % crate_path)
                             else:
                                 print("Would remove `{}`{} package from {}".format(*print_msg))

--- a/python/servo/util.py
+++ b/python/servo/util.py
@@ -14,6 +14,7 @@ import os.path
 import platform
 import shutil
 from socket import error as socket_error
+import stat
 import StringIO
 import sys
 import zipfile
@@ -35,9 +36,15 @@ else:
     URLOPEN_KWARGS = {}
 
 
+def remove_readonly(func, path, _):
+    "Clear the readonly bit and reattempt the removal"
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
+
+
 def delete(path):
     if os.path.isdir(path) and not os.path.islink(path):
-        shutil.rmtree(path)
+        shutil.rmtree(path, onerror=remove_readonly)
     else:
         os.remove(path)
 


### PR DESCRIPTION
This is based off of https://bugs.python.org/issue19643. At worst, it makes our deletion function more robust and doesn't help with the ongoing windows CI problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20244)
<!-- Reviewable:end -->
