### PR TITLE
remove misleading spec url

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -628,8 +628,6 @@ impl Node {
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth
     // https://drafts.csswg.org/cssom-view/#dom-element-scrollheight
-    // https://drafts.csswg.org/cssom-view/#dom-element-scrolltop
-    // https://drafts.csswg.org/cssom-view/#dom-element-scrollleft
     pub fn scroll_area(&self) -> Rect<i32> {
         // Step 1
         let document = self.owner_doc();


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

`pub fn scroll_area(&self)` in `node.rs` is only called by `fn ScrollHeight(&self)` and `fn ScrollWidth(&self)` in `element.rs`.

`scrolltop` and `scrollleft` are actually implemented in `element.rs`.

The misleading spec urls should be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20864)
<!-- Reviewable:end -->
