### PR TITLE
Use BufferSource in bluetooth APIs

### DIFF
--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -167,8 +167,8 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
 
         // Step 2 - 3.
         let vec = match value {
-            ArrayBufferViewOrArrayBuffer::ArrayBufferView(mut avb) => avb.to_vec(),
-            ArrayBufferViewOrArrayBuffer::ArrayBuffer(mut ab) => ab.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(avb) => avb.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(ab) => ab.to_vec(),
         };
 
         if vec.len() > MAXIMUM_ATTRIBUTE_LENGTH {

--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -12,6 +12,7 @@ use dom::bindings::codegen::Bindings::BluetoothRemoteGATTCharacteristicBinding::
     BluetoothRemoteGATTCharacteristicMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServiceBinding::BluetoothRemoteGATTServiceMethods;
+use dom::bindings::codegen::UnionTypes::ArrayBufferViewOrArrayBuffer;
 use dom::bindings::error::Error::{self, InvalidModification, Network, NotSupported, Security};
 use dom::bindings::inheritance::Castable;
 use dom::bindings::reflector::{DomObject, reflect_dom_object};
@@ -155,7 +156,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
 
     #[allow(unrooted_must_root)]
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-writevalue
-    fn WriteValue(&self, value: Vec<u8>) -> Rc<Promise> {
+    fn WriteValue(&self, value: ArrayBufferViewOrArrayBuffer) -> Rc<Promise> {
         let p = Promise::new(&self.global());
 
         // Step 1.
@@ -165,7 +166,12 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         }
 
         // Step 2 - 3.
-        if value.len() > MAXIMUM_ATTRIBUTE_LENGTH {
+        let vec = match value {
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(mut avb) => avb.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(mut ab) => ab.to_vec(),
+        };
+
+        if vec.len() > MAXIMUM_ATTRIBUTE_LENGTH {
             p.reject_error(InvalidModification);
             return p;
         }
@@ -190,7 +196,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         // in writeValue function and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(
-            BluetoothRequest::WriteValue(self.get_instance_id(), value, sender)).unwrap();
+            BluetoothRequest::WriteValue(self.get_instance_id(), vec, sender)).unwrap();
         return p;
     }
 

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -11,6 +11,7 @@ use dom::bindings::codegen::Bindings::BluetoothRemoteGATTDescriptorBinding;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTDescriptorBinding::BluetoothRemoteGATTDescriptorMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
 use dom::bindings::codegen::Bindings::BluetoothRemoteGATTServiceBinding::BluetoothRemoteGATTServiceMethods;
+use dom::bindings::codegen::UnionTypes::ArrayBufferViewOrArrayBuffer;
 use dom::bindings::error::Error::{self, InvalidModification, Network, Security};
 use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
 use dom::bindings::root::{Dom, DomRoot};
@@ -114,7 +115,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
 
     #[allow(unrooted_must_root)]
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-writevalue
-    fn WriteValue(&self, value: Vec<u8>) -> Rc<Promise> {
+    fn WriteValue(&self, value: ArrayBufferViewOrArrayBuffer) -> Rc<Promise> {
         let p = Promise::new(&self.global());
 
         // Step 1.
@@ -124,7 +125,11 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
         }
 
         // Step 2 - 3.
-        if value.len() > MAXIMUM_ATTRIBUTE_LENGTH {
+        let v = match value {
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(mut avb) => avb.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(mut ab) => ab.to_vec(),
+        };
+        if v.len() > MAXIMUM_ATTRIBUTE_LENGTH {
             p.reject_error(InvalidModification);
             return p;
         }
@@ -140,7 +145,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
         // in writeValue function and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(
-            BluetoothRequest::WriteValue(self.get_instance_id(), value, sender)).unwrap();
+            BluetoothRequest::WriteValue(self.get_instance_id(), v, sender)).unwrap();
         return p;
     }
 }

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -126,8 +126,8 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
 
         // Step 2 - 3.
         let vec = match value {
-            ArrayBufferViewOrArrayBuffer::ArrayBufferView(mut avb) => avb.to_vec(),
-            ArrayBufferViewOrArrayBuffer::ArrayBuffer(mut ab) => ab.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(avb) => avb.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(ab) => ab.to_vec(),
         };
         if vec.len() > MAXIMUM_ATTRIBUTE_LENGTH {
             p.reject_error(InvalidModification);

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -125,11 +125,11 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
         }
 
         // Step 2 - 3.
-        let v = match value {
+        let vec = match value {
             ArrayBufferViewOrArrayBuffer::ArrayBufferView(mut avb) => avb.to_vec(),
             ArrayBufferViewOrArrayBuffer::ArrayBuffer(mut ab) => ab.to_vec(),
         };
-        if v.len() > MAXIMUM_ATTRIBUTE_LENGTH {
+        if vec.len() > MAXIMUM_ATTRIBUTE_LENGTH {
             p.reject_error(InvalidModification);
             return p;
         }
@@ -145,7 +145,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
         // in writeValue function and in handle_response function.
         let sender = response_async(&p, self);
         self.get_bluetooth_thread().send(
-            BluetoothRequest::WriteValue(self.get_instance_id(), v, sender)).unwrap();
+            BluetoothRequest::WriteValue(self.get_instance_id(), vec, sender)).unwrap();
         return p;
     }
 }

--- a/components/script/dom/webidls/Bluetooth.webidl
+++ b/components/script/dom/webidls/Bluetooth.webidl
@@ -5,10 +5,8 @@
 // https://webbluetoothcg.github.io/web-bluetooth/#bluetooth
 
 dictionary BluetoothDataFilterInit {
-  // BufferSource dataPrefix;
-  sequence<octet> dataPrefix;
-  // BufferSource mask;
-  sequence<octet> mask;
+  BufferSource dataPrefix;
+  BufferSource mask;
 };
 
 dictionary BluetoothLEScanFilterInit {

--- a/components/script/dom/webidls/BluetoothRemoteGATTCharacteristic.webidl
+++ b/components/script/dom/webidls/BluetoothRemoteGATTCharacteristic.webidl
@@ -16,8 +16,7 @@ interface BluetoothRemoteGATTCharacteristic : EventTarget {
   getDescriptors(optional BluetoothDescriptorUUID descriptor);
   Promise<ByteString> readValue();
   //Promise<DataView> readValue();
-  Promise<void> writeValue(sequence<octet> value);
-  //Promise<void> writeValue(BufferSource value);
+  Promise<void> writeValue(BufferSource value);
   Promise<BluetoothRemoteGATTCharacteristic> startNotifications();
   Promise<BluetoothRemoteGATTCharacteristic> stopNotifications();
 };

--- a/components/script/dom/webidls/BluetoothRemoteGATTDescriptor.webidl
+++ b/components/script/dom/webidls/BluetoothRemoteGATTDescriptor.webidl
@@ -11,7 +11,6 @@ interface BluetoothRemoteGATTDescriptor {
   readonly attribute DOMString uuid;
   readonly attribute ByteString? value;
   Promise<ByteString> readValue();
-  //Promise<DataView> readValue();
-  Promise<void> writeValue(sequence<octet> value);
-  //Promise<void> writeValue(BufferSource value);
+  // Promise<DataView> readValue();
+  Promise<void> writeValue(BufferSource value);
 };

--- a/components/script/dom/webidls/BluetoothRemoteGATTDescriptor.webidl
+++ b/components/script/dom/webidls/BluetoothRemoteGATTDescriptor.webidl
@@ -11,6 +11,6 @@ interface BluetoothRemoteGATTDescriptor {
   readonly attribute DOMString uuid;
   readonly attribute ByteString? value;
   Promise<ByteString> readValue();
-  // Promise<DataView> readValue();
+  //Promise<DataView> readValue();
   Promise<void> writeValue(BufferSource value);
 };

--- a/tests/wpt/mozilla/tests/bluetooth/writeValue/characteristic/write-updates-value.html
+++ b/tests/wpt/mozilla/tests/bluetooth/writeValue/characteristic/write-updates-value.html
@@ -15,8 +15,8 @@ promise_test(() => {
     .then(service => service.getCharacteristic(device_name.name))
     .then(characteristic => {
         assert_equals(characteristic.value, null);
-        return characteristic.writeValue(asciiToDecimal('foo'))
-        .then(() => assert_equals(characteristic.value, 'foo'));
+        return characteristic.writeValue(Uint8Array.of(1, 2))
+        .then(() => assert_equals(characteristic.value, '\x01\x02'));
     });
 }, 'A regular write request to a writable characteristic should update value.');
 </script>

--- a/tests/wpt/mozilla/tests/bluetooth/writeValue/descriptor/write-updates-value.html
+++ b/tests/wpt/mozilla/tests/bluetooth/writeValue/descriptor/write-updates-value.html
@@ -17,7 +17,7 @@ promise_test(() => {
     .then(descriptor => {
         assert_equals(descriptor.value, null);
         return descriptor.writeValue(Uint8Array.of(1, 2))
-        .then(() => assert_equals(descriptor.value, "\x01\x02"));
+        .then(() => assert_equals(descriptor.value, '\x01\x02'));
     });
 }, 'A regular write request to a writable descriptor should update value.');
 </script>

--- a/tests/wpt/mozilla/tests/bluetooth/writeValue/descriptor/write-updates-value.html
+++ b/tests/wpt/mozilla/tests/bluetooth/writeValue/descriptor/write-updates-value.html
@@ -16,8 +16,8 @@ promise_test(() => {
     .then(characteristic => characteristic.getDescriptor(number_of_digitals.name))
     .then(descriptor => {
         assert_equals(descriptor.value, null);
-        return descriptor.writeValue(asciiToDecimal('foo'))
-        .then(() => assert_equals(descriptor.value, 'foo'));
+        return descriptor.writeValue(Uint8Array.of(1, 2))
+        .then(() => assert_equals(descriptor.value, "\x01\x02"));
     });
 }, 'A regular write request to a writable descriptor should update value.');
 </script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Updates `RemoveGATTDescriptor.webidl`, `BluetoothDataFilterInit`, and `BluetoothRemoteGATTCharacteristic` to use `BufferSource`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #20345 (github issue number if applicable).
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20422)
<!-- Reviewable:end -->
