### PR TITLE
fix(fetch): rethrow jsexception when parsing json fails

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -12,12 +12,12 @@ use dom::blob::{Blob, BlobImpl};
 use dom::formdata::FormData;
 use dom::globalscope::GlobalScope;
 use dom::promise::Promise;
+use js::jsapi::{JS_ClearPendingException, JS_GetPendingException, JS_ParseJSON};
 use js::jsapi::Heap;
 use js::jsapi::JSContext;
 use js::jsapi::JSObject;
-use js::jsapi::JS_ClearPendingException;
-use js::jsapi::JS_ParseJSON;
 use js::jsapi::Value as JSValue;
+use js::jsval::JSVal;
 use js::jsval::UndefinedValue;
 use js::typedarray::{ArrayBuffer, CreateWith};
 use mime::{Mime, TopLevel, SubLevel};
@@ -42,6 +42,7 @@ pub enum FetchedData {
     BlobData(DomRoot<Blob>),
     FormData(DomRoot<FormData>),
     ArrayBuffer(RootedTraceableBox<Heap<*mut JSObject>>),
+    JSException(RootedTraceableBox<Heap<JSVal>>),
 }
 
 // https://fetch.spec.whatwg.org/#concept-body-consume-body
@@ -90,7 +91,8 @@ pub fn consume_body_with_promise<T: BodyOperations + DomObject>(object: &T,
                 FetchedData::Json(j) => promise.resolve_native(&j),
                 FetchedData::BlobData(b) => promise.resolve_native(&b),
                 FetchedData::FormData(f) => promise.resolve_native(&f),
-                FetchedData::ArrayBuffer(a) => promise.resolve_native(&a)
+                FetchedData::ArrayBuffer(a) => promise.resolve_native(&a),
+                FetchedData::JSException(e) => promise.reject_native(&e)
             };
         },
         Err(err) => promise.reject_error(err),
@@ -133,9 +135,15 @@ fn run_json_data_algorithm(cx: *mut JSContext,
                          json_text.as_ptr(),
                          json_text.len() as u32,
                          rval.handle_mut()) {
+            rooted!(in(cx) let mut exception = UndefinedValue());
+            if !JS_GetPendingException(cx, exception.handle_mut()) {
+                JS_ClearPendingException(cx);
+                error!("Uncaught exception: JS_GetPendingException failed");
+                return Err(Error::Type("Failed to parse JSON".to_string()));
+            }
             JS_ClearPendingException(cx);
-            // TODO: See issue #13464. Exception should be thrown instead of cleared.
-            return Err(Error::Type("Failed to parse JSON".to_string()));
+            let rooted_heap = RootedTraceableBox::from_box(Heap::boxed(exception.get()));
+            return Ok(FetchedData::JSException(rooted_heap));
         }
         let rooted_heap = RootedTraceableBox::from_box(Heap::boxed(rval.get()));
         Ok(FetchedData::Json(rooted_heap))

--- a/tests/wpt/metadata/fetch/api/request/request-consume.html.ini
+++ b/tests/wpt/metadata/fetch/api/request/request-consume.html.ini
@@ -6,9 +6,6 @@
   [Consume String request's body as formData]
     expected: FAIL
 
-  [Trying to consume bad JSON text as JSON: 'undefined']
-    expected: FAIL
-
   [Consume Int8Array request's body as text]
     expected: FAIL
 
@@ -45,15 +42,6 @@
   [Consume FormData request's body as FormData]
     expected: FAIL
 
-  [Trying to consume bad JSON text as JSON: 'undefined']
-    expected: FAIL
-
-  [Trying to consume bad JSON text as JSON: '{']
-    expected: FAIL
-
-  [Trying to consume bad JSON text as JSON: 'a']
-    expected: FAIL
-
   [Consume ArrayBuffer request's body as blob]
     expected: FAIL
 
@@ -79,8 +67,5 @@
     expected: FAIL
 
   [Consume Float32Array request's body as text]
-    expected: FAIL
-
-  [Trying to consume bad JSON text as JSON: '[']
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Relates to #13464.

This PR try to rethrow js exception when parsing json in fetch fails. If getting pending exception fails, it still try to clear pending exception and swallow it.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13464 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____
- Locally run wpt tests on macOS, with updated test cases.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20440)
<!-- Reviewable:end -->
