### PR TITLE
Make (dictionary)::empty() safe

### DIFF
--- a/components/script/dom/bindings/iterable.rs
+++ b/components/script/dom/bindings/iterable.rs
@@ -115,7 +115,7 @@ fn dict_return(cx: *mut JSContext,
                mut result: MutableHandleObject,
                done: bool,
                value: HandleValue) -> Fallible<()> {
-    let mut dict = unsafe { IterableKeyOrValueResult::empty(cx) };
+    let mut dict = IterableKeyOrValueResult::empty();
     dict.done = done;
     dict.value.set(value.get());
     rooted!(in(cx) let mut dict_value = UndefinedValue());
@@ -130,7 +130,7 @@ fn key_and_value_return(cx: *mut JSContext,
                         mut result: MutableHandleObject,
                         key: HandleValue,
                         value: HandleValue) -> Fallible<()> {
-    let mut dict = unsafe { IterableKeyAndValueResult::empty(cx) };
+    let mut dict = IterableKeyAndValueResult::empty();
     dict.done = false;
     dict.value = Some(vec![key, value]
         .into_iter()


### PR DESCRIPTION
It currently works by constructing from null (which will throw a runtime
error if there are non-defaultable members).

This changes it so that we no longer need a JSContext to construct this,
so it can be safely constructed. In the case of non-defaultable members,
this method simply does not exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21131)
<!-- Reviewable:end -->
