### PR TITLE
Don't make logical properties animatable

### DIFF
--- a/components/style/properties/data.py
+++ b/components/style/properties/data.py
@@ -210,7 +210,7 @@ class Longhand(object):
             # discrete). For now, it is still non-animatable.
             self.animatable = False
             self.transitionable = False
-            self.animation_type = None
+            self.animation_value_type = None
 
         # See compute_damage for the various values this can take
         self.servo_restyle_damage = servo_restyle_damage


### PR DESCRIPTION
|animation_type| was renamed in 94fb839fdde, but the commit missed renaming
one place.  It means that some of logical properties might have been
accidentally animatable.  Logical properties should be animatable but we
haven't yet implemented the proper Animate trait for logical properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20602)
<!-- Reviewable:end -->
