### PR TITLE
Partially revert #21746.

### DIFF
--- a/components/fallible/Cargo.toml
+++ b/components/fallible/Cargo.toml
@@ -10,7 +10,7 @@ name = "fallible"
 path = "lib.rs"
 
 [dependencies]
-smallvec = { version = "0.6", features = ["std", "union"] }
+smallvec = "0.6"
 hashglobe = { path = "../hashglobe" }
 
 # This crate effectively does nothing except if the `known_system_malloc`

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -37,7 +37,7 @@ serde_bytes = { version = "0.10", optional = true }
 servo_arc = { path = "../servo_arc" }
 servo_channel = { path = "../channel", optional = true }
 smallbitvec = "2.1.0"
-smallvec = { version = "0.6", features = ["std", "union"] }
+smallvec = "0.6"
 string_cache = { version = "0.7", optional = true }
 thin-slice = "0.1.0"
 time = { version = "0.1.17", optional = true }

--- a/components/selectors/Cargo.toml
+++ b/components/selectors/Cargo.toml
@@ -28,7 +28,7 @@ fxhash = "0.2"
 phf = "0.7.18"
 precomputed-hash = "0.1"
 servo_arc = { version = "0.1", path = "../servo_arc" }
-smallvec = { version = "0.6", features = ["std", "union"] }
+smallvec = "0.6"
 thin-slice = "0.1.0"
 
 [build-dependencies]

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -62,7 +62,7 @@ servo_atoms = {path = "../atoms", optional = true}
 servo_channel = {path = "../channel", optional = true}
 servo_config = {path = "../config", optional = true}
 smallbitvec = "2.1.1"
-smallvec = { version = "0.6", features = ["std", "union"] }
+smallvec = "0.6"
 string_cache = { version = "0.7", optional = true }
 style_derive = {path = "../style_derive"}
 style_traits = {path = "../style_traits"}


### PR DESCRIPTION
This reverts the relevant bits from #21746 so that style and dependencies can
build with stable.

This is important because:

 * `selectors` is a published crate.

 * Gecko compiles with stable (more or less).

I reviewed that PR under the assumption that the union feature was stable, since
untagged unions are stable since 1.19, but turns out that smallvec uses non-Copy
types in unions, which are still unstable.

This leaves the union feature used on Servo, so that it gets testing, taking
advantage of features being additive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21788)
<!-- Reviewable:end -->
