### PR TITLE
Add a no-op 'android-x86' set of Buildbot steps

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -159,6 +159,9 @@ android:
   - bash ./etc/ci/lockfile_changed.sh
   - python ./etc/ci/check_dynamic_symbols.py
 
+android-x86:
+  - echo FIXME To be filled in once Buildbot is configured
+
 android-nightly:
   - ./mach clean-nightlies --keep 3 --force
   - ./mach clean-cargo-cache --keep 3 --force


### PR DESCRIPTION
This seems to exist before we configure Buildbot to look for it. Actual compilation and testing steps will be added once Buildbot is configured to run them.

CC https://github.com/servo/servo/issues/21124, https://github.com/servo/servo/issues/21116.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21162)
<!-- Reviewable:end -->
