### PR TITLE
Provide useful defaults for Android logcat output

### DIFF
--- a/ports/libsimpleservo/src/jniapi.rs
+++ b/ports/libsimpleservo/src/jniapi.rs
@@ -64,11 +64,19 @@ pub fn Java_com_mozilla_servoview_JNIServo_init(
         // Note: Android debug logs are stripped from a release build.
         // debug!() will only show in a debug build. Use info!() if logs
         // should show up in adb logcat with a release build.
-        let mut filter = Filter::default()
-            .with_min_level(Level::Debug)
-            .with_allowed_module_path("simpleservo::api")
-            .with_allowed_module_path("simpleservo::jniapi")
-            .with_allowed_module_path("simpleservo::gl_glue::egl");
+        let filters = [
+            "simpleservo::api",
+            "simpleservo::jniapi",
+            "simpleservo::gl_glue::egl",
+            // Show JS errors by default.
+            "script::dom::bindings::error",
+            // Show GL errors by default.
+            "canvas::webgl_thread",
+        ];
+        let mut filter = Filter::default().with_min_level(Level::Debug);
+        for &module in &filters {
+            filter = filter.with_allowed_module_path(module);
+        }
         let log_str = env.get_string(log_str).ok();
         let log_str = log_str.as_ref().map_or(Cow::Borrowed(""), |s| s.to_string_lossy());
         for module in log_str.split(',') {

--- a/ports/libsimpleservo/src/jniapi.rs
+++ b/ports/libsimpleservo/src/jniapi.rs
@@ -10,14 +10,14 @@ use gl_glue;
 use jni::{JNIEnv, JavaVM};
 use jni::objects::{GlobalRef, JClass, JObject, JString, JValue};
 use jni::sys::{jboolean, jfloat, jint, jstring, JNI_TRUE};
+use libc::{pipe, dup2, read};
 use log::Level;
 use std;
 use std::borrow::Cow;
 use std::ffi::CString;
-use std::mem;
-use std::os::raw::{c_char, c_int, c_long, c_void};
-use std::ptr;
+use std::os::raw::{c_char, c_int, c_void};
 use std::sync::{Arc, Mutex};
+use std::thread;
 
 struct HostCallbacks {
     callbacks: GlobalRef,
@@ -447,91 +447,71 @@ fn initialize_android_glue(env: &JNIEnv, activity: JObject) {
     }
 }
 
-
-#[allow(non_camel_case_types)]
-type pthread_t = c_long;
-#[allow(non_camel_case_types)]
-type pthread_mutexattr_t = c_long;
-#[allow(non_camel_case_types)]
-type pthread_attr_t = c_void; // FIXME: wrong
-
 extern {
-    fn pipe(_: *mut c_int) -> c_int;
-    fn dup2(fildes: c_int, fildes2: c_int) -> c_int;
-    fn read(fd: c_int, buf: *mut c_void, count: usize) -> isize;
-    fn pthread_create(_: *mut pthread_t, _: *const pthread_attr_t,
-                      _: extern fn(*mut c_void) -> *mut c_void, _: *mut c_void) -> c_int;
-    fn pthread_detach(thread: pthread_t) -> c_int;
-
     pub fn __android_log_write(prio: c_int, tag: *const c_char, text: *const c_char) -> c_int;
 }
+
 fn redirect_stdout_to_logcat() {
     // The first step is to redirect stdout and stderr to the logs.
+    // We redirect stdout and stderr to a custom descriptor.
+    let mut pfd: [c_int; 2] = [0, 0];
     unsafe {
-        // We redirect stdout and stderr to a custom descriptor.
-        let mut pfd: [c_int; 2] = [0, 0];
         pipe(pfd.as_mut_ptr());
         dup2(pfd[1], 1);
         dup2(pfd[1], 2);
+    }
 
-        // Then we spawn a thread whose only job is to read from the other side of the
-        // pipe and redirect to the logs.
-        extern fn logging_thread(descriptor: *mut c_void) -> *mut c_void {
-            unsafe {
-                let descriptor = descriptor as usize as c_int;
-                let mut buf: Vec<c_char> = Vec::with_capacity(512);
-                let mut cursor = 0_usize;
+    let descriptor = pfd[0];
 
-                // TODO: shouldn't use Rust stdlib
-                let tag = CString::new("simpleservo").unwrap();
-                let tag = tag.as_ptr();
+    // Then we spawn a thread whose only job is to read from the other side of the
+    // pipe and redirect to the logs.
+    let _detached = thread::spawn(move || {
+        unsafe {
+            let mut buf: Vec<c_char> = Vec::with_capacity(512);
+            let mut cursor = 0_usize;
 
-                loop {
-                    let result = read(descriptor, buf.as_mut_ptr().offset(cursor as isize) as *mut _,
-                                      buf.capacity() - 1 - cursor);
+            // TODO: shouldn't use Rust stdlib
+            let tag = CString::new("simpleservo").unwrap();
+            let tag = tag.as_ptr();
 
-                    let len = if result == 0 {
-                        return ptr::null_mut();
-                    } else if result < 0 {
-                        return ptr::null_mut(); /* TODO: report problem */
-                    } else {
-                        result as usize + cursor
-                    };
+            loop {
+                let result = read(descriptor, buf.as_mut_ptr().offset(cursor as isize) as *mut _,
+                                  buf.capacity() - 1 - cursor);
 
-                    buf.set_len(len);
+                let len = if result == 0 {
+                    return;
+                } else if result < 0 {
+                    return; /* TODO: report problem */
+                } else {
+                    result as usize + cursor
+                };
 
-                    if let Some(last_newline_pos) = buf.iter().rposition(|&c| c == b'\n' as c_char) {
-                        buf[last_newline_pos] = b'\0' as c_char;
-                        __android_log_write(3, tag, buf.as_ptr());
-                        if last_newline_pos < buf.len() - 1 {
-                            let last_newline_pos = last_newline_pos + 1;
-                            cursor = buf.len() - last_newline_pos;
-                            debug_assert!(cursor < buf.capacity());
-                            for j in 0..cursor as usize {
-                                buf[j] = buf[last_newline_pos + j];
-                            }
-                            buf[cursor] = b'\0' as c_char;
-                            buf.set_len(cursor + 1);
-                        } else {
-                            cursor = 0;
+                buf.set_len(len);
+
+                if let Some(last_newline_pos) = buf.iter().rposition(|&c| c == b'\n' as c_char) {
+                    buf[last_newline_pos] = b'\0' as c_char;
+                    __android_log_write(3, tag, buf.as_ptr());
+                    if last_newline_pos < buf.len() - 1 {
+                        let last_newline_pos = last_newline_pos + 1;
+                        cursor = buf.len() - last_newline_pos;
+                        debug_assert!(cursor < buf.capacity());
+                        for j in 0..cursor as usize {
+                            buf[j] = buf[last_newline_pos + j];
                         }
+                        buf[cursor] = b'\0' as c_char;
+                        buf.set_len(cursor + 1);
                     } else {
-                        cursor = buf.len();
-                    }
-                    if cursor == buf.capacity() - 1 {
-                        __android_log_write(3, tag, buf.as_ptr());
-                        buf.set_len(0);
                         cursor = 0;
                     }
+                } else {
+                    cursor = buf.len();
+                }
+                if cursor == buf.capacity() - 1 {
+                    __android_log_write(3, tag, buf.as_ptr());
+                    buf.set_len(0);
+                    cursor = 0;
                 }
             }
         }
-
-        let mut thread = mem::uninitialized();
-        let result = pthread_create(&mut thread, ptr::null(), logging_thread,
-                                    pfd[0] as usize as *mut c_void);
-        assert_eq!(result, 0);
-        let result = pthread_detach(thread);
-        assert_eq!(result, 0);
-    }
+    });
 }


### PR DESCRIPTION
These changes integrate the stdout/stderr redirection from https://github.com/tomaka/android-rs-glue/blob/0e80cfbcee362f207389dc2660525c3d74987f70/cargo-apk/injected-glue/lib.rs#L240-L303, and set up the default RUST_LOG filters so that useful JS errors and GL errors appear in the logcat output. I have verified that thread panics appear in output as well (without backtraces, sadly) by visiting https://acid3.acidtests.org.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21637 and fix #21783
- [x] These changes do not require tests because no tests for logcat.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21812)
<!-- Reviewable:end -->
