### PR TITLE
Avoid crash using freetype in debug android builds

### DIFF
--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -56,7 +56,7 @@ pub trait FontHandleMethods: Sized {
     ) -> Result<Self, ()>;
 
     fn template(&self) -> Arc<FontTemplateData>;
-    fn family_name(&self) -> String;
+    fn family_name(&self) -> Option<String>;
     fn face_name(&self) -> Option<String>;
 
     fn style(&self) -> font_style::T;
@@ -289,7 +289,8 @@ impl Font {
 
         debug!("{} font table[{}] with family={}, face={}",
                status, tag.tag_to_str(),
-               self.handle.family_name(), self.handle.face_name().unwrap_or("unavailable".to_owned()));
+               self.handle.family_name().unwrap_or("unavailable".to_owned()),
+               self.handle.face_name().unwrap_or("unavailable".to_owned()));
 
         result
     }

--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -148,9 +148,14 @@ impl FontHandleMethods for FontHandle {
         self.font_data.clone()
     }
 
-    fn family_name(&self) -> String {
+    fn family_name(&self) -> Option<String> {
         unsafe {
-            c_str_to_string((*self.face).family_name as *const c_char)
+            let family_name = (*self.face).family_name;
+            if !family_name.is_null() {
+                Some(c_str_to_string(family_name as *const c_char))
+            } else {
+                None
+            }
         }
     }
 

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -195,8 +195,8 @@ impl FontHandleMethods for FontHandle {
         self.font_data.clone()
     }
 
-    fn family_name(&self) -> String {
-        self.ctfont.family_name()
+    fn family_name(&self) -> Option<String> {
+        Some(self.ctfont.family_name())
     }
 
     fn face_name(&self) -> Option<String> {

--- a/components/gfx/platform/windows/font.rs
+++ b/components/gfx/platform/windows/font.rs
@@ -294,8 +294,8 @@ impl FontHandleMethods for FontHandle {
         self.font_data.clone()
     }
 
-    fn family_name(&self) -> String {
-        self.info.family_name.clone()
+    fn family_name(&self) -> Option<String> {
+        Some(self.info.family_name.clone())
     }
 
     fn face_name(&self) -> Option<String> {


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21327 
- [x] These changes do not require tests because this code is only executed in debug builds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21365)
<!-- Reviewable:end -->
