### PR TITLE
fix(window): apply dpi aware viewport

### DIFF
--- a/ports/servo/glutin_app/window.rs
+++ b/ports/servo/glutin_app/window.rs
@@ -295,7 +295,7 @@ impl Window {
         match self.kind {
             WindowKind::Window(ref window, _) => {
                 let (_, height) = window.get_inner_size().expect("Failed to get window inner size.");
-                height as f32 * dpr.get()
+                height as f32
             },
             WindowKind::Headless(ref context) => {
                 context.height as f32 * dpr.get()
@@ -698,7 +698,7 @@ impl WindowMethods for Window {
                 let screen = (self.screen_size.to_f32() * dpr).to_u32();
 
                 let (width, height) = window.get_inner_size().expect("Failed to get window inner size.");
-                let inner_size = (TypedSize2D::new(width as f32, height as f32) * dpr).to_u32();
+                let inner_size = TypedSize2D::new(width, height);
 
                 let viewport = DeviceUintRect::new(TypedPoint2D::zero(), inner_size);
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Closes https://github.com/servo/servo/issues/20505.

**This PR is mostly open for discussion, I feel PR may need to be shaped with better organization.**

In PR #20228, `window::get_coordinates()` migrates coordinate calculation includes inner frame viewport
https://github.com/servo/servo/blob/master/ports/servo/glutin_app/window.rs#L700-L701

which was located here previously
https://github.com/servo/servo/blob/28c92db26837531e75327cff7727ed8bc1c70b48/ports/servo/glutin_app/window.rs#L891-L893

It have one differences between, while previous logic was using `window::inner_size` property while current logic asks to get inner size via `get_inner_size()`. Those 2 value can be different when dpi_factor is not 1, cause when setting value to `inner_size` property it calculates back using dpi_factor.

https://github.com/servo/servo/blob/master/ports/servo/glutin_app/window.rs#L546

So previous logic scale via dpi_factor was get correct viewport size, while current logic doubles up its scale. Currently this PR simply looks for places where it asks for `get_inner_size()` and doesn't apply dpi factor.

Still, it feels somewhat confusing / inconsistent between stored property is differ to what window reports back. Maybe either rename `inner_size` for more clear (like `virtual_inner`?), or just store inner_size from get_inner_size() as is and calculate where it's needed, or even could just get rid of inner_size and rely on `get_coordinates` only.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [ ] `./mach build-geckolib` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #20505 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____
- manually verified on windows machine, 150% dpi scaling.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20522)
<!-- Reviewable:end -->
