### PR TITLE
style: Let overflow parse two values.

### DIFF
--- a/components/style/properties/shorthand/box.mako.rs
+++ b/components/style/properties/shorthand/box.mako.rs
@@ -4,8 +4,11 @@
 
 <%namespace name="helpers" file="/helpers.mako.rs" />
 
-<%helpers:shorthand name="overflow" sub_properties="overflow-x overflow-y"
-                    spec="https://drafts.csswg.org/css-overflow/#propdef-overflow">
+<%helpers:shorthand
+    name="overflow"
+    sub_properties="overflow-x overflow-y"
+    spec="https://drafts.csswg.org/css-overflow/#propdef-overflow"
+>
     use properties::longhands::overflow_x::parse as parse_overflow;
     % if product == "gecko":
         use properties::longhands::overflow_x::SpecifiedValue;
@@ -42,20 +45,23 @@
                 return moz_kw_found
             }
         % endif
-        let overflow = parse_overflow(context, input)?;
+        let overflow_x = parse_overflow(context, input)?;
+        let overflow_y =
+            input.try(|i| parse_overflow(context, i)).unwrap_or(overflow_x);
         Ok(expanded! {
-            overflow_x: overflow,
-            overflow_y: overflow,
+            overflow_x: overflow_x,
+            overflow_y: overflow_y,
         })
     }
 
     impl<'a> ToCss for LonghandsToSerialize<'a>  {
         fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result where W: fmt::Write {
-            if self.overflow_x == self.overflow_y {
-                self.overflow_x.to_css(dest)
-            } else {
-                Ok(())
+            self.overflow_x.to_css(dest)?;
+            if self.overflow_x != self.overflow_y {
+                dest.write_char(' ')?;
+                self.overflow_y.to_css(dest)?;
             }
+            Ok(())
         }
     }
 </%helpers:shorthand>

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -75,39 +75,6 @@ mod shorthand_serialization {
         block.to_css_string()
     }
 
-    // Add Test to show error if a longhand property is missing!!!!!!
-
-    mod overflow {
-        pub use super::*;
-        use style::properties::longhands::overflow_x::SpecifiedValue as OverflowValue;
-
-        #[test]
-        fn equal_overflow_properties_should_serialize_to_single_value() {
-            let mut properties = Vec::new();
-
-            let overflow = OverflowValue::Auto;
-            properties.push(PropertyDeclaration::OverflowX(overflow));
-            properties.push(PropertyDeclaration::OverflowY(overflow));
-
-            let serialization = shorthand_properties_to_string(properties);
-            assert_eq!(serialization, "overflow: auto;");
-        }
-
-        #[test]
-        fn different_overflow_properties_should_serialize_to_two_values() {
-            let mut properties = Vec::new();
-
-            let overflow_x = OverflowValue::Scroll;
-            properties.push(PropertyDeclaration::OverflowX(overflow_x));
-
-            let overflow_y = OverflowValue::Auto;
-            properties.push(PropertyDeclaration::OverflowY(overflow_y));
-
-            let serialization = shorthand_properties_to_string(properties);
-            assert_eq!(serialization, "overflow-x: scroll; overflow-y: auto;");
-        }
-    }
-
     mod four_sides_shorthands {
         pub use super::*;
 

--- a/tests/wpt/metadata/css/cssom/index-002.html.ini
+++ b/tests/wpt/metadata/css/cssom/index-002.html.ini
@@ -24,9 +24,6 @@
   [border is expected to be border: dotted;]
     expected: FAIL
 
-  [overflow is expected to be overflow: scroll hidden;]
-    expected: FAIL
-
   [outline is expected to be outline: blue dotted 2px;]
     expected: FAIL
 


### PR DESCRIPTION
Per https://github.com/w3c/csswg-drafts/issues/2484.

Bug: 1453148
Reviewed-by: xidorn
MozReview-Commit-ID: D7M3PhnTtD2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20627)
<!-- Reviewable:end -->
