### PR TITLE
Use the global entry url in Location::SetHref

### DIFF
--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -164,7 +164,8 @@ impl LocationMethods for Location {
     // https://html.spec.whatwg.org/multipage/#dom-location-href
     fn SetHref(&self, value: USVString) -> ErrorResult {
         // Note: no call to self.check_same_origin_domain()
-        let url = match self.window.get_url().join(&value.0) {
+        let entry_url = GlobalScope::entry().get_url();
+        let url = match entry_url.join(&value.0) {
             Ok(url) => url,
             Err(e) => return Err(Error::Type(format!("Couldn't parse URL: {}", e))),
         };

--- a/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/005.html.ini
+++ b/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/005.html.ini
@@ -1,3 +1,0 @@
-[005.html]
-  type: testharness
-  expected: ERROR


### PR DESCRIPTION
Now the `/html/browsers/browsing-the-web/navigating-across-documents/005.htm` test is intermittent too for the same reason as `006.htm`.

See #21382.

Fixes #20906.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21926)
<!-- Reviewable:end -->
