### PR TITLE
Use standard buffer format for DEPTH_STENCIL

### DIFF
--- a/components/script/dom/webglrenderbuffer.rs
+++ b/components/script/dom/webglrenderbuffer.rs
@@ -122,9 +122,9 @@ impl WebGLRenderbuffer {
         let actual_format = match internal_format {
             constants::RGBA4 |
             constants::DEPTH_COMPONENT16 |
-            constants::STENCIL_INDEX8 |
-            // https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.7
-            constants::DEPTH_STENCIL => internal_format,
+            constants::STENCIL_INDEX8 => internal_format,
+            // https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.8
+            constants::DEPTH_STENCIL => WebGl2Constants::DEPTH24_STENCIL8,
             constants::RGB5_A1 => {
                 // 16-bit RGBA formats are not supported on desktop GL.
                 if is_gles() {


### PR DESCRIPTION
This makes the Going Home title display for me on my Pixel 2.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21763
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21784)
<!-- Reviewable:end -->
