### PR TITLE
Enable fake fillText API in nightly builds.

### DIFF
--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -1,7 +1,7 @@
 {
   "dom.bluetooth.enabled": false,
   "dom.bluetooth.testing.enabled": false,
-  "dom.canvas-text.enabled": false,
+  "dom.canvas-text.enabled": true,
   "dom.compositionevent.enabled": false,
   "dom.customelements.enabled": true,
   "dom.forcetouch.enabled": false,

--- a/tests/wpt/metadata/2dcontext/__dir__.ini
+++ b/tests/wpt/metadata/2dcontext/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: ["dom.canvas-text.enabled:false"]

--- a/tests/wpt/metadata/html/dom/interfaces.https.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.https.html.ini
@@ -4259,9 +4259,6 @@
   [CanvasRenderingContext2D interface: operation scrollPathIntoView(Path2D)]
     expected: FAIL
 
-  [CanvasRenderingContext2D interface: operation fillText(DOMString, unrestricted double, unrestricted double, unrestricted double)]
-    expected: FAIL
-
   [CanvasRenderingContext2D interface: operation strokeText(DOMString, unrestricted double, unrestricted double, unrestricted double)]
     expected: FAIL
 
@@ -4332,12 +4329,6 @@
     expected: FAIL
 
   [CanvasRenderingContext2D interface: calling scrollPathIntoView(Path2D) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fillText(DOMString, unrestricted double, unrestricted double, unrestricted double)" with the proper type]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: calling fillText(DOMString, unrestricted double, unrestricted double, unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError]
     expected: FAIL
 
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "strokeText(DOMString, unrestricted double, unrestricted double, unrestricted double)" with the proper type]
@@ -10292,9 +10283,6 @@
   [CanvasRenderingContext2D interface: operation scrollPathIntoView(Path2D)]
     expected: FAIL
 
-  [CanvasRenderingContext2D interface: operation fillText(DOMString, unrestricted double, unrestricted double, unrestricted double)]
-    expected: FAIL
-
   [CanvasRenderingContext2D interface: operation strokeText(DOMString, unrestricted double, unrestricted double, unrestricted double)]
     expected: FAIL
 
@@ -10365,12 +10353,6 @@
     expected: FAIL
 
   [CanvasRenderingContext2D interface: calling scrollPathIntoView(Path2D) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "fillText(DOMString, unrestricted double, unrestricted double, unrestricted double)" with the proper type]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: calling fillText(DOMString, unrestricted double, unrestricted double, unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError]
     expected: FAIL
 
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "strokeText(DOMString, unrestricted double, unrestricted double, unrestricted double)" with the proper type]


### PR DESCRIPTION
The [three.js examples](https://threejs.org/examples/) are really useful for checking Servo WebGL support, but if the fillText API is not available they only display a blank screen. I think it's worth lying to web content about this API in order to make it easy to make use of these examples without using local development builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21826)
<!-- Reviewable:end -->
