### PR TITLE
Remove unnecessary define from android build.

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -383,7 +383,6 @@ class MachCommands(CommandBase):
                 "-I" + cxx_include,
                 "-isystem", sysroot_include,
                 "-L" + gcc_libs,
-                "-D__STDC_CONSTANT_MACROS",
                 "-D__NDK_FPABI__="])
             env["NDK_ANDROID_VERSION"] = android_platform.replace("android-", "")
             env['CPPFLAGS'] = ' '.join(["--sysroot", env['ANDROID_SYSROOT']])


### PR DESCRIPTION
This regularly shows me this warning:
```
warning: In file included from <built-in>:1:
warning: In file included from /Users/jdm/src/servo/target/armv7-linux-androideabi/debug/build/mozjs_sys-dd0a269b31bf3a8b/out/js/src/js-confdefs.h:91:
warning: /Users/jdm/src/servo/target/armv7-linux-androideabi/debug/build/mozjs_sys-dd0a269b31bf3a8b/out/dist/include/js/RequiredDefines.h:28:9: warning: '__STDC_CONSTANT_MACROS' macro redefined [-Wmacro-redefined]
warning: #define __STDC_CONSTANT_MACROS
warning:         ^
warning: <command line>:2:9: note: previous definition is here
warning: #define __STDC_CONSTANT_MACROS 1
warning:         ^
warning: 1 warning generated.
```

This was added originally before we understood the need for js-confdefs.h, but wasn't removed after our understanding grew.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21782)
<!-- Reviewable:end -->
