### PR TITLE
This updates the smallvec crate and enables the union feature

### DIFF
--- a/components/fallible/Cargo.toml
+++ b/components/fallible/Cargo.toml
@@ -10,7 +10,7 @@ name = "fallible"
 path = "lib.rs"
 
 [dependencies]
-smallvec = "0.6.2"
+smallvec = { version = "0.6", features = ["std", "union"] }
 hashglobe = { path = "../hashglobe" }
 
 # This crate effectively does nothing except if the `known_system_malloc`

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -36,7 +36,7 @@ serde = "1.0"
 servo_arc = {path = "../servo_arc"}
 servo_atoms = {path = "../atoms"}
 servo_url = {path = "../url"}
-smallvec = "0.6.2"
+smallvec = { version = "0.6", features = ["std", "union"] }
 style = {path = "../style"}
 time = "0.1.12"
 unicode-bidi = {version = "0.3", features = ["with_serde"]}

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -44,7 +44,7 @@ servo_geometry = {path = "../geometry"}
 serde_json = "1.0"
 servo_config = {path = "../config"}
 servo_url = {path = "../url"}
-smallvec = "0.6.2"
+smallvec = { version = "0.6", features = ["std", "union"] }
 style = {path = "../style", features = ["servo"]}
 style_traits = {path = "../style_traits"}
 unicode-bidi = {version = "0.3", features = ["with_serde"]}

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -37,7 +37,7 @@ serde_bytes = { version = "0.10", optional = true }
 servo_arc = { path = "../servo_arc" }
 servo_channel = { path = "../channel", optional = true }
 smallbitvec = "2.1.0"
-smallvec = "0.6"
+smallvec = { version = "0.6", features = ["std", "union"] }
 string_cache = { version = "0.7", optional = true }
 thin-slice = "0.1.0"
 time = { version = "0.1.17", optional = true }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -91,7 +91,7 @@ servo_geometry = {path = "../geometry" }
 servo-media = {git = "https://github.com/servo/media"}
 servo_rand = {path = "../rand"}
 servo_url = {path = "../url"}
-smallvec = "0.6.2"
+smallvec = { version = "0.6", features = ["std", "union"] }
 style = {path = "../style", features = ["servo"]}
 style_traits = {path = "../style_traits"}
 swapper = "0.1"

--- a/components/selectors/Cargo.toml
+++ b/components/selectors/Cargo.toml
@@ -28,7 +28,7 @@ fxhash = "0.2"
 phf = "0.7.18"
 precomputed-hash = "0.1"
 servo_arc = { version = "0.1", path = "../servo_arc" }
-smallvec = "0.6.2"
+smallvec = { version = "0.6", features = ["std", "union"] }
 thin-slice = "0.1.0"
 
 [build-dependencies]

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -62,7 +62,7 @@ servo_atoms = {path = "../atoms", optional = true}
 servo_channel = {path = "../channel", optional = true}
 servo_config = {path = "../config", optional = true}
 smallbitvec = "2.1.1"
-smallvec = "0.6.2"
+smallvec = { version = "0.6", features = ["std", "union"] }
 string_cache = { version = "0.7", optional = true }
 style_derive = {path = "../style_derive"}
 style_traits = {path = "../style_traits"}


### PR DESCRIPTION
We had a mix of 0.6.2 and 0.6.5 (which is the current release), this unifies to the latest version. It also enables the union feature which removes the discriminant, reducing memory usage.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21746)
<!-- Reviewable:end -->
