### PR TITLE
README: clarify Mac keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,8 @@ Run Servo with the command:
 
 - `Ctrl`+`-` zooms out
 - `Ctrl`+`=` zooms in
-- `Alt`+`left arrow` goes backwards in the history
-- `Alt`+`right arrow` goes forwards in the history
+- `Alt`+`left arrow` goes backwards in the history (`Cmd`+`left arrow` on Mac)
+- `Alt`+`right arrow` goes forwards in the history (`Cmd`+`right arrow` on Mac)
 - `Esc` exits servo
 
 ## Developing


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Add clarifications to the README's section on keyboard shortcuts for Mac users.

Relatedly, I couldn't get the zoom-related shortcuts to work at all on Mac; I tried each of `Ctrl`, `Opt`, and `Cmd` with `-` and `=` on a couple different webpages.  I can file a separate issue for that if it's warranted, or amend this PR to add a note to the README for this as well.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they only touch the README

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21447)
<!-- Reviewable:end -->
