### PR TITLE
Fix flickering on Android

### DIFF
--- a/support/android/apk/servoview/src/main/java/org/mozilla/servoview/Servo.java
+++ b/support/android/apk/servoview/src/main/java/org/mozilla/servoview/Servo.java
@@ -54,6 +54,10 @@ public class Servo {
         return mJNI.version();
     }
 
+    public void performUpdates() {
+        mRunCallback.inGLThread(() -> mJNI.performUpdates());
+    }
+
     public void setBatchMode(boolean mode) {
         mRunCallback.inGLThread(() -> mJNI.setBatchMode(mode));
     }

--- a/support/android/apk/servoview/src/main/java/org/mozilla/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/mozilla/servoview/ServoView.java
@@ -197,7 +197,7 @@ public class ServoView extends GLSurfaceView
         }
 
         if (!zoomNecessary && !scrollNecessary && mAnimating) {
-            requestRender();
+            mServo.performUpdates();
         }
 
         if (mZooming || mScrolling || mAnimating) {


### PR DESCRIPTION
This is particularly noticeable in debug builds on WebGL pages, but also appears during startup when loading normal pages. requestRender() causes Android to swap buffers under the assumption that the buffer contains a fully rendered frame, but when calling it from `doFrame` there are no guarantees that Servo has finished compositing yet. This causes stale buffers to be composited instead, leading to flickering at startup when there is no content, or general jerkiness on pages using animation callbacks as previous frames replace current frames.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21796 
- [x] These changes do not require tests because no android integration tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21842)
<!-- Reviewable:end -->
