### PR TITLE
Add support for IpcBytesReceiver in profile_traits::ipc - #21704

### DIFF
--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -151,6 +151,7 @@ impl Formattable for ProfilerCategory {
             ProfilerCategory::TimeToFirstContentfulPaint => "Time To First Contentful Paint",
             ProfilerCategory::TimeToInteractive => "Time to Interactive",
             ProfilerCategory::IpcReceiver => "Blocked at IPC Receive",
+            ProfilerCategory::IpcBytesReceiver => "Blocked at IPC Bytes Receive",
             ProfilerCategory::ApplicationHeartbeat => "Application Heartbeat",
         };
         format!("{}{}", padding, name)

--- a/components/profile_traits/ipc.rs
+++ b/components/profile_traits/ipc.rs
@@ -53,3 +53,33 @@ where
     };
     Ok((ipc_sender, profiled_ipc_receiver))
 }
+
+pub struct IpcBytesReceiver
+{
+    ipc_bytes_receiver: ipc::IpcBytesReceiver,
+    time_profile_chan: ProfilerChan,
+}
+
+impl IpcBytesReceiver
+{
+    pub fn recv(&self) -> Result<Vec<u8>, bincode::Error> {
+        time::profile(
+            ProfilerCategory::IpcBytesReceiver,
+            None,
+            self.time_profile_chan.clone(),
+            move || self.ipc_bytes_receiver.recv(),
+        )
+    }
+}
+
+pub fn bytes_channel(
+    time_profile_chan: ProfilerChan,
+) -> Result<(ipc::IpcBytesSender, IpcBytesReceiver), Error>
+{
+    let (ipc_bytes_sender, ipc_bytes_receiver) = ipc::bytes_channel()?;
+    let profiled_ipc_bytes_receiver = IpcBytesReceiver {
+        ipc_bytes_receiver,
+        time_profile_chan,
+    };
+    Ok((ipc_bytes_sender, profiled_ipc_bytes_receiver))
+}

--- a/components/profile_traits/time.rs
+++ b/components/profile_traits/time.rs
@@ -110,6 +110,7 @@ pub enum ProfilerCategory {
     TimeToFirstContentfulPaint = 0x81,
     TimeToInteractive = 0x82,
     IpcReceiver = 0x83,
+    IpcBytesReceiver = 0x84,
     ApplicationHeartbeat = 0x90,
 }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Added support for IpcBytesReceiver in profile_trails::ipc. Added a new test-point that exercises bytes_channel().

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #21704 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21771)
<!-- Reviewable:end -->
