### PR TITLE
Test the style/bindgen feature in CI

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -114,6 +114,7 @@ linux-dev:
     - ./mach package --dev
     - ./mach build --dev --no-default-features --features default-except-unstable
     - ./mach build-geckolib
+    - ./mach check -p style --features bindgen --manifest-path ports/geckolib/Cargo.toml
     - ./mach test-stylo
     - bash ./etc/ci/lockfile_changed.sh
     - bash ./etc/ci/manifest_changed.sh


### PR DESCRIPTION
This feature isn't used in the Servo build, but it's required by the Firefox build.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes OR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20467)
<!-- Reviewable:end -->
