### PR TITLE
Automatically provide a resource reader for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,7 +3088,6 @@ dependencies = [
  "app_units 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.23.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "embedder_traits 0.0.1",
  "euclid 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.22.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/bluetooth_traits/Cargo.toml
+++ b/components/bluetooth_traits/Cargo.toml
@@ -14,3 +14,6 @@ ipc-channel = "0.10"
 regex = "0.2"
 serde = "1.0"
 embedder_traits = { path = "../embedder_traits" }
+
+[dev-dependencies]
+embedder_traits = { path = "../embedder_traits", features = ["tests"] }

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -26,6 +26,7 @@ url = "1.2"
 
 [dev-dependencies]
 env_logger = "0.5"
+embedder_traits = { path = "../embedder_traits", features = ["tests"] }
 
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
 xdg = "2.0"

--- a/components/config/tests/opts.rs
+++ b/components/config/tests/opts.rs
@@ -2,10 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate embedder_traits;
 extern crate servo_config;
 
-use embedder_traits::resources::register_resources_for_tests;
 use servo_config::opts::{parse_url_or_filename, parse_pref_from_command_line};
 use servo_config::prefs::{PrefValue, PREFS};
 use std::path::Path;
@@ -75,7 +73,6 @@ fn test_argument_parsing_special() {
 
 #[test]
 fn test_parse_pref_from_command_line() {
-    register_resources_for_tests();
     // Test with boolean values.
     parse_pref_from_command_line("testtrue=true");
     assert_eq!(*PREFS.get("testtrue"), PrefValue::Boolean(true));

--- a/components/config/tests/prefs.rs
+++ b/components/config/tests/prefs.rs
@@ -2,10 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate embedder_traits;
 extern crate servo_config;
 
-use embedder_traits::resources::register_resources_for_tests;
 use servo_config::basedir;
 use servo_config::prefs::{PREFS, PrefValue, read_prefs};
 use std::fs::{self, File};
@@ -28,7 +26,6 @@ fn test_create_pref() {
 
 #[test]
 fn test_get_set_reset_extend() {
-    register_resources_for_tests();
     let json_str = "{\
   \"layout.writing-mode.enabled\": true,\
   \"extra.stuff\": false,\

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -43,3 +43,6 @@ webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "ios")))'.dependencies]
 gaol = {git = "https://github.com/servo/gaol"}
+
+[dev-dependencies]
+embedder_traits = { path = "../embedder_traits", features = ["tests"] }

--- a/components/embedder_traits/Cargo.toml
+++ b/components/embedder_traits/Cargo.toml
@@ -9,5 +9,8 @@ publish = false
 name = "embedder_traits"
 path = "lib.rs"
 
+[features]
+tests = []
+
 [dependencies]
 lazy_static = "1"

--- a/components/embedder_traits/resources.rs
+++ b/components/embedder_traits/resources.rs
@@ -2,14 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::env;
-use std::fs::File;
-use std::io::Read;
 use std::path::PathBuf;
-use std::sync::{Once, ONCE_INIT, RwLock};
+use std::sync::RwLock;
 
 lazy_static! {
-    static ref RES: RwLock<Option<Box<ResourceReaderMethods + Sync + Send>>> = RwLock::new(None);
+    static ref RES: RwLock<Option<Box<ResourceReaderMethods + Sync + Send>>> = RwLock::new({
+        #[cfg(not(feature = "tests"))] {
+            None
+        }
+        #[cfg(feature = "tests")] {
+            Some(resources_for_tests())
+        }
+    });
 }
 
 pub fn set(reader: Box<ResourceReaderMethods + Sync + Send>) {
@@ -53,45 +57,45 @@ pub trait ResourceReaderMethods {
     fn sandbox_access_files_dirs(&self) -> Vec<PathBuf>;
 }
 
-static INIT: Once = ONCE_INIT;
-
-pub fn register_resources_for_tests() {
-    INIT.call_once(|| {
-        struct ResourceReader;
-        impl ResourceReaderMethods for ResourceReader {
-            fn sandbox_access_files(&self) -> Vec<PathBuf> { vec![] }
-            fn sandbox_access_files_dirs(&self) -> Vec<PathBuf> { vec![] }
-            fn read(&self, file: Resource) -> Vec<u8> {
-                let file = match file {
-                    Resource::Preferences => "prefs.json",
-                    Resource::BluetoothBlocklist => "gatt_blocklist.txt",
-                    Resource::DomainList => "public_domains.txt",
-                    Resource::HstsPreloadList => "hsts_preload.json",
-                    Resource::SSLCertificates => "certs",
-                    Resource::BadCertHTML => "badcert.html",
-                    Resource::NetErrorHTML => "neterror.html",
-                    Resource::UserAgentCSS => "user-agent.css",
-                    Resource::ServoCSS => "servo.css",
-                    Resource::PresentationalHintsCSS => "presentational-hints.css",
-                    Resource::QuirksModeCSS => "quirks-mode.css",
-                    Resource::RippyPNG => "rippy.png",
-                };
-                let mut path = env::current_exe().unwrap();
-                path = path.canonicalize().unwrap();
-                while path.pop() {
-                    path.push("resources");
-                    if path.is_dir() {
-                        break;
-                    }
-                    path.pop();
+#[cfg(feature = "tests")]
+fn resources_for_tests() -> Box<ResourceReaderMethods + Sync + Send> {
+    use std::env;
+    use std::fs::File;
+    use std::io::Read;
+    struct ResourceReader;
+    impl ResourceReaderMethods for ResourceReader {
+        fn sandbox_access_files(&self) -> Vec<PathBuf> { vec![] }
+        fn sandbox_access_files_dirs(&self) -> Vec<PathBuf> { vec![] }
+        fn read(&self, file: Resource) -> Vec<u8> {
+            let file = match file {
+                Resource::Preferences => "prefs.json",
+                Resource::BluetoothBlocklist => "gatt_blocklist.txt",
+                Resource::DomainList => "public_domains.txt",
+                Resource::HstsPreloadList => "hsts_preload.json",
+                Resource::SSLCertificates => "certs",
+                Resource::BadCertHTML => "badcert.html",
+                Resource::NetErrorHTML => "neterror.html",
+                Resource::UserAgentCSS => "user-agent.css",
+                Resource::ServoCSS => "servo.css",
+                Resource::PresentationalHintsCSS => "presentational-hints.css",
+                Resource::QuirksModeCSS => "quirks-mode.css",
+                Resource::RippyPNG => "rippy.png",
+            };
+            let mut path = env::current_exe().unwrap();
+            path = path.canonicalize().unwrap();
+            while path.pop() {
+                path.push("resources");
+                if path.is_dir() {
+                    break;
                 }
-                path.push(file);
-                let mut buffer = vec![];
-                File::open(path).expect(&format!("Can't find file: {}", file))
-                                .read_to_end(&mut buffer).expect("Can't read file");
-                buffer
+                path.pop();
             }
+            path.push(file);
+            let mut buffer = vec![];
+            File::open(path).expect(&format!("Can't find file: {}", file))
+                .read_to_end(&mut buffer).expect("Can't read file");
+            buffer
         }
-        set(Box::new(ResourceReader));
-    });
+    }
+    Box::new(ResourceReader)
 }

--- a/components/layout_thread/Cargo.toml
+++ b/components/layout_thread/Cargo.toml
@@ -51,3 +51,6 @@ servo_url = {path = "../url"}
 style = {path = "../style"}
 style_traits = {path = "../style_traits"}
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
+
+[dev-dependencies]
+embedder_traits = { path = "../embedder_traits", features = ["tests"] }

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -49,6 +49,9 @@ url = "1.2"
 uuid = {version = "0.6", features = ["v4"]}
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
 
+[dev-dependencies]
+embedder_traits = { path = "../embedder_traits", features = ["tests"] }
+
 [[test]]
 name = "main"
 path = "tests/main.rs"

--- a/components/net/tests/cookie.rs
+++ b/components/net/tests/cookie.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use cookie_rs;
-use embedder_traits::resources::register_resources_for_tests;
 use hyper::header::{Header, SetCookie};
 use net::cookie::Cookie;
 use net::cookie_storage::CookieStorage;
@@ -57,7 +56,6 @@ fn test_default_path() {
 #[test]
 fn fn_cookie_constructor() {
     use net_traits::CookieSource;
-    register_resources_for_tests();
 
     let url = &ServoUrl::parse("http://example.com/foo").unwrap();
 
@@ -104,7 +102,6 @@ fn fn_cookie_constructor() {
 
 #[test]
 fn test_cookie_secure_prefix() {
-    register_resources_for_tests();
     let url = &ServoUrl::parse("https://example.com").unwrap();
     let cookie = cookie_rs::Cookie::parse("__Secure-SID=12345").unwrap();
     assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
@@ -132,7 +129,6 @@ fn test_cookie_secure_prefix() {
 
 #[test]
 fn test_cookie_host_prefix() {
-    register_resources_for_tests();
     let url = &ServoUrl::parse("https://example.com").unwrap();
     let cookie = cookie_rs::Cookie::parse("__Host-SID=12345").unwrap();
     assert!(Cookie::new_wrapped(cookie, url, CookieSource::HTTP).is_none());
@@ -186,7 +182,6 @@ fn delay_to_ensure_different_timestamp() {}
 #[test]
 fn test_sort_order() {
     use std::cmp::Ordering;
-    register_resources_for_tests();
 
     let url = &ServoUrl::parse("http://example.com/foo").unwrap();
     let a_wrapped = cookie_rs::Cookie::parse("baz=bar; Path=/foo/bar/").unwrap();
@@ -206,7 +201,6 @@ fn test_sort_order() {
 
 fn add_cookie_to_storage(storage: &mut CookieStorage, url: &ServoUrl, cookie_str: &str)
 {
-    register_resources_for_tests();
     let source = CookieSource::HTTP;
     let cookie = cookie_rs::Cookie::parse(cookie_str.to_owned()).unwrap();
     let cookie = Cookie::new_wrapped(cookie, url, source).unwrap();
@@ -215,7 +209,6 @@ fn add_cookie_to_storage(storage: &mut CookieStorage, url: &ServoUrl, cookie_str
 
 #[test]
 fn test_insecure_cookies_cannot_evict_secure_cookie() {
-    register_resources_for_tests();
     let mut storage = CookieStorage::new(5);
     let secure_url = ServoUrl::parse("https://home.example.org:8888/cookie-parser?0001").unwrap();
     let source = CookieSource::HTTP;
@@ -252,7 +245,6 @@ fn test_insecure_cookies_cannot_evict_secure_cookie() {
 
 #[test]
 fn test_secure_cookies_eviction() {
-    register_resources_for_tests();
     let mut storage = CookieStorage::new(5);
     let url = ServoUrl::parse("https://home.example.org:8888/cookie-parser?0001").unwrap();
     let source = CookieSource::HTTP;
@@ -288,7 +280,6 @@ fn test_secure_cookies_eviction() {
 
 #[test]
 fn test_secure_cookies_eviction_non_http_source() {
-    register_resources_for_tests();
     let mut storage = CookieStorage::new(5);
     let url = ServoUrl::parse("https://home.example.org:8888/cookie-parser?0001").unwrap();
     let source = CookieSource::NonHTTP;
@@ -350,7 +341,6 @@ fn add_retrieve_cookies(set_location: &str,
 
 #[test]
 fn test_cookie_eviction_expired() {
-    register_resources_for_tests();
     let mut vec = Vec::new();
     for i in 1..6 {
         let st = format!("extra{}=bar; Secure; expires=Sun, 18-Apr-2000 21:06:29 GMT",
@@ -366,7 +356,6 @@ fn test_cookie_eviction_expired() {
 
 #[test]
 fn test_cookie_eviction_all_secure_one_nonsecure() {
-    register_resources_for_tests();
     let mut vec = Vec::new();
     for i in 1..5 {
         let st = format!("extra{}=bar; Secure; expires=Sun, 18-Apr-2026 21:06:29 GMT",
@@ -383,7 +372,6 @@ fn test_cookie_eviction_all_secure_one_nonsecure() {
 
 #[test]
 fn test_cookie_eviction_all_secure_new_nonsecure() {
-    register_resources_for_tests();
     let mut vec = Vec::new();
     for i in 1..6 {
         let st = format!("extra{}=bar; Secure; expires=Sun, 18-Apr-2026 21:06:29 GMT",
@@ -399,7 +387,6 @@ fn test_cookie_eviction_all_secure_new_nonsecure() {
 
 #[test]
 fn test_cookie_eviction_all_nonsecure_new_secure() {
-    register_resources_for_tests();
     let mut vec = Vec::new();
     for i in 1..6 {
         let st = format!("extra{}=bar; expires=Sun, 18-Apr-2026 21:06:29 GMT", i);
@@ -414,7 +401,6 @@ fn test_cookie_eviction_all_nonsecure_new_secure() {
 
 #[test]
 fn test_cookie_eviction_all_nonsecure_new_nonsecure() {
-    register_resources_for_tests();
     let mut vec = Vec::new();
     for i in 1..6 {
         let st = format!("extra{}=bar; expires=Sun, 18-Apr-2026 21:06:29 GMT", i);

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -6,7 +6,6 @@ use {DEFAULT_USER_AGENT, new_fetch_context, create_embedder_proxy, fetch, make_s
 use devtools_traits::DevtoolsControlMsg;
 use devtools_traits::HttpRequest as DevtoolsHttpRequest;
 use devtools_traits::HttpResponse as DevtoolsHttpResponse;
-use embedder_traits::resources::register_resources_for_tests;
 use fetch_with_context;
 use fetch_with_cors_cache;
 use http_loader::{expect_devtools_http_request, expect_devtools_http_response};
@@ -49,7 +48,6 @@ use unicase::UniCase;
 
 #[test]
 fn test_fetch_response_is_not_network_error() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"";
     let handler = move |_: HyperRequest, response: HyperResponse| {
         response.send(MESSAGE).unwrap();
@@ -69,7 +67,6 @@ fn test_fetch_response_is_not_network_error() {
 
 #[test]
 fn test_fetch_on_bad_port_is_network_error() {
-    register_resources_for_tests();
     let url = ServoUrl::parse("http://www.example.org:6667").unwrap();
     let origin = Origin::Origin(url.origin());
     let mut request = Request::new(url, Some(origin), None);
@@ -82,7 +79,6 @@ fn test_fetch_on_bad_port_is_network_error() {
 
 #[test]
 fn test_fetch_response_body_matches_const_message() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"Hello World!";
     let handler = move |_: HyperRequest, response: HyperResponse| {
         response.send(MESSAGE).unwrap();
@@ -108,7 +104,6 @@ fn test_fetch_response_body_matches_const_message() {
 
 #[test]
 fn test_fetch_aboutblank() {
-    register_resources_for_tests();
     let url = ServoUrl::parse("about:blank").unwrap();
     let origin = Origin::Origin(url.origin());
     let mut request = Request::new(url, Some(origin), None);
@@ -120,7 +115,6 @@ fn test_fetch_aboutblank() {
 
 #[test]
 fn test_fetch_blob() {
-    register_resources_for_tests();
     use ipc_channel::ipc;
     use net_traits::blob_url_store::BlobBuf;
 
@@ -161,7 +155,6 @@ fn test_fetch_blob() {
 
 #[test]
 fn test_fetch_file() {
-    register_resources_for_tests();
     let path = Path::new("../../resources/servo.css").canonicalize().unwrap();
     let url = ServoUrl::from_file_path(path.clone()).unwrap();
     let origin = Origin::Origin(url.origin());
@@ -188,7 +181,6 @@ fn test_fetch_file() {
 
 #[test]
 fn test_fetch_ftp() {
-    register_resources_for_tests();
     let url = ServoUrl::parse("ftp://not-supported").unwrap();
     let origin = Origin::Origin(url.origin());
     let mut request = Request::new(url, Some(origin), None);
@@ -199,7 +191,6 @@ fn test_fetch_ftp() {
 
 #[test]
 fn test_fetch_bogus_scheme() {
-    register_resources_for_tests();
     let url = ServoUrl::parse("bogus://whatever").unwrap();
     let origin = Origin::Origin(url.origin());
     let mut request = Request::new(url, Some(origin), None);
@@ -210,7 +201,6 @@ fn test_fetch_bogus_scheme() {
 
 #[test]
 fn test_cors_preflight_fetch() {
-    register_resources_for_tests();
     static ACK: &'static [u8] = b"ACK";
     let state = Arc::new(AtomicUsize::new(0));
     let handler = move |request: HyperRequest, mut response: HyperResponse| {
@@ -248,7 +238,6 @@ fn test_cors_preflight_fetch() {
 
 #[test]
 fn test_cors_preflight_cache_fetch() {
-    register_resources_for_tests();
     static ACK: &'static [u8] = b"ACK";
     let state = Arc::new(AtomicUsize::new(0));
     let counter = state.clone();
@@ -301,7 +290,6 @@ fn test_cors_preflight_cache_fetch() {
 
 #[test]
 fn test_cors_preflight_fetch_network_error() {
-    register_resources_for_tests();
     static ACK: &'static [u8] = b"ACK";
     let state = Arc::new(AtomicUsize::new(0));
     let handler = move |request: HyperRequest, mut response: HyperResponse| {
@@ -332,7 +320,6 @@ fn test_cors_preflight_fetch_network_error() {
 
 #[test]
 fn test_fetch_response_is_basic_filtered() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"";
     let handler = move |_: HyperRequest, mut response: HyperResponse| {
         response.headers_mut().set(SetCookie(vec![]));
@@ -359,7 +346,6 @@ fn test_fetch_response_is_basic_filtered() {
 
 #[test]
 fn test_fetch_response_is_cors_filtered() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"";
     let handler = move |_: HyperRequest, mut response: HyperResponse| {
         // this is mandatory for the Cors Check to pass
@@ -414,7 +400,6 @@ fn test_fetch_response_is_cors_filtered() {
 
 #[test]
 fn test_fetch_response_is_opaque_filtered() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"";
     let handler = move |_: HyperRequest, response: HyperResponse| {
         response.send(MESSAGE).unwrap();
@@ -448,7 +433,6 @@ fn test_fetch_response_is_opaque_filtered() {
 
 #[test]
 fn test_fetch_response_is_opaque_redirect_filtered() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"";
     let handler = move |request: HyperRequest, mut response: HyperResponse| {
         let redirects = match request.uri {
@@ -495,7 +479,6 @@ fn test_fetch_response_is_opaque_redirect_filtered() {
 
 #[test]
 fn test_fetch_with_local_urls_only() {
-    register_resources_for_tests();
     // If flag `local_urls_only` is set, fetching a non-local URL must result in network error.
 
     static MESSAGE: &'static [u8] = b"";
@@ -534,7 +517,6 @@ fn test_fetch_with_local_urls_only() {
 // And make sure to specify `localhost` as the server name.
 #[test]
 fn test_fetch_with_hsts() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"";
     let handler = move |_: HyperRequest, response: HyperResponse| {
         response.send(MESSAGE).unwrap();
@@ -581,7 +563,6 @@ fn test_fetch_with_hsts() {
 
 #[test]
 fn test_fetch_with_sri_network_error() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"alert('Hello, Network Error');";
     let handler = move |_: HyperRequest, response: HyperResponse| {
         response.send(MESSAGE).unwrap();
@@ -606,7 +587,6 @@ fn test_fetch_with_sri_network_error() {
 
 #[test]
 fn test_fetch_with_sri_sucess() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"alert('Hello, world.');";
     let handler = move |_: HyperRequest, response: HyperResponse| {
         response.send(MESSAGE).unwrap();
@@ -674,7 +654,6 @@ fn test_fetch_blocked_nosniff() {
 }
 
 fn setup_server_and_fetch(message: &'static [u8], redirect_cap: u32) -> Response {
-    register_resources_for_tests();
     let handler = move |request: HyperRequest, mut response: HyperResponse| {
         let redirects = match request.uri {
             RequestUri::AbsolutePath(url) =>
@@ -705,7 +684,6 @@ fn setup_server_and_fetch(message: &'static [u8], redirect_cap: u32) -> Response
 
 #[test]
 fn test_fetch_redirect_count_ceiling() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"no more redirects";
     // how many redirects to cause
     let redirect_cap = 20;
@@ -725,7 +703,6 @@ fn test_fetch_redirect_count_ceiling() {
 
 #[test]
 fn test_fetch_redirect_count_failure() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"this message shouldn't be reachable";
     // how many redirects to cause
     let redirect_cap = 21;
@@ -791,7 +768,6 @@ fn test_fetch_redirect_updates_method_runner(tx: Sender<bool>, status_code: Stat
 
 #[test]
 fn test_fetch_redirect_updates_method() {
-    register_resources_for_tests();
     let (tx, rx) = channel();
 
     test_fetch_redirect_updates_method_runner(tx.clone(), StatusCode::MovedPermanently, Method::Post);
@@ -850,7 +826,6 @@ fn response_is_done(response: &Response) -> bool {
 
 #[test]
 fn test_fetch_async_returns_complete_response() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"this message should be retrieved in full";
     let handler = move |_: HyperRequest, response: HyperResponse| {
         response.send(MESSAGE).unwrap();
@@ -869,7 +844,6 @@ fn test_fetch_async_returns_complete_response() {
 
 #[test]
 fn test_opaque_filtered_fetch_async_returns_complete_response() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"";
     let handler = move |_: HyperRequest, response: HyperResponse| {
         response.send(MESSAGE).unwrap();
@@ -891,7 +865,6 @@ fn test_opaque_filtered_fetch_async_returns_complete_response() {
 
 #[test]
 fn test_opaque_redirect_filtered_fetch_async_returns_complete_response() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"";
     let handler = move |request: HyperRequest, mut response: HyperResponse| {
         let redirects = match request.uri {
@@ -928,7 +901,6 @@ fn test_opaque_redirect_filtered_fetch_async_returns_complete_response() {
 
 #[test]
 fn test_fetch_with_devtools() {
-    register_resources_for_tests();
     static MESSAGE: &'static [u8] = b"Yay!";
     let handler = move |_: HyperRequest, response: HyperResponse| {
         response.send(MESSAGE).unwrap();

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -6,7 +6,6 @@ use cookie_rs::Cookie as CookiePair;
 use devtools_traits::{ChromeToDevtoolsControlMsg, DevtoolsControlMsg, NetworkEvent};
 use devtools_traits::HttpRequest as DevtoolsHttpRequest;
 use devtools_traits::HttpResponse as DevtoolsHttpResponse;
-use embedder_traits::resources::register_resources_for_tests;
 use fetch;
 use fetch_with_context;
 use flate2::Compression;
@@ -313,7 +312,6 @@ fn test_request_and_response_message_from_devtool_without_pipeline_id() {
 
 #[test]
 fn test_redirected_request_to_devtools() {
-    register_resources_for_tests();
     let post_handler = move |request: HyperRequest, response: HyperResponse| {
         assert_eq!(request.method, Method::Get);
         response.send(b"Yay!").unwrap();

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -31,3 +31,6 @@ servo_url = {path = "../url"}
 url = "1.2"
 uuid = {version = "0.6", features = ["v4", "serde"]}
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
+
+[dev-dependencies]
+embedder_traits = { path = "../embedder_traits", features = ["tests"] }

--- a/components/net_traits/tests/pub_domains.rs
+++ b/components/net_traits/tests/pub_domains.rs
@@ -2,17 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate embedder_traits;
 extern crate net_traits;
 
-use embedder_traits::resources::register_resources_for_tests;
 use net_traits::pub_domains::{is_pub_domain, is_reg_domain, pub_suffix, reg_suffix};
 
 // These tests may need to be updated if the PSL changes.
 
 #[test]
 fn test_is_pub_domain_plain() {
-    register_resources_for_tests();
     assert!(is_pub_domain("com"));
     assert!(is_pub_domain(".org"));
     assert!(is_pub_domain("za.org"));
@@ -22,7 +19,6 @@ fn test_is_pub_domain_plain() {
 
 #[test]
 fn test_is_pub_domain_wildcard() {
-    register_resources_for_tests();
     assert!(is_pub_domain("hello.bd"));
     assert!(is_pub_domain("world.jm"));
     assert!(is_pub_domain("toto.kobe.jp"));
@@ -30,7 +26,6 @@ fn test_is_pub_domain_wildcard() {
 
 #[test]
 fn test_is_pub_domain_exception() {
-    register_resources_for_tests();
     assert_eq!(is_pub_domain("www.ck"), false);
     assert_eq!(is_pub_domain("city.kawasaki.jp"), false);
     assert_eq!(is_pub_domain("city.nagoya.jp"), false);
@@ -39,7 +34,6 @@ fn test_is_pub_domain_exception() {
 
 #[test]
 fn test_is_pub_domain_not() {
-    register_resources_for_tests();
     assert_eq!(is_pub_domain(""), false);
     assert_eq!(is_pub_domain("."), false);
     assert_eq!(is_pub_domain("..."), false);
@@ -52,7 +46,6 @@ fn test_is_pub_domain_not() {
 
 #[test]
 fn test_is_pub_domain() {
-    register_resources_for_tests();
     assert!(!is_pub_domain("city.yokohama.jp"));
     assert!(!is_pub_domain("foo.bar.baz.yokohama.jp"));
     assert!(!is_pub_domain("foo.bar.city.yokohama.jp"));
@@ -71,7 +64,6 @@ fn test_is_pub_domain() {
 
 #[test]
 fn test_is_reg_domain() {
-    register_resources_for_tests();
     assert!(!is_reg_domain("com"));
     assert!(!is_reg_domain("foo.bar.baz.yokohama.jp"));
     assert!(!is_reg_domain("foo.bar.com"));
@@ -89,7 +81,6 @@ fn test_is_reg_domain() {
 
 #[test]
 fn test_pub_suffix() {
-    register_resources_for_tests();
     assert_eq!(pub_suffix("city.yokohama.jp"), "yokohama.jp");
     assert_eq!(pub_suffix("com"), "com");
     assert_eq!(pub_suffix("foo.bar.baz.yokohama.jp"), "baz.yokohama.jp");
@@ -107,7 +98,6 @@ fn test_pub_suffix() {
 
 #[test]
 fn test_reg_suffix() {
-    register_resources_for_tests();
     assert_eq!(reg_suffix("city.yokohama.jp"), "city.yokohama.jp");
     assert_eq!(reg_suffix("com"), "com");
     assert_eq!(reg_suffix("foo.bar.baz.yokohama.jp"), "bar.baz.yokohama.jp");
@@ -125,7 +115,6 @@ fn test_reg_suffix() {
 
 #[test]
 fn test_weirdness() {
-    register_resources_for_tests();
     // These are weird results, but AFAICT they are spec-compliant.
     assert_ne!(pub_suffix("city.yokohama.jp"), pub_suffix(pub_suffix("city.yokohama.jp")));
     assert!(!is_pub_domain(pub_suffix("city.yokohama.jp")));

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -103,3 +103,6 @@ webvr_traits = {path = "../webvr_traits"}
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]
 mozangle = "0.1"
+
+[dev-dependencies]
+embedder_traits = { path = "../embedder_traits", features = ["tests"] }

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -66,3 +66,6 @@ webvr_traits = {path = "../webvr_traits"}
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "ios")))'.dependencies]
 gaol = {git = "https://github.com/servo/gaol"}
+
+[dev-dependencies]
+embedder_traits = { path = "../embedder_traits", features = ["tests"] }

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -13,7 +13,6 @@ doctest = false
 byteorder = "1.0"
 app_units = "0.6"
 cssparser = "0.23.0"
-embedder_traits = {path = "../../../components/embedder_traits"}
 euclid = "0.17"
 html5ever = "0.22"
 parking_lot = "0.5"

--- a/tests/unit/style/lib.rs
+++ b/tests/unit/style/lib.rs
@@ -7,7 +7,6 @@
 
 extern crate app_units;
 extern crate cssparser;
-extern crate embedder_traits;
 extern crate euclid;
 #[macro_use] extern crate html5ever;
 extern crate parking_lot;

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use cssparser::{self, SourceLocation};
-use embedder_traits::resources::register_resources_for_tests;
 use html5ever::{Namespace as NsAtom};
 use media_queries::CSSErrorReporterTest;
 use parking_lot::RwLock;
@@ -322,7 +321,6 @@ impl ParseErrorReporter for TestingErrorReporter {
 
 #[test]
 fn test_report_error_stylesheet() {
-    register_resources_for_tests();
     PREFS.set("layout.viewport.enabled", PrefValue::Boolean(true));
     let css = r"
     div {


### PR DESCRIPTION
Fix #20710 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [ ] `./mach build-geckolib` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #20710 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20718)
<!-- Reviewable:end -->
