### PR TITLE
Add framebuffer check for mark_as_dirty, #21691

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -435,9 +435,13 @@ impl WebGLRenderingContext {
     }
 
     fn mark_as_dirty(&self) {
-        self.canvas
-            .upcast::<Node>()
-            .dirty(NodeDamage::OtherNodeDamage);
+        // If we don't have a bound framebuffer, then don't mark the canvas
+        // as dirty.
+        if self.bound_framebuffer.get().is_none() {
+            self.canvas
+                .upcast::<Node>()
+                .dirty(NodeDamage::OtherNodeDamage);
+        }
     }
 
     fn vertex_attrib(&self, indx: u32, x: f32, y: f32, z: f32, w: f32) {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Check `bound_framebuffer` in each `mark_as_dirty` call, so that we don't dirty the canvas if we don't have a bound framebuffer.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #21691  (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because there isn't a direct way to test it (yet).

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21785)
<!-- Reviewable:end -->
