### PR TITLE
Simplify ctx.drawImage a bit

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -7,7 +7,6 @@ use canvas_data::*;
 use canvas_traits::canvas::*;
 use euclid::Size2D;
 use ipc_channel::ipc::{self, IpcSender};
-use pixels;
 use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::thread;
@@ -139,13 +138,10 @@ impl<'a> CanvasPaintThread <'a> {
                 source_rect,
                 smoothing_enabled,
             ) => {
-                let data = match imagedata {
-                    None => vec![0; image_size.width as usize * image_size.height as usize * 4],
-                    Some(mut data) => {
-                        pixels::byte_swap_colors_inplace(&mut data);
-                        data.into()
-                    },
-                };
+                let data = imagedata.map_or_else(
+                    || vec![0; image_size.width as usize * image_size.height as usize * 4],
+                    |bytes| bytes.into(),
+                );
                 self.canvas(canvas_id).draw_image(
                     data,
                     image_size,


### PR DESCRIPTION
There is no need to swap between RGBA and BGRA twice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21911)
<!-- Reviewable:end -->
