### PR TITLE
Add some support for WPT tests in an Android emulator through WebDriver

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -931,7 +931,12 @@ impl<Message, LTF, STF> Constellation<Message, LTF, STF>
             FromCompositorMsg::GetFocusTopLevelBrowsingContext(resp_chan) => {
                 let focus_browsing_context = self.focus_pipeline_id
                     .and_then(|pipeline_id| self.pipelines.get(&pipeline_id))
-                    .map(|pipeline| pipeline.top_level_browsing_context_id);
+                    .map(|pipeline| pipeline.top_level_browsing_context_id)
+                    .filter(|&top_level_browsing_context_id| {
+                        let browsing_context_id =
+                            BrowsingContextId::from(top_level_browsing_context_id);
+                        self.browsing_contexts.contains_key(&browsing_context_id)
+                    });
                 let _ = resp_chan.send(focus_browsing_context);
             }
             FromCompositorMsg::KeyEvent(ch, key, state, modifiers) => {

--- a/etc/run_in_headless_android_emulator.py
+++ b/etc/run_in_headless_android_emulator.py
@@ -139,6 +139,14 @@ def forward_webdriver(adb, args):
         check_call(adb + ["forward", port, port])
         sys.stderr.write("Forwarding WebDriver port %s to the emulator\n" % webdriver_port)
 
+    split = os.environ.get("EMULATOR_REVERSE_FORWARD_PORTS", "").split(",")
+    ports = [int(part) for part in split if part]
+    for port in ports:
+        port = "tcp:%s" % port
+        check_call(adb + ["reverse", port, port])
+    if ports:
+        sys.stderr.write("Reverse-forwarding ports %s\n" % ", ".join(map(str, ports)))
+
 
 def extract_arg(name, args):
     for _, arg in extract_args(name, args):

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -84,6 +84,7 @@ class ServoWebDriverBrowser(Browser):
         self.proc = None
         self.debug_info = debug_info
         self.hosts_path = write_hosts_file(server_config)
+        self.server_ports = server_config.ports if server_config else {}
         self.command = None
         self.user_stylesheets = user_stylesheets if user_stylesheets else []
 
@@ -94,6 +95,11 @@ class ServoWebDriverBrowser(Browser):
         env = os.environ.copy()
         env["HOST_FILE"] = self.hosts_path
         env["RUST_BACKTRACE"] = "1"
+        env["EMULATOR_REVERSE_FORWARD_PORTS"] = ",".join(
+            str(port)
+            for _protocol, ports in self.server_ports.items()
+            for port in ports
+        )
 
         debug_args, command = browser_command(
             self.binary,

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -38,6 +38,7 @@ def browser_kwargs(test_type, run_info_data, **kwargs):
     return {
         "binary": kwargs["binary"],
         "debug_info": kwargs["debug_info"],
+        "server_config": kwargs["config"],
         "user_stylesheets": kwargs.get("user_stylesheets"),
     }
 
@@ -73,14 +74,14 @@ class ServoWebDriverBrowser(Browser):
     used_ports = set()
 
     def __init__(self, logger, binary, debug_info=None, webdriver_host="127.0.0.1",
-                 user_stylesheets=None):
+                 server_config=None, user_stylesheets=None):
         Browser.__init__(self, logger)
         self.binary = binary
         self.webdriver_host = webdriver_host
         self.webdriver_port = None
         self.proc = None
         self.debug_info = debug_info
-        self.hosts_path = write_hosts_file()
+        self.hosts_path = write_hosts_file(server_config)
         self.command = None
         self.user_stylesheets = user_stylesheets if user_stylesheets else []
 
@@ -151,7 +152,7 @@ class ServoWebDriverBrowser(Browser):
 
     def cleanup(self):
         self.stop()
-        shutil.rmtree(os.path.dirname(self.hosts_file))
+        os.remove(self.hosts_path)
 
     def executor_browser(self):
         assert self.webdriver_port is not None

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -73,6 +73,7 @@ def write_hosts_file(config):
 
 class ServoWebDriverBrowser(Browser):
     used_ports = set()
+    init_timeout = 300  # Large timeout for cases where we're booting an Android emulator
 
     def __init__(self, logger, binary, debug_info=None, webdriver_host="127.0.0.1",
                  server_config=None, binary_args=None, user_stylesheets=None):
@@ -166,4 +167,5 @@ class ServoWebDriverBrowser(Browser):
     def executor_browser(self):
         assert self.webdriver_port is not None
         return ExecutorBrowser, {"webdriver_host": self.webdriver_host,
-                                 "webdriver_port": self.webdriver_port}
+                                 "webdriver_port": self.webdriver_port,
+                                 "init_timeout": self.init_timeout}

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -37,6 +37,7 @@ def check_args(**kwargs):
 def browser_kwargs(test_type, run_info_data, **kwargs):
     return {
         "binary": kwargs["binary"],
+        "binary_args": kwargs["binary_args"],
         "debug_info": kwargs["debug_info"],
         "server_config": kwargs["config"],
         "user_stylesheets": kwargs.get("user_stylesheets"),
@@ -74,9 +75,10 @@ class ServoWebDriverBrowser(Browser):
     used_ports = set()
 
     def __init__(self, logger, binary, debug_info=None, webdriver_host="127.0.0.1",
-                 server_config=None, user_stylesheets=None):
+                 server_config=None, binary_args=None, user_stylesheets=None):
         Browser.__init__(self, logger)
         self.binary = binary
+        self.binary_args = binary_args or []
         self.webdriver_host = webdriver_host
         self.webdriver_port = None
         self.proc = None
@@ -95,7 +97,7 @@ class ServoWebDriverBrowser(Browser):
 
         debug_args, command = browser_command(
             self.binary,
-            [
+            self.binary_args + [
                 "--hard-fail",
                 "--webdriver", str(self.webdriver_port),
                 "about:blank",

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -99,6 +99,7 @@ class ServoWebDriverBrowser(Browser):
             str(port)
             for _protocol, ports in self.server_ports.items()
             for port in ports
+            if port
         )
 
         debug_args, command = browser_command(

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -57,8 +57,8 @@ class ServoWebDriverProtocol(Protocol):
 
     def connect(self):
         """Connect to browser via WebDriver."""
-        # Largish timeout for the case where we're booting an Android emulator.
-        wait_for_service((self.host, self.port), timeout=120)
+        # Large timeout for the case where we're booting an Android emulator.
+        wait_for_service((self.host, self.port), timeout=300)
 
         self.session = webdriver.Session(self.host, self.port, extension=ServoCommandExtensions)
         self.session.start()

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -6,6 +6,7 @@ import time
 import traceback
 
 from .base import (Protocol,
+                   BaseProtocolPart,
                    RefTestExecutor,
                    RefTestImplementation,
                    TestharnessExecutor,
@@ -46,7 +47,23 @@ def do_delayed_imports():
             return self.session.send_command("POST", "servo/prefs/reset", body)
 
 
+class ServoBaseProtocolPart(BaseProtocolPart):
+    def execute_script(self, script, async=False):
+        pass
+
+    def set_timeout(self, timeout):
+        pass
+
+    def wait(self):
+        pass
+
+    def set_window(self, handle):
+        pass
+
+
 class ServoWebDriverProtocol(Protocol):
+    implements = [ServoBaseProtocolPart]
+
     def __init__(self, executor, browser, capabilities, **kwargs):
         do_delayed_imports()
         Protocol.__init__(self, executor, browser)

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -88,12 +88,12 @@ class ServoWebDriverProtocol(Protocol):
         self.capabilities = capabilities
         self.host = browser.webdriver_host
         self.port = browser.webdriver_port
+        self.init_timeout = browser.init_timeout
         self.session = None
 
     def connect(self):
         """Connect to browser via WebDriver."""
-        # Large timeout for the case where we're booting an Android emulator.
-        wait_for_service((self.host, self.port), timeout=300)
+        wait_for_service((self.host, self.port), timeout=self.init_timeout)
 
         self.session = webdriver.Session(self.host, self.port, extension=ServoCommandExtensions)
         self.session.start()

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -57,6 +57,9 @@ class ServoWebDriverProtocol(Protocol):
 
     def connect(self):
         """Connect to browser via WebDriver."""
+        # Largish timeout for the case where we're booting an Android emulator.
+        wait_for_service((self.host, self.port), timeout=120)
+
         self.session = webdriver.Session(self.host, self.port, extension=ServoCommandExtensions)
         self.session.start()
 

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -34,17 +34,35 @@ def do_delayed_imports():
         @webdriver.client.command
         def get_prefs(self, *prefs):
             body = {"prefs": list(prefs)}
-            return self.session.send_command("POST", "servo/prefs/get", body)
+            return self.session.send_session_command("POST", "servo/prefs/get", body)
 
         @webdriver.client.command
         def set_prefs(self, prefs):
             body = {"prefs": prefs}
-            return self.session.send_command("POST", "servo/prefs/set", body)
+            return self.session.send_session_command("POST", "servo/prefs/set", body)
 
         @webdriver.client.command
         def reset_prefs(self, *prefs):
             body = {"prefs": list(prefs)}
-            return self.session.send_command("POST", "servo/prefs/reset", body)
+            return self.session.send_session_command("POST", "servo/prefs/reset", body)
+
+        def change_prefs(self, old_prefs, new_prefs):
+            # Servo interprets reset with an empty list as reset everything
+            if old_prefs:
+                self.reset_prefs(*old_prefs.keys())
+            self.set_prefs({k: parse_pref_value(v) for k, v in new_prefs.items()})
+
+
+# See parse_pref_from_command_line() in components/config/opts.rs
+def parse_pref_value(value):
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    try:
+        return float(value)
+    except ValueError:
+        return value
 
 
 class ServoBaseProtocolPart(BaseProtocolPart):
@@ -110,11 +128,6 @@ class ServoWebDriverProtocol(Protocol):
             except Exception as e:
                 self.logger.error(traceback.format_exc(e))
                 break
-
-    def on_environment_change(self, old_environment, new_environment):
-        #Unset all the old prefs
-        self.session.extension.reset_prefs(*old_environment.get("prefs", {}).keys())
-        self.session.extension.set_prefs(new_environment.get("prefs", {}))
 
 
 class ServoWebDriverRun(object):
@@ -215,6 +228,12 @@ class ServoWebDriverTestharnessExecutor(TestharnessExecutor):
         session.back()
         return result
 
+    def on_environment_change(self, new_environment):
+        self.protocol.session.extension.change_prefs(
+            self.last_environment.get("prefs", {}),
+            new_environment.get("prefs", {})
+        )
+
 
 class TimeoutError(Exception):
     pass
@@ -281,3 +300,9 @@ class ServoWebDriverRefTestExecutor(RefTestExecutor):
         session.url = url
         session.execute_async_script(self.wait_script)
         return session.screenshot()
+
+    def on_environment_change(self, new_environment):
+        self.protocol.session.extension.change_prefs(
+            self.last_environment.get("prefs", {}),
+            new_environment.get("prefs", {})
+        )


### PR DESCRIPTION
This succeeds on my machine:

`./mach test-wpt --product servodriver --binary etc/run_in_headless_android_emulator.py --binary-arg servo-x86 --binary-arg target/i686-linux-android/release/servo.apk /_mozilla/mozilla/DOMParser.html`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21213)
<!-- Reviewable:end -->
