### PR TITLE
Fix error name in comment for try_match_ident_ignore_ascii_case

### DIFF
--- a/components/style/macros.rs
+++ b/components/style/macros.rs
@@ -47,7 +47,7 @@ macro_rules! trivial_to_computed_value {
     };
 }
 
-/// A macro to parse an identifier, or return an `UnexpectedIndent` error
+/// A macro to parse an identifier, or return an `UnexpectedIdent` error
 /// otherwise.
 ///
 /// FIXME(emilio): The fact that `UnexpectedIdent` is a `SelectorParseError`


### PR DESCRIPTION
Trivial spelling error fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20656)
<!-- Reviewable:end -->
