### PR TITLE
Use the incumbent global as the source of x-origin postMessage

### DIFF
--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -192,9 +192,13 @@ impl DissimilarOriginWindowMethods for DissimilarOriginWindow {
 
 impl DissimilarOriginWindow {
     pub fn post_message(&self, origin: Option<ImmutableOrigin>, data: StructuredCloneData) {
+        let incumbent = match GlobalScope::incumbent() {
+            None => return warn!("postMessage called with no incumbent global"),
+            Some(incumbent) => incumbent,
+        };
         let msg = ScriptMsg::PostMessage(self.window_proxy.browsing_context_id(),
                                                 origin,
                                                 data.move_to_arraybuffer());
-        let _ = self.upcast::<GlobalScope>().script_to_constellation_chan().send(msg);
+        let _ = incumbent.script_to_constellation_chan().send(msg);
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach build-geckolib` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #20604 (github issue number if applicable).
- [X] These changes do not require tests because it's already caught by existing WPT

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20614)
<!-- Reviewable:end -->
