### PR TITLE
Taskcluster: cache ~/.gradle 

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -28,7 +28,7 @@ tasks:
           # Granted to role "repo:github.com/servo/servo:branch:*"
           - "queue:create-task:highest:aws-provisioner-v1/servo-*"
           - "queue:route:index.project.servo.servo.*"
-          - "docker-worker:cache:cargo-*"
+          - "docker-worker:cache:servo-*"
 
         payload:
           maxRunTime: {$eval: '20 * 60'}

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -255,6 +255,7 @@ def linux_build_task(name):
             "servo-cargo-git": "/root/.cargo/git",
             "servo-rustup": "/root/.rustup",
             "servo-sccache": "/root/.cache/sccache",
+            "servo-gradle": "/root/.gradle",
         })
         .with_index_and_artifacts_expire_in(build_artifacts_expire_in)
         .with_max_run_time_minutes(60)

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -249,13 +249,12 @@ def linux_build_task(name):
     return (
         linux_task(name)
         # https://docs.taskcluster.net/docs/reference/workers/docker-worker/docs/caches
-        # FIMXE: move to servo-* cache names
-        .with_scopes("docker-worker:cache:cargo-*")
+        .with_scopes("docker-worker:cache:servo-*")
         .with_caches(**{
-            "cargo-registry-cache": "/root/.cargo/registry",
-            "cargo-git-cache": "/root/.cargo/git",
-            "cargo-rustup": "/root/.rustup",
-            "cargo-sccache": "/root/.cache/sccache",
+            "servo-cargo-registry": "/root/.cargo/registry",
+            "servo-cargo-git": "/root/.cargo/git",
+            "servo-rustup": "/root/.rustup",
+            "servo-sccache": "/root/.cache/sccache",
         })
         .with_index_and_artifacts_expire_in(build_artifacts_expire_in)
         .with_max_run_time_minutes(60)


### PR DESCRIPTION
This is where are kept files whose downloads sometimes fail, so downloading less often will reduce the impact of those failures.

```
> Could not get resource 'https://jcenter.bintray.com/com/android/tools/build/gradle/3.1.3/gradle-3.1.3.pom'.
   > Could not GET 'https://jcenter.bintray.com/com/android/tools/build/gradle/3.1.3/gradle-3.1.3.pom'.
      > Read timed out
```

https://tools.taskcluster.net/groups/PGuIkH5QQmqghZozhVtmoQ/tasks/CBa6IbLmQJqYgoswRn-hiw/runs/0/logs/public%2Flogs%2Flive.log#L3411

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21918)
<!-- Reviewable:end -->
