### PR TITLE
Rename FontTemplates to FontTemplateFamily

### DIFF
--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -28,7 +28,7 @@ use style::values::computed::font::FamilyName;
 use webrender_api;
 
 /// A list of font templates that make up a given font family.
-pub struct FontTemplates {
+pub struct FontTemplateFamily {
     templates: Vec<FontTemplate>,
 }
 
@@ -38,9 +38,9 @@ pub struct FontTemplateInfo {
     pub font_key: webrender_api::FontKey,
 }
 
-impl FontTemplates {
-    pub fn new() -> FontTemplates {
-        FontTemplates {
+impl FontTemplateFamily {
+    pub fn new() -> FontTemplateFamily {
+        FontTemplateFamily {
             templates: vec!(),
         }
     }
@@ -123,8 +123,8 @@ struct FontCache {
     port: IpcReceiver<Command>,
     channel_to_self: IpcSender<Command>,
     generic_fonts: HashMap<FontFamilyName, LowercaseString>,
-    local_families: HashMap<LowercaseString, FontTemplates>,
-    web_families: HashMap<LowercaseString, FontTemplates>,
+    local_families: HashMap<LowercaseString, FontTemplateFamily>,
+    web_families: HashMap<LowercaseString, FontTemplateFamily>,
     font_context: FontContextHandle,
     core_resource_thread: CoreResourceThread,
     webrender_api: webrender_api::RenderApi,
@@ -219,8 +219,8 @@ impl FontCache {
         };
 
         if !self.web_families.contains_key(&family_name) {
-            let templates = FontTemplates::new();
-            self.web_families.insert(family_name.clone(), templates);
+            let family = FontTemplateFamily::new();
+            self.web_families.insert(family_name.clone(), family);
         }
 
         match src {
@@ -310,8 +310,8 @@ impl FontCache {
         for_each_available_family(|family_name| {
             let family_name = LowercaseString::new(&family_name);
             if !self.local_families.contains_key(&family_name) {
-                let templates = FontTemplates::new();
-                self.local_families.insert(family_name, templates);
+                let family = FontTemplateFamily::new();
+                self.local_families.insert(family_name, family);
             }
         });
     }

--- a/components/gfx/tests/font_context.rs
+++ b/components/gfx/tests/font_context.rs
@@ -11,7 +11,7 @@ extern crate webrender_api;
 
 use app_units::Au;
 use gfx::font::{fallback_font_families, FontDescriptor, FontFamilyDescriptor, FontFamilyName, FontSearchScope};
-use gfx::font_cache_thread::{FontTemplates, FontTemplateInfo};
+use gfx::font_cache_thread::{FontTemplateFamily, FontTemplateInfo};
 use gfx::font_context::{FontContext, FontContextHandle, FontSource};
 use gfx::font_template::FontTemplateDescriptor;
 use servo_arc::Arc;
@@ -30,19 +30,19 @@ use style::values::generics::font::FontStyle;
 
 struct TestFontSource {
     handle: FontContextHandle,
-    families: HashMap<String, FontTemplates>,
+    families: HashMap<String, FontTemplateFamily>,
     find_font_count: Rc<Cell<isize>>,
 }
 
 impl TestFontSource {
     fn new() -> TestFontSource {
-        let mut csstest_ascii = FontTemplates::new();
+        let mut csstest_ascii = FontTemplateFamily::new();
         Self::add_face(&mut csstest_ascii, "csstest-ascii", None);
 
-        let mut csstest_basic = FontTemplates::new();
+        let mut csstest_basic = FontTemplateFamily::new();
         Self::add_face(&mut csstest_basic, "csstest-basic-regular", None);
 
-        let mut fallback = FontTemplates::new();
+        let mut fallback = FontTemplateFamily::new();
         Self::add_face(&mut fallback, "csstest-basic-regular", Some("fallback"));
 
         let mut families = HashMap::new();
@@ -57,7 +57,7 @@ impl TestFontSource {
         }
     }
 
-    fn add_face(family: &mut FontTemplates, name: &str, identifier: Option<&str>) {
+    fn add_face(family: &mut FontTemplateFamily, name: &str, identifier: Option<&str>) {
         let mut path: PathBuf = [
             env!("CARGO_MANIFEST_DIR"),
             "tests",


### PR DESCRIPTION
It just feels like better naming.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20835)
<!-- Reviewable:end -->
