### PR TITLE
Use upstream mozjs 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,7 +1617,7 @@ dependencies = [
  "cssparser 0.23.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashglobe 0.1.0",
- "mozjs 0.3.0 (git+https://github.com/Xanewok/rust-mozjs?branch=remove-heap-constructor)",
+ "mozjs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.19.0",
  "servo_arc 0.1.1",
  "smallbitvec 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.3.0"
-source = "git+https://github.com/Xanewok/rust-mozjs?branch=remove-heap-constructor#d8b6ae7fcff342c2fddca8df5a7556bcc3b9e415"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2467,7 +2467,7 @@ dependencies = [
  "mime_guess 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mitochondria 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mozangle 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mozjs 0.3.0 (git+https://github.com/Xanewok/rust-mozjs?branch=remove-heap-constructor)",
+ "mozjs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3862,7 +3862,7 @@ dependencies = [
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum mitochondria 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9de3eca27871df31c33b807f834b94ef7d000956f57aa25c5aed9c5f0aae8f6f"
 "checksum mozangle 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1f0583e6792917f498bb3a7440f777a59353102063445ab7f5e9d1dc4ed593aa"
-"checksum mozjs 0.3.0 (git+https://github.com/Xanewok/rust-mozjs?branch=remove-heap-constructor)" = "<none>"
+"checksum mozjs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53720714c395cbc3b8f31411ca855a97c51618c76fa5584654a0e3e2ecfc16cc"
 "checksum mozjs_sys 0.50.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e61a792a125b1364c5ec50255ed8343ce02dc56098f8868dd209d472c8de006a"
 "checksum mp3-metadata 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ab5f1d2693586420208d1200ce5a51cd44726f055b635176188137aff42c7de"
 "checksum mp4parse 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f821e3799bc0fd16d9b861fb02fa7ee1b5fba29f45ad591dade105c48ca9a1a0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ opt-level = 3
 # lto = false
 
 [patch.crates-io]
-mozjs = { git = "https://github.com/Xanewok/rust-mozjs", branch = "remove-heap-constructor" }
+
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:
 #


### PR DESCRIPTION
Pulls published mozjs 0.3 instead of my forked version (https://github.com/servo/servo/pull/20314).

r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20333)
<!-- Reviewable:end -->
