### PR TITLE
Create a Maven repository on package

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -198,7 +198,12 @@ class PackageCommands(CommandBase):
     @CommandArgument('--flavor', '-f',
                      default=None,
                      help='Package using the given Gradle flavor')
-    def package(self, release=False, dev=False, android=None, debug=False, debugger=None, target=None, flavor=None):
+    @CommandArgument('--maven',
+                     default=None,
+                     action='store_true',
+                     help='Create a local Maven repository')
+    def package(self, release=False, dev=False, android=None, debug=False,
+                debugger=None, target=None, flavor=None, maven=False):
         if android is None:
             android = self.config["build"]["android"]
         if target and android:
@@ -235,9 +240,13 @@ class PackageCommands(CommandBase):
             variant = ":assemble" + flavor_name + build_type + build_mode
             apk_task_name = ":servoapp" + variant
             aar_task_name = ":servoview" + variant
+            maven_task_name = ":servoview:uploadArchive"
+            argv = ["./gradlew", "--no-daemon", apk_task_name, aar_task_name]
+            if maven:
+                argv.append(maven_task_name)
             try:
                 with cd(path.join("support", "android", "apk")):
-                    subprocess.check_call(["./gradlew", "--no-daemon", apk_task_name, aar_task_name], env=env)
+                    subprocess.check_call(argv, env=env)
             except subprocess.CalledProcessError as e:
                 print("Packaging Android exited with return value %d" % e.returncode)
                 return e.returncode

--- a/support/android/apk/servoview/build.gradle
+++ b/support/android/apk/servoview/build.gradle
@@ -18,7 +18,7 @@ android {
     }
 
     compileOptions {
-      incremental false
+        incremental false
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -258,4 +258,43 @@ class ServoDependency {
     }
     public String fileName;
     public String folderFilter;
+}
+
+apply plugin: 'maven'
+import org.gradle.api.internal.artifacts.publish.DefaultPublishArtifact
+
+uploadArchives {
+  doFirst {
+      for ( arch in ["arm", "armv7", "arm64", "x86"] ) {
+        def target = getTargetDir(false, arch)
+        def aar = new File(target, "servoview.aar")
+        if (aar.exists()) {
+          def art = new DefaultPublishArtifact("servoview-" + arch, "aar", "aar", null, new Date(), aar);
+          project.artifacts.add('archives', art)
+        }
+      }
+    }
+    repositories.mavenDeployer {
+        repository(url: "file://localhost/${buildDir}/maven")
+        def cmd = "git rev-parse --short HEAD"
+        def proc = cmd.execute()
+        def commit = proc.text.trim()
+        def version = "0.0.1." + new Date().format('yyyyMMdd') + "." + commit
+        for ( arch_ in ["arm", "armv7", "arm64", "x86"] ) {
+          def arch = arch_
+          addFilter(arch) {artifact, file -> artifact.name == "servoview-" + arch}
+          pom(arch).artifactId = "servoview-" + arch
+          pom(arch).groupId = 'org.mozilla.servoview'
+          pom(arch).version = version
+          pom(arch).project {
+              licenses {
+                  license {
+                      name 'The Mozilla Public License, v. 2.0'
+                      url 'http://mozilla.org/MPL/2.0/'
+                      distribution 'repo'
+                  }
+              }
+          }
+        }
+    }
 }


### PR DESCRIPTION
This new step will go through all the *release* builds of the servoview AAR, and create a maven repo (just a tree of directories) with the relevant POM files under `target/gradle/servoview/maven`.

For example, after building for armv7 and x86, it looks like this:

```
/Users/paul/git/servo/target/gradle/servoview/maven
└── org
    └── mozilla
        └── servoview
            ├── servoview-armv7
            │   ├── 0.0.1.20181002
            │   │   ├── servoview-armv7-0.0.1.20181002.aar
            │   │   ├── servoview-armv7-0.0.1.20181002.aar.md5
            │   │   ├── servoview-armv7-0.0.1.20181002.aar.sha1
            │   │   ├── servoview-armv7-0.0.1.20181002.pom
            │   │   ├── servoview-armv7-0.0.1.20181002.pom.md5
            │   │   └── servoview-armv7-0.0.1.20181002.pom.sha1
            │   ├── maven-metadata.xml
            │   ├── maven-metadata.xml.md5
            │   └── maven-metadata.xml.sha1
            └── servoview-x86
                ├── 0.0.1.20181002
                │   ├── servoview-x86-0.0.1.20181002.aar
                │   ├── servoview-x86-0.0.1.20181002.aar.md5
                │   ├── servoview-x86-0.0.1.20181002.aar.sha1
                │   ├── servoview-x86-0.0.1.20181002.pom
                │   ├── servoview-x86-0.0.1.20181002.pom.md5
                │   └── servoview-x86-0.0.1.20181002.pom.sha1
                ├── maven-metadata.xml
                ├── maven-metadata.xml.md5
                └── maven-metadata.xml.sha1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21851)
<!-- Reviewable:end -->
