### PR TITLE
Support i686-linux-android target for android-x86 emulator

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -10,6 +10,10 @@ ar = "arm-linux-androideabi-ar"
 linker = "./ports/servo/fake-ld-arm64.sh"
 ar = "aarch64-linux-android-ar"
 
+[target.i686-linux-android]
+linker = "./ports/servo/fake-ld-x86.sh"
+ar = "i686-linux-android-ar"
+
 [target.arm-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
 ar = "arm-linux-gnueabihf-ar"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "blurdroid"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -677,7 +677,7 @@ name = "device"
 version = "0.0.1"
 source = "git+https://github.com/servo/devices#eeb6eaddb79c019bb5c85558b3410b836da57a57"
 dependencies = [
- "blurdroid 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blurdroid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "blurmac 0.1.0 (git+https://github.com/servo/devices)",
  "blurmock 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blurz 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3769,7 +3769,7 @@ dependencies = [
 "checksum bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5cde24d1b2e2216a726368b2363a273739c91f4e3eb4e0dd12d672d396ad989"
 "checksum bitreader 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "80b13e2ab064ff3aa0bdbf1eff533f9822dc37899821f5f98c67f263eab51707"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-"checksum blurdroid 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7daba519d29beebfc7d302795af88a16b43f431b9b268586926ac61cc655a68"
+"checksum blurdroid 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "19b23557dd27704797128f9db2816416bef20dad62d4a9768714eeb65f07d296"
 "checksum blurmac 0.1.0 (git+https://github.com/servo/devices)" = "<none>"
 "checksum blurmock 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "68dd72da3a3bb40f3d3bdd366c4cf8e2b1d208c366304f382c80cef8126ca8da"
 "checksum blurz 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e73bda0f4c71c63a047351070097f3f507e6718e86b9ee525173371ef7b94b73"

--- a/ports/servo/build.rs
+++ b/ports/servo/build.rs
@@ -48,7 +48,7 @@ fn android_main() {
         "arch-arm"
     } else if target.contains("aarch64") {
         "arch-arm64"
-    } else if target.contains("x86") {
+    } else if target.contains("x86") || target.contains("i686") {
         "arch-x86"
     } else if target.contains("mips") {
         "arch-mips"
@@ -62,10 +62,13 @@ fn android_main() {
         "android-18"
     };
 
-    let toolchain = if target.contains("armv7") {
-        "arm-linux-androideabi".into()
+    let (toolchain, prefix) = if target.contains("armv7") {
+        let toolchain = "arm-linux-androideabi";
+        (toolchain.into(), toolchain.into())
+    } else if target.contains("i686") {
+        ("x86".into(), target)
     } else {
-        target
+        (target.clone(), target)
     };
 
     let toolchain_path = ndk_path.join("toolchains").join(format!("{}-4.9", toolchain)).join("prebuilt").
@@ -77,7 +80,7 @@ fn android_main() {
     let directory = Path::new(&out_dir);
 
     // compiling android_native_app_glue.c
-    if Command::new(toolchain_path.join("bin").join(format!("{}-gcc", toolchain)))
+    if Command::new(toolchain_path.join("bin").join(format!("{}-gcc", prefix)))
         .arg(ndk_path.join("sources").join("android").join("native_app_glue").join("android_native_app_glue.c"))
         .arg("-c")
         .arg("-o").arg(directory.join("android_native_app_glue.o"))
@@ -91,7 +94,7 @@ fn android_main() {
     }
 
     // compiling libandroid_native_app_glue.a
-    if Command::new(toolchain_path.join("bin").join(format!("{}-ar", toolchain)))
+    if Command::new(toolchain_path.join("bin").join(format!("{}-ar", prefix)))
         .arg("rcs")
         .arg(directory.join("libandroid_native_app_glue.a"))
         .arg(directory.join("android_native_app_glue.o"))

--- a/ports/servo/fake-ld-armv7.sh
+++ b/ports/servo/fake-ld-armv7.sh
@@ -11,4 +11,5 @@ set -o pipefail
 source ./ports/servo/fake-ld.sh
 
 export _GCC_PARAMS="${@}"
-call_gcc "arch-arm" "arm-linux-androideabi" "android-18" "armeabi-v7a"
+call_gcc "arch-arm" "arm-linux-androideabi" "android-18" "armeabi-v7a" \
+         "arm-linux-androideabi"

--- a/ports/servo/fake-ld-x86.sh
+++ b/ports/servo/fake-ld-x86.sh
@@ -11,5 +11,4 @@ set -o pipefail
 source ./ports/servo/fake-ld.sh
 
 export _GCC_PARAMS="${@}"
-call_gcc "arch-arm" "arm-linux-androideabi" "android-18" "armeabi" \
-         "arm-linux-androideabi"
+call_gcc "arch-x86" "x86" "android-18" "x86" "i686-linux-android"

--- a/ports/servo/fake-ld.sh
+++ b/ports/servo/fake-ld.sh
@@ -32,7 +32,7 @@ call_gcc()
   echo "sysroot: ${ANDROID_SYSROOT}"
   echo "targetdir: ${ANDROID_CXX_LIBS}"
 
-  "${ANDROID_TOOLCHAIN}/${_ANDROID_EABI}-gcc" \
+  "${ANDROID_TOOLCHAIN}/$5-gcc" \
     --sysroot="${ANDROID_SYSROOT}" -L "${ANDROID_CXX_LIBS}" ${_GCC_PARAMS} -lc++ \
     -o "${TARGET_DIR}/libservo.so" -shared && touch "${TARGET_DIR}/servo"
 }

--- a/ports/servo/glutin_app/window.rs
+++ b/ports/servo/glutin_app/window.rs
@@ -387,12 +387,12 @@ impl Window {
         }
     }
 
-    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
+    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64", target_os = "android")))]
     fn gl_version() -> GlRequest {
         return GlRequest::Specific(Api::OpenGl, (3, 2));
     }
 
-    #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
+    #[cfg(any(target_arch = "arm", target_arch = "aarch64", target_os = "android"))]
     fn gl_version() -> GlRequest {
         GlRequest::Specific(Api::OpenGlEs, (3, 0))
     }

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -295,6 +295,7 @@ class MachCommands(CommandBase):
                     sys.exit(1)
 
             env["RUST_TARGET"] = target
+            env["ANDROID_TOOLCHAIN_NAME"] = self.config["android"]["toolchain_prefix"]
             with cd(openssl_dir):
                 status = call(
                     make_cmd + ["-f", "openssl.makefile"],

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -607,6 +607,7 @@ class CommandBase(object):
         if target == "arm-linux-androideabi":
             self.config["android"]["platform"] = "android-18"
             self.config["android"]["target"] = target
+            self.config["android"]["toolchain_prefix"] = target
             self.config["android"]["arch"] = "arm"
             self.config["android"]["lib"] = "armeabi"
             self.config["android"]["toolchain_name"] = target + "-4.9"
@@ -614,6 +615,7 @@ class CommandBase(object):
         elif target == "armv7-linux-androideabi":
             self.config["android"]["platform"] = "android-18"
             self.config["android"]["target"] = target
+            self.config["android"]["toolchain_prefix"] = "arm-linux-androideabi"
             self.config["android"]["arch"] = "arm"
             self.config["android"]["lib"] = "armeabi-v7a"
             self.config["android"]["toolchain_name"] = "arm-linux-androideabi-4.9"
@@ -621,9 +623,18 @@ class CommandBase(object):
         elif target == "aarch64-linux-android":
             self.config["android"]["platform"] = "android-21"
             self.config["android"]["target"] = target
+            self.config["android"]["toolchain_prefix"] = target
             self.config["android"]["arch"] = "arm64"
             self.config["android"]["lib"] = "arm64-v8a"
             self.config["android"]["toolchain_name"] = target + "-4.9"
+            return True
+        elif target == "i686-linux-android":
+            self.config["android"]["platform"] = "android-18"
+            self.config["android"]["target"] = target
+            self.config["android"]["toolchain_prefix"] = "x86"
+            self.config["android"]["arch"] = "x86"
+            self.config["android"]["lib"] = "x86"
+            self.config["android"]["toolchain_name"] = "x86-4.9"
             return True
         return False
 

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -200,6 +200,8 @@ class PackageCommands(CommandBase):
                 build_type = "Arm64"
             elif "armv7" in android_target:
                 build_type = "Armv7"
+            elif "i686" in android_target:
+                build_type = "x86"
             else:
                 build_type = "Arm"
 

--- a/support/android/apk/app/build.gradle
+++ b/support/android/apk/app/build.gradle
@@ -240,7 +240,7 @@ String getRustTarget(String arch) {
         case 'arm' : return 'arm-linux-androideabi'
         case 'armv7' : return 'armv7-linux-androideabi'
         case 'arm64' : return 'aarch64-linux-android'
-        case 'x86' : return 'x86'
+        case 'x86' : return 'i686-linux-android'
         default: throw new GradleException("Invalid target architecture " + arch)
     }
 }

--- a/support/android/openssl.sh
+++ b/support/android/openssl.sh
@@ -50,7 +50,7 @@ case $RUST_TARGET in
       _OPENSSL_ARCH="arm64"
       _OPENSSL_CONFIG="linux-generic64 -DB_ENDIAN"
       ;;
-    x86*)
+    x86* | i686*)
       _ANDROID_TARGET=$RUST_TARGET
       _ANDROID_ARCH=arch-x86
       _OPENSSL_MACHINE="x86"
@@ -62,7 +62,7 @@ case $RUST_TARGET in
       ;;
 esac
 
-_ANDROID_EABI="$_ANDROID_TARGET-4.9"
+_ANDROID_EABI="$ANDROID_TOOLCHAIN_NAME-4.9"
 
 
 # Set _ANDROID_API to the API you want to use. You should set it


### PR DESCRIPTION
The first commit allows `./mach build --target=i686-linux-android` to build successfully. The second commit is temporary as I attempt to find the cause of the mysterious crash that takes down the browser.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20472)
<!-- Reviewable:end -->
