### PR TITLE
refactor(counter_style): parse int via parse_non_negative

### DIFF
--- a/components/style/gecko/rules.rs
+++ b/components/style/gecko/rules.rs
@@ -281,7 +281,7 @@ impl ToNsCssValue for counter_style::System {
                 let mut a = nsCSSValue::null();
                 let mut b = nsCSSValue::null();
                 a.set_enum(structs::NS_STYLE_COUNTER_SYSTEM_FIXED as i32);
-                b.set_integer(first_symbol_value.unwrap_or(1));
+                b.set_integer(first_symbol_value.map_or(1, |v| v.value()));
                 nscssvalue.set_pair(&a, &b);
             }
             Extends(other) => {
@@ -345,7 +345,7 @@ impl ToNsCssValue for counter_style::Pad {
     fn convert(self, nscssvalue: &mut nsCSSValue) {
         let mut min_length = nsCSSValue::null();
         let mut pad_with = nsCSSValue::null();
-        min_length.set_integer(self.0 as i32);
+        min_length.set_integer(self.0.value());
         pad_with.set_from(self.1);
         nscssvalue.set_pair(&min_length, &pad_with);
     }
@@ -372,7 +372,7 @@ impl ToNsCssValue for counter_style::AdditiveSymbols {
         nscssvalue.set_pair_list(self.0.into_iter().map(|tuple| {
             let mut weight = nsCSSValue::null();
             let mut symbol = nsCSSValue::null();
-            weight.set_integer(tuple.weight as i32);
+            weight.set_integer(tuple.weight.value());
             symbol.set_from(tuple.symbol);
             (weight, symbol)
         }));


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Relates to #20332.

This PR intends to refactor `counter_style` to use `parse_non_negative` where applicable, mostly which uses `expect_integer` currently. Change still grabs value from parsed result then assign it into each struct as needed and does not change definition of struct (i.e `AdditiveTuple`) itself.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #20332 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____
- This PR has locally built & ran unit test on macOS.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20368)
<!-- Reviewable:end -->
