### PR TITLE
Remove some generics

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -99,9 +99,9 @@ impl FrameTreeId {
 enum LayerPixel {}
 
 /// NB: Never block on the constellation, because sometimes the constellation blocks on us.
-pub struct IOCompositor<Window: WindowMethods> {
+pub struct IOCompositor {
     /// The application window.
-    pub window: Rc<Window>,
+    pub window: Rc<WindowMethods>,
 
     /// The port on which we receive messages.
     port: CompositorReceiver,
@@ -292,8 +292,8 @@ impl webrender_api::RenderNotifier for RenderNotifier {
     }
 }
 
-impl<Window: WindowMethods> IOCompositor<Window> {
-    fn new(window: Rc<Window>, state: InitialCompositorState) -> Self {
+impl IOCompositor {
+    fn new(window: Rc<WindowMethods>, state: InitialCompositorState) -> Self {
         let composite_target = match opts::get().output_file {
             Some(_) => CompositeTarget::PngFile,
             None => CompositeTarget::Window,
@@ -332,7 +332,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         }
     }
 
-    pub fn create(window: Rc<Window>, state: InitialCompositorState) -> Self {
+    pub fn create(window: Rc<WindowMethods>, state: InitialCompositorState) -> Self {
         let mut compositor = IOCompositor::new(window, state);
 
         // Set the size of the root layer.

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -121,18 +121,15 @@ pub use msg::constellation_msg::{KeyState, TopLevelBrowsingContextId as BrowserI
 /// application Servo is embedded in. Clients then create an event
 /// loop to pump messages between the embedding application and
 /// various browser components.
-pub struct Servo<Window: WindowMethods + 'static> {
-    compositor: IOCompositor<Window>,
+pub struct Servo {
+    compositor: IOCompositor,
     constellation_chan: Sender<ConstellationMsg>,
     embedder_receiver: EmbedderReceiver,
     embedder_events: Vec<(Option<BrowserId>, EmbedderMsg)>,
 }
 
-impl<Window> Servo<Window>
-where
-    Window: WindowMethods + 'static,
-{
-    pub fn new(window: Rc<Window>) -> Servo<Window> {
+impl Servo {
+    pub fn new(window: Rc<WindowMethods>) -> Servo {
         // Global configuration options, parsed from the command line.
         let opts = opts::get();
 

--- a/ports/libsimpleservo/src/api.rs
+++ b/ports/libsimpleservo/src/api.rs
@@ -71,7 +71,7 @@ pub trait HostTrait {
 }
 
 pub struct ServoGlue {
-    servo: Servo<ServoCallbacks>,
+    servo: Servo,
     batch_mode: bool,
     callbacks: Rc<ServoCallbacks>,
     /// id of the top level browsing context. It is unique as tabs


### PR DESCRIPTION
This simplify the signature of `Servo` and `IOCompositor`.
I'm not sure why `'static` was necessary in the first place.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21671)
<!-- Reviewable:end -->
