### PR TITLE
Save local storage at every change and not just on shutdown

### DIFF
--- a/components/net/storage_thread.rs
+++ b/components/net/storage_thread.rs
@@ -67,25 +67,32 @@ impl StorageManager {
                     self.keys(sender, url, storage_type)
                 }
                 StorageThreadMsg::SetItem(sender, url, storage_type, name, value) => {
-                    self.set_item(sender, url, storage_type, name, value)
+                    self.set_item(sender, url, storage_type, name, value);
+                    self.save_state()
                 }
                 StorageThreadMsg::GetItem(sender, url, storage_type, name) => {
                     self.request_item(sender, url, storage_type, name)
                 }
                 StorageThreadMsg::RemoveItem(sender, url, storage_type, name) => {
-                    self.remove_item(sender, url, storage_type, name)
+                    self.remove_item(sender, url, storage_type, name);
+                    self.save_state()
                 }
                 StorageThreadMsg::Clear(sender, url, storage_type) => {
-                    self.clear(sender, url, storage_type)
+                    self.clear(sender, url, storage_type);
+                    self.save_state()
                 }
                 StorageThreadMsg::Exit(sender) => {
-                    if let Some(ref config_dir) = self.config_dir {
-                        resource_thread::write_json_to_file(&self.local_data, config_dir, "local_data.json");
-                    }
+                    // Nothing to do since we save localstorage set eagerly.
                     let _ = sender.send(());
                     break
                 }
             }
+        }
+    }
+
+    fn save_state(&self) {
+        if let Some(ref config_dir) = self.config_dir {
+            resource_thread::write_json_to_file(&self.local_data, config_dir, "local_data.json");
         }
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Currently local storage is saved to `local_data.json` only at shutdown when the storage thread receives the `StorageThreadMsg::Exit` message. This is not reliable enough in any case, and especially problematic for a young engine like Servo. Data loss ensues...

I kept the exit message in the storage thread even if we are not doing work anymore. I can remove it if needed but it should be useful once we move to a better storage backend than a json file.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because we don't have tests for that persistence layer.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20840)
<!-- Reviewable:end -->
