### PR TITLE
style: Implement the non-functional :host selector.

### DIFF
--- a/components/selectors/builder.rs
+++ b/components/selectors/builder.rs
@@ -314,6 +314,7 @@ fn complex_selector_specificity<Impl>(mut iter: slice::Iter<Component<Impl>>)
             Component::FirstChild | Component::LastChild |
             Component::OnlyChild | Component::Root |
             Component::Empty | Component::Scope |
+            Component::Host |
             Component::NthChild(..) |
             Component::NthLastChild(..) |
             Component::NthOfType(..) |

--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -466,15 +466,9 @@ where
             //   pseudo-classes are allowed to match it.
             //
             // Since we know that the parent is a shadow root, we necessarily
-            // are in a shadow tree of the host.
-            let all_selectors_could_match = selector.clone().all(|component| {
-                match *component {
-                    Component::NonTSPseudoClass(ref pc) => pc.is_host(),
-                    _ => false,
-                }
-            });
-
-            if !all_selectors_could_match {
+            // are in a shadow tree of the host, and the next selector will only
+            // match if the selector is a featureless :host selector.
+            if !selector.clone().is_featureless_host_selector() {
                 return None;
             }
 
@@ -819,6 +813,9 @@ where
         Component::Empty => {
             flags_setter(element, ElementSelectorFlags::HAS_EMPTY_SELECTOR);
             element.is_empty()
+        }
+        Component::Host => {
+            context.shared.shadow_host().map_or(false, |host| host == element.opaque())
         }
         Component::Scope => {
             match context.shared.scope_element {

--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -42,9 +42,6 @@ pub trait NonTSPseudoClass : Sized + ToCss {
 
     /// Whether this pseudo-class is :active or :hover.
     fn is_active_or_hover(&self) -> bool;
-
-    /// Whether this pseudo-class is :host.
-    fn is_host(&self) -> bool;
 }
 
 fn to_ascii_lowercase(s: &str) -> Cow<str> {
@@ -142,6 +139,11 @@ pub trait Parser<'i> {
 
     /// Whether to parse the `::slotted()` pseudo-element.
     fn parse_slotted(&self) -> bool {
+        false
+    }
+
+    /// Whether to parse the `:host` pseudo-class.
+    fn parse_host(&self) -> bool {
         false
     }
 
@@ -513,6 +515,13 @@ impl<Impl: SelectorImpl> Selector<Impl> {
         }
     }
 
+    /// Whether this selector is a featureless :host selector, with no
+    /// combinators to the left.
+    #[inline]
+    pub fn is_featureless_host_selector(&self) -> bool {
+        self.iter().is_featureless_host_selector()
+    }
+
     /// Returns an iterator over this selector in matching order (right-to-left),
     /// skipping the rightmost |offset| Components.
     #[inline]
@@ -603,6 +612,14 @@ impl<'a, Impl: 'a + SelectorImpl> SelectorIter<'a, Impl> {
     #[inline]
     pub fn next_sequence(&mut self) -> Option<Combinator> {
         self.next_combinator.take()
+    }
+
+    /// Whether this selector is a featureless host selector, with no
+    /// combinators to the left.
+    #[inline]
+    pub(crate) fn is_featureless_host_selector(&mut self) -> bool {
+        self.all(|component| matches!(*component, Component::Host)) &&
+        self.next_sequence().is_none()
     }
 
     /// Returns remaining count of the simple selectors and combinators in the Selector.
@@ -776,6 +793,10 @@ pub enum Component<Impl: SelectorImpl> {
     Root,
     Empty,
     Scope,
+    /// The `:host` pseudo-class:
+    ///
+    /// https://drafts.csswg.org/css-scoping/#host-selector
+    Host,
     NthChild(i32, i32),
     NthLastChild(i32, i32),
     NthOfType(i32, i32),
@@ -1098,6 +1119,7 @@ impl<Impl: SelectorImpl> ToCss for Component<Impl> {
             Root => dest.write_str(":root"),
             Empty => dest.write_str(":empty"),
             Scope => dest.write_str(":scope"),
+            Host => dest.write_str(":host"),
             FirstOfType => dest.write_str(":first-of-type"),
             LastOfType => dest.write_str(":last-of-type"),
             OnlyOfType => dest.write_str(":only-of-type"),
@@ -1947,9 +1969,10 @@ where
         "root" => Ok(Component::Root),
         "empty" => Ok(Component::Empty),
         "scope" => Ok(Component::Scope),
+        "host" if P::parse_host(parser) => Ok(Component::Host),
         "first-of-type" => Ok(Component::FirstOfType),
-        "last-of-type"  => Ok(Component::LastOfType),
-        "only-of-type"  => Ok(Component::OnlyOfType),
+        "last-of-type" => Ok(Component::LastOfType),
+        "only-of-type" => Ok(Component::OnlyOfType),
         _ => Err(())
     }).or_else(|()| {
         P::parse_non_ts_pseudo_class(parser, location, name)
@@ -1998,11 +2021,6 @@ pub mod tests {
         #[inline]
         fn is_active_or_hover(&self) -> bool {
             matches!(*self, PseudoClass::Active | PseudoClass::Hover)
-        }
-
-        #[inline]
-        fn is_host(&self) -> bool {
-            false
         }
     }
 

--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -262,8 +262,8 @@ impl ElementData {
 
         let mut non_document_styles = SmallVec::<[_; 3]>::new();
         let matches_doc_author_rules =
-            element.each_applicable_non_document_style_rule_data(|data, quirks_mode| {
-                non_document_styles.push((data, quirks_mode))
+            element.each_applicable_non_document_style_rule_data(|data, quirks_mode, host| {
+                non_document_styles.push((data, quirks_mode, host.map(|h| h.opaque())))
             });
 
         let mut processor = StateAndAttrInvalidationProcessor::new(

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -772,24 +772,37 @@ pub trait TElement
     /// Executes the callback for each applicable style rule data which isn't
     /// the main document's data (which stores UA / author rules).
     ///
+    /// The element passed to the callback is the containing shadow host for the
+    /// data if it comes from Shadow DOM, None if it comes from XBL.
+    ///
     /// Returns whether normal document author rules should apply.
     fn each_applicable_non_document_style_rule_data<'a, F>(&self, mut f: F) -> bool
     where
         Self: 'a,
-        F: FnMut(&'a CascadeData, QuirksMode),
+        F: FnMut(&'a CascadeData, QuirksMode, Option<Self>),
     {
-        let mut doc_rules_apply = !self.each_xbl_cascade_data(&mut f);
+        let mut doc_rules_apply = !self.each_xbl_cascade_data(|data, quirks_mode| {
+            f(data, quirks_mode, None);
+        });
 
         if let Some(shadow) = self.containing_shadow() {
             doc_rules_apply = false;
-            f(shadow.style_data(), self.as_node().owner_doc().quirks_mode());
+            f(
+                shadow.style_data(),
+                self.as_node().owner_doc().quirks_mode(),
+                Some(shadow.host()),
+            );
         }
 
         let mut current = self.assigned_slot();
         while let Some(slot) = current {
             // Slots can only have assigned nodes when in a shadow tree.
-            let data = slot.containing_shadow().unwrap().style_data();
-            f(data, self.as_node().owner_doc().quirks_mode());
+            let shadow = slot.containing_shadow().unwrap();
+            f(
+                shadow.style_data(),
+                self.as_node().owner_doc().quirks_mode(),
+                Some(shadow.host()),
+            );
             current = slot.assigned_slot();
         }
 

--- a/components/style/gecko/selector_parser.rs
+++ b/components/style/gecko/selector_parser.rs
@@ -117,7 +117,8 @@ impl Visit for NonTSPseudoClass {
     type Impl = SelectorImpl;
 
     fn visit<V>(&self, visitor: &mut V) -> bool
-        where V: SelectorVisitor<Impl = Self::Impl>,
+    where
+        V: SelectorVisitor<Impl = Self::Impl>,
     {
         if let NonTSPseudoClass::MozAny(ref selectors) = *self {
             for selector in selectors.iter() {
@@ -161,8 +162,6 @@ impl NonTSPseudoClass {
                 match *self {
                     $(NonTSPseudoClass::$name => check_flag!($flags),)*
                     $(NonTSPseudoClass::$s_name(..) => check_flag!($s_flags),)*
-                    // TODO(emilio): Maybe -moz-locale-dir shouldn't be
-                    // content-exposed.
                     NonTSPseudoClass::MozLocaleDir(_) |
                     NonTSPseudoClass::Dir(_) |
                     NonTSPseudoClass::MozAny(_) => false,
@@ -275,11 +274,6 @@ impl ::selectors::parser::NonTSPseudoClass for NonTSPseudoClass {
     fn is_active_or_hover(&self) -> bool {
         matches!(*self, NonTSPseudoClass::Active | NonTSPseudoClass::Hover)
     }
-
-    #[inline]
-    fn is_host(&self) -> bool {
-        false // TODO(emilio)
-    }
 }
 
 /// The dummy struct we use to implement our selector parsing.
@@ -349,11 +343,17 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
     type Impl = SelectorImpl;
     type Error = StyleParseErrorKind<'i>;
 
+    #[inline]
     fn parse_slotted(&self) -> bool {
         // NOTE(emilio): Slot assignment and such works per-document, but
         // getting a document around here is not trivial, and it's not worth
         // anyway to handle this in a per-doc basis.
         unsafe { structs::nsContentUtils_sIsShadowDOMEnabled }
+    }
+
+    #[inline]
+    fn parse_host(&self) -> bool {
+        self.parse_slotted()
     }
 
     fn pseudo_element_allows_single_colon(name: &str) -> bool {

--- a/components/style/servo/selector_parser.rs
+++ b/components/style/servo/selector_parser.rs
@@ -312,11 +312,6 @@ impl ::selectors::parser::NonTSPseudoClass for NonTSPseudoClass {
     type Impl = SelectorImpl;
 
     #[inline]
-    fn is_host(&self) -> bool {
-        false
-    }
-
-    #[inline]
     fn is_active_or_hover(&self) -> bool {
         matches!(*self, NonTSPseudoClass::Active | NonTSPseudoClass::Hover)
     }

--- a/components/style/sharing/mod.rs
+++ b/components/style/sharing/mod.rs
@@ -553,6 +553,16 @@ impl<E: TElement> StyleSharingCache<E> {
             return;
         }
 
+        // We can't share style across shadow hosts right now, because they may
+        // match different :host rules.
+        //
+        // TODO(emilio): We could share across the ones that don't have :host
+        // rules or have the same.
+        if element.shadow_root().is_some() {
+            debug!("Failing to insert into the cache: Shadow Host");
+            return;
+        }
+
         // If the element has running animations, we can't share style.
         //
         // This is distinct from the specifies_{animations,transitions} check below,
@@ -713,6 +723,11 @@ impl<E: TElement> StyleSharingCache<E> {
             // TODO(emilio): We could have a look at whether the shadow roots
             // actually have slotted rules and such.
             trace!("Miss: Different assigned slots");
+            return None;
+        }
+
+        if target.element.shadow_root().is_some() {
+            trace!("Miss: Shadow host");
             return None;
         }
 

--- a/ports/geckolib/glue.rs
+++ b/ports/geckolib/glue.rs
@@ -4914,7 +4914,7 @@ pub extern "C" fn Servo_StyleSet_MightHaveAttributeDependency(
 
     unsafe {
         Atom::with(local_name, |atom| {
-            data.stylist.any_applicable_rule_data(element, |data, _| {
+            data.stylist.any_applicable_rule_data(element, |data| {
                 data.might_have_attribute_dependency(atom)
             })
         })
@@ -4932,7 +4932,7 @@ pub extern "C" fn Servo_StyleSet_HasStateDependency(
     let state = ElementState::from_bits_truncate(state);
     let data = PerDocumentStyleData::from_ffi(raw_data).borrow();
 
-    data.stylist.any_applicable_rule_data(element, |data, _| {
+    data.stylist.any_applicable_rule_data(element, |data| {
         data.has_state_dependency(state)
     })
 }


### PR DESCRIPTION
Kinda tricky because :host only matches rules on the shadow root where the rules
come from. So we need to be careful during invalidation and style sharing.

I didn't use the non_ts_pseudo_class_list bits because as soon as we implement
the :host(..) bits we're going to need to special-case it anyway.

The general schema is the following:

 * Rightmost featureless :host selectors are handled inserting them in the
   host_rules hashmap. Note that we only insert featureless stuff there. We
   could insert all of them and just filter during matching, but that's slightly
   annoying.

 * The other selectors, like non-featureless :host or what not, are added to the
   normal cascade data. This is harmless, since the shadow host rules are never
   matched against the host, so we know they'll just never match, and avoids
   adding more special-cases.

 * Featureless :host selectors to the left of a combinator are handled during
   matching, in the special-case of next_element_for_combinator in selectors.
   This prevents this from being more invasive, and keeps the usual fast path
   slim, but it's a bit hard to match the spec and the implementation.

   We could keep a copy of the SelectorIter instead in the matching context to
   make the handling of featureless-ness explicit in match_non_ts_pseudo_class,
   but we'd still need the special-case anyway, so I'm not fond of it.

 * We take advantage of one thing that makes this sound. As you may have
   noticed, if you had `root` element which is a ShadowRoot, and you matched
   something like `div:host` against it, using a MatchingContext with
   current_host == root, we'd incorrectly report a match. But this is impossible
   due to the following constraints:

    * Shadow root rules aren't matched against the host during styling (except
      these featureless selectors).

    * DOM APIs' current_host needs to be the _containing_ host, not the element
      itself if you're a Shadow host.

Bug: 992245
Reviewed-by: xidorn
MozReview-Commit-ID: KayYNfTXb5h

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20597)
<!-- Reviewable:end -->
