### PR TITLE
use dedicated TaskCluster workertype

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -8,7 +8,7 @@ metadata:
   source: '{{ event.head.repo.url }}'
 tasks:
   - provisionerId: '{{ taskcluster.docker.provisionerId }}'
-    workerType: '{{ taskcluster.docker.workerType }}'
+    workerType: 'servo-docker-worker'
     extra:
       github:
         events:


### PR DESCRIPTION
The previous default of a shared github workertype had a side effect of preventing individuals from manually spinning up debug builds. 

This change sets a custom workertype which is pretty much identical to the old one except that we can have the TC team do arbitrary things to permissions, so we can manually rerun failed builds to test and debug them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20769)
<!-- Reviewable:end -->
