### PR TITLE
Disable tests for unsupported JS modules

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -77,6 +77,14 @@ skip: true
   skip: false
 [html]
   skip: false
+  [semantics]
+    skip: false
+    [scripting-1]
+      skip: false
+      [the-script-element]
+        skip: false
+        [module]
+          skip: true
 [js]
   skip: false
 [navigation-timing]


### PR DESCRIPTION
There's no point to running these since the all just time out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21203)
<!-- Reviewable:end -->
