### PR TITLE
Support cloning steps for textarea/input 

### DIFF
--- a/tests/wpt/metadata/html/semantics/forms/the-textarea-element/cloning-steps.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-textarea-element/cloning-steps.html.ini
@@ -1,8 +1,0 @@
-[cloning-steps.html]
-  type: testharness
-  [textarea element's value should be cloned]
-    expected: FAIL
-
-  [textarea element's dirty value flag should be cloned, so setAttribute doesn't affect the cloned textarea's value]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #13282 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21015)
<!-- Reviewable:end -->
