### PR TITLE
Make tests for uninitialized renderbuffers pass

### DIFF
--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -532,6 +532,7 @@ impl WebGLFramebuffer {
 
     pub fn invalidate_renderbuffer(&self, rb: &WebGLRenderbuffer) {
         self.with_matching_renderbuffers(rb, |_att, _| {
+            self.is_initialized.set(false);
             self.update_status();
         });
     }

--- a/components/script/dom/webglrenderbuffer.rs
+++ b/components/script/dom/webglrenderbuffer.rs
@@ -145,6 +145,7 @@ impl WebGLRenderbuffer {
         };
 
         self.internal_format.set(Some(internal_format));
+        self.is_initialized.set(false);
 
         // FIXME: Invalidate completeness after the call
 

--- a/tests/wpt/webgl/meta/conformance/canvas/drawingbuffer-test.html.ini
+++ b/tests/wpt/webgl/meta/conformance/canvas/drawingbuffer-test.html.ini
@@ -1,2 +1,3 @@
 [drawingbuffer-test.html]
+  bug: https://github.com/servo/servo/issues/21718
   expected: CRASH

--- a/tests/wpt/webgl/meta/conformance/glsl/variables/gl-pointcoord.html.ini
+++ b/tests/wpt/webgl/meta/conformance/glsl/variables/gl-pointcoord.html.ini
@@ -1,4 +1,5 @@
 [gl-pointcoord.html]
+  bug: https://github.com/servo/servo/issues/21719
   [WebGL test #48: pixel 48,192 should be 65,125,0\nat (48, 192) expected: 65,125,0 was 0,0,0]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance/misc/uninitialized-test.html.ini
+++ b/tests/wpt/webgl/meta/conformance/misc/uninitialized-test.html.ini
@@ -1,2 +1,2 @@
 [uninitialized-test.html]
-  disabled: https://github.com/servo/servo/issues/13710
+  disabled: https://github.com/servo/servo/issues/21716

--- a/tests/wpt/webgl/meta/conformance/renderbuffers/depth-renderbuffer-initialization.html.ini
+++ b/tests/wpt/webgl/meta/conformance/renderbuffers/depth-renderbuffer-initialization.html.ini
@@ -1,2 +1,0 @@
-[depth-renderbuffer-initialization.html]
-  disabled: https://github.com/servo/servo/issues/13710

--- a/tests/wpt/webgl/meta/conformance/renderbuffers/renderbuffer-initialization.html.ini
+++ b/tests/wpt/webgl/meta/conformance/renderbuffers/renderbuffer-initialization.html.ini
@@ -1,2 +1,0 @@
-[renderbuffer-initialization.html]
-  disabled: https://github.com/servo/servo/issues/13710

--- a/tests/wpt/webgl/meta/conformance/renderbuffers/stencil-renderbuffer-initialization.html.ini
+++ b/tests/wpt/webgl/meta/conformance/renderbuffers/stencil-renderbuffer-initialization.html.ini
@@ -1,2 +1,0 @@
-[stencil-renderbuffer-initialization.html]
-  disabled: https://github.com/servo/servo/issues/13710


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13710 
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21717)
<!-- Reviewable:end -->
