### PR TITLE
Adjust import path for WPT tests to accommodate upstream.

### DIFF
--- a/tests/wpt/run.py
+++ b/tests/wpt/run.py
@@ -22,7 +22,8 @@ def servo_path(*args):
 paths = {"include_manifest": wpt_path("include.ini"),
          "config": wpt_path("config.ini")}
 # Imports
-sys.path.append(wpt_path("web-platform-tests", "tools", "wptrunner"))
+sys.path.append(wpt_path("web-platform-tests", "tools"))
+import localpaths
 from wptrunner import wptrunner, wptcommandline
 
 

--- a/tests/wpt/run.py
+++ b/tests/wpt/run.py
@@ -23,7 +23,7 @@ paths = {"include_manifest": wpt_path("include.ini"),
          "config": wpt_path("config.ini")}
 # Imports
 sys.path.append(wpt_path("web-platform-tests", "tools"))
-import localpaths
+import localpaths  # noqa: flake8
 from wptrunner import wptrunner, wptcommandline
 
 


### PR DESCRIPTION
This should avoid the ongoing issues where new dependencies are vendored upstream and our setup throws exceptions when some code tries to import them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21244)
<!-- Reviewable:end -->
