### PR TITLE
Unify the task source and task canceller API

### DIFF
--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -129,6 +129,7 @@ impl Formattable for ProfilerCategory {
             ProfilerCategory::ScriptDomEvent => "Script Dom Event",
             ProfilerCategory::ScriptEvaluate => "Script JS Evaluate",
             ProfilerCategory::ScriptFileRead => "Script File Read",
+            ProfilerCategory::ScriptHistoryEvent => "Script History Event",
             ProfilerCategory::ScriptImageCacheMsg => "Script Image Cache Msg",
             ProfilerCategory::ScriptInputEvent => "Script Input Event",
             ProfilerCategory::ScriptNetworkEvent => "Script Network Event",

--- a/components/profile_traits/time.rs
+++ b/components/profile_traits/time.rs
@@ -103,6 +103,7 @@ pub enum ProfilerCategory {
     ScriptWebVREvent = 0x79,
     ScriptWorkletEvent = 0x7a,
     ScriptPerformanceEvent = 0x7b,
+    ScriptHistoryEvent = 0x7c,
     TimeToFirstPaint = 0x80,
     TimeToFirstContentfulPaint = 0x81,
     TimeToInteractive = 0x82,

--- a/components/script/dom/analysernode.rs
+++ b/components/script/dom/analysernode.rs
@@ -17,7 +17,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::window::Window;
-use crate::task_source::{TaskSource, TaskSourceName};
+use crate::task_source::TaskSource;
 use dom_struct::dom_struct;
 use ipc_channel::ipc::{self, IpcReceiver};
 use ipc_channel::router::ROUTER;
@@ -97,8 +97,9 @@ impl AnalyserNode {
     ) -> Fallible<DomRoot<AnalyserNode>> {
         let (node, recv) = AnalyserNode::new_inherited(window, context, options)?;
         let object = reflect_dom_object(Box::new(node), window, AnalyserNodeBinding::Wrap);
-        let source = window.dom_manipulation_task_source();
-        let canceller = window.task_canceller(TaskSourceName::DOMManipulation);
+        let (source, canceller) = window
+            .task_manager()
+            .dom_manipulation_task_source_with_canceller();
         let this = Trusted::new(&*object);
 
         ROUTER.add_route(

--- a/components/script/dom/audiocontext.rs
+++ b/components/script/dom/audiocontext.rs
@@ -126,7 +126,7 @@ impl AudioContextMethods for AudioContext {
 
         // Steps 4 and 5.
         let window = DomRoot::downcast::<Window>(self.global()).unwrap();
-        let task_source = window.dom_manipulation_task_source();
+        let task_source = window.task_manager().dom_manipulation_task_source();
         let trusted_promise = TrustedPromise::new(promise.clone());
         match self.context.audio_context_impl().suspend() {
             Ok(_) => {
@@ -141,7 +141,7 @@ impl AudioContextMethods for AudioContext {
                     if base_context.State() != AudioContextState::Suspended {
                         base_context.set_state_attribute(AudioContextState::Suspended);
                         let window = DomRoot::downcast::<Window>(context.global()).unwrap();
-                        window.dom_manipulation_task_source().queue_simple_event(
+                        window.task_manager().dom_manipulation_task_source().queue_simple_event(
                             context.upcast(),
                             atom!("statechange"),
                             &window
@@ -188,7 +188,7 @@ impl AudioContextMethods for AudioContext {
 
         // Steps 4 and 5.
         let window = DomRoot::downcast::<Window>(self.global()).unwrap();
-        let task_source = window.dom_manipulation_task_source();
+        let task_source = window.task_manager().dom_manipulation_task_source();
         let trusted_promise = TrustedPromise::new(promise.clone());
         match self.context.audio_context_impl().close() {
             Ok(_) => {
@@ -203,7 +203,7 @@ impl AudioContextMethods for AudioContext {
                     if base_context.State() != AudioContextState::Closed {
                         base_context.set_state_attribute(AudioContextState::Closed);
                         let window = DomRoot::downcast::<Window>(context.global()).unwrap();
-                        window.dom_manipulation_task_source().queue_simple_event(
+                        window.task_manager().dom_manipulation_task_source().queue_simple_event(
                             context.upcast(),
                             atom!("statechange"),
                             &window

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -521,6 +521,7 @@ impl Document {
                 if self.ready_state.get() == DocumentReadyState::Complete {
                     let document = Trusted::new(self);
                     self.window
+                        .task_manager()
                         .dom_manipulation_task_source()
                         .queue(
                             task!(fire_pageshow_event: move || {
@@ -1869,6 +1870,7 @@ impl Document {
         debug!("Document loads are complete.");
         let document = Trusted::new(self);
         self.window
+            .task_manager()
             .dom_manipulation_task_source()
             .queue(
                 task!(fire_load_event: move || {
@@ -1922,6 +1924,7 @@ impl Document {
         let document = Trusted::new(self);
         if document.root().browsing_context().is_some() {
             self.window
+                .task_manager()
                 .dom_manipulation_task_source()
                 .queue(
                     task!(fire_pageshow_event: move || {
@@ -2104,13 +2107,16 @@ impl Document {
 
         // Step 4.1.
         let window = self.window();
-        window.dom_manipulation_task_source().queue_event(
-            self.upcast(),
-            atom!("DOMContentLoaded"),
-            EventBubbles::Bubbles,
-            EventCancelable::NotCancelable,
-            window,
-        );
+        window
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue_event(
+                self.upcast(),
+                atom!("DOMContentLoaded"),
+                EventBubbles::Bubbles,
+                EventCancelable::NotCancelable,
+                window,
+            );
 
         window.reflow(ReflowGoal::Full, ReflowReason::DOMContentLoaded);
         update_with_current_time_ms(&self.dom_content_loaded_event_end);

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -476,7 +476,7 @@ impl GlobalScope {
     /// this global scope.
     pub fn networking_task_source(&self) -> NetworkingTaskSource {
         if let Some(window) = self.downcast::<Window>() {
-            return window.networking_task_source();
+            return window.task_manager().networking_task_source();
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
             return worker.networking_task_source();
@@ -488,7 +488,7 @@ impl GlobalScope {
     /// this global scope.
     pub fn remote_event_task_source(&self) -> RemoteEventTaskSource {
         if let Some(window) = self.downcast::<Window>() {
-            return window.remote_event_task_source();
+            return window.task_manager().remote_event_task_source();
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
             return worker.remote_event_task_source();
@@ -500,7 +500,7 @@ impl GlobalScope {
     /// this global scope.
     pub fn websocket_task_source(&self) -> WebsocketTaskSource {
         if let Some(window) = self.downcast::<Window>() {
-            return window.websocket_task_source();
+            return window.task_manager().websocket_task_source();
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
             return worker.websocket_task_source();
@@ -635,7 +635,7 @@ impl GlobalScope {
     /// properly cancelled when the global scope is destroyed.
     pub fn task_canceller(&self, name: TaskSourceName) -> TaskCanceller {
         if let Some(window) = self.downcast::<Window>() {
-            return window.task_canceller(name);
+            return window.task_manager().task_canceller(name);
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
             // Note: the "name" is not passed to the worker,
@@ -691,7 +691,7 @@ impl GlobalScope {
 
     pub fn dom_manipulation_task_source(&self) -> DOMManipulationTaskSource {
         if let Some(window) = self.downcast::<Window>() {
-            return window.dom_manipulation_task_source();
+            return window.task_manager().dom_manipulation_task_source();
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
             return worker.dom_manipulation_task_source();
@@ -703,7 +703,7 @@ impl GlobalScope {
     /// this of this global scope.
     pub fn file_reading_task_source(&self) -> FileReadingTaskSource {
         if let Some(window) = self.downcast::<Window>() {
-            return window.file_reading_task_source();
+            return window.task_manager().file_reading_task_source();
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
             return worker.file_reading_task_source();
@@ -756,7 +756,7 @@ impl GlobalScope {
     /// of this global scope.
     pub fn performance_timeline_task_source(&self) -> PerformanceTimelineTaskSource {
         if let Some(window) = self.downcast::<Window>() {
-            return window.performance_timeline_task_source();
+            return window.task_manager().performance_timeline_task_source();
         }
         if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
             return worker.performance_timeline_task_source();

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -76,7 +76,7 @@ impl VirtualMethods for HTMLDetailsElement {
             let window = window_from_node(self);
             let this = Trusted::new(self);
             // FIXME(nox): Why are errors silenced here?
-            let _ = window.dom_manipulation_task_source().queue(
+            let _ = window.task_manager().dom_manipulation_task_source().queue(
                 task!(details_notification_task_steps: move || {
                     let this = this.root();
                     if counter == this.toggle_counter.get() {

--- a/components/script/dom/htmldialogelement.rs
+++ b/components/script/dom/htmldialogelement.rs
@@ -90,7 +90,8 @@ impl HTMLDialogElementMethods for HTMLDialogElement {
         // TODO: Step 4 implement pending dialog stack removal
 
         // Step 5
-        win.dom_manipulation_task_source()
+        win.task_manager()
+            .dom_manipulation_task_source()
             .queue_simple_event(target, atom!("close"), &win);
     }
 }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -523,6 +523,7 @@ impl HTMLFormElement {
 
         // Step 3.
         target
+            .task_manager()
             .dom_manipulation_task_source()
             .queue(task, target.upcast())
             .unwrap();

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -237,7 +237,7 @@ impl HTMLIFrameElement {
             let this = Trusted::new(self);
             let pipeline_id = self.pipeline_id().unwrap();
             // FIXME(nox): Why are errors silenced here?
-            let _ = window.dom_manipulation_task_source().queue(
+            let _ = window.task_manager().dom_manipulation_task_source().queue(
                 task!(iframe_load_event_steps: move || {
                     this.root().iframe_load_event_steps(pipeline_id);
                 }),

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1515,13 +1515,16 @@ impl VirtualMethods for HTMLInputElement {
         {
             if event.IsTrusted() {
                 let window = window_from_node(self);
-                let _ = window.user_interaction_task_source().queue_event(
-                    &self.upcast(),
-                    atom!("input"),
-                    EventBubbles::Bubbles,
-                    EventCancelable::NotCancelable,
-                    &window,
-                );
+                let _ = window
+                    .task_manager()
+                    .user_interaction_task_source()
+                    .queue_event(
+                        &self.upcast(),
+                        atom!("input"),
+                        EventBubbles::Bubbles,
+                        EventCancelable::NotCancelable,
+                        &window,
+                    );
             }
         }
     }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -25,7 +25,6 @@ use crate::dom::node::{document_from_node, window_from_node};
 use crate::dom::node::{ChildrenMutation, CloneChildrenFlag, Node};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::network_listener::{NetworkListener, PreInvoke};
-use crate::task_source::TaskSourceName;
 use dom_struct::dom_struct;
 use encoding_rs::Encoding;
 use html5ever::{LocalName, Prefix};
@@ -294,10 +293,14 @@ fn fetch_a_classic_script(
     }));
 
     let (action_sender, action_receiver) = ipc::channel().unwrap();
+    let (task_source, canceller) = doc
+        .window()
+        .task_manager()
+        .networking_task_source_with_canceller();
     let listener = NetworkListener {
-        context: context,
-        task_source: doc.window().networking_task_source(),
-        canceller: Some(doc.window().task_canceller(TaskSourceName::Networking)),
+        context,
+        task_source,
+        canceller: Some(canceller),
     };
 
     ROUTER.add_route(
@@ -623,11 +626,10 @@ impl HTMLScriptElement {
 
     pub fn queue_error_event(&self) {
         let window = window_from_node(self);
-        window.dom_manipulation_task_source().queue_simple_event(
-            self.upcast(),
-            atom!("error"),
-            &window,
-        );
+        window
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue_simple_event(self.upcast(), atom!("error"), &window);
     }
 
     pub fn dispatch_load_event(&self) {

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -127,11 +127,10 @@ impl HTMLStyleElement {
         // No subresource loads were triggered, queue load event
         if self.pending_loads.get() == 0 {
             let window = window_from_node(self);
-            window.dom_manipulation_task_source().queue_simple_event(
-                self.upcast(),
-                atom!("load"),
-                &window,
-            );
+            window
+                .task_manager()
+                .dom_manipulation_task_source()
+                .queue_simple_event(self.upcast(), atom!("load"), &window);
         }
 
         self.set_stylesheet(sheet);

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -565,13 +565,16 @@ impl VirtualMethods for HTMLTextAreaElement {
         } else if event.type_() == atom!("keypress") && !event.DefaultPrevented() {
             if event.IsTrusted() {
                 let window = window_from_node(self);
-                let _ = window.user_interaction_task_source().queue_event(
-                    &self.upcast(),
-                    atom!("input"),
-                    EventBubbles::Bubbles,
-                    EventCancelable::NotCancelable,
-                    &window,
-                );
+                let _ = window
+                    .task_manager()
+                    .user_interaction_task_source()
+                    .queue_event(
+                        &self.upcast(),
+                        atom!("input"),
+                        EventBubbles::Bubbles,
+                        EventCancelable::NotCancelable,
+                        &window,
+                    );
             }
         }
     }

--- a/components/script/dom/offlineaudiocontext.rs
+++ b/components/script/dom/offlineaudiocontext.rs
@@ -20,7 +20,7 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::offlineaudiocompletionevent::OfflineAudioCompletionEvent;
 use crate::dom::promise::Promise;
 use crate::dom::window::Window;
-use crate::task_source::{TaskSource, TaskSourceName};
+use crate::task_source::TaskSource;
 use dom_struct::dom_struct;
 use servo_media::audio::context::OfflineAudioContextOptions as ServoMediaOfflineAudioContextOptions;
 use std::cell::Cell;
@@ -141,8 +141,9 @@ impl OfflineAudioContextMethods for OfflineAudioContext {
         let this = Trusted::new(self);
         let global = self.global();
         let window = global.as_window();
-        let task_source = window.dom_manipulation_task_source();
-        let canceller = window.task_canceller(TaskSourceName::DOMManipulation);
+        let (task_source, canceller) = window
+            .task_manager()
+            .dom_manipulation_task_source_with_canceller();
         Builder::new()
             .name("OfflineAudioContextResolver".to_owned())
             .spawn(move || {

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -209,6 +209,7 @@ impl Storage {
         let this = Trusted::new(self);
         global
             .as_window()
+            .task_manager()
             .dom_manipulation_task_source()
             .queue(
                 task!(send_storage_notification: move || {

--- a/components/script/dom/textcontrol.rs
+++ b/components/script/dom/textcontrol.rs
@@ -297,13 +297,16 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
         // Step 6
         if textinput.selection_state() != original_selection_state {
             let window = window_from_node(self.element);
-            window.user_interaction_task_source().queue_event(
-                &self.element.upcast::<EventTarget>(),
-                atom!("select"),
-                EventBubbles::Bubbles,
-                EventCancelable::NotCancelable,
-                &window,
-            );
+            window
+                .task_manager()
+                .user_interaction_task_source()
+                .queue_event(
+                    &self.element.upcast::<EventTarget>(),
+                    atom!("select"),
+                    EventBubbles::Bubbles,
+                    EventCancelable::NotCancelable,
+                    &window,
+                );
         }
 
         self.element

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -381,12 +381,9 @@ impl Window {
         self.networking_task_source.clone()
     }
 
-    pub fn history_traversal_task_source(&self) -> Box<dyn ScriptChan + Send> {
-        self.history_traversal_task_source.clone()
-    }
-
-    pub fn file_reading_task_source(&self) -> FileReadingTaskSource {
-        self.file_reading_task_source.clone()
+    pub fn file_reading_task_source(&self) -> TaskManagement<FileReadingTaskSource> {
+        let canceller = self.task_canceller(TaskSourceName::FileReading);
+        TaskManagement(self.file_reading_task_source.clone(), canceller)
     }
 
     pub fn performance_timeline_task_source(&self) -> PerformanceTimelineTaskSource {

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -10,7 +10,6 @@
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::node::{document_from_node, Node};
 use crate::network_listener::{NetworkListener, PreInvoke};
-use crate::task_source::TaskSourceName;
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use net_traits::image_cache::{ImageCache, PendingImageId};
@@ -57,13 +56,16 @@ pub fn fetch_image_for_layout(
     }));
 
     let document = document_from_node(node);
-    let window = document.window();
 
     let (action_sender, action_receiver) = ipc::channel().unwrap();
+    let (task_source, canceller) = document
+        .window()
+        .task_manager()
+        .networking_task_source_with_canceller();
     let listener = NetworkListener {
-        context: context,
-        task_source: window.networking_task_source(),
-        canceller: Some(window.task_canceller(TaskSourceName::Networking)),
+        context,
+        task_source,
+        canceller: Some(canceller),
     };
     ROUTER.add_route(
         action_receiver.to_opaque(),

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -69,6 +69,7 @@ pub mod script_thread;
 mod serviceworker_manager;
 mod serviceworkerjob;
 mod stylesheet_loader;
+mod task_manager;
 mod task_queue;
 mod task_source;
 pub mod test;

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -100,6 +100,7 @@ pub enum ScriptThreadEventCategory {
     DomEvent,
     FileRead,
     FormPlannedNavigation,
+    HistoryEvent,
     ImageCacheMsg,
     InputEvent,
     NetworkEvent,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -521,7 +521,7 @@ pub struct ScriptThread {
 
     networking_task_sender: Box<dyn ScriptChan>,
 
-    history_traversal_task_source: HistoryTraversalTaskSource,
+    history_traversal_task_sender: Sender<MainThreadScriptMsg>,
 
     file_reading_task_sender: Box<dyn ScriptChan>,
 
@@ -1042,7 +1042,7 @@ impl ScriptThread {
             performance_timeline_task_sender: boxed_script_sender.clone(),
             remote_event_task_sender: boxed_script_sender.clone(),
 
-            history_traversal_task_source: HistoryTraversalTaskSource(chan),
+            history_traversal_task_sender: chan.clone(),
 
             control_chan: state.control_chan,
             control_port: control_port,
@@ -1409,6 +1409,7 @@ impl ScriptThread {
                 ScriptThreadEventCategory::FormPlannedNavigation => {
                     ProfilerCategory::ScriptPlannedNavigation
                 },
+                ScriptThreadEventCategory::HistoryEvent => ProfilerCategory::ScriptHistoryEvent,
                 ScriptThreadEventCategory::ImageCacheMsg => ProfilerCategory::ScriptImageCacheMsg,
                 ScriptThreadEventCategory::InputEvent => ProfilerCategory::ScriptInputEvent,
                 ScriptThreadEventCategory::NetworkEvent => ProfilerCategory::ScriptNetworkEvent,
@@ -2180,6 +2181,13 @@ impl ScriptThread {
         PerformanceTimelineTaskSource(self.performance_timeline_task_sender.clone(), pipeline_id)
     }
 
+    pub fn history_traversal_task_source(
+        &self,
+        pipeline_id: PipelineId,
+    ) -> HistoryTraversalTaskSource {
+        HistoryTraversalTaskSource(self.history_traversal_task_sender.clone(), pipeline_id)
+    }
+
     pub fn user_interaction_task_source(
         &self,
         pipeline_id: PipelineId,
@@ -2560,7 +2568,6 @@ impl ScriptThread {
         );
 
         let MainThreadScriptChan(ref sender) = self.chan;
-        let HistoryTraversalTaskSource(ref history_sender) = self.history_traversal_task_source;
 
         let (ipc_timer_event_chan, ipc_timer_event_port) = ipc::channel().unwrap();
         route_ipc_receiver_to_new_servo_sender(ipc_timer_event_port, self.timer_event_chan.clone());
@@ -2584,7 +2591,7 @@ impl ScriptThread {
             self.media_element_task_source(incomplete.pipeline_id),
             self.user_interaction_task_source(incomplete.pipeline_id),
             self.networking_task_source(incomplete.pipeline_id),
-            HistoryTraversalTaskSource(history_sender.clone()),
+            self.history_traversal_task_source(incomplete.pipeline_id),
             self.file_reading_task_source(incomplete.pipeline_id),
             self.performance_timeline_task_source(incomplete.pipeline_id)
                 .clone(),

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -1,0 +1,162 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::dom::bindings::cell::DomRefCell;
+use crate::task::TaskCanceller;
+use crate::task_source::dom_manipulation::DOMManipulationTaskSource;
+use crate::task_source::file_reading::FileReadingTaskSource;
+use crate::task_source::history_traversal::HistoryTraversalTaskSource;
+use crate::task_source::media_element::MediaElementTaskSource;
+use crate::task_source::networking::NetworkingTaskSource;
+use crate::task_source::performance_timeline::PerformanceTimelineTaskSource;
+use crate::task_source::remote_event::RemoteEventTaskSource;
+use crate::task_source::user_interaction::UserInteractionTaskSource;
+use crate::task_source::websocket::WebsocketTaskSource;
+use crate::task_source::TaskSourceName;
+use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+macro_rules! task_source_functions {
+    ($self:ident,$with_canceller:ident,$task_source:ident,$task_source_type:ident,$task_source_name:ident) => {
+        pub fn $with_canceller(&$self) -> ($task_source_type, TaskCanceller) {
+            ($self.$task_source.clone(), $self.task_canceller(TaskSourceName::$task_source_name))
+        }
+
+        pub fn $task_source(&$self) -> $task_source_type {
+            $self.$task_source.clone()
+        }
+    }
+}
+
+#[derive(JSTraceable, MallocSizeOf)]
+pub struct TaskManager {
+    #[ignore_malloc_size_of = "task sources are hard"]
+    pub task_cancellers: DomRefCell<HashMap<TaskSourceName, Arc<AtomicBool>>>,
+    #[ignore_malloc_size_of = "task sources are hard"]
+    dom_manipulation_task_source: DOMManipulationTaskSource,
+    #[ignore_malloc_size_of = "task sources are hard"]
+    file_reading_task_source: FileReadingTaskSource,
+    #[ignore_malloc_size_of = "task sources are hard"]
+    history_traversal_task_source: HistoryTraversalTaskSource,
+    #[ignore_malloc_size_of = "task sources are hard"]
+    media_element_task_source: MediaElementTaskSource,
+    #[ignore_malloc_size_of = "task sources are hard"]
+    networking_task_source: NetworkingTaskSource,
+    #[ignore_malloc_size_of = "task sources are hard"]
+    performance_timeline_task_source: PerformanceTimelineTaskSource,
+    #[ignore_malloc_size_of = "task sources are hard"]
+    user_interaction_task_source: UserInteractionTaskSource,
+    #[ignore_malloc_size_of = "task sources are hard"]
+    remote_event_task_source: RemoteEventTaskSource,
+    #[ignore_malloc_size_of = "task sources are hard"]
+    websocket_task_source: WebsocketTaskSource,
+}
+
+impl TaskManager {
+    pub fn new(
+        dom_manipulation_task_source: DOMManipulationTaskSource,
+        file_reading_task_source: FileReadingTaskSource,
+        history_traversal_task_source: HistoryTraversalTaskSource,
+        media_element_task_source: MediaElementTaskSource,
+        networking_task_source: NetworkingTaskSource,
+        performance_timeline_task_source: PerformanceTimelineTaskSource,
+        user_interaction_task_source: UserInteractionTaskSource,
+        remote_event_task_source: RemoteEventTaskSource,
+        websocket_task_source: WebsocketTaskSource,
+    ) -> Self {
+        TaskManager {
+            dom_manipulation_task_source,
+            file_reading_task_source,
+            history_traversal_task_source,
+            media_element_task_source,
+            networking_task_source,
+            performance_timeline_task_source,
+            user_interaction_task_source,
+            remote_event_task_source,
+            websocket_task_source,
+            task_cancellers: Default::default(),
+        }
+    }
+
+    task_source_functions!(
+        self,
+        dom_manipulation_task_source_with_canceller,
+        dom_manipulation_task_source,
+        DOMManipulationTaskSource,
+        DOMManipulation
+    );
+
+    task_source_functions!(
+        self,
+        media_element_task_source_with_canceller,
+        media_element_task_source,
+        MediaElementTaskSource,
+        MediaElement
+    );
+
+    task_source_functions!(
+        self,
+        user_interaction_task_source_with_canceller,
+        user_interaction_task_source,
+        UserInteractionTaskSource,
+        UserInteraction
+    );
+
+    task_source_functions!(
+        self,
+        networking_task_source_with_canceller,
+        networking_task_source,
+        NetworkingTaskSource,
+        Networking
+    );
+
+    task_source_functions!(
+        self,
+        file_reading_task_source_with_canceller,
+        file_reading_task_source,
+        FileReadingTaskSource,
+        FileReading
+    );
+
+    task_source_functions!(
+        self,
+        history_traversal_task_source_with_canceller,
+        history_traversal_task_source,
+        HistoryTraversalTaskSource,
+        HistoryTraversal
+    );
+
+    task_source_functions!(
+        self,
+        performance_timeline_task_source_with_canceller,
+        performance_timeline_task_source,
+        PerformanceTimelineTaskSource,
+        PerformanceTimeline
+    );
+
+    task_source_functions!(
+        self,
+        remote_event_task_source_with_canceller,
+        remote_event_task_source,
+        RemoteEventTaskSource,
+        RemoteEvent
+    );
+
+    task_source_functions!(
+        self,
+        websocket_task_source_with_canceller,
+        websocket_task_source,
+        WebsocketTaskSource,
+        Websocket
+    );
+
+    pub fn task_canceller(&self, name: TaskSourceName) -> TaskCanceller {
+        let mut flags = self.task_cancellers.borrow_mut();
+        let cancel_flag = flags.entry(name).or_insert(Default::default());
+        TaskCanceller {
+            cancelled: Some(cancel_flag.clone()),
+        }
+    }
+}

--- a/components/script/task_source/history_traversal.rs
+++ b/components/script/task_source/history_traversal.rs
@@ -2,27 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::script_runtime::{CommonScriptMsg, ScriptThreadEventCategory};
+use crate::script_thread::MainThreadScriptMsg;
+use crate::task::{TaskCanceller, TaskOnce};
+use crate::task_source::{TaskSource, TaskSourceName};
 use msg::constellation_msg::PipelineId;
-use script_runtime::{CommonScriptMsg, ScriptChan, ScriptThreadEventCategory};
-use script_thread::MainThreadScriptMsg;
 use servo_channel::Sender;
-use task::{TaskCanceller, TaskOnce};
-use task_source::{TaskSource, TaskSourceName};
 
-#[derive(JSTraceable)]
+#[derive(Clone, JSTraceable)]
 pub struct HistoryTraversalTaskSource(pub Sender<MainThreadScriptMsg>, pub PipelineId);
-
-impl ScriptChan for HistoryTraversalTaskSource {
-    fn send(&self, msg: CommonScriptMsg) -> Result<(), ()> {
-        self.0
-            .send(MainThreadScriptMsg::Common(msg))
-            .map_err(|_| ())
-    }
-
-    fn clone(&self) -> Box<ScriptChan + Send> {
-        Box::new(HistoryTraversalTaskSource((&self.0).clone(), (&self.1).clone()))
-    }
-}
 
 impl TaskSource for HistoryTraversalTaskSource {
     const NAME: TaskSourceName = TaskSourceName::HistoryTraversal;

--- a/components/script/task_source/history_traversal.rs
+++ b/components/script/task_source/history_traversal.rs
@@ -2,12 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::script_runtime::{CommonScriptMsg, ScriptChan};
-use crate::script_thread::MainThreadScriptMsg;
+use msg::constellation_msg::PipelineId;
+use script_runtime::{CommonScriptMsg, ScriptChan, ScriptThreadEventCategory};
+use script_thread::MainThreadScriptMsg;
 use servo_channel::Sender;
+use task::{TaskCanceller, TaskOnce};
+use task_source::{TaskSource, TaskSourceName};
 
 #[derive(JSTraceable)]
-pub struct HistoryTraversalTaskSource(pub Sender<MainThreadScriptMsg>);
+pub struct HistoryTraversalTaskSource(pub Sender<MainThreadScriptMsg>, pub PipelineId);
 
 impl ScriptChan for HistoryTraversalTaskSource {
     fn send(&self, msg: CommonScriptMsg) -> Result<(), ()> {
@@ -16,7 +19,24 @@ impl ScriptChan for HistoryTraversalTaskSource {
             .map_err(|_| ())
     }
 
-    fn clone(&self) -> Box<dyn ScriptChan + Send> {
-        Box::new(HistoryTraversalTaskSource((&self.0).clone()))
+    fn clone(&self) -> Box<ScriptChan + Send> {
+        Box::new(HistoryTraversalTaskSource((&self.0).clone(), (&self.1).clone()))
+    }
+}
+
+impl TaskSource for HistoryTraversalTaskSource {
+    const NAME: TaskSourceName = TaskSourceName::HistoryTraversal;
+
+    fn queue_with_canceller<T>(&self, task: T, canceller: &TaskCanceller) -> Result<(), ()>
+    where
+        T: TaskOnce + 'static,
+    {
+        let msg = MainThreadScriptMsg::Common(CommonScriptMsg::Task(
+            ScriptThreadEventCategory::HistoryEvent,
+            Box::new(canceller.wrap_task(task)),
+            Some(self.1),
+            HistoryTraversalTaskSource::NAME,
+        ));
+        self.0.send(msg).map_err(|_| ())
     }
 }


### PR DESCRIPTION
To do so, I created a struct `TaskManagement(TaskSource,
TaskCanceller)` and made `*_task_source` return that instead of just
the task source.

Next, I refactored all places in which `task_canceller` by basically
removing them in favour of a previously called `*_task_source`.

I tried to make `task_canceller` a private method in `Window`, with the
hope of enforcing the use of `*_task_source`. However, it's used in
components/script/dom/globalscope.rs:575 in such a way that will make it
harder to avoid. I decided to leave it that way.

It'd be possible to unify `*_task_source` in such a way that we would
have only one method. However, I decided not to do it because one of the
`TaskSource` implementations is special:
`history_traversal_task_source`. Not wanting to over complicate things,
I decided to leave the structure this way.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21154 (github issue number if applicable).

- [x] These changes do not require tests because it's refactoring code that should already be tested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21804)
<!-- Reviewable:end -->
