### PR TITLE
Add rustfmt command to devenv commands

### DIFF
--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -228,7 +228,7 @@ class MachCommands(CommandBase):
 
         with cd(self.context.topdir):
             return self.call_rustup_run(["cargo", "fetch"], env=self.build_env())
-          
+
     @Command('rustfmt',
              description='Format the Rust code using Cargo fmt',
              category='devenv')
@@ -241,7 +241,7 @@ class MachCommands(CommandBase):
 
         with cd(self.context.topdir):
             return self.call_rustup_run(["cargo", "fmt", "--", directory], env=self.build_env())
-          
+
     @Command('ndk-stack',
              description='Invoke the ndk-stack tool with the expected symbol paths',
              category='devenv')

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -227,3 +227,16 @@ class MachCommands(CommandBase):
 
         with cd(self.context.topdir):
             return self.call_rustup_run(["cargo", "fetch"], env=self.build_env())
+
+    @Command('rustfmt',
+             description='Format the Rust code using Cargo fmt',
+             category='devenv')
+    @CommandArgument(
+        '--directory', '-d', default=None,
+        help='Command-line argument to specify the directory for formatting')
+    def rustfmt(self, directory=""):
+        if directory == "":
+            directory = self.context.topdir
+
+        with cd(self.context.topdir):
+            return self.call_rustup_run(["cargo", "fmt", "--", directory], env=self.build_env())


### PR DESCRIPTION
Added the rustfmt command to devenv commands which runs cargo fmt on a specified directory.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #21374 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they only included a simple command that was added to the devenv_commands python script.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21376)
<!-- Reviewable:end -->
