### PR TITLE
Try to unlock the global lock in StructuredLogger after reloading log…

### DIFF
--- a/tests/wpt/web-platform-tests/tools/serve/serve.py
+++ b/tests/wpt/web-platform-tests/tools/serve/serve.py
@@ -19,8 +19,10 @@ from collections import defaultdict, OrderedDict
 from multiprocessing import Process, Event
 
 from localpaths import repo_root
+from six.moves import reload_module
 
 from manifest.sourcefile import read_script_metadata, js_meta_re, parse_variants
+from mozlog.structuredlog import StructuredLogger
 from wptserve import server as wptserve, handlers
 from wptserve import stash
 from wptserve import config
@@ -631,9 +633,10 @@ class WebSocketDaemon(object):
 def start_ws_server(host, port, paths, routes, bind_address, config, **kwargs):
     # Ensure that when we start this in a new process we have the global lock
     # in the logging module unlocked
+    reload_module(logging)
     try:
-        logging._releaseLock()
-    except RuntimeError:
+        StructuredLogger._lock.release()
+    except threading.ThreadError:
         pass
     return WebSocketDaemon(host,
                            str(port),
@@ -647,9 +650,10 @@ def start_ws_server(host, port, paths, routes, bind_address, config, **kwargs):
 def start_wss_server(host, port, paths, routes, bind_address, config, **kwargs):
     # Ensure that when we start this in a new process we have the global lock
     # in the logging module unlocked
+    reload_module(logging)
     try:
-        logging._releaseLock()
-    except RuntimeError:
+        StructuredLogger._lock.release()
+    except threading.ThreadError:
         pass
     return WebSocketDaemon(host,
                            str(port),


### PR DESCRIPTION
…ging

This should finally fix all the websockets related failures we've been
seeing lately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21741)
<!-- Reviewable:end -->
