### PR TITLE
Add doc comments to specified `float` and `clear` CSS properties

### DIFF
--- a/components/style/values/specified/box.rs
+++ b/components/style/values/specified/box.rs
@@ -833,6 +833,7 @@ impl TransitionProperty {
 #[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Eq, Hash, MallocSizeOf, Parse, PartialEq,
          SpecifiedValueInfo, ToCss)]
+/// https://drafts.csswg.org/css-box/#propdef-float
 pub enum Float {
     Left,
     Right,
@@ -846,6 +847,7 @@ pub enum Float {
 #[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(Clone, Copy, Debug, Eq, Hash, MallocSizeOf, Parse, PartialEq,
          SpecifiedValueInfo, ToCss)]
+/// https://drafts.csswg.org/css-box/#propdef-clear
 pub enum Clear {
     None,
     Left,


### PR DESCRIPTION
As discussed in #21156. I also added the doc comment to `float`.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

No tests needed as this in only a doc change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21159)
<!-- Reviewable:end -->
