### PR TITLE
Assert that DOM structs have the correct first field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,10 @@ dependencies = [
 [[package]]
 name = "dom_struct"
 version = "0.0.1"
+dependencies = [
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "domobject_derive"

--- a/components/dom_struct/Cargo.toml
+++ b/components/dom_struct/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
-name = "dom_struct"
-version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
+name = "dom_struct"
 publish = false
+version = "0.0.1"
+
+[dependencies]
+quote = "0.6.3"
+syn = { version = "0.14.2", features = ["full"] }
 
 [lib]
 path = "lib.rs"

--- a/components/script/dom/bindings/inheritance.rs
+++ b/components/script/dom/bindings/inheritance.rs
@@ -41,3 +41,8 @@ pub trait Castable: IDLInterface + DomObject + Sized {
         }
     }
 }
+
+pub trait HasParent {
+    type Parent;
+    fn as_parent(&self) -> &Self::Parent;
+}

--- a/components/script/dom/filereadersync.rs
+++ b/components/script/dom/filereadersync.rs
@@ -5,11 +5,10 @@
 use dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
 use dom::bindings::codegen::Bindings::FileReaderSyncBinding::{FileReaderSyncBinding, FileReaderSyncMethods};
 use dom::bindings::error::{Error, Fallible};
-use dom::bindings::reflector::reflect_dom_object;
+use dom::bindings::reflector::{Reflector, reflect_dom_object};
 use dom::bindings::root::DomRoot;
 use dom::bindings::str::DOMString;
 use dom::blob::Blob;
-use dom::eventtarget::EventTarget;
 use dom::filereader::FileReaderSharedFunctionality;
 use dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
@@ -20,13 +19,13 @@ use std::ptr::NonNull;
 
 #[dom_struct]
 pub struct FileReaderSync {
-    eventtarget: EventTarget,
+    reflector: Reflector,
 }
 
 impl FileReaderSync {
     pub fn new_inherited() -> FileReaderSync {
         FileReaderSync {
-            eventtarget: EventTarget::new_inherited(),
+            reflector: Reflector::new(),
         }
     }
 


### PR DESCRIPTION
Not having the right field can lead to fun bugs like https://github.com/ferjm/servo/pull/1 where the struct gets mis-reinterpreted as what should be its parent (but is not layout-wise)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21105)
<!-- Reviewable:end -->
