### PR TITLE
Disable codegen-units on macOS

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -559,6 +559,10 @@ class CommandBase(object):
             # where we want to run doctests as part of `./mach test-unit`
             env['RUSTDOC'] = path.join(self.context.topdir, 'etc', 'rustdoc-with-private')
 
+        # Workaround for https://github.com/servo/servo/issues/20756
+        if sys.platform == "darwin":
+            env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C codegen-units=1"
+
         if self.config["build"]["rustflags"]:
             env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " " + self.config["build"]["rustflags"]
 


### PR DESCRIPTION
If this makes https://github.com/servo/servo/issues/20756 go away, it suggests a rustc non-deterministic compilation bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20795)
<!-- Reviewable:end -->
