### PR TITLE
move test `dom-element-scroll.html` from mozilla to wpt

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -31791,12 +31791,6 @@
      {}
     ]
    ],
-   "css/cssom-view/dom-element-scroll.html": [
-    [
-     "/_mozilla/css/cssom-view/dom-element-scroll.html",
-     {}
-    ]
-   ],
    "css/empty-keyframes.html": [
     [
      "/_mozilla/css/empty-keyframes.html",
@@ -61181,10 +61175,6 @@
   "css/css/ahem.css": [
    "16a4dd68da41156fbdd139b4a56547f94ad4dbe7",
    "support"
-  ],
-  "css/cssom-view/dom-element-scroll.html": [
-   "247b85d5988878a7b27bc9f0f7b817085725c038",
-   "testharness"
   ],
   "css/data_img_a.html": [
    "323bf50369f98ed02acccdd3a5824e38d3f353bf",

--- a/tests/wpt/web-platform-tests/css/cssom-view/dom-element-scroll.html
+++ b/tests/wpt/web-platform-tests/css/cssom-view/dom-element-scroll.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>dom-element-scroll tests</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrolltop">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The test `dom-element-scroll.html` was originally landed on #19127. 
It was designed for testing `scrollLeft` and `scrollTop`.
It is not only for servo. I thought I put a wrong place at that time. It should not be under `mozilla`. It's better placed under `wpt`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20858)
<!-- Reviewable:end -->
