### PR TITLE
Start running simple wdspec tests

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -111,6 +111,12 @@ skip: true
   skip: false
 [WebCryptoAPI]
   skip: false
+[webdriver]
+  skip: true
+  [tests]
+    skip: true
+    [new_session]
+      skip: false
 [webgl]
   skip: false
 [webvr]

--- a/tests/wpt/metadata/webdriver/tests/new_session/create_alwaysMatch.py.ini
+++ b/tests/wpt/metadata/webdriver/tests/new_session/create_alwaysMatch.py.ini
@@ -1,0 +1,70 @@
+[create_alwaysMatch.py]
+  [test_valid[acceptInsecureCerts-False\]]
+    expected: FAIL
+
+  [test_valid[acceptInsecureCerts-None\]]
+    expected: FAIL
+
+  [test_valid[browserName-None\]]
+    expected: FAIL
+
+  [test_valid[browserVersion-None\]]
+    expected: FAIL
+
+  [test_valid[platformName-None\]]
+    expected: FAIL
+
+  [test_valid[pageLoadStrategy-none\]]
+    expected: FAIL
+
+  [test_valid[pageLoadStrategy-eager\]]
+    expected: FAIL
+
+  [test_valid[pageLoadStrategy-normal\]]
+    expected: FAIL
+
+  [test_valid[pageLoadStrategy-None\]]
+    expected: FAIL
+
+  [test_valid[proxy-None\]]
+    expected: FAIL
+
+  [test_valid[timeouts-value10\]]
+    expected: FAIL
+
+  [test_valid[timeouts-value11\]]
+    expected: FAIL
+
+  [test_valid[timeouts-value12\]]
+    expected: FAIL
+
+  [test_valid[timeouts-value13\]]
+    expected: FAIL
+
+  [test_valid[unhandledPromptBehavior-dismiss\]]
+    expected: FAIL
+
+  [test_valid[unhandledPromptBehavior-accept\]]
+    expected: FAIL
+
+  [test_valid[unhandledPromptBehavior-None\]]
+    expected: FAIL
+
+  [test_valid[test:extension-True\]]
+    expected: FAIL
+
+  [test_valid[test:extension-abc\]]
+    expected: FAIL
+
+  [test_valid[test:extension-123\]]
+    expected: FAIL
+
+  [test_valid[test:extension-value20\]]
+    expected: FAIL
+
+  [test_valid[test:extension-value21\]]
+    expected: FAIL
+
+  [test_valid[test:extension-None\]]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webdriver/tests/new_session/create_alwaysMatch.py.ini
+++ b/tests/wpt/metadata/webdriver/tests/new_session/create_alwaysMatch.py.ini
@@ -5,30 +5,6 @@
   [test_valid[acceptInsecureCerts-None\]]
     expected: FAIL
 
-  [test_valid[browserName-None\]]
-    expected: FAIL
-
-  [test_valid[browserVersion-None\]]
-    expected: FAIL
-
-  [test_valid[platformName-None\]]
-    expected: FAIL
-
-  [test_valid[pageLoadStrategy-none\]]
-    expected: FAIL
-
-  [test_valid[pageLoadStrategy-eager\]]
-    expected: FAIL
-
-  [test_valid[pageLoadStrategy-normal\]]
-    expected: FAIL
-
-  [test_valid[pageLoadStrategy-None\]]
-    expected: FAIL
-
-  [test_valid[proxy-None\]]
-    expected: FAIL
-
   [test_valid[timeouts-value10\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/webdriver/tests/new_session/create_firstMatch.py.ini
+++ b/tests/wpt/metadata/webdriver/tests/new_session/create_firstMatch.py.ini
@@ -1,0 +1,67 @@
+[create_firstMatch.py]
+  [test_valid[acceptInsecureCerts-None\]]
+    expected: FAIL
+
+  [test_valid[browserName-None\]]
+    expected: FAIL
+
+  [test_valid[browserVersion-None\]]
+    expected: FAIL
+
+  [test_valid[platformName-None\]]
+    expected: FAIL
+
+  [test_valid[pageLoadStrategy-none\]]
+    expected: FAIL
+
+  [test_valid[pageLoadStrategy-eager\]]
+    expected: FAIL
+
+  [test_valid[pageLoadStrategy-normal\]]
+    expected: FAIL
+
+  [test_valid[pageLoadStrategy-None\]]
+    expected: FAIL
+
+  [test_valid[proxy-None\]]
+    expected: FAIL
+
+  [test_valid[timeouts-value10\]]
+    expected: FAIL
+
+  [test_valid[timeouts-value11\]]
+    expected: FAIL
+
+  [test_valid[timeouts-value12\]]
+    expected: FAIL
+
+  [test_valid[timeouts-value13\]]
+    expected: FAIL
+
+  [test_valid[unhandledPromptBehavior-dismiss\]]
+    expected: FAIL
+
+  [test_valid[unhandledPromptBehavior-accept\]]
+    expected: FAIL
+
+  [test_valid[unhandledPromptBehavior-None\]]
+    expected: FAIL
+
+  [test_valid[test:extension-True\]]
+    expected: FAIL
+
+  [test_valid[test:extension-abc\]]
+    expected: FAIL
+
+  [test_valid[test:extension-123\]]
+    expected: FAIL
+
+  [test_valid[test:extension-value20\]]
+    expected: FAIL
+
+  [test_valid[test:extension-value21\]]
+    expected: FAIL
+
+  [test_valid[test:extension-None\]]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webdriver/tests/new_session/create_firstMatch.py.ini
+++ b/tests/wpt/metadata/webdriver/tests/new_session/create_firstMatch.py.ini
@@ -1,67 +1,7 @@
 [create_firstMatch.py]
+  [test_valid[acceptInsecureCerts-False\]]
+    expected: FAIL
+
   [test_valid[acceptInsecureCerts-None\]]
-    expected: FAIL
-
-  [test_valid[browserName-None\]]
-    expected: FAIL
-
-  [test_valid[browserVersion-None\]]
-    expected: FAIL
-
-  [test_valid[platformName-None\]]
-    expected: FAIL
-
-  [test_valid[pageLoadStrategy-none\]]
-    expected: FAIL
-
-  [test_valid[pageLoadStrategy-eager\]]
-    expected: FAIL
-
-  [test_valid[pageLoadStrategy-normal\]]
-    expected: FAIL
-
-  [test_valid[pageLoadStrategy-None\]]
-    expected: FAIL
-
-  [test_valid[proxy-None\]]
-    expected: FAIL
-
-  [test_valid[timeouts-value10\]]
-    expected: FAIL
-
-  [test_valid[timeouts-value11\]]
-    expected: FAIL
-
-  [test_valid[timeouts-value12\]]
-    expected: FAIL
-
-  [test_valid[timeouts-value13\]]
-    expected: FAIL
-
-  [test_valid[unhandledPromptBehavior-dismiss\]]
-    expected: FAIL
-
-  [test_valid[unhandledPromptBehavior-accept\]]
-    expected: FAIL
-
-  [test_valid[unhandledPromptBehavior-None\]]
-    expected: FAIL
-
-  [test_valid[test:extension-True\]]
-    expected: FAIL
-
-  [test_valid[test:extension-abc\]]
-    expected: FAIL
-
-  [test_valid[test:extension-123\]]
-    expected: FAIL
-
-  [test_valid[test:extension-value20\]]
-    expected: FAIL
-
-  [test_valid[test:extension-value21\]]
-    expected: FAIL
-
-  [test_valid[test:extension-None\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/webdriver/tests/new_session/default_values.py.ini
+++ b/tests/wpt/metadata/webdriver/tests/new_session/default_values.py.ini
@@ -1,0 +1,25 @@
+[default_values.py]
+  [test_basic]
+    expected: FAIL
+
+  [test_repeat_new_session]
+    expected: FAIL
+
+  [test_no_capabilites]
+    expected: FAIL
+
+  [test_missing_first_match]
+    expected: FAIL
+
+  [test_missing_always_match]
+    expected: FAIL
+
+  [test_desired]
+    expected: FAIL
+
+  [test_ignore_non_spec_fields_in_capabilities]
+    expected: FAIL
+
+  [test_valid_but_unmatchable_key]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webdriver/tests/new_session/default_values.py.ini
+++ b/tests/wpt/metadata/webdriver/tests/new_session/default_values.py.ini
@@ -5,9 +5,6 @@
   [test_repeat_new_session]
     expected: FAIL
 
-  [test_no_capabilites]
-    expected: FAIL
-
   [test_missing_first_match]
     expected: FAIL
 

--- a/tests/wpt/metadata/webdriver/tests/new_session/invalid_capabilities.py.ini
+++ b/tests/wpt/metadata/webdriver/tests/new_session/invalid_capabilities.py.ini
@@ -1,0 +1,553 @@
+[invalid_capabilities.py]
+  [test_invalid_values[acceptInsecureCerts-1-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[acceptInsecureCerts-1-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[acceptInsecureCerts-value1-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[acceptInsecureCerts-value1-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[acceptInsecureCerts-value2-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[acceptInsecureCerts-value2-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[acceptInsecureCerts-false-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[acceptInsecureCerts-false-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[browserName-1-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[browserName-1-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[browserName-value5-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[browserName-value5-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[browserName-value6-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[browserName-value6-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[browserName-False-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[browserName-False-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[browserVersion-1-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[browserVersion-1-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[browserVersion-value9-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[browserVersion-value9-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[browserVersion-value10-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[browserVersion-value10-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[browserVersion-False-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[browserVersion-False-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[platformName-1-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[platformName-1-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[platformName-value13-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[platformName-value13-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[platformName-value14-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[platformName-value14-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[platformName-False-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[platformName-False-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-1-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-1-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-value17-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-value17-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-value18-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-value18-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-False-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-False-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-invalid-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-invalid-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-NONE-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-NONE-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-Eager-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-Eager-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-eagerblah-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-eagerblah-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-interactive-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-interactive-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy- eager-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy- eager-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-eager -body0\]]
+    expected: FAIL
+
+  [test_invalid_values[pageLoadStrategy-eager -body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-1-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-1-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value28-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value28-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-{}-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-{}-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value30-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value30-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value31-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value31-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value32-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value32-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value33-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value33-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value34-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value34-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value35-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value35-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value36-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value36-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value37-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value37-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value38-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value38-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value39-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value39-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value40-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value40-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value41-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value41-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value42-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value42-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value43-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value43-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value44-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[proxy-value44-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-1-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-1-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value46-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value46-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-{}-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-{}-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-False-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-False-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value49-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value49-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value50-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value50-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value51-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value51-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value52-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value52-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value53-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value53-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value54-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value54-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value55-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value55-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value56-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value56-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value57-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value57-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value58-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value58-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value59-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value59-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value60-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value60-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value61-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[timeouts-value61-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-1-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-1-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-value63-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-value63-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-value64-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-value64-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-False-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-False-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-DISMISS-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-DISMISS-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-dismissABC-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-dismissABC-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-Accept-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-Accept-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior- dismiss-body0\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior- dismiss-body1\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-dismiss -body0\]]
+    expected: FAIL
+
+  [test_invalid_values[unhandledPromptBehavior-dismiss -body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[firefox-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[firefox-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[firefox_binary-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[firefox_binary-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[firefoxOptions-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[firefoxOptions-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[chromeOptions-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[chromeOptions-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[automaticInspection-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[automaticInspection-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[automaticProfiling-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[automaticProfiling-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[platform-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[platform-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[version-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[version-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[browser-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[browser-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[platformVersion-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[platformVersion-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[javascriptEnabled-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[javascriptEnabled-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[nativeEvents-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[nativeEvents-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[seleniumProtocol-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[seleniumProtocol-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[profile-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[profile-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[trustAllSSLCertificates-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[trustAllSSLCertificates-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[initialBrowserUrl-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[initialBrowserUrl-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[requireWindowFocus-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[requireWindowFocus-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[logFile-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[logFile-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[logLevel-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[logLevel-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[safari.options-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[safari.options-body1\]]
+    expected: FAIL
+
+  [test_invalid_extensions[ensureCleanSession-body0\]]
+    expected: FAIL
+
+  [test_invalid_extensions[ensureCleanSession-body1\]]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webdriver/tests/new_session/merge.py.ini
+++ b/tests/wpt/metadata/webdriver/tests/new_session/merge.py.ini
@@ -1,0 +1,28 @@
+[merge.py]
+  [test_platform_name[body0\]]
+    expected: FAIL
+
+  [test_platform_name[body1\]]
+    expected: FAIL
+
+  [test_merge_invalid[acceptInsecureCerts-value0\]]
+    expected: FAIL
+
+  [test_merge_invalid[unhandledPromptBehavior-value1\]]
+    expected: FAIL
+
+  [test_merge_invalid[unhandledPromptBehavior-value2\]]
+    expected: FAIL
+
+  [test_merge_invalid[timeouts-value3\]]
+    expected: FAIL
+
+  [test_merge_invalid[timeouts-value4\]]
+    expected: FAIL
+
+  [test_merge_platformName]
+    expected: FAIL
+
+  [test_merge_browserName]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webdriver/tests/new_session/response.py.ini
+++ b/tests/wpt/metadata/webdriver/tests/new_session/response.py.ini
@@ -1,0 +1,13 @@
+[response.py]
+  [test_resp_capabilites]
+    expected: FAIL
+
+  [test_resp_data]
+    expected: FAIL
+
+  [test_timeouts]
+    expected: FAIL
+
+  [test_pageLoadStrategy]
+    expected: FAIL
+


### PR DESCRIPTION
We should validate our webdriver implementation using the tests that exist for that purpose. This change gets that ball rolling.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21370)
<!-- Reviewable:end -->
