### PR TITLE
Do not suppress errors from packaging android build.

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -406,8 +406,10 @@ class MachCommands(CommandBase):
         # Do some additional things if the build succeeded
         if status == 0:
             if android and not no_package:
-                Registrar.dispatch("package", context=self.context,
-                                   release=release, dev=dev, target=target)
+                rv = Registrar.dispatch("package", context=self.context,
+                                        release=release, dev=dev, target=target)
+                if rv:
+                    return rv
 
             if sys.platform == "win32":
                 servo_exe_dir = path.join(base_path, "debug" if dev else "release")


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21765

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21766)
<!-- Reviewable:end -->
