### PR TITLE
DevTools - add DeviceActor and update Root to own global actors

### DIFF
--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use actor::{Actor, ActorMessageStatus, ActorRegistry};
+use serde_json::{Map, Value};
+use std::net::TcpStream;
+use protocol::{ActorDescription,  Method};
+use protocol::JsonPacketStream;
+
+#[derive(Serialize)]
+struct GetDescriptionReply {
+    from: String,
+    value: SystemInfo,
+}
+
+#[derive(Serialize)]
+struct SystemInfo {
+    apptype: String,
+    platformVersion: String,
+}
+
+pub struct DeviceActor {
+    pub name: String,
+}
+
+impl Actor for DeviceActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+    fn handle_message(
+        &self,
+        _registry: &ActorRegistry,
+        msg_type: &str,
+        _msg: &Map<String, Value>,
+        stream: &mut TcpStream,
+    ) -> Result<ActorMessageStatus, ()> {
+
+        Ok(match msg_type {
+            "getDescription" => {
+
+                let msg = GetDescriptionReply {
+                    from: self.name(),
+                    value: SystemInfo {
+                        apptype: "servo".to_string(),
+                        platformVersion: "63.0".to_string(),
+                    }
+                };
+                stream.write_json_packet(&msg);
+                ActorMessageStatus::Processed
+            },
+
+            _ => ActorMessageStatus::Ignored,
+        })
+    }
+}
+
+impl DeviceActor {
+    pub fn new(name: String) -> DeviceActor {
+        DeviceActor { name: name }
+    }
+
+    pub fn description() -> ActorDescription {
+        ActorDescription {
+            category: "actor",
+            typeName: "device",
+            methods: vec![Method {
+                name: "getDescription",
+                request: Value::Null,
+                response: Value::Object(
+                    vec![(
+                        "value".to_owned(),
+                        Value::Object(
+                            vec![("_retval".to_owned(), Value::String("json".to_owned()))]
+                                .into_iter()
+                                .collect(),
+                        ),
+                    )].into_iter()
+                    .collect(),
+                ),
+            }],
+        }
+    }
+}
+
+

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use actor::{Actor, ActorMessageStatus, ActorRegistry};
-use serde_json::{Map, Value};
-use std::net::TcpStream;
 use protocol::{ActorDescription,  Method};
 use protocol::JsonPacketStream;
+use serde_json::{Map, Value};
+use std::net::TcpStream;
 
 #[derive(Serialize)]
 struct GetDescriptionReply {
@@ -35,10 +35,8 @@ impl Actor for DeviceActor {
         _msg: &Map<String, Value>,
         stream: &mut TcpStream,
     ) -> Result<ActorMessageStatus, ()> {
-
         Ok(match msg_type {
             "getDescription" => {
-
                 let msg = GetDescriptionReply {
                     from: self.name(),
                     value: SystemInfo {

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -27,6 +27,7 @@ extern crate time;
 use actor::{Actor, ActorRegistry};
 use actors::browsing_context::BrowsingContextActor;
 use actors::console::ConsoleActor;
+use actors::device::DeviceActor;
 use actors::framerate::FramerateActor;
 use actors::inspector::InspectorActor;
 use actors::network_event::{EventActor, NetworkEventActor, ResponseStartMsg};
@@ -57,6 +58,7 @@ mod actor;
 mod actors {
     pub mod browsing_context;
     pub mod console;
+    pub mod device;
     pub mod framerate;
     pub mod inspector;
     pub mod memory;
@@ -146,9 +148,19 @@ fn run_server(
 
     let mut registry = ActorRegistry::new();
 
-    let root = Box::new(RootActor { tabs: vec![] });
+    let performance = PerformanceActor::new(registry.new_name("performance"));
+
+    let device = DeviceActor::new(registry.new_name("device"));
+
+    let root = Box::new(RootActor {
+        tabs: vec![],
+        device: device.name(),
+        performance: performance.name(),
+    });
 
     registry.register(root);
+    registry.register(Box::new(performance));
+    registry.register(Box::new(device));
     registry.find::<RootActor>("root");
 
     let actors = registry.create_shareable();


### PR DESCRIPTION
This is one of three pull requests that allows the DevTools Debugger to render. This pr also introduces global actors to the root actor, the same as exists in FF devtools. At a later point I would like to reorganize this.

The two related prs are #21943 and #21944

This is the most significant change of the three. It introduces both Device and Performance as global actors, and leaves the Performance actor also as a target actor. It also introduces the concept of ownership to the root actor, with regards to the two Global Actors. 

The Device actor as added to allow the JS Debugger to start up. This required the DeviceActor's `getDescription` method. `getDescription`, in the case of servo, returns a couple of basic fields that the debugger is interested in but doesn't use, specifically `apptype` -- which is returning a fake value of `servo`, and the version number `63.0`. 

The version number is interesting because devtools has [dropped support for any versions below 2 version numbers from the current firefox](https://searchfox.org/mozilla-central/rev/3a54520d8d2319a4116866371ed3d9ed2ec0cc2b/devtools/client/debugger/new/src/client/firefox/commands.js#398). 

This means that if we want the servo server to be supported, we will need to keep this number synced with FF's versioning. It isn't great, but hopefully we can introduce a different approach later on.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21942)
<!-- Reviewable:end -->
