### PR TITLE
Allow webgl tests using unit test harness to run to completion.

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -30472,6 +30472,11 @@
     [
      {}
     ]
+   ],
+   "webgl/tools/unit2.patch": [
+    [
+     {}
+    ]
    ]
   },
   "testharness": {
@@ -73039,7 +73044,7 @@
    "support"
   ],
   "webgl/conformance-1.0.3/conformance/more/unit.js": [
-   "e0d1158bdc411b87961a4c67abeb3dceed506008",
+   "82efd8b7a11d3ac344a3e1b563e99503f452226e",
    "support"
   ],
   "webgl/conformance-1.0.3/conformance/more/util.js": [
@@ -99147,7 +99152,7 @@
    "testharness"
   ],
   "webgl/tools/import-conformance-tests.py": [
-   "73e9fad27290f3f10246390fca47bfeb64bc86ec",
+   "9e5e82b781ef02299db6406754b7d1d8abeb3c54",
    "support"
   ],
   "webgl/tools/js-test-pre.patch": [
@@ -99164,6 +99169,10 @@
   ],
   "webgl/tools/unit.patch": [
    "1d3713862875b47ae9c07462e6962eb21e40e404",
+   "support"
+  ],
+  "webgl/tools/unit2.patch": [
+   "cdccf819e756a9443f2ccf41b393b76fe5c398e9",
    "support"
   ],
   "webgl/uniformMatrixNfv.html": [

--- a/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/more/conformance/quickCheckAPI-G_I.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/more/conformance/quickCheckAPI-G_I.html.ini
@@ -1,3 +1,0 @@
-[quickCheckAPI-G_I.html]
-  type: testharness
-  disabled: https://github.com/servo/servo/issues/10656

--- a/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/more/conformance/quickCheckAPI-S_V.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/more/conformance/quickCheckAPI-S_V.html.ini
@@ -1,3 +1,4 @@
 [quickCheckAPI-S_V.html]
   type: testharness
-  disabled: https://github.com/servo/servo/issues/10698
+  expected:
+    if os == "mac": CRASH

--- a/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/more/functions/copyTexSubImage2D.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/more/functions/copyTexSubImage2D.html.ini
@@ -1,0 +1,4 @@
+[copyTexSubImage2D.html]
+  [WebGL test #1: testRoundtrip]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/more/functions/readPixelsBadArgs.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/more/functions/readPixelsBadArgs.html.ini
@@ -1,0 +1,7 @@
+[readPixelsBadArgs.html]
+  [WebGL test #1: testReadPixelsSOPIMG]
+    expected: FAIL
+
+  [WebGL test #2: testReadPixelsSOPCanvas]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/more/functions/texImage2DHTML.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/more/functions/texImage2DHTML.html.ini
@@ -1,0 +1,4 @@
+[texImage2DHTML.html]
+  [WebGL test #1: testTexImage2DNonSOP]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/more/functions/texSubImage2DHTML.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/more/functions/texSubImage2DHTML.html.ini
@@ -1,0 +1,4 @@
+[texSubImage2DHTML.html]
+  [WebGL test #1: testTexImage2DNonSOP]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/more/glsl/uniformOutOfBounds.html.ini
+++ b/tests/wpt/mozilla/meta/webgl/conformance-1.0.3/conformance/more/glsl/uniformOutOfBounds.html.ini
@@ -1,3 +1,0 @@
-[uniformOutOfBounds.html]
-  type: testharness
-  disabled: https://github.com/servo/servo/issues/13662

--- a/tests/wpt/mozilla/tests/webgl/conformance-1.0.3/conformance/more/unit.js
+++ b/tests/wpt/mozilla/tests/webgl/conformance-1.0.3/conformance/more/unit.js
@@ -53,6 +53,10 @@ if (window.internals) {
   window.internals.settings.setWebGLErrorsToConsoleEnabled(false);
 }
 
+if (window.async_test) {
+    var __overall_test = async_test('Overall test');
+}
+
 /* -- end platform specific code --*/
 Tests = {
   autorun : true,
@@ -906,6 +910,9 @@ function reportTestResultsToHarness(success, msg) {
 function notifyFinishedToHarness() {
   if (window.parent.webglTestHarness) {
     window.parent.webglTestHarness.notifyFinished(window.location.pathname);
+  }
+  if (window.__overall_test) {
+    window.__overall_test.done();
   }
 }
 

--- a/tests/wpt/mozilla/tests/webgl/tools/import-conformance-tests.py
+++ b/tests/wpt/mozilla/tests/webgl/tools/import-conformance-tests.py
@@ -13,12 +13,14 @@ KHRONOS_REPO_URL = "https://github.com/KhronosGroup/WebGL.git"
 PATCHES_1X = [
     ("js-test-pre.patch", "resources/js-test-pre.js"),
     ("unit.patch", "conformance/more/unit.js"),
+    ("unit2.patch", "conformance/more/unit.js"),
     ("timeout.patch", None)
 ]
 # Patches for conformance tests 2.0.x
 PATCHES_2X = [
     ("js-test-pre2.patch", "js/js-test-pre.js"),
     ("unit.patch", "conformance/more/unit.js")
+    ("unit2.patch", "conformance/more/unit.js")
 ]
 
 # Fix for 'UnicodeDecodeError: 'ascii' codec can't decode byte'

--- a/tests/wpt/mozilla/tests/webgl/tools/unit2.patch
+++ b/tests/wpt/mozilla/tests/webgl/tools/unit2.patch
@@ -1,0 +1,25 @@
+diff --git a/conformance-suites/1.0.3/conformance/more/unit.js b/conformance-suits/1.0.3/conformance/more/unit.js
+index 742f8d7b9d..428c164699 100644
+--- a/conformance-suites/1.0.3/conformance/more/unit.js
++++ b/conformance-suites/1.0.3/conformance/more/unit.js
+@@ -53,6 +53,10 @@ if (window.internals) {
+   window.internals.settings.setWebGLErrorsToConsoleEnabled(false);
+ }
+
++if (window.async_test) {
++    var __overall_test = async_test('Overall test');
++}
++
+ /* -- end platform specific code --*/
+ Tests = {
+   autorun : true,
+@@ -907,6 +911,9 @@ function notifyFinishedToHarness() {
+   if (window.parent.webglTestHarness) {
+     window.parent.webglTestHarness.notifyFinished(window.location.pathname);
+   }
++  if (window.__overall_test) {
++    window.__overall_test.done();
++  }
+ }
+
+ function initTests() {


### PR DESCRIPTION
This is an equivalent change to https://github.com/servo/servo/pull/14962/commits/5af2603ec4f59f2bbabc8aa9d73deed29acf9492 that affects a subset of webgl tests that use a different test harness.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13662 fix #10656
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21249)
<!-- Reviewable:end -->
