### PR TITLE
fix(browser): do not omit unexpected keyevent

### DIFF
--- a/ports/servo/browser.rs
+++ b/ports/servo/browser.rs
@@ -108,7 +108,7 @@ impl Browser {
             (CMD_OR_CONTROL, Some('q'), _) => {
                 self.event_queue.push(WindowEvent::Quit);
             }
-            (_, Some('3'), _) => if mods ^ KeyModifiers::CONTROL == KeyModifiers::SHIFT {
+            (_, Some('3'), _) if mods ^ KeyModifiers::CONTROL == KeyModifiers::SHIFT => {
                 self.event_queue.push(WindowEvent::CaptureWebRender);
             }
             (KeyModifiers::CONTROL, None, Key::F10) => {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
- closes #20681

This PR intends to fix regression caused by changes I created in #20315. In code, it matches keyevent aggressively for any pattern includes `Some('3')`, ends up actual key event does not bubbles up. This PR applies correct pattern guard to pick up specific keyevent only, other events falls back to default patterns.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [ ] `./mach build-geckolib` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #20681 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____
- manually verified
1. typing `3` in input field works
2. ctrl-shift-3 create webrender capture (verified on mac os)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20687)
<!-- Reviewable:end -->
