### PR TITLE
Implement window.length DOM attribute.

### DIFF
--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -31,7 +31,7 @@
 
   // other browsing contexts
   [Replaceable] readonly attribute WindowProxy frames;
-  //[Replaceable] readonly attribute unsigned long length;
+  [Replaceable] readonly attribute unsigned long length;
   // Note that this can return null in the case that the browsing context has been discarded.
   // https://github.com/whatwg/html/issues/2115
   [Unforgeable] readonly attribute WindowProxy? top;

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -694,6 +694,12 @@ impl WindowMethods for Window {
         self.window_proxy()
     }
 
+    // https://html.spec.whatwg.org/multipage/#accessing-other-browsing-contexts
+    fn Length(&self) -> u32 {
+        let doc = self.Document();
+        doc.iter_iframes().count() as u32
+    }
+
     // https://html.spec.whatwg.org/multipage/#dom-parent
     fn GetParent(&self) -> Option<DomRoot<WindowProxy>> {
         // Steps 1-3.

--- a/tests/wpt/metadata/html/browsers/the-window-object/accessing-other-browsing-contexts/window_length.html.ini
+++ b/tests/wpt/metadata/html/browsers/the-window-object/accessing-other-browsing-contexts/window_length.html.ini
@@ -1,19 +1,5 @@
 [window_length.html]
   type: testharness
-  [No child browsing contexts]
-    expected: FAIL
-
-  [iframe not inserted into the document]
-    expected: FAIL
-
-  [One iframe inserted into the document]
-    expected: FAIL
-
-  [Child browsing context has a child browsing context]
-    expected: FAIL
-
-  [window.length in child frame]
-    expected: FAIL
 
   [Opened window]
     expected: FAIL

--- a/tests/wpt/metadata/html/browsers/the-window-object/security-window/window-security.https.html.ini
+++ b/tests/wpt/metadata/html/browsers/the-window-object/security-window/window-security.https.html.ini
@@ -335,9 +335,6 @@
   [A SecurityError exception must be thrown when window.stop is accessed from a different origin.]
     expected: FAIL
 
-  [A SecurityError exception should not be thrown when window.length is accessed from a different origin.]
-    expected: FAIL
-
   [A SecurityError exception should not be thrown when window.opener is accessed from a different origin.]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/browsers/the-window-object/window-properties.https.html.ini
+++ b/tests/wpt/metadata/html/browsers/the-window-object/window-properties.https.html.ini
@@ -56,9 +56,6 @@
   [Window replaceable attribute: external]
     expected: FAIL
 
-  [Window replaceable attribute: length]
-    expected: FAIL
-
   [Window replaceable attribute: screen]
     expected: FAIL
 


### PR DESCRIPTION
Implements the `window.length` DOM attribute for enumerating frames on the document.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21051)
<!-- Reviewable:end -->
