### PR TITLE
Issue #20593: Implement proper checks in WebGLRenderingContext's getFramebufferAttachmentParameter().

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -2339,7 +2339,36 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             _ => false
         };
 
-        if !target_matches || !attachment_matches || !pname_matches {
+        let bound_attachment_matches = match self.bound_framebuffer.get().unwrap().attachment(attachment) {
+            Some(attachment_root) => {
+                match attachment_root {
+                    WebGLFramebufferAttachmentRoot::Renderbuffer(_) => {
+                        match pname {
+                            constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE |
+                            constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME => true,
+                            _ => false
+                        }
+                    },
+                    WebGLFramebufferAttachmentRoot::Texture(_) => {
+                        match pname {
+                            constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE |
+                            constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME |
+                            constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL |
+                            constants::FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE => true,
+                            _ => false
+                        }
+                    }
+                }
+            },
+            _ => {
+                match pname {
+                    constants::FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE => true,
+                    _ => false
+                }
+            }
+        };
+
+        if !target_matches || !attachment_matches || !pname_matches || !bound_attachment_matches {
             self.webgl_error(InvalidEnum);
             return NullValue();
         }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -39299,6 +39299,12 @@
      {}
     ]
    ],
+   "mozilla/webgl/getFramebufferAttachmentParameter.html": [
+    [
+     "/_mozilla/mozilla/webgl/getFramebufferAttachmentParameter.html",
+     {}
+    ]
+   ],
    "mozilla/webgl/get_supported_extensions.html": [
     [
      "/_mozilla/mozilla/webgl/get_supported_extensions.html",
@@ -70975,6 +70981,10 @@
   "mozilla/webgl/draw_arrays_simple_ref.html": [
    "a163189d8674be83c9e8c9055da31a1c5ed46be5",
    "support"
+  ],
+  "mozilla/webgl/getFramebufferAttachmentParameter.html": [
+   "71a8c1829f703ff43a30d1b3fb9b99e59d3db973",
+   "testharness"
   ],
   "mozilla/webgl/get_supported_extensions.html": [
    "719c7c4cb91f3c1b2bbc4cbe35285fc63ce6263f",

--- a/tests/wpt/mozilla/tests/mozilla/webgl/getFramebufferAttachmentParameter.html
+++ b/tests/wpt/mozilla/tests/mozilla/webgl/getFramebufferAttachmentParameter.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>getFramebufferAttachmentParameter input type check (issue #20593)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {
+    var gl = document.createElement("canvas").getContext("webgl");
+
+    // Error if no buffer is bound
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.COLOR_ATTACHMENT0,
+                                         gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
+    assert_equals(gl.INVALID_OPERATION, gl.getError());
+
+    // Bind a framebuffer
+    var framebuffer = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+
+    // 'target' parameter checks
+    gl.getFramebufferAttachmentParameter(gl.READ_FRAMEBUFFER,
+                                         gl.COLOR_ATTACHMENT0,
+                                         gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
+    assert_equals(gl.INVALID_ENUM, gl.getError());
+    gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER,
+                                         gl.COLOR_ATTACHMENT0,
+                                         gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
+    assert_equals(gl.INVALID_ENUM, gl.getError());
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.COLOR_ATTACHMENT0,
+                                         gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
+    assert_equals(gl.NO_ERROR, gl.getError());
+
+    // 'attachment' parameter checks
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.DEPTH_STENCIL_ATTACHMENT,
+                                         gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
+    assert_equals(gl.NO_ERROR, gl.getError());
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.COLOR_ATTACHMENT0,
+                                         gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
+    assert_equals(gl.NO_ERROR, gl.getError());
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.DEPTH_ATTACHMENT,
+                                         gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
+    assert_equals(gl.NO_ERROR, gl.getError());
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.STENCIL_ATTACHMENT,
+                                         gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
+    assert_equals(gl.NO_ERROR, gl.getError());
+
+    // 'pname' parameter checks: invalid values
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.STENCIL_ATTACHMENT,
+                                         gl.FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE);
+    assert_equals(gl.INVALID_ENUM, gl.getError());
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.STENCIL_ATTACHMENT,
+                                         gl.FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE);
+    assert_equals(gl.INVALID_ENUM, gl.getError());
+
+    // 'pname' parameter checks: no attached object at the named attachment point
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.STENCIL_ATTACHMENT,
+                                         gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME);
+    assert_equals(gl.INVALID_ENUM, gl.getError());
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.STENCIL_ATTACHMENT,
+                                         gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
+    assert_equals(gl.NO_ERROR, gl.getError());
+
+    // 'pname' parameter checks: the attached object at the named attachment point is GL_RENDERBUFFER
+    var renderbuffer = gl.createRenderbuffer();
+    gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, renderbuffer);
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.COLOR_ATTACHMENT0,
+                                         gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL);
+    assert_equals(gl.INVALID_ENUM, gl.getError());
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.COLOR_ATTACHMENT0,
+                                         gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE);
+    assert_equals(gl.INVALID_ENUM, gl.getError());
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.COLOR_ATTACHMENT0,
+                                         gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
+    assert_equals(gl.NO_ERROR, gl.getError());
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.COLOR_ATTACHMENT0,
+                                         gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME);
+    assert_equals(gl.NO_ERROR, gl.getError());
+
+    // 'pname' parameter checks: the attached object at the named attachment point is GL_TEXTURE
+    var texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.COLOR_ATTACHMENT0,
+                                         gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL);
+    assert_equals(gl.NO_ERROR, gl.getError());
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.COLOR_ATTACHMENT0,
+                                         gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE);
+    assert_equals(gl.NO_ERROR, gl.getError());
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.COLOR_ATTACHMENT0,
+                                         gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
+    assert_equals(gl.NO_ERROR, gl.getError());
+    gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
+                                         gl.COLOR_ATTACHMENT0,
+                                         gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME);
+    assert_equals(gl.NO_ERROR, gl.getError());
+});
+</script>


### PR DESCRIPTION
Add missing input checks.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach build-geckolib` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #20593 
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20699)
<!-- Reviewable:end -->
