### PR TITLE
Android: Use info! instead of debug!

### DIFF
--- a/ports/libsimpleservo/src/api.rs
+++ b/ports/libsimpleservo/src/api.rs
@@ -190,7 +190,7 @@ impl ServoGlue {
 
     /// Load an URL. This needs to be a valid url.
     pub fn load_uri(&mut self, url: &str) -> Result<(), &'static str> {
-        debug!("load_uri: {}", url);
+        info!("load_uri: {}", url);
         ServoUrl::parse(url)
             .map_err(|_| "Can't parse URL")
             .and_then(|url| {
@@ -202,7 +202,7 @@ impl ServoGlue {
 
     /// Reload the page.
     pub fn reload(&mut self) -> Result<(), &'static str> {
-        debug!("reload");
+        info!("reload");
         let browser_id = self.get_browser_id()?;
         let event = WindowEvent::Reload(browser_id);
         self.process_event(event)
@@ -210,13 +210,13 @@ impl ServoGlue {
 
     /// Stop loading the page.
     pub fn stop(&mut self) -> Result<(), &'static str> {
-        debug!("TODO can't stop won't stop");
+        warn!("TODO can't stop won't stop");
         Ok(())
     }
 
     /// Go back in history.
     pub fn go_back(&mut self) -> Result<(), &'static str> {
-        debug!("go_back");
+        info!("go_back");
         let browser_id = self.get_browser_id()?;
         let event = WindowEvent::Navigation(browser_id, TraversalDirection::Back(1));
         self.process_event(event)
@@ -224,7 +224,7 @@ impl ServoGlue {
 
     /// Go forward in history.
     pub fn go_forward(&mut self) -> Result<(), &'static str> {
-        debug!("go_forward");
+        info!("go_forward");
         let browser_id = self.get_browser_id()?;
         let event = WindowEvent::Navigation(browser_id, TraversalDirection::Forward(1));
         self.process_event(event)
@@ -232,7 +232,7 @@ impl ServoGlue {
 
     /// Let Servo know that the window has been resized.
     pub fn resize(&mut self, width: u32, height: u32) -> Result<(), &'static str> {
-        debug!("resize");
+        info!("resize");
         self.callbacks.width.set(width);
         self.callbacks.height.set(height);
         self.process_event(WindowEvent::Resize)
@@ -464,7 +464,7 @@ impl resources::ResourceReaderMethods for ResourceReader {
             Resource::QuirksModeCSS => "quirks-mode.css",
             Resource::RippyPNG => "rippy.png",
         };
-        debug!("ResourceReader::read({})", file);
+        info!("ResourceReader::read({})", file);
         self.0.readfile(file)
     }
     fn sandbox_access_files_dirs(&self) -> Vec<PathBuf> {

--- a/ports/libsimpleservo/src/gl_glue.rs
+++ b/ports/libsimpleservo/src/gl_glue.rs
@@ -39,23 +39,25 @@ pub mod egl {
 
     #[cfg(target_os = "android")]
     pub fn init() -> Result<Rc<Gl>, &'static str> {
-        debug!("init_egl");
+        info!("Loading EGL...");
         unsafe {
             let egl = Egl;
             let d = egl.GetCurrentDisplay();
             egl.SwapInterval(d, 1);
-            Ok(GlesFns::load_with(|addr| {
+            let egl = GlesFns::load_with(|addr| {
                 let addr = CString::new(addr.as_bytes()).unwrap();
                 let addr = addr.as_ptr();
                 let egl = Egl;
                 egl.GetProcAddress(addr) as *const c_void
-            }))
+            });
+            info!("EGL loaded");
+            Ok(egl)
         }
     }
 
     #[cfg(target_os = "windows")]
     pub fn init() -> Result<Rc<Gl>, &'static str> {
-        debug!("init_egl");
+        info!("Loading EGL...");
 
         let dll = b"libEGL.dll\0" as &[u8];
         let dll = unsafe { LoadLibraryA(dll.as_ptr() as *const _) };
@@ -63,11 +65,13 @@ pub mod egl {
             Err("Can't find libEGL.dll")
         } else {
             unsafe {
-                Ok(GlesFns::load_with(|addr| {
+                let egl = GlesFns::load_with(|addr| {
                     let addr = CString::new(addr.as_bytes()).unwrap();
                     let addr = addr.as_ptr();
                     GetProcAddress(dll, addr) as *const _
-                }))
+                });
+                info!("EGL loaded");
+                Ok(egl)
             }
         }
     }

--- a/ports/libsimpleservo/src/jniapi.rs
+++ b/ports/libsimpleservo/src/jniapi.rs
@@ -55,16 +55,20 @@ pub fn Java_com_mozilla_servoview_JNIServo_init(
     log: jboolean,
 ) {
     if log == JNI_TRUE {
+        // Note: Android debug logs are stripped from a release build.
+        // debug!() will only show in a debug build. Use info!() if logs
+        // should show up in adb logcat with a release build.
         android_logger::init_once(
             Filter::default()
                 .with_min_level(Level::Debug)
                 .with_allowed_module_path("simpleservo::api")
-                .with_allowed_module_path("simpleservo::jniapi"),
+                .with_allowed_module_path("simpleservo::jniapi")
+                .with_allowed_module_path("simpleservo::gl_glue::egl"),
             Some("simpleservo")
         );
     }
 
-    debug!("init");
+    info!("init");
 
     initialize_android_glue(&env, activity);
 


### PR DESCRIPTION
Fix #21390 

As explained in #21390, we are missing some important logs in release builds, and nightly is not available as a debug build for testers.

For the most important logs, let's use `info` instead of `debug`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21391)
<!-- Reviewable:end -->
