### PR TITLE
Add unshipped port message queue task

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -482,7 +482,6 @@ impl DedicatedWorkerGlobalScopeMethods for DedicatedWorkerGlobalScope {
         let task = Box::new(task!(post_worker_message: move || {
             Worker::handle_message(worker, data);
         }));
-        // TODO: Change this task source to a new `unshipped-port-message-queue` task source
         self.parent_sender.send(CommonScriptMsg::Task(
             WorkerEvent,
             task,

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -487,7 +487,7 @@ impl DedicatedWorkerGlobalScopeMethods for DedicatedWorkerGlobalScope {
             WorkerEvent,
             task,
             Some(pipeline_id),
-            TaskSourceName::DOMManipulation,
+            TaskSourceName::UnshippedPortMessageQueue,
         )).unwrap();
         Ok(())
     }

--- a/components/script/task_source/mod.rs
+++ b/components/script/task_source/mod.rs
@@ -28,7 +28,8 @@ pub enum TaskSourceName {
     Networking,
     PerformanceTimeline,
     UserInteraction,
-    RemoteEvent
+    RemoteEvent,
+    UnshippedPortMessageQueue,
 }
 
 impl TaskSourceName {

--- a/components/script/task_source/unshipped_port_message_queue.rs
+++ b/components/script/task_source/unshipped_port_message_queue.rs
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use dom::bindings::inheritance::Castable;
+use dom::bindings::refcounted::Trusted;
+use dom::event::{EventBubbles, EventCancelable, EventTask, SimpleEventTask};
+use dom::eventtarget::EventTarget;
+use dom::window::Window;
+use msg::constellation_msg::PipelineId;
+use script_runtime::{CommonScriptMsg, ScriptThreadEventCategory};
+use script_thread::MainThreadScriptMsg;
+use servo_atoms::Atom;
+use std::fmt;
+use std::result::Result;
+use std::sync::mpsc::Sender;
+use task::{TaskCanceller, TaskOnce};
+use task_source::{TaskSource, TaskSourceName};
+
+#[derive(Clone, JSTraceable)]
+pub struct UnshippedPortMessageQueueTaskSource(pub Sender<MainThreadScriptMsg>, pub PipelineId);
+
+impl fmt::Debug for UnshippedPortMessageQueueTaskSource {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "UnshippedPortMessageQueueTaskSource(...)")
+    }
+}
+
+impl TaskSource for UnshippedPortMessageQueueTaskSource {
+    const NAME: TaskSourceName = TaskSourceName::UnshippedPortMessageQueue;
+
+    fn queue_with_canceller<T>(
+        &self,
+        task: T,
+        canceller: &TaskCanceller,
+    ) -> Result<(), ()>
+    where
+        T: TaskOnce + 'static,
+    {
+        let msg = MainThreadScriptMsg::Common(CommonScriptMsg::Task(
+            ScriptThreadEventCategory::ScriptEvent,
+            Box::new(canceller.wrap_task(task)),
+            Some(self.1),
+            UnshippedPortMessageQueueTaskSource::NAME,
+        ));
+        self.0.send(msg).map_err(|_| ())
+    }
+}


### PR DESCRIPTION
Add a new task source for the Message Ports.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21589 
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it's refactoring code and not adding new behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21609)
<!-- Reviewable:end -->
