### PR TITLE
Session history fixup

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2453,13 +2453,13 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             self.trim_history(top_level_id);
         }
 
+        self.notify_history_changed(change.top_level_browsing_context_id);
         self.update_frame_tree_if_active(change.top_level_browsing_context_id);
     }
 
     fn trim_history(&mut self, top_level_browsing_context_id: TopLevelBrowsingContextId) {
         let pipelines_to_evict = {
-            let session_history = self.joint_session_histories.entry(top_level_browsing_context_id)
-                .or_insert(JointSessionHistory::new());
+            let session_history = self.get_joint_session_history(top_level_browsing_context_id);
 
             let history_length = PREFS.get("session-history.max-length").as_u64().unwrap_or(20) as usize;
 
@@ -2493,8 +2493,7 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             self.close_pipeline(evicted_id, DiscardBrowsingContext::No, ExitPipelineMode::Normal);
         }
 
-        let session_history = self.joint_session_histories.entry(top_level_browsing_context_id)
-            .or_insert(JointSessionHistory::new());
+        let session_history = self.get_joint_session_history(top_level_browsing_context_id);
 
         for (alive_id, dead) in dead_pipelines {
             session_history.replace(NeedsToReload::No(alive_id), dead);
@@ -2778,6 +2777,11 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             Some(browsing_context) => browsing_context,
         };
 
+        {
+            let session_history = self.get_joint_session_history(browsing_context.top_level_id);
+            session_history.remove_entries_for_browsing_context(browsing_context_id);
+        }
+
         if BrowsingContextId::from(browsing_context.top_level_id) == browsing_context_id {
             self.event_loops.remove(&browsing_context.top_level_id);
         }
@@ -2903,6 +2907,10 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
                 }
             }
         }
+    }
+
+    fn get_joint_session_history(&mut self, top_level_id: TopLevelBrowsingContextId) -> &mut JointSessionHistory {
+        self.joint_session_histories.entry(top_level_id).or_insert(JointSessionHistory::new())
     }
 
     // Convert a browsing context to a sendable form to pass to the compositor

--- a/components/constellation/session_history.rs
+++ b/components/constellation/session_history.rs
@@ -42,6 +42,15 @@ impl JointSessionHistory {
             diff.replace(&old_reloader, &new_reloader);
         }
     }
+
+    pub fn remove_entries_for_browsing_context(&mut self, context_id: BrowsingContextId) {
+        self.past.retain(|&SessionHistoryDiff::BrowsingContextDiff { browsing_context_id, .. }| {
+            browsing_context_id != context_id
+        });
+        self.future.retain(|&SessionHistoryDiff::BrowsingContextDiff { browsing_context_id, .. }| {
+            browsing_context_id != context_id
+        });
+    }
 }
 
 /// Represents a pending change in a session history, that will be applied

--- a/tests/wpt/web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-filler.html
+++ b/tests/wpt/web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-filler.html
@@ -1,0 +1,1 @@
+<body>Filler</body>

--- a/tests/wpt/web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-remove-iframe.html
+++ b/tests/wpt/web-platform-tests/html/browsers/history/joint-session-history/joint-session-history-remove-iframe.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Joint session history length does not include entries from a removed iframe.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<iframe id="frame" src="about:blank"></iframe>
+<script>
+async_test(function(t) {
+    t.step_timeout(() => {
+        var child = document.getElementById("frame");
+        var old_history_len = history.length;
+        child.onload = () => {
+            assert_equals(old_history_len + 1, history.length);
+            document.body.removeChild(document.getElementById("frame"));
+            assert_equals(old_history_len, history.length);
+            t.done();
+        }
+        child.src = "joint-session-history-filler.html";
+    }, 1000);
+});
+</script>
+</body>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
When a browsing context was removed, its entries were not removed from the joint session history.
The embedder should be notified that the history changed after a navigation matures.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach build-geckolib` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20629)
<!-- Reviewable:end -->
