### PR TITLE
Add llvm to macOS required dependencies in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ Please select your operating system:
 #### On macOS (homebrew)
 
 ``` sh
-brew install automake autoconf@2.13 pkg-config python cmake yasm
+brew install automake autoconf@2.13 pkg-config python cmake yasm llvm
 brew install gstreamer gst-plugins-base gst-plugins-good       gst-plugins-bad gst-plugins-ugly gst-libav gst-rtsp-server       --with-orc -with-libogg --with-opus --with-pango --with-theora       --with-libvorbis
 pip install virtualenv
 ```
 #### On macOS (MacPorts)
 
 ``` sh
-sudo port install python27 py27-virtualenv cmake yasm
+sudo port install python27 py27-virtualenv cmake yasm llvm
 ```
 #### On macOS >= 10.11 (El Capitan), you also have to install OpenSSL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

@gterzian described it [in their comment](https://github.com/servo/servo/issues/21498#issuecomment-415698332) pretty well:

> latest "command line tools" that come with it(and include Apple's version of llvm), it might be that the current default Mac llvm is too old to compile the latest mozjs version(it appeared that after the OS update, no version of clang/llvm was installed until I downloaded the "new" command-line tools for the new OS)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #21498 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's a change to markdown file.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21731)
<!-- Reviewable:end -->
