### PR TITLE
Make fetch() API use same-origin credentials by default

### DIFF
--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -106,7 +106,7 @@ impl Request {
                 // Step 5.5
                 fallback_mode = Some(NetTraitsRequestMode::CorsMode);
                 // Step 5.6
-                fallback_credentials = Some(NetTraitsRequestCredentials::Omit);
+                fallback_credentials = Some(NetTraitsRequestCredentials::CredentialsSameOrigin);
             }
             // Step 6
             RequestInfo::Request(ref input_request) => {

--- a/tests/wpt/metadata/fetch/api/request/request-init-003.sub.html.ini
+++ b/tests/wpt/metadata/fetch/api/request/request-init-003.sub.html.ini
@@ -1,4 +1,0 @@
-[request-init-003.sub.html]
-  [Check request values when initialized from url string]
-    expected: FAIL
-

--- a/tests/wpt/metadata/fetch/api/request/request-structure.html.ini
+++ b/tests/wpt/metadata/fetch/api/request/request-structure.html.ini
@@ -1,7 +1,4 @@
 [request-structure.html]
-  [Check credentials attribute]
-    expected: FAIL
-
   [Check isReloadNavigation attribute]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #21146 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21187)
<!-- Reviewable:end -->
