### PR TITLE
fix(window): set enter key as non-printable char

### DIFF
--- a/ports/servo/glutin_app/keyutils.rs
+++ b/ports/servo/glutin_app/keyutils.rs
@@ -293,6 +293,7 @@ pub fn is_printable(key_code: VirtualKeyCode) -> bool {
         Right |
         Down |
         Back |
+        Return |
         LAlt |
         LControl |
         LMenu |


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
**Mostly for discussion around #20630, #20726**.
If this PR's accepted & merged, it may serve as temporal workaround only.

This PR changes behavior of `window` to consider ENTER key as non-printable, let document does not appends redundant carriage return when press enter on textinput field. But this PR instead omits `keypress` event on `Enter` like

![image](https://user-images.githubusercontent.com/1210596/39463399-a369e384-4ccc-11e8-8d74-c7ffbc92ba9d.png)

while other browsers does emit 
![image](https://user-images.githubusercontent.com/1210596/39463408-b3dcd8ac-4ccc-11e8-861a-e28eceefd427.png)

makes me feel proper fix would be something like #20726, revise flow to send over keyevent to document itself. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes fix #20630 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20727)
<!-- Reviewable:end -->
