### PR TITLE
Refactor winit key handling

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -367,10 +367,8 @@ impl<Window> Servo<Window> where Window: WindowMethods + 'static {
 
                 (EmbedderMsg::KeyEvent(ch, key, state, modified),
                  ShutdownState::NotShuttingDown) => {
-                    if state == KeyState::Pressed {
-                        let event = (top_level_browsing_context, EmbedderMsg::KeyEvent(ch, key, state, modified));
-                        self.embedder_events.push(event);
-                    }
+                    let event = (top_level_browsing_context, EmbedderMsg::KeyEvent(ch, key, state, modified));
+                    self.embedder_events.push(event);
                 },
 
                 (msg, ShutdownState::NotShuttingDown) => {

--- a/ports/servo/glutin_app/keyutils.rs
+++ b/ports/servo/glutin_app/keyutils.rs
@@ -329,23 +329,3 @@ pub fn is_printable(key_code: VirtualKeyCode) -> bool {
     }
 }
 
-/// Detect if given char is default ignorable in unicode
-/// http://www.unicode.org/L2/L2002/02368-default-ignorable.pdf
-pub fn is_identifier_ignorable(ch: &char) -> bool {
-    match *ch {
-        '\u{0000}'...'\u{0008}' | '\u{000E}'...'\u{001F}' |
-            '\u{007F}'...'\u{0084}' | '\u{0086}'...'\u{009F}' |
-            '\u{06DD}' | '\u{070F}' |
-            '\u{180B}'...'\u{180D}' | '\u{180E}' |
-            '\u{200C}'...'\u{200F}' |
-            '\u{202A}'...'\u{202E}' | '\u{2060}'...'\u{2063}' |
-            '\u{2064}'...'\u{2069}' | '\u{206A}'...'\u{206F}' |
-            '\u{FE00}'...'\u{FE0F}' | '\u{FEFF}' |
-            '\u{FFF0}'...'\u{FFF8}' | '\u{FFF9}'...'\u{FFFB}' |
-            '\u{1D173}'...'\u{1D17A}' | '\u{E0000}' |
-            '\u{E0001}' |
-            '\u{E0002}'...'\u{E001F}' | '\u{E0020}'...'\u{E007F}' |
-            '\u{E0080}'...'\u{E0FFF}' => true,
-        _ => false
-    }
-}

--- a/ports/servo/glutin_app/window.rs
+++ b/ports/servo/glutin_app/window.rs
@@ -412,29 +412,23 @@ impl Window {
     }
 
     fn handle_received_character(&self, ch: char) {
-        let modifiers = keyutils::winit_mods_to_script_mods(self.key_modifiers.get());
-        if keyutils::is_identifier_ignorable(&ch) {
-            return
-        }
-        if let Some(last_pressed_key) = self.last_pressed_key.get() {
-            let event = WindowEvent::KeyEvent(Some(ch), last_pressed_key, KeyState::Pressed, modifiers);
-            self.event_queue.borrow_mut().push(event);
+        let last_key = if let Some(key) = self.last_pressed_key.get() {
+            key
         } else {
-            // Only send the character if we can print it (by ignoring characters like backspace)
-            if !ch.is_control() {
-                match keyutils::char_to_script_key(ch) {
-                    Some(key) => {
-                        let event = WindowEvent::KeyEvent(Some(ch),
-                                                          key,
-                                                          KeyState::Pressed,
-                                                          modifiers);
-                        self.event_queue.borrow_mut().push(event);
-                    }
-                    None => {}
-                }
-            }
-        }
+            return;
+        };
+
         self.last_pressed_key.set(None);
+
+        let (key, ch) = if let Some(key) = keyutils::char_to_script_key(ch) {
+            (key, Some(ch))
+        } else {
+            (last_key, None)
+        };
+
+        let modifiers = keyutils::winit_mods_to_script_mods(self.key_modifiers.get());
+        let event = WindowEvent::KeyEvent(ch, key, KeyState::Pressed, modifiers);
+        self.event_queue.borrow_mut().push(event);
     }
 
     fn toggle_keyboard_modifiers(&self, virtual_key_code: VirtualKeyCode) {
@@ -459,13 +453,14 @@ impl Window {
                 ElementState::Pressed => KeyState::Pressed,
                 ElementState::Released => KeyState::Released,
             };
-            if element_state == ElementState::Pressed {
-                if keyutils::is_printable(virtual_key_code) {
-                    self.last_pressed_key.set(Some(key));
-                }
+            if element_state == ElementState::Pressed && keyutils::is_printable(virtual_key_code) {
+                // If pressed and printable, we expect a ReceivedCharacter event.
+                self.last_pressed_key.set(Some(key));
+            } else {
+                self.last_pressed_key.set(None);
+                let modifiers = keyutils::winit_mods_to_script_mods(self.key_modifiers.get());
+                self.event_queue.borrow_mut().push(WindowEvent::KeyEvent(None, key, state, modifiers));
             }
-            let modifiers = keyutils::winit_mods_to_script_mods(self.key_modifiers.get());
-            self.event_queue.borrow_mut().push(WindowEvent::KeyEvent(None, key, state, modifiers));
         }
     }
 


### PR DESCRIPTION
This should improve keys input on Linux and Windows.
Should fix #17146 and fix #21161

Tested Mac, Windows and Linux. Basic typing works, combo work, text navigation works. I hit some strange issues where sometimes the text would be displayed late, but I believe it is unrelated to this PR.

If we land that now, we will hit a regression on Mac, we need a winit update that includes https://github.com/tomaka/winit/pull/610.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21250)
<!-- Reviewable:end -->
