### PR TITLE
GamepadButtonList::sync_from_vr should use more iterators #20392

### DIFF
--- a/components/script/dom/gamepadbuttonlist.rs
+++ b/components/script/dom/gamepadbuttonlist.rs
@@ -37,10 +37,8 @@ impl GamepadButtonList {
     }
 
     pub fn sync_from_vr(&self, vr_buttons: &[WebVRGamepadButton]) {
-        let mut index = 0;
-        for btn in vr_buttons {
-            self.list.get(index).as_ref().unwrap().update(btn.pressed, btn.touched);
-            index += 1;
+        for (gp_btn, btn) in self.list.iter().zip(vr_buttons.iter()) {
+            gp_btn.update(btn.pressed, btn.touched);
         }
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Used the zip function instead of iterating over both vectors with an indexing variable and using unwrap.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #20392(github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it says in the issue description no need for tests
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20404)
<!-- Reviewable:end -->
