### PR TITLE
Remove StyleBackendType uses

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -1190,7 +1190,6 @@ impl<'le> TElement for GeckoElement<'le> {
             let base_declaration: &structs::DeclarationBlock =
                 slots.mSMILOverrideStyleDeclaration.mRawPtr.as_ref()?;
 
-            assert_eq!(base_declaration.mType, structs::StyleBackendType_Servo);
             let declaration: &structs::ServoDeclarationBlock =
                 mem::transmute(base_declaration);
 


### PR DESCRIPTION
This is the Servo side change of [bug 1447828](https://bugzilla.mozilla.org/show_bug.cgi?id=1447828).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20460)
<!-- Reviewable:end -->
