### PR TITLE
Rename Gecko string DataFlags::SHARED to REFCOUNTED

### DIFF
--- a/support/gecko/nsstring/src/lib.rs
+++ b/support/gecko/nsstring/src/lib.rs
@@ -140,7 +140,8 @@ mod data_flags {
         pub struct DataFlags: u16 {
             const TERMINATED = 1 << 0; // IsTerminated returns true
             const VOIDED = 1 << 1; // IsVoid returns true
-            const SHARED = 1 << 2; // mData points to a heap-allocated, shared buffer
+            const REFCOUNTED = 1 << 2; // mData points to a heap-allocated, shareable, refcounted
+                                       // buffer
             const OWNED = 1 << 3; // mData points to a heap-allocated, raw buffer
             const INLINE = 1 << 4; // mData points to a writable, inline buffer
             const LITERAL = 1 << 5; // mData points to a string literal; TERMINATED will also be set
@@ -1184,7 +1185,7 @@ pub mod test_helpers {
     #[allow(non_snake_case)]
     pub extern fn Rust_Test_NsStringFlags(f_terminated: *mut u16,
                                           f_voided: *mut u16,
-                                          f_shared: *mut u16,
+                                          f_refcounted: *mut u16,
                                           f_owned: *mut u16,
                                           f_inline: *mut u16,
                                           f_literal: *mut u16,
@@ -1193,7 +1194,7 @@ pub mod test_helpers {
         unsafe {
             *f_terminated = DataFlags::TERMINATED.bits();
             *f_voided = DataFlags::VOIDED.bits();
-            *f_shared = DataFlags::SHARED.bits();
+            *f_refcounted = DataFlags::REFCOUNTED.bits();
             *f_owned = DataFlags::OWNED.bits();
             *f_inline = DataFlags::INLINE.bits();
             *f_literal = DataFlags::LITERAL.bits();


### PR DESCRIPTION
This is the servo piece of:

[Bug 1448138](https://bugzilla.mozilla.org/show_bug.cgi?id=1448138) - Rename string DataFlags::SHARED to REFCOUNTED to make it clearer to those reading the code.  r=erahm

This is a renaming in the internals of Gecko's string library that should also have a corresponding rename in the rust bindings.  This is already reviewed as part of the Gecko change, and the two pieces should be able to land separately.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20407)
<!-- Reviewable:end -->
