### PR TITLE
Issue #20623: Check the input to WebGLRenderingContext's clear().

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1866,6 +1866,9 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         if !self.validate_framebuffer_complete() {
             return;
         }
+        if mask & !(constants::DEPTH_BUFFER_BIT | constants::STENCIL_BUFFER_BIT | constants::COLOR_BUFFER_BIT) != 0 {
+            return self.webgl_error(InvalidValue);
+        }
 
         self.send_command(WebGLCommand::Clear(mask));
         self.mark_as_dirty();

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -39229,6 +39229,12 @@
      {}
     ]
    ],
+   "mozilla/webgl/clear.html": [
+    [
+     "/_mozilla/mozilla/webgl/clear.html",
+     {}
+    ]
+   ],
    "mozilla/webgl/context_creation_error.html": [
     [
      "/_mozilla/mozilla/webgl/context_creation_error.html",
@@ -70862,6 +70868,10 @@
   ],
   "mozilla/webgl/bufferSubData.html": [
    "c333c7b99156d63fcd3ad28014c7915a12cf8169",
+   "testharness"
+  ],
+  "mozilla/webgl/clear.html": [
+   "14cc534be5da96b0cc128d5c44f662b2fdfb294c",
    "testharness"
   ],
   "mozilla/webgl/clearcolor.html": [

--- a/tests/wpt/mozilla/tests/mozilla/webgl/clear.html
+++ b/tests/wpt/mozilla/tests/mozilla/webgl/clear.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>WebGLRenderingContext.clear testing (issue #20623)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {
+    var gl = document.createElement("canvas").getContext("webgl");
+    // Valid values
+    gl.clear(gl.DEPTH_BUFFER_BIT);
+    assert_equals(gl.NO_ERROR, gl.getError());
+    gl.clear(gl.STENCIL_BUFFER_BIT);
+    assert_equals(gl.NO_ERROR, gl.getError());
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    assert_equals(gl.NO_ERROR, gl.getError());
+    gl.clear(gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT | gl.COLOR_BUFFER_BIT);
+    assert_equals(gl.NO_ERROR, gl.getError());
+
+    // Invalid value
+    gl.clear(42);
+    assert_equals(gl.INVALID_VALUE, gl.getError());
+});
+</script>


### PR DESCRIPTION
Validate the input to this function as per specifications.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach build-geckolib` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #20623 
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20669)
<!-- Reviewable:end -->
