### PR TITLE
send pageErrors to devtools console

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -27,7 +27,7 @@ trait EncodableConsoleMessage {
 impl EncodableConsoleMessage for CachedConsoleMessage {
     fn encode(&self) -> serde_json::Result<String> {
         match *self {
-            CachedConsoleMessage::PageError(ref a) => serde_json::to_string(a),
+            CachedConsoleMessage::PageErrorAPI(ref a) => serde_json::to_string(a),
             CachedConsoleMessage::ConsoleAPI(ref a) => serde_json::to_string(a),
         }
     }

--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -83,6 +83,7 @@ pub enum ScriptToDevtoolsControlMsg {
     ),
     /// A particular page has invoked the console API.
     ConsoleAPI(PipelineId, ConsoleMessage, Option<WorkerId>),
+    PageErrorAPI(PipelineId, PageErrorAPI, Option<WorkerId>),
     /// An animation frame with the given timestamp was processed in a script thread.
     /// The actor with the provided name should be notified.
     FramerateTick(String, f64),
@@ -261,9 +262,7 @@ bitflags! {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct PageError {
-    #[serde(rename = "_type")]
-    pub type_: String,
+pub struct PageErrorAPI {
     pub errorMessage: String,
     pub sourceName: String,
     pub lineText: String,
@@ -293,7 +292,7 @@ pub struct ConsoleAPI {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum CachedConsoleMessage {
-    PageError(PageError),
+    PageErrorAPI(PageErrorAPI),
     ConsoleAPI(ConsoleAPI),
 }
 

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use devtools_traits::{AutoMargins, CachedConsoleMessage, CachedConsoleMessageTypes};
-use devtools_traits::{ComputedNodeLayout, ConsoleAPI, PageError};
+use devtools_traits::{ComputedNodeLayout, ConsoleAPI, PageErrorAPI};
 use devtools_traits::{EvaluateJSReply, Modification, NodeInfo, TimelineMarker};
 use devtools_traits::TimelineMarkerType;
 use dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
@@ -173,8 +173,7 @@ pub fn handle_get_cached_messages(_pipeline_id: PipelineId,
     if message_types.contains(CachedConsoleMessageTypes::PAGE_ERROR) {
         // TODO: make script error reporter pass all reported errors
         //      to devtools and cache them for returning here.
-        let msg = PageError {
-            type_: "PageError".to_owned(),
+        let msg = PageErrorAPI {
             errorMessage: "page error test".to_owned(),
             sourceName: String::new(),
             lineText: String::new(),
@@ -188,7 +187,7 @@ pub fn handle_get_cached_messages(_pipeline_id: PipelineId,
             strict: false,
             private: false,
         };
-        messages.push(CachedConsoleMessage::PageError(msg));
+        messages.push(CachedConsoleMessage::PageErrorAPI(msg));
     }
     if message_types.contains(CachedConsoleMessageTypes::CONSOLE_API) {
         // TODO: do for real


### PR DESCRIPTION
Fixes : #13161

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

Handle pageErrors differently than normal console messages, since these contains stacktrace, which will be supported soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21678)
<!-- Reviewable:end -->
