### PR TITLE
Avoid crash when pressing stop button on Android

### DIFF
--- a/ports/libsimpleservo/src/api.rs
+++ b/ports/libsimpleservo/src/api.rs
@@ -194,6 +194,12 @@ impl ServoGlue {
         self.process_event(event)
     }
 
+    /// Stop loading the page.
+    pub fn stop(&mut self) -> Result<(), &'static str> {
+        debug!("TODO can't stop won't stop");
+        Ok(())
+    }
+
     /// Go back in history.
     pub fn go_back(&mut self) -> Result<(), &'static str> {
         debug!("go_back");

--- a/ports/libsimpleservo/src/capi.rs
+++ b/ports/libsimpleservo/src/capi.rs
@@ -139,6 +139,12 @@ pub extern "C" fn reload() {
 }
 
 #[no_mangle]
+pub extern "C" fn stop() {
+    debug!("stop");
+    call(|s| s.stop());
+}
+
+#[no_mangle]
 pub extern "C" fn go_back() {
     debug!("go_back");
     call(|s| s.go_back());

--- a/ports/libsimpleservo/src/jniapi.rs
+++ b/ports/libsimpleservo/src/jniapi.rs
@@ -140,6 +140,12 @@ pub fn Java_com_mozilla_servoview_JNIServo_reload(env: JNIEnv, _class: JClass) {
 }
 
 #[no_mangle]
+pub fn Java_com_mozilla_servoview_JNIServo_stop(env: JNIEnv, _class: JClass) {
+    debug!("stop");
+    call(env, |s| s.stop());
+}
+
+#[no_mangle]
 pub fn Java_com_mozilla_servoview_JNIServo_goBack(env: JNIEnv, _class: JClass) {
     debug!("goBack");
     call(env, |s| s.go_back());


### PR DESCRIPTION
This doesn't actually implement stopping; it just works around the crash that happens when you press it.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21328
- [x] These changes do not require tests because we have no tests for the android UI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21364)
<!-- Reviewable:end -->
