### PR TITLE
Change "OS X" to "macOS" in Readme and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Servo is a prototype web browser engine written in the
 [Rust](https://github.com/rust-lang/rust) language. It is currently developed on
-64-bit OS X, 64-bit Linux, 64-bit Windows, and Android.
+64-bit macOS, 64-bit Linux, 64-bit Windows, and Android.
 
 Servo welcomes contribution from everyone.  See
 [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`HACKING_QUICKSTART.md`](docs/HACKING_QUICKSTART.md)
@@ -41,7 +41,7 @@ https://github.com/rust-lang-nursery/rustup.rs/#other-installation-methods)
 ### Other dependencies
 
 Please select your operating system:
-* [OS X](#os-x)
+* [macOS](#macos)
 * [Debian-based Linuxes](#on-debian-based-linuxes)
 * [Fedora](#on-fedora)
 * [Arch Linux](#on-arch-linux)
@@ -50,19 +50,19 @@ Please select your operating system:
 * [Microsoft Windows](#on-windows-msvc)
 * [Android](#cross-compilation-for-android)
 
-#### OS X
-#### On OS X (homebrew)
+#### macOS
+#### On macOS (homebrew)
 
 ``` sh
 brew install automake pkg-config python cmake yasm
 pip install virtualenv
 ```
-#### On OS X (MacPorts)
+#### On macOS (MacPorts)
 
 ``` sh
 sudo port install python27 py27-virtualenv cmake yasm
 ```
-#### On OS X >= 10.11 (El Capitan), you also have to install OpenSSL
+#### On macOS >= 10.11 (El Capitan), you also have to install OpenSSL
 
 ``` sh
 brew install openssl

--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -153,7 +153,7 @@ A typical command might be:
 
 … to avoid using too many threads and make things easier to understand.
 
-On OSX, you can add some Cocoa-specific debug options:
+On macOS, you can add some Cocoa-specific debug options:
 
 ``` shell
 ./mach run -d -- /tmp/a.html -- -NSShowAllViews YES

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -13,7 +13,7 @@ Shell scripts should be written against bash, starting with this shebang:
 #!/usr/bin/env bash
 ```
 
-Note that the version of bash available on OS X by default is quite old, so be
+Note that the version of bash available on macOS by default is quite old, so be
 careful when using new features.
 
 Scripts should enable a few options at the top for robustness:


### PR DESCRIPTION
Apple no longer uses the OS X branding.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20451)
<!-- Reviewable:end -->
