### PR TITLE
Add mach command to setup remote debugging on Android devices.

### DIFF
--- a/support/android/apk/jni/Application.mk
+++ b/support/android/apk/jni/Application.mk
@@ -2,3 +2,4 @@ NDK_TOOLCHAIN_VERSION := 4.9
 APP_MODULES := c++_shared servojni gstreamer
 APP_PLATFORM := android-18
 APP_STL:= c++_shared
+APP_ABI:= armeabi-v7a x86

--- a/support/android/apk/jni/Application.mk
+++ b/support/android/apk/jni/Application.mk
@@ -1,4 +1,4 @@
-NDK_TOOLCHAIN_VERSION := 4.9
+NDK_TOOLCHAIN_VERSION := clang
 APP_MODULES := c++_shared servojni gstreamer
 APP_PLATFORM := android-18
 APP_STL:= c++_shared


### PR DESCRIPTION
This removes any need to fiddle with search paths for source files and makes the experience of remote debugging much less frustrating. I've tried this on a Pixel, Pixel 2, and emulator and successfully set breakpoints and investigated variables on all of them. The APP_ABI changes are necessary to prevent ndk-gdb from thinking that the build is arm64 when it's not.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21759)
<!-- Reviewable:end -->
