### PR TITLE
style: Fix font-stretch animation.

### DIFF
--- a/components/style/values/computed/font.rs
+++ b/components/style/values/computed/font.rs
@@ -21,7 +21,7 @@ use std::slice;
 use style_traits::{CssWriter, ParseError, ToCss};
 use values::CSSFloat;
 use values::animated::{ToAnimatedValue, ToAnimatedZero};
-use values::computed::{Angle, Context, Integer, NonNegative, NonNegativeLength, NonNegativePercentage};
+use values::computed::{Angle, Context, Integer, NonNegativeLength, NonNegativePercentage};
 use values::computed::{Number, Percentage, ToComputedValue};
 use values::generics::font::{self as generics, FeatureTagValue, FontSettings, VariationValue};
 use values::specified::font::{self as specified, MIN_FONT_WEIGHT, MAX_FONT_WEIGHT};
@@ -953,12 +953,12 @@ impl ToAnimatedValue for FontStretch {
 
     #[inline]
     fn to_animated_value(self) -> Self::AnimatedValue {
-        (self.0).0
+        self.0.to_animated_value()
     }
 
     #[inline]
     fn from_animated_value(animated: Self::AnimatedValue) -> Self {
-        FontStretch(NonNegative(animated))
+        FontStretch(NonNegativePercentage::from_animated_value(animated))
     }
 }
 


### PR DESCRIPTION
This is a regression from #20506 which Gecko tests caught while trying to import
this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20843)
<!-- Reviewable:end -->
