### PR TITLE
Correct edge case for background color clip

### DIFF
--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -844,14 +844,17 @@ impl FragmentDisplayListBuilding for Fragment {
         // http://dev.w3.org/csswg/css-backgrounds-3/#the-background-clip
         let mut bounds = *absolute_bounds;
 
-        // This is the clip for the color (which is the last element in the bg array)
-        // Background clips are never empty.
-        let color_clip = &background.background_clip.0.last().unwrap();
+        // Quote from CSS Backgrounds and Borders Module Level 3:
+        //
+        // > The background color is clipped according to the background-clip value associated
+        // > with the bottom-most background image layer.
+        let last_background_image_index = background.background_image.0.len() - 1;
+        let color_clip = get_cyclic(&background.background_clip.0, last_background_image_index);
 
         // Adjust the clipping region as necessary to account for `border-radius`.
         let mut border_radii = build_border_radius(absolute_bounds, style.get_border());
 
-        match **color_clip {
+        match color_clip {
             BackgroundClip::BorderBox => {},
             BackgroundClip::PaddingBox => {
                 let border = style.logical_border_width().to_physical(style.writing_mode);

--- a/tests/wpt/web-platform-tests/css/css-backgrounds/background-color-clip.html
+++ b/tests/wpt/web-platform-tests/css/css-backgrounds/background-color-clip.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Background Color Clip</title>
+<link rel="match" href="reference/background-color-clip.html">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#background-color">
+<meta name="assert" content="Check that the background color is clipped according to the background-clip value associated with the bottom-most background image layer.">
+<style>
+    div {
+        width: 120px;
+        height: 100px;
+        background-color: green;
+        background-clip: border-box, content-box, border-box;
+        background-image: none, none;
+        border-style: solid;
+        border-width: 10px;
+        border-color: transparent;
+    }
+</style>
+<div></div>

--- a/tests/wpt/web-platform-tests/css/css-backgrounds/reference/background-color-clip.html
+++ b/tests/wpt/web-platform-tests/css/css-backgrounds/reference/background-color-clip.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Green Rectangle</title>
+<style>
+    div {
+        width: 120px;
+        height: 100px;
+        background-color: green;
+        background-clip: content-box;
+        border-style: solid;
+        border-width: 10px;
+        border-color: transparent;
+    }
+</style>
+<div></div>


### PR DESCRIPTION
Use the color clip corresponding to the last background-image instead
of the last background-clip. (There may be more clips than images and
clips are repeated if there are less clips than images.)

Add a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20744)
<!-- Reviewable:end -->
