### PR TITLE
Add timeout pref to the mozilla/worklets wpt tests

### DIFF
--- a/tests/wpt/mozilla/meta/mozilla/worklets/__dir__.ini
+++ b/tests/wpt/mozilla/meta/mozilla/worklets/__dir__.ini
@@ -1,1 +1,1 @@
-prefs: [dom.worklet.enabled:true,dom.worklet.blockingsleep.enabled:true]
+prefs: [dom.worklet.enabled:true,dom.worklet.blockingsleep.enabled:true,dom.worklet.timeout_ms:5000]

--- a/tests/wpt/mozilla/meta/mozilla/worklets/test_paint_worklet_timeout.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/worklets/test_paint_worklet_timeout.html.ini
@@ -1,0 +1,3 @@
+[test_paint_worklet_timeout.html]
+  type: testharness
+  prefs: [dom.worklet.timeout_ms:10]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #20292 
- [X] These changes do not require tests because this is test infrastructure

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20296)
<!-- Reviewable:end -->
