### PR TITLE
Format component allocator

### DIFF
--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -9,7 +9,6 @@ static ALLOC: Allocator = Allocator;
 
 pub use platform::*;
 
-
 #[cfg(not(windows))]
 mod platform {
     extern crate jemalloc_sys as ffi;
@@ -31,19 +30,31 @@ mod platform {
 
     // The minimum alignment guaranteed by the architecture. This value is used to
     // add fast paths for low alignment values.
-    #[cfg(all(any(target_arch = "arm",
-                  target_arch = "mips",
-                  target_arch = "mipsel",
-                  target_arch = "powerpc")))]
+    #[cfg(
+        all(
+            any(
+                target_arch = "arm",
+                target_arch = "mips",
+                target_arch = "mipsel",
+                target_arch = "powerpc"
+            )
+        )
+    )]
     const MIN_ALIGN: usize = 8;
-    #[cfg(all(any(target_arch = "x86",
-                  target_arch = "x86_64",
-                  target_arch = "aarch64",
-                  target_arch = "powerpc64",
-                  target_arch = "powerpc64le",
-                  target_arch = "mips64",
-                  target_arch = "s390x",
-                  target_arch = "sparc64")))]
+    #[cfg(
+        all(
+            any(
+                target_arch = "x86",
+                target_arch = "x86_64",
+                target_arch = "aarch64",
+                target_arch = "powerpc64",
+                target_arch = "powerpc64le",
+                target_arch = "mips64",
+                target_arch = "s390x",
+                target_arch = "sparc64"
+            )
+        )
+    )]
     const MIN_ALIGN: usize = 16;
 
     fn layout_to_flags(align: usize, size: usize) -> c_int {
@@ -84,10 +95,7 @@ mod platform {
         }
 
         #[inline]
-        unsafe fn realloc(&self,
-                          ptr: *mut u8,
-                          layout: Layout,
-                          new_size: usize) -> *mut u8 {
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
             let flags = layout_to_flags(layout.align(), new_size);
             ffi::rallocx(ptr as *mut _, new_size, flags) as *mut u8
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Format `components/allocator` with:

```bash
rustfmt components/allocator/*.rs
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors. Waiting for #21423 to be resolved.
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix a part of #21373.
- [x] These changes do not require tests because they format the code only.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21428)
<!-- Reviewable:end -->
