### PR TITLE
DevTools - add ListWorkers method to BrowsingContextTargetActor

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -55,6 +55,20 @@ struct FrameMsg {
 }
 
 #[derive(Serialize)]
+struct ListWorkersReply {
+    from: String,
+    workers: Vec<WorkerMsg>,
+}
+
+#[derive(Serialize)]
+struct WorkerMsg {
+    id: u32,
+    url: String,
+    title: String,
+    parentID: u32,
+}
+
+#[derive(Serialize)]
 pub struct BrowsingContextActorMsg {
     actor: String,
     title: String,
@@ -152,6 +166,15 @@ impl Actor for BrowsingContextActor {
                 let msg = ListFramesReply {
                     from: self.name(),
                     frames: vec![],
+                };
+                stream.write_json_packet(&msg);
+                ActorMessageStatus::Processed
+            },
+
+            "listWorkers" => {
+                let msg = ListWorkersReply {
+                    from: self.name(),
+                    workers: vec![],
                 };
                 stream.write_json_packet(&msg);
                 ActorMessageStatus::Processed

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -63,9 +63,6 @@ struct ListWorkersReply {
 #[derive(Serialize)]
 struct WorkerMsg {
     id: u32,
-    url: String,
-    title: String,
-    parentID: u32,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
This is one of three pull requests that allows the DevTools Debugger to render.

The two related prs are #21942 and #21944

This pr introduces a `ListWorkers` method, which the debugger relies on for startup. At the moment, we are returning an empty array, but later on we can return an array populated by all workers associated with a target.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21943)
<!-- Reviewable:end -->
