### PR TITLE
Thread the status through navigation redirects

### DIFF
--- a/components/constellation/network_listener.rs
+++ b/components/constellation/network_listener.rs
@@ -113,6 +113,9 @@ impl NetworkListener {
                             location_url: metadata.location_url.clone(),
                             headers: headers.clone().into_inner(),
                             referrer: metadata.referrer.clone(),
+                            status_code: metadata.status.as_ref()
+                                .map(|&(code, _)| code)
+                                .unwrap_or(200),
                         });
 
                         // XXXManishearth we don't have the cancel_chan anymore and

--- a/components/net_traits/response.rs
+++ b/components/net_traits/response.rs
@@ -82,6 +82,7 @@ pub struct ResponseInit {
             serialize_with = "::hyper_serde::serialize")]
     #[ignore_malloc_size_of = "Defined in hyper"]
     pub headers: Headers,
+    pub status_code: u16,
     pub referrer: Option<ServoUrl>,
     pub location_url: Option<Result<ServoUrl, String>>,
 }
@@ -147,6 +148,7 @@ impl Response {
         res.location_url = init.location_url;
         res.headers = init.headers;
         res.referrer = init.referrer;
+        res.status = Some(StatusCode::from_u16(init.status_code));
         res
     }
 

--- a/tests/wpt/web-platform-tests/fetch/redirect-navigate/302-found-post-handler.py
+++ b/tests/wpt/web-platform-tests/fetch/redirect-navigate/302-found-post-handler.py
@@ -1,0 +1,13 @@
+def main(request, response):
+    if request.method == "POST":
+        response.add_required_headers = False
+        response.writer.write_status(302)
+        response.writer.write_header("Location", request.url)
+        response.writer.end_headers()
+        response.writer.write("")
+    elif request.method == "GET":
+        return ([("Content-Type", "text/plain")],
+                "OK")
+    else:
+        return ([("Content-Type", "text/plain")],
+                "FAIL")

--- a/tests/wpt/web-platform-tests/fetch/redirect-navigate/302-found-post.html
+++ b/tests/wpt/web-platform-tests/fetch/redirect-navigate/302-found-post.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<!-- Step 1: send POST request to a URL which will then 302 Found redirect -->
+<title>HTTP 302 Found POST Navigation Test</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+async_test(function(t) {
+  window.addEventListener("load", function() {
+    var frame = document.getElementById("frame");
+    var link = new URL("302-found-post-handler.py", window.location.href);
+    frame.contentWindow.document.body.innerHTML = '<form action="' + link.href + '" method="POST" id="form"><input name="n"></form>';
+    frame.contentWindow.document.getElementById("form").submit();
+    frame.addEventListener("load", t.step_func_done(function() {
+      assert_equals(frame.contentWindow.document.body.textContent, "OK");
+    }));
+  });
+}, "HTTP 302 Found POST Navigation");
+</script>
+<body>
+<iframe id="frame" src="about:blank"></iframe>


### PR DESCRIPTION
This is necessary because status codes affect whether the redirect is done with the same HTTP method or a different one.

This is part of #21886, but there's also a flaw in how iframes are handled that is causing the redirect to take over the entire window, so this commit doesn't entirely fix slither.io.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #21886, but more changes are needed to actually fix it

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21933)
<!-- Reviewable:end -->
