### PR TITLE
"./mach env" cause unclear message.

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -38,12 +38,12 @@ class MachCommands(CommandBase):
              category='bootstrap')
     def env(self):
         env = self.build_env()
-        print("export RUSTFLAGS=%s" % env["RUSTFLAGS"])
-        print("export PATH=%s" % env["PATH"])
+        print("export RUSTFLAGS=%s" % env.get("RUSTFLAGS", ""))
+        print("export PATH=%s" % env.get("PATH", ""))
         if sys.platform == "darwin":
-            print("export DYLD_LIBRARY_PATH=%s" % env["DYLD_LIBRARY_PATH"])
+            print("export DYLD_LIBRARY_PATH=%s" % env.get("DYLD_LIBRARY_PATH", ""))
         else:
-            print("export LD_LIBRARY_PATH=%s" % env["LD_LIBRARY_PATH"])
+            print("export LD_LIBRARY_PATH=%s" % env.get("LD_LIBRARY_PATH", ""))
 
     @Command('bootstrap',
              description='Install required packages for building.',


### PR DESCRIPTION
We did't use "LD_LIBRARY_PATH" and no need display this.

<!-- Please describe your changes on the following line: -->
Remove the print message.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ X] `./mach build -d` does not report any errors
- [ X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21104)
<!-- Reviewable:end -->
