### PR TITLE
Use a depth buffer when embedding Servo on android.

### DIFF
--- a/support/android/apk/servoview/src/main/java/org/mozilla/servoview/ServoSurface.java
+++ b/support/android/apk/servoview/src/main/java/org/mozilla/servoview/ServoSurface.java
@@ -136,7 +136,7 @@ public class ServoSurface {
                     EGL14.EGL_GREEN_SIZE, 8,
                     EGL14.EGL_BLUE_SIZE, 8,
                     EGL14.EGL_ALPHA_SIZE, 8,
-                    EGL14.EGL_DEPTH_SIZE, 0,
+                    EGL14.EGL_DEPTH_SIZE, 24,
                     EGL14.EGL_STENCIL_SIZE, 0,
                     EGL14.EGL_NONE
             };


### PR DESCRIPTION
Webrender uses the z-buffer but does not check that it's present. We need to provide one for pages to render correctly.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21807
- [x] These changes do not require tests because there are no automated tests for embedding Servo in Firefox Reality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21921)
<!-- Reviewable:end -->
