### PR TITLE
Don't suppress errors when executing mach bootstrap processes.

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -119,7 +119,7 @@ def _process_exec(args):
                 err.seek(0)
                 shutil.copyfileobj(err, sys.stdout)
 
-                sys.exit()
+                sys.exit(1)
 
 
 def wpt_path(is_firefox, topdir, *paths):

--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -193,11 +193,18 @@ def _activate_virtualenv(topdir, is_firefox):
     if need_pip_upgrade:
         # Upgrade pip when virtualenv is created to fix the issue
         # https://github.com/servo/servo/issues/11074
-        pip = _get_exec_path(PIP_NAMES, is_valid_path=check_exec_path)
-        if not pip:
-            sys.exit("Python pip is either not installed or not found in virtualenv.")
+        if sys.platform in ['msys', 'win32']:
+            python = _get_exec_path(PYTHON_NAMES, is_valid_path=check_exec_path)
+            if not python:
+                sys.exit("Python is either not installed or not found in virtualenv.")
 
-        _process_exec([pip, "install", "-I", "-U", "pip"])
+            _process_exec([python, "-m", "pip", "install", "-I", "-U", "pip"])
+        else:
+            pip = _get_exec_path(PIP_NAMES, is_valid_path=check_exec_path)
+            if not pip:
+                sys.exit("Python pip is either not installed or not found in virtualenv.")
+
+            _process_exec([pip, "install", "-I", "-U", "pip"])
 
     for req_rel_path in requirements_paths:
         req_path = os.path.join(topdir, req_rel_path)


### PR DESCRIPTION
[Omitting an argument](https://docs.python.org/2/library/sys.html#sys.exit) to sys.exit causes it to default to 0, so buildbot doesn't report it as an error.

We were just lucky that the android builders happened to have a build step that failed that didn't rely on running python!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20782)
<!-- Reviewable:end -->
