### PR TITLE
Stop using NS_STYLE_FONT_WEIGHT_NORMAL and NS_STYLE_FONT_WEIGHT_BOLD

### DIFF
--- a/components/style/gecko/rules.rs
+++ b/components/style/gecko/rules.rs
@@ -33,9 +33,9 @@ impl<'a> ToNsCssValue for &'a FontWeight {
     fn convert(self, nscssvalue: &mut nsCSSValue) {
         match *self {
             FontWeight::Normal =>
-                nscssvalue.set_enum(structs::NS_STYLE_FONT_WEIGHT_NORMAL as i32),
+                nscssvalue.set_enum(structs::NS_FONT_WEIGHT_NORMAL as i32),
             FontWeight::Bold =>
-                nscssvalue.set_enum(structs::NS_STYLE_FONT_WEIGHT_BOLD as i32),
+                nscssvalue.set_enum(structs::NS_FONT_WEIGHT_BOLD as i32),
             FontWeight::Weight(weight) => nscssvalue.set_integer(weight.0 as i32),
         }
     }

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -5330,8 +5330,8 @@ pub extern "C" fn Servo_ParseFontShorthandForMatching(
     });
     match font.font_weight {
         FontWeight::Weight(w) => weight.set_from(w),
-        FontWeight::Normal => weight.set_enum(structs::NS_STYLE_FONT_WEIGHT_NORMAL as i32),
-        FontWeight::Bold => weight.set_enum(structs::NS_STYLE_FONT_WEIGHT_BOLD as i32),
+        FontWeight::Normal => weight.set_enum(structs::NS_FONT_WEIGHT_NORMAL as i32),
+        FontWeight::Bold => weight.set_enum(structs::NS_FONT_WEIGHT_BOLD as i32),
         // Resolve relative font weights against the initial of font-weight
         // (normal, which is equivalent to 400).
         FontWeight::Bolder => weight.set_enum(structs::NS_FONT_WEIGHT_BOLD as i32),


### PR DESCRIPTION
The Servo side of the changes for
https://bugzilla.mozilla.org/show_bug.cgi?id=1452040

- [X] `./mach build -d` does not report any errors
- [X] `./mach build-geckolib` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's a trivial change to internal constants

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20572)
<!-- Reviewable:end -->
