### PR TITLE
Add task source name

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2837,7 +2837,14 @@ impl Document {
         let trusted_pending = Trusted::new(pending);
         let trusted_promise = TrustedPromise::new(promise.clone());
         let handler = ElementPerformFullscreenEnter::new(trusted_pending, trusted_promise, error);
-        let script_msg = CommonScriptMsg::Task(ScriptThreadEventCategory::EnterFullscreen, handler, pipeline_id);
+        // NOTE: This steps should be running in parallel
+        // https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen
+        let script_msg = CommonScriptMsg::Task(
+            ScriptThreadEventCategory::EnterFullscreen,
+            handler,
+            pipeline_id,
+            TaskSourceName::DOMManipulation,
+        );
         let msg = MainThreadScriptMsg::Common(script_msg);
         window.main_thread_script_chan().send(msg).unwrap();
 
@@ -2870,7 +2877,14 @@ impl Document {
         let trusted_promise = TrustedPromise::new(promise.clone());
         let handler = ElementPerformFullscreenExit::new(trusted_element, trusted_promise);
         let pipeline_id = Some(global.pipeline_id());
-        let script_msg = CommonScriptMsg::Task(ScriptThreadEventCategory::ExitFullscreen, handler, pipeline_id);
+        // NOTE: This steps should be running in parallel
+        // https://fullscreen.spec.whatwg.org/#exit-fullscreen
+        let script_msg = CommonScriptMsg::Task(
+            ScriptThreadEventCategory::ExitFullscreen,
+            handler,
+            pipeline_id,
+            TaskSourceName::DOMManipulation,
+        );
         let msg = MainThreadScriptMsg::Common(script_msg);
         window.main_thread_script_chan().send(msg).unwrap();
 

--- a/components/script/dom/vrdisplay.rs
+++ b/components/script/dom/vrdisplay.rs
@@ -42,6 +42,7 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::mpsc;
 use std::thread;
+use task_source::TaskSourceName;
 use webvr_traits::{WebVRDisplayData, WebVRDisplayEvent, WebVRFrameData, WebVRLayer, WebVRMsg};
 
 #[dom_struct]
@@ -517,7 +518,14 @@ impl VRDisplay {
                 let task = Box::new(task!(handle_vrdisplay_raf: move || {
                     this.root().handle_raf(&sender);
                 }));
-                js_sender.send(CommonScriptMsg::Task(WebVREvent, task, Some(pipeline_id))).unwrap();
+                // NOTE: WebVR spec doesn't specify what task source we should use. Is
+                // dom-manipulation a good choice long term?
+                js_sender.send(CommonScriptMsg::Task(
+                    WebVREvent,
+                    task,
+                    Some(pipeline_id),
+                    TaskSourceName::DOMManipulation,
+                )).unwrap();
 
                 // Run Sync Poses in parallell on Render thread
                 let msg = WebVRCommand::SyncPoses(display_id, near, far, sync_sender.clone());

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -268,7 +268,13 @@ impl WebSocket {
             let pipeline_id = self.global().pipeline_id();
             self.global()
                 .script_chan()
-                .send(CommonScriptMsg::Task(WebSocketEvent, task, Some(pipeline_id)))
+                // TODO: Use a dedicated `websocket-task-source` task source instead.
+                .send(CommonScriptMsg::Task(
+                    WebSocketEvent,
+                    task,
+                    Some(pipeline_id),
+                    TaskSourceName::Networking,
+                ))
                 .unwrap();
         }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1666,7 +1666,8 @@ impl Window {
                     let _ = self.script_chan.send(CommonScriptMsg::Task(
                         ScriptThreadEventCategory::DomEvent,
                         Box::new(self.task_canceller(TaskSourceName::DOMManipulation).wrap_task(task)),
-                        self.pipeline_id()
+                        self.pipeline_id(),
+                        TaskSourceName::DOMManipulation,
                     ));
                     doc.set_url(url.clone());
                     return
@@ -2123,7 +2124,8 @@ impl Window {
         let _ = self.script_chan.send(CommonScriptMsg::Task(
             ScriptThreadEventCategory::DomEvent,
             Box::new(self.task_canceller(TaskSourceName::DOMManipulation).wrap_task(task)),
-            self.pipeline_id()
+            self.pipeline_id(),
+            TaskSourceName::DOMManipulation,
         ));
     }
 }

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -397,7 +397,7 @@ impl WorkerGlobalScope {
 
     pub fn process_event(&self, msg: CommonScriptMsg) {
         match msg {
-            CommonScriptMsg::Task(_, task, _) => {
+            CommonScriptMsg::Task(_, task, _, _) => {
                 task.run_box()
             },
             CommonScriptMsg::CollectReports(reports_chan) => {

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -66,6 +66,7 @@ use style::thread_state::{self, ThreadState};
 use swapper::Swapper;
 use swapper::swapper;
 use task::TaskBox;
+use task_source::TaskSourceName;
 use uuid::Uuid;
 
 // Magic numbers
@@ -644,7 +645,14 @@ impl WorkletThread {
     where
         T: TaskBox + 'static,
     {
-        let msg = CommonScriptMsg::Task(ScriptThreadEventCategory::WorkletEvent, Box::new(task), None);
+        // NOTE: It's unclear which task source should be used here:
+        // https://drafts.css-houdini.org/worklets/#dom-worklet-addmodule
+        let msg = CommonScriptMsg::Task(
+            ScriptThreadEventCategory::WorkletEvent,
+            Box::new(task),
+            None,
+            TaskSourceName::DOMManipulation,
+        );
         let msg = MainThreadScriptMsg::Common(msg);
         self.global_init.to_script_thread_sender.send(msg).expect("Worklet thread outlived script thread.");
     }

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -43,6 +43,7 @@ use std::panic::AssertUnwindSafe;
 use std::ptr;
 use style::thread_state::{self, ThreadState};
 use task::TaskBox;
+use task_source::TaskSourceName;
 use time::{Tm, now};
 
 /// Common messages used to control the event loops in both the script and the worker
@@ -51,14 +52,14 @@ pub enum CommonScriptMsg {
     /// supplied channel.
     CollectReports(ReportsChan),
     /// Generic message that encapsulates event handling.
-    Task(ScriptThreadEventCategory, Box<TaskBox>, Option<PipelineId>),
+    Task(ScriptThreadEventCategory, Box<TaskBox>, Option<PipelineId>, TaskSourceName),
 }
 
 impl fmt::Debug for CommonScriptMsg {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             CommonScriptMsg::CollectReports(_) => write!(f, "CollectReports(...)"),
-            CommonScriptMsg::Task(ref category, ref task, _) => {
+            CommonScriptMsg::Task(ref category, ref task, _, _) => {
                 f.debug_tuple("Task").field(category).field(task).finish()
             },
         }

--- a/components/script/task_source/dom_manipulation.rs
+++ b/components/script/task_source/dom_manipulation.rs
@@ -27,7 +27,7 @@ impl fmt::Debug for DOMManipulationTaskSource {
 }
 
 impl TaskSource for DOMManipulationTaskSource {
-     const NAME: TaskSourceName = TaskSourceName::DOMManipulation;
+    const NAME: TaskSourceName = TaskSourceName::DOMManipulation;
 
     fn queue_with_canceller<T>(
         &self,
@@ -40,7 +40,8 @@ impl TaskSource for DOMManipulationTaskSource {
         let msg = MainThreadScriptMsg::Common(CommonScriptMsg::Task(
             ScriptThreadEventCategory::ScriptEvent,
             Box::new(canceller.wrap_task(task)),
-            Some(self.1)
+            Some(self.1),
+            DOMManipulationTaskSource::NAME,
         ));
         self.0.send(msg).map_err(|_| ())
     }

--- a/components/script/task_source/file_reading.rs
+++ b/components/script/task_source/file_reading.rs
@@ -34,6 +34,7 @@ impl TaskSource for FileReadingTaskSource {
             ScriptThreadEventCategory::FileRead,
             Box::new(canceller.wrap_task(task)),
             Some(self.1),
+            FileReadingTaskSource::NAME,
         ))
     }
 }

--- a/components/script/task_source/mod.rs
+++ b/components/script/task_source/mod.rs
@@ -20,7 +20,7 @@ use task::{TaskCanceller, TaskOnce};
 // Note: When adding a task source, update this enum.
 // Note: The HistoryTraversalTaskSource is not part of this,
 // because it doesn't implement TaskSource.
-#[derive(Eq, Hash, IntoEnumIterator, JSTraceable, PartialEq)]
+#[derive(Clone, Eq, Hash, IntoEnumIterator, JSTraceable, PartialEq)]
 pub enum TaskSourceName {
     DOMManipulation,
     FileReading,

--- a/components/script/task_source/networking.rs
+++ b/components/script/task_source/networking.rs
@@ -31,6 +31,7 @@ impl TaskSource for NetworkingTaskSource {
             ScriptThreadEventCategory::NetworkEvent,
             Box::new(canceller.wrap_task(task)),
             Some(self.1),
+            NetworkingTaskSource::NAME,
         ))
     }
 }
@@ -46,6 +47,7 @@ impl NetworkingTaskSource {
             ScriptThreadEventCategory::NetworkEvent,
             Box::new(task),
             Some(self.1),
+            NetworkingTaskSource::NAME,
         ))
     }
 }

--- a/components/script/task_source/performance_timeline.rs
+++ b/components/script/task_source/performance_timeline.rs
@@ -44,7 +44,8 @@ impl TaskSource for PerformanceTimelineTaskSource {
         let msg = CommonScriptMsg::Task(
             ScriptThreadEventCategory::PerformanceTimelineTask,
             Box::new(canceller.wrap_task(task)),
-            Some(self.1)
+            Some(self.1),
+            PerformanceTimelineTaskSource::NAME,
         );
         self.0.send(msg).map_err(|_| ())
     }

--- a/components/script/task_source/remote_event.rs
+++ b/components/script/task_source/remote_event.rs
@@ -31,6 +31,7 @@ impl TaskSource for RemoteEventTaskSource {
             ScriptThreadEventCategory::NetworkEvent,
             Box::new(canceller.wrap_task(task)),
             Some(self.1),
+            RemoteEventTaskSource::NAME,
         ))
     }
 }

--- a/components/script/task_source/user_interaction.rs
+++ b/components/script/task_source/user_interaction.rs
@@ -40,7 +40,8 @@ impl TaskSource for UserInteractionTaskSource {
         let msg = MainThreadScriptMsg::Common(CommonScriptMsg::Task(
             ScriptThreadEventCategory::InputEvent,
             Box::new(canceller.wrap_task(task)),
-            Some(self.1)
+            Some(self.1),
+            UserInteractionTaskSource::NAME,
         ));
         self.0.send(msg).map_err(|_| ())
     }


### PR DESCRIPTION
Refactor `CommonScriptMsg::Task` to include `TaskSourceName`.

Sorry for the delay, between doing this after work and the time I spent trying to ramp up on the project, it took me a bit longer than I expected.

Test still don't pass in local, but they fail the same way on master, so I guess it's ok.

I may have forgotten something, I refactored mostly the stuff that the compiler complained about. Please let me know if I missed anything.

I tried to dump my thought process on the commit messages, so feel free to go commit by commit to understand context.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21527

- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it's mostly refactor, no new behavior added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21583)
<!-- Reviewable:end -->
