### PR TITLE
Support memory report logs with interleaved non-report output

### DIFF
--- a/etc/memory_reports_over_time.py
+++ b/etc/memory_reports_over_time.py
@@ -28,7 +28,8 @@ def extract_memory_reports(lines):
         elif line == 'End memory reports\n':
             in_report = False
         elif in_report:
-            report_lines[-1].append(line.strip())
+            if line.startswith('|'):
+                report_lines[-1].append(line.strip())
     return (report_lines, times)
 
 
@@ -72,6 +73,17 @@ def transform_report_for_test(report):
     return transformed
 
 
+def test_extract_memory_reports():
+    input = ["Begin memory reports",
+             "|",
+             "  154.56 MiB -- explicit\n",
+             "|     107.88 MiB -- system-heap-unclassified\n",
+             "End memory reports\n"]
+    expected = ([['|', '|     107.88 MiB -- system-heap-unclassified']], ['reports'])
+    assert(extract_memory_reports(input) == expected)
+    return 0
+
+
 def test():
     input = '''|
 |   23.89 MiB -- explicit
@@ -105,6 +117,7 @@ def test():
     assert(sorted(transformed.keys()) == sorted(expected.keys()))
     for k, v in transformed.items():
         assert(v == expected[k])
+    test_extract_memory_reports()
     return 0
 
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`line 30-31` in `servo/etc/memory_reports_over_time.py`  should just ignore any line that doesn't begin with `|`.

The new if statement added such as `if line.startswith('|'):` then continue to append. So, only lines begin with `|` will be appended.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #20257(github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because of __

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20259)
<!-- Reviewable:end -->
