### PR TITLE
Resume WPT syncing on mac builders.

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -68,6 +68,9 @@ mac-nightly:
   - env PKG_CONFIG_PATH=/usr/local/opt/zlib/lib/pkgconfig ./mach build --release
   - ./mach package --release
   - ./mach upload-nightly mac
+  - ./etc/ci/update-wpt-checkout fetch-and-update-expectations
+  - ./etc/ci/update-wpt-checkout open-pr
+  - ./etc/ci/update-wpt-checkout cleanup
 
 linux-rel-intermittent:
   - ./mach clean-nightlies --keep 3 --force
@@ -148,9 +151,6 @@ linux-nightly:
   - python3 ./etc/ci/performance/download_buildbot_timings.py --verbose
   - aws s3 sync --size-only --acl public-read ./etc/ci/performance/output s3://servo-perf
   - rm -rf ./python/_virtualenv
-  - ./etc/ci/update-wpt-checkout fetch-and-update-expectations
-  - ./etc/ci/update-wpt-checkout open-pr
-  - ./etc/ci/update-wpt-checkout cleanup
 
 android:
   - ./mach clean-nightlies --keep 3 --force


### PR DESCRIPTION
This reverts https://github.com/servo/servo/pull/21148 to avoid the virtualenv problems that come with using the linux builders.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21209)
<!-- Reviewable:end -->
