### PR TITLE
[WIP] Handle nondeterministic paint worklet registration

### DIFF
--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -1023,7 +1023,7 @@ impl FragmentDisplayListBuilding for Fragment {
                 painter.draw_a_paint_image(size_in_px, device_pixel_ratio, properties, arguments)
             },
             None => {
-                debug!("Worklet {} called before registration.", name);
+                debug!("Paint worklet {} does not have a valid definition.", name);
                 return None;
             },
         };

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -756,6 +756,9 @@ impl LayoutThread {
                 };
                 self.registered_painters.insert_painter(name, registered_painter);
             },
+            Msg::InvalidatePaint(name) => {
+                self.registered_painters.invalidate_painter(name);
+            },
             Msg::PrepareToExit(response_chan) => {
                 self.prepare_to_exit(response_chan);
                 return false
@@ -1848,6 +1851,11 @@ impl RegisteredPaintersImpl {
                 vacant.insert(PaintDefinition::Registered(painter));
             }
         }
+    }
+
+    fn invalidate_painter(&mut self, name: Atom) {
+        debug!("Invalidating definition of painter {}", name);
+        self.0.insert(name, PaintDefinition::Conflict);
     }
 
     fn get_painter(&self, name: &Atom) -> Option<&RegisteredPainterImpl> {

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -501,10 +501,8 @@ impl PaintWorkletGlobalScopeMethods for PaintWorkletGlobalScope {
         debug!("Registering definition {}.", name);
         self.paint_definitions.borrow_mut().insert(name.clone(), definition);
 
-        // TODO: Step 21.
-
+        // Step 21.
         // Inform layout that there is a registered paint worklet.
-        // TODO: layout will end up getting this message multiple times.
         let painter = self.painter(name.clone());
         self.worklet_global.register_paint_worklet(name, properties, input_arguments.len(), alpha, painter);
 

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -208,14 +208,15 @@ impl PaintWorkletGlobalScope {
         let cx = self.worklet_global.get_cx();
         let _ac = JSAutoCompartment::new(cx, self.worklet_global.reflector().get_jsobject().get());
 
-        // TODO: Steps 1-2.1.
-        // Step 2.2-5.1.
+        // TODO: Step 1.
+        // Step 2-5.1.
         rooted!(in(cx) let mut class_constructor = UndefinedValue());
         rooted!(in(cx) let mut paint_function = UndefinedValue());
         let rendering_context = match self.paint_definitions.borrow().get(name) {
             None => {
-                // Step 2.2.
-                warn!("Drawing un-registered paint definition {}.", name);
+                // Step 2.
+                warn!("Paint class {} was not registered in all worklet scopes.", name);
+                self.worklet_global.invalidate_paint_worklet(name.clone());
                 return self.invalid_image(size_in_dpx, vec![]);
             }
             Some(definition) => {

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -506,7 +506,7 @@ impl PaintWorkletGlobalScopeMethods for PaintWorkletGlobalScope {
         // Inform layout that there is a registered paint worklet.
         // TODO: layout will end up getting this message multiple times.
         let painter = self.painter(name.clone());
-        self.worklet_global.register_paint_worklet(name, properties, painter);
+        self.worklet_global.register_paint_worklet(name, properties, input_arguments.len(), alpha, painter);
 
         Ok(())
     }

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -96,6 +96,8 @@ impl WorkletGlobalScope {
         &self,
         name: Atom,
         properties: Vec<Atom>,
+        input_arguments_len: usize,
+        alpha: bool,
         painter: Box<Painter>,
     ) {
         self.to_script_thread_sender
@@ -103,6 +105,8 @@ impl WorkletGlobalScope {
                 pipeline_id: self.globalscope.pipeline_id(),
                 name,
                 properties,
+                input_arguments_len,
+                alpha,
                 painter,
             })
             .expect("Worklet thread outlived script thread.");

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -112,6 +112,16 @@ impl WorkletGlobalScope {
             .expect("Worklet thread outlived script thread.");
     }
 
+    /// Invalidate a paint worklet's definition in the script thread.
+    pub fn invalidate_paint_worklet(&self, name: Atom) {
+        let pipeline_id = self.globalscope.pipeline_id();
+        self.to_script_thread_sender
+            .send(
+                MainThreadScriptMsg::InvalidatePaintWorklet(pipeline_id, name)
+            )
+            .expect("Worklet thread outlived script thread.");
+    }
+
     /// The base URL of this global.
     pub fn base_url(&self) -> ServoUrl {
         self.base_url.clone()

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -233,6 +233,8 @@ pub enum MainThreadScriptMsg {
         pipeline_id: PipelineId,
         name: Atom,
         properties: Vec<Atom>,
+        input_arguments_len: usize,
+        alpha: bool,
         painter: Box<Painter>
     },
     /// Dispatches a job queue.
@@ -734,6 +736,8 @@ impl ScriptThread {
         pipeline_id: PipelineId,
         name: Atom,
         properties: Vec<Atom>,
+        input_arguments_len: usize,
+        alpha: bool,
         painter: Box<Painter>)
     {
         let window = self.documents.borrow().find_window(pipeline_id);
@@ -742,7 +746,7 @@ impl ScriptThread {
             None => return warn!("Paint worklet registered after pipeline {} closed.", pipeline_id),
         };
         let _ = window.layout_chan().send(
-            Msg::RegisterPaint(name, properties, painter),
+            Msg::RegisterPaint(name, properties, input_arguments_len, alpha, painter),
         );
     }
 
@@ -1349,12 +1353,16 @@ impl ScriptThread {
                 pipeline_id,
                 name,
                 properties,
+                input_arguments_len,
+                alpha,
                 painter,
             } => {
                 self.handle_register_paint_worklet(
                     pipeline_id,
                     name,
                     properties,
+                    input_arguments_len,
+                    alpha,
                     painter,
                 )
             },

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -94,7 +94,7 @@ pub enum Msg {
     UpdateScrollStateFromScript(ScrollState),
 
     /// Tells layout that script has added some paint worklet modules.
-    RegisterPaint(Atom, Vec<Atom>, Box<Painter>),
+    RegisterPaint(Atom, Vec<Atom>, usize, bool, Box<Painter>),
 
     /// Send to layout the precise time when the navigation started.
     SetNavigationStart(u64),

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -96,6 +96,9 @@ pub enum Msg {
     /// Tells layout that script has added some paint worklet modules.
     RegisterPaint(Atom, Vec<Atom>, usize, bool, Box<Painter>),
 
+    /// Tells layout that script has encountered a paint worklet that isn't valid in all scopes.
+    InvalidatePaint(Atom),
+
     /// Send to layout the precise time when the navigation started.
     SetNavigationStart(u64),
 }


### PR DESCRIPTION
When different global paint worklet scopes register document paint definitions of the same name with different parameters, the registration should be marked invalid [1]. Currently, Servo unconditionally overwrites any prior registrations when a new definition is received.

This commit passes the parameters from the paint worklet global scope through to the layout thread so that they can be tracked there. In the absence of support for parsing input arguments, I'm passing the length of the input argument vector as a placeholder.

TODO:

- [X] When the act of registering a paint class in the first place is non-deterministic, a paint worklet global scope may attempt to invoke a paint callback for a class it has not registered. When this happens, the spec states that the document paint definition should be invalidated and an invalid image should be output [2]. Currently, [only the latter](https://github.com/servo/servo/blob/72d09202f4e5207cee606e122729dd007e6b5ac8/components/script/dom/paintworkletglobalscope.rs#L211) happens.

- [ ] No tests yet. It's pretty easy to generate conflicting registrations manually, but I don't think it's possible to make this fully deterministic without a stateful server component or something.

[1] https://drafts.css-houdini.org/css-paint-api/#registering-custom-paint
[2] https://drafts.css-houdini.org/css-paint-api/#invoke-a-paint-callback

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #17584 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20269)
<!-- Reviewable:end -->
