### PR TITLE
style: Reorder style sharing checks so that cheaper and broader ones are earlier.

### DIFF
--- a/components/style/sharing/mod.rs
+++ b/components/style/sharing/mod.rs
@@ -656,6 +656,29 @@ impl<E: TElement> StyleSharingCache<E> {
             return None;
         }
 
+        if target.local_name() != candidate.element.local_name() {
+            trace!("Miss: Local Name");
+            return None;
+        }
+
+        if target.namespace() != candidate.element.namespace() {
+            trace!("Miss: Namespace");
+            return None;
+        }
+
+        // We do not ignore visited state here, because Gecko needs to store
+        // extra bits on visited style contexts, so these contexts cannot be
+        // shared.
+        if target.element.state() != candidate.state() {
+            trace!("Miss: User and Author State");
+            return None;
+        }
+
+        if target.is_link() != candidate.element.is_link() {
+            trace!("Miss: Link");
+            return None;
+        }
+
         // Note that in the XBL case, we should be able to assert that the
         // scopes are different, since two elements with different XBL bindings
         // need to necessarily have different style (and thus children of them
@@ -676,32 +699,9 @@ impl<E: TElement> StyleSharingCache<E> {
             return None;
         }
 
-        if target.local_name() != candidate.element.local_name() {
-            trace!("Miss: Local Name");
-            return None;
-        }
-
-        if target.namespace() != candidate.element.namespace() {
-            trace!("Miss: Namespace");
-            return None;
-        }
-
-        if target.is_link() != candidate.element.is_link() {
-            trace!("Miss: Link");
-            return None;
-        }
-
         if target.matches_user_and_author_rules() !=
             candidate.element.matches_user_and_author_rules() {
             trace!("Miss: User and Author Rules");
-            return None;
-        }
-
-        // We do not ignore visited state here, because Gecko
-        // needs to store extra bits on visited style contexts,
-        // so these contexts cannot be shared
-        if target.element.state() != candidate.state() {
-            trace!("Miss: User and Author State");
             return None;
         }
 


### PR DESCRIPTION
This was reviewed by Xidorn in #20223, but that needs to wait for a few days so let's land this separately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20250)
<!-- Reviewable:end -->
