### PR TITLE
Android: run ./mach package implicitly after ./mach build

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -164,7 +164,6 @@ android-x86:
   - ./mach clean-cargo-cache --keep 3 --force
   - ./etc/ci/bootstrap-android-and-accept-licences.sh
   - env --unset ANDROID_NDK --unset ANDROID_SDK ./mach build --target i686-linux-android --release
-  - env --unset ANDROID_NDK --unset ANDROID_SDK ./mach package --target i686-linux-android --release
   - env --unset ANDROID_NDK --unset ANDROID_SDK ./mach test-android-startup --release
   - bash ./etc/ci/lockfile_changed.sh
 

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -23,6 +23,7 @@ from mach.decorators import (
     CommandProvider,
     Command,
 )
+from mach.registrar import Registrar
 
 from servo.command_base import CommandBase, cd, call, check_call, BIN_SUFFIX
 from servo.util import host_triple
@@ -160,6 +161,9 @@ class MachCommands(CommandBase):
                      default=None,
                      action='store_true',
                      help='Build for Android')
+    @CommandArgument('--no-package',
+                     action='store_true',
+                     help='For Android, disable packaging into a .apk after building')
     @CommandArgument('--debug-mozjs',
                      default=None,
                      action='store_true',
@@ -177,7 +181,7 @@ class MachCommands(CommandBase):
                      action='store_true',
                      help='Enable debug assertions in release')
     def build(self, target=None, release=False, dev=False, jobs=None,
-              features=None, android=None, verbose=False, very_verbose=False,
+              features=None, android=None, no_package=False, verbose=False, very_verbose=False,
               debug_mozjs=False, params=None, with_debug_assertions=False):
 
         opts = params or []
@@ -357,6 +361,10 @@ class MachCommands(CommandBase):
 
         # Do some additional things if the build succeeded
         if status == 0:
+            if android and not no_package:
+                Registrar.dispatch("package", context=self.context,
+                                   release=release, dev=dev, target=target)
+
             if sys.platform == "win32":
                 servo_exe_dir = path.join(base_path, "debug" if dev else "release")
 


### PR DESCRIPTION
The result of `./mach build` for Android is a `.so` file that cannot be used on its own, so running build without package is presumably never useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21183)
<!-- Reviewable:end -->
