### PR TITLE
Update the MULTIPROCESS static when changing default options

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -911,6 +911,9 @@ lazy_static! {
 }
 
 pub fn set_defaults(opts: Opts) {
+    // Set the static to the new default value.
+    MULTIPROCESS.store(opts.multiprocess, Ordering::SeqCst);
+
     unsafe {
         assert!(DEFAULT_OPTIONS.is_null());
         assert_ne!(DEFAULT_OPTIONS, INVALID_OPTIONS);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
When the options are set not from the command line but by calling `set_defaults()` which is common for embedders, the MULTIPROCESS static is not set, and so the setting is ignored. This patch fixes that.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because we have no tests around that.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20310)
<!-- Reviewable:end -->
