### PR TITLE
Issue #20556: Implement proper checks in WebGLRenderingContext's bindBuffer()

### DIFF
--- a/components/script/dom/webglbuffer.rs
+++ b/components/script/dom/webglbuffer.rs
@@ -77,6 +77,9 @@ impl WebGLBuffer {
 
     // NB: Only valid buffer targets come here
     pub fn bind(&self, target: u32) -> WebGLResult<()> {
+        if self.is_deleted() || self.is_pending_delete() {
+            return Err(WebGLError::InvalidOperation);
+        }
         if let Some(previous_target) = self.target.get() {
             if target != previous_target {
                 return Err(WebGLError::InvalidOperation);
@@ -139,6 +142,10 @@ impl WebGLBuffer {
 
     pub fn set_pending_delete(&self) {
         self.pending_delete.set(true);
+    }
+
+    pub fn is_pending_delete(&self) -> bool {
+        self.pending_delete.get()
     }
 
     pub fn add_vao_reference(&self, id: WebGLVertexArrayId) {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -39217,6 +39217,12 @@
      {}
     ]
    ],
+   "mozilla/webgl/bindBuffer.html": [
+    [
+     "/_mozilla/mozilla/webgl/bindBuffer.html",
+     {}
+    ]
+   ],
    "mozilla/webgl/bufferData.html": [
     [
      "/_mozilla/mozilla/webgl/bufferData.html",
@@ -70854,6 +70860,10 @@
   ],
   "mozilla/weakref.html": [
    "bc2a964c294e678b3c0e98ba83ce30a59a8bee3f",
+   "testharness"
+  ],
+  "mozilla/webgl/bindBuffer.html": [
+   "659d53041373a6e40b9ab4cbf7e2afad45048377",
    "testharness"
   ],
   "mozilla/webgl/bufferData.html": [

--- a/tests/wpt/mozilla/tests/mozilla/webgl/bindBuffer.html
+++ b/tests/wpt/mozilla/tests/mozilla/webgl/bindBuffer.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>bindBuffer checks test (issue #20556)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {
+    var gl = document.createElement("canvas").getContext("webgl");
+
+    // Simple bindings should work
+    var array_buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, array_buffer);
+    assert_equals(gl.NO_ERROR, gl.getError());
+
+    var element_array_buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, element_array_buffer);
+    assert_equals(gl.NO_ERROR, gl.getError());
+
+    // Re-bindings should not work
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, array_buffer);
+    assert_equals(gl.INVALID_OPERATION, gl.getError());
+
+    gl.bindBuffer(gl.ARRAY_BUFFER, element_array_buffer);
+    assert_equals(gl.INVALID_OPERATION, gl.getError());
+
+    // Binding buffers pending deletion should fail
+    var buffer = gl.createBuffer();
+    gl.deleteBuffer(buffer);
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    assert_equals(gl.INVALID_OPERATION, gl.getError());
+});
+</script>


### PR DESCRIPTION
Implement missing check, about deleted buffers.
---
- [X] `./mach build -d` does not report any errors
- [X] `./mach build-geckolib` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #20556 
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20674)
<!-- Reviewable:end -->
