### PR TITLE
Replace Servo DL items with WR ones

### DIFF
--- a/tests/unit/metrics/paint_time.rs
+++ b/tests/unit/metrics/paint_time.rs
@@ -4,13 +4,13 @@
 
 use gfx_traits::Epoch;
 use ipc_channel::ipc;
-use layout::display_list::items::{BaseDisplayItem, DisplayItem, DisplayList, ImageDisplayItem};
+use layout::display_list::items::{BaseDisplayItem, CommonDisplayItem, DisplayItem, DisplayList};
 use metrics::{PaintTimeMetrics, ProfilerMetadataFactory, ProgressiveWebMetric};
 use msg::constellation_msg::TEST_PIPELINE_ID;
 use profile_traits::time::{ProfilerChan, TimerMetadata};
 use servo_url::ServoUrl;
 use time;
-use webrender_api::{ImageKey, ImageRendering, LayoutSize};
+use webrender_api::{AlphaType, ImageDisplayItem, ImageKey, ImageRendering, LayoutSize};
 
 struct DummyProfilerMetadataFactory {}
 impl ProfilerMetadataFactory for DummyProfilerMetadataFactory {
@@ -116,13 +116,16 @@ fn test_first_paint_setter() {
 
 #[test]
 fn test_first_contentful_paint_setter() {
-    let image = DisplayItem::Image(Box::new(ImageDisplayItem {
-        base: BaseDisplayItem::empty(),
-        id: ImageKey::DUMMY,
-        stretch_size: LayoutSize::zero(),
-        tile_spacing: LayoutSize::zero(),
-        image_rendering: ImageRendering::Auto,
-    }));
+    let image = DisplayItem::Image(CommonDisplayItem::new(
+        BaseDisplayItem::empty(),
+        ImageDisplayItem {
+            image_key: ImageKey::DUMMY,
+            stretch_size: LayoutSize::zero(),
+            tile_spacing: LayoutSize::zero(),
+            image_rendering: ImageRendering::Auto,
+            alpha_type: AlphaType::PremultipliedAlpha,
+        }
+    ));
     let display_list = DisplayList {
         list: vec![image],
         clip_scroll_nodes: Vec::new(),


### PR DESCRIPTION
The Servo internal display list items are already pretty much
equivalent to the WebRender ones. Except that Servo items contain
base information and associated glyphs and gradient stops which are
stored implicitly in WebRender. Remove the display items for
rectangles, text, images, border, gradients and box shadow and
replace them with their WebRender counter parts.

Some more internal items like line, text shadow and iframe can definitively be replaced with WebRender equivalents but I think the PR is already quite huge. If WebRender would expose a quite minimal API which allowed servo to directly push items onto the display list most of webrender_helpers boilerplate code could go away. As WebRender performs normalization of gradients this would need to be called by servo explicitly in this case.

It should be noted that gradient borders don't actually work neither with the old version nor with this PR as the measurements are all set to zero.

Part of #19676

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21348)
<!-- Reviewable:end -->
