### PR TITLE
fix(webgl): fix issue https://github.com/servo/servo/issues/21352

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -93,10 +93,9 @@ macro_rules! handle_object_deletion {
         if let Some(bound_object) = $binding.get() {
             if bound_object.id() == $object.id() {
                 $binding.set(None);
-            }
-
-            if let Some(command) = $unbind_command {
-                $self_.send_command(command);
+                if let Some(command) = $unbind_command {
+                    $self_.send_command(command);
+                }
             }
         }
     };


### PR DESCRIPTION
If we have a bounded framebuffer previously, which is not the one to delete.
we would not change the !binding, but we would change the GLSide with Command::BindFramebuffer(Default).

change it to: 

check the id before sending the Command


---

- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes fix #21352

- [ ] There are tests for these changes OR
- [x] These changes do not require tests because `it's obviously simple.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21353)
<!-- Reviewable:end -->
