### PR TITLE
Use local android toolchain for dynamic symbol check.

### DIFF
--- a/etc/ci/check_dynamic_symbols.py
+++ b/etc/ci/check_dynamic_symbols.py
@@ -20,7 +20,7 @@ actual_symbols = set()
 
 objdump_output = subprocess.check_output([
     os.path.join(
-        os.environ['ANDROID_NDK'], 'toolchains', 'arm-linux-androideabi-4.9',
+        'android-toolchains', 'ndk', 'toolchains', 'arm-linux-androideabi-4.9',
         'prebuilt', 'linux-x86_64', 'bin', 'arm-linux-androideabi-objdump'),
     '-T',
     'target/armv7-linux-androideabi/debug/libservo.so']


### PR DESCRIPTION
Fixes https://github.com/servo/saltfs/issues/869 and unbreaks all of the android builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21275)
<!-- Reviewable:end -->
