### PR TITLE
More gstreamer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ sudo apt install git curl autoconf libx11-dev \
     libssl1.0-dev libbz2-dev libosmesa6-dev libxmu6 libxmu-dev \
     libglu1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev \
     libharfbuzz-dev ccache clang \
-    libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+    libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev
 ```
 
 If you using a version prior to **Ubuntu 17.04** or **Debian Sid**, replace `libssl1.0-dev` with `libssl-dev`.


### PR DESCRIPTION
Was running into this issue:

```
error: failed to run custom build command for `gstreamer-player-sys v0.5.0`
process didn't exit successfully: `/home/paul/git/servo/target/debug/build/gstreamer-player-sys-3591c80c70153c3c/build-script-build` (exit code: 1)
--- stderr
`"pkg-config" "--libs" "--cflags" "gstreamer-player-1.0 >= 1.12"` did not exit successfully: exit code: 1
--- stderr
Package gstreamer-player-1.0 was not found in the pkg-config search path.
Perhaps you should add the directory containing `gstreamer-player-1.0.pc'
to the PKG_CONFIG_PATH environment variable
No package 'gstreamer-player-1.0' found
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21427)
<!-- Reviewable:end -->
