### PR TITLE
Remove unused compositing dependency from bluetooth crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,6 @@ version = "0.0.1"
 dependencies = [
  "bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bluetooth_traits 0.0.1",
- "compositing 0.0.1",
  "device 0.0.1 (git+https://github.com/servo/devices)",
  "embedder_traits 0.0.1",
  "ipc-channel 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/bluetooth/Cargo.toml
+++ b/components/bluetooth/Cargo.toml
@@ -12,7 +12,6 @@ path = "lib.rs"
 [dependencies]
 bitflags = "1.0"
 bluetooth_traits = {path = "../bluetooth_traits"}
-compositing = {path = "../compositing"}
 device = {git = "https://github.com/servo/devices", features = ["bluetooth-test"]}
 embedder_traits = {path = "../embedder_traits"}
 ipc-channel = "0.10"


### PR DESCRIPTION
Closes #21176 

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21346)
<!-- Reviewable:end -->
