### PR TITLE
Add --cap-lints warn to rustdoc script

### DIFF
--- a/etc/rustdoc-with-private
+++ b/etc/rustdoc-with-private
@@ -1,4 +1,7 @@
 #!/bin/sh
-# Skip the strip-private and strip-hidden rustdoc passes
-# https://github.com/rust-lang/rust/issues/15347
-rustdoc --no-defaults --passes collapse-docs --passes unindent-comments --passes strip-priv-imports "$@"
+# Emit documentation for private items so it is easier to look
+# up internal definitions.
+# 
+# Deny "deny warnings" to ensure documenting the crates
+# succeeds even if new warnings are introduced to the compiler.
+rustdoc -Z "unstable-options" --cap-lints warn --document-private-items "$@"


### PR DESCRIPTION
Use --document-private-items instead of
manually specifying passes as this is deprecated.

Closes #21179

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21345)
<!-- Reviewable:end -->
