### PR TITLE
Enable wasm tests.

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -109,6 +109,8 @@ skip: true
   skip: false
 [url]
   skip: false
+[wasm]
+  skip: false
 [webaudio]
   skip: false
 [WebCryptoAPI]

--- a/tests/wpt/metadata/wasm/idlharness.any.js.ini
+++ b/tests/wpt/metadata/wasm/idlharness.any.js.ini
@@ -1,0 +1,429 @@
+[idlharness.any.worker.html]
+  [Global interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Table interface object length]
+    expected: FAIL
+
+  [Instance must be primary interface of instance]
+    expected: FAIL
+
+  [Instance interface object name]
+    expected: FAIL
+
+  [Table interface: operation grow(unsigned long)]
+    expected: FAIL
+
+  [Memory interface object name]
+    expected: FAIL
+
+  [Memory interface: memory must inherit property "grow(unsigned long)" with the proper type]
+    expected: FAIL
+
+  [Module interface: operation exports(Module)]
+    expected: FAIL
+
+  [Stringification of mod]
+    expected: FAIL
+
+  [Instance interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [Memory must be primary interface of memory]
+    expected: FAIL
+
+  [Module interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [Global interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [WebAssembly namespace: operation instantiate(BufferSource, object)]
+    expected: FAIL
+
+  [Instance interface: attribute exports]
+    expected: FAIL
+
+  [Module interface: mod must inherit property "imports(Module)" with the proper type]
+    expected: FAIL
+
+  [Global interface: operation valueOf()]
+    expected: FAIL
+
+  [Module interface object name]
+    expected: FAIL
+
+  [Memory interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [Table interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Module interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Table interface: operation get(unsigned long)]
+    expected: FAIL
+
+  [Instance interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Stringification of instance]
+    expected: FAIL
+
+  [Table interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [Instance interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Module interface: calling customSections(Module, USVString) on mod with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Global interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [Module interface: calling imports(Module) on mod with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Module interface: mod must inherit property "exports(Module)" with the proper type]
+    expected: FAIL
+
+  [Memory interface: operation grow(unsigned long)]
+    expected: FAIL
+
+  [Global interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Table interface: attribute length]
+    expected: FAIL
+
+  [Module interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Global interface object length]
+    expected: FAIL
+
+  [Table interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [Memory interface: calling grow(unsigned long) on memory with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [WebAssembly namespace: operation validate(BufferSource)]
+    expected: FAIL
+
+  [Memory interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Module interface: operation customSections(Module, USVString)]
+    expected: FAIL
+
+  [Global interface object name]
+    expected: FAIL
+
+  [Module interface: mod must inherit property "customSections(Module, USVString)" with the proper type]
+    expected: FAIL
+
+  [Memory interface: memory must inherit property "buffer" with the proper type]
+    expected: FAIL
+
+  [Module interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [Table interface: operation set(unsigned long, Function)]
+    expected: FAIL
+
+  [Memory interface object length]
+    expected: FAIL
+
+  [WebAssembly namespace: operation instantiate(Module, object)]
+    expected: FAIL
+
+  [Memory interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Module interface object length]
+    expected: FAIL
+
+  [Instance interface: instance must inherit property "exports" with the proper type]
+    expected: FAIL
+
+  [Global interface: attribute value]
+    expected: FAIL
+
+  [Table interface object name]
+    expected: FAIL
+
+  [Memory interface: attribute buffer]
+    expected: FAIL
+
+  [Module interface: operation imports(Module)]
+    expected: FAIL
+
+  [Instance interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [WebAssembly namespace: operation compile(BufferSource)]
+    expected: FAIL
+
+  [Stringification of memory]
+    expected: FAIL
+
+  [Memory interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [Module interface: calling exports(Module) on mod with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Instance interface object length]
+    expected: FAIL
+
+  [Table interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Module must be primary interface of mod]
+    expected: FAIL
+
+
+[idlharness.any.html]
+  [RuntimeError interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [CompileError interface object length]
+    expected: FAIL
+
+  [Global interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Table interface object length]
+    expected: FAIL
+
+  [Instance must be primary interface of instance]
+    expected: FAIL
+
+  [LinkError interface object name]
+    expected: FAIL
+
+  [LinkError interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Instance interface object name]
+    expected: FAIL
+
+  [LinkError interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [Table interface: operation grow(unsigned long)]
+    expected: FAIL
+
+  [Memory interface object name]
+    expected: FAIL
+
+  [Memory interface: memory must inherit property "grow(unsigned long)" with the proper type]
+    expected: FAIL
+
+  [Module interface: operation exports(Module)]
+    expected: FAIL
+
+  [Stringification of mod]
+    expected: FAIL
+
+  [Instance interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [RuntimeError interface object length]
+    expected: FAIL
+
+  [Memory must be primary interface of memory]
+    expected: FAIL
+
+  [Module interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [Global interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [WebAssembly namespace: operation instantiate(BufferSource, object)]
+    expected: FAIL
+
+  [Instance interface: attribute exports]
+    expected: FAIL
+
+  [RuntimeError interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Module interface: mod must inherit property "imports(Module)" with the proper type]
+    expected: FAIL
+
+  [CompileError interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Global interface: operation valueOf()]
+    expected: FAIL
+
+  [Module interface object name]
+    expected: FAIL
+
+  [CompileError interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [Memory interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [Table interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Module interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Table interface: operation get(unsigned long)]
+    expected: FAIL
+
+  [CompileError interface object name]
+    expected: FAIL
+
+  [Instance interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Stringification of instance]
+    expected: FAIL
+
+  [Table interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [RuntimeError interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Instance interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Module interface: calling customSections(Module, USVString) on mod with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Global interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [CompileError interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Module interface: calling imports(Module) on mod with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Module interface: mod must inherit property "exports(Module)" with the proper type]
+    expected: FAIL
+
+  [Memory interface: operation grow(unsigned long)]
+    expected: FAIL
+
+  [Global interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Table interface: attribute length]
+    expected: FAIL
+
+  [Module interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Global interface object length]
+    expected: FAIL
+
+  [Table interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [Memory interface: calling grow(unsigned long) on memory with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [WebAssembly namespace: operation validate(BufferSource)]
+    expected: FAIL
+
+  [LinkError interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Memory interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Module interface: operation customSections(Module, USVString)]
+    expected: FAIL
+
+  [Global interface object name]
+    expected: FAIL
+
+  [Module interface: mod must inherit property "customSections(Module, USVString)" with the proper type]
+    expected: FAIL
+
+  [Memory interface: memory must inherit property "buffer" with the proper type]
+    expected: FAIL
+
+  [CompileError interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [Module interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [Table interface: operation set(unsigned long, Function)]
+    expected: FAIL
+
+  [RuntimeError interface object name]
+    expected: FAIL
+
+  [Memory interface object length]
+    expected: FAIL
+
+  [WebAssembly namespace: operation instantiate(Module, object)]
+    expected: FAIL
+
+  [LinkError interface object length]
+    expected: FAIL
+
+  [LinkError interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [Memory interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Module interface object length]
+    expected: FAIL
+
+  [Instance interface: instance must inherit property "exports" with the proper type]
+    expected: FAIL
+
+  [Global interface: attribute value]
+    expected: FAIL
+
+  [Table interface object name]
+    expected: FAIL
+
+  [Memory interface: attribute buffer]
+    expected: FAIL
+
+  [Module interface: operation imports(Module)]
+    expected: FAIL
+
+  [Instance interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [WebAssembly namespace: operation compile(BufferSource)]
+    expected: FAIL
+
+  [Stringification of memory]
+    expected: FAIL
+
+  [RuntimeError interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [Memory interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [Module interface: calling exports(Module) on mod with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [Instance interface object length]
+    expected: FAIL
+
+  [Table interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Module must be primary interface of mod]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/constructor/compile.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/constructor/compile.any.js.ini
@@ -1,0 +1,45 @@
+[compile.any.worker.html]
+  [Invalid arguments]
+    expected: FAIL
+
+  [Invalid code]
+    expected: FAIL
+
+  [Branding]
+    expected: FAIL
+
+  [Missing argument]
+    expected: FAIL
+
+  [Result type]
+    expected: FAIL
+
+  [Promise type]
+    expected: FAIL
+
+  [Changing the buffer]
+    expected: FAIL
+
+
+[compile.any.html]
+  [Invalid arguments]
+    expected: FAIL
+
+  [Invalid code]
+    expected: FAIL
+
+  [Branding]
+    expected: FAIL
+
+  [Missing argument]
+    expected: FAIL
+
+  [Result type]
+    expected: FAIL
+
+  [Promise type]
+    expected: FAIL
+
+  [Changing the buffer]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/constructor/instantiate-bad-imports.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/constructor/instantiate-bad-imports.any.js.ini
@@ -1,0 +1,179 @@
+[instantiate-bad-imports.any.html]
+  expected: ERROR
+  [WebAssembly.instantiate(module): Non-object module: NaN]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: null]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object imports argument: null]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: 0.1]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: undefined]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object module: 1]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object imports argument: symbol "Symbol()"]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object module: ""]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: ""]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object module: true]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object module: symbol "Symbol()"]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object imports argument: 1]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: symbol "Symbol()"]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: object "[object Object\]"]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing an i64 global]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Imports argument with missing property: empty object]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object imports argument: true]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Imports argument with missing property: wrong property]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: 1]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Imports argument with missing property: undefined]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object imports argument: NaN]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object module: null]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: true]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object module: 0.1]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: NaN]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object module: undefined]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object imports argument: ""]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object imports argument: 0.1]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Missing imports argument]
+    expected: FAIL
+
+
+[instantiate-bad-imports.any.worker.html]
+  expected: ERROR
+  [WebAssembly.instantiate(module): Non-object module: NaN]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: null]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object imports argument: null]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: 0.1]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: undefined]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object module: 1]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object imports argument: symbol "Symbol()"]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object module: ""]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: ""]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object module: true]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object module: symbol "Symbol()"]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object imports argument: 1]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: symbol "Symbol()"]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: object "[object Object\]"]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing an i64 global]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Imports argument with missing property: empty object]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object imports argument: true]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Imports argument with missing property: wrong property]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: 1]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Imports argument with missing property: undefined]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object imports argument: NaN]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object module: null]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: true]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object module: 0.1]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Importing a function with an incorrectly-typed value: NaN]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object module: undefined]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object imports argument: ""]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Non-object imports argument: 0.1]
+    expected: FAIL
+
+  [WebAssembly.instantiate(module): Missing imports argument]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/constructor/instantiate.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/constructor/instantiate.any.js.ini
@@ -1,0 +1,63 @@
+[instantiate.any.html]
+  [Invalid arguments]
+    expected: FAIL
+
+  [exports and imports: buffer argument]
+    expected: FAIL
+
+  [Invalid code]
+    expected: FAIL
+
+  [BufferSource argument]
+    expected: FAIL
+
+  [Branding]
+    expected: FAIL
+
+  [Missing arguments]
+    expected: FAIL
+
+  [exports and imports: Module argument]
+    expected: FAIL
+
+  [Module argument]
+    expected: FAIL
+
+  [Changing the buffer]
+    expected: FAIL
+
+  [Promise type]
+    expected: FAIL
+
+
+[instantiate.any.worker.html]
+  [Invalid arguments]
+    expected: FAIL
+
+  [exports and imports: buffer argument]
+    expected: FAIL
+
+  [Invalid code]
+    expected: FAIL
+
+  [BufferSource argument]
+    expected: FAIL
+
+  [Branding]
+    expected: FAIL
+
+  [Missing arguments]
+    expected: FAIL
+
+  [exports and imports: Module argument]
+    expected: FAIL
+
+  [Module argument]
+    expected: FAIL
+
+  [Changing the buffer]
+    expected: FAIL
+
+  [Promise type]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/global/constructor.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/global/constructor.any.js.ini
@@ -1,0 +1,189 @@
+[constructor.any.html]
+  [Explicit value object with toString for type f32]
+    expected: FAIL
+
+  [Explicit value true for type f64]
+    expected: FAIL
+
+  [Explicit value undefined for type f64]
+    expected: FAIL
+
+  [Explicit value 2 for type f32]
+    expected: FAIL
+
+  [i64 with default]
+    expected: FAIL
+
+  [Explicit value 2 for type i32]
+    expected: FAIL
+
+  [Explicit value false for type i32]
+    expected: FAIL
+
+  [Default value for type f32]
+    expected: FAIL
+
+  [Explicit value undefined for type i32]
+    expected: FAIL
+
+  [Explicit value object with valueOf for type f32]
+    expected: FAIL
+
+  [Explicit value false for type f32]
+    expected: FAIL
+
+  [Explicit value true for type i32]
+    expected: FAIL
+
+  [Explicit value null for type f32]
+    expected: FAIL
+
+  [Explicit value undefined for type f32]
+    expected: FAIL
+
+  [Explicit value 2 for type f64]
+    expected: FAIL
+
+  [Default value for type i32]
+    expected: FAIL
+
+  [Explicit value false for type f64]
+    expected: FAIL
+
+  [Explicit value "3" for type f64]
+    expected: FAIL
+
+  [Explicit value null for type i32]
+    expected: FAIL
+
+  [Explicit value object with toString for type i32]
+    expected: FAIL
+
+  [Explicit value true for type f32]
+    expected: FAIL
+
+  [Explicit value object with valueOf for type f64]
+    expected: FAIL
+
+  [name]
+    expected: FAIL
+
+  [Explicit value null for type f64]
+    expected: FAIL
+
+  [Explicit value object with toString for type f64]
+    expected: FAIL
+
+  [Default value for type f64]
+    expected: FAIL
+
+  [Explicit value "3" for type i32]
+    expected: FAIL
+
+  [length]
+    expected: FAIL
+
+  [Explicit value object with valueOf for type i32]
+    expected: FAIL
+
+  [Order of evaluation]
+    expected: FAIL
+
+  [Explicit value "3" for type f32]
+    expected: FAIL
+
+
+[constructor.any.worker.html]
+  [Explicit value object with toString for type f32]
+    expected: FAIL
+
+  [Explicit value true for type f64]
+    expected: FAIL
+
+  [Explicit value undefined for type f64]
+    expected: FAIL
+
+  [Explicit value 2 for type f32]
+    expected: FAIL
+
+  [i64 with default]
+    expected: FAIL
+
+  [Explicit value 2 for type i32]
+    expected: FAIL
+
+  [Explicit value false for type i32]
+    expected: FAIL
+
+  [Default value for type f32]
+    expected: FAIL
+
+  [Explicit value undefined for type i32]
+    expected: FAIL
+
+  [Explicit value object with valueOf for type f32]
+    expected: FAIL
+
+  [Explicit value false for type f32]
+    expected: FAIL
+
+  [Explicit value true for type i32]
+    expected: FAIL
+
+  [Explicit value null for type f32]
+    expected: FAIL
+
+  [Explicit value undefined for type f32]
+    expected: FAIL
+
+  [Explicit value 2 for type f64]
+    expected: FAIL
+
+  [Default value for type i32]
+    expected: FAIL
+
+  [Explicit value false for type f64]
+    expected: FAIL
+
+  [Explicit value "3" for type f64]
+    expected: FAIL
+
+  [Explicit value null for type i32]
+    expected: FAIL
+
+  [Explicit value object with toString for type i32]
+    expected: FAIL
+
+  [Explicit value true for type f32]
+    expected: FAIL
+
+  [Explicit value object with valueOf for type f64]
+    expected: FAIL
+
+  [name]
+    expected: FAIL
+
+  [Explicit value null for type f64]
+    expected: FAIL
+
+  [Explicit value object with toString for type f64]
+    expected: FAIL
+
+  [Default value for type f64]
+    expected: FAIL
+
+  [Explicit value "3" for type i32]
+    expected: FAIL
+
+  [length]
+    expected: FAIL
+
+  [Explicit value object with valueOf for type i32]
+    expected: FAIL
+
+  [Order of evaluation]
+    expected: FAIL
+
+  [Explicit value "3" for type f32]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/global/toString.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/global/toString.any.js.ini
@@ -1,0 +1,9 @@
+[toString.any.html]
+  [Object.prototype.toString on an Global]
+    expected: FAIL
+
+
+[toString.any.worker.html]
+  [Object.prototype.toString on an Global]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/global/value-set.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/global/value-set.any.js.ini
@@ -1,0 +1,201 @@
+[value-set.any.html]
+  [Mutable f64 (true on prototype)]
+    expected: FAIL
+
+  [Mutable i32 (true on prototype)]
+    expected: FAIL
+
+  [Immutable f32 (missing)]
+    expected: FAIL
+
+  [Immutable i32 (empty string)]
+    expected: FAIL
+
+  [i64 with default]
+    expected: FAIL
+
+  [Mutable f64 (one)]
+    expected: FAIL
+
+  [Mutable f32 (string)]
+    expected: FAIL
+
+  [Mutable i32 (true)]
+    expected: FAIL
+
+  [Mutable i32 (string)]
+    expected: FAIL
+
+  [Immutable f32 (false)]
+    expected: FAIL
+
+  [Immutable f64 (empty string)]
+    expected: FAIL
+
+  [Immutable i32 (undefined)]
+    expected: FAIL
+
+  [Mutable f32 (one)]
+    expected: FAIL
+
+  [Calling setter without argument]
+    expected: FAIL
+
+  [Immutable i32 (zero)]
+    expected: FAIL
+
+  [Immutable f64 (undefined)]
+    expected: FAIL
+
+  [Mutable i32 (one)]
+    expected: FAIL
+
+  [Immutable f32 (zero)]
+    expected: FAIL
+
+  [Immutable i32 (null)]
+    expected: FAIL
+
+  [Immutable f64 (false)]
+    expected: FAIL
+
+  [Immutable f64 (missing)]
+    expected: FAIL
+
+  [Immutable f64 (null)]
+    expected: FAIL
+
+  [Mutable f32 (true on prototype)]
+    expected: FAIL
+
+  [Immutable i32 (false)]
+    expected: FAIL
+
+  [Immutable i32 (missing)]
+    expected: FAIL
+
+  [Mutable f32 (true)]
+    expected: FAIL
+
+  [Immutable f32 (null)]
+    expected: FAIL
+
+  [Branding]
+    expected: FAIL
+
+  [Immutable f64 (zero)]
+    expected: FAIL
+
+  [Mutable f64 (true)]
+    expected: FAIL
+
+  [Mutable f64 (string)]
+    expected: FAIL
+
+  [Immutable f32 (empty string)]
+    expected: FAIL
+
+  [Immutable f32 (undefined)]
+    expected: FAIL
+
+
+[value-set.any.worker.html]
+  [Mutable f64 (true on prototype)]
+    expected: FAIL
+
+  [Mutable i32 (true on prototype)]
+    expected: FAIL
+
+  [Immutable f32 (missing)]
+    expected: FAIL
+
+  [Immutable i32 (empty string)]
+    expected: FAIL
+
+  [i64 with default]
+    expected: FAIL
+
+  [Mutable f64 (one)]
+    expected: FAIL
+
+  [Mutable f32 (string)]
+    expected: FAIL
+
+  [Mutable i32 (true)]
+    expected: FAIL
+
+  [Mutable i32 (string)]
+    expected: FAIL
+
+  [Immutable f32 (false)]
+    expected: FAIL
+
+  [Immutable f64 (empty string)]
+    expected: FAIL
+
+  [Immutable i32 (undefined)]
+    expected: FAIL
+
+  [Mutable f32 (one)]
+    expected: FAIL
+
+  [Calling setter without argument]
+    expected: FAIL
+
+  [Immutable i32 (zero)]
+    expected: FAIL
+
+  [Immutable f64 (undefined)]
+    expected: FAIL
+
+  [Mutable i32 (one)]
+    expected: FAIL
+
+  [Immutable f32 (zero)]
+    expected: FAIL
+
+  [Immutable i32 (null)]
+    expected: FAIL
+
+  [Immutable f64 (false)]
+    expected: FAIL
+
+  [Immutable f64 (missing)]
+    expected: FAIL
+
+  [Immutable f64 (null)]
+    expected: FAIL
+
+  [Mutable f32 (true on prototype)]
+    expected: FAIL
+
+  [Immutable i32 (false)]
+    expected: FAIL
+
+  [Immutable i32 (missing)]
+    expected: FAIL
+
+  [Mutable f32 (true)]
+    expected: FAIL
+
+  [Immutable f32 (null)]
+    expected: FAIL
+
+  [Branding]
+    expected: FAIL
+
+  [Immutable f64 (zero)]
+    expected: FAIL
+
+  [Mutable f64 (true)]
+    expected: FAIL
+
+  [Mutable f64 (string)]
+    expected: FAIL
+
+  [Immutable f32 (empty string)]
+    expected: FAIL
+
+  [Immutable f32 (undefined)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/global/valueOf.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/global/valueOf.any.js.ini
@@ -1,0 +1,9 @@
+[valueOf.any.worker.html]
+  [Branding]
+    expected: FAIL
+
+
+[valueOf.any.html]
+  [Branding]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/instance/constructor-bad-imports.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/instance/constructor-bad-imports.any.js.ini
@@ -1,0 +1,5 @@
+[constructor-bad-imports.any.worker.html]
+  expected: ERROR
+
+[constructor-bad-imports.any.html]
+  expected: ERROR

--- a/tests/wpt/metadata/wasm/jsapi/instance/constructor.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/instance/constructor.any.js.ini
@@ -1,0 +1,9 @@
+[constructor.any.html]
+  [exports]
+    expected: FAIL
+
+
+[constructor.any.worker.html]
+  [exports]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/interface.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/interface.any.js.ini
@@ -1,0 +1,101 @@
+[interface.any.html]
+  expected: ERROR
+  [WebAssembly.Table.get]
+    expected: FAIL
+
+  [WebAssembly.Table.length]
+    expected: FAIL
+
+  [WebAssembly.Module.imports]
+    expected: FAIL
+
+  [WebAssembly.Module.exports]
+    expected: FAIL
+
+  [WebAssembly.Memory.grow]
+    expected: FAIL
+
+  [WebAssembly.Memory.buffer]
+    expected: FAIL
+
+  [WebAssembly.Global: prototype]
+    expected: FAIL
+
+  [WebAssembly.compile]
+    expected: FAIL
+
+  [WebAssembly.Module.customSections]
+    expected: FAIL
+
+  [WebAssembly.Table.set]
+    expected: FAIL
+
+  [WebAssembly.Instance.exports]
+    expected: FAIL
+
+  [WebAssembly.validate]
+    expected: FAIL
+
+  [WebAssembly.Global: prototype.constructor]
+    expected: FAIL
+
+  [WebAssembly.Global: property descriptor]
+    expected: FAIL
+
+  [WebAssembly.instantiate]
+    expected: FAIL
+
+  [WebAssembly.Table.grow]
+    expected: FAIL
+
+
+[interface.any.worker.html]
+  expected: ERROR
+  [WebAssembly.Table.get]
+    expected: FAIL
+
+  [WebAssembly.Table.length]
+    expected: FAIL
+
+  [WebAssembly.Module.imports]
+    expected: FAIL
+
+  [WebAssembly.Module.exports]
+    expected: FAIL
+
+  [WebAssembly.Memory.grow]
+    expected: FAIL
+
+  [WebAssembly.Memory.buffer]
+    expected: FAIL
+
+  [WebAssembly.Global: prototype]
+    expected: FAIL
+
+  [WebAssembly.compile]
+    expected: FAIL
+
+  [WebAssembly.Module.customSections]
+    expected: FAIL
+
+  [WebAssembly.Table.set]
+    expected: FAIL
+
+  [WebAssembly.Instance.exports]
+    expected: FAIL
+
+  [WebAssembly.validate]
+    expected: FAIL
+
+  [WebAssembly.Global: prototype.constructor]
+    expected: FAIL
+
+  [WebAssembly.Global: property descriptor]
+    expected: FAIL
+
+  [WebAssembly.instantiate]
+    expected: FAIL
+
+  [WebAssembly.Table.grow]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/memory/constructor.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/memory/constructor.any.js.ini
@@ -1,0 +1,93 @@
+[constructor.any.worker.html]
+  [Out-of-range maximum value in descriptor: -Infinity]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: NaN]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: 4294967296]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: NaN]
+    expected: FAIL
+
+  [Proxy descriptor]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: Infinity]
+    expected: FAIL
+
+  [Undefined initial value in descriptor]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: 68719476736]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: 4294967296]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: -1]
+    expected: FAIL
+
+  [Invalid descriptor argument]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: -Infinity]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: Infinity]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: -1]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: 68719476736]
+    expected: FAIL
+
+
+[constructor.any.html]
+  [Out-of-range maximum value in descriptor: -Infinity]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: NaN]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: 4294967296]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: NaN]
+    expected: FAIL
+
+  [Proxy descriptor]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: Infinity]
+    expected: FAIL
+
+  [Undefined initial value in descriptor]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: 68719476736]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: 4294967296]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: -1]
+    expected: FAIL
+
+  [Invalid descriptor argument]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: -Infinity]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: Infinity]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: -1]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: 68719476736]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/memory/grow.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/memory/grow.any.js.ini
@@ -1,0 +1,63 @@
+[grow.any.worker.html]
+  [Out-of-range argument: 68719476736]
+    expected: FAIL
+
+  [Out-of-range argument: 4294967296]
+    expected: FAIL
+
+  [Missing arguments]
+    expected: FAIL
+
+  [Out-of-range argument: -1]
+    expected: FAIL
+
+  [Out-of-range argument: NaN]
+    expected: FAIL
+
+  [Out-of-range argument: object "[object Object\]"]
+    expected: FAIL
+
+  [Out-of-range argument: -Infinity]
+    expected: FAIL
+
+  [Out-of-range argument: "0x100000000"]
+    expected: FAIL
+
+  [Out-of-range argument: undefined]
+    expected: FAIL
+
+  [Out-of-range argument: Infinity]
+    expected: FAIL
+
+
+[grow.any.html]
+  [Out-of-range argument: 68719476736]
+    expected: FAIL
+
+  [Out-of-range argument: 4294967296]
+    expected: FAIL
+
+  [Missing arguments]
+    expected: FAIL
+
+  [Out-of-range argument: -1]
+    expected: FAIL
+
+  [Out-of-range argument: NaN]
+    expected: FAIL
+
+  [Out-of-range argument: object "[object Object\]"]
+    expected: FAIL
+
+  [Out-of-range argument: -Infinity]
+    expected: FAIL
+
+  [Out-of-range argument: "0x100000000"]
+    expected: FAIL
+
+  [Out-of-range argument: undefined]
+    expected: FAIL
+
+  [Out-of-range argument: Infinity]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/module/customSections.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/module/customSections.any.js.ini
@@ -1,0 +1,9 @@
+[customSections.any.html]
+  [Missing arguments]
+    expected: FAIL
+
+
+[customSections.any.worker.html]
+  [Missing arguments]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/module/exports.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/module/exports.any.js.ini
@@ -1,0 +1,9 @@
+[exports.any.html]
+  [exports]
+    expected: FAIL
+
+
+[exports.any.worker.html]
+  [exports]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/table/constructor.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/table/constructor.any.js.ini
@@ -1,0 +1,99 @@
+[constructor.any.html]
+  [Out-of-range maximum value in descriptor: -Infinity]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: NaN]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: 4294967296]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: NaN]
+    expected: FAIL
+
+  [Proxy descriptor]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: Infinity]
+    expected: FAIL
+
+  [Undefined initial value in descriptor]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: 68719476736]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: 4294967296]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: -1]
+    expected: FAIL
+
+  [Order of evaluation for descriptor]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: -Infinity]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: Infinity]
+    expected: FAIL
+
+  [Type conversion for descriptor.element]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: -1]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: 68719476736]
+    expected: FAIL
+
+
+[constructor.any.worker.html]
+  [Out-of-range maximum value in descriptor: -Infinity]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: NaN]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: 4294967296]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: NaN]
+    expected: FAIL
+
+  [Proxy descriptor]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: Infinity]
+    expected: FAIL
+
+  [Undefined initial value in descriptor]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: 68719476736]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: 4294967296]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: -1]
+    expected: FAIL
+
+  [Order of evaluation for descriptor]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: -Infinity]
+    expected: FAIL
+
+  [Out-of-range maximum value in descriptor: Infinity]
+    expected: FAIL
+
+  [Type conversion for descriptor.element]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: -1]
+    expected: FAIL
+
+  [Out-of-range initial value in descriptor: 68719476736]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/table/get-set.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/table/get-set.any.js.ini
@@ -1,0 +1,117 @@
+[get-set.any.worker.html]
+  [Setting out-of-range argument: NaN]
+    expected: FAIL
+
+  [Getting out-of-range argument: undefined]
+    expected: FAIL
+
+  [Setting out-of-range argument: -1]
+    expected: FAIL
+
+  [Setting out-of-range argument: 4294967296]
+    expected: FAIL
+
+  [Getting out-of-range argument: NaN]
+    expected: FAIL
+
+  [Getting out-of-range argument: 4294967296]
+    expected: FAIL
+
+  [Setting out-of-range argument: "0x100000000"]
+    expected: FAIL
+
+  [Setting out-of-range argument: object "[object Object\]"]
+    expected: FAIL
+
+  [Setting out-of-range argument: Infinity]
+    expected: FAIL
+
+  [Setting out-of-range argument: 68719476736]
+    expected: FAIL
+
+  [Missing arguments: get]
+    expected: FAIL
+
+  [Getting out-of-range argument: 68719476736]
+    expected: FAIL
+
+  [Getting out-of-range argument: Infinity]
+    expected: FAIL
+
+  [Setting out-of-range argument: undefined]
+    expected: FAIL
+
+  [Getting out-of-range argument: -1]
+    expected: FAIL
+
+  [Getting out-of-range argument: "0x100000000"]
+    expected: FAIL
+
+  [Getting out-of-range argument: object "[object Object\]"]
+    expected: FAIL
+
+  [Setting out-of-range argument: -Infinity]
+    expected: FAIL
+
+  [Getting out-of-range argument: -Infinity]
+    expected: FAIL
+
+
+[get-set.any.html]
+  [Setting out-of-range argument: NaN]
+    expected: FAIL
+
+  [Getting out-of-range argument: undefined]
+    expected: FAIL
+
+  [Setting out-of-range argument: -1]
+    expected: FAIL
+
+  [Setting out-of-range argument: 4294967296]
+    expected: FAIL
+
+  [Getting out-of-range argument: NaN]
+    expected: FAIL
+
+  [Getting out-of-range argument: 4294967296]
+    expected: FAIL
+
+  [Setting out-of-range argument: "0x100000000"]
+    expected: FAIL
+
+  [Setting out-of-range argument: object "[object Object\]"]
+    expected: FAIL
+
+  [Setting out-of-range argument: Infinity]
+    expected: FAIL
+
+  [Setting out-of-range argument: 68719476736]
+    expected: FAIL
+
+  [Missing arguments: get]
+    expected: FAIL
+
+  [Getting out-of-range argument: 68719476736]
+    expected: FAIL
+
+  [Getting out-of-range argument: Infinity]
+    expected: FAIL
+
+  [Setting out-of-range argument: undefined]
+    expected: FAIL
+
+  [Getting out-of-range argument: -1]
+    expected: FAIL
+
+  [Getting out-of-range argument: "0x100000000"]
+    expected: FAIL
+
+  [Getting out-of-range argument: object "[object Object\]"]
+    expected: FAIL
+
+  [Setting out-of-range argument: -Infinity]
+    expected: FAIL
+
+  [Getting out-of-range argument: -Infinity]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/jsapi/table/grow.any.js.ini
+++ b/tests/wpt/metadata/wasm/jsapi/table/grow.any.js.ini
@@ -1,0 +1,63 @@
+[grow.any.html]
+  [Out-of-range argument: 68719476736]
+    expected: FAIL
+
+  [Out-of-range argument: -Infinity]
+    expected: FAIL
+
+  [Out-of-range argument: 4294967296]
+    expected: FAIL
+
+  [Out-of-range argument: Infinity]
+    expected: FAIL
+
+  [Missing arguments]
+    expected: FAIL
+
+  [Out-of-range argument: -1]
+    expected: FAIL
+
+  [Out-of-range argument: undefined]
+    expected: FAIL
+
+  [Out-of-range argument: NaN]
+    expected: FAIL
+
+  [Out-of-range argument: object "[object Object\]"]
+    expected: FAIL
+
+  [Out-of-range argument: "0x100000000"]
+    expected: FAIL
+
+
+[grow.any.worker.html]
+  [Out-of-range argument: 68719476736]
+    expected: FAIL
+
+  [Out-of-range argument: -Infinity]
+    expected: FAIL
+
+  [Out-of-range argument: 4294967296]
+    expected: FAIL
+
+  [Out-of-range argument: Infinity]
+    expected: FAIL
+
+  [Missing arguments]
+    expected: FAIL
+
+  [Out-of-range argument: -1]
+    expected: FAIL
+
+  [Out-of-range argument: undefined]
+    expected: FAIL
+
+  [Out-of-range argument: NaN]
+    expected: FAIL
+
+  [Out-of-range argument: object "[object Object\]"]
+    expected: FAIL
+
+  [Out-of-range argument: "0x100000000"]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/serialization/broadcastchannel-success-and-failure.html.ini
+++ b/tests/wpt/metadata/wasm/serialization/broadcastchannel-success-and-failure.html.ini
@@ -1,0 +1,4 @@
+[broadcastchannel-success-and-failure.html]
+  [WebAssembly.Module cannot cross agent clusters, BroadcastChannel edition]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/serialization/broadcastchannel-success.html.ini
+++ b/tests/wpt/metadata/wasm/serialization/broadcastchannel-success.html.ini
@@ -1,0 +1,4 @@
+[broadcastchannel-success.html]
+  [Structured cloning of WebAssembly.Module: BroadcastChannel within the same agent cluster]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/serialization/identity-not-preserved.html.ini
+++ b/tests/wpt/metadata/wasm/serialization/identity-not-preserved.html.ini
@@ -1,0 +1,11 @@
+[identity-not-preserved.html]
+  expected: TIMEOUT
+  [postMessaging to this window does not give back the same WebAssembly.Module]
+    expected: TIMEOUT
+
+  [postMessaging to a worker and back does not give back the same WebAssembly.Module]
+    expected: TIMEOUT
+
+  [postMessaging to an iframe and back does not give back the same WebAssembly.Module]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/wasm/serialization/nested-worker-success.any.js.ini
+++ b/tests/wpt/metadata/wasm/serialization/nested-worker-success.any.js.ini
@@ -1,0 +1,9 @@
+[nested-worker-success.any.sharedworker.html]
+  [nested-worker-success]
+    expected: FAIL
+
+
+[nested-worker-success.any.worker.html]
+  [postMessaging to a dedicated sub-worker allows them to see each others' modifications]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/serialization/no-transferring.html.ini
+++ b/tests/wpt/metadata/wasm/serialization/no-transferring.html.ini
@@ -1,0 +1,10 @@
+[no-transferring.html]
+  [Trying to transfer a WebAssembly.Module to a worker throws]
+    expected: FAIL
+
+  [Trying to transfer a WebAssembly.Module through a MessagePort throws]
+    expected: FAIL
+
+  [Trying to transfer a WebAssembly.Module to this window throws]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/serialization/serialization-via-idb.any.js.ini
+++ b/tests/wpt/metadata/wasm/serialization/serialization-via-idb.any.js.ini
@@ -1,0 +1,15 @@
+[serialization-via-idb.any.worker.html]
+  [WebAssembly.Module cloning via the IndexedDB: is interleaved correctly]
+    expected: FAIL
+
+  [WebAssembly.Module cloning via IndexedDB: basic case]
+    expected: FAIL
+
+
+[serialization-via-idb.any.html]
+  [WebAssembly.Module cloning via the IndexedDB: is interleaved correctly]
+    expected: FAIL
+
+  [WebAssembly.Module cloning via IndexedDB: basic case]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/serialization/serialization-via-notifications-api.any.js.ini
+++ b/tests/wpt/metadata/wasm/serialization/serialization-via-notifications-api.any.js.ini
@@ -1,0 +1,15 @@
+[serialization-via-notifications-api.any.html]
+  [WebAssembly.Module cloning via the Notifications API's data member: basic case]
+    expected: FAIL
+
+  [WebAssembly.Module cloning via the Notifications API's data member: is interleaved correctly]
+    expected: FAIL
+
+
+[serialization-via-notifications-api.any.worker.html]
+  [WebAssembly.Module cloning via the Notifications API's data member: basic case]
+    expected: FAIL
+
+  [WebAssembly.Module cloning via the Notifications API's data member: is interleaved correctly]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/serialization/window-domain-success.sub.html.ini
+++ b/tests/wpt/metadata/wasm/serialization/window-domain-success.sub.html.ini
@@ -1,0 +1,4 @@
+[window-domain-success.sub.html]
+  [postMessaging to a same-origin-domain (but not same-origin) iframe allows them to instantiate]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/serialization/window-messagechannel-success.html.ini
+++ b/tests/wpt/metadata/wasm/serialization/window-messagechannel-success.html.ini
@@ -1,0 +1,4 @@
+[window-messagechannel-success.html]
+  [postMessaging to a dedicated worker via MessageChannel allows them to instantiate]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/serialization/window-serviceworker-failure.https.html.ini
+++ b/tests/wpt/metadata/wasm/serialization/window-serviceworker-failure.https.html.ini
@@ -1,0 +1,4 @@
+[window-serviceworker-failure.https.html]
+  [WebAssembly.Module cannot cross agent clusters, service worker edition]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/serialization/window-sharedworker-failure.html.ini
+++ b/tests/wpt/metadata/wasm/serialization/window-sharedworker-failure.html.ini
@@ -1,0 +1,4 @@
+[window-sharedworker-failure.html]
+  [WebAssembly.Modules cannot cross agent clusters, shared worker edition]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/serialization/window-similar-but-cross-origin-success.sub.html.ini
+++ b/tests/wpt/metadata/wasm/serialization/window-similar-but-cross-origin-success.sub.html.ini
@@ -1,0 +1,4 @@
+[window-similar-but-cross-origin-success.sub.html]
+  [postMessaging to a not same-origin-domain, but similar origin, iframe allows them to instantiate]
+    expected: FAIL
+

--- a/tests/wpt/metadata/wasm/serialization/window-simple-success.html.ini
+++ b/tests/wpt/metadata/wasm/serialization/window-simple-success.html.ini
@@ -1,0 +1,13 @@
+[window-simple-success.html]
+  [postMessaging to a same-origin opened window allows them to instantiate]
+    expected: FAIL
+
+  [postMessaging to a same-origin deeply-nested iframe allows them to instantiate]
+    expected: FAIL
+
+  [postMessaging to a dedicated worker allows them to instantiate]
+    expected: FAIL
+
+  [postMessaging to a same-origin iframe allows them to instantiate]
+    expected: FAIL
+


### PR DESCRIPTION
Now that we support WASM, we should avoid regressing that existing support and get a better idea about the pieces we're still missing.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21668)
<!-- Reviewable:end -->
