### PR TITLE
Remove unnecessary sysroot and platform configuration from build script.

### DIFF
--- a/ports/libsimpleservo/build.rs
+++ b/ports/libsimpleservo/build.rs
@@ -24,36 +24,14 @@ fn android_main() {
         env::var_os("ANDROID_NDK").expect("Please set the ANDROID_NDK environment variable");
     let ndk_path = Path::new(&ndk_path);
 
-    let target = env::var("TARGET").unwrap();
-    let arch = if target.contains("arm") {
-        "arch-arm"
-    } else if target.contains("aarch64") {
-        "arch-arm64"
-    } else if target.contains("x86") || target.contains("i686") {
-        "arch-x86"
-    } else if target.contains("mips") {
-        "arch-mips"
-    } else {
-        panic!("Invalid target architecture {}", target);
-    };
-
-    let platform = if target.contains("aarch64") {
-        "android-21"
-    } else {
-        "android-18"
-    };
-
     // compiling android_native_app_glue.c
     let c_file = ndk_path
         .join("sources")
         .join("android")
         .join("native_app_glue")
         .join("android_native_app_glue.c");
-    let sysroot = ndk_path.join("platforms").join(platform).join(arch);
     cc::Build::new()
         .file(c_file)
-        .flag("--sysroot")
-        .flag(sysroot.to_str().unwrap())
         .warnings(false)
         .compile("android_native_app_glue");
 


### PR DESCRIPTION
All of the proper compiler arguments and paths are set up by mach ahead of time, so there should be no need to duplicate any of that logic in the build script.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21769)
<!-- Reviewable:end -->
