### PR TITLE
build(cmake): detect python binary for specified version

### DIFF
--- a/components/script/CMakeLists.txt
+++ b/components/script/CMakeLists.txt
@@ -49,7 +49,7 @@ set(bindinggen_deps
   ${bindings_src}/CodegenRust.py
   ${bindings_src}/parser/WebIDL.py
   )
-  
+
 add_custom_command(
   OUTPUT Bindings
   COMMAND ${CMAKE_COMMAND} -E make_directory Bindings
@@ -59,9 +59,12 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E make_directory _cache
   )
 
+# Specify python 2 as required
+find_package( PythonInterp 2 REQUIRED )
+
 add_custom_command(
   OUTPUT ParserResults.pkl
-  COMMAND python -B ${bindings_src}/pythonpath.py -I ${bindings_src}/parser -I ${bindings_src}/ply
+  COMMAND ${PYTHON_EXECUTABLE} -B ${bindings_src}/pythonpath.py -I ${bindings_src}/parser -I ${bindings_src}/ply
                  ${bindings_src}/GlobalGen.py
                  --cachedir=_cache
                  --filelist=webidls.list
@@ -74,7 +77,7 @@ add_custom_command(
 
 add_custom_command(
   OUTPUT apis.html
-  COMMAND python -B ${bindings_src}/pythonpath.py -I ${bindings_src}/parser -I ${bindings_src}/ply
+  COMMAND ${PYTHON_EXECUTABLE} -B ${bindings_src}/pythonpath.py -I ${bindings_src}/parser -I ${bindings_src}/ply
                  ${bindings_src}/GlobalGen.py
                  --cachedir=_cache
                  --filelist=webidls.list
@@ -100,7 +103,7 @@ add_custom_target(generate-bindings ALL)
 foreach(binding IN LISTS bindings)
   add_custom_command(
     OUTPUT Bindings/${binding}Binding.rs
-    COMMAND python -B ${bindings_src}/pythonpath.py -I ${bindings_src}/parser -I ${bindings_src}/ply
+    COMMAND ${PYTHON_EXECUTABLE} -B ${bindings_src}/pythonpath.py -I ${bindings_src}/parser -I ${bindings_src}/ply
                    ${bindings_src}/BindingGen.py
                    ${bindings_src}/Bindings.conf
                    .


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR aims to address #20268, by updating cmake definition to lookup python binary to use. Instead of directly asking `python` binary, this PR uses `${PYTHON_EXECUTABLE}` to lookup desired python binary where applicable.

This PR was locally tested on win32 / mac / arch linux via `mach build --dev`, so far local testing shows no build failure regressions, not sure if this is sufficient test.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #20268 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because _it's build script update_

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20290)
<!-- Reviewable:end -->
