### PR TITLE
 Store vertex attribs data in DOM and optimise GetVertexAttrib

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -826,8 +826,6 @@ impl WebGLImpl {
                 ctx.gl().uniform_matrix_3fv(uniform_id, transpose, v),
             WebGLCommand::UniformMatrix4fv(uniform_id, transpose,  ref v) =>
                 ctx.gl().uniform_matrix_4fv(uniform_id, transpose, v),
-            WebGLCommand::UseProgram(program_id) =>
-                ctx.gl().use_program(program_id.get()),
             WebGLCommand::ValidateProgram(program_id) =>
                 ctx.gl().validate_program(program_id.get()),
             WebGLCommand::VertexAttrib(attrib_id, x, y, z, w) =>
@@ -964,6 +962,9 @@ impl WebGLImpl {
             }
             WebGLCommand::LinkProgram(program_id, ref sender) => {
                 return sender.send(Self::link_program(ctx.gl(), program_id)).unwrap();
+            }
+            WebGLCommand::UseProgram(program_id) => {
+                ctx.gl().use_program(program_id.map_or(0, |p| p.get()))
             }
         }
 

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -211,7 +211,6 @@ pub enum WebGLCommand {
     GetActiveUniform(WebGLProgramId, u32, WebGLSender<WebGLResult<(i32, u32, String)>>),
     GetAttribLocation(WebGLProgramId, String, WebGLSender<Option<i32>>),
     GetUniformLocation(WebGLProgramId, String, WebGLSender<Option<i32>>),
-    GetVertexAttribOffset(u32, u32, WebGLSender<isize>),
     GetShaderInfoLog(WebGLShaderId, WebGLSender<String>),
     GetProgramInfoLog(WebGLProgramId, WebGLSender<String>),
     GetFramebufferAttachmentParameter(u32, u32, u32, WebGLSender<i32>),
@@ -278,9 +277,7 @@ pub enum WebGLCommand {
     GetProgramParameterInt(WebGLProgramId, ProgramParameterInt, WebGLSender<i32>),
     GetShaderParameterBool(WebGLShaderId, ShaderParameterBool, WebGLSender<bool>),
     GetShaderParameterInt(WebGLShaderId, ShaderParameterInt, WebGLSender<i32>),
-    GetVertexAttribBool(u32, VertexAttribBool, WebGLSender<WebGLResult<bool>>),
-    GetVertexAttribInt(u32, VertexAttribInt, WebGLSender<WebGLResult<i32>>),
-    GetVertexAttribFloat4(u32, VertexAttribFloat4, WebGLSender<WebGLResult<[f32; 4]>>),
+    GetCurrentVertexAttrib(u32, WebGLSender<[f32; 4]>),
     GetTexParameterFloat(u32, TexParameterFloat, WebGLSender<f32>),
     GetTexParameterInt(u32, TexParameterInt, WebGLSender<i32>),
     TexParameteri(u32, TexParameterInt, i32),
@@ -565,23 +562,6 @@ parameters! {
             TextureMinFilter = gl::TEXTURE_MIN_FILTER,
             TextureWrapS = gl::TEXTURE_WRAP_S,
             TextureWrapT = gl::TEXTURE_WRAP_T,
-        }),
-    }
-}
-
-parameters! {
-    VertexAttrib {
-        Bool(VertexAttribBool {
-            VertexAttribArrayEnabled = gl::VERTEX_ATTRIB_ARRAY_ENABLED,
-            VertexAttribArrayNormalized = gl::VERTEX_ATTRIB_ARRAY_NORMALIZED,
-        }),
-        Int(VertexAttribInt {
-            VertexAttribArraySize = gl::VERTEX_ATTRIB_ARRAY_SIZE,
-            VertexAttribArrayStride = gl::VERTEX_ATTRIB_ARRAY_STRIDE,
-            VertexAttribArrayType = gl::VERTEX_ATTRIB_ARRAY_TYPE,
-        }),
-        Float4(VertexAttribFloat4 {
-            CurrentVertexAttrib = gl::CURRENT_VERTEX_ATTRIB,
         }),
     }
 }

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -249,7 +249,7 @@ pub enum WebGLCommand {
     UniformMatrix2fv(i32, bool, Vec<f32>),
     UniformMatrix3fv(i32, bool, Vec<f32>),
     UniformMatrix4fv(i32, bool, Vec<f32>),
-    UseProgram(WebGLProgramId),
+    UseProgram(Option<WebGLProgramId>),
     ValidateProgram(WebGLProgramId),
     VertexAttrib(u32, f32, f32, f32, f32),
     VertexAttribPointer(u32, i32, u32, bool, i32, u32),

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -32,7 +32,7 @@
 use app_units::Au;
 use canvas_traits::canvas::{CanvasGradientStop, CanvasId, LinearGradientStyle, RadialGradientStyle};
 use canvas_traits::canvas::{CompositionOrBlending, LineCapStyle, LineJoinStyle, RepetitionStyle};
-use canvas_traits::webgl::{WebGLBufferId, WebGLFramebufferId, WebGLProgramId, WebGLRenderbufferId};
+use canvas_traits::webgl::{ActiveAttribInfo, WebGLBufferId, WebGLFramebufferId, WebGLProgramId, WebGLRenderbufferId};
 use canvas_traits::webgl::{WebGLChan, WebGLContextShareMode, WebGLError, WebGLPipeline, WebGLMsgSender};
 use canvas_traits::webgl::{WebGLReceiver, WebGLSender, WebGLShaderId, WebGLTextureId, WebGLVertexArrayId};
 use canvas_traits::webgl::{WebGLSLVersion, WebGLVersion};
@@ -342,6 +342,7 @@ unsafe impl<A: JSTraceable, B: JSTraceable, C: JSTraceable> JSTraceable for (A, 
     }
 }
 
+unsafe_no_jsmanaged_fields!(ActiveAttribInfo);
 unsafe_no_jsmanaged_fields!(bool, f32, f64, String, AtomicBool, AtomicUsize, Uuid, char);
 unsafe_no_jsmanaged_fields!(usize, u8, u16, u32, u64);
 unsafe_no_jsmanaged_fields!(isize, i8, i16, i32, i64);

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -594,7 +594,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
-    fn LinkProgram(&self, program: Option<&WebGLProgram>) {
+    fn LinkProgram(&self, program: &WebGLProgram) {
         self.base.LinkProgram(program)
     }
 

--- a/components/script/dom/webgl_extensions/ext/oesvertexarrayobject.rs
+++ b/components/script/dom/webgl_extensions/ext/oesvertexarrayobject.rs
@@ -75,8 +75,8 @@ impl OESVertexArrayObjectMethods for OESVertexArrayObject {
             }
 
             // Remove VAO references from buffers
-            for (_, ref buffer) in vao.vertex_attribs().borrow().iter() {
-                if let Some(ref buffer) = *buffer {
+            for attrib_data in &*vao.vertex_attribs().borrow() {
+                if let Some(buffer) = attrib_data.buffer() {
                     buffer.remove_vao_reference(vao.id());
                 }
             }
@@ -101,8 +101,8 @@ impl OESVertexArrayObjectMethods for OESVertexArrayObject {
         if let Some(bound_vao) = self.bound_vao.get() {
             // Store buffers attached to attrib pointers
             bound_vao.vertex_attribs().set_from(&self.ctx.vertex_attribs());
-            for (_, ref buffer) in bound_vao.vertex_attribs().borrow().iter() {
-                if let Some(ref buffer) = *buffer {
+            for attrib_data in &*bound_vao.vertex_attribs().borrow() {
+                if let Some(buffer) = attrib_data.buffer() {
                     buffer.add_vao_reference(bound_vao.id());
                 }
             }

--- a/components/script/dom/webgl_extensions/ext/oesvertexarrayobject.rs
+++ b/components/script/dom/webgl_extensions/ext/oesvertexarrayobject.rs
@@ -100,7 +100,7 @@ impl OESVertexArrayObjectMethods for OESVertexArrayObject {
     fn BindVertexArrayOES(&self, vao: Option<&WebGLVertexArrayObjectOES>) {
         if let Some(bound_vao) = self.bound_vao.get() {
             // Store buffers attached to attrib pointers
-            bound_vao.vertex_attribs().set_from(&self.ctx.vertex_attribs());
+            bound_vao.vertex_attribs().clone_from(&self.ctx.vertex_attribs());
             for attrib_data in &*bound_vao.vertex_attribs().borrow() {
                 if let Some(buffer) = attrib_data.buffer() {
                     buffer.add_vao_reference(bound_vao.id());
@@ -125,7 +125,7 @@ impl OESVertexArrayObjectMethods for OESVertexArrayObject {
             self.bound_vao.set(Some(&vao));
 
             // Restore WebGLRenderingContext current bindings
-            self.ctx.vertex_attribs().set_from(&vao.vertex_attribs());
+            self.ctx.vertex_attribs().clone_from(&vao.vertex_attribs());
             let element_array = vao.bound_buffer_element_array();
             self.ctx.set_bound_buffer_element_array(element_array.as_ref().map(|buffer| &**buffer));
         } else {

--- a/components/script/dom/webgl_extensions/ext/oesvertexarrayobject.rs
+++ b/components/script/dom/webgl_extensions/ext/oesvertexarrayobject.rs
@@ -50,7 +50,13 @@ impl OESVertexArrayObjectMethods for OESVertexArrayObject {
         self.ctx.send_command(WebGLCommand::CreateVertexArray(sender));
 
         let result = receiver.recv().unwrap();
-        result.map(|vao_id| WebGLVertexArrayObjectOES::new(&self.global(), vao_id))
+        result.map(|vao_id| {
+            WebGLVertexArrayObjectOES::new(
+                &self.global(),
+                vao_id,
+                self.ctx.limits().max_vertex_attribs,
+            )
+        })
     }
 
     // https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/
@@ -69,7 +75,7 @@ impl OESVertexArrayObjectMethods for OESVertexArrayObject {
             }
 
             // Remove VAO references from buffers
-            for (_, &(_, ref buffer)) in vao.bound_attrib_buffers().borrow().iter() {
+            for (_, ref buffer) in vao.vertex_attribs().borrow().iter() {
                 if let Some(ref buffer) = *buffer {
                     buffer.remove_vao_reference(vao.id());
                 }
@@ -94,8 +100,8 @@ impl OESVertexArrayObjectMethods for OESVertexArrayObject {
     fn BindVertexArrayOES(&self, vao: Option<&WebGLVertexArrayObjectOES>) {
         if let Some(bound_vao) = self.bound_vao.get() {
             // Store buffers attached to attrib pointers
-            bound_vao.bound_attrib_buffers().set_from(&self.ctx.bound_attrib_buffers());
-            for (_, (_, ref buffer)) in bound_vao.bound_attrib_buffers().borrow().iter() {
+            bound_vao.vertex_attribs().set_from(&self.ctx.vertex_attribs());
+            for (_, ref buffer) in bound_vao.vertex_attribs().borrow().iter() {
                 if let Some(ref buffer) = *buffer {
                     buffer.add_vao_reference(bound_vao.id());
                 }
@@ -119,13 +125,13 @@ impl OESVertexArrayObjectMethods for OESVertexArrayObject {
             self.bound_vao.set(Some(&vao));
 
             // Restore WebGLRenderingContext current bindings
-            self.ctx.bound_attrib_buffers().set_from(&vao.bound_attrib_buffers());
+            self.ctx.vertex_attribs().set_from(&vao.vertex_attribs());
             let element_array = vao.bound_buffer_element_array();
             self.ctx.set_bound_buffer_element_array(element_array.as_ref().map(|buffer| &**buffer));
         } else {
             self.ctx.send_command(WebGLCommand::BindVertexArray(None));
             self.bound_vao.set(None);
-            self.ctx.bound_attrib_buffers().clear();
+            self.ctx.vertex_attribs().clear();
         }
     }
 }

--- a/components/script/dom/webglprogram.rs
+++ b/components/script/dom/webglprogram.rs
@@ -130,19 +130,6 @@ impl WebGLProgram {
         Ref::map(self.active_attribs.borrow(), |attribs| &**attribs)
     }
 
-    /// glUseProgram
-    pub fn use_program(&self) -> WebGLResult<()> {
-        if self.is_deleted() {
-            return Err(WebGLError::InvalidOperation);
-        }
-        if !self.linked.get() {
-            return Err(WebGLError::InvalidOperation);
-        }
-
-        self.renderer.send(WebGLCommand::UseProgram(self.id)).unwrap();
-        Ok(())
-    }
-
     /// glValidateProgram
     pub fn validate(&self) -> WebGLResult<()> {
         if self.is_deleted() {

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -3811,7 +3811,7 @@ impl VertexAttribs {
         }
     }
 
-    pub fn set_from(&self, other: &Self) {
+    pub fn clone_from(&self, other: &Self) {
         self.attribs.borrow_mut().clone_from_slice(&other.attribs.borrow());
     }
 

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -2202,13 +2202,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             }
         }
 
-        {
-            // https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.2
-            let buffers = self.vertex_attribs.borrow();
-            if buffers.iter().any(|data| data.enabled_as_array && data.buffer.is_none()) {
-                return self.webgl_error(InvalidOperation);
-            }
-        }
+        handle_potential_webgl_error!(self, self.vertex_attribs.validate_for_draw(), return);
 
         if !self.validate_framebuffer_complete() {
             return;
@@ -2277,13 +2271,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             }
         }
 
-        {
-            // https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.2
-            let buffers = self.vertex_attribs.borrow();
-            if buffers.iter().any(|data| data.enabled_as_array && data.buffer.is_none()) {
-                return self.webgl_error(InvalidOperation);
-            }
-        }
+        handle_potential_webgl_error!(self, self.vertex_attribs.validate_for_draw(), return);
 
         if !self.validate_framebuffer_complete() {
             return;
@@ -3851,6 +3839,14 @@ impl VertexAttribs {
 
     fn bind_buffer(&self, index: u32, buffer: &WebGLBuffer) {
         self.attribs.borrow_mut()[index as usize].buffer = Some(Dom::from_ref(buffer));
+    }
+
+    fn validate_for_draw(&self) -> WebGLResult<()> {
+        // https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.2
+        if self.borrow().iter().any(|data| data.enabled_as_array && data.buffer.is_none()) {
+            return Err(InvalidOperation);
+        }
+        Ok(())
     }
 }
 

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -2947,12 +2947,9 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
-    fn LinkProgram(&self, program: Option<&WebGLProgram>) {
-        if let Some(program) = program {
-            if let Err(e) = program.link() {
-                self.webgl_error(e);
-            }
-        }
+    fn LinkProgram(&self, program: &WebGLProgram) {
+        // FIXME(nox): INVALID_OPERATION if program comes from a different context.
+        handle_potential_webgl_error!(self, program.link());
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -193,7 +193,7 @@ pub struct WebGLRenderingContext {
     bound_texture_unit: Cell<u32>,
     bound_buffer_array: MutNullableDom<WebGLBuffer>,
     bound_buffer_element_array: MutNullableDom<WebGLBuffer>,
-    bound_attrib_buffers: BoundAttribBuffers,
+    vertex_attribs: VertexAttribs,
     current_program: MutNullableDom<WebGLProgram>,
     #[ignore_malloc_size_of = "Because it's small"]
     current_vertex_attrib_0: Cell<(f32, f32, f32, f32)>,
@@ -234,6 +234,7 @@ impl WebGLRenderingContext {
                 share_mode: ctx_data.share_mode,
                 webgl_version,
                 glsl_version: ctx_data.glsl_version,
+                vertex_attribs: VertexAttribs::new(ctx_data.limits.max_vertex_attribs),
                 limits: ctx_data.limits,
                 canvas: Dom::from_ref(canvas),
                 last_error: Cell::new(None),
@@ -244,7 +245,6 @@ impl WebGLRenderingContext {
                 bound_texture_unit: Cell::new(constants::TEXTURE0),
                 bound_buffer_array: MutNullableDom::new(None),
                 bound_buffer_element_array: MutNullableDom::new(None),
-                bound_attrib_buffers: Default::default(),
                 bound_renderbuffer: MutNullableDom::new(None),
                 current_program: MutNullableDom::new(None),
                 current_vertex_attrib_0: Cell::new((0f32, 0f32, 0f32, 1f32)),
@@ -312,8 +312,8 @@ impl WebGLRenderingContext {
         })
     }
 
-    pub fn bound_attrib_buffers(&self) -> &BoundAttribBuffers {
-        &self.bound_attrib_buffers
+    pub fn vertex_attribs(&self) -> &VertexAttribs {
+        &self.vertex_attribs
     }
 
     pub fn bound_buffer_element_array(&self) -> Option<DomRoot<WebGLBuffer>> {
@@ -2075,7 +2075,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             }
 
             // Remove deleted buffer from bound attrib buffers.
-            self.bound_attrib_buffers.remove_buffer(buffer);
+            self.vertex_attribs.delete_buffer(buffer);
 
             // Delete buffer.
             handle_object_deletion!(self, self.bound_buffer_array, buffer,
@@ -2204,8 +2204,8 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
         {
             // https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.2
-            let buffers = self.bound_attrib_buffers.borrow();
-            if buffers.iter().any(|(_, &(enabled, ref buffer))| enabled && buffer.is_none()) {
+            let buffers = self.vertex_attribs.borrow();
+            if buffers.iter().any(|&(enabled, ref buffer)| enabled && buffer.is_none()) {
                 return self.webgl_error(InvalidOperation);
             }
         }
@@ -2279,8 +2279,8 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
         {
             // https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.2
-            let buffers = self.bound_attrib_buffers.borrow();
-            if buffers.iter().any(|(_, &(enabled, ref buffer))| enabled && buffer.is_none()) {
+            let buffers = self.vertex_attribs.borrow();
+            if buffers.iter().any(|&(enabled, ref buffer)| enabled && buffer.is_none()) {
                 return self.webgl_error(InvalidOperation);
             }
         }
@@ -2299,7 +2299,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             return self.webgl_error(InvalidValue);
         }
 
-        self.bound_attrib_buffers.enabled(attrib_id, true);
+        self.vertex_attribs.enabled_as_array(attrib_id, true);
         self.send_command(WebGLCommand::EnableVertexAttribArray(attrib_id));
     }
 
@@ -2309,7 +2309,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             return self.webgl_error(InvalidValue);
         }
 
-        self.bound_attrib_buffers.enabled(attrib_id, false);
+        self.vertex_attribs.enabled_as_array(attrib_id, false);
         self.send_command(WebGLCommand::DisableVertexAttribArray(attrib_id));
     }
 
@@ -2601,7 +2601,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
         if param == constants::VERTEX_ATTRIB_ARRAY_BUFFER_BINDING {
             rooted!(in(cx) let mut jsval = NullValue());
-            if let Some(buffer) = self.bound_attrib_buffers.get(index) {
+            if let Some(buffer) = self.vertex_attribs.get(index) {
                 buffer.to_jsval(cx, jsval.handle_mut());
             }
             return jsval.get();
@@ -3367,7 +3367,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
         }
 
-        self.bound_attrib_buffers.bind_buffer(attrib_id, &buffer_array);
+        self.vertex_attribs.bind_buffer(attrib_id, &buffer_array);
 
         let msg = WebGLCommand::VertexAttribPointer(attrib_id, size, data_type, normalized, stride, offset as u32);
         self.send_command(msg);
@@ -3805,48 +3805,51 @@ impl UniformSetterType {
     }
 }
 
-#[derive(Default, JSTraceable, MallocSizeOf)]
+#[derive(JSTraceable, MallocSizeOf)]
 #[must_root]
-pub struct BoundAttribBuffers {
-    elements: DomRefCell<FnvHashMap<u32, (bool, Option<Dom<WebGLBuffer>>)>>,
+pub struct VertexAttribs {
+    attribs: DomRefCell<Box<[(bool, Option<Dom<WebGLBuffer>>)]>>,
 }
 
-impl BoundAttribBuffers {
+impl VertexAttribs {
+    pub fn new(max: u32) -> Self {
+        // High-end GPUs have 16 of those, let's just use a boxed slice.
+        Self { attribs: DomRefCell::new(vec![Default::default(); max as usize].into()) }
+    }
+
     pub fn clear(&self) {
-        self.elements.borrow_mut().clear()
+        for attrib in &mut **self.attribs.borrow_mut() {
+            *attrib = Default::default();
+        }
     }
 
-    pub fn set_from(&self, other: &BoundAttribBuffers) {
-        *self.elements.borrow_mut() = other.elements.borrow().clone();
+    pub fn set_from(&self, other: &Self) {
+        self.attribs.borrow_mut().clone_from_slice(&other.attribs.borrow());
     }
 
-    pub fn borrow(&self) -> Ref<FnvHashMap<u32, (bool, Option<Dom<WebGLBuffer>>)>> {
-        self.elements.borrow()
+    pub fn borrow(&self) -> Ref<[(bool, Option<Dom<WebGLBuffer>>)]> {
+        Ref::map(self.attribs.borrow(), |attribs| &**attribs)
     }
 
-    fn remove_buffer(&self, buffer: &WebGLBuffer) {
-        self.elements.borrow_mut().retain(|_, v| {
-            v.1.as_ref().map_or(true, |b| b.id() != buffer.id())
-        })
+    fn delete_buffer(&self, buffer: &WebGLBuffer) {
+        for attrib in &mut **self.attribs.borrow_mut() {
+            if attrib.1.as_ref().map_or(false, |b| b.id() == buffer.id()) {
+                attrib.1 = None;
+            }
+        }
     }
 
     fn get(&self, index: u32) -> Option<Ref<WebGLBuffer>> {
-        ref_filter_map(self.elements.borrow(), |elements| {
-            elements.get(&index).and_then(|&(_, ref buffer)| {
-                buffer.as_ref().map(|b| &**b)
-            })
+        ref_filter_map(self.attribs.borrow(), |attribs| {
+            attribs[index as usize].1.as_ref().map(|buffer| &**buffer)
         })
     }
 
-    fn enabled(&self, index: u32, value: bool) {
-        let mut elements = self.elements.borrow_mut();
-        let pair = elements.entry(index).or_insert((false, None));
-        pair.0 = value;
+    fn enabled_as_array(&self, index: u32, value: bool) {
+        self.attribs.borrow_mut()[index as usize].0 = value;
     }
 
     fn bind_buffer(&self, index: u32, buffer: &WebGLBuffer) {
-        let mut elements = self.elements.borrow_mut();
-        let pair = elements.entry(index).or_insert((false, None));
-        pair.1 = Some(Dom::from_ref(buffer));
+        self.attribs.borrow_mut()[index as usize].1 = Some(Dom::from_ref(buffer));
     }
 }

--- a/components/script/dom/webglvertexarrayobjectoes.rs
+++ b/components/script/dom/webglvertexarrayobjectoes.rs
@@ -9,7 +9,7 @@ use dom::bindings::root::{DomRoot, MutNullableDom};
 use dom::globalscope::GlobalScope;
 use dom::webglbuffer::WebGLBuffer;
 use dom::webglobject::WebGLObject;
-use dom::webglrenderingcontext::BoundAttribBuffers;
+use dom::webglrenderingcontext::VertexAttribs;
 use dom_struct::dom_struct;
 use std::cell::Cell;
 
@@ -19,30 +19,36 @@ pub struct WebGLVertexArrayObjectOES {
     id: WebGLVertexArrayId,
     ever_bound: Cell<bool>,
     is_deleted: Cell<bool>,
-    bound_attrib_buffers: BoundAttribBuffers,
+    vertex_attribs: VertexAttribs,
     bound_buffer_element_array: MutNullableDom<WebGLBuffer>,
 }
 
 impl WebGLVertexArrayObjectOES {
-    fn new_inherited(id: WebGLVertexArrayId) -> WebGLVertexArrayObjectOES {
+    fn new_inherited(id: WebGLVertexArrayId, max_vertex_attribs: u32) -> Self {
         Self {
             webgl_object_: WebGLObject::new_inherited(),
             id: id,
             ever_bound: Cell::new(false),
             is_deleted: Cell::new(false),
-            bound_attrib_buffers: Default::default(),
+            vertex_attribs: VertexAttribs::new(max_vertex_attribs),
             bound_buffer_element_array: MutNullableDom::new(None),
         }
     }
 
-    pub fn new(global: &GlobalScope, id: WebGLVertexArrayId) -> DomRoot<WebGLVertexArrayObjectOES> {
-        reflect_dom_object(Box::new(WebGLVertexArrayObjectOES::new_inherited(id)),
-                           global,
-                           WebGLVertexArrayObjectOESBinding::Wrap)
+    pub fn new(
+        global: &GlobalScope,
+        id: WebGLVertexArrayId,
+        max_vertex_attribs: u32,
+    ) -> DomRoot<Self> {
+        reflect_dom_object(
+            Box::new(WebGLVertexArrayObjectOES::new_inherited(id, max_vertex_attribs)),
+            global,
+            WebGLVertexArrayObjectOESBinding::Wrap,
+        )
     }
 
-    pub fn bound_attrib_buffers(&self) -> &BoundAttribBuffers {
-        &self.bound_attrib_buffers
+    pub fn vertex_attribs(&self) -> &VertexAttribs {
+        &self.vertex_attribs
     }
 
     pub fn id(&self) -> WebGLVertexArrayId {

--- a/components/script/dom/webidls/WebGLRenderingContext.webidl
+++ b/components/script/dom/webidls/WebGLRenderingContext.webidl
@@ -597,7 +597,7 @@ interface WebGLRenderingContextBase
     [WebGLHandlesContextLoss] GLboolean isShader(WebGLShader? shader);
     [WebGLHandlesContextLoss] GLboolean isTexture(WebGLTexture? texture);
     void lineWidth(GLfloat width);
-    void linkProgram(WebGLProgram? program);
+    void linkProgram(WebGLProgram program);
     void pixelStorei(GLenum pname, GLint param);
     void polygonOffset(GLfloat factor, GLfloat units);
 

--- a/components/script_plugins/unrooted_must_root.rs
+++ b/components/script_plugins/unrooted_must_root.rs
@@ -52,6 +52,7 @@ fn is_unrooted_ty(cx: &LateContext, ty: &ty::TyS, in_new_function: bool) -> bool
                 } else if match_def_path(cx, did.did, &["core", "cell", "Ref"])
                         || match_def_path(cx, did.did, &["core", "cell", "RefMut"])
                         || match_def_path(cx, did.did, &["core", "slice", "Iter"])
+                        || match_def_path(cx, did.did, &["core", "slice", "IterMut"])
                         || match_def_path(cx, did.did, &["std", "collections", "hash", "map", "Entry"])
                         || match_def_path(cx, did.did, &["std", "collections", "hash", "map", "OccupiedEntry"])
                         || match_def_path(cx, did.did, &["std", "collections", "hash", "map", "VacantEntry"])

--- a/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/programs/program-test.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/programs/program-test.html.ini
@@ -2,9 +2,6 @@
   [WebGL test #53: getError expected: INVALID_OPERATION. Was NO_ERROR : drawing with a null program should generate INVALID_OPERATION]
     expected: FAIL
 
-  [WebGL test #58: linking should fail with in-use formerly good program, with new bad shader attached]
-    expected: FAIL
-
   [WebGL test #64: getError expected: NO_ERROR. Was INVALID_OPERATION : delete the current program shouldn't change the current rendering state]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/programs/program-test.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/programs/program-test.html.ini
@@ -1,7 +1,4 @@
 [program-test.html]
-  [WebGL test #53: getError expected: INVALID_OPERATION. Was NO_ERROR : drawing with a null program should generate INVALID_OPERATION]
-    expected: FAIL
-
   [WebGL test #64: getError expected: NO_ERROR. Was INVALID_OPERATION : delete the current program shouldn't change the current rendering state]
     expected: FAIL
 


### PR DESCRIPTION
This is not an extremely useful change on its own but those things need to be stored on the DOM side to implement some draw checks anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21118)
<!-- Reviewable:end -->
