### PR TITLE
style: Fix a typo in Integer struct docs

### DIFF
--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -377,7 +377,7 @@ impl ToComputedValue for Opacity {
     }
 }
 
-/// An specified `<integer>`, optionally coming from a `calc()` expression.
+/// A specified `<integer>`, optionally coming from a `calc()` expression.
 ///
 /// <https://drafts.csswg.org/css-values/#integers>
 #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq, PartialOrd)]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fix a typo in `Integer` struct documentation.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] These changes fix #__ (github issue number if applicable).
- [x] These changes do not require tests because: documentation

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20283)
<!-- Reviewable:end -->
