### PR TITLE
build(servo): bump up llvm to 6.0.0

### DIFF
--- a/python/servo/packages.py
+++ b/python/servo/packages.py
@@ -4,7 +4,7 @@
 
 WINDOWS_MSVC = {
     "cmake": "3.7.2",
-    "llvm": "4.0.0",
+    "llvm": "6.0.0",
     "moztools": "0.0.1-5",
     "ninja": "1.7.1",
     "openssl": "1.1.0e-vs2015",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR bumps up llvm to 6.0.0 to allow vs2017 build works on windows.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes fix #20888 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20895)
<!-- Reviewable:end -->
