### PR TITLE
Allow supported window attributes to be replacable.

### DIFF
--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -104,7 +104,7 @@ dictionary ScrollToOptions : ScrollOptions {
 // http://dev.w3.org/csswg/cssom-view/#extensions-to-the-window-interface
 partial interface Window {
   [Exposed=(Window), NewObject] MediaQueryList matchMedia(DOMString query);
-  [SameObject] readonly attribute Screen screen;
+  [SameObject, Replaceable] readonly attribute Screen screen;
 
   // browsing context
   void moveTo(long x, long y);
@@ -113,14 +113,14 @@ partial interface Window {
   void resizeBy(long x, long y);
 
   // viewport
-  readonly attribute long innerWidth;
-  readonly attribute long innerHeight;
+  [Replaceable] readonly attribute long innerWidth;
+  [Replaceable] readonly attribute long innerHeight;
 
   // viewport scrolling
-  readonly attribute long scrollX;
-  readonly attribute long pageXOffset;
-  readonly attribute long scrollY;
-  readonly attribute long pageYOffset;
+  [Replaceable] readonly attribute long scrollX;
+  [Replaceable] readonly attribute long pageXOffset;
+  [Replaceable] readonly attribute long scrollY;
+  [Replaceable] readonly attribute long pageYOffset;
   void scroll(optional ScrollToOptions options);
   void scroll(unrestricted double x, unrestricted double y);
   void scrollTo(optional ScrollToOptions options);
@@ -129,11 +129,11 @@ partial interface Window {
   void scrollBy(unrestricted double x, unrestricted double y);
 
   // client
-  readonly attribute long screenX;
-  readonly attribute long screenY;
-  readonly attribute long outerWidth;
-  readonly attribute long outerHeight;
-  readonly attribute double devicePixelRatio;
+  [Replaceable] readonly attribute long screenX;
+  [Replaceable] readonly attribute long screenY;
+  [Replaceable] readonly attribute long outerWidth;
+  [Replaceable] readonly attribute long outerHeight;
+  [Replaceable] readonly attribute double devicePixelRatio;
 };
 
 // Proprietary extensions.

--- a/tests/wpt/metadata/css/cssom-view/window-interface.xht.ini
+++ b/tests/wpt/metadata/css/cssom-view/window-interface.xht.ini
@@ -1,0 +1,4 @@
+[window-interface.xht]
+  [window_properties_readonly]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/browsers/the-window-object/window-properties.https.html.ini
+++ b/tests/wpt/metadata/html/browsers/the-window-object/window-properties.https.html.ini
@@ -53,39 +53,3 @@
   [Window replaceable attribute: external]
     expected: FAIL
 
-  [Window replaceable attribute: screen]
-    expected: FAIL
-
-  [Window replaceable attribute: scrollX]
-    expected: FAIL
-
-  [Window replaceable attribute: scrollY]
-    expected: FAIL
-
-  [Window replaceable attribute: pageXOffset]
-    expected: FAIL
-
-  [Window replaceable attribute: pageYOffset]
-    expected: FAIL
-
-  [Window replaceable attribute: innerWidth]
-    expected: FAIL
-
-  [Window replaceable attribute: innerHeight]
-    expected: FAIL
-
-  [Window replaceable attribute: screenX]
-    expected: FAIL
-
-  [Window replaceable attribute: screenY]
-    expected: FAIL
-
-  [Window replaceable attribute: outerWidth]
-    expected: FAIL
-
-  [Window replaceable attribute: outerHeight]
-    expected: FAIL
-
-  [Window replaceable attribute: devicePixelRatio]
-    expected: FAIL
-


### PR DESCRIPTION
As seen in https://github.com/servo/servo/pull/21045 some Window attributes don't support JavaScript from being able to shadow and replace their values.

This PR adds all other attributes I could find that are supported by servo to be replaceable.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21050)
<!-- Reviewable:end -->
