### PR TITLE
Respect the source rectangle when drawing a canvas to another canvas.

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -96,20 +96,20 @@ impl<'a> CanvasData<'a> {
         // In this case source and target are the same canvas
         let image_data = self.read_pixels(source_rect.to_i32(), image_size);
 
+        let writer = |draw_target: &DrawTarget| {
+            write_image(draw_target, image_data, source_rect.size, dest_rect,
+                        smoothing_enabled, self.state.draw_options.composition,
+                        self.state.draw_options.alpha);
+        };
+
         if self.need_to_draw_shadow() {
             let rect = Rect::new(Point2D::new(dest_rect.origin.x as f32, dest_rect.origin.y as f32),
                                  Size2D::new(dest_rect.size.width as f32, dest_rect.size.height as f32));
 
-            self.draw_with_shadow(&rect, |new_draw_target: &DrawTarget| {
-                write_image(&new_draw_target, image_data, source_rect.size, dest_rect,
-                            smoothing_enabled, self.state.draw_options.composition,
-                            self.state.draw_options.alpha);
-            });
+            self.draw_with_shadow(&rect, writer);
         } else {
             // Writes on target canvas
-            write_image(&self.drawtarget, image_data, image_size, dest_rect,
-                        smoothing_enabled, self.state.draw_options.composition,
-                        self.state.draw_options.alpha);
+            writer(&self.drawtarget);
         }
     }
 

--- a/tests/wpt/web-platform-tests/2dcontext/drawing-images-to-the-canvas/drawimage_canvas_self.html
+++ b/tests/wpt/web-platform-tests/2dcontext/drawing-images-to-the-canvas/drawimage_canvas_self.html
@@ -1,0 +1,17 @@
+<link rel="match" href="drawimage_canvas_self_ref.html">
+<canvas id="dest" height="100" width="100"></canvas>
+<script>
+var canvasWidth = canvasHeight = 100;
+var destWidth = canvasWidth / 4;
+var destHeight = canvasHeight / 4;
+var destCanvas = document.getElementById('dest');
+var destCtx = destCanvas.getContext('2d');
+
+destCtx.fillStyle = 'red';
+destCtx.fillRect(0, 0,  canvasWidth, canvasHeight);
+destCtx.fillStyle = 'green';
+destCtx.fillRect(0, 0, canvasWidth / 2, canvasHeight / 2);
+destCtx.drawImage(destCanvas,
+                  0, 0, destWidth, destHeight,
+                  canvasWidth / 2, canvasHeight / 2, destWidth, destHeight);
+</script>

--- a/tests/wpt/web-platform-tests/2dcontext/drawing-images-to-the-canvas/drawimage_canvas_self_ref.html
+++ b/tests/wpt/web-platform-tests/2dcontext/drawing-images-to-the-canvas/drawimage_canvas_self_ref.html
@@ -1,0 +1,11 @@
+<canvas id="dest" height="100" width="100"></canvas>
+<script>
+var canvasWidth = canvasHeight = 100;
+var destCanvas = document.getElementById('dest');
+var destCtx = destCanvas.getContext('2d');
+destCtx.fillStyle = 'red';
+destCtx.fillRect(0, 0,  canvasWidth, canvasHeight);
+destCtx.fillStyle = 'green';
+destCtx.fillRect(0, 0, canvasWidth / 2, canvasHeight / 2);
+destCtx.fillRect(canvasWidth / 2, canvasHeight / 2, canvasWidth / 4, canvasHeight / 4);
+</script>


### PR DESCRIPTION
This allows us to run the three.js examples without panicking, since they use self-drawing canvases to scroll the FPS graph.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20923)
<!-- Reviewable:end -->
