### PR TITLE
Make layout use available image data before querying the image cache.

### DIFF
--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -36,6 +36,7 @@ use html5ever::{LocalName, Namespace};
 use layout::data::StyleAndLayoutData;
 use layout::wrapper::GetRawData;
 use msg::constellation_msg::{BrowsingContextId, PipelineId};
+use net_traits::image::base::{Image, ImageMetadata};
 use range::Range;
 use script::layout_exports::{CharacterDataTypeId, ElementTypeId, HTMLElementTypeId, NodeTypeId};
 use script::layout_exports::{Document, Element, Node, Text};
@@ -59,6 +60,7 @@ use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::ptr::NonNull;
+use std::sync::Arc as StdArc;
 use std::sync::atomic::Ordering;
 use style::CaseSensitivityExt;
 use style::applicable_declarations::ApplicableDeclarationBlock;
@@ -1046,6 +1048,11 @@ impl<'ln> ThreadSafeLayoutNode for ServoThreadSafeLayoutNode<'ln> {
     fn image_density(&self) -> Option<f64> {
         let this = unsafe { self.get_jsmanaged() };
         this.image_density()
+    }
+
+    fn image_data(&self) -> Option<(Option<StdArc<Image>>, Option<ImageMetadata>)> {
+        let this = unsafe { self.get_jsmanaged() };
+        this.image_data()
     }
 
     fn canvas_data(&self) -> Option<HTMLCanvasData> {

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1328,6 +1328,9 @@ pub trait LayoutHTMLImageElementHelpers {
     #[allow(unsafe_code)]
     unsafe fn image_density(&self) -> Option<f64>;
 
+    #[allow(unsafe_code)]
+    unsafe fn image_data(&self) -> (Option<Arc<Image>>, Option<ImageMetadata>);
+
     fn get_width(&self) -> LengthOrPercentageOrAuto;
     fn get_height(&self) -> LengthOrPercentageOrAuto;
 }
@@ -1349,6 +1352,14 @@ impl LayoutHTMLImageElementHelpers for LayoutDom<HTMLImageElement> {
             .borrow_for_layout()
             .parsed_url
             .clone()
+    }
+
+    #[allow(unsafe_code)]
+    unsafe fn image_data(&self) -> (Option<Arc<Image>>, Option<ImageMetadata>) {
+        let current_request = (*self.unsafe_get())
+            .current_request
+            .borrow_for_layout();
+        (current_request.image.clone(), current_request.metadata.clone())
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -62,6 +62,7 @@ use js::jsapi::{JSContext, JSObject, JSRuntime};
 use libc::{self, c_void, uintptr_t};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use msg::constellation_msg::{BrowsingContextId, PipelineId};
+use net_traits::image::base::{Image, ImageMetadata};
 use ref_slice::ref_slice;
 use script_layout_interface::{HTMLCanvasData, HTMLMediaData, LayoutElementType, LayoutNodeType};
 use script_layout_interface::{OpaqueStyleAndLayoutData, SVGSVGData, TrustedNodeAddress};
@@ -81,6 +82,7 @@ use std::default::Default;
 use std::iter;
 use std::mem;
 use std::ops::Range;
+use std::sync::Arc as StdArc;
 use style::context::QuirksMode;
 use style::dom::OpaqueNode;
 use style::selector_parser::{SelectorImpl, SelectorParser};
@@ -1086,6 +1088,7 @@ pub trait LayoutNodeHelpers {
     fn selection(&self) -> Option<Range<usize>>;
     fn image_url(&self) -> Option<ServoUrl>;
     fn image_density(&self) -> Option<f64>;
+    fn image_data(&self) -> Option<(Option<StdArc<Image>>, Option<ImageMetadata>)>;
     fn canvas_data(&self) -> Option<HTMLCanvasData>;
     fn media_data(&self) -> Option<HTMLMediaData>;
     fn svg_data(&self) -> Option<SVGSVGData>;
@@ -1230,6 +1233,13 @@ impl LayoutNodeHelpers for LayoutDom<Node> {
             self.downcast::<HTMLImageElement>()
                 .expect("not an image!")
                 .image_url()
+        }
+    }
+
+    #[allow(unsafe_code)]
+    fn image_data(&self) -> Option<(Option<StdArc<Image>>, Option<ImageMetadata>)> {
+        unsafe {
+            self.downcast::<HTMLImageElement>().map(|e| e.image_data())
         }
     }
 

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -13,10 +13,12 @@ use atomic_refcell::AtomicRef;
 use gfx_traits::{ByteIndex, FragmentType, combine_id_with_fragment_type};
 use html5ever::{Namespace, LocalName};
 use msg::constellation_msg::{BrowsingContextId, PipelineId};
+use net_traits::image::base::{Image, ImageMetadata};
 use range::Range;
 use servo_arc::Arc;
 use servo_url::ServoUrl;
 use std::fmt::Debug;
+use std::sync::Arc as StdArc;
 use style::attr::AttrValue;
 use style::context::SharedStyleContext;
 use style::data::ElementData;
@@ -275,6 +277,9 @@ pub trait ThreadSafeLayoutNode:
 
     /// If this is an image element, returns its current-pixel-density. If this is not an image element, fails.
     fn image_density(&self) -> Option<f64>;
+
+    /// If this is an image element, returns its image data. Otherwise, returns `None`.
+    fn image_data(&self) -> Option<(Option<StdArc<Image>>, Option<ImageMetadata>)>;
 
     fn canvas_data(&self) -> Option<HTMLCanvasData>;
 

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-img-element/available-images-ref.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-img-element/available-images-ref.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<img src="3.jpg">

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-img-element/available-images.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-img-element/available-images.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html class="reftest-wait">
+<title>Ensure images from available images list are rendered</title>
+<meta charset="utf-8">
+<link rel="match" href="available-images-ref.html">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-img-element">
+<div id="log"></div>
+<script>
+  var i = new Image();
+  i.onload = function() {
+    var i2 = new Image();
+    i2.src = "3.jpg";
+    document.body.appendChild(i2);
+    document.documentElement.classList.remove("reftest-wait");
+  };
+  i.src = "3.jpg";
+</script>


### PR DESCRIPTION
These changes make layout more efficient for any page which contains images that have already loaded, since it does not require synchronously querying the image cache thread for each image present. It also makes reloading a page actually display the images that are already in the image cache.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21919
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21931)
<!-- Reviewable:end -->
