### PR TITLE
Change to pip dependency install invocation during virtualenv setup in build

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -193,18 +193,7 @@ def _activate_virtualenv(topdir, is_firefox):
     if need_pip_upgrade:
         # Upgrade pip when virtualenv is created to fix the issue
         # https://github.com/servo/servo/issues/11074
-        if sys.platform in ['msys', 'win32']:
-            python = _get_exec_path(PYTHON_NAMES, is_valid_path=check_exec_path)
-            if not python:
-                sys.exit("Python is either not installed or not found in virtualenv.")
-
-            _process_exec([python, "-m", "pip", "install", "-I", "-U", "pip"])
-        else:
-            pip = _get_exec_path(PIP_NAMES, is_valid_path=check_exec_path)
-            if not pip:
-                sys.exit("Python pip is either not installed or not found in virtualenv.")
-
-            _process_exec([pip, "install", "-I", "-U", "pip"])
+        _process_exec([python, "-m", "pip", "install", "-I", "-U", "pip"])
 
     for req_rel_path in requirements_paths:
         req_path = os.path.join(topdir, req_rel_path)
@@ -216,10 +205,6 @@ def _activate_virtualenv(topdir, is_firefox):
                 continue
         except OSError:
             pass
-
-        pip = _get_exec_path(PIP_NAMES, is_valid_path=check_exec_path)
-        if not pip:
-            sys.exit("Python pip is either not installed or not found in virtualenv.")
 
         _process_exec([python, "-m", "pip", "install", "-I", "-r", req_path])
 

--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -221,7 +221,7 @@ def _activate_virtualenv(topdir, is_firefox):
         if not pip:
             sys.exit("Python pip is either not installed or not found in virtualenv.")
 
-        _process_exec([pip, "install", "-I", "-r", req_path])
+        _process_exec([python, "-m", "pip", "install", "-I", "-r", req_path])
 
         open(marker_path, 'w').close()
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fix for https://github.com/servo/servo/issues/20990

In short, the pip invocation was causing my build on OSX to break. Using `python -m pip` in place of `pip` when setting up the virtual environment fixes the environment setup failure and allows the build to proceed. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #20990

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/20998)
<!-- Reviewable:end -->
