### PR TITLE
Expose more WebGL extensions

### DIFF
--- a/components/script/dom/webgl_extensions/ext/extcolorbufferhalffloat.rs
+++ b/components/script/dom/webgl_extensions/ext/extcolorbufferhalffloat.rs
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use canvas_traits::webgl::WebGLVersion;
+use dom::bindings::codegen::Bindings::EXTColorBufferHalfFloatBinding;
+use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
+use dom::bindings::root::DomRoot;
+use dom::webgl_extensions::ext::oestexturehalffloat::OESTextureHalfFloat;
+use dom::webglrenderingcontext::WebGLRenderingContext;
+use dom_struct::dom_struct;
+use super::{WebGLExtension, WebGLExtensions, WebGLExtensionSpec};
+
+#[dom_struct]
+pub struct EXTColorBufferHalfFloat {
+    reflector_: Reflector,
+}
+
+impl EXTColorBufferHalfFloat {
+    fn new_inherited() -> EXTColorBufferHalfFloat {
+        Self {
+            reflector_: Reflector::new(),
+        }
+    }
+}
+
+impl WebGLExtension for EXTColorBufferHalfFloat {
+    type Extension = EXTColorBufferHalfFloat;
+    fn new(ctx: &WebGLRenderingContext) -> DomRoot<EXTColorBufferHalfFloat> {
+        reflect_dom_object(Box::new(EXTColorBufferHalfFloat::new_inherited()),
+                           &*ctx.global(),
+                           EXTColorBufferHalfFloatBinding::Wrap)
+    }
+
+    fn spec() -> WebGLExtensionSpec {
+        WebGLExtensionSpec::Specific(WebGLVersion::WebGL1)
+    }
+
+    fn is_supported(ext: &WebGLExtensions) -> bool {
+        ext.is_enabled::<OESTextureHalfFloat>()
+    }
+
+    fn enable(_ext: &WebGLExtensions) {
+    }
+
+    fn name() -> &'static str {
+        "EXT_color_buffer_half_float"
+    }
+}

--- a/components/script/dom/webgl_extensions/ext/mod.rs
+++ b/components/script/dom/webgl_extensions/ext/mod.rs
@@ -7,6 +7,7 @@ use super::{ext_constants, WebGLExtension, WebGLExtensions, WebGLExtensionSpec};
 
 pub mod angleinstancedarrays;
 pub mod extblendminmax;
+pub mod extcolorbufferhalffloat;
 pub mod extshadertexturelod;
 pub mod exttexturefilteranisotropic;
 pub mod oeselementindexuint;
@@ -16,3 +17,4 @@ pub mod oestexturefloatlinear;
 pub mod oestexturehalffloat;
 pub mod oestexturehalffloatlinear;
 pub mod oesvertexarrayobject;
+pub mod webglcolorbufferfloat;

--- a/components/script/dom/webgl_extensions/ext/webglcolorbufferfloat.rs
+++ b/components/script/dom/webgl_extensions/ext/webglcolorbufferfloat.rs
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use canvas_traits::webgl::WebGLVersion;
+use dom::bindings::codegen::Bindings::WEBGLColorBufferFloatBinding;
+use dom::bindings::reflector::{DomObject, Reflector, reflect_dom_object};
+use dom::bindings::root::DomRoot;
+use dom::webgl_extensions::ext::oestexturefloat::OESTextureFloat;
+use dom::webglrenderingcontext::WebGLRenderingContext;
+use dom_struct::dom_struct;
+use super::{WebGLExtension, WebGLExtensions, WebGLExtensionSpec};
+
+#[dom_struct]
+pub struct WEBGLColorBufferFloat {
+    reflector_: Reflector,
+}
+
+impl WEBGLColorBufferFloat {
+    fn new_inherited() -> WEBGLColorBufferFloat {
+        Self {
+            reflector_: Reflector::new(),
+        }
+    }
+}
+
+impl WebGLExtension for WEBGLColorBufferFloat {
+    type Extension = WEBGLColorBufferFloat;
+    fn new(ctx: &WebGLRenderingContext) -> DomRoot<WEBGLColorBufferFloat> {
+        reflect_dom_object(Box::new(WEBGLColorBufferFloat::new_inherited()),
+                           &*ctx.global(),
+                           WEBGLColorBufferFloatBinding::Wrap)
+    }
+
+    fn spec() -> WebGLExtensionSpec {
+        WebGLExtensionSpec::Specific(WebGLVersion::WebGL1)
+    }
+
+    fn is_supported(ext: &WebGLExtensions) -> bool {
+        ext.is_enabled::<OESTextureFloat>()
+    }
+
+    fn enable(_ext: &WebGLExtensions) {
+    }
+
+    fn name() -> &'static str {
+        "WEBGL_color_buffer_float"
+    }
+}

--- a/components/script/dom/webgl_extensions/extensions.rs
+++ b/components/script/dom/webgl_extensions/extensions.rs
@@ -270,6 +270,7 @@ impl WebGLExtensions {
     fn register_all_extensions(&self) {
         self.register::<ext::angleinstancedarrays::ANGLEInstancedArrays>();
         self.register::<ext::extblendminmax::EXTBlendMinmax>();
+        self.register::<ext::extcolorbufferhalffloat::EXTColorBufferHalfFloat>();
         self.register::<ext::extshadertexturelod::EXTShaderTextureLod>();
         self.register::<ext::exttexturefilteranisotropic::EXTTextureFilterAnisotropic>();
         self.register::<ext::oeselementindexuint::OESElementIndexUint>();
@@ -279,6 +280,7 @@ impl WebGLExtensions {
         self.register::<ext::oestexturehalffloat::OESTextureHalfFloat>();
         self.register::<ext::oestexturehalffloatlinear::OESTextureHalfFloatLinear>();
         self.register::<ext::oesvertexarrayobject::OESVertexArrayObject>();
+        self.register::<ext::webglcolorbufferfloat::WEBGLColorBufferFloat>();
     }
 
     pub fn enable_element_index_uint(&self) {

--- a/components/script/dom/webidls/EXTColorBufferHalfFloat.webidl
+++ b/components/script/dom/webidls/EXTColorBufferHalfFloat.webidl
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/*
+ * WebGL IDL definitions from the Khronos specification:
+ * https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/
+ */
+
+[NoInterfaceObject]
+interface EXTColorBufferHalfFloat {
+  const GLenum RGBA16F_EXT = 0x881A;
+  const GLenum RGB16F_EXT = 0x881B;
+  const GLenum FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT = 0x8211;
+  const GLenum UNSIGNED_NORMALIZED_EXT = 0x8C17;
+}; // interface EXT_color_buffer_half_float

--- a/components/script/dom/webidls/WEBGLColorBufferFloat.webidl
+++ b/components/script/dom/webidls/WEBGLColorBufferFloat.webidl
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/*
+ * WebGL IDL definitions from the Khronos specification:
+ * https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/
+ */
+
+[NoInterfaceObject]
+interface WEBGLColorBufferFloat {
+  const GLenum RGBA32F_EXT = 0x8814;
+  const GLenum FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT = 0x8211;
+  const GLenum UNSIGNED_NORMALIZED_EXT = 0x8C17;
+}; // interface WEBGL_color_buffer_float

--- a/tests/wpt/webgl/meta/conformance/extensions/oes-texture-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance/extensions/oes-texture-float.html.ini
@@ -1,4 +1,0 @@
-[oes-texture-float.html]
-  [WebGL test #24: RGBA/FLOAT is color renderable but WEBGL_color_buffer_float not exposed]
-    expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance/extensions/oes-texture-half-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance/extensions/oes-texture-half-float.html.ini
@@ -1,4 +1,79 @@
 [oes-texture-half-float.html]
-  [WebGL test #72: RGBA/HALF_FLOAT_OES is color renderable but EXT_color_buffer_half_float not exposed]
+  [WebGL test #101: getError expected: NO_ERROR. Was INVALID_OPERATION : readPixels should return NO_ERROR when reading FLOAT data.]
+    expected: FAIL
+
+  [WebGL test #85: getError expected: INVALID_OPERATION. Was NO_ERROR : IMPLEMENTATION_COLOR_READ_FORMAT should fail for incomplete framebuffers.]
+    expected: FAIL
+
+  [WebGL test #86: gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_TYPE) should be null (of type object). Was 5121 (of type number).]
+    expected: FAIL
+
+  [WebGL test #110: getError expected: NO_ERROR. Was INVALID_OPERATION : readPixels should return NO_ERROR when reading FLOAT data.]
+    expected: FAIL
+
+  [WebGL test #98: gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_TYPE) should be null (of type object). Was 5121 (of type number).]
+    expected: FAIL
+
+  [WebGL test #90: gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_FORMAT) should be null (of type object). Was 6408 (of type number).]
+    expected: FAIL
+
+  [WebGL test #88: getError expected: INVALID_FRAMEBUFFER_OPERATION. Was INVALID_OPERATION : readPixels should fail on incomplete framebuffers.]
+    expected: FAIL
+
+  [WebGL test #97: getError expected: INVALID_OPERATION. Was NO_ERROR : IMPLEMENTATION_COLOR_READ_FORMAT should fail for incomplete framebuffers.]
+    expected: FAIL
+
+  [WebGL test #96: gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_FORMAT) should be null (of type object). Was 6408 (of type number).]
+    expected: FAIL
+
+  [WebGL test #87: getError expected: INVALID_OPERATION. Was NO_ERROR : IMPLEMENTATION_COLOR_READ_TYPE should fail for incomplete framebuffers.]
+    expected: FAIL
+
+  [WebGL test #89: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36054. Was 36053.]
+    expected: FAIL
+
+  [WebGL test #84: gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_FORMAT) should be null (of type object). Was 6408 (of type number).]
+    expected: FAIL
+
+  [WebGL test #105: Alpha channel should be 0.75 for FLOAT readPixels. Received: 0]
+    expected: FAIL
+
+  [WebGL test #114: Alpha channel should be 1 for FLOAT readPixels. Received: 0]
+    expected: FAIL
+
+  [WebGL test #95: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36054. Was 36053.]
+    expected: FAIL
+
+  [WebGL test #104: Blue channel should be 0.5 for FLOAT readPixels. Received: 0]
+    expected: FAIL
+
+  [WebGL test #99: getError expected: INVALID_OPERATION. Was NO_ERROR : IMPLEMENTATION_COLOR_READ_TYPE should fail for incomplete framebuffers.]
+    expected: FAIL
+
+  [WebGL test #113: Blue channel should be 0.5 for FLOAT readPixels. Received: 0]
+    expected: FAIL
+
+  [WebGL test #92: gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_TYPE) should be null (of type object). Was 5121 (of type number).]
+    expected: FAIL
+
+  [WebGL test #112: Green channel should be 0.25 for FLOAT readPixels. Received: 0]
+    expected: FAIL
+
+  [WebGL test #93: getError expected: INVALID_OPERATION. Was NO_ERROR : IMPLEMENTATION_COLOR_READ_TYPE should fail for incomplete framebuffers.]
+    expected: FAIL
+
+  [WebGL test #103: Green channel should be 0.25 for FLOAT readPixels. Received: 0]
+    expected: FAIL
+
+  [WebGL test #100: getError expected: INVALID_FRAMEBUFFER_OPERATION. Was INVALID_OPERATION : readPixels should fail on incomplete framebuffers.]
+    expected: FAIL
+
+  [WebGL test #94: getError expected: INVALID_FRAMEBUFFER_OPERATION. Was INVALID_OPERATION : readPixels should fail on incomplete framebuffers.]
+    expected: FAIL
+
+  [WebGL test #91: getError expected: INVALID_OPERATION. Was NO_ERROR : IMPLEMENTATION_COLOR_READ_FORMAT should fail for incomplete framebuffers.]
+    expected: FAIL
+
+  [WebGL test #83: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36054. Was 36053.]
     expected: FAIL
 


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/EXT_color_buffer_half_float and https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_color_buffer_float these are implicitly exposed by the corresponding OES texture extensions. The tests were testing for the presence of the extension along with the ability to make use of its features.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21665)
<!-- Reviewable:end -->
