### PR TITLE
Workaround Windows issue with URL prompt

### DIFF
--- a/ports/servo/browser.rs
+++ b/ports/servo/browser.rs
@@ -91,7 +91,10 @@ impl Browser {
                     self.event_queue.push(WindowEvent::Reload(id));
                 }
             }
-            (CMD_OR_CONTROL, Some('l'), _) => {
+            // FIXME (#17146): Workaround for Ctrl + L not working on Windows.
+            // When #17146 is fixed revert this line back to:
+            // (CMD_OR_CONTROL, Some('l'), _) => {
+            (CMD_OR_CONTROL, _, Key::L) => {
                 if let Some(id) = self.browser_id {
                     let url: String = if let Some(ref current_url) = self.current_url {
                         current_url.to_string()


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This change was cherry picked from #17062. Servo's URL prompt does not currently work in Windows which really hurts the current usability of the Windows version.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21103)
<!-- Reviewable:end -->
