### PR TITLE
Handle wpt version number changes when updating the manifest.

### DIFF
--- a/tests/wpt/manifestupdate.py
+++ b/tests/wpt/manifestupdate.py
@@ -54,10 +54,14 @@ def update(logger, wpt_dir, check_clean=True, rebuild=False):
 def _update(logger, test_paths, rebuild):
     for url_base, paths in test_paths.iteritems():
         manifest_path = os.path.join(paths["metadata_path"], "MANIFEST.json")
-        if rebuild:
+        m = None
+        if not rebuild:
+            try:
+                m = manifest.manifest.load(paths["tests_path"], manifest_path)
+            except manifest.manifest.ManifestVersionMismatch:
+                logger.info("Manifest format changed, rebuilding")
+        if m is None:
             m = manifest.manifest.Manifest(url_base)
-        else:
-            m = manifest.manifest.load(paths["tests_path"], manifest_path)
         manifest.update.update(paths["tests_path"], m, working_copy=True)
         manifest.manifest.write(m, manifest_path)
     return 0


### PR DESCRIPTION
Based on https://phabricator.services.mozilla.com/D3771. This fixes https://github.com/web-platform-tests/wpt/issues/12589 and unbreaks the automated WPT sync.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21473)
<!-- Reviewable:end -->
