### PR TITLE
Implement support for Element.toggleAttribute

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1680,6 +1680,43 @@ impl ElementMethods for Element {
         self.get_attribute(namespace, &LocalName::from(local_name))
     }
 
+    // https://dom.spec.whatwg.org/#dom-element-toggleattribute
+    fn ToggleAttribute(&self, name: DOMString, force: Option<bool>) -> Fallible<bool> {
+        // Step 1.
+        if xml_name_type(&name) == InvalidXMLName {
+            return Err(Error::InvalidCharacter);
+        }
+
+        // Step 3.
+        let attribute = self.GetAttribute(name.clone());
+
+        // Step 2.
+        let name = self.parsed_name(name);
+        match attribute {
+            // Step 4
+            None => match force {
+                // Step 4.1.
+                None | Some(true) => {
+                    self.set_first_matching_attribute(
+                        name.clone(), AttrValue::String(String::new()), name.clone(), ns!(), None,
+                        |attr| *attr.name() == name);
+                    Ok(true)
+                },
+                // Step 4.2.
+                Some(false) => Ok(false),
+            },
+            Some(_index) => match force {
+                // Step 5.
+                None | Some(false) => {
+                    self.remove_attribute_by_name(&name);
+                    Ok(false)
+                },
+                // Step 6.
+                Some(true) => Ok(true),
+            },
+        }
+    }
+
     // https://dom.spec.whatwg.org/#dom-element-setattribute
     fn SetAttribute(&self, name: DOMString, value: DOMString) -> ErrorResult {
         // Step 1.

--- a/components/script/dom/webidls/Element.webidl
+++ b/components/script/dom/webidls/Element.webidl
@@ -41,6 +41,8 @@ interface Element : Node {
   [Pure]
   DOMString? getAttributeNS(DOMString? namespace, DOMString localName);
   [CEReactions, Throws]
+  boolean toggleAttribute(DOMString name, optional boolean force);
+  [CEReactions, Throws]
   void setAttribute(DOMString name, DOMString value);
   [CEReactions, Throws]
   void setAttributeNS(DOMString? namespace, DOMString name, DOMString value);


### PR DESCRIPTION
Copy implementation following from [Firefox implementation](https://bugzilla.mozilla.org/show_bug.cgi?id=1469592) of soon to be standardised [Element.toggleAttribute](https://github.com/whatwg/dom/pull/656). [Other implementers agreed to ship](https://github.com/whatwg/dom/issues/461)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes don't fix an issue however the wpt-tests will merge soon and will cause an issue etc.

<!-- Either: -->
- [X] There are tests for these changes **(coming soon in wpt from Firefox and I tested them on this patch)**

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21074)
<!-- Reviewable:end -->
