### PR TITLE
Fix JS object conversion in unions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,7 +1620,7 @@ dependencies = [
  "cssparser 0.23.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashglobe 0.1.0",
- "mozjs 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mozjs 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.19.0",
  "servo_arc 0.1.1",
  "smallbitvec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1795,13 +1795,13 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mozjs_sys 0.50.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2462,7 +2462,7 @@ dependencies = [
  "mime_guess 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mitochondria 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mozangle 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "mozjs 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mozjs 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3844,7 +3844,7 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum mitochondria 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9de3eca27871df31c33b807f834b94ef7d000956f57aa25c5aed9c5f0aae8f6f"
 "checksum mozangle 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4d916e4f2d39a00eeeb082ceb7c63c741e7c9d4f7915945f9225ae5e3b284092"
-"checksum mozjs 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "199f707066bf05b559ef6e46741c20e4f7bca8ae3a9c9d953d728dbb840f4eaa"
+"checksum mozjs 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "23e86a4da33f9325da4ccc652506284e00ff20f06d63f721eaebeb804eaca62d"
 "checksum mozjs_sys 0.50.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e61a792a125b1364c5ec50255ed8343ce02dc56098f8868dd209d472c8de006a"
 "checksum mp3-metadata 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ab5f1d2693586420208d1200ce5a51cd44726f055b635176188137aff42c7de"
 "checksum mp4parse 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f821e3799bc0fd16d9b861fb02fa7ee1b5fba29f45ad591dade105c48ca9a1a0"

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -765,7 +765,12 @@ unsafe impl<T: JSTraceable + 'static> JSTraceable for RootedTraceableBox<T> {
 impl<T: JSTraceable + 'static> RootedTraceableBox<T> {
     /// DomRoot a JSTraceable thing for the life of this RootedTraceable
     pub fn new(traceable: T) -> RootedTraceableBox<T> {
-        let traceable = Box::into_raw(Box::new(traceable));
+        Self::from_box(Box::new(traceable))
+    }
+
+    /// Consumes a boxed JSTraceable and roots it for the life of this RootedTraceable.
+    pub fn from_box(boxed_traceable: Box<T>) -> RootedTraceableBox<T> {
+        let traceable = Box::into_raw(boxed_traceable);
         unsafe {
             RootedTraceableSet::add(traceable);
         }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -293,6 +293,14 @@ impl TestBindingMethods for TestBinding {
     fn ReceiveInterfaceSequence(&self) -> Vec<DomRoot<Blob>> {
         vec![Blob::new(&self.global(), BlobImpl::new_from_bytes(vec![]), "".to_owned())]
     }
+    #[allow(unsafe_code)]
+    unsafe fn ReceiveUnionIdentity(
+        &self,
+        _: *mut JSContext,
+        arg: UnionTypes::StringOrObject,
+    ) -> UnionTypes::StringOrObject {
+        arg
+    }
 
     fn ReceiveNullableBoolean(&self) -> Option<bool> { Some(false) }
     fn ReceiveNullableByte(&self) -> Option<i8> { Some(0) }

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -228,6 +228,8 @@ interface TestBinding {
   TestDictionary receiveTestDictionaryWithSuccessOnKeyword();
   boolean dictMatchesPassedValues(TestDictionary arg);
 
+  (DOMString or object) receiveUnionIdentity((DOMString or object) arg);
+
   void passBoolean(boolean arg);
   void passByte(byte arg);
   void passOctet(octet arg);

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -31972,6 +31972,12 @@
      {}
     ]
    ],
+   "mozilla/codegen_unions.html": [
+    [
+     "/_mozilla/mozilla/codegen_unions.html",
+     {}
+    ]
+   ],
    "mozilla/collections.html": [
     [
      "/_mozilla/mozilla/collections.html",
@@ -64749,6 +64755,10 @@
   ],
   "mozilla/client-top-left-height-width.html": [
    "5183977a0d29ba4d74d049c9391090e3c27264a8",
+   "testharness"
+  ],
+  "mozilla/codegen_unions.html": [
+   "7f772fffb75acc92f9c949a482d387b3ed18d0ed",
    "testharness"
   ],
   "mozilla/collections.html": [

--- a/tests/wpt/mozilla/meta/mozilla/codegen_unions.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/codegen_unions.html.ini
@@ -1,0 +1,3 @@
+[codegen_unions.html]
+  type: testharness
+  prefs: [dom.testbinding.enabled:true]

--- a/tests/wpt/mozilla/tests/mozilla/codegen_unions.html
+++ b/tests/wpt/mozilla/tests/mozilla/codegen_unions.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<meta charset="utf-8">
+<title>WebIDL conversions are performed correctly and don't lose values</title>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<script>
+test(function() {
+  var t = new TestBinding;
+
+  // (DOMString or object) receiveUnionIdentity((DOMString or object) arg)
+  var obj = { 'some': 'key', 'num': 42 };
+  assert_equals(t.receiveUnionIdentity(obj), obj);
+
+  var str = "myString";
+  assert_equals(t.receiveUnionIdentity(str), str);
+}, "(DOMString or object) conversion is performed correctly");
+</script>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Requires safe `Heap::boxed` constructor from https://github.com/servo/rust-mozjs/pull/395 (more info on it is in the PR).

Since unions currently assume that their respective members root themselves and can be stored on heap, I modified the union member object conversion branch to convert to a `RootedTraceableBox<Heap<*mut JSObject>>` (which is the currently generated type for objects in said unions).

I did it only for Unions and not dictionaries, since some dictionaries had bare `*mut JSObject` members - is this a mistake and something that needs further fixing?

Does this need a test, e.g. passing a union with object to a function that returns said object, and comparing the results for equality?

r? @jdm

Generated code with this patch (for `StringOrObject`):
```rust
impl FromJSValConvertible for StringOrObject {
    type Config = ();
    unsafe fn from_jsval(cx: *mut JSContext,
                         value: HandleValue,
                         _option: ())
                         -> Result<ConversionResult<StringOrObject>, ()> {
        if value.get().is_object() {
            match StringOrObject::TryConvertToObject(cx, value) {
                Err(_) => return Err(()),
                Ok(Some(value)) => return Ok(ConversionResult::Success(StringOrObject::Object(value))),
                Ok(None) => (),
            }

        }
        // (...)
    }
}

impl StringOrObject {
    // (...)
    unsafe fn TryConvertToObject(cx: *mut JSContext, value: HandleValue) -> Result<Option<RootedTraceableBox<Heap<*mut JSObject>>>, ()> {
        Ok(Some(RootedTraceableBox::from_box(Heap::boxed(value.get().to_object()))))
    }
}
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #17011 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20265)
<!-- Reviewable:end -->
