### PR TITLE
Improve rendering of transformed 2d paths

### DIFF
--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.scale.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.scale.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arcTo.scale.html]
-  type: testharness
-  [arcTo scales the curve, not just the control points]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.transformation.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.transformation.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arcTo.transformation.html]
-  type: testharness
-  [arcTo joins up to the last subpath point correctly]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.clip.unaffected.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.clip.unaffected.html.ini
@@ -1,5 +1,0 @@
-[2d.path.clip.unaffected.html]
-  type: testharness
-  [Canvas test: 2d.path.clip.unaffected]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.fill.closed.unaffected.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.fill.closed.unaffected.html.ini
@@ -1,5 +1,0 @@
-[2d.path.fill.closed.unaffected.html]
-  type: testharness
-  [Canvas test: 2d.path.fill.closed.unaffected]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.isPointInPath.transform.2.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.isPointInPath.transform.2.html.ini
@@ -1,5 +1,0 @@
-[2d.path.isPointInPath.transform.2.html]
-  type: testharness
-  [isPointInPath() handles transformations correctly]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.isPointInPath.transform.4.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.isPointInPath.transform.4.html.ini
@@ -1,5 +1,0 @@
-[2d.path.isPointInPath.transform.4.html]
-  type: testharness
-  [isPointInPath() handles transformations correctly]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.stroke.scale1.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.stroke.scale1.html.ini
@@ -1,5 +1,0 @@
-[2d.path.stroke.scale1.html]
-  type: testharness
-  [Stroke line widths are scaled by the current transformation matrix]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.stroke.unaffected.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.stroke.unaffected.html.ini
@@ -1,5 +1,0 @@
-[2d.path.stroke.unaffected.html]
-  type: testharness
-  [Stroking does not start a new path or subpath]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.transformation.basic.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.transformation.basic.html.ini
@@ -1,5 +1,0 @@
-[2d.path.transformation.basic.html]
-  type: testharness
-  [Canvas test: 2d.path.transformation.basic]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.transformation.changing.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.transformation.changing.html.ini
@@ -1,5 +1,0 @@
-[2d.path.transformation.changing.html]
-  type: testharness
-  [Transformations are applied while building paths, not when drawing]
-    expected: FAIL
-


### PR DESCRIPTION
This makes http://webglreport.com/ render correctly by porting the [equivalent code](https://searchfox.org/mozilla-central/rev/196560b95f191b48ff7cba7c2ba9237bba6b5b6a/dom/canvas/CanvasRenderingContext2D.h#847-875) from Gecko's 2d canvas implementation that handles paths with transformations. The first commit fixes the rendering issue, and the second commit fixes some new test failures that were exposed by that change.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21169
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21310)
<!-- Reviewable:end -->
