### PR TITLE
Revert "Disable event_timeupdate_noautoplay test on mac"

### DIFF
--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_timeupdate_noautoplay.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/event_timeupdate_noautoplay.html.ini
@@ -1,7 +1,5 @@
 [event_timeupdate_noautoplay.html]
   type: testharness
-  disabled:
-    if os == "mac": https://github.com/servo/saltfs/pull/898
   expected: TIMEOUT
   [calling play() on a sufficiently long audio should trigger timeupdate event]
     expected: NOTRUN


### PR DESCRIPTION
Hopefully the builders now have the right gstreamer things.

From https://github.com/servo/servo/pull/21543 , needs https://github.com/servo/saltfs/pull/898

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21895)
<!-- Reviewable:end -->
