### PR TITLE
Make ndk-stack mach command support x86 builds.

### DIFF
--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -255,6 +255,7 @@ class MachCommands(CommandBase):
             return -1
         env = self.build_env(target=target)
         ndk_stack = path.join(env["ANDROID_NDK"], "ndk-stack")
+        self.handle_android_target(target)
         sym_path = path.join(
             "target",
             target,
@@ -262,5 +263,5 @@ class MachCommands(CommandBase):
             "apk",
             "obj",
             "local",
-            "armeabi-v7a")
+            self.config["android"]["lib"])
         print(subprocess.check_output([ndk_stack, "-sym", sym_path, "-dump", logfile]))


### PR DESCRIPTION
Tested locally and it now provides usable output.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because no automated tests for build environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21622)
<!-- Reviewable:end -->
