### PR TITLE
mach: android install/run: infer adb path from SDK dir

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -626,6 +626,13 @@ class CommandBase(object):
     def android_aar_dir(self):
         return path.join(self.context.topdir, "target", "android_aar")
 
+    def android_adb_path(self, env):
+        if "ANDROID_SDK" in env:
+            sdk_adb = path.join(env["ANDROID_SDK"], "platform-tools", "adb")
+            if path.exists(sdk_adb):
+                return sdk_adb
+        return "adb"
+
     def handle_android_target(self, target):
         if target == "arm-linux-androideabi":
             self.config["android"]["platform"] = "android-18"

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -391,6 +391,7 @@ class PackageCommands(CommandBase):
                      default=None,
                      help='Install the given target platform')
     def install(self, release=False, dev=False, android=False, target=None):
+        env = self.build_env()
         if target and android:
             print("Please specify either --target or --android.")
             sys.exit(1)
@@ -413,7 +414,7 @@ class PackageCommands(CommandBase):
 
         if android:
             pkg_path = binary_path + ".apk"
-            exec_command = ["adb", "install", "-r", pkg_path]
+            exec_command = [self.android_adb_path(env), "install", "-r", pkg_path]
         elif is_windows():
             pkg_path = path.join(path.dirname(binary_path), 'msi', 'Servo.msi')
             exec_command = ["msiexec", "/i", pkg_path]
@@ -426,7 +427,7 @@ class PackageCommands(CommandBase):
                 return result
 
         print(" ".join(exec_command))
-        return subprocess.call(exec_command, env=self.build_env())
+        return subprocess.call(exec_command, env=env)
 
     @Command('upload-nightly',
              description='Upload Servo nightly to S3',

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -93,7 +93,7 @@ class PostBuildCommands(CommandBase):
                 "am start com.mozilla.servo/com.mozilla.servo.MainActivity",
                 "exit"
             ]
-            shell = subprocess.Popen(["adb", "shell"], stdin=subprocess.PIPE)
+            shell = subprocess.Popen([self.android_adb_path(env), "shell"], stdin=subprocess.PIPE)
             shell.communicate("\n".join(script) + "\n")
             return shell.wait()
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Infer Android `adb` path from SDK directory in environment variables.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #20219 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it is a build script change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20421)
<!-- Reviewable:end -->
