### PR TITLE
Null image source check for src, srcset and picture parent 

### DIFF
--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-img-element/null-image-source.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-img-element/null-image-source.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Null image source check for src, srcset and picture parent</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<img id="src_id" src="">
+<img id="srcset_id" srcset="">
+<picture><img id="parent_picture_id"></picture>
+<script>
+async_test(function(t) {
+    img = document.getElementById('src_id');
+    img.onerror = t.step_func(function(e) {
+        assert_equals(e.type, "error", "null image source check failed");
+        t.done();
+    });
+}, "img with empty src");
+
+async_test(function(t) {
+    img = document.getElementById('srcset_id');
+    img.onerror = t.unreached_func("empty srcset fires an error");
+    t.step_timeout(function() { t.done(); }, 2000);
+}, "img with empty srcset");
+
+async_test(function(t) {
+    img = document.getElementById('parent_picture_id');
+    img.onerror = t.unreached_func("null img with picture parent fires an error");
+    t.step_timeout(function() { t.done(); }, 2000);
+}, "img with picture parent");
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
---
This PR includes a test which checks for empty src, empty srcset and picture parent.
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21221 

<!-- Either: -->
- [x] These changes require tests and added

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21222)
<!-- Reviewable:end -->
