### PR TITLE
Make bootstrap handle linux setup, include gstreamer, make bootstrap run standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ If you've already partially compiled servo but forgot to do this step, run `./ma
 
 #### On Debian-based Linuxes
 
-Simply running `./mach bootstrap` should be enough. If not, run the commands below:
+Please run `sudo apt install python-virtualenv build-essential libssl-dev libffi-dev python-dev` followed by `./mach bootstrap`.
+
+If this doesn't work, file a bug, and, run the commands below:
 
 ``` sh
 sudo apt install git curl autoconf libx11-dev \
@@ -101,7 +103,9 @@ If `virtualenv` does not exist, try `python-virtualenv`.
 
 #### On Fedora
 
-Simply running `./mach bootstrap` should be enough. If not, run the commands below:
+Please run `sudo dnf install python2-virtualenv gcc libffi-devel python-devel openssl-devel` followed by `./mach bootstrap`.
+
+If this doesn't work, file a bug, and, run the commands below:
 
 ``` sh
 sudo dnf install curl libtool gcc-c++ libXi-devel \
@@ -113,7 +117,10 @@ sudo dnf install curl libtool gcc-c++ libXi-devel \
 ```
 #### On CentOS
 
-Simply running `./mach bootstrap` should be enough. If not, run the commands below:
+
+Please run `sudo yum install python2-virtualenv gcc libffi-devel python-devel openssl-devel` followed by `./mach bootstrap`.
+
+If this doesn't work, file a bug, and, run the commands below:
 
 ``` sh
 sudo yum install curl libtool gcc-c++ libXi-devel \

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ sudo apt install git curl autoconf libx11-dev \
 ```
 
 If you using a version prior to **Ubuntu 17.04** or **Debian Sid**, replace `libssl1.0-dev` with `libssl-dev`.
+Additionally, you'll need a local copy of GStreamer with a version later than 12.0. You can place it in `support/linux/gstreamer/gstreamer`, or run `./mach bootstrap-gstreamer` to set it up.
 
 If you are using **Ubuntu 16.04** run `export HARFBUZZ_SYS_NO_PKG_CONFIG=1` before building to avoid an error with harfbuzz.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you've already partially compiled servo but forgot to do this step, run `./ma
 
 #### On Debian-based Linuxes
 
-Please run `sudo apt install python-virtualenv build-essential libssl-dev libffi-dev python-dev` followed by `./mach bootstrap`.
+Please run `./mach bootstrap`.
 
 If this doesn't work, file a bug, and, run the commands below:
 
@@ -103,7 +103,7 @@ If `virtualenv` does not exist, try `python-virtualenv`.
 
 #### On Fedora
 
-Please run `sudo dnf install python2-virtualenv gcc libffi-devel python-devel openssl-devel` followed by `./mach bootstrap`.
+Please run `./mach bootstrap`.
 
 If this doesn't work, file a bug, and, run the commands below:
 
@@ -118,7 +118,7 @@ sudo dnf install curl libtool gcc-c++ libXi-devel \
 #### On CentOS
 
 
-Please run `sudo yum install python2-virtualenv gcc libffi-devel python-devel openssl-devel` followed by `./mach bootstrap`.
+Please run `./mach bootstrap`.
 
 If this doesn't work, file a bug, and, run the commands below:
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,37 @@ Additionally, you'll need a local copy of GStreamer with a version later than 12
 
 If you are using **Ubuntu 16.04** run `export HARFBUZZ_SYS_NO_PKG_CONFIG=1` before building to avoid an error with harfbuzz.
 
-If you are on **Ubuntu 14.04** and encountered errors on installing these dependencies involving `libcheese`, see [#6158](https://github.com/servo/servo/issues/6158) for a workaround.
+If you are on **Ubuntu 14.04** and encountered errors on installing these dependencies involving `libcheese`, see [#6158](https://github.com/servo/servo/issues/6158) for a workaround. You may also need to install gcc 4.9, clang 4.0, and cmake 3.2:
+
+<details>
+gcc 4.9:
+
+```sh
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+sudo apt-get update
+sudo apt-get install gcc-4.9 g++-4.9
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
+```
+
+clang 4.0:
+
+```sh
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main"
+sudo apt-get update
+sudo apt-get install -y clang-4.0
+```
+
+cmake 3.2:
+
+```sh
+sudo apt-get install software-properties-common
+sudo add-apt-repository ppa:george-edison55/cmake-3.x
+sudo apt-get update
+sudo apt-get install cmake
+```
+
+</details>
 
 If `virtualenv` does not exist, try `python-virtualenv`.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ If you've already partially compiled servo but forgot to do this step, run `./ma
 
 #### On Debian-based Linuxes
 
+Simply running `./mach bootstrap` should be enough. If not, run the commands below:
+
 ``` sh
 sudo apt install git curl autoconf libx11-dev \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
@@ -98,6 +100,8 @@ If `virtualenv` does not exist, try `python-virtualenv`.
 
 #### On Fedora
 
+Simply running `./mach bootstrap` should be enough. If not, run the commands below:
+
 ``` sh
 sudo dnf install curl libtool gcc-c++ libXi-devel \
     freetype-devel mesa-libGL-devel mesa-libEGL-devel glib2-devel libX11-devel libXrandr-devel gperf \
@@ -107,6 +111,8 @@ sudo dnf install curl libtool gcc-c++ libXi-devel \
     gstreamer1-plugins-base-devel gstreamer1-plugins-bad-free-devel autoconf213
 ```
 #### On CentOS
+
+Simply running `./mach bootstrap` should be enough. If not, run the commands below:
 
 ``` sh
 sudo yum install curl libtool gcc-c++ libXi-devel \

--- a/mach
+++ b/mach
@@ -20,8 +20,11 @@ def main(args):
     topdir = os.path.abspath(os.path.dirname(sys.argv[0]))
     sys.path.insert(0, os.path.join(topdir, "python"))
     import mach_bootstrap
-    mach = mach_bootstrap.bootstrap(topdir)
-    sys.exit(mach.run(sys.argv[1:]))
+    if len(sys.argv) > 1 and sys.argv[1] == "bootstrap":
+        sys.exit(mach_bootstrap.bootstrap_command_only(topdir))
+    else:
+        mach = mach_bootstrap.bootstrap(topdir)
+        sys.exit(mach.run(sys.argv[1:]))
 
 
 if __name__ == '__main__':

--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -224,10 +224,28 @@ def _is_windows():
     return sys.platform == 'win32'
 
 
+class DummyContext(object):
+    pass
+
+
+def bootstrap_command_only(topdir):
+    from servo.bootstrap import bootstrap
+
+    context = DummyContext()
+    context.topdir = topdir
+    force = False
+    if len(sys.argv) == 3 and sys.argv[2] == "-f":
+        force = True
+    bootstrap(context, force)
+    return 0
+
+
 def bootstrap(topdir):
     _ensure_case_insensitive_if_windows()
 
     topdir = os.path.abspath(topdir)
+
+    len(sys.argv) > 1 and sys.argv[1] == "bootstrap"
 
     # We don't support paths with Unicode characters for now
     # https://github.com/servo/servo/issues/10002

--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -108,8 +108,7 @@ def linux(context, force=False):
                 'build-essential', 'cmake', 'python-pip',
                 'libbz2-dev', 'libosmesa6-dev', 'libxmu6', 'libxmu-dev', 'libglu1-mesa-dev',
                 'libgles2-mesa-dev', 'libegl1-mesa-dev', 'libdbus-1-dev', 'libharfbuzz-dev',
-                'ccache', 'clang', 'libgstreamer1.0-dev', 'libgstreamer-plugins-base1.0-dev',
-                'libgstreamer-plugins-bad1.0-dev', 'autoconf2.13']
+                'ccache', 'clang', 'autoconf2.13']
     pkgs_dnf = ['libtool', 'gcc-c++', 'libXi-devel', 'freetype-devel',
                 'mesa-libGL-devel', 'mesa-libEGL-devel', 'glib2-devel', 'libX11-devel',
                 'libXrandr-devel', 'gperf', 'fontconfig-devel', 'cabextract', 'ttmkfdir',
@@ -130,6 +129,8 @@ def linux(context, force=False):
             pkgs_apt += ["python-virtualenv"]
         else:
             pkgs_apt += ["virtualenv"]
+            pkgs_apt += ['libgstreamer1.0-dev', 'libgstreamer-plugins-base1.0-dev',
+                         'libgstreamer-plugins-bad1.0-dev']
 
     elif context.distro == "Debian" and context.distro_version == "Sid":
         pkgs_apt += ["libssl-dev"]

--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -67,7 +67,7 @@ def linux(context, force=False):
     # Please keep these in sync with the packages in README.md
     pkgs_apt = ['git', 'curl', 'autoconf', 'libx11-dev', 'libfreetype6-dev',
                 'libgl1-mesa-dri', 'libglib2.0-dev', 'xorg-dev', 'gperf', 'g++',
-                'build-essential', 'cmake', 'virtualenv', 'python-pip',
+                'build-essential', 'cmake', 'python-pip',
                 'libbz2-dev', 'libosmesa6-dev', 'libxmu6', 'libxmu-dev', 'libglu1-mesa-dev',
                 'libgles2-mesa-dev', 'libegl1-mesa-dev', 'libdbus-1-dev', 'libharfbuzz-dev',
                 'ccache', 'clang', 'libgstreamer1.0-dev', 'libgstreamer-plugins-base1.0-dev',
@@ -87,6 +87,12 @@ def linux(context, force=False):
             pkgs_apt += ["libssl-dev"]
         else:
             pkgs_apt += ["libssl1.0-dev"]
+
+        if context.distro_version == "14.04":
+            pkgs_apt += ["python-virtualenv"]
+        else:
+            pkgs_apt += ["virtualenv"]
+
     elif context.distro == "Debian" and context.distro_version == "Sid":
         pkgs_apt += ["libssl-dev"]
     else:

--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -326,10 +326,12 @@ def windows_msvc(context, force=False):
 
     return 0
 
+
 LINUX_SPECIFIC_BOOTSTRAPPERS = {
     "salt": salt,
     "gstreamer": gstreamer,
 }
+
 
 def bootstrap(context, force=False, specific=None):
     '''Dispatches to the right bootstrapping function for the OS.'''

--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -18,8 +18,8 @@ from servo.util import extract, download_file, host_triple
 
 
 def check_gstreamer_lib():
-    subprocess.call(["pkg-config", "gstreamer-1.0 >= 1.12"],
-                                   stdout=PIPE, stderr=PIPE) == 0
+    return subprocess.call(["pkg-config", "gstreamer-1.0 >= 1.12"],
+                           stdout=PIPE, stderr=PIPE) == 0
 
 def run_as_root(command):
     if os.geteuid() != 0:
@@ -56,7 +56,12 @@ def install_salt_dependencies(context, force):
     install_linux_deps(context, pkgs_apt, pkgs_dnf, force)
 
 def gstreamer(context, force=False):
-    pass
+    cur = os.curdir
+    gstdir = os.path.join(cur, "support", "linux", "gstreamer")
+    if not os.path.isdir(os.path.join(gstdir, "gstreamer", "lib")):
+        os.chdir(gstdir)
+        subprocess.call(["bash", "gstreamer.sh"])
+        os.chdir(cur)
 
 def linux(context, force=False):
     # Please keep these in sync with the packages in README.md

--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -49,11 +49,16 @@ def install_linux_deps(context, pkgs_ubuntu, pkgs_fedora, force):
             command.append('-y')
         print("Installing missing dependencies...")
         run_as_root(command + pkgs)
+        return True
+    return False
+
 
 def install_salt_dependencies(context, force):
     pkgs_apt = ['build-essential', 'libssl-dev', 'libffi-dev', 'python-dev']
     pkgs_dnf = ['gcc', 'libffi-devel', 'python-devel', 'openssl-devel']
-    install_linux_deps(context, pkgs_apt, pkgs_dnf, force)
+    if not install_linux_deps(context, pkgs_apt, pkgs_dnf, force):
+        print("Dependencies are already installed")
+
 
 def gstreamer(context, force=False):
     cur = os.curdir
@@ -62,6 +67,9 @@ def gstreamer(context, force=False):
         os.chdir(gstdir)
         subprocess.call(["bash", "gstreamer.sh"])
         os.chdir(cur)
+        return True
+    return False
+
 
 def linux(context, force=False):
     # Please keep these in sync with the packages in README.md
@@ -98,11 +106,13 @@ def linux(context, force=False):
     else:
         pkgs_apt += ["libssl1.0-dev"]
 
-    install_linux_deps(context, pkgs_apt, pkgs_dnf, force)
+    installed_something = install_linux_deps(context, pkgs_apt, pkgs_dnf, force)
 
     if not check_gstreamer_lib():
-        gstreamer(context, force)
+        installed_something |= gstreamer(context, force)
 
+    if not installed_something:
+        print("Dependencies were already installed!")
 
 
 def salt(context, force=False):

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -55,6 +55,15 @@ class MachCommands(CommandBase):
     def bootstrap(self, force=False):
         return bootstrap.bootstrap(self.context, force=force)
 
+    @Command('bootstrap-salt',
+             description='Install and set up the salt environment.',
+             category='bootstrap')
+    @CommandArgument('--force', '-f',
+                     action='store_true',
+                     help='Boostrap without confirmation')
+    def bootstrap_salt(self, force=False):
+        return bootstrap.bootstrap(self.context, force=force, specific="salt")
+
     @Command('bootstrap-android',
              description='Install the Android SDK and NDK.',
              category='bootstrap')

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -53,6 +53,9 @@ class MachCommands(CommandBase):
                      action='store_true',
                      help='Boostrap without confirmation')
     def bootstrap(self, force=False):
+        # This entry point isn't actually invoked, ./mach bootstrap is directly
+        # called by mach (see mach_bootstrap.bootstrap_command_only) so that
+        # it can install dependencies without needing mach's dependencies
         return bootstrap.bootstrap(self.context, force=force)
 
     @Command('bootstrap-salt',

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -64,6 +64,15 @@ class MachCommands(CommandBase):
     def bootstrap_salt(self, force=False):
         return bootstrap.bootstrap(self.context, force=force, specific="salt")
 
+    @Command('bootstrap-gstreamer',
+             description='Set up a local copy of the gstreamer libraries (linux only).',
+             category='bootstrap')
+    @CommandArgument('--force', '-f',
+                     action='store_true',
+                     help='Boostrap without confirmation')
+    def bootstrap_gstreamer(self, force=False):
+        return bootstrap.bootstrap(self.context, force=force, specific="gstreamer")
+
     @Command('bootstrap-android',
              description='Install the Android SDK and NDK.',
              category='bootstrap')

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -549,9 +549,16 @@ class CommandBase(object):
             gstpath = path.join(self.context.topdir, "support", "linux", "gstreamer", "gstreamer")
             extra_path += [path.join(gstpath, "bin")]
             libpath = path.join(gstpath, "lib", "x86_64-linux-gnu")
-            extra_path += [libpath]
-            extra_lib += [libpath]
+            # we append in the reverse order so that system gstreamer libraries
+            # do not get precedence
+            extra_path = [libpath] + extra_path
+            extra_lib = [libpath] + extra_path
             append_to_path_env(path.join(libpath, "pkgconfig"), env, "PKG_CONFIG_PATH")
+
+        if sys.platform == "linux2":
+            distro, version, _ = platform.linux_distribution()
+            if distro == "Ubuntu" and (version == "16.04" or version == "14.04"):
+                env["HARFBUZZ_SYS_NO_PKG_CONFIG"] = "true"
 
         if extra_path:
             env["PATH"] = "%s%s%s" % (os.pathsep.join(extra_path), os.pathsep, env["PATH"])

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -24,6 +24,7 @@ import tarfile
 from xml.etree.ElementTree import XML
 from servo.util import download_file
 import urllib2
+from bootstrap import check_gstreamer_lib
 
 from mach.registrar import Registrar
 import toml
@@ -476,10 +477,6 @@ class CommandBase(object):
             bin_folder = path.join(destination_folder, "PFiles", "Mozilla research", "Servo Tech Demo")
         return path.join(bin_folder, "servo{}".format(BIN_SUFFIX))
 
-    def check_gstreamer_lib(self):
-        return subprocess.call(["pkg-config", "gstreamer-1.0 >= 1.12"],
-                               stdout=PIPE, stderr=PIPE) == 0
-
     def build_env(self, hosts_file_path=None, target=None, is_build=False, test_unit=False):
         """Return an extended environment dictionary."""
         env = os.environ.copy()
@@ -524,7 +521,7 @@ class CommandBase(object):
 
         gstpath = path.join(os.getcwd(), "support", "linux", "gstreamer", "gstreamer")
         if sys.platform == "linux2" and path.isdir(gstpath):
-            if True:
+            if not check_gstreamer_lib():
                 if "x86_64" not in (target or host_triple()):
                     raise Exception("We don't currently support using local gstreamer builds \
                                      for non-x86_64, please file a bug")

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -503,10 +503,10 @@ class CommandBase(object):
 install them, let us know by filing a bug!")
         return False
 
-    def set_run_env(self):
+    def set_run_env(self, android=False):
         """Some commands, like test-wpt, don't use a full build env,
            but may still need dynamic search paths. This command sets that up"""
-        if self.needs_gstreamer_env(None):
+        if not android and self.needs_gstreamer_env(None):
             gstpath = self.get_gstreamer_path()
             os.environ["LD_LIBRARY_PATH"] = path.join(gstpath, "lib", "x86_64-linux-gnu")
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -348,6 +348,9 @@ class CommandBase(object):
         build_type = "release" if release else "debug"
         return path.join(base_path, build_type, apk_name)
 
+    def get_gstreamer_path(self):
+        return path.join(self.context.topdir, "support", "linux", "gstreamer", "gstreamer")
+
     def get_binary_path(self, release, dev, android=False):
         # TODO(autrilla): this function could still use work - it shouldn't
         # handle quitting, or printing. It should return the path, or an error.
@@ -480,7 +483,7 @@ class CommandBase(object):
     def needs_gstreamer_env(self, target):
         if check_gstreamer_lib():
             return False
-        gstpath = path.join(self.context.topdir, "support", "linux", "gstreamer", "gstreamer")
+        gstpath = self.get_gstreamer_path()
         if sys.platform == "linux2":
             if "x86_64" not in (target or host_triple()):
                 raise Exception("We don't currently support using local gstreamer builds \
@@ -500,7 +503,7 @@ class CommandBase(object):
         """Some commands, like test-wpt, don't use a full build env,
            but may still need dynamic search paths. This command sets that up"""
         if self.needs_gstreamer_env(None):
-            gstpath = path.join(self.context.topdir, "support", "linux", "gstreamer", "gstreamer")
+            gstpath = self.get_gstreamer_path()
             os.environ["LD_LIBRARY_PATH"] = path.join(gstpath, "lib", "x86_64-linux-gnu")
 
     def build_env(self, hosts_file_path=None, target=None, is_build=False, test_unit=False):
@@ -546,7 +549,7 @@ class CommandBase(object):
             env["HARFBUZZ_SYS_NO_PKG_CONFIG"] = "true"
 
         if self.needs_gstreamer_env(target):
-            gstpath = path.join(self.context.topdir, "support", "linux", "gstreamer", "gstreamer")
+            gstpath = self.get_gstreamer_path()
             extra_path += [path.join(gstpath, "bin")]
             libpath = path.join(gstpath, "lib", "x86_64-linux-gnu")
             # we append in the reverse order so that system gstreamer libraries

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -478,13 +478,22 @@ class CommandBase(object):
         return path.join(bin_folder, "servo{}".format(BIN_SUFFIX))
 
     def needs_gstreamer_env(self, target):
+        if check_gstreamer_lib():
+            return False
         gstpath = path.join(self.context.topdir, "support", "linux", "gstreamer", "gstreamer")
-        if sys.platform == "linux2" and path.isdir(gstpath):
-            if not check_gstreamer_lib():
-                if "x86_64" not in (target or host_triple()):
-                    raise Exception("We don't currently support using local gstreamer builds \
+        if sys.platform == "linux2":
+            if "x86_64" not in (target or host_triple()):
+                raise Exception("We don't currently support using local gstreamer builds \
                                      for non-x86_64, please file a bug")
+            if path.isdir(gstpath):
                 return True
+            else:
+                raise Exception("Your system's gstreamer libraries are out of date \
+                                     (we need at least 1.12). Please run ./mach bootstrap-gstreamer")
+        else:
+                raise Exception("Your system's gstreamer libraries are out of date \
+                                     (we need at least 1.12). If you're unable to \
+                                     install them, let us know by filing a bug!")
         return False
 
     def set_run_env(self):

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -488,8 +488,9 @@ class CommandBase(object):
             # Some systems don't have pkg-config; we can't probe in this case
             # and must hope for the best
             return False
-        if "x86_64" not in (target or host_triple()):
-            # We don't build gstreamer for non-x86_64 yet
+        effective_target = target or host_triple()
+        if "x86_64" not in effective_target or "android" in effective_target:
+            # We don't build gstreamer for non-x86_64 / android yet
             return False
         if sys.platform == "linux2":
             if path.isdir(self.get_gstreamer_path()):

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -481,7 +481,12 @@ class CommandBase(object):
         return path.join(bin_folder, "servo{}".format(BIN_SUFFIX))
 
     def needs_gstreamer_env(self, target):
-        if check_gstreamer_lib():
+        try:
+            if check_gstreamer_lib():
+                return False
+        except:
+            # Some systems don't have pkg-config; we can't probe in this case
+            # and must hope for the best
             return False
         if "x86_64" not in (target or host_triple()):
             # We don't build gstreamer for non-x86_64 yet

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -483,20 +483,19 @@ class CommandBase(object):
     def needs_gstreamer_env(self, target):
         if check_gstreamer_lib():
             return False
-        gstpath = self.get_gstreamer_path()
+        if "x86_64" not in (target or host_triple()):
+            # We don't build gstreamer for non-x86_64 yet
+            return False
         if sys.platform == "linux2":
-            if "x86_64" not in (target or host_triple()):
-                raise Exception("We don't currently support using local gstreamer builds \
-                                     for non-x86_64, please file a bug")
-            if path.isdir(gstpath):
+            if path.isdir(self.get_gstreamer_path()):
                 return True
             else:
                 raise Exception("Your system's gstreamer libraries are out of date \
-                                     (we need at least 1.12). Please run ./mach bootstrap-gstreamer")
+(we need at least 1.12). Please run ./mach bootstrap-gstreamer")
         else:
                 raise Exception("Your system's gstreamer libraries are out of date \
-                                     (we need at least 1.12). If you're unable to \
-                                     install them, let us know by filing a bug!")
+(we need at least 1.12). If you're unable to \
+install them, let us know by filing a bug!")
         return False
 
     def set_run_env(self):

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -184,7 +184,6 @@ class PackageCommands(CommandBase):
                      default=None,
                      help='Package using the given Gradle flavor')
     def package(self, release=False, dev=False, android=None, debug=False, debugger=None, target=None, flavor=None):
-        env = self.build_env(target=target)
         if android is None:
             android = self.config["build"]["android"]
         if target and android:
@@ -192,6 +191,9 @@ class PackageCommands(CommandBase):
             sys.exit(1)
         if not android:
             android = self.handle_android_target(target)
+        else:
+            target = self.config["android"]["target"]
+        env = self.build_env(target=target)
         binary_path = self.get_binary_path(release, dev, android=android)
         dir_to_root = self.get_top_dir()
         target_dir = path.dirname(binary_path)

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -184,7 +184,7 @@ class PackageCommands(CommandBase):
                      default=None,
                      help='Package using the given Gradle flavor')
     def package(self, release=False, dev=False, android=None, debug=False, debugger=None, target=None, flavor=None):
-        env = self.build_env()
+        env = self.build_env(target=target)
         if android is None:
             android = self.config["build"]["android"]
         if target and android:

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -383,6 +383,7 @@ class MachCommands(CommandBase):
         return self._test_wpt(**kwargs)
 
     def _test_wpt(self, **kwargs):
+        self.set_run_env()
         hosts_file_path = path.join(self.context.topdir, 'tests', 'wpt', 'hosts')
         os.environ["hosts_file_path"] = hosts_file_path
         run_file = path.abspath(path.join(self.context.topdir, "tests", "wpt", "run.py"))

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -380,10 +380,10 @@ class MachCommands(CommandBase):
             binary_args=self.in_android_emulator(release, dev) + (binary_args or []),
             binary=sys.executable,
         )
-        return self._test_wpt(**kwargs)
+        return self._test_wpt(android=True, **kwargs)
 
-    def _test_wpt(self, **kwargs):
-        self.set_run_env()
+    def _test_wpt(self, android=False, **kwargs):
+        self.set_run_env(android)
         hosts_file_path = path.join(self.context.topdir, 'tests', 'wpt', 'hosts')
         os.environ["hosts_file_path"] = hosts_file_path
         run_file = path.abspath(path.join(self.context.topdir, "tests", "wpt", "run.py"))

--- a/python/servo/util.py
+++ b/python/servo/util.py
@@ -20,7 +20,6 @@ import StringIO
 import sys
 import zipfile
 import urllib2
-import certifi
 
 
 try:
@@ -30,6 +29,7 @@ except ImportError:
 
 # The cafile parameter was added in 2.7.9
 if HAS_SNI and sys.version_info >= (2, 7, 9):
+    import certifi
     STATIC_RUST_LANG_ORG_DIST = "https://static.rust-lang.org/dist"
     URLOPEN_KWARGS = {"cafile": certifi.where()}
 else:

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -65,6 +65,7 @@ files = [
   "./resources/hsts_preload.json",
   "./tests/wpt/metadata/MANIFEST.json",
   "./support/android/openssl.sh",
+  "./support/linux/gstreamer/gstreamer.sh",
   # Upstream code from Khronos/WebGL uses tabs for indentation
   "./tests/wpt/webgl/tests",
   # Our import script is not currently respecting the lint.

--- a/support/linux/gstreamer/.gitignore
+++ b/support/linux/gstreamer/.gitignore
@@ -1,0 +1,2 @@
+gstreamer/
+

--- a/support/linux/gstreamer/gstreamer.sh
+++ b/support/linux/gstreamer/gstreamer.sh
@@ -1,0 +1,4 @@
+wget https://github.com/ferjm/gstreamer-1.14.1-ubuntu-trusty/raw/master/gstreamer.tar.gz
+tar -zxvf gstreamer.tar.gz
+rm gstreamer.tar.gz
+sed -i "s;prefix=/root/gstreamer;prefix=$PWD/gstreamer;g" $PWD/gstreamer/lib/x86_64-linux-gnu/pkgconfig/*.pc

--- a/support/linux/gstreamer/gstreamer.sh
+++ b/support/linux/gstreamer/gstreamer.sh
@@ -1,4 +1,12 @@
-wget https://github.com/ferjm/gstreamer-1.14.1-ubuntu-trusty/raw/master/gstreamer.tar.gz
-tar -zxvf gstreamer.tar.gz
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -o errexit
+
+wget https://github.com/ferjm/gstreamer-1.14.1-ubuntu-trusty/raw/master/gstreamer.tar.gz -O gstreamer.tar.gz
+tar -zxf gstreamer.tar.gz
 rm gstreamer.tar.gz
-sed -i "s;prefix=/root/gstreamer;prefix=$PWD/gstreamer;g" $PWD/gstreamer/lib/x86_64-linux-gnu/pkgconfig/*.pc
+sed -i "s;prefix=/root/gstreamer;prefix=${PWD}/gstreamer;g" ${PWD}/gstreamer/lib/x86_64-linux-gnu/pkgconfig/*.pc

--- a/support/linux/gstreamer/gstreamer.sh
+++ b/support/linux/gstreamer/gstreamer.sh
@@ -6,7 +6,7 @@
 
 set -o errexit
 
-wget https://github.com/ferjm/gstreamer-1.14.1-ubuntu-trusty/raw/master/gstreamer.tar.gz -O gstreamer.tar.gz
+wget http://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-x86_64-linux-gnu.tar.gz -O gstreamer.tar.gz
 tar -zxf gstreamer.tar.gz
 rm gstreamer.tar.gz
 sed -i "s;prefix=/root/gstreamer;prefix=${PWD}/gstreamer;g" ${PWD}/gstreamer/lib/x86_64-linux-gnu/pkgconfig/*.pc


### PR DESCRIPTION
Previously `./mach bootstrap` wasn't very useful on Linux, it would just install salt. This PR moves that to `./mach bootstrap-salt`, and has `./mach bootstrap` perform the installation steps mentioned in the README.


With these changes `./mach bootstrap` is a valid way of setting up the servo build. Additionally, this adds gstreamer setup to this for cases where gstreamer is not up to date.

Edit: And now, mach bootstrap is able to be run on a fresh system with just python installed (no need for virtualenv or libffi). 

Fixes https://github.com/servo/servo/issues/21446 , fixes https://github.com/servo/servo/issues/21417

r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21586)
<!-- Reviewable:end -->
