### PR TITLE
Remove update-manifest argument that is no longer valid.

### DIFF
--- a/etc/ci/update-wpt-checkout
+++ b/etc/ci/update-wpt-checkout
@@ -41,7 +41,7 @@ function unsafe_pull_from_upstream() {
     fi
 
     # Update the manifest to include the new changes.
-    ./mach update-manifest --release || return 3
+    ./mach update-manifest || return 3
 
     # Amend the existing commit with the new changes from updating the manifest.
     git commit -a --amend --no-edit || return 4


### PR DESCRIPTION
This nightly sync job is now broken since #20312 because it doesn't need to select a particular binary. We can get rid of the unnecessary argument to fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20321)
<!-- Reviewable:end -->
