### PR TITLE
Create ScriptMsg::GetBrowsingContextInfo

### DIFF
--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -108,14 +108,16 @@ pub enum ScriptMsg {
     Focus,
     /// Requests that the constellation retrieve the current contents of the clipboard
     GetClipboardContents(IpcSender<String>),
-    /// Get the browsing context id for a given pipeline.
-    GetBrowsingContextId(PipelineId, IpcSender<Option<BrowsingContextId>>),
-    /// Get the parent info for a given pipeline.
-    GetParentInfo(PipelineId, IpcSender<Option<PipelineId>>),
     /// Get the top-level browsing context info for a given browsing context.
     GetTopForBrowsingContext(
         BrowsingContextId,
         IpcSender<Option<TopLevelBrowsingContextId>>,
+    ),
+    /// Get the browsing context id of the browsing context in which pipeline is
+    /// embedded and the parent pipeline id of that browsing context.
+    GetBrowsingContextInfo(
+        PipelineId,
+        IpcSender<Option<(BrowsingContextId, Option<PipelineId>)>>,
     ),
     /// Get the nth child browsing context ID for a given browsing context, sorted in tree order.
     GetChildBrowsingContextId(
@@ -201,8 +203,7 @@ impl fmt::Debug for ScriptMsg {
             CreateCanvasPaintThread(..) => "CreateCanvasPaintThread",
             Focus => "Focus",
             GetClipboardContents(..) => "GetClipboardContents",
-            GetBrowsingContextId(..) => "GetBrowsingContextId",
-            GetParentInfo(..) => "GetParentInfo",
+            GetBrowsingContextInfo(..) => "GetBrowsingContextInfo",
             GetTopForBrowsingContext(..) => "GetParentBrowsingContext",
             GetChildBrowsingContextId(..) => "GetChildBrowsingContextId",
             LoadComplete => "LoadComplete",


### PR DESCRIPTION
Script used to send two messages to constellation to first retrieve the id of the browsing context in which a pipeline resides and then its parent pipeline's id. This patch introduces a minor optimization to instead retrieve those fields in a single message.

Also, fixed a potential bug introduced in #21559 where if a browsing context wasn't found for a pipeline in response to `GetParentInfo` (which is now deleted), constellation sent nothing back, presumably causing the script thread to hang on the receiving channel.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21703 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because no new behaviour was introduced.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21705)
<!-- Reviewable:end -->
