### PR TITLE
Avoid virtualenv conflicts when running nightly jobs

### DIFF
--- a/etc/ci/performance/test_perf.sh
+++ b/etc/ci/performance/test_perf.sh
@@ -39,8 +39,8 @@ fi
 # Make sure we're running with an up-to-date warc test repo
 git -C ${WARC_DIR} pull --progress
 
-virtualenv venv --python="$(which python3)"
-PS1="" source venv/bin/activate
+virtualenv venv ./perf-venv --python="$(which python3)"
+PS1="" source ./perf-venv/bin/activate
 # `PS1` must be defined before activating virtualenv
 pip install \
     "boto3>=1.4.0" \


### PR DESCRIPTION
To avoid the errors that appear in http://build.servo.org/builders/linux-nightly/builds/750, I'm trying to keep the regular mach virtualenv and the one used for test-perf separate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21167)
<!-- Reviewable:end -->
