### PR TITLE
Don't OOM when laying out basic web pages on Android

### DIFF
--- a/components/layout/inline.rs
+++ b/components/layout/inline.rs
@@ -266,10 +266,10 @@ impl LineBreaker {
     }
 
     /// Reinitializes the pending line to blank data.
-    fn reset_line(&mut self) -> Line {
+    fn reset_line(&mut self) {
         self.last_known_line_breaking_opportunity = None;
-        mem::replace(&mut self.pending_line,
-                     Line::new(self.floats.writing_mode, &self.minimum_metrics))
+        // https://github.com/rust-lang/rust/issues/49282
+        self.pending_line = Line::new(self.floats.writing_mode, &self.minimum_metrics);
     }
 
     /// Reflows fragments for the given inline flow.


### PR DESCRIPTION
This is a workaround for the symptom described in https://github.com/servo/servo/issues/20149#issuecomment-375366991 which looks like either a standard library or compiler bug. My release android build can load all sorts of web pages as expected with this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20390)
<!-- Reviewable:end -->
