### PR TITLE
Unbreak the docs build.

### DIFF
--- a/etc/ci/upload_docs.sh
+++ b/etc/ci/upload_docs.sh
@@ -38,9 +38,6 @@ cp apis.html ../../target/doc/servo/
 echo "Copied apis.html."
 cd ../..
 
-# Clean up the traces of the current doc build.
-./etc/ci/clean_build_artifacts.sh
-
 echo "Starting ghp-import."
 ghp-import -n target/doc
 echo "Finished ghp-import."
@@ -48,3 +45,6 @@ git push -qf \
     "https://${TOKEN}@github.com/servo/doc.servo.org.git" gh-pages \
     &>/dev/null
 echo "Finished git push."
+
+# Clean up the traces of the current doc build.
+./etc/ci/clean_build_artifacts.sh


### PR DESCRIPTION
I added this to avoid the problem with doc builds leaving around large build artifacts while also working around #17243, but it appears to break the doc build entirely. This won't end up executing on servo-linux1 or servo-linux2 because of #17243, but I'm looking into the correct solution for that simultaneously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20273)
<!-- Reviewable:end -->
