### PR TITLE
Actually clean all build artifacts.

### DIFF
--- a/etc/ci/clean_build_artifacts.sh
+++ b/etc/ci/clean_build_artifacts.sh
@@ -8,4 +8,4 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-rm -rf target/{debug,release,doc}
+rm -rf target/


### PR DESCRIPTION
I forgot that the remove-build-directories script on saltfs and the cleanup script in etc/ci are completely separate things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21309)
<!-- Reviewable:end -->
