### PR TITLE
Update GStreamer binaries for Android. Include required codecs

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -426,16 +426,18 @@ class MachCommands(CommandBase):
             # Build the name of the package containing all GStreamer dependencies
             # according to the build target.
             gst_lib = "gst-build-{}".format(self.config["android"]["lib"])
-            gst_lib_zip = "%s.zip" % gst_lib
+            gst_lib_zip = "gstreamer-{}-1.14.3-20181105-103937.zip".format(self.config["android"]["lib"])
             gst_dir = os.path.join(base_path, "gstreamer")
             gst_lib_path = os.path.join(base_path, gst_dir, gst_lib)
             pkg_config_path = os.path.join(gst_lib_path, "pkgconfig")
             env["PKG_CONFIG_PATH"] = pkg_config_path
             if not os.path.exists(gst_lib_path):
                 # Download GStreamer dependencies if they have not already been downloaded
+                # This bundle is generated with `libgstreamer_android_gen`
+                # Follow these instructions to build and deploy new binaries
+                # https://github.com/servo/libgstreamer_android_gen#build
                 print("Downloading GStreamer dependencies")
-                gst_url = "https://github.com/servo/libgstreamer_android_gen/blob/" \
-                    "ebb0f0097fec985e0cef988c54a28c2ba06761aa/out/%s?raw=true" % gst_lib_zip
+                gst_url = "http://servo-deps.s3.amazonaws.com/gstreamer/%s" % gst_lib_zip
                 print(gst_url)
                 urllib.urlretrieve(gst_url, gst_lib_zip)
                 zip_ref = zipfile.ZipFile(gst_lib_zip, "r")


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

This should finally work for both armv7 and x86. I moved the binaries from Github to S3.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21864)
<!-- Reviewable:end -->
