### PR TITLE
Unbreak the doc build.

### DIFF
--- a/etc/ci/upload_docs.sh
+++ b/etc/ci/upload_docs.sh
@@ -38,9 +38,6 @@ cp apis.html ../../target/doc/servo/
 echo "Copied apis.html."
 cd ../..
 
-# Clean up the traces of the current doc build.
-./etc/ci/clean_build_artifacts.sh
-
 echo "Starting ghp-import."
 ghp-import -n target/doc
 echo "Finished ghp-import."


### PR DESCRIPTION
I added this to avoid the problem with doc builds leaving around large build artifacts while also working around #17243, but it appears to break the doc build entirely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20272)
<!-- Reviewable:end -->
