### PR TITLE
Various webgl fixes for framebuffer attachment test

### DIFF
--- a/components/canvas/gl_context.rs
+++ b/components/canvas/gl_context.rs
@@ -11,7 +11,7 @@ use offscreen_gl_context::{GLLimits, GLVersion};
 use offscreen_gl_context::{NativeGLContext, NativeGLContextHandle, NativeGLContextMethods};
 use offscreen_gl_context::{OSMesaContext, OSMesaContextHandle};
 use std::sync::{Arc, Mutex};
-use super::webgl_thread::WebGLImpl;
+use super::webgl_thread::{WebGLImpl, GLState};
 
 /// The GLContextFactory is used to create shared GL contexts with the main thread GL context.
 /// Currently, shared textures are used to render WebGL textures into the WR compositor.
@@ -144,13 +144,13 @@ impl GLContextWrapper {
         }
     }
 
-    pub fn apply_command(&self, cmd: WebGLCommand) {
+    pub fn apply_command(&self, cmd: WebGLCommand, state: &mut GLState) {
         match *self {
             GLContextWrapper::Native(ref ctx) => {
-                WebGLImpl::apply(ctx, cmd);
+                WebGLImpl::apply(ctx, state, cmd);
             }
             GLContextWrapper::OSMesa(ref ctx) => {
-                WebGLImpl::apply(ctx, cmd);
+                WebGLImpl::apply(ctx, state, cmd);
             }
         }
     }

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -693,12 +693,31 @@ impl WebGLImpl {
                 ctx.gl().disable(cap),
             WebGLCommand::Enable(cap) =>
                 ctx.gl().enable(cap),
-            WebGLCommand::FramebufferRenderbuffer(target, attachment, renderbuffertarget, rb) =>
-                ctx.gl().framebuffer_renderbuffer(target, attachment, renderbuffertarget,
-                                                  rb.map_or(0, WebGLRenderbufferId::get)),
-            WebGLCommand::FramebufferTexture2D(target, attachment, textarget, texture, level) =>
-                ctx.gl().framebuffer_texture_2d(target, attachment, textarget,
-                                                texture.map_or(0, WebGLTextureId::get), level),
+            WebGLCommand::FramebufferRenderbuffer(target, attachment, renderbuffertarget, rb) => {
+                let attach = |attachment| {
+                    ctx.gl().framebuffer_renderbuffer(target, attachment,
+                                                      renderbuffertarget,
+                                                      rb.map_or(0, WebGLRenderbufferId::get))
+                };
+                if attachment == gl::DEPTH_STENCIL_ATTACHMENT {
+                    attach(gl::DEPTH_ATTACHMENT);
+                    attach(gl::STENCIL_ATTACHMENT);
+                } else {
+                    attach(attachment);
+                }
+            }
+            WebGLCommand::FramebufferTexture2D(target, attachment, textarget, texture, level) => {
+                let attach = |attachment| {
+                    ctx.gl().framebuffer_texture_2d(target, attachment, textarget,
+                                                    texture.map_or(0, WebGLTextureId::get), level)
+                };
+                if attachment == gl::DEPTH_STENCIL_ATTACHMENT {
+                    attach(gl::DEPTH_ATTACHMENT);
+                    attach(gl::STENCIL_ATTACHMENT);
+                } else {
+                    attach(attachment)
+                }
+            }
             WebGLCommand::FrontFace(mode) =>
                 ctx.gl().front_face(mode),
             WebGLCommand::DisableVertexAttribArray(attrib_id) =>

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -18,6 +18,33 @@ use webrender_api;
 /// It allows to get a WebGLThread handle for each script pipeline.
 pub use ::webgl_mode::WebGLThreads;
 
+struct GLContextData {
+    ctx: GLContextWrapper,
+    state: GLState,
+}
+
+pub struct GLState {
+    clear_color: (f32, f32, f32, f32),
+    scissor_test_enabled: bool,
+    stencil_write_mask: (u32, u32),
+    stencil_clear_value: i32,
+    depth_write_mask: bool,
+    depth_clear_value: f64,
+}
+
+impl Default for GLState {
+    fn default() -> GLState {
+        GLState {
+            clear_color: (0., 0., 0., 0.),
+            scissor_test_enabled: false,
+            stencil_write_mask: (0, 0),
+            stencil_clear_value: 0,
+            depth_write_mask: true,
+            depth_clear_value: 1.,
+        }
+    }
+}
+
 /// A WebGLThread manages the life cycle and message multiplexing of
 /// a set of WebGLContexts living in the same thread.
 pub struct WebGLThread<VR: WebVRRenderHandler + 'static, OB: WebGLThreadObserver> {
@@ -26,7 +53,7 @@ pub struct WebGLThread<VR: WebVRRenderHandler + 'static, OB: WebGLThreadObserver
     /// Channel used to generate/update or delete `webrender_api::ImageKey`s.
     webrender_api: webrender_api::RenderApi,
     /// Map of live WebGLContexts.
-    contexts: FnvHashMap<WebGLContextId, GLContextWrapper>,
+    contexts: FnvHashMap<WebGLContextId, GLContextData>,
     /// Cached information for WebGLContexts.
     cached_context_info: FnvHashMap<WebGLContextId, WebGLContextInfo>,
     /// Current bound context.
@@ -93,9 +120,9 @@ impl<VR: WebVRRenderHandler + 'static, OB: WebGLThreadObserver> WebGLThread<VR, 
             WebGLMsg::CreateContext(version, size, attributes, result_sender) => {
                 let result = self.create_webgl_context(version, size, attributes);
                 result_sender.send(result.map(|(id, limits, share_mode)| {
-                    let ctx = Self::make_current_if_needed(id, &self.contexts, &mut self.bound_context_id)
+                    let data = Self::make_current_if_needed(id, &self.contexts, &mut self.bound_context_id)
                                     .expect("WebGLContext not found");
-                    let glsl_version = Self::get_glsl_version(ctx);
+                    let glsl_version = Self::get_glsl_version(&data.ctx);
 
                     WebGLCreateContextResult {
                         sender: WebGLMsgSender::new(id, webgl_chan.clone()),
@@ -139,8 +166,9 @@ impl<VR: WebVRRenderHandler + 'static, OB: WebGLThreadObserver> WebGLThread<VR, 
 
     /// Handles a WebGLCommand for a specific WebGLContext
     fn handle_webgl_command(&mut self, context_id: WebGLContextId, command: WebGLCommand) {
-        if let Some(ctx) = Self::make_current_if_needed(context_id, &self.contexts, &mut self.bound_context_id) {
-            ctx.apply_command(command);
+        let data = Self::make_current_if_needed_mut(context_id, &mut self.contexts, &mut self.bound_context_id);
+        if let Some(data) = data {
+            data.ctx.apply_command(command, &mut data.state);
         }
     }
 
@@ -158,28 +186,28 @@ impl<VR: WebVRRenderHandler + 'static, OB: WebGLThreadObserver> WebGLThread<VR, 
 
     /// Handles a lock external callback received from webrender::ExternalImageHandler
     fn handle_lock(&mut self, context_id: WebGLContextId, sender: WebGLSender<(u32, Size2D<i32>, usize)>) {
-        let ctx = Self::make_current_if_needed(context_id, &self.contexts, &mut self.bound_context_id)
+        let data = Self::make_current_if_needed(context_id, &self.contexts, &mut self.bound_context_id)
                         .expect("WebGLContext not found in a WebGLMsg::Lock message");
         let info = self.cached_context_info.get_mut(&context_id).unwrap();
         // Insert a OpenGL Fence sync object that sends a signal when all the WebGL commands are finished.
         // The related gl().wait_sync call is performed in the WR thread. See WebGLExternalImageApi for mor details.
-        let gl_sync = ctx.gl().fence_sync(gl::SYNC_GPU_COMMANDS_COMPLETE, 0);
+        let gl_sync = data.ctx.gl().fence_sync(gl::SYNC_GPU_COMMANDS_COMPLETE, 0);
         info.gl_sync = Some(gl_sync);
         // It is important that the fence sync is properly flushed into the GPU's command queue.
         // Without proper flushing, the sync object may never be signaled.
-        ctx.gl().flush();
+        data.ctx.gl().flush();
 
         sender.send((info.texture_id, info.size, gl_sync as usize)).unwrap();
     }
 
     /// Handles an unlock external callback received from webrender::ExternalImageHandler
     fn handle_unlock(&mut self, context_id: WebGLContextId) {
-        let ctx = Self::make_current_if_needed(context_id, &self.contexts, &mut self.bound_context_id)
+        let data = Self::make_current_if_needed(context_id, &self.contexts, &mut self.bound_context_id)
                         .expect("WebGLContext not found in a WebGLMsg::Unlock message");
         let info = self.cached_context_info.get_mut(&context_id).unwrap();
         if let Some(gl_sync) = info.gl_sync.take() {
             // Release the GLSync object.
-            ctx.gl().delete_sync(gl_sync);
+            data.ctx.gl().delete_sync(gl_sync);
         }
     }
 
@@ -207,7 +235,10 @@ impl<VR: WebVRRenderHandler + 'static, OB: WebGLThreadObserver> WebGLThread<VR, 
                 let id = WebGLContextId(self.next_webgl_id);
                 let (size, texture_id, limits) = ctx.get_info();
                 self.next_webgl_id += 1;
-                self.contexts.insert(id, ctx);
+                self.contexts.insert(id, GLContextData {
+                    ctx,
+                    state: Default::default(),
+                });
                 self.cached_context_info.insert(id, WebGLContextInfo {
                     texture_id,
                     size,
@@ -232,10 +263,14 @@ impl<VR: WebVRRenderHandler + 'static, OB: WebGLThreadObserver> WebGLThread<VR, 
                             context_id: WebGLContextId,
                             size: Size2D<i32>,
                             sender: WebGLSender<Result<(), String>>) {
-        let ctx = Self::make_current_if_needed_mut(context_id, &mut self.contexts, &mut self.bound_context_id);
-        match ctx.resize(size) {
+        let data = Self::make_current_if_needed_mut(
+            context_id,
+            &mut self.contexts,
+            &mut self.bound_context_id
+        ).expect("Missing WebGL context!");
+        match data.ctx.resize(size) {
             Ok(_) => {
-                let (real_size, texture_id, _) = ctx.get_info();
+                let (real_size, texture_id, _) = data.ctx.get_info();
                 self.observer.on_context_resize(context_id, texture_id, real_size);
 
                 let info = self.cached_context_info.get_mut(&context_id).unwrap();
@@ -306,7 +341,7 @@ impl<VR: WebVRRenderHandler + 'static, OB: WebGLThreadObserver> WebGLThread<VR, 
                 })
             },
             WebGLContextShareMode::Readback => {
-                let pixels = Self::raw_pixels(&self.contexts[&context_id], info.size);
+                let pixels = Self::raw_pixels(&self.contexts[&context_id].ctx, info.size);
                 match info.image_key.clone() {
                     Some(image_key) => {
                         // ImageKey was already created, but WR Images must
@@ -339,18 +374,20 @@ impl<VR: WebVRRenderHandler + 'static, OB: WebGLThreadObserver> WebGLThread<VR, 
     fn handle_dom_to_texture(&mut self, command: DOMToTextureCommand) {
         match command {
             DOMToTextureCommand::Attach(context_id, texture_id, document_id, pipeline_id, size) => {
-                let ctx = Self::make_current_if_needed(context_id, &self.contexts, &mut self.bound_context_id)
+                let data = Self::make_current_if_needed(context_id, &self.contexts, &mut self.bound_context_id)
                                 .expect("WebGLContext not found in a WebGL DOMToTextureCommand::Attach command");
                 // Initialize the texture that WR will use for frame outputs.
-                ctx.gl().tex_image_2d(gl::TEXTURE_2D,
-                                      0,
-                                      gl::RGBA as gl::GLint,
-                                      size.width,
-                                      size.height,
-                                      0,
-                                      gl::RGBA,
-                                      gl::UNSIGNED_BYTE,
-                                      None);
+                data.ctx.gl().tex_image_2d(
+                    gl::TEXTURE_2D,
+                    0,
+                    gl::RGBA as gl::GLint,
+                    size.width,
+                    size.height,
+                    0,
+                    gl::RGBA,
+                    gl::UNSIGNED_BYTE,
+                    None
+                );
                 self.dom_outputs.insert(pipeline_id, DOMToTextureData {
                     context_id, texture_id, document_id, size
                 });
@@ -361,14 +398,14 @@ impl<VR: WebVRRenderHandler + 'static, OB: WebGLThreadObserver> WebGLThread<VR, 
             DOMToTextureCommand::Lock(pipeline_id, gl_sync, sender) => {
                 let contexts = &self.contexts;
                 let bound_context_id = &mut self.bound_context_id;
-                let result = self.dom_outputs.get(&pipeline_id).and_then(|data| {
-                    let ctx = Self::make_current_if_needed(data.context_id, contexts, bound_context_id);
-                    ctx.and_then(|ctx| {
+                let result = self.dom_outputs.get(&pipeline_id).and_then(|dom_data| {
+                    let data = Self::make_current_if_needed(dom_data.context_id, contexts, bound_context_id);
+                    data.and_then(|data| {
                         // The next glWaitSync call is used to synchronize the two flows of
                         // OpenGL commands (WR and WebGL) in order to avoid using semi-ready WR textures.
                         // glWaitSync doesn't block WebGL CPU thread.
-                        ctx.gl().wait_sync(gl_sync as gl::GLsync, 0, gl::TIMEOUT_IGNORED);
-                        Some((data.texture_id.get(), data.size))
+                        data.ctx.gl().wait_sync(gl_sync as gl::GLsync, 0, gl::TIMEOUT_IGNORED);
+                        Some((dom_data.texture_id.get(), dom_data.size))
                     })
                 });
 
@@ -390,28 +427,37 @@ impl<VR: WebVRRenderHandler + 'static, OB: WebGLThreadObserver> WebGLThread<VR, 
 
     /// Gets a reference to a GLContextWrapper for a given WebGLContextId and makes it current if required.
     fn make_current_if_needed<'a>(context_id: WebGLContextId,
-                                  contexts: &'a FnvHashMap<WebGLContextId, GLContextWrapper>,
-                                  bound_id: &mut Option<WebGLContextId>) -> Option<&'a GLContextWrapper> {
-        contexts.get(&context_id).and_then(|ctx| {
+                                  contexts: &'a FnvHashMap<WebGLContextId, GLContextData>,
+                                  bound_id: &mut Option<WebGLContextId>) -> Option<&'a GLContextData> {
+        let data = contexts.get(&context_id);
+
+        if let Some(data) = data {
             if Some(context_id) != *bound_id {
-                ctx.make_current();
+                data.ctx.make_current();
                 *bound_id = Some(context_id);
             }
+        }
 
-            Some(ctx)
-        })
+        data
     }
 
     /// Gets a mutable reference to a GLContextWrapper for a WebGLContextId and makes it current if required.
-    fn make_current_if_needed_mut<'a>(context_id: WebGLContextId,
-                                      contexts: &'a mut FnvHashMap<WebGLContextId, GLContextWrapper>,
-                                      bound_id: &mut Option<WebGLContextId>) -> &'a mut GLContextWrapper {
-        let ctx = contexts.get_mut(&context_id).expect("WebGLContext not found!");
-        if Some(context_id) != *bound_id {
-            ctx.make_current();
-            *bound_id = Some(context_id);
+    fn make_current_if_needed_mut<'a>(
+        context_id: WebGLContextId,
+        contexts: &'a mut FnvHashMap<WebGLContextId, GLContextData>,
+        bound_id: &mut Option<WebGLContextId>)
+        -> Option<&'a mut GLContextData>
+    {
+        let data = contexts.get_mut(&context_id);
+
+        if let Some(ref data) = data {
+            if Some(context_id) != *bound_id {
+                data.ctx.make_current();
+                *bound_id = Some(context_id);
+            }
         }
-        ctx
+
+        data
     }
 
     /// Creates a `webrender_api::ImageKey` that uses shared textures.
@@ -636,7 +682,11 @@ pub struct WebGLImpl;
 
 impl WebGLImpl {
     #[allow(unsafe_code)]
-    pub fn apply<Native: NativeGLContextMethods>(ctx: &GLContext<Native>, command: WebGLCommand) {
+    pub fn apply<Native: NativeGLContextMethods>(
+        ctx: &GLContext<Native>,
+        state: &mut GLState,
+        command: WebGLCommand
+    ) {
         match command {
             WebGLCommand::GetContextAttributes(ref sender) =>
                 sender.send(*ctx.borrow_attributes()).unwrap(),
@@ -667,13 +717,19 @@ impl WebGLImpl {
             },
             WebGLCommand::Clear(mask) =>
                 ctx.gl().clear(mask),
-            WebGLCommand::ClearColor(r, g, b, a) =>
-                ctx.gl().clear_color(r, g, b, a),
-            WebGLCommand::ClearDepth(depth) => {
-                ctx.gl().clear_depth(depth.max(0.).min(1.) as f64)
+            WebGLCommand::ClearColor(r, g, b, a) => {
+                state.clear_color = (r, g, b, a);
+                ctx.gl().clear_color(r, g, b, a);
             }
-            WebGLCommand::ClearStencil(stencil) =>
-                ctx.gl().clear_stencil(stencil),
+            WebGLCommand::ClearDepth(depth) => {
+                let value = depth.max(0.).min(1.) as f64;
+                state.depth_clear_value = value;
+                ctx.gl().clear_depth(value)
+            }
+            WebGLCommand::ClearStencil(stencil) => {
+                state.stencil_clear_value = stencil;
+                ctx.gl().clear_stencil(stencil);
+            }
             WebGLCommand::ColorMask(r, g, b, a) =>
                 ctx.gl().color_mask(r, g, b, a),
             WebGLCommand::CopyTexImage2D(target, level, internal_format, x, y, width, height, border) =>
@@ -684,15 +740,25 @@ impl WebGLImpl {
                 ctx.gl().cull_face(mode),
             WebGLCommand::DepthFunc(func) =>
                 ctx.gl().depth_func(func),
-            WebGLCommand::DepthMask(flag) =>
-                ctx.gl().depth_mask(flag),
+            WebGLCommand::DepthMask(flag) => {
+                state.depth_write_mask = flag;
+                ctx.gl().depth_mask(flag);
+            }
             WebGLCommand::DepthRange(near, far) => {
                 ctx.gl().depth_range(near.max(0.).min(1.) as f64, far.max(0.).min(1.) as f64)
             }
-            WebGLCommand::Disable(cap) =>
-                ctx.gl().disable(cap),
-            WebGLCommand::Enable(cap) =>
-                ctx.gl().enable(cap),
+            WebGLCommand::Disable(cap) => {
+                if cap == gl::SCISSOR_TEST {
+                    state.scissor_test_enabled = false;
+                }
+                ctx.gl().disable(cap);
+            }
+            WebGLCommand::Enable(cap) => {
+                if cap == gl::SCISSOR_TEST {
+                    state.scissor_test_enabled = true;
+                }
+                ctx.gl().enable(cap);
+            }
             WebGLCommand::FramebufferRenderbuffer(target, attachment, renderbuffertarget, rb) => {
                 let attach = |attachment| {
                     ctx.gl().framebuffer_renderbuffer(target, attachment,
@@ -745,10 +811,18 @@ impl WebGLImpl {
                 ctx.gl().stencil_func(func, ref_, mask),
             WebGLCommand::StencilFuncSeparate(face, func, ref_, mask) =>
                 ctx.gl().stencil_func_separate(face, func, ref_, mask),
-            WebGLCommand::StencilMask(mask) =>
-                ctx.gl().stencil_mask(mask),
-            WebGLCommand::StencilMaskSeparate(face, mask) =>
-                ctx.gl().stencil_mask_separate(face, mask),
+            WebGLCommand::StencilMask(mask) => {
+                state.stencil_write_mask = (mask, mask);
+                ctx.gl().stencil_mask(mask);
+            }
+            WebGLCommand::StencilMaskSeparate(face, mask) => {
+                if face == gl::FRONT {
+                    state.stencil_write_mask.0 = mask;
+                } else {
+                    state.stencil_write_mask.1 = mask;
+                }
+                ctx.gl().stencil_mask_separate(face, mask);
+            }
             WebGLCommand::StencilOp(fail, zfail, zpass) =>
                 ctx.gl().stencil_op(fail, zfail, zpass),
             WebGLCommand::StencilOpSeparate(face, fail, zfail, zpass) =>
@@ -1124,6 +1198,9 @@ impl WebGLImpl {
                 }
                 sender.send(value).unwrap();
             }
+            WebGLCommand::InitializeFramebuffer { color, depth, stencil } => {
+                Self::initialize_framebuffer(ctx.gl(), state, color, depth, stencil)
+            }
         }
 
         // TODO: update test expectations in order to enable debug assertions
@@ -1132,6 +1209,62 @@ impl WebGLImpl {
             error!("Last GL operation failed: {:?}", command)
         }
         assert_eq!(error, gl::NO_ERROR, "Unexpected WebGL error: 0x{:x} ({})", error, error);
+    }
+
+    fn initialize_framebuffer(
+        gl: &gl::Gl,
+        state: &GLState,
+        color: bool,
+        depth: bool,
+        stencil: bool,
+    ) {
+        let bits = [
+            (color, gl::COLOR_BUFFER_BIT),
+            (depth, gl::DEPTH_BUFFER_BIT),
+            (stencil, gl::STENCIL_BUFFER_BIT),
+        ].iter().fold(0, |bits, &(enabled, bit)| bits | if enabled { bit } else { 0 });
+
+        if state.scissor_test_enabled {
+            gl.disable(gl::SCISSOR_TEST);
+        }
+
+        if color {
+            gl.clear_color(0., 0., 0., 0.);
+        }
+
+        if depth {
+            gl.depth_mask(true);
+            gl.clear_depth(1.);
+        }
+
+        if stencil {
+            gl.stencil_mask_separate(gl::FRONT, 0xFFFFFFFF);
+            gl.stencil_mask_separate(gl::BACK, 0xFFFFFFFF);
+            gl.clear_stencil(0);
+        }
+
+        gl.clear(bits);
+
+        if state.scissor_test_enabled {
+            gl.enable(gl::SCISSOR_TEST);
+        }
+
+        if color {
+            let (r, g, b, a) = state.clear_color;
+            gl.clear_color(r, g, b, a);
+        }
+
+        if depth {
+            gl.depth_mask(state.depth_write_mask);
+            gl.clear_depth(state.depth_clear_value);
+        }
+
+        if stencil {
+            let (front, back) = state.stencil_write_mask;
+            gl.stencil_mask_separate(gl::FRONT, front);
+            gl.stencil_mask_separate(gl::BACK, back);
+            gl.clear_stencil(state.stencil_clear_value);
+        }
     }
 
     #[allow(unsafe_code)]

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -296,6 +296,7 @@ pub enum WebGLCommand {
     GetUniformFloat4(WebGLProgramId, i32, WebGLSender<[f32; 4]>),
     GetUniformFloat9(WebGLProgramId, i32, WebGLSender<[f32; 9]>),
     GetUniformFloat16(WebGLProgramId, i32, WebGLSender<[f32; 16]>),
+    InitializeFramebuffer { color: bool, depth: bool, stencil: bool },
 }
 
 macro_rules! define_resource_id_struct {

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -128,7 +128,7 @@ impl WebGLFramebuffer {
         let has_zs = zs.is_some();
         let attachments = [&*c, &*z, &*s, &*zs];
         let attachment_constraints = [
-            &[constants::RGBA4, constants::RGB5_A1, constants::RGB565][..],
+            &[constants::RGBA4, constants::RGB5_A1, constants::RGB565, constants::RGBA][..],
             &[constants::DEPTH_COMPONENT16][..],
             &[constants::STENCIL_INDEX8][..],
             &[constants::DEPTH_STENCIL][..],
@@ -162,7 +162,7 @@ impl WebGLFramebuffer {
                 }
                 Some(WebGLFramebufferAttachment::Texture { texture: ref att_tex, level } ) => {
                     let info = att_tex.image_info_at_face(0, level as u32);
-                    (info.data_type().map(|t| t.as_gl_constant()),
+                    (info.internal_format().map(|t| t.as_gl_constant()),
                      Some((info.width() as i32, info.height() as i32)))
                 }
                 None => (None, None),

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -66,7 +66,7 @@ impl WebGLFramebuffer {
             target: Cell::new(None),
             is_deleted: Cell::new(false),
             size: Cell::new(None),
-            status: Cell::new(constants::FRAMEBUFFER_UNSUPPORTED),
+            status: Cell::new(constants::FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT),
             color: DomRefCell::new(None),
             depth: DomRefCell::new(None),
             stencil: DomRefCell::new(None),
@@ -206,7 +206,7 @@ impl WebGLFramebuffer {
                 self.status.set(constants::FRAMEBUFFER_INCOMPLETE_ATTACHMENT);
             }
         } else {
-            self.status.set(constants::FRAMEBUFFER_UNSUPPORTED);
+            self.status.set(constants::FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT);
         }
     }
 

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -274,7 +274,7 @@ impl WebGLFramebuffer {
 
         let rb_id = match rb {
             Some(rb) => {
-                rb.attach(self);
+                rb.attach(self)?;
                 *binding.borrow_mut() = Some(WebGLFramebufferAttachment::Renderbuffer(Dom::from_ref(rb)));
                 Some(rb.id())
             }

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -203,6 +203,16 @@ impl WebGLFramebuffer {
         return self.status.get();
     }
 
+    pub fn check_status_for_rendering(&self) -> u32 {
+        let result = self.check_status();
+        if result == constants::FRAMEBUFFER_COMPLETE {
+            if self.color.borrow().is_none() {
+                return constants::FRAMEBUFFER_INCOMPLETE_ATTACHMENT;
+            }
+        }
+        result
+    }
+
     pub fn renderbuffer(&self, attachment: u32, rb: Option<&WebGLRenderbuffer>) -> WebGLResult<()> {
         let binding = match attachment {
             constants::COLOR_ATTACHMENT0 => &self.color,

--- a/components/script/dom/webglrenderbuffer.rs
+++ b/components/script/dom/webglrenderbuffer.rs
@@ -23,6 +23,7 @@ pub struct WebGLRenderbuffer {
     is_deleted: Cell<bool>,
     size: Cell<Option<(i32, i32)>>,
     internal_format: Cell<Option<u32>>,
+    is_initialized: Cell<bool>,
 }
 
 impl WebGLRenderbuffer {
@@ -34,6 +35,7 @@ impl WebGLRenderbuffer {
             is_deleted: Cell::new(false),
             internal_format: Cell::new(None),
             size: Cell::new(None),
+            is_initialized: Cell::new(false),
         }
     }
 
@@ -64,6 +66,14 @@ impl WebGLRenderbuffer {
 
     pub fn internal_format(&self) -> u32 {
         self.internal_format.get().unwrap_or(constants::RGBA4)
+    }
+
+    pub fn mark_initialized(&self) {
+        self.is_initialized.set(true);
+    }
+
+    pub fn is_initialized(&self) -> bool {
+        self.is_initialized.get()
     }
 
     pub fn bind(&self, target: u32) {

--- a/components/script/dom/webglrenderbuffer.rs
+++ b/components/script/dom/webglrenderbuffer.rs
@@ -174,8 +174,12 @@ impl WebGLRenderbuffer {
         Ok(())
     }
 
-    pub fn attach(&self, framebuffer: &WebGLFramebuffer) {
+    pub fn attach(&self, framebuffer: &WebGLFramebuffer) -> WebGLResult<()> {
+        if !self.ever_bound.get() {
+            return Err(WebGLError::InvalidOperation);
+        }
         self.attached_framebuffers.borrow_mut().push(Dom::from_ref(framebuffer));
+        Ok(())
     }
 
     pub fn unattach(&self, fb: &WebGLFramebuffer) {

--- a/components/script/dom/webglrenderbuffer.rs
+++ b/components/script/dom/webglrenderbuffer.rs
@@ -4,14 +4,12 @@
 
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use canvas_traits::webgl::{webgl_channel, WebGLCommand, WebGLError, WebGLRenderbufferId, WebGLResult};
-use dom::bindings::cell::DomRefCell;
 use dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as WebGl2Constants;
 use dom::bindings::codegen::Bindings::WebGLRenderbufferBinding;
 use dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextConstants as constants;
 use dom::bindings::inheritance::Castable;
 use dom::bindings::reflector::{DomObject, reflect_dom_object};
-use dom::bindings::root::{DomRoot, Dom};
-use dom::webglframebuffer::WebGLFramebuffer;
+use dom::bindings::root::DomRoot;
 use dom::webglobject::WebGLObject;
 use dom::webglrenderingcontext::{WebGLRenderingContext, is_gles};
 use dom_struct::dom_struct;
@@ -26,8 +24,6 @@ pub struct WebGLRenderbuffer {
     size: Cell<Option<(i32, i32)>>,
     internal_format: Cell<Option<u32>>,
     is_initialized: Cell<bool>,
-    // Framebuffer that this texture is attached to.
-    attached_framebuffers: DomRefCell<Vec<Dom<WebGLFramebuffer>>>,
 }
 
 impl WebGLRenderbuffer {
@@ -40,7 +36,6 @@ impl WebGLRenderbuffer {
             internal_format: Cell::new(None),
             size: Cell::new(None),
             is_initialized: Cell::new(false),
-            attached_framebuffers: Default::default(),
         }
     }
 
@@ -102,16 +97,9 @@ impl WebGLRenderbuffer {
             let currently_bound_framebuffer =
                 self.upcast::<WebGLObject>()
                     .context()
-                    .bound_framebuffer()
-                    .map_or(0, |fb| fb.id().get());
-            let current_framebuffer =
-                self.attached_framebuffers
-                    .borrow()
-                    .iter()
-                    .position(|fb| fb.id().get() == currently_bound_framebuffer);
-            if let Some(fb_index) = current_framebuffer {
-                self.attached_framebuffers.borrow()[fb_index].detach_renderbuffer(self);
-                self.attached_framebuffers.borrow_mut().remove(fb_index);
+                    .bound_framebuffer();
+            if let Some(fb) = currently_bound_framebuffer {
+                fb.detach_renderbuffer(self);
             }
 
             self.upcast::<WebGLObject>()
@@ -172,23 +160,5 @@ impl WebGLRenderbuffer {
         self.size.set(Some((width, height)));
 
         Ok(())
-    }
-
-    pub fn attach(&self, framebuffer: &WebGLFramebuffer) -> WebGLResult<()> {
-        if !self.ever_bound.get() {
-            return Err(WebGLError::InvalidOperation);
-        }
-        self.attached_framebuffers.borrow_mut().push(Dom::from_ref(framebuffer));
-        Ok(())
-    }
-
-    pub fn unattach(&self, fb: &WebGLFramebuffer) {
-        let mut attached_framebuffers = self.attached_framebuffers.borrow_mut();
-        let idx = attached_framebuffers.iter().position(|attached| {
-            attached.id() == fb.id()
-        });
-        if let Some(idx) = idx {
-            attached_framebuffers.remove(idx);
-        }
     }
 }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1061,6 +1061,17 @@ impl WebGLRenderingContext {
             _ => Err(InvalidEnum),
         }
     }
+
+    pub fn initialize_framebuffer(&self, clear_bits: u32) {
+        if clear_bits == 0 {
+            return;
+        }
+        self.send_command(WebGLCommand::InitializeFramebuffer {
+            color: clear_bits & constants::COLOR_BUFFER_BIT != 0,
+            depth: clear_bits & constants::DEPTH_BUFFER_BIT != 0,
+            stencil: clear_bits & constants::STENCIL_BUFFER_BIT != 0,
+        });
+    }
 }
 
 impl Drop for WebGLRenderingContext {
@@ -2727,10 +2738,12 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
     fn StencilMaskSeparate(&self, face: u32, mask: u32) {
         match face {
-            constants::FRONT | constants::BACK | constants::FRONT_AND_BACK =>
+            constants::FRONT |
+            constants::BACK |
+            constants::FRONT_AND_BACK =>
                 self.send_command(WebGLCommand::StencilMaskSeparate(face, mask)),
             _ => return self.webgl_error(InvalidEnum),
-        }
+        };
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1072,6 +1072,10 @@ impl WebGLRenderingContext {
             stencil: clear_bits & constants::STENCIL_BUFFER_BIT != 0,
         });
     }
+
+    pub fn bound_framebuffer(&self) -> Option<DomRoot<WebGLFramebuffer>> {
+        self.bound_framebuffer.get()
+    }
 }
 
 impl Drop for WebGLRenderingContext {
@@ -1587,6 +1591,10 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
                 renderbuffer.bind(target);
             }
             _ => {
+                if renderbuffer.is_some() {
+                    self.webgl_error(InvalidOperation);
+                }
+
                 self.bound_renderbuffer.set(None);
                 // Unbind the currently bound renderbuffer
                 self.send_command(WebGLCommand::BindRenderbuffer(target, None));
@@ -1986,20 +1994,6 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             handle_potential_webgl_error!(self, self.validate_ownership(renderbuffer), return);
             handle_object_deletion!(self, self.bound_renderbuffer, renderbuffer,
                                     Some(WebGLCommand::BindRenderbuffer(constants::RENDERBUFFER, None)));
-            // From the GLES 2.0.25 spec, page 113:
-            //
-            //     "If a renderbuffer object is deleted while its
-            //     image is attached to the currently bound
-            //     framebuffer, then it is as if
-            //     FramebufferRenderbuffer had been called, with a
-            //     renderbuffer of 0, for each attachment point to
-            //     which this image was attached in the currently
-            //     bound framebuffer."
-            //
-            if let Some(fb) = self.bound_framebuffer.get() {
-                fb.detach_renderbuffer(renderbuffer);
-            }
-
             renderbuffer.delete()
         }
     }
@@ -2033,18 +2027,6 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
                 self.send_command(WebGLCommand::ActiveTexture(
                     self.textures.active_unit_enum(),
                 ));
-            }
-
-            // From the GLES 2.0.25 spec, page 113:
-            //
-            //     "If a texture object is deleted while its image is
-            //      attached to the currently bound framebuffer, then
-            //      it is as if FramebufferTexture2D had been called,
-            //      with a texture of 0, for each attachment point to
-            //      which this image was attached in the currently
-            //      bound framebuffer."
-            if let Some(fb) = self.bound_framebuffer.get() {
-                fb.detach_texture(texture);
             }
 
             texture.delete()

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -39,7 +39,7 @@ use dom::webgl_validations::types::{TexDataType, TexFormat, TexImageTarget};
 use dom::webglactiveinfo::WebGLActiveInfo;
 use dom::webglbuffer::WebGLBuffer;
 use dom::webglcontextevent::WebGLContextEvent;
-use dom::webglframebuffer::{WebGLFramebuffer, WebGLFramebufferAttachmentRoot};
+use dom::webglframebuffer::{WebGLFramebuffer, WebGLFramebufferAttachmentRoot, CompleteForRendering};
 use dom::webglobject::WebGLObject;
 use dom::webglprogram::WebGLProgram;
 use dom::webglrenderbuffer::WebGLRenderbuffer;
@@ -339,10 +339,14 @@ impl WebGLRenderingContext {
     // this: clear() and getParameter(IMPLEMENTATION_COLOR_READ_*).
     fn validate_framebuffer(&self) -> WebGLResult<()> {
         match self.bound_framebuffer.get() {
-            Some(ref fb) if fb.check_status_for_rendering() != constants::FRAMEBUFFER_COMPLETE => {
-                Err(InvalidFramebufferOperation)
+            Some(fb) => match fb.check_status_for_rendering() {
+                CompleteForRendering::Complete => Ok(()),
+                CompleteForRendering::Incomplete =>
+                    Err(InvalidFramebufferOperation),
+                CompleteForRendering::MissingColorAttachment =>
+                    Err(InvalidOperation),
             },
-            _ => Ok(()),
+            None => Ok(()),
         }
     }
 

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -339,7 +339,7 @@ impl WebGLRenderingContext {
     // this: clear() and getParameter(IMPLEMENTATION_COLOR_READ_*).
     fn validate_framebuffer(&self) -> WebGLResult<()> {
         match self.bound_framebuffer.get() {
-            Some(ref fb) if fb.check_status() != constants::FRAMEBUFFER_COMPLETE => {
+            Some(ref fb) if fb.check_status_for_rendering() != constants::FRAMEBUFFER_COMPLETE => {
                 Err(InvalidFramebufferOperation)
             },
             _ => Ok(()),

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -146,7 +146,7 @@ impl WebGLTexture {
             }
         };
 
-        let base_image_info = self.base_image_info().unwrap();
+        let base_image_info = self.base_image_info();
         if !base_image_info.is_initialized() {
             return Err(WebGLError::InvalidOperation);
         }
@@ -327,7 +327,7 @@ impl WebGLTexture {
     fn is_cube_complete(&self) -> bool {
         debug_assert_eq!(self.face_count.get(), 6);
 
-        let image_info = self.base_image_info().unwrap();
+        let image_info = self.base_image_info();
         if !image_info.is_defined() {
             return false;
         }
@@ -389,10 +389,10 @@ impl WebGLTexture {
         self.image_info_array.borrow_mut()[pos as usize] = image_info;
     }
 
-    fn base_image_info(&self) -> Option<ImageInfo> {
+    fn base_image_info(&self) -> ImageInfo {
         assert!((self.base_mipmap_level as usize) < MAX_LEVEL_COUNT);
 
-        Some(self.image_info_at_face(0, self.base_mipmap_level))
+        self.image_info_at_face(0, self.base_mipmap_level)
     }
 
     pub fn set_attached_to_dom(&self) {

--- a/tests/wpt/webgl/meta/conformance/misc/webgl-specific-stencil-settings.html.ini
+++ b/tests/wpt/webgl/meta/conformance/misc/webgl-specific-stencil-settings.html.ini
@@ -1,2 +1,97 @@
 [webgl-specific-stencil-settings.html]
-  expected: CRASH
+  [WebGL test #623: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #642: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #565: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #611: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #555: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #629: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #513: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #584: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #578: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #620: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #614: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #650: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #488: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #543: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #501: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #590: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #2: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #534: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #632: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #494: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #626: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #537: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #658: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #507: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #571: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #5: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #546: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #549: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #667: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #540: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #552: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+
+  [WebGL test #617: getError expected: INVALID_OPERATION. Was NO_ERROR : after evaluating: wtu.dummySetProgramAndDrawNothing(gl)]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance/renderbuffers/framebuffer-object-attachment.html.ini
+++ b/tests/wpt/webgl/meta/conformance/renderbuffers/framebuffer-object-attachment.html.ini
@@ -1,12 +1,3 @@
 [framebuffer-object-attachment.html]
   [WebGL test #139: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
     expected: fail
-
-  [WebGL test #559: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After CopyTexSubImage2D from missing attachment]
-    expected: FAIL
-
-  [WebGL test #555: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After ReadPixels from missing attachment]
-    expected: FAIL
-
-  [WebGL test #557: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After CopyTexImage2D from missing attachment]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/renderbuffers/framebuffer-object-attachment.html.ini
+++ b/tests/wpt/webgl/meta/conformance/renderbuffers/framebuffer-object-attachment.html.ini
@@ -1,91 +1,43 @@
 [framebuffer-object-attachment.html]
-  [WebGL test #474: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+  [WebGL test #522: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
     expected: FAIL
 
-  [WebGL test #475: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+  [WebGL test #483: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
     expected: FAIL
 
-  [WebGL test #465: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+  [WebGL test #537: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
     expected: FAIL
 
-  [WebGL test #547: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After CopyTexSubImage2D from missing attachment]
+  [WebGL test #476: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
     expected: FAIL
 
-  [WebGL test #463: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+  [WebGL test #491: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
     expected: FAIL
 
-  [WebGL test #478: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+  [WebGL test #478: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
     expected: FAIL
 
-  [WebGL test #470: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+  [WebGL test #488: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
     expected: FAIL
 
-  [WebGL test #1: gl.checkFramebufferStatus(gl.FRAMEBUFFER) returned 36054]
+  [WebGL test #481: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
     expected: FAIL
 
-  [WebGL test #543: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After ReadPixels from missing attachment]
+  [WebGL test #486: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
     expected: FAIL
 
-  [WebGL test #2: gl.checkFramebufferStatus(gl.FRAMEBUFFER) returned 36054]
+  [WebGL test #559: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After CopyTexSubImage2D from missing attachment]
     expected: FAIL
 
-  [WebGL test #469: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+  [WebGL test #555: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After ReadPixels from missing attachment]
     expected: FAIL
 
-  [WebGL test #483: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : ]
+  [WebGL test #473: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
     expected: FAIL
 
-  [WebGL test #477: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+  [WebGL test #519: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
     expected: FAIL
 
-  [WebGL test #476: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : ]
-    expected: FAIL
-
-  [WebGL test #473: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
-    expected: FAIL
-
-  [WebGL test #467: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #468: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
-    expected: FAIL
-
-  [WebGL test #3: gl.checkFramebufferStatus(gl.FRAMEBUFFER) returned 36054]
-    expected: FAIL
-
-  [WebGL test #466: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : ]
-    expected: FAIL
-
-  [WebGL test #471: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : ]
-    expected: FAIL
-
-  [WebGL test #545: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After CopyTexImage2D from missing attachment]
-    expected: FAIL
-
-  [WebGL test #481: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : ]
-    expected: FAIL
-
-  [WebGL test #507: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
-    expected: FAIL
-
-  [WebGL test #482: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #510: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
-    expected: FAIL
-
-  [WebGL test #480: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
-    expected: FAIL
-
-  [WebGL test #472: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #479: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #464: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #525: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
+  [WebGL test #557: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After CopyTexImage2D from missing attachment]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance/renderbuffers/framebuffer-object-attachment.html.ini
+++ b/tests/wpt/webgl/meta/conformance/renderbuffers/framebuffer-object-attachment.html.ini
@@ -1,5 +1,91 @@
 [framebuffer-object-attachment.html]
-  expected: CRASH
-  [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #474: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #475: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+    expected: FAIL
+
+  [WebGL test #465: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+    expected: FAIL
+
+  [WebGL test #547: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After CopyTexSubImage2D from missing attachment]
+    expected: FAIL
+
+  [WebGL test #463: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+    expected: FAIL
+
+  [WebGL test #478: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+    expected: FAIL
+
+  [WebGL test #470: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+    expected: FAIL
+
+  [WebGL test #1: gl.checkFramebufferStatus(gl.FRAMEBUFFER) returned 36054]
+    expected: FAIL
+
+  [WebGL test #543: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After ReadPixels from missing attachment]
+    expected: FAIL
+
+  [WebGL test #2: gl.checkFramebufferStatus(gl.FRAMEBUFFER) returned 36054]
+    expected: FAIL
+
+  [WebGL test #469: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #483: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : ]
+    expected: FAIL
+
+  [WebGL test #477: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #476: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : ]
+    expected: FAIL
+
+  [WebGL test #473: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+    expected: FAIL
+
+  [WebGL test #467: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #468: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+    expected: FAIL
+
+  [WebGL test #3: gl.checkFramebufferStatus(gl.FRAMEBUFFER) returned 36054]
+    expected: FAIL
+
+  [WebGL test #466: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : ]
+    expected: FAIL
+
+  [WebGL test #471: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : ]
+    expected: FAIL
+
+  [WebGL test #545: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After CopyTexImage2D from missing attachment]
+    expected: FAIL
+
+  [WebGL test #481: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : ]
+    expected: FAIL
+
+  [WebGL test #507: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
+    expected: FAIL
+
+  [WebGL test #482: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #510: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
+    expected: FAIL
+
+  [WebGL test #480: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+    expected: FAIL
+
+  [WebGL test #472: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #479: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #464: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #525: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance/renderbuffers/framebuffer-object-attachment.html.ini
+++ b/tests/wpt/webgl/meta/conformance/renderbuffers/framebuffer-object-attachment.html.ini
@@ -1,29 +1,11 @@
 [framebuffer-object-attachment.html]
+  [WebGL test #139: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
+    expected: fail
+
   [WebGL test #522: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
     expected: FAIL
 
-  [WebGL test #483: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
   [WebGL test #537: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
-    expected: FAIL
-
-  [WebGL test #476: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
-    expected: FAIL
-
-  [WebGL test #491: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
-    expected: FAIL
-
-  [WebGL test #478: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #488: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #481: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
-    expected: FAIL
-
-  [WebGL test #486: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
     expected: FAIL
 
   [WebGL test #559: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After CopyTexSubImage2D from missing attachment]
@@ -32,12 +14,8 @@
   [WebGL test #555: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After ReadPixels from missing attachment]
     expected: FAIL
 
-  [WebGL test #473: at (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
   [WebGL test #519: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
     expected: FAIL
 
   [WebGL test #557: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After CopyTexImage2D from missing attachment]
     expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance/renderbuffers/framebuffer-object-attachment.html.ini
+++ b/tests/wpt/webgl/meta/conformance/renderbuffers/framebuffer-object-attachment.html.ini
@@ -1,3 +1,0 @@
-[framebuffer-object-attachment.html]
-  [WebGL test #139: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
-    expected: fail

--- a/tests/wpt/webgl/meta/conformance/renderbuffers/framebuffer-object-attachment.html.ini
+++ b/tests/wpt/webgl/meta/conformance/renderbuffers/framebuffer-object-attachment.html.ini
@@ -2,19 +2,10 @@
   [WebGL test #139: at (0, 0) expected: 0,255,0,255 was 255,0,0,255]
     expected: fail
 
-  [WebGL test #522: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
-    expected: FAIL
-
-  [WebGL test #537: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
-    expected: FAIL
-
   [WebGL test #559: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After CopyTexSubImage2D from missing attachment]
     expected: FAIL
 
   [WebGL test #555: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After ReadPixels from missing attachment]
-    expected: FAIL
-
-  [WebGL test #519: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT was FRAMEBUFFER_UNSUPPORTED or FRAMEBUFFER_UNSUPPORTED]
     expected: FAIL
 
   [WebGL test #557: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : After CopyTexImage2D from missing attachment]

--- a/tests/wpt/webgl/meta/conformance/textures/misc/copy-tex-image-2d-formats.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/misc/copy-tex-image-2d-formats.html.ini
@@ -26,3 +26,12 @@
   [WebGL test #16: Creating framebuffer from ALPHA texture succeeded even though it is not a renderable format]
     expected: FAIL
 
+  [WebGL test #32: getError expected: INVALID_OPERATION. Was NO_ERROR : should not be able to copyTexImage2D ALPHA from RGB]
+    expected: FAIL
+
+  [WebGL test #40: getError expected: INVALID_OPERATION. Was NO_ERROR : should not be able to copyTexImage2D RGBA from RGB]
+    expected: FAIL
+
+  [WebGL test #36: getError expected: INVALID_OPERATION. Was NO_ERROR : should not be able to copyTexImage2D LUMINANCE_ALPHA from RGB]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/framebuffer-object-attachment.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/framebuffer-object-attachment.html.ini
@@ -1,2 +1,31 @@
 [framebuffer-object-attachment.html]
-  expected: CRASH
+  [WebGL test #13: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
+    expected: FAIL
+
+  [WebGL test #20: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
+    expected: FAIL
+
+  [WebGL test #30: getError expected: NO_ERROR. Was INVALID_ENUM : ]
+    expected: FAIL
+
+  [WebGL test #21: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_UNSUPPORTED]
+    expected: FAIL
+
+  [WebGL test #25: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_UNSUPPORTED]
+    expected: FAIL
+
+  [WebGL test #23: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_UNSUPPORTED]
+    expected: FAIL
+
+  [WebGL test #24: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_UNSUPPORTED]
+    expected: FAIL
+
+  [WebGL test #22: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_UNSUPPORTED]
+    expected: FAIL
+
+  [WebGL test #14: getError expected: NO_ERROR. Was INVALID_ENUM : ]
+    expected: FAIL
+
+  [WebGL test #16: gl.getParameter(gl.RED_BITS) + gl.getParameter(gl.GREEN_BITS) + gl.getParameter(gl.BLUE_BITS) + gl.getParameter(gl.ALPHA_BITS) >= 16 should be true. Was false.]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/framebuffer-object-attachment.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/framebuffer-object-attachment.html.ini
@@ -29,3 +29,6 @@
   [WebGL test #16: gl.getParameter(gl.RED_BITS) + gl.getParameter(gl.GREEN_BITS) + gl.getParameter(gl.BLUE_BITS) + gl.getParameter(gl.ALPHA_BITS) >= 16 should be true. Was false.]
     expected: FAIL
 
+  [WebGL test #59: getError expected: NO_ERROR. Was INVALID_ENUM : Query should not generate error]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/rendering/framebuffer-texture-level1.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/framebuffer-texture-level1.html.ini
@@ -1,10 +1,10 @@
 [framebuffer-texture-level1.html]
-  [WebGL test #1: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36054. Was 36061.]
-    expected: FAIL
-
   [WebGL test #3: getError expected: NO_ERROR. Was INVALID_VALUE : Setup framebuffer with texture should succeed.]
     expected: FAIL
 
-  [WebGL test #2: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36061.]
+  [WebGL test #2: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36055.]
+    expected: FAIL
+
+  [WebGL test #1: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36054. Was 36055.]
     expected: FAIL
 


### PR DESCRIPTION
These changes resolve all panics on macOS when running framebuffer-object-attachment.html in headless and headful testing.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes OR
- [x] Fixes #13710. Fixes #20570.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21461)
<!-- Reviewable:end -->
