### PR TITLE
Add renderbuffer checks; #21485

### DIFF
--- a/components/script/dom/webglrenderbuffer.rs
+++ b/components/script/dom/webglrenderbuffer.rs
@@ -149,6 +149,15 @@ impl WebGLRenderbuffer {
 
         // FIXME: Invalidate completeness after the call
 
+        let max_size = self.upcast::<WebGLObject>()
+                           .context()
+                           .limits()
+                           .max_renderbuffer_size as i32;
+
+        if width > max_size || height > max_size {
+            return Err(WebGLError::InvalidValue);
+        }
+
         self.upcast::<WebGLObject>()
             .context()
             .send_command(WebGLCommand::RenderbufferStorage(


### PR DESCRIPTION
Added a check for width and height during render buffer creation. I will add a test after the initial review (there are existing tests too, I think).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #21485 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21813)
<!-- Reviewable:end -->
