### PR TITLE
Enable MutationObserver by default.

### DIFF
--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -8,7 +8,7 @@
   "dom.gamepad.enabled": false,
   "dom.microdata.testing.enabled": true,
   "dom.mouseevent.which.enabled": false,
-  "dom.mutation_observer.enabled": false,
+  "dom.mutation_observer.enabled": true,
   "dom.permissions.enabled": false,
   "dom.permissions.testing.allowed_in_nonsecure_contexts": false,
   "dom.serviceworker.timeout_seconds": 60,

--- a/tests/wpt/metadata/css/cssom/css-style-attr-decl-block.html.ini
+++ b/tests/wpt/metadata/css/cssom/css-style-attr-decl-block.html.ini
@@ -1,7 +1,0 @@
-[css-style-attr-decl-block.html]
-  [Changes to CSS declaration block should queue mutation record for style attribute]
-    expected: FAIL
-
-  [Removing non-existing property or setting invalid value on CSS declaration block shouldn't queue mutation record]
-    expected: FAIL
-

--- a/tests/wpt/metadata/css/cssom/cssstyledeclaration-mutationrecord-001.html.ini
+++ b/tests/wpt/metadata/css/cssom/cssstyledeclaration-mutationrecord-001.html.ini
@@ -1,8 +1,0 @@
-[cssstyledeclaration-mutationrecord-001.html]
-  expected: ERROR
-  [CSSStyleDeclaration.setPropertyValue queues a mutation record, even if not mutated]
-    expected: NOTRUN
-
-  [CSSStyleDeclaration.setPropertyValue queues a mutation record when serialization is changed]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/css/cssom/cssstyledeclaration-mutationrecord-002.html.ini
+++ b/tests/wpt/metadata/css/cssom/cssstyledeclaration-mutationrecord-002.html.ini
@@ -1,5 +1,0 @@
-[cssstyledeclaration-mutationrecord-002.html]
-  expected: ERROR
-  [CSSStyleDeclaration.setPropertyValue doesn't queue a mutation record when setting invalid values]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/css/cssom/cssstyledeclaration-mutationrecord-003.html.ini
+++ b/tests/wpt/metadata/css/cssom/cssstyledeclaration-mutationrecord-003.html.ini
@@ -1,5 +1,0 @@
-[cssstyledeclaration-mutationrecord-003.html]
-  expected: ERROR
-  [CSSStyleDeclaration.removeProperty doesn't queue a mutation record when not actually removed, invoked from setPropertyValue]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/css/cssom/cssstyledeclaration-mutationrecord-004.html.ini
+++ b/tests/wpt/metadata/css/cssom/cssstyledeclaration-mutationrecord-004.html.ini
@@ -1,5 +1,0 @@
-[cssstyledeclaration-mutationrecord-004.html]
-  expected: ERROR
-  [CSSStyleDeclaration.removeProperty doesn't queue a mutation record when not actually removed]
-    expected: NOTRUN
-

--- a/tests/wpt/metadata/custom-elements/microtasks-and-constructors.html.ini
+++ b/tests/wpt/metadata/custom-elements/microtasks-and-constructors.html.ini
@@ -1,0 +1,9 @@
+[microtasks-and-constructors.html]
+  [Microtasks evaluate immediately when the stack is empty inside the parser]
+    expected: FAIL
+
+  [Microtasks evaluate immediately when the stack is empty inside the parser, causing the checks on no attributes to fail]
+    expected: FAIL
+
+  [Microtasks evaluate afterward when the stack is not empty using createElement()]
+    expected: FAIL

--- a/tests/wpt/metadata/html/webappapis/scripting/event-loops/task_microtask_ordering.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/event-loops/task_microtask_ordering.html.ini
@@ -1,6 +1,5 @@
 [task_microtask_ordering.html]
-  type: testharness
+  expected: TIMEOUT
   [Level 1 bossfight (synthetic click)]
-    expected: FAIL
-    bug: https://github.com/servo/servo/issues/1980
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events.html.ini
@@ -34,18 +34,6 @@
   [unhandledrejection: from Promise.reject, indirected through Promise.all]
     expected: TIMEOUT
 
-  [delayed handling: a microtask delay before attaching a handler prevents both events (Promise.reject-created promise)]
-    expected: FAIL
-
-  [delayed handling: a microtask delay before attaching a handler prevents both events (immediately-rejected new Promise-created promise)]
-    expected: FAIL
-
-  [delayed handling: a microtask delay before attaching the handler, and before rejecting the promise, indirected through Promise.all]
-    expected: FAIL
-
-  [microtask nesting: attaching a handler inside a combination of mutationObserverMicrotask + promise microtasks]
-    expected: FAIL
-
   [delayed handling: a nested-task delay before attaching a handler causes unhandledrejection]
     expected: TIMEOUT
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -65267,7 +65267,7 @@
    "testharness"
   ],
   "mozilla/interfaces.html": [
-   "365c76c771b3d79a671b04047923f5644efb9b93",
+   "079065a1870bb9d3f790e9e8a3e17417c7195204",
    "testharness"
   ],
   "mozilla/interfaces.js": [

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.html
@@ -152,6 +152,8 @@ test_interfaces([
   "MimeType",
   "MimeTypeArray",
   "MouseEvent",
+  "MutationObserver",
+  "MutationRecord",
   "NamedNodeMap",
   "Navigator",
   "Node",


### PR DESCRIPTION
All of the WebIDL APIs are implemented, so we might as well have it enabled by default now. I've filed https://github.com/servo/servo/issues/21233 for the remaining test failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21232)
<!-- Reviewable:end -->
