### PR TITLE
#21467 : Process blob url in chunks instead of only at end

### DIFF
--- a/components/net/blob_loader.rs
+++ b/components/net/blob_loader.rs
@@ -2,25 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use fetch::methods::DoneChannel;
 use filemanager_thread::FileManager;
-use hyper::header::{Charset, ContentLength, ContentType, Headers};
-use hyper::header::{ContentDisposition, DispositionParam, DispositionType};
-use ipc_channel::ipc;
-use mime::{Attr, Mime};
 use net_traits::NetworkError;
 use net_traits::blob_url_store::parse_blob_url;
-use net_traits::filemanager_thread::ReadFileProgress;
+use net_traits::response::{Response, ResponseBody};
 use servo_url::ServoUrl;
+use std::sync::mpsc::channel;
 
 // TODO: Check on GET
 // https://w3c.github.io/FileAPI/#requestResponseModel
 
 /// https://fetch.spec.whatwg.org/#concept-basic-fetch (partial)
-// TODO: make async.
-pub fn load_blob_sync
+pub fn load_blob_async
             (url: ServoUrl,
-             filemanager: FileManager)
-             -> Result<(Headers, Vec<u8>), NetworkError> {
+             filemanager: FileManager,
+             response: &Response,
+             done_chan: &mut DoneChannel)
+             -> Result<(), NetworkError> {
     let (id, origin) = match parse_blob_url(&url) {
         Ok((id, origin)) => (id, origin),
         Err(()) => {
@@ -29,56 +28,11 @@ pub fn load_blob_sync
         }
     };
 
-    let (sender, receiver) = ipc::channel().unwrap();
+    let (sender, receiver) = channel();
+    *done_chan = Some((sender.clone(), receiver));
+    *response.body.lock().unwrap() = ResponseBody::Receiving(vec![]);
     let check_url_validity = true;
-    filemanager.read_file(sender, id, check_url_validity, origin);
+    filemanager.fetch_file(sender, id, check_url_validity, origin, response);
 
-    let blob_buf = match receiver.recv().unwrap() {
-        Ok(ReadFileProgress::Meta(blob_buf)) => blob_buf,
-        Ok(_) => {
-            return Err(NetworkError::Internal("Invalid filemanager reply".to_string()));
-        }
-        Err(e) => {
-            return Err(NetworkError::Internal(format!("{:?}", e)));
-        }
-    };
-
-    let content_type: Mime = blob_buf.type_string.parse().unwrap_or(mime!(Text / Plain));
-    let charset = content_type.get_param(Attr::Charset);
-
-    let mut headers = Headers::new();
-
-    if let Some(name) = blob_buf.filename {
-        let charset = charset.and_then(|c| c.as_str().parse().ok());
-        headers.set(ContentDisposition {
-            disposition: DispositionType::Inline,
-            parameters: vec![
-                DispositionParam::Filename(charset.unwrap_or(Charset::Us_Ascii),
-                                           None, name.as_bytes().to_vec())
-            ]
-        });
-    }
-
-    // Basic fetch, Step 4.
-    headers.set(ContentLength(blob_buf.size as u64));
-    // Basic fetch, Step 5.
-    headers.set(ContentType(content_type.clone()));
-
-    let mut bytes = blob_buf.bytes;
-    loop {
-        match receiver.recv().unwrap() {
-            Ok(ReadFileProgress::Partial(ref mut new_bytes)) => {
-                bytes.append(new_bytes);
-            }
-            Ok(ReadFileProgress::EOF) => {
-                return Ok((headers, bytes));
-            }
-            Ok(_) => {
-                return Err(NetworkError::Internal("Invalid filemanager reply".to_string()));
-            }
-            Err(e) => {
-                return Err(NetworkError::Internal(format!("{:?}", e)));
-            }
-        }
-    }
+    Ok(())
 }

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -552,12 +552,8 @@ fn scheme_fetch(request: &mut Request,
             if request.method != Method::Get {
                 return Response::network_error(NetworkError::Internal("Unexpected method for blob".into()));
             }
-
-            let mut response = Response::new(url);
-
-            load_blob_async(url.clone(), context.filemanager.clone(), &response, done_chan);
-
-            response
+            
+            load_blob_async(url.clone(), context.filemanager.clone(), done_chan)
         },
 
         "ftp" => {

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use blob_loader::load_blob_sync;
+use blob_loader::load_blob_async;
 use data_loader::decode;
 use devtools_traits::DevtoolsControlMsg;
 use fetch::cors_cache::CorsCache;
@@ -553,18 +553,11 @@ fn scheme_fetch(request: &mut Request,
                 return Response::network_error(NetworkError::Internal("Unexpected method for blob".into()));
             }
 
-            match load_blob_sync(url.clone(), context.filemanager.clone()) {
-                Ok((headers, bytes)) => {
-                    let mut response = Response::new(url);
-                    response.headers = headers;
-                    *response.body.lock().unwrap() = ResponseBody::Done(bytes);
-                    response
-                },
-                Err(e) => {
-                    debug!("Failed to load {}: {:?}", url, e);
-                    Response::network_error(e)
-                },
-            }
+            let mut response = Response::new(url);
+
+            load_blob_async(url.clone(), context.filemanager.clone(), &response, done_chan);
+
+            response
         },
 
         "ftp" => {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

I changed the way that load_blob_sync works so that it takes the target and processes incrementally on the blob_url as opposed to simply appending the bytes to a vec. I used the same ideas as specified in the comments of #21466 to determine the correct way to process incrementally and am passing the tests and checklist, but am not 100% sure this is the best or correct way to do this and any feedback would be greatly appreciated (it seems like too easy of a solution).

---
- [X ] `./mach build -d` does not report any errors
- [X ] `./mach test-tidy` does not report any errors
- [X (first pass I think this does) ] These changes fix #21467 (github issue number if applicable).

- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____
- [ X] What's the best way to bulletproof test this?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21553)
<!-- Reviewable:end -->
