### PR TITLE
Fix private browsing mode preservation when loading URL

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2064,12 +2064,13 @@ where
                 return None;
             },
         };
-        let (window_size, pipeline_id, parent_pipeline_id, is_visible) =
+        let (window_size, pipeline_id, parent_pipeline_id, is_private, is_visible) =
             match self.browsing_contexts.get(&browsing_context_id) {
                 Some(ctx) => (
                     ctx.size,
                     ctx.pipeline_id,
                     ctx.parent_pipeline_id,
+                    ctx.is_private,
                     ctx.is_visible,
                 ),
                 None => {
@@ -2141,9 +2142,6 @@ where
 
                 let new_pipeline_id = PipelineId::new();
                 let sandbox = IFrameSandboxState::IFrameUnsandboxed;
-                // TODO(mandreyel): why is this false? Should we not inherit the
-                // privacy of the (existing) browsing context?
-                let is_private = false;
                 self.new_pipeline(
                     new_pipeline_id,
                     browsing_context_id,


### PR DESCRIPTION
`Constellation::load_url` disregards the existing `BrowsingContext`'s `is_private` field when loading a new URL and creating a new `Pipeline` for the page load, which means that the `Pipeline` is always passed the public resource thread, even if its browsing context is in private browsing mode. This PR fixes that.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21706 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___
- [x] I'm not actually sure. I haven't found tests related to private browsing so maybe that's why this bug wasn't caught earlier?

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21710)
<!-- Reviewable:end -->
