### PR TITLE
Bug 1172897 - Rename Tab Actor to BrowsingContextActor

### DIFF
--- a/components/devtools/actors/root.rs
+++ b/components/devtools/actors/root.rs
@@ -5,10 +5,10 @@
 /// Liberally derived from the [Firefox JS implementation]
 /// (http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/root.js).
 /// Connection point for all new remote devtools interactions, providing lists of know actors
-/// that perform more specific actions (tabs, addons, browser chrome, etc.)
+/// that perform more specific actions (targets, addons, browser chrome, etc.)
 use actor::{Actor, ActorMessageStatus, ActorRegistry};
+use actors::browsing_context::{BrowsingContextActor, BrowsingContextActorMsg};
 use actors::performance::PerformanceActor;
-use actors::tab::{TabActor, TabActorMsg};
 use protocol::{ActorDescription, JsonPacketStream};
 use serde_json::{Map, Value};
 use std::net::TcpStream;
@@ -34,7 +34,7 @@ enum AddonMsg {}
 struct ListTabsReply {
     from: String,
     selected: u32,
-    tabs: Vec<TabActorMsg>,
+    tabs: Vec<BrowsingContextActorMsg>,
 }
 
 #[derive(Serialize)]
@@ -81,7 +81,7 @@ impl Actor for RootActor {
                 ActorMessageStatus::Processed
             },
 
-            //https://wiki.mozilla.org/Remote_Debugging_Protocol#Listing_Browser_Tabs
+            // https://docs.firefox-dev.tools/backend/protocol.html#listing-browser-tabs
             "listTabs" => {
                 let actor = ListTabsReply {
                     from: "root".to_owned(),
@@ -89,7 +89,7 @@ impl Actor for RootActor {
                     tabs: self
                         .tabs
                         .iter()
-                        .map(|tab| registry.find::<TabActor>(tab).encodable())
+                        .map(|target| registry.find::<BrowsingContextActor>(target).encodable())
                         .collect(),
                 };
                 stream.write_json_packet(&actor);


### PR DESCRIPTION
As part of [Bug 1172987](https://bugzilla.mozilla.org/show_bug.cgi?id=1172897) we renamed TabActor, as the actor does not represent tabs (as in a browser tab), it instead represents a browsing context as defined by the the [HTML standard](https://html.spec.whatwg.org/multipage/browsers.html#windows). In a later PR I will mirror the structure we have on devtools to have a targets folder, which contains all target types. At the moment it looks like servo only represents workers and browsing contexts.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
Unfortunately, I am unable to build due to #21792 -- I will try to find a linux machine to build on
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix Bugzilla [Bug 1172987](https://bugzilla.mozilla.org/show_bug.cgi?id=1172897).

<!-- Either: -->
- [x] These changes do not require tests because this is a renaming and shouldn't impact tests as far as I can tell

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21799)
<!-- Reviewable:end -->
