### PR TITLE
style: Add a fast path to each_anonymous_content_child.

### DIFF
--- a/components/style/gecko/wrapper.rs
+++ b/components/style/gecko/wrapper.rs
@@ -1121,6 +1121,10 @@ impl<'le> TElement for GeckoElement<'le> {
     where
         F: FnMut(Self),
     {
+        if !self.may_have_anonymous_children() {
+            return;
+        }
+
         let array: *mut structs::nsTArray<*mut nsIContent> =
             unsafe { bindings::Gecko_GetAnonymousContentForElement(self.0) };
 


### PR DESCRIPTION
If we know that we don't have anon children it is pointless to go through FFI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20479)
<!-- Reviewable:end -->
