### PR TITLE
Remove outdated comment in stylist.rs

### DIFF
--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -824,9 +824,6 @@ impl Stylist {
     ///
     /// layout_parent_style is the style used for some property fixups.  It's
     /// the style of the nearest ancestor with a layout box.
-    ///
-    /// is_link should be true if we're computing style for a link; that affects
-    /// how :visited handling is done.
     pub fn cascade_style_and_visited<E>(
         &self,
         element: Option<E>,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This comment on `cascade_style_and_visited` is unclear because it refers to `is_link`, which is not a parameter of that function.  It used to refer to a flag in `CascadeFlags` back when there was a `cascade_flags: CascadeFlags` parameter; that parameter was removed in commit cd04664.  I don't believe it accurately reflects how the code works anymore, and is best just removed.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they only touch comments

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21487)
<!-- Reviewable:end -->
