### PR TITLE
Make `mach test-unit` not recompile components after `mach build`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,6 +2316,7 @@ dependencies = [
  "servo_channel 0.0.1",
  "servo_config 0.0.1",
  "servo_url 0.0.1",
+ "std_test_override 0.0.1",
  "threadpool 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2355,6 +2356,7 @@ dependencies = [
  "servo_arc 0.1.1",
  "servo_config 0.0.1",
  "servo_url 0.0.1",
+ "std_test_override 0.0.1",
  "url 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_api 0.57.2 (git+https://github.com/servo/webrender)",
@@ -3392,6 +3394,7 @@ dependencies = [
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_geometry 0.0.1",
  "servo_url 0.0.1",
+ "std_test_override 0.0.1",
  "url 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3526,6 +3529,13 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "std_test_override"
+version = "0.0.1"
+dependencies = [
+ "embedder_traits 0.0.1",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3647,6 +3657,7 @@ dependencies = [
  "servo_config 0.0.1",
  "servo_url 0.0.1",
  "size_of_test 0.0.1",
+ "std_test_override 0.0.1",
  "style 0.0.1",
  "style_traits 0.0.1",
 ]

--- a/components/bluetooth/Cargo.toml
+++ b/components/bluetooth/Cargo.toml
@@ -19,6 +19,3 @@ log = "0.4"
 servo_config = {path = "../config"}
 servo_rand = {path = "../rand"}
 uuid = {version = "0.6", features = ["v4"]}
-
-[dev-dependencies]
-embedder_traits = { path = "../embedder_traits", features = ["tests"]}

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -37,6 +37,3 @@ webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
 
 [build-dependencies]
 toml = "0.4.5"
-
-[dev-dependencies]
-embedder_traits = { path = "../embedder_traits", features = ["tests"]}

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -26,7 +26,7 @@ url = "1.2"
 
 [dev-dependencies]
 env_logger = "0.5"
-embedder_traits = { path = "../embedder_traits", features = ["tests"] }
+std_test_override = { path = "../std_test_override" }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 dirs = "1.0"

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -44,6 +44,3 @@ webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "ios")))'.dependencies]
 gaol = {git = "https://github.com/servo/gaol"}
-
-[dev-dependencies]
-embedder_traits = { path = "../embedder_traits", features = ["tests"] }

--- a/components/embedder_traits/Cargo.toml
+++ b/components/embedder_traits/Cargo.toml
@@ -9,9 +9,6 @@ publish = false
 name = "embedder_traits"
 path = "lib.rs"
 
-[features]
-tests = []
-
 [dependencies]
 ipc-channel = "0.11"
 lazy_static = "1"

--- a/components/embedder_traits/resources.rs
+++ b/components/embedder_traits/resources.rs
@@ -3,23 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::path::PathBuf;
-use std::sync::RwLock;
+use std::sync::{Once, RwLock};
 
 lazy_static! {
-    static ref RES: RwLock<Option<Box<ResourceReaderMethods + Sync + Send>>> = RwLock::new({
-        #[cfg(not(feature = "tests"))]
-        {
-            None
-        }
-        #[cfg(feature = "tests")]
-        {
-            Some(resources_for_tests())
-        }
-    });
+    static ref RES: RwLock<Option<Box<ResourceReaderMethods + Sync + Send>>> = RwLock::new(None);
 }
 
 pub fn set(reader: Box<ResourceReaderMethods + Sync + Send>) {
     *RES.write().unwrap() = Some(reader);
+}
+
+pub fn set_for_tests() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| set(resources_for_tests()));
 }
 
 pub fn read_bytes(res: Resource) -> Vec<u8> {
@@ -71,7 +67,6 @@ pub trait ResourceReaderMethods {
     fn sandbox_access_files_dirs(&self) -> Vec<PathBuf>;
 }
 
-#[cfg(feature = "tests")]
 fn resources_for_tests() -> Box<ResourceReaderMethods + Sync + Send> {
     use std::env;
     use std::fs::File;

--- a/components/layout_thread/Cargo.toml
+++ b/components/layout_thread/Cargo.toml
@@ -53,6 +53,3 @@ servo_url = {path = "../url"}
 style = {path = "../style"}
 style_traits = {path = "../style_traits"}
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
-
-[dev-dependencies]
-embedder_traits = { path = "../embedder_traits", features = ["tests"] }

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -51,7 +51,7 @@ webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
 ws = { version = "0.7", features = ["ssl"] }
 
 [dev-dependencies]
-embedder_traits = { path = "../embedder_traits", features = ["tests"] }
+std_test_override = { path = "../std_test_override" }
 
 [[test]]
 name = "main"

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -33,4 +33,4 @@ uuid = {version = "0.6", features = ["v4", "serde"]}
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
 
 [dev-dependencies]
-embedder_traits = { path = "../embedder_traits", features = ["tests"] }
+std_test_override = { path = "../std_test_override" }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -109,6 +109,3 @@ webvr_traits = {path = "../webvr_traits"}
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]
 mozangle = "0.1"
-
-[dev-dependencies]
-embedder_traits = { path = "../embedder_traits", features = ["tests"] }

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -36,6 +36,3 @@ time = "0.1.12"
 url = "1.2"
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
 webvr_traits = {path = "../webvr_traits"}
-
-[dev-dependencies]
-embedder_traits = { path = "../embedder_traits", features = ["tests"]}

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -72,6 +72,3 @@ webvr_traits = {path = "../webvr_traits"}
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "ios")))'.dependencies]
 gaol = {git = "https://github.com/servo/gaol"}
-
-[dev-dependencies]
-embedder_traits = { path = "../embedder_traits", features = ["tests"] }

--- a/components/std_test_override/Cargo.toml
+++ b/components/std_test_override/Cargo.toml
@@ -1,16 +1,13 @@
 [package]
-name = "bluetooth_traits"
+name = "std_test_override"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 publish = false
 
 [lib]
-name = "bluetooth_traits"
+name = "test"
 path = "lib.rs"
 
 [dependencies]
-ipc-channel = "0.11"
-regex = "1.0"
-serde = "1.0"
 embedder_traits = { path = "../embedder_traits" }

--- a/components/std_test_override/lib.rs
+++ b/components/std_test_override/lib.rs
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![feature(test)]
+
+extern crate embedder_traits;
+extern crate test;
+
+pub use test::*;
+
+pub fn test_main_static(tests: &[&TestDescAndFn]) {
+    embedder_traits::resources::set_for_tests();
+    test::test_main_static(tests);
+}

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -26,3 +26,4 @@ servo_url = {path = "../../../components/url"}
 size_of_test = {path = "../../../components/size_of_test"}
 style = {path = "../../../components/style"}
 style_traits = {path = "../../../components/style_traits"}
+std_test_override = { path = "../../../components/std_test_override" }


### PR DESCRIPTION
Previously, the `tests` feature flag of the `embedder_traits` crate caused it and every crate recursively depending on it to be built twice.

This feature flag was used to provide a specific set of "resources" when running tests. Instead, this commits overrides the `main()` function of the test harness to change resources at runtime before running any test.

This is done by adding a dependency that has `name = "test"` in its `[lib]` section of `Cargo.toml`. This overrides the crate found by `extern crate test;` in code generated by `rustc --test`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21884)
<!-- Reviewable:end -->
