### PR TITLE
Add support for percentages in column-gap.

### DIFF
--- a/components/layout/multicol.rs
+++ b/components/layout/multicol.rs
@@ -106,9 +106,8 @@ impl Flow for MulticolFlow {
         {
             let column_style = self.block_flow.fragment.style.get_column();
 
-            // FIXME(#20498): This should support percentages too.
             let column_gap = match column_style.column_gap {
-                Either::First(len) => len.into(),
+                Either::First(len) => len.0.to_pixel_length(content_inline_size).into(),
                 Either::Second(_normal) => self.block_flow.fragment.style.get_font().font_size.size(),
             };
 

--- a/components/style/properties/longhand/column.mako.rs
+++ b/components/style/properties/longhand/column.mako.rs
@@ -31,7 +31,6 @@ ${helpers.predefined_type(
 
 
 <%
-# FIXME(#20498): Servo should support percentages in column-gap.
 col_gap_type = "NonNegativeLengthOrPercentageOrNormal"
 %>
 ${helpers.predefined_type(

--- a/components/style/properties/longhand/column.mako.rs
+++ b/components/style/properties/longhand/column.mako.rs
@@ -30,16 +30,14 @@ ${helpers.predefined_type(
 )}
 
 
-<%
-col_gap_type = "NonNegativeLengthOrPercentageOrNormal"
-%>
+
 ${helpers.predefined_type(
     "column-gap",
-    "length::%s" % col_gap_type,
+    "length::NonNegativeLengthOrPercentageOrNormal",
     "Either::Second(Normal)",
     extra_prefixes="moz",
     servo_pref="layout.columns.enabled",
-    animation_value_type=col_gap_type,
+    animation_value_type="NonNegativeLengthOrPercentageOrNormal",
     spec="https://drafts.csswg.org/css-multicol/#propdef-column-gap",
     servo_restyle_damage = "reflow",
 )}

--- a/components/style/properties/longhand/column.mako.rs
+++ b/components/style/properties/longhand/column.mako.rs
@@ -32,7 +32,7 @@ ${helpers.predefined_type(
 
 <%
 # FIXME(#20498): Servo should support percentages in column-gap.
-col_gap_type = "NonNegativeLengthOrPercentageOrNormal" if product == "gecko" else "NonNegativeLengthOrNormal"
+col_gap_type = "NonNegativeLengthOrPercentageOrNormal"
 %>
 ${helpers.predefined_type(
     "column-gap",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
# Changes in this PR
* I've removed the `if product == "gecko"` line in order to make the column_gap type "NonNegativeLengthOrPercentageOrNormal" always.

* Then I've changed this line
```rust
Either::First(len) => len.into(),
```
to
```rust
Either::First(len) => len.0.to_pixel_length(content_inline_size).into(),
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach build-geckolib` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #20498  (github issue number if applicable).

<!-- Either: -->
- [X] These changes do not require tests because there are tests already for this in wpt, in particular css/css-align/gaps/column-gap-parsing-001.html for the parsing bits, and css/css-multicol/multicol-gap-percentage-001.html for the layout bits.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20573)
<!-- Reviewable:end -->
