### PR TITLE
Enable use of RUST_LOG with mach run --android.

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -99,6 +99,9 @@ class PostBuildCommands(CommandBase):
             ]
             json_params = shell_quote(json.dumps(params))
             extra = "-e servoargs " + json_params
+            rust_log = env.get("RUST_LOG", None)
+            if rust_log:
+                extra += " -e servolog " + rust_log
             script += [
                 "am start " + extra + " com.mozilla.servo/com.mozilla.servo.MainActivity",
                 "sleep 0.5",

--- a/support/android/apk/servoapp/src/main/java/com/mozilla/servo/MainActivity.java
+++ b/support/android/apk/servoapp/src/main/java/com/mozilla/servo/MainActivity.java
@@ -71,7 +71,8 @@ public class MainActivity extends Activity implements Servo.Client {
         }
 
         String args = getIntent().getStringExtra("servoargs");
-        mServoView.setServoArgs(args);
+        String log = getIntent().getStringExtra("servolog");
+        mServoView.setServoArgs(args, log);
 
         setupUrlField();
     }

--- a/support/android/apk/servoview/src/main/java/com/mozilla/servoview/JNIServo.java
+++ b/support/android/apk/servoview/src/main/java/com/mozilla/servoview/JNIServo.java
@@ -22,6 +22,7 @@ public class JNIServo {
     public native void init(Activity activity,
                             String args,
                             String url,
+                            String logstr,
                             Callbacks callbacks,
                             int width, int height, boolean log);
 

--- a/support/android/apk/servoview/src/main/java/com/mozilla/servoview/Servo.java
+++ b/support/android/apk/servoview/src/main/java/com/mozilla/servoview/Servo.java
@@ -24,7 +24,9 @@ public class Servo {
             GfxCallbacks gfxcb,
             Client client,
             Activity activity,
-            String args, String url,
+            String args,
+            String url,
+            String logstr,
             int width, int height, boolean log) {
 
         mRunCallback = runCallback;
@@ -34,7 +36,7 @@ public class Servo {
         Callbacks cbs = new Callbacks(client, gfxcb);
 
         mRunCallback.inGLThread(() -> {
-            mJNI.init(activity, args, url, cbs, width, height, log);
+            mJNI.init(activity, args, url, logstr, cbs, width, height, log);
         });
     }
 

--- a/support/android/apk/servoview/src/main/java/com/mozilla/servoview/ServoSurface.java
+++ b/support/android/apk/servoview/src/main/java/com/mozilla/servoview/ServoSurface.java
@@ -38,6 +38,7 @@ public class ServoSurface {
     private Servo mServo;
     private Client mClient = null;
     private String mServoArgs = "";
+    private String mServoLog = "";
     private String mInitialUri = null;
     private Activity mActivity;
 
@@ -53,8 +54,9 @@ public class ServoSurface {
         mClient = client;
     }
 
-    public void setServoArgs(String args) {
+    public void setServoArgs(String args, String log) {
         mServoArgs = args != null ? args : "";
+        mServoLog = log != null ? log : "";
     }
 
     public void setActivity(Activity activity) {
@@ -204,7 +206,7 @@ public class ServoSurface {
             inUIThread(() -> {
               final boolean showLogs = true;
               String uri = mInitialUri == null ? null : mInitialUri;
-              mServo = new Servo(this, surface, mClient, mActivity, mServoArgs, uri, mWidth, mHeight, showLogs);
+              mServo = new Servo(this, surface, mClient, mActivity, mServoArgs, uri, mServoLog, mWidth, mHeight, showLogs);
             });
 
             Looper.loop();

--- a/support/android/apk/servoview/src/main/java/com/mozilla/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/com/mozilla/servoview/ServoView.java
@@ -41,6 +41,7 @@ public class ServoView extends GLSurfaceView
     private Uri mInitialUri = null;
     private boolean mAnimating;
     private String mServoArgs = "";
+    private String mServoLog = "";
     private GestureDetector mGestureDetector;
     private ScaleGestureDetector mScaleGestureDetector;
 
@@ -72,8 +73,9 @@ public class ServoView extends GLSurfaceView
         initGestures(context);
     }
 
-    public void setServoArgs(String args) {
+    public void setServoArgs(String args, String log) {
         mServoArgs = args != null ? args : "";
+        mServoLog = log != null ? log : "";
     }
 
     public void reload() {
@@ -139,7 +141,7 @@ public class ServoView extends GLSurfaceView
         int height = getHeight();
         inGLThread(() -> {
             String uri = mInitialUri == null ? null : mInitialUri.toString();
-            mServo = new Servo(this, this, mClient, mActivity, mServoArgs, uri, width, height, showLogs);
+            mServo = new Servo(this, this, mClient, mActivity, mServoArgs, uri, mServoLog, width, height, showLogs);
         });
     }
 


### PR DESCRIPTION
This allows running `RUST_LOG=layout_thread ./mach run --android` and seeing the appropriate logging output appear in `./adb logcat`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21764

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21767)
<!-- Reviewable:end -->
