### PR TITLE
Use real values for GL maximums when compiling shaders.

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -2025,7 +2025,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     fn CompileShader(&self, shader: &WebGLShader) {
         handle_potential_webgl_error!(
             self,
-            shader.compile(self.webgl_version, self.glsl_version, &self.extension_manager)
+            shader.compile(self.webgl_version, self.glsl_version, &self.extension_manager, &self.limits)
         )
     }
 


### PR DESCRIPTION
This matches [the equivalent Gecko code](https://searchfox.org/mozilla-central/rev/c621276fbdd9591f52009042d959b9e19b66d49f/dom/canvas/WebGLShaderValidator.cpp#150-156) and makes a lot of three.js examples render as expected.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #20928.
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21026)
<!-- Reviewable:end -->
