### PR TITLE
Use Servo data to back @font-face rule in Gecko

### DIFF
--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -13,7 +13,6 @@ use computed_values::{font_stretch, font_style, font_weight};
 use cssparser::{AtRuleParser, DeclarationListParser, DeclarationParser, Parser};
 use cssparser::{SourceLocation, CowRcStr};
 use error_reporting::{ContextualParseError, ParseErrorReporter};
-#[cfg(feature = "gecko")] use gecko_bindings::structs::CSSFontFaceDescriptors;
 #[cfg(feature = "gecko")] use cssparser::UnicodeRange;
 use parser::{ParserContext, ParserErrorContext, Parse};
 #[cfg(feature = "gecko")]
@@ -271,7 +270,8 @@ macro_rules! font_face_descriptors_common {
         }
 
         impl FontFaceRuleData {
-            fn empty(location: SourceLocation) -> Self {
+            /// Create an empty font-face rule
+            pub fn empty(location: SourceLocation) -> Self {
                 FontFaceRuleData {
                     $(
                         $ident: None,
@@ -280,24 +280,8 @@ macro_rules! font_face_descriptors_common {
                 }
             }
 
-            /// Convert to Gecko types
-            #[cfg(feature = "gecko")]
-            pub fn set_descriptors(self, descriptors: &mut CSSFontFaceDescriptors) {
-                $(
-                    if let Some(value) = self.$ident {
-                        descriptors.$gecko_ident.set_from(value)
-                    }
-                )*
-                // Leave unset descriptors to eCSSUnit_Null,
-                // FontFaceSet::FindOrCreateUserFontEntryFromFontFace does the defaulting
-                // to initial values.
-            }
-        }
-
-        impl ToCssWithGuard for FontFaceRuleData {
-            // Serialization of FontFaceRule is not specced.
-            fn to_css(&self, _guard: &SharedRwLockReadGuard, dest: &mut CssStringWriter) -> fmt::Result {
-                dest.write_str("@font-face {\n")?;
+            /// Serialization of declarations in the FontFaceRule
+            pub fn decl_to_css(&self, dest: &mut CssStringWriter) -> fmt::Result {
                 $(
                     if let Some(ref value) = self.$ident {
                         dest.write_str(concat!("  ", $name, ": "))?;
@@ -305,7 +289,7 @@ macro_rules! font_face_descriptors_common {
                         dest.write_str(";\n")?;
                     }
                 )*
-                dest.write_str("}")
+                Ok(())
             }
         }
 
@@ -331,6 +315,15 @@ macro_rules! font_face_descriptors_common {
                 Ok(())
             }
         }
+    }
+}
+
+impl ToCssWithGuard for FontFaceRuleData {
+    // Serialization of FontFaceRule is not specced.
+    fn to_css(&self, _guard: &SharedRwLockReadGuard, dest: &mut CssStringWriter) -> fmt::Result {
+        dest.write_str("@font-face {\n")?;
+        self.decl_to_css(dest)?;
+        dest.write_str("}")
     }
 }
 

--- a/components/style/gecko/arc_types.rs
+++ b/components/style/gecko/arc_types.rs
@@ -8,13 +8,13 @@
 
 #![allow(non_snake_case, missing_docs)]
 
-use gecko_bindings::bindings::{RawServoFontFeatureValuesRule, RawServoImportRule, RawServoSupportsRule};
-use gecko_bindings::bindings::{RawServoKeyframe, RawServoKeyframesRule};
+use gecko_bindings::bindings::{RawServoFontFeatureValuesRule, RawServoImportRule};
+use gecko_bindings::bindings::{RawServoKeyframe, RawServoKeyframesRule, RawServoSupportsRule};
 use gecko_bindings::bindings::{RawServoMediaRule, RawServoNamespaceRule, RawServoPageRule};
 use gecko_bindings::bindings::{RawServoRuleNode, RawServoRuleNodeStrong, RawServoDocumentRule};
 use gecko_bindings::bindings::ServoCssRules;
-use gecko_bindings::structs::{RawServoAnimationValue, RawServoDeclarationBlock, RawServoStyleRule};
-use gecko_bindings::structs::{RawServoMediaList, RawServoStyleSheetContents};
+use gecko_bindings::structs::{RawServoAnimationValue, RawServoDeclarationBlock, RawServoFontFaceRule};
+use gecko_bindings::structs::{RawServoMediaList, RawServoStyleRule, RawServoStyleSheetContents};
 use gecko_bindings::sugar::ownership::{HasArcFFI, HasFFI, Strong};
 use media_queries::MediaList;
 use properties::{ComputedValues, PropertyDeclarationBlock};
@@ -24,7 +24,7 @@ use servo_arc::{Arc, ArcBorrow};
 use shared_lock::Locked;
 use std::{mem, ptr};
 use stylesheets::{CssRules, StylesheetContents, StyleRule, ImportRule, KeyframesRule, MediaRule};
-use stylesheets::{FontFeatureValuesRule, NamespaceRule, PageRule, SupportsRule, DocumentRule};
+use stylesheets::{FontFaceRule, FontFeatureValuesRule, NamespaceRule, PageRule, SupportsRule, DocumentRule};
 use stylesheets::keyframes_rule::Keyframe;
 
 macro_rules! impl_arc_ffi {
@@ -90,6 +90,9 @@ impl_arc_ffi!(Locked<DocumentRule> => RawServoDocumentRule
 
 impl_arc_ffi!(Locked<FontFeatureValuesRule> => RawServoFontFeatureValuesRule
               [Servo_FontFeatureValuesRule_AddRef, Servo_FontFeatureValuesRule_Release]);
+
+impl_arc_ffi!(Locked<FontFaceRule> => RawServoFontFaceRule
+              [Servo_FontFaceRule_AddRef, Servo_FontFaceRule_Release]);
 
 // RuleNode is a Arc-like type but it does not use Arc.
 

--- a/components/style/gecko/generated/bindings.rs
+++ b/components/style/gecko/generated/bindings.rs
@@ -38,6 +38,7 @@ use gecko_bindings::structs::RawGeckoComputedKeyframeValuesList;
 use gecko_bindings::structs::RawGeckoFontFaceRuleList;
 use gecko_bindings::structs::RawGeckoNode;
 use gecko_bindings::structs::RawServoAnimationValue;
+use gecko_bindings::structs::RawServoFontFaceRule;
 use gecko_bindings::structs::RawGeckoServoAnimationValueList;
 use gecko_bindings::structs::RawServoMediaList;
 use gecko_bindings::structs::RawServoStyleSheetContents;
@@ -77,7 +78,6 @@ use gecko_bindings::structs::gfxFontFeatureValueSet;
 use gecko_bindings::structs::nsCSSCounterDesc;
 use gecko_bindings::structs::nsCSSCounterStyleRule;
 use gecko_bindings::structs::nsCSSFontDesc;
-use gecko_bindings::structs::nsCSSFontFaceRule;
 use gecko_bindings::structs::nsCSSKeyword;
 use gecko_bindings::structs::nsCSSPropertyID;
 use gecko_bindings::structs::nsCSSPropertyIDSet;
@@ -430,6 +430,9 @@ pub type RawServoRuleNodeBorrowed<'a> = &'a RawServoRuleNode;
 pub type RawServoRuleNodeBorrowedOrNull<'a> = Option<&'a RawServoRuleNode>;
 enum RawServoRuleNodeVoid { }
 pub struct RawServoRuleNode(RawServoRuleNodeVoid);
+pub type RawServoFontFaceRuleStrong = ::gecko_bindings::sugar::ownership::Strong<RawServoFontFaceRule>;
+pub type RawServoFontFaceRuleBorrowed<'a> = &'a RawServoFontFaceRule;
+pub type RawServoFontFaceRuleBorrowedOrNull<'a> = Option<&'a RawServoFontFaceRule>;
 
 extern "C" {
     pub fn Gecko_EnsureTArrayCapacity(
@@ -540,6 +543,12 @@ extern "C" {
 }
 extern "C" {
     pub fn Servo_RuleNode_Release(ptr: RawServoRuleNodeBorrowed);
+}
+extern "C" {
+    pub fn Servo_FontFaceRule_AddRef(ptr: RawServoFontFaceRuleBorrowed);
+}
+extern "C" {
+    pub fn Servo_FontFaceRule_Release(ptr: RawServoFontFaceRuleBorrowed);
 }
 extern "C" {
     pub fn Servo_StyleSet_Drop(ptr: RawServoStyleSetOwned);
@@ -1564,21 +1573,6 @@ extern "C" {
     ) -> *const ::std::os::raw::c_char;
 }
 extern "C" {
-    pub fn Gecko_CSSFontFaceRule_Create(line: u32, column: u32) -> *mut nsCSSFontFaceRule;
-}
-extern "C" {
-    pub fn Gecko_CSSFontFaceRule_Clone(rule: *const nsCSSFontFaceRule) -> *mut nsCSSFontFaceRule;
-}
-extern "C" {
-    pub fn Gecko_CSSFontFaceRule_GetCssText(rule: *const nsCSSFontFaceRule, result: *mut nsAString);
-}
-extern "C" {
-    pub fn Gecko_CSSFontFaceRule_AddRef(aPtr: *mut nsCSSFontFaceRule);
-}
-extern "C" {
-    pub fn Gecko_CSSFontFaceRule_Release(aPtr: *mut nsCSSFontFaceRule);
-}
-extern "C" {
     pub fn Gecko_CSSCounterStyle_Create(name: *mut nsAtom) -> *mut nsCSSCounterStyleRule;
 }
 extern "C" {
@@ -2462,7 +2456,18 @@ extern "C" {
     pub fn Servo_CssRules_GetFontFaceRuleAt(
         rules: ServoCssRulesBorrowed,
         index: u32,
-    ) -> *mut nsCSSFontFaceRule;
+        line: *mut u32,
+        column: *mut u32,
+    ) -> RawServoFontFaceRuleStrong;
+}
+extern "C" {
+    pub fn Servo_FontFaceRule_Debug(rule: RawServoFontFaceRuleBorrowed, result: *mut nsACString);
+}
+extern "C" {
+    pub fn Servo_FontFaceRule_GetCssText(
+        rule: RawServoFontFaceRuleBorrowed,
+        result: *mut nsAString,
+    );
 }
 extern "C" {
     pub fn Servo_CssRules_GetCounterStyleRuleAt(
@@ -2610,6 +2615,64 @@ extern "C" {
     pub fn Servo_FontFeatureValuesRule_GetValueText(
         rule: RawServoFontFeatureValuesRuleBorrowed,
         result: *mut nsAString,
+    );
+}
+extern "C" {
+    pub fn Servo_FontFaceRule_CreateEmpty() -> RawServoFontFaceRuleStrong;
+}
+extern "C" {
+    pub fn Servo_FontFaceRule_Clone(
+        rule: RawServoFontFaceRuleBorrowed,
+    ) -> RawServoFontFaceRuleStrong;
+}
+extern "C" {
+    pub fn Servo_FontFaceRule_GetSourceLocation(
+        rule: RawServoFontFaceRuleBorrowed,
+        line: *mut u32,
+        column: *mut u32,
+    );
+}
+extern "C" {
+    pub fn Servo_FontFaceRule_Length(rule: RawServoFontFaceRuleBorrowed) -> u32;
+}
+extern "C" {
+    pub fn Servo_FontFaceRule_IndexGetter(
+        rule: RawServoFontFaceRuleBorrowed,
+        index: u32,
+    ) -> nsCSSFontDesc;
+}
+extern "C" {
+    pub fn Servo_FontFaceRule_GetDeclCssText(
+        rule: RawServoFontFaceRuleBorrowed,
+        result: *mut nsAString,
+    );
+}
+extern "C" {
+    pub fn Servo_FontFaceRule_GetDescriptor(
+        rule: RawServoFontFaceRuleBorrowed,
+        desc: nsCSSFontDesc,
+        result: nsCSSValueBorrowedMut,
+    );
+}
+extern "C" {
+    pub fn Servo_FontFaceRule_GetDescriptorCssText(
+        rule: RawServoFontFaceRuleBorrowed,
+        desc: nsCSSFontDesc,
+        result: *mut nsAString,
+    );
+}
+extern "C" {
+    pub fn Servo_FontFaceRule_SetDescriptor(
+        rule: RawServoFontFaceRuleBorrowed,
+        desc: nsCSSFontDesc,
+        value: *const nsACString,
+        data: *mut RawGeckoURLExtraData,
+    ) -> bool;
+}
+extern "C" {
+    pub fn Servo_FontFaceRule_ResetDescriptor(
+        rule: RawServoFontFaceRuleBorrowed,
+        desc: nsCSSFontDesc,
     );
 }
 extern "C" {
@@ -3263,14 +3326,6 @@ extern "C" {
         aValue: *const nsACString,
         aURLExtraData: *mut RawGeckoURLExtraData,
         aResult: *mut nsCSSValue,
-    ) -> bool;
-}
-extern "C" {
-    pub fn Servo_ParseFontDescriptor(
-        desc_id: nsCSSFontDesc,
-        value: *const nsAString,
-        data: *mut RawGeckoURLExtraData,
-        arg1: nsCSSValueBorrowedMut,
     ) -> bool;
 }
 extern "C" {

--- a/components/style/gecko/generated/structs.rs
+++ b/components/style/gecko/generated/structs.rs
@@ -13378,161 +13378,6 @@ pub mod root {
                 *self
             }
         }
-        #[repr(C)]
-        #[derive(Debug)]
-        pub struct CSSFontFaceDescriptors {
-            pub mFamily: root::nsCSSValue,
-            pub mStyle: root::nsCSSValue,
-            pub mWeight: root::nsCSSValue,
-            pub mStretch: root::nsCSSValue,
-            pub mSrc: root::nsCSSValue,
-            pub mUnicodeRange: root::nsCSSValue,
-            pub mFontFeatureSettings: root::nsCSSValue,
-            pub mFontVariationSettings: root::nsCSSValue,
-            pub mFontLanguageOverride: root::nsCSSValue,
-            pub mDisplay: root::nsCSSValue,
-        }
-        extern "C" {
-            #[link_name = "\u{1}_ZN7mozilla22CSSFontFaceDescriptors6FieldsE"]
-            pub static mut CSSFontFaceDescriptors_Fields: [*const root::nsCSSValue; 0usize];
-        }
-        #[test]
-        fn bindgen_test_layout_CSSFontFaceDescriptors() {
-            assert_eq!(
-                ::std::mem::size_of::<CSSFontFaceDescriptors>(),
-                160usize,
-                concat!("Size of: ", stringify!(CSSFontFaceDescriptors))
-            );
-            assert_eq!(
-                ::std::mem::align_of::<CSSFontFaceDescriptors>(),
-                8usize,
-                concat!("Alignment of ", stringify!(CSSFontFaceDescriptors))
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<CSSFontFaceDescriptors>())).mFamily as *const _ as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(CSSFontFaceDescriptors),
-                    "::",
-                    stringify!(mFamily)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<CSSFontFaceDescriptors>())).mStyle as *const _ as usize
-                },
-                16usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(CSSFontFaceDescriptors),
-                    "::",
-                    stringify!(mStyle)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<CSSFontFaceDescriptors>())).mWeight as *const _ as usize
-                },
-                32usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(CSSFontFaceDescriptors),
-                    "::",
-                    stringify!(mWeight)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<CSSFontFaceDescriptors>())).mStretch as *const _ as usize
-                },
-                48usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(CSSFontFaceDescriptors),
-                    "::",
-                    stringify!(mStretch)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<CSSFontFaceDescriptors>())).mSrc as *const _ as usize
-                },
-                64usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(CSSFontFaceDescriptors),
-                    "::",
-                    stringify!(mSrc)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<CSSFontFaceDescriptors>())).mUnicodeRange as *const _
-                        as usize
-                },
-                80usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(CSSFontFaceDescriptors),
-                    "::",
-                    stringify!(mUnicodeRange)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<CSSFontFaceDescriptors>())).mFontFeatureSettings
-                        as *const _ as usize
-                },
-                96usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(CSSFontFaceDescriptors),
-                    "::",
-                    stringify!(mFontFeatureSettings)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<CSSFontFaceDescriptors>())).mFontVariationSettings
-                        as *const _ as usize
-                },
-                112usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(CSSFontFaceDescriptors),
-                    "::",
-                    stringify!(mFontVariationSettings)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<CSSFontFaceDescriptors>())).mFontLanguageOverride
-                        as *const _ as usize
-                },
-                128usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(CSSFontFaceDescriptors),
-                    "::",
-                    stringify!(mFontLanguageOverride)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<CSSFontFaceDescriptors>())).mDisplay as *const _ as usize
-                },
-                144usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(CSSFontFaceDescriptors),
-                    "::",
-                    stringify!(mDisplay)
-                )
-            );
-        }
         pub mod intl {
             #[allow(unused_imports)]
             use self::super::super::super::root;
@@ -23544,6 +23389,16 @@ pub mod root {
             *self
         }
     }
+    #[repr(C)]
+    #[derive(Debug, Copy)]
+    pub struct RawServoFontFaceRule {
+        _unused: [u8; 0],
+    }
+    impl Clone for RawServoFontFaceRule {
+        fn clone(&self) -> Self {
+            *self
+        }
+    }
     pub mod nsStyleTransformMatrix {
         #[allow(unused_imports)]
         use self::super::super::root;
@@ -23626,6 +23481,49 @@ pub mod root {
     pub type RawGeckoServoStyleRuleListBorrowedMut = *mut root::RawGeckoServoStyleRuleList;
     pub type RawGeckoCSSPropertyIDListBorrowed = *const root::RawGeckoCSSPropertyIDList;
     pub type RawGeckoStyleChildrenIteratorBorrowedMut = *mut root::RawGeckoStyleChildrenIterator;
+    #[repr(C)]
+    #[derive(Debug)]
+    pub struct nsFontFaceRuleContainer {
+        pub mRule: root::RefPtr<root::RawServoFontFaceRule>,
+        pub mSheetType: root::mozilla::SheetType,
+    }
+    #[test]
+    fn bindgen_test_layout_nsFontFaceRuleContainer() {
+        assert_eq!(
+            ::std::mem::size_of::<nsFontFaceRuleContainer>(),
+            16usize,
+            concat!("Size of: ", stringify!(nsFontFaceRuleContainer))
+        );
+        assert_eq!(
+            ::std::mem::align_of::<nsFontFaceRuleContainer>(),
+            8usize,
+            concat!("Alignment of ", stringify!(nsFontFaceRuleContainer))
+        );
+        assert_eq!(
+            unsafe {
+                &(*(::std::ptr::null::<nsFontFaceRuleContainer>())).mRule as *const _ as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(nsFontFaceRuleContainer),
+                "::",
+                stringify!(mRule)
+            )
+        );
+        assert_eq!(
+            unsafe {
+                &(*(::std::ptr::null::<nsFontFaceRuleContainer>())).mSheetType as *const _ as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(nsFontFaceRuleContainer),
+                "::",
+                stringify!(mSheetType)
+            )
+        );
+    }
     #[repr(C)]
     #[derive(Debug, Copy)]
     pub struct nsDOMStyleSheetSetList {
@@ -39873,140 +39771,6 @@ pub mod root {
         );
     }
     #[repr(C)]
-    #[derive(Debug)]
-    pub struct nsCSSFontFaceStyleDecl {
-        pub _base: root::nsICSSDeclaration,
-        pub mDescriptors: root::mozilla::CSSFontFaceDescriptors,
-    }
-    #[test]
-    fn bindgen_test_layout_nsCSSFontFaceStyleDecl() {
-        assert_eq!(
-            ::std::mem::size_of::<nsCSSFontFaceStyleDecl>(),
-            192usize,
-            concat!("Size of: ", stringify!(nsCSSFontFaceStyleDecl))
-        );
-        assert_eq!(
-            ::std::mem::align_of::<nsCSSFontFaceStyleDecl>(),
-            8usize,
-            concat!("Alignment of ", stringify!(nsCSSFontFaceStyleDecl))
-        );
-        assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<nsCSSFontFaceStyleDecl>())).mDescriptors as *const _ as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsCSSFontFaceStyleDecl),
-                "::",
-                stringify!(mDescriptors)
-            )
-        );
-    }
-    #[repr(C)]
-    #[derive(Debug)]
-    pub struct nsCSSFontFaceRule {
-        pub _base: root::mozilla::css::Rule,
-        pub mDecl: root::nsCSSFontFaceStyleDecl,
-    }
-    #[repr(C)]
-    #[derive(Debug, Copy)]
-    pub struct nsCSSFontFaceRule_cycleCollection {
-        pub _base: root::mozilla::css::Rule_cycleCollection,
-    }
-    #[test]
-    fn bindgen_test_layout_nsCSSFontFaceRule_cycleCollection() {
-        assert_eq!(
-            ::std::mem::size_of::<nsCSSFontFaceRule_cycleCollection>(),
-            16usize,
-            concat!("Size of: ", stringify!(nsCSSFontFaceRule_cycleCollection))
-        );
-        assert_eq!(
-            ::std::mem::align_of::<nsCSSFontFaceRule_cycleCollection>(),
-            8usize,
-            concat!(
-                "Alignment of ",
-                stringify!(nsCSSFontFaceRule_cycleCollection)
-            )
-        );
-    }
-    impl Clone for nsCSSFontFaceRule_cycleCollection {
-        fn clone(&self) -> Self {
-            *self
-        }
-    }
-    extern "C" {
-        #[link_name = "\u{1}_ZN17nsCSSFontFaceRule21_cycleCollectorGlobalE"]
-        pub static mut nsCSSFontFaceRule__cycleCollectorGlobal:
-            root::nsCSSFontFaceRule_cycleCollection;
-    }
-    #[test]
-    fn bindgen_test_layout_nsCSSFontFaceRule() {
-        assert_eq!(
-            ::std::mem::size_of::<nsCSSFontFaceRule>(),
-            256usize,
-            concat!("Size of: ", stringify!(nsCSSFontFaceRule))
-        );
-        assert_eq!(
-            ::std::mem::align_of::<nsCSSFontFaceRule>(),
-            8usize,
-            concat!("Alignment of ", stringify!(nsCSSFontFaceRule))
-        );
-        assert_eq!(
-            unsafe { &(*(::std::ptr::null::<nsCSSFontFaceRule>())).mDecl as *const _ as usize },
-            64usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsCSSFontFaceRule),
-                "::",
-                stringify!(mDecl)
-            )
-        );
-    }
-    #[repr(C)]
-    #[derive(Debug)]
-    pub struct nsFontFaceRuleContainer {
-        pub mRule: root::RefPtr<root::nsCSSFontFaceRule>,
-        pub mSheetType: root::mozilla::SheetType,
-    }
-    #[test]
-    fn bindgen_test_layout_nsFontFaceRuleContainer() {
-        assert_eq!(
-            ::std::mem::size_of::<nsFontFaceRuleContainer>(),
-            16usize,
-            concat!("Size of: ", stringify!(nsFontFaceRuleContainer))
-        );
-        assert_eq!(
-            ::std::mem::align_of::<nsFontFaceRuleContainer>(),
-            8usize,
-            concat!("Alignment of ", stringify!(nsFontFaceRuleContainer))
-        );
-        assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<nsFontFaceRuleContainer>())).mRule as *const _ as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsFontFaceRuleContainer),
-                "::",
-                stringify!(mRule)
-            )
-        );
-        assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<nsFontFaceRuleContainer>())).mSheetType as *const _ as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsFontFaceRuleContainer),
-                "::",
-                stringify!(mSheetType)
-            )
-        );
-    }
-    #[repr(C)]
     #[derive(Debug, Copy)]
     pub struct nsHtml5StringParser {
         _unused: [u8; 0],
@@ -47147,6 +46911,25 @@ pub mod root {
         );
     }
     #[test]
+    fn __bindgen_test_layout_RefPtr_open0_RawServoFontFaceRule_close0_instantiation() {
+        assert_eq!(
+            ::std::mem::size_of::<root::RefPtr<root::RawServoFontFaceRule>>(),
+            8usize,
+            concat!(
+                "Size of template specialization: ",
+                stringify!(root::RefPtr<root::RawServoFontFaceRule>)
+            )
+        );
+        assert_eq!(
+            ::std::mem::align_of::<root::RefPtr<root::RawServoFontFaceRule>>(),
+            8usize,
+            concat!(
+                "Alignment of template specialization: ",
+                stringify!(root::RefPtr<root::RawServoFontFaceRule>)
+            )
+        );
+    }
+    #[test]
     fn __bindgen_test_layout_RefPtr_open0_RawServoAnimationValue_close0_instantiation_1() {
         assert_eq!(
             ::std::mem::size_of::<root::RefPtr<root::RawServoAnimationValue>>(),
@@ -49302,25 +49085,6 @@ pub mod root {
             concat!(
                 "Alignment of template specialization: ",
                 stringify!(root::RefPtr<root::nsAtom>)
-            )
-        );
-    }
-    #[test]
-    fn __bindgen_test_layout_RefPtr_open0_nsCSSFontFaceRule_close0_instantiation() {
-        assert_eq!(
-            ::std::mem::size_of::<root::RefPtr<root::nsCSSFontFaceRule>>(),
-            8usize,
-            concat!(
-                "Size of template specialization: ",
-                stringify!(root::RefPtr<root::nsCSSFontFaceRule>)
-            )
-        );
-        assert_eq!(
-            ::std::mem::align_of::<root::RefPtr<root::nsCSSFontFaceRule>>(),
-            8usize,
-            concat!(
-                "Alignment of template specialization: ",
-                stringify!(root::RefPtr<root::nsCSSFontFaceRule>)
             )
         );
     }

--- a/components/style/gecko_bindings/sugar/refptr.rs
+++ b/components/style/gecko_bindings/sugar/refptr.rs
@@ -260,8 +260,6 @@ macro_rules! impl_refcount {
     );
 }
 
-impl_refcount!(::gecko_bindings::structs::nsCSSFontFaceRule,
-               Gecko_CSSFontFaceRule_AddRef, Gecko_CSSFontFaceRule_Release);
 impl_refcount!(::gecko_bindings::structs::nsCSSCounterStyleRule,
                Gecko_CSSCounterStyleRule_AddRef, Gecko_CSSCounterStyleRule_Release);
 

--- a/components/style/stylesheets/font_face_rule.rs
+++ b/components/style/stylesheets/font_face_rule.rs
@@ -2,23 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// TODO(emilio): unify this, components/style/font_face.rs, and
-// components/style/gecko/rules.rs
 #![allow(missing_docs)]
 
-#[cfg(feature = "servo")]
 pub use font_face::FontFaceRuleData as FontFaceRule;
-#[cfg(feature = "gecko")]
-pub use gecko::rules::FontFaceRule;
-
-impl FontFaceRule {
-    #[cfg(feature = "servo")]
-    pub fn clone_conditionally_gecko_or_servo(&self) -> FontFaceRule {
-        self.clone()
-    }
-
-    #[cfg(feature = "gecko")]
-    pub fn clone_conditionally_gecko_or_servo(&self) -> FontFaceRule {
-        self.deep_clone_from_gecko()
-    }
-}

--- a/components/style/stylesheets/mod.rs
+++ b/components/style/stylesheets/mod.rs
@@ -306,8 +306,7 @@ impl DeepCloneWithLock for CssRule {
             },
             CssRule::FontFace(ref arc) => {
                 let rule = arc.read_with(guard);
-                CssRule::FontFace(Arc::new(lock.wrap(
-                    rule.clone_conditionally_gecko_or_servo())))
+                CssRule::FontFace(Arc::new(lock.wrap(rule.clone())))
             },
             CssRule::FontFeatureValues(ref arc) => {
                 let rule = arc.read_with(guard);

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -1612,7 +1612,7 @@ pub struct ExtraStyleData {
 }
 
 // FIXME(emilio): This is kind of a lie, and relies on us not cloning
-// nsCSSFontFaceRules or nsCSSCounterStyleRules OMT (which we don't).
+// nsCSSCounterStyleRules OMT (which we don't).
 #[cfg(feature = "gecko")]
 unsafe impl Sync for ExtraStyleData {}
 #[cfg(feature = "gecko")]


### PR DESCRIPTION
This is the Servo side change of [bug 1449087](https://bugzilla.mozilla.org/show_bug.cgi?id=1449087).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20519)
<!-- Reviewable:end -->
