### PR TITLE
Add `autoconf` as required dependency for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Please select your operating system:
 #### On macOS (homebrew)
 
 ``` sh
-brew install automake pkg-config python cmake yasm
+brew install automake autoconf@2.13 pkg-config python cmake yasm
 brew install gstreamer gst-plugins-base gst-plugins-good       gst-plugins-bad gst-plugins-ugly gst-libav gst-rtsp-server       --with-orc -with-libogg --with-opus --with-pango --with-theora       --with-libvorbis
 pip install virtualenv
 ```


### PR DESCRIPTION
Update README

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21471 
- [x] These changes do not require tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21472)
<!-- Reviewable:end -->
