### PR TITLE
Be less judgemental when tearing down WebGL rendering contexts

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1193,7 +1193,7 @@ impl WebGLRenderingContext {
 
 impl Drop for WebGLRenderingContext {
     fn drop(&mut self) {
-        self.webgl_sender.send_remove().unwrap();
+        let _ = self.webgl_sender.send_remove();
     }
 }
 


### PR DESCRIPTION
r? nox

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it relies on the webgl thread behaving badly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20877)
<!-- Reviewable:end -->
