### PR TITLE
fix logic in overflow_direction, also add a FIXME

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -393,6 +393,7 @@ impl UnioningFragmentScrollAreaIterator {
             origin_rect: Rect::zero(),
             level: None,
             is_child: false,
+            // FIXME(#20867)
             overflow_direction: OverflowDirection::RightAndDown
         }
     }
@@ -634,6 +635,7 @@ pub fn process_node_scroll_id_request<N: LayoutNode>(
     layout_node.generate_scroll_id(id)
 }
 
+/// https://drafts.csswg.org/cssom-view/#scrolling-area
 pub fn process_node_scroll_area_request< N: LayoutNode>(requested_node: N, layout_root: &mut Flow)
         -> Rect<i32> {
     let mut iterator = UnioningFragmentScrollAreaIterator::new(requested_node.opaque());
@@ -646,7 +648,7 @@ pub fn process_node_scroll_area_request< N: LayoutNode>(requested_node: N, layou
         },
         OverflowDirection::LeftAndDown => {
             let bottom = max(iterator.union_rect.size.height, iterator.origin_rect.size.height);
-            let left = max(iterator.union_rect.origin.x, iterator.origin_rect.origin.x);
+            let left = min(iterator.union_rect.origin.x, iterator.origin_rect.origin.x);
             Rect::new(Point2D::new(left, iterator.origin_rect.origin.y),
                       Size2D::new(iterator.origin_rect.size.width, bottom))
         },


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR fix #19477, which the logic is obviously wrong.

However, it is impossible to add a test for this.

Due to #20867, the ` overflow_direction` is a hard code now. It never go to other conditions.
I add a FIXME there, and also add a SPEC link.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19477(github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20868)
<!-- Reviewable:end -->
