### PR TITLE
Fix setup instructions for Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ sudo zypper install libX11-devel libexpat-devel libbz2-devel Mesa-libEGL-devel M
 
 ``` sh
 sudo pacman -S --needed base-devel git python2 python2-virtualenv python2-pip mesa cmake bzip2 libxmu glu \
-    pkg-config ttf-fira-sans harfbuzz ccache clang 
+    pkg-config ttf-fira-sans harfbuzz ccache clang autoconf2.13
 ```
 #### On Gentoo Linux
 


### PR DESCRIPTION
base-devel contains the last version of autoconf. However, some
dependencies of the project rely on autoconf 2.13. Without this change,
the build fails with the following message:

```
ERROR: Could not find autoconf 2.13

--- stderr
ERROR: Could not find autoconf 2.13
make: *** [makefile.cargo:143: maybe-configure] Error 1
thread 'main' panicked at 'assertion failed: result.success()', build.rs:110:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they just change documentation on how to build.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21540)
<!-- Reviewable:end -->
