### PR TITLE
format components/selectors

### DIFF
--- a/components/selectors/bloom.rs
+++ b/components/selectors/bloom.rs
@@ -318,8 +318,9 @@ fn create_and_insert_some_stuff() {
         assert!(bf.might_contain_hash(hash_as_str(i)));
     }
 
-    let false_positives =
-        (1001_usize..2000).filter(|i| bf.might_contain_hash(hash_as_str(*i))).count();
+    let false_positives = (1001_usize..2000)
+        .filter(|i| bf.might_contain_hash(hash_as_str(*i)))
+        .count();
 
     assert!(false_positives < 190, "{} is not < 190", false_positives); // 19%.
 
@@ -331,7 +332,9 @@ fn create_and_insert_some_stuff() {
         assert!(bf.might_contain_hash(hash_as_str(i)));
     }
 
-    let false_positives = (0_usize..100).filter(|i| bf.might_contain_hash(hash_as_str(*i))).count();
+    let false_positives = (0_usize..100)
+        .filter(|i| bf.might_contain_hash(hash_as_str(*i)))
+        .count();
 
     assert!(false_positives < 20, "{} is not < 20", false_positives); // 20%.
 

--- a/components/selectors/builder.rs
+++ b/components/selectors/builder.rs
@@ -161,7 +161,8 @@ struct SelectorBuilderIter<'a, Impl: SelectorImpl> {
 
 impl<'a, Impl: SelectorImpl> ExactSizeIterator for SelectorBuilderIter<'a, Impl> {
     fn len(&self) -> usize {
-        self.current_simple_selectors.len() + self.rest_of_simple_selectors.len() +
+        self.current_simple_selectors.len() +
+            self.rest_of_simple_selectors.len() +
             self.combinators.len()
     }
 }
@@ -227,7 +228,6 @@ struct Specificity {
     class_like_selectors: u32,
     element_selectors: u32,
 }
-
 
 impl AddAssign for Specificity {
     #[inline]
@@ -306,10 +306,9 @@ where
             Component::Combinator(ref combinator) => {
                 unreachable!(
                     "Found combinator {:?} in simple selectors vector? {:?}",
-                    combinator,
-                    builder,
+                    combinator, builder,
                 );
-            }
+            },
             Component::PseudoElement(..) | Component::LocalName(..) => {
                 specificity.element_selectors += 1
             },
@@ -329,7 +328,7 @@ where
                     // See: https://github.com/w3c/csswg-drafts/issues/1915
                     *specificity += Specificity::from(selector.specificity());
                 }
-            }
+            },
             Component::ID(..) => {
                 specificity.id_selectors += 1;
             },

--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -261,11 +261,10 @@ where
     let iter = selector.iter_from(selector.len() - from_offset);
     debug_assert!(
         iter.clone().next().is_some() ||
-            (from_offset != selector.len() &&
-                matches!(
-                    selector.combinator_at_parse_order(from_offset),
-                    Combinator::SlotAssignment | Combinator::PseudoElement
-                )),
+            (from_offset != selector.len() && matches!(
+                selector.combinator_at_parse_order(from_offset),
+                Combinator::SlotAssignment | Combinator::PseudoElement
+            )),
         "Got the math wrong: {:?} | {:?} | {} {}",
         selector,
         selector.iter_raw_match_order().as_slice(),
@@ -663,8 +662,9 @@ where
         Component::Combinator(_) => unreachable!(),
         Component::Slotted(ref selector) => {
             // <slots> are never flattened tree slottables.
-            !element.is_html_slot_element() && element.assigned_slot().is_some() &&
-                context.shared.nest(|context| {
+            !element.is_html_slot_element() && element.assigned_slot().is_some() && context
+                .shared
+                .nest(|context| {
                     matches_complex_selector(selector.iter(), element, context, flags_setter)
                 })
         },
@@ -729,7 +729,7 @@ where
                 None => {
                     empty_string = ::parser::namespace_empty_string::<E::Impl>();
                     NamespaceConstraint::Specific(&empty_string)
-                }
+                },
             };
             element.attr_matches(
                 &namespace,
@@ -750,7 +750,8 @@ where
         },
         Component::NonTSPseudoClass(ref pc) => {
             if context.matches_hover_and_active_quirk == MatchesHoverAndActiveQuirk::Yes &&
-                !context.shared.is_nested() && pc.is_active_or_hover() &&
+                !context.shared.is_nested() &&
+                pc.is_active_or_hover() &&
                 !element.is_link()
             {
                 return false;


### PR DESCRIPTION
Format with `rustfmt components/selectors/*.rs`
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21679)
<!-- Reviewable:end -->
