### PR TITLE
ServoView: Add default constructor.

### DIFF
--- a/support/android/apk/servoview/src/main/java/org/mozilla/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/mozilla/servoview/ServoView.java
@@ -60,8 +60,17 @@ public class ServoView extends GLSurfaceView
 
     private boolean mRedrawing;
 
+    public ServoView(Context context) {
+        super(context);
+        init(context);
+    }
+
     public ServoView(Context context, AttributeSet attrs) {
         super(context, attrs);
+        init(context);
+    }
+
+    private void init(Context context) {
         mActivity = (Activity) context;
         setFocusable(true);
         setFocusableInTouchMode(true);


### PR DESCRIPTION
Android's `View` has multiple constructors. Currently only `ServoView(Context, AttributeSet)` is available. This constructor is usually used by Android when inflating a View from a layout XML file. However when creating the `View` in code no `AttributeSet` is available.

---

- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21890)
<!-- Reviewable:end -->
