### PR TITLE
updated rustup requirement

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -309,8 +309,8 @@ class CommandBase(object):
                     return 1
                 raise
             version = tuple(map(int, re.match("rustup (\d+)\.(\d+)\.(\d+)", version_line).groups()))
-            if version < (1, 8, 0):
-                print "rustup is at version %s.%s.%s, Servo requires 1.8.0 or more recent." % version
+            if version < (1, 11, 0):
+                print "rustup is at version %s.%s.%s, Servo requires 1.11.0 or more recent." % version
                 print "Try running 'rustup self update'."
                 return 1
             toolchain = self.toolchain()


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Rustup changed their argparsing, which resulted in `./mach test-unit --nocapture` not working. Servo now requires a higher rustup version to ensure that mach commands work

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20885)
<!-- Reviewable:end -->
