### PR TITLE
Update the influent crate from 0.4.0 to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,11 +1620,10 @@ dependencies = [
 
 [[package]]
 name = "influent"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2721,7 +2720,7 @@ name = "profile"
 version = "0.0.1"
 dependencies = [
  "heartbeats-simple 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "influent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "influent 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemalloc-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4466,7 +4465,7 @@ dependencies = [
 "checksum image 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebdff791af04e30089bde8ad2a632b86af433b40c04db8d70ad4b21487db7a6a"
 "checksum immeta 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7371aa3c98fad60de2d9b517e2e1ed45593c32b0c77249310fa507749a2a318b"
 "checksum inflate 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6f53b811ee8e2057ccf9643ca6b4277de90efaf5e61e55fd5254576926bb4245"
-"checksum influent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a22b311b83431be3ab9af96ca9ea41554bb4a8551ea871ae44c3ce0c57e55f2c"
+"checksum influent 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9bc265d6f1f53ae16fd3c18cc737c8c91ec1381afc6a15bee35fecd16a83070e"
 "checksum io-surface 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9a33981dff54baaff80f4decb487a65d148a3c00facc97820d0f09128f74dd"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipc-channel 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd75debad4ffd295c00c6e3634d254df30050b0837a85e5cd039ac424365f24a"

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -425,7 +425,9 @@ class MachCommands(CommandBase):
             if not os.path.exists(gst_lib_path):
                 # Download GStreamer dependencies if they have not already been downloaded
                 print("Downloading GStreamer dependencies")
-                gst_url = "https://github.com/servo/libgstreamer_android_gen/blob/master/out/%s?raw=true" % gst_lib_zip
+                gst_url = "https://github.com/servo/libgstreamer_android_gen/blob/" \
+                    "ebb0f0097fec985e0cef988c54a28c2ba06761aa/out/%s?raw=true" % gst_lib_zip
+                print(gst_url)
                 urllib.urlretrieve(gst_url, gst_lib_zip)
                 zip_ref = zipfile.ZipFile(gst_lib_zip, "r")
                 zip_ref.extractall(gst_dir)


### PR DESCRIPTION
The tarball for 0.4.1 is 44 KB uncompressed and contains 18 files.

The tarball for 0.4.0 is 45 MB uncompressed and contains 22113 files, most of which appear to be the output of `cargo doc` that was accidentally included in a release.

CC https://github.com/servo/servo/pull/21863#issuecomment-426609991

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21865)
<!-- Reviewable:end -->
