### PR TITLE
Pin pycparser to known working version

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -10,7 +10,7 @@ setuptools == 18.5
 toml == 0.9.2
 
 # For pycparser 2.19 release bustage
-pycparser == 2.18
+pycparser != 2.19
 
 # For Python linting
 flake8 == 2.4.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,11 +6,8 @@ mach == 0.6.0
 mozdebug == 0.1
 mozinfo == 0.8
 mozlog == 3.6
-setuptools == 18.5
+setuptools == 39.0
 toml == 0.9.2
-
-# For pycparser 2.19 release bustage
-pycparser != 2.19
 
 # For Python linting
 flake8 == 2.4.1

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,6 +9,9 @@ mozlog == 3.6
 setuptools == 18.5
 toml == 0.9.2
 
+# For pycparser 2.19 release bustage
+pycparser == 2.18
+
 # For Python linting
 flake8 == 2.4.1
 pep8 == 1.5.7


### PR DESCRIPTION
Attempting to work around CI bustage caused by the release of pycparser 2.19.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21749)
<!-- Reviewable:end -->
