### PR TITLE
style: Simplify border-image-repeat serialization.

### DIFF
--- a/components/style/values/computed/border.rs
+++ b/components/style/values/computed/border.rs
@@ -5,10 +5,8 @@
 //! Computed types for CSS values related to borders.
 
 use app_units::Au;
-use std::fmt::{self, Write};
-use style_traits::{ToCss, CssWriter};
 use values::animated::ToAnimatedZero;
-use values::computed::{Context, Number, NumberOrPercentage, ToComputedValue};
+use values::computed::{Number, NumberOrPercentage};
 use values::computed::length::{LengthOrPercentage, NonNegativeLength};
 use values::generics::border::BorderCornerRadius as GenericBorderCornerRadius;
 use values::generics::border::BorderImageSideWidth as GenericBorderImageSideWidth;
@@ -17,7 +15,8 @@ use values::generics::border::BorderRadius as GenericBorderRadius;
 use values::generics::border::BorderSpacing as GenericBorderSpacing;
 use values::generics::rect::Rect;
 use values::generics::size::Size;
-use values::specified::border::{BorderImageRepeat as SpecifiedBorderImageRepeat, BorderImageRepeatKeyword};
+
+pub use values::specified::border::BorderImageRepeat;
 
 /// A computed value for the `border-image-width` property.
 pub type BorderImageWidth = Rect<BorderImageSideWidth>;
@@ -74,46 +73,5 @@ impl ToAnimatedZero for BorderCornerRadius {
     fn to_animated_zero(&self) -> Result<Self, ()> {
         // FIXME(nox): Why?
         Err(())
-    }
-}
-
-/// The computed value of the `border-image-repeat` property:
-///
-/// https://drafts.csswg.org/css-backgrounds/#the-border-image-repeat
-#[derive(Clone, Copy, Debug, MallocSizeOf, PartialEq)]
-pub struct BorderImageRepeat(pub BorderImageRepeatKeyword, pub BorderImageRepeatKeyword);
-
-impl BorderImageRepeat {
-    /// Returns the `stretch` value.
-    pub fn stretch() -> Self {
-        BorderImageRepeat(BorderImageRepeatKeyword::Stretch, BorderImageRepeatKeyword::Stretch)
-    }
-}
-
-impl ToCss for BorderImageRepeat {
-    fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
-    where
-        W: Write,
-    {
-        self.0.to_css(dest)?;
-        if self.0 != self.1 {
-            dest.write_str(" ")?;
-            self.1.to_css(dest)?;
-        }
-        Ok(())
-    }
-}
-
-impl ToComputedValue for SpecifiedBorderImageRepeat {
-    type ComputedValue = BorderImageRepeat;
-
-    #[inline]
-    fn to_computed_value(&self, _: &Context) -> Self::ComputedValue {
-        BorderImageRepeat(self.0, self.1.unwrap_or(self.0))
-    }
-
-    #[inline]
-    fn from_computed_value(computed: &Self::ComputedValue) -> Self {
-        SpecifiedBorderImageRepeat(computed.0, Some(computed.1))
     }
 }

--- a/components/style/values/specified/border.rs
+++ b/components/style/values/specified/border.rs
@@ -6,7 +6,8 @@
 
 use cssparser::Parser;
 use parser::{Parse, ParserContext};
-use style_traits::ParseError;
+use std::fmt::{self, Write};
+use style_traits::{CssWriter, ParseError, ToCss};
 use values::computed::{self, Context, ToComputedValue};
 use values::generics::border::BorderCornerRadius as GenericBorderCornerRadius;
 use values::generics::border::BorderImageSideWidth as GenericBorderImageSideWidth;
@@ -54,9 +55,8 @@ impl BorderSideWidth {
     pub fn parse_quirky<'i, 't>(
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
-        allow_quirks: AllowQuirks)
-        -> Result<Self, ParseError<'i>>
-    {
+        allow_quirks: AllowQuirks,
+    ) -> Result<Self, ParseError<'i>> {
         if let Ok(length) = input.try(|i| Length::parse_non_negative_quirky(context, i, allow_quirks)) {
             return Ok(BorderSideWidth::Length(length));
         }
@@ -186,14 +186,31 @@ pub enum BorderImageRepeatKeyword {
 /// The specified value for the `border-image-repeat` property.
 ///
 /// https://drafts.csswg.org/css-backgrounds/#the-border-image-repeat
-#[derive(Clone, Copy, Debug, MallocSizeOf, PartialEq, ToCss)]
-pub struct BorderImageRepeat(pub BorderImageRepeatKeyword, pub Option<BorderImageRepeatKeyword>);
+#[derive(Clone, Copy, Debug, MallocSizeOf, PartialEq, ToComputedValue)]
+pub struct BorderImageRepeat(pub BorderImageRepeatKeyword, pub BorderImageRepeatKeyword);
+
+impl ToCss for BorderImageRepeat {
+    fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
+    where
+        W: Write,
+    {
+        self.0.to_css(dest)?;
+        if self.0 != self.1 {
+            dest.write_str(" ")?;
+            self.1.to_css(dest)?;
+        }
+        Ok(())
+    }
+}
 
 impl BorderImageRepeat {
     /// Returns the `stretch` value.
     #[inline]
     pub fn stretch() -> Self {
-        BorderImageRepeat(BorderImageRepeatKeyword::Stretch, None)
+        BorderImageRepeat(
+            BorderImageRepeatKeyword::Stretch,
+            BorderImageRepeatKeyword::Stretch,
+        )
     }
 }
 
@@ -204,6 +221,6 @@ impl Parse for BorderImageRepeat {
     ) -> Result<Self, ParseError<'i>> {
         let horizontal = BorderImageRepeatKeyword::parse(input)?;
         let vertical = input.try(BorderImageRepeatKeyword::parse).ok();
-        Ok(BorderImageRepeat(horizontal, vertical))
+        Ok(BorderImageRepeat(horizontal, vertical.unwrap_or(horizontal)))
     }
 }


### PR DESCRIPTION
We're the only ones to preserve explicitly the second keyword, as noticed in:

  https://github.com/w3c/web-platform-tests/pull/10170

Reland of #20610 because it got backed out because I wasn't paying attention to IRC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20616)
<!-- Reviewable:end -->
