### PR TITLE
Fix build with __uint32_t etc. not found errors on NetBSD/amd64

### DIFF
--- a/components/style/build_gecko.rs
+++ b/components/style/build_gecko.rs
@@ -612,6 +612,8 @@ mod bindings {
                 .borrowed_type(ty)
                 .zero_size_type(ty, &structs_types);
         }
+        builder = builder
+            .raw_line(format!("pub use gecko_bindings::structs::root::*;"));
         write_binding_file(builder, BINDINGS_FILE, &fixups);
     }
 


### PR DESCRIPTION
I haven't been building servo but firefox.
I got a lot of errors (this is a 16MB file containing them: http://coypu.sdf.org/firefox-hg-hugefile)

The short version of the error output is that I get messages like:
error[E0412]: cannot find type `__uint32_t` in this scope

I've been told to mention to upstream (here), rather than make a firefox bugzilla bug.
I don't expect building servo to be straightforward, so I did not try it.

I don't know rust, there's a decent change this is an awful hack, let me know how to better fix it if that's wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20622)
<!-- Reviewable:end -->
