### PR TITLE
style: Move `float` CSS property outside mako

### DIFF
--- a/components/style/properties/longhands/box.mako.rs
+++ b/components/style/properties/longhands/box.mako.rs
@@ -54,61 +54,18 @@ ${helpers.single_keyword("position", "static absolute relative fixed sticky",
                          spec="https://drafts.csswg.org/css-position/#position-property",
                          servo_restyle_damage="rebuild_and_reflow")}
 
-<%helpers:single_keyword
-    name="float"
-    values="none left right"
-    // https://drafts.csswg.org/css-logical-props/#float-clear
-    extra_specified="inline-start inline-end"
-    needs_conversion="True"
-    animation_value_type="discrete"
-    gecko_enum_prefix="StyleFloat"
-    gecko_inexhaustive="True"
+${helpers.predefined_type(
+    "float",
+    "Float",
+    "computed::Float::None",
+    initial_specified_value="specified::Float::None",
+    spec="https://drafts.csswg.org/css-box/#propdef-float",
+    animation_value_type="discrete",
+    needs_context=False,
+    flags="APPLIES_TO_FIRST_LETTER",
+    servo_restyle_damage="rebuild_and_reflow",
     gecko_ffi_name="mFloat"
-    flags="APPLIES_TO_FIRST_LETTER"
-    spec="https://drafts.csswg.org/css-box/#propdef-float"
-    servo_restyle_damage="rebuild_and_reflow"
->
-    impl ToComputedValue for SpecifiedValue {
-        type ComputedValue = computed_value::T;
-
-        #[inline]
-        fn to_computed_value(&self, context: &Context) -> computed_value::T {
-            let ltr = context.style().writing_mode.is_bidi_ltr();
-            // https://drafts.csswg.org/css-logical-props/#float-clear
-            match *self {
-                SpecifiedValue::InlineStart => {
-                    context.rule_cache_conditions.borrow_mut()
-                        .set_writing_mode_dependency(context.builder.writing_mode);
-                    if ltr {
-                        computed_value::T::Left
-                    } else {
-                        computed_value::T::Right
-                    }
-                }
-                SpecifiedValue::InlineEnd => {
-                    context.rule_cache_conditions.borrow_mut()
-                        .set_writing_mode_dependency(context.builder.writing_mode);
-                    if ltr {
-                        computed_value::T::Right
-                    } else {
-                        computed_value::T::Left
-                    }
-                }
-                % for value in "None Left Right".split():
-                    SpecifiedValue::${value} => computed_value::T::${value},
-                % endfor
-            }
-        }
-        #[inline]
-        fn from_computed_value(computed: &computed_value::T) -> SpecifiedValue {
-            match *computed {
-                % for value in "None Left Right".split():
-                    computed_value::T::${value} => SpecifiedValue::${value},
-                % endfor
-            }
-        }
-    }
-</%helpers:single_keyword>
+)}
 
 <%helpers:single_keyword
     name="clear"

--- a/components/style/values/computed/box.rs
+++ b/components/style/values/computed/box.rs
@@ -4,13 +4,14 @@
 
 //! Computed types for box properties.
 
-use values::computed::Number;
+use values::computed::{Context, Number, ToComputedValue};
 use values::computed::length::{LengthOrPercentage, NonNegativeLength};
 use values::generics::box_::AnimationIterationCount as GenericAnimationIterationCount;
 use values::generics::box_::Perspective as GenericPerspective;
 use values::generics::box_::VerticalAlign as GenericVerticalAlign;
 
 pub use values::specified::box_::{AnimationName, Contain, Display, OverflowClipBox};
+pub use values::specified::box_::Float as SpecifiedFloat;
 pub use values::specified::box_::{OverscrollBehavior, ScrollSnapType, TouchAction, TransitionProperty, WillChange};
 
 /// A computed value for the `vertical-align` property.
@@ -29,3 +30,56 @@ impl AnimationIterationCount {
 
 /// A computed value for the `perspective` property.
 pub type Perspective = GenericPerspective<NonNegativeLength>;
+
+#[allow(missing_docs)]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, MallocSizeOf, Parse, PartialEq,
+         SpecifiedValueInfo, ToCss)]
+/// A computed value for the `float` property.
+pub enum Float {
+    Left,
+    Right,
+    None
+}
+
+impl ToComputedValue for SpecifiedFloat {
+    type ComputedValue = Float;
+
+    #[inline]
+    fn to_computed_value(&self, context: &Context) -> Self::ComputedValue {
+        let ltr = context.style().writing_mode.is_bidi_ltr();
+        // https://drafts.csswg.org/css-logical-props/#float-clear
+        match *self {
+            SpecifiedFloat::InlineStart => {
+                context.rule_cache_conditions.borrow_mut()
+                    .set_writing_mode_dependency(context.builder.writing_mode);
+                if ltr {
+                    Float::Left
+                } else {
+                    Float::Right
+                }
+            },
+            SpecifiedFloat::InlineEnd => {
+                context.rule_cache_conditions.borrow_mut()
+                    .set_writing_mode_dependency(context.builder.writing_mode);
+                if ltr {
+                    Float::Right
+                } else {
+                    Float::Left
+                }
+            },
+            SpecifiedFloat::Left => Float::Left,
+            SpecifiedFloat::Right => Float::Right,
+            SpecifiedFloat::None => Float::None
+        }
+    }
+
+    #[inline]
+    fn from_computed_value(computed: &Self::ComputedValue) -> SpecifiedFloat {
+        match *computed {
+            Float::Left => SpecifiedFloat::Left,
+            Float::Right => SpecifiedFloat::Right,
+            Float::None => SpecifiedFloat::None
+        }
+    }
+}

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -43,6 +43,7 @@ pub use self::font::{FontFamily, FontLanguageOverride, FontStyle, FontVariantEas
 pub use self::font::{FontFeatureSettings, FontVariantLigatures, FontVariantNumeric};
 pub use self::font::{MozScriptLevel, MozScriptMinSize, MozScriptSizeMultiplier, XLang, XTextZoom};
 pub use self::box_::{AnimationIterationCount, AnimationName, Contain, Display, TransitionProperty};
+pub use self::box_::Float;
 pub use self::box_::{OverflowClipBox, OverscrollBehavior, Perspective};
 pub use self::box_::{ScrollSnapType, TouchAction, VerticalAlign, WillChange};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};

--- a/components/style/values/specified/box.rs
+++ b/components/style/values/specified/box.rs
@@ -828,3 +828,16 @@ impl TransitionProperty {
         })
     }
 }
+
+#[allow(missing_docs)]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Eq, Hash, MallocSizeOf, Parse, PartialEq,
+         SpecifiedValueInfo, ToCss)]
+pub enum Float {
+    Left,
+    Right,
+    None,
+    // https://drafts.csswg.org/css-logical-props/#float-clear
+    InlineStart,
+    InlineEnd
+}

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -38,6 +38,7 @@ pub use self::font::{FontFamily, FontLanguageOverride, FontStyle, FontVariantEas
 pub use self::font::{FontFeatureSettings, FontVariantLigatures, FontVariantNumeric};
 pub use self::font::{MozScriptLevel, MozScriptMinSize, MozScriptSizeMultiplier, XLang, XTextZoom};
 pub use self::box_::{AnimationIterationCount, AnimationName, Contain, Display};
+pub use self::box_::Float;
 pub use self::box_::{OverflowClipBox, OverscrollBehavior, Perspective};
 pub use self::box_::{ScrollSnapType, TouchAction, TransitionProperty, VerticalAlign, WillChange};
 pub use self::color::{Color, ColorPropertyValue, RGBAColor};


### PR DESCRIPTION
Hi, I am fairly new to Rust and this is my first contribution to a Rust project.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21130

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

I'm not sure if the approach with the two enums is good. Please let me know if this can be improved. 
Regarding the tests I'm unsure: `tests/wpt/web-platform-tests/css/css-display/display-contents-float-001.html` seems to fail already before this PR, (and the cause is maybe not related to the style property definition).

Also I would like to add some docs, is it allowed to use the descriptions from MDN (https://developer.mozilla.org/en-US/docs/Web/CSS/float).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21139)
<!-- Reviewable:end -->
