### PR TITLE
style: Make the generated bindings really be formatted.

### DIFF
--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -207,7 +207,7 @@ mod bindings {
             let mut builder = Builder::default()
                 .rust_target(RustTarget::Stable_1_0);
             let rustfmt_path = env::var_os("MOZ_AUTOMATION").and_then(|_| {
-                env::var_os("TOOLTOOL_DIR")
+                env::var_os("TOOLTOOL_DIR").or_else(|| env::var_os("MOZ_SRC"))
             }).map(PathBuf::from);
 
             builder = match rustfmt_path {


### PR DESCRIPTION
TOOLTOOL_DIR isn't passed down to the rust scripts it seems, per:

  https://treeherder.mozilla.org/#/jobs?repo=try&revision=46854db239166ab3a43d36c7a954debb56968eab

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20274)
<!-- Reviewable:end -->
