### PR TITLE
Increase taskcluster runtime

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -16,7 +16,7 @@ tasks:
           - pull_request.reopened
           - pull_request.synchronize
     payload:
-      maxRunTime: 3600
+      maxRunTime: 7200
       image: 'servobrowser/servo-linux-dev:servo-linux-build-deps-2017-06-30'
       command:
         - /bin/bash

--- a/etc/ci/taskcluster-test.sh
+++ b/etc/ci/taskcluster-test.sh
@@ -8,6 +8,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+set -x
+
 curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain none -y
 export PATH="${HOME}/.cargo/bin:${PATH}"
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Based on the Taskcluster log for
(https://taskcluster-artifacts.net/HkxDh1oKQceXH1fL9RSGow/0/public/logs/live_backing.log),
it looks like the job is running successfully but hitting the max time limit.

Our builds + tests shouldn't take this long to run normally,
but we'll need to set up sccache with cache uploading/downloading
in order to improve most build times.

For now, bump the max run time to 2 hours;
since we complete one build + som tests within an hour,
2 hours should be enough for the second build to finish as well.

Also, add `set -x` for easier debugging.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they are trying to fix the testing infra

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20841)
<!-- Reviewable:end -->
