### PR TITLE
Fix typo for worklet in globalscope

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -300,9 +300,9 @@ impl GlobalScope {
             // https://html.spec.whatwg.org/multipage/#script-settings-for-workers:api-base-url
             return worker.get_url().clone();
         }
-        if let Some(worker) = self.downcast::<WorkletGlobalScope>() {
+        if let Some(worklet) = self.downcast::<WorkletGlobalScope>() {
             // https://drafts.css-houdini.org/worklets/#script-settings-for-worklets
-            return worker.base_url();
+            return worklet.base_url();
         }
         unreachable!();
     }
@@ -315,9 +315,9 @@ impl GlobalScope {
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
             return worker.get_url().clone();
         }
-        if let Some(worker) = self.downcast::<WorkletGlobalScope>() {
+        if let Some(worklet) = self.downcast::<WorkletGlobalScope>() {
             // TODO: is this the right URL to return?
-            return worker.base_url();
+            return worklet.base_url();
         }
         unreachable!();
     }


### PR DESCRIPTION
As the `self` will downcast to `WorkletGlobalScope`, I think it would be more reasonable to name the variable with `worklet` in `if let`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it just renames the variable name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20905)
<!-- Reviewable:end -->
