### PR TITLE
Make a doc URL a clickable link

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -4,7 +4,7 @@
 
 #![deny(missing_docs)]
 
-//! A memory cache implementing the logic specified in http://tools.ietf.org/html/rfc7234
+//! A memory cache implementing the logic specified in <http://tools.ietf.org/html/rfc7234>
 //! and <http://tools.ietf.org/html/rfc7232>.
 
 use fetch::methods::{Data, DoneChannel};


### PR DESCRIPTION
Made a URL in the docs of net::http_cache a clickable link.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's just a doc fix.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21019)
<!-- Reviewable:end -->
