### PR TITLE
Allow window.parent attribute to be replaceable by JavaScript.

### DIFF
--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -38,7 +38,7 @@
   //         attribute any opener;
   // Note that this can return null in the case that the browsing context has been discarded.
   // https://github.com/whatwg/html/issues/2115
-  readonly attribute WindowProxy? parent;
+  [Replaceable] readonly attribute WindowProxy? parent;
   readonly attribute Element? frameElement;
   //WindowProxy open(optional DOMString url = "about:blank", optional DOMString target = "_blank",
   //                 optional DOMString features = "", optional boolean replace = false);

--- a/tests/wpt/metadata/html/browsers/the-window-object/window-properties.https.html.ini
+++ b/tests/wpt/metadata/html/browsers/the-window-object/window-properties.https.html.ini
@@ -50,9 +50,6 @@
   [Window replaceable attribute: toolbar]
     expected: FAIL
 
-  [Window replaceable attribute: parent]
-    expected: FAIL
-
   [Window replaceable attribute: external]
     expected: FAIL
 


### PR DESCRIPTION
Permit JS to override the window.parent attribute.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] These changes fix #20932 (github issue number if applicable).
- [x] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21045)
<!-- Reviewable:end -->
