### PR TITLE
Format components dom_struct, domobject_derive and embedder_traits #21373

### DIFF
--- a/components/dom_struct/lib.rs
+++ b/components/dom_struct/lib.rs
@@ -25,7 +25,6 @@ pub fn dom_struct(args: TokenStream, input: TokenStream) -> TokenStream {
     // Work around https://github.com/rust-lang/rust/issues/46489
     let attributes: TokenStream = attributes.to_string().parse().unwrap();
 
-
     let output: TokenStream = attributes.into_iter().chain(input.into_iter()).collect();
 
     let item: Item = syn::parse(output).unwrap();
@@ -36,7 +35,11 @@ pub fn dom_struct(args: TokenStream, input: TokenStream) -> TokenStream {
             return quote!(#s2).into();
         }
         if let Fields::Named(ref f) = s.fields {
-            let f = f.named.first().expect("Must have at least one field").into_value();
+            let f = f
+                .named
+                .first()
+                .expect("Must have at least one field")
+                .into_value();
             let ident = f.ident.as_ref().expect("Must have named fields");
             let name = &s.ident;
             let ty = &f.ty;

--- a/components/domobject_derive/lib.rs
+++ b/components/domobject_derive/lib.rs
@@ -5,8 +5,10 @@
 #![recursion_limit = "128"]
 
 extern crate proc_macro;
-#[macro_use] extern crate quote;
-#[macro_use] extern crate syn;
+#[macro_use]
+extern crate quote;
+#[macro_use]
+extern crate syn;
 
 #[proc_macro_derive(DomObject)]
 pub fn expand_token_stream(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -74,7 +76,9 @@ fn expand_dom_object(input: syn::DeriveInput) -> quote::Tokens {
     }));
 
     let mut generics = input.generics.clone();
-    generics.params.push(parse_quote!(__T: ::dom::bindings::reflector::DomObject));
+    generics
+        .params
+        .push(parse_quote!(__T: ::dom::bindings::reflector::DomObject));
 
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 

--- a/components/embedder_traits/lib.rs
+++ b/components/embedder_traits/lib.rs
@@ -24,9 +24,8 @@ use std::sync::mpsc::{Receiver, Sender};
 use style_traits::cursor::CursorKind;
 use webrender_api::{DeviceIntPoint, DeviceUintSize};
 
-
 /// Used to wake up the event loop, provided by the servo port/embedder.
-pub trait EventLoopWaker : 'static + Send {
+pub trait EventLoopWaker: 'static + Send {
     fn clone(&self) -> Box<EventLoopWaker + Send>;
     fn wake(&self);
 }
@@ -58,11 +57,13 @@ impl Clone for EmbedderProxy {
 
 /// The port that the embedder receives messages on.
 pub struct EmbedderReceiver {
-    pub receiver: Receiver<(Option<TopLevelBrowsingContextId>, EmbedderMsg)>
+    pub receiver: Receiver<(Option<TopLevelBrowsingContextId>, EmbedderMsg)>,
 }
 
 impl EmbedderReceiver {
-    pub fn try_recv_embedder_msg(&mut self) -> Option<(Option<TopLevelBrowsingContextId>, EmbedderMsg)> {
+    pub fn try_recv_embedder_msg(
+        &mut self,
+    ) -> Option<(Option<TopLevelBrowsingContextId>, EmbedderMsg)> {
         self.receiver.try_recv().ok()
     }
     pub fn recv_embedder_msg(&mut self) -> (Option<TopLevelBrowsingContextId>, EmbedderMsg) {
@@ -148,7 +149,7 @@ impl Debug for EmbedderMsg {
             EmbedderMsg::HideIME => write!(f, "HideIME"),
             EmbedderMsg::Shutdown => write!(f, "Shutdown"),
             EmbedderMsg::AllowOpeningBrowser(..) => write!(f, "AllowOpeningBrowser"),
-            EmbedderMsg::BrowserCreated(..) => write!(f, "BrowserCreated")
+            EmbedderMsg::BrowserCreated(..) => write!(f, "BrowserCreated"),
         }
     }
 }

--- a/components/embedder_traits/resources.rs
+++ b/components/embedder_traits/resources.rs
@@ -7,10 +7,12 @@ use std::sync::RwLock;
 
 lazy_static! {
     static ref RES: RwLock<Option<Box<ResourceReaderMethods + Sync + Send>>> = RwLock::new({
-        #[cfg(not(feature = "tests"))] {
+        #[cfg(not(feature = "tests"))]
+        {
             None
         }
-        #[cfg(feature = "tests")] {
+        #[cfg(feature = "tests")]
+        {
             Some(resources_for_tests())
         }
     });
@@ -21,7 +23,11 @@ pub fn set(reader: Box<ResourceReaderMethods + Sync + Send>) {
 }
 
 pub fn read_bytes(res: Resource) -> Vec<u8> {
-    RES.read().unwrap().as_ref().expect("Resource reader not set.").read(res)
+    RES.read()
+        .unwrap()
+        .as_ref()
+        .expect("Resource reader not set.")
+        .read(res)
 }
 
 pub fn read_string(res: Resource) -> String {
@@ -29,11 +35,19 @@ pub fn read_string(res: Resource) -> String {
 }
 
 pub fn sandbox_access_files() -> Vec<PathBuf> {
-    RES.read().unwrap().as_ref().expect("Resource reader not set.").sandbox_access_files()
+    RES.read()
+        .unwrap()
+        .as_ref()
+        .expect("Resource reader not set.")
+        .sandbox_access_files()
 }
 
 pub fn sandbox_access_files_dirs() -> Vec<PathBuf> {
-    RES.read().unwrap().as_ref().expect("Resource reader not set.").sandbox_access_files_dirs()
+    RES.read()
+        .unwrap()
+        .as_ref()
+        .expect("Resource reader not set.")
+        .sandbox_access_files_dirs()
 }
 
 pub enum Resource {
@@ -64,8 +78,12 @@ fn resources_for_tests() -> Box<ResourceReaderMethods + Sync + Send> {
     use std::io::Read;
     struct ResourceReader;
     impl ResourceReaderMethods for ResourceReader {
-        fn sandbox_access_files(&self) -> Vec<PathBuf> { vec![] }
-        fn sandbox_access_files_dirs(&self) -> Vec<PathBuf> { vec![] }
+        fn sandbox_access_files(&self) -> Vec<PathBuf> {
+            vec![]
+        }
+        fn sandbox_access_files_dirs(&self) -> Vec<PathBuf> {
+            vec![]
+        }
         fn read(&self, file: Resource) -> Vec<u8> {
             let file = match file {
                 Resource::Preferences => "prefs.json",
@@ -92,8 +110,10 @@ fn resources_for_tests() -> Box<ResourceReaderMethods + Sync + Send> {
             }
             path.push(file);
             let mut buffer = vec![];
-            File::open(path).expect(&format!("Can't find file: {}", file))
-                .read_to_end(&mut buffer).expect("Can't read file");
+            File::open(path)
+                .expect(&format!("Can't find file: {}", file))
+                .read_to_end(&mut buffer)
+                .expect("Can't read file");
             buffer
         }
     }


### PR DESCRIPTION
```bash
rustfmt $(find components/dom_struct -type f -name "*.rs")
rustfmt $(find components/domobject_derive -type f -name "*.rs")
rustfmt $(find components/embedder_traits -type f -name "*.rs")
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21584)
<!-- Reviewable:end -->
