### PR TITLE
Make has_listeners_for follow the spec

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2127,7 +2127,7 @@ impl Document {
         let event = beforeunload_event.upcast::<Event>();
         event.set_trusted(true);
         let event_target = self.window.upcast::<EventTarget>();
-        let has_listeners = event.has_listeners_for(&event_target, &atom!("beforeunload"));
+        let has_listeners = event_target.has_listeners_for(&atom!("beforeunload"));
         self.window.dispatch_event_with_target_override(&event);
         // TODO: Step 6, decrease the event loop's termination nesting level by 1.
         // Step 7
@@ -2197,7 +2197,7 @@ impl Document {
             );
             event.set_trusted(true);
             let event_target = self.window.upcast::<EventTarget>();
-            let has_listeners = event.has_listeners_for(&event_target, &atom!("unload"));
+            let has_listeners = event_target.has_listeners_for(&atom!("unload"));
             let _ = self.window.dispatch_event_with_target_override(&event);
             self.fired_unload.set(true);
             // Step 9

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -138,18 +138,6 @@ impl Event {
         self.cancelable.set(cancelable);
     }
 
-    // Determine if there are any listeners for a given target and type.
-    // See https://github.com/whatwg/dom/issues/453
-    pub fn has_listeners_for(&self, target: &EventTarget, type_: &Atom) -> bool {
-        // TODO: take 'removed' into account? Not implemented in Servo yet.
-        // https://dom.spec.whatwg.org/#event-listener-removed
-        let mut event_path = self.construct_event_path(&target);
-        event_path.push(DomRoot::from_ref(target));
-        event_path
-            .iter()
-            .any(|target| target.has_listeners_for(type_))
-    }
-
     // https://dom.spec.whatwg.org/#event-path
     // TODO: shadow roots put special flags in the path,
     // and it will stop just being a list of bare EventTargets

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -367,6 +367,8 @@ impl EventTarget {
         Ok(EventTarget::new(global, proto))
     }
 
+    /// Determine if there are any listeners for a given event type.
+    /// See <https://github.com/whatwg/dom/issues/453>.
     pub fn has_listeners_for(&self, type_: &Atom) -> bool {
         match self.handlers.borrow().get(type_) {
             Some(listeners) => listeners.has_listeners(),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
In the light of https://github.com/whatwg/dom/issues/453#issuecomment-394246176 I found out our previous implementations was a bit over the top and that checking the entire event path is in fact unnecessary. 

Matches Gecko's implementations, and the soon to follow spec concept...

Tests were added for this in https://github.com/servo/servo/pull/20837, and those are still passing...

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21044)
<!-- Reviewable:end -->
