### PR TITLE
Hide non-Servo heap measurement.

### DIFF
--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -10,9 +10,13 @@ path = "lib.rs"
 
 [features]
 servo = [
+    "hyper",
+    "hyper_serde",
     "mozjs",
+    "serde",
     "serde_bytes",
     "string_cache",
+    "time",
     "url",
     "webrender_api",
     "xml5ever",
@@ -23,17 +27,17 @@ app_units = "0.6"
 cssparser = "0.23.0"
 euclid = "0.17"
 hashglobe = { path = "../hashglobe" }
-hyper = "0.10"
-hyper_serde = "0.8"
+hyper = { version = "0.10", optional = true }
+hyper_serde = { version = "0.8", optional = true }
 mozjs = { version = "0.6", features = ["promises"], optional = true }
 selectors = { path = "../selectors" }
-serde = "1.0.27"
+serde = { version = "1.0.27", optional = true }
 serde_bytes = { version = "0.10", optional = true }
 servo_arc = { path = "../servo_arc" }
 smallbitvec = "1.0.3"
 smallvec = "0.6"
 string_cache = { version = "0.7", optional = true }
-time = "0.1.17"
+time = { version = "0.1.17", optional = true }
 url = { version = "1.2", optional = true }
 webrender_api = { git = "https://github.com/servo/webrender", features = ["ipc"], optional = true }
 xml5ever = { version = "0.12", optional = true }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -47,11 +47,14 @@ extern crate app_units;
 extern crate cssparser;
 extern crate euclid;
 extern crate hashglobe;
+#[cfg(feature = "servo")]
 extern crate hyper;
+#[cfg(feature = "servo")]
 extern crate hyper_serde;
 #[cfg(feature = "servo")]
 extern crate mozjs as js;
 extern crate selectors;
+#[cfg(feature = "servo")]
 extern crate serde;
 #[cfg(feature = "servo")]
 extern crate serde_bytes;
@@ -60,6 +63,7 @@ extern crate smallbitvec;
 extern crate smallvec;
 #[cfg(feature = "servo")]
 extern crate string_cache;
+#[cfg(feature = "servo")]
 extern crate time;
 #[cfg(feature = "url")]
 extern crate url;
@@ -820,6 +824,7 @@ impl MallocSizeOf for xml5ever::QualName {
     }
 }
 
+#[cfg(feature = "servo")]
 impl MallocSizeOf for hyper::header::Headers {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.iter().fold(0, |acc, x| {
@@ -830,12 +835,14 @@ impl MallocSizeOf for hyper::header::Headers {
     }
 }
 
+#[cfg(feature = "servo")]
 impl MallocSizeOf for hyper::header::ContentType {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.0.size_of(ops)
     }
 }
 
+#[cfg(feature = "servo")]
 impl MallocSizeOf for hyper::mime::Mime {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.0.size_of(ops) +
@@ -844,6 +851,7 @@ impl MallocSizeOf for hyper::mime::Mime {
     }
 }
 
+#[cfg(feature = "servo")]
 impl MallocSizeOf for hyper::mime::Attr {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         match *self {
@@ -853,15 +861,19 @@ impl MallocSizeOf for hyper::mime::Attr {
     }
 }
 
+#[cfg(feature = "servo")]
 impl MallocSizeOf for hyper::mime::Value {
     fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
         self.len() // Length of string value in bytes (not the char length of a string)!
     }
 }
 
+#[cfg(feature = "servo")]
 malloc_size_of_is_0!(time::Duration);
+#[cfg(feature = "servo")]
 malloc_size_of_is_0!(time::Tm);
 
+#[cfg(feature = "servo")]
 impl<T> MallocSizeOf for hyper_serde::Serde<T> where
     for <'de> hyper_serde::De<T>: serde::Deserialize<'de>,
     for <'a> hyper_serde::Ser<'a, T>: serde::Serialize,
@@ -879,6 +891,7 @@ impl<T> MallocSizeOf for std::sync::mpsc::Sender<T> {
     }
 }
 
+#[cfg(feature = "servo")]
 impl MallocSizeOf for hyper::status::StatusCode {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         match *self {


### PR DESCRIPTION
This hides the changes in #20391 from Gecko builds that use the malloc_size_of crate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20504)
<!-- Reviewable:end -->
