### PR TITLE
Add Websocket task source

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -59,6 +59,7 @@ use task_source::file_reading::FileReadingTaskSource;
 use task_source::networking::NetworkingTaskSource;
 use task_source::performance_timeline::PerformanceTimelineTaskSource;
 use task_source::remote_event::RemoteEventTaskSource;
+use task_source::websocket::WebsocketTaskSource;
 use time::{Timespec, get_time};
 use timers::{IsInterval, OneshotTimerCallback, OneshotTimerHandle};
 use timers::{OneshotTimers, TimerCallback};
@@ -426,6 +427,18 @@ impl GlobalScope {
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
             return worker.remote_event_task_source();
+        }
+        unreachable!();
+    }
+
+    /// `ScriptChan` to send messages to the websocket task source of
+    /// this global scope.
+    pub fn websocket_task_source(&self) -> WebsocketTaskSource {
+        if let Some(window) = self.downcast::<Window>() {
+            return window.websocket_task_source();
+        }
+        if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
+            return worker.websocket_task_source();
         }
         unreachable!();
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -128,6 +128,7 @@ use task_source::networking::NetworkingTaskSource;
 use task_source::performance_timeline::PerformanceTimelineTaskSource;
 use task_source::remote_event::RemoteEventTaskSource;
 use task_source::user_interaction::UserInteractionTaskSource;
+use task_source::websocket::WebsocketTaskSource;
 use time;
 use timers::{IsInterval, TimerCallback};
 use url::Position;
@@ -186,6 +187,8 @@ pub struct Window {
     performance_timeline_task_source: PerformanceTimelineTaskSource,
     #[ignore_malloc_size_of = "task sources are hard"]
     remote_event_task_source: RemoteEventTaskSource,
+    #[ignore_malloc_size_of = "task sources are hard"]
+    websocket_task_source: WebsocketTaskSource,
     navigator: MutNullableDom<Navigator>,
     #[ignore_malloc_size_of = "Arc"]
     image_cache: Arc<ImageCache>,
@@ -374,6 +377,10 @@ impl Window {
 
     pub fn remote_event_task_source(&self) -> RemoteEventTaskSource {
         self.remote_event_task_source.clone()
+    }
+
+    pub fn websocket_task_source(&self) -> WebsocketTaskSource {
+        self.websocket_task_source.clone()
     }
 
     pub fn main_thread_script_chan(&self) -> &Sender<MainThreadScriptMsg> {
@@ -1904,6 +1911,7 @@ impl Window {
         file_reading_task_source: FileReadingTaskSource,
         performance_timeline_task_source: PerformanceTimelineTaskSource,
         remote_event_task_source: RemoteEventTaskSource,
+        websocket_task_source: WebsocketTaskSource,
         image_cache_chan: Sender<ImageCacheMsg>,
         image_cache: Arc<ImageCache>,
         resource_threads: ResourceThreads,
@@ -1957,6 +1965,7 @@ impl Window {
             file_reading_task_source,
             performance_timeline_task_source,
             remote_event_task_source,
+            websocket_task_source,
             image_cache_chan,
             image_cache,
             navigator: Default::default(),

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -47,6 +47,7 @@ use task_source::file_reading::FileReadingTaskSource;
 use task_source::networking::NetworkingTaskSource;
 use task_source::performance_timeline::PerformanceTimelineTaskSource;
 use task_source::remote_event::RemoteEventTaskSource;
+use task_source::websocket::WebsocketTaskSource;
 use time::precise_time_ns;
 use timers::{IsInterval, TimerCallback};
 
@@ -384,6 +385,10 @@ impl WorkerGlobalScope {
 
     pub fn remote_event_task_source(&self) -> RemoteEventTaskSource {
         RemoteEventTaskSource(self.script_chan(), self.pipeline_id())
+    }
+
+    pub fn websocket_task_source(&self) -> WebsocketTaskSource {
+        WebsocketTaskSource(self.script_chan(), self.pipeline_id())
     }
 
     pub fn new_script_pair(&self) -> (Box<ScriptChan + Send>, Box<ScriptPort + Send>) {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -125,6 +125,7 @@ use task_source::networking::NetworkingTaskSource;
 use task_source::performance_timeline::PerformanceTimelineTaskSource;
 use task_source::remote_event::RemoteEventTaskSource;
 use task_source::user_interaction::UserInteractionTaskSource;
+use task_source::websocket::WebsocketTaskSource;
 use time::{get_time, precise_time_ns, Tm};
 use url::Position;
 use url::percent_encoding::percent_decode;
@@ -1896,6 +1897,10 @@ impl ScriptThread {
         RemoteEventTaskSource(self.remote_event_task_sender.clone(), pipeline_id)
     }
 
+    pub fn websocket_task_source(&self, pipeline_id: PipelineId) -> WebsocketTaskSource {
+        WebsocketTaskSource(self.remote_event_task_sender.clone(), pipeline_id)
+    }
+
     /// Handles a request for the window title.
     fn handle_get_title_msg(&self, pipeline_id: PipelineId) {
         let document = match { self.documents.borrow().find_document(pipeline_id) } {
@@ -2220,6 +2225,7 @@ impl ScriptThread {
             self.file_reading_task_source(incomplete.pipeline_id),
             self.performance_timeline_task_source(incomplete.pipeline_id).clone(),
             self.remote_event_task_source(incomplete.pipeline_id),
+            self.websocket_task_source(incomplete.pipeline_id),
             self.image_cache_channel.clone(),
             self.image_cache.clone(),
             self.resource_threads.clone(),

--- a/components/script/task_source/mod.rs
+++ b/components/script/task_source/mod.rs
@@ -10,6 +10,7 @@ pub mod networking;
 pub mod performance_timeline;
 pub mod remote_event;
 pub mod user_interaction;
+pub mod websocket;
 
 use dom::globalscope::GlobalScope;
 use enum_iterator::IntoEnumIterator;
@@ -28,7 +29,8 @@ pub enum TaskSourceName {
     Networking,
     PerformanceTimeline,
     UserInteraction,
-    RemoteEvent
+    RemoteEvent,
+    Websocket,
 }
 
 impl TaskSourceName {

--- a/components/script/task_source/websocket.rs
+++ b/components/script/task_source/websocket.rs
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use msg::constellation_msg::PipelineId;
+use script_runtime::{CommonScriptMsg, ScriptChan, ScriptThreadEventCategory};
+use task::{TaskCanceller, TaskOnce};
+use task_source::{TaskSource, TaskSourceName};
+
+#[derive(JSTraceable)]
+pub struct WebsocketTaskSource(pub Box<ScriptChan + Send + 'static>, pub PipelineId);
+
+impl Clone for WebsocketTaskSource {
+    fn clone(&self) -> WebsocketTaskSource {
+        WebsocketTaskSource(self.0.clone(), self.1.clone())
+    }
+}
+
+impl TaskSource for WebsocketTaskSource {
+    const NAME: TaskSourceName = TaskSourceName::Websocket;
+
+    fn queue_with_canceller<T>(
+        &self,
+        task: T,
+        canceller: &TaskCanceller,
+    ) -> Result<(), ()>
+    where
+        T: TaskOnce + 'static,
+    {
+        self.0.send(CommonScriptMsg::Task(
+            ScriptThreadEventCategory::NetworkEvent,
+            Box::new(canceller.wrap_task(task)),
+            Some(self.1),
+            WebsocketTaskSource::NAME,
+        ))
+    }
+}


### PR DESCRIPTION
According to the doc: https://html.spec.whatwg.org/multipage/web-sockets.html#network

The task source for all tasks queued in the websocket section are the
websocket task source, so this commit also updates those references to
use the appropriate one.

Also, while working on this, I made a typo here: https://github.com/AgustinCB/servo/blob/5dd6e21c2e7e1c35a2a4a57812126e28a4b58599/components/script/dom/window.rs#L191

Setting the name incorrectly. The error, however, was this:

```bash
error[E0412]: cannot find type `WebsocketEventTaskSource` in this scope
     --> components/script/dom/window.rs:171:1
       |
171 | #[dom_struct]
       | ^^^^^^^^^^^^^ did you mean `WebsocketTaskSource`?
```

Which isn't useful at all. Not sure if it's a rustc problem or something related with htis code base, but I thought it was worth mentioning.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21590
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they don't include new behavior and existing tests should cover this code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21645)
<!-- Reviewable:end -->
