### PR TITLE
Remove unnecessary thread specification when flushing GL on Android.

### DIFF
--- a/support/android/apk/servoview/src/main/java/com/mozilla/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/com/mozilla/servoview/ServoView.java
@@ -111,9 +111,7 @@ public class ServoView extends GLSurfaceView
     }
 
     public void flushGLBuffers() {
-      inUIThread(() -> {
-        requestRender();
-      });
+      requestRender();
     }
 
     // Scroll and click


### PR DESCRIPTION
According to [the docs](https://developer.android.com/reference/android/opengl/GLSurfaceView#requestRender()) requestRender can be called from any thread, so we're just introducing unnecessary latency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21848)
<!-- Reviewable:end -->
