### PR TITLE
DevTools - add Interrupt method to ThreadActor

### DIFF
--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -34,6 +34,13 @@ struct ThreadResumedReply {
 }
 
 #[derive(Serialize)]
+struct ThreadInterruptedReply {
+    from: String,
+    #[serde(rename = "type")]
+    type_: String,
+}
+
+#[derive(Serialize)]
 struct ReconfigureReply {
     from: String,
 }
@@ -88,6 +95,15 @@ impl Actor for ThreadActor {
                 let msg = ThreadResumedReply {
                     from: self.name(),
                     type_: "resumed".to_owned(),
+                };
+                stream.write_json_packet(&msg);
+                ActorMessageStatus::Processed
+            },
+
+            "interrupt" => {
+                let msg = ThreadInterruptedReply {
+                    from: self.name(),
+                    type_: "interrupted".to_owned(),
                 };
                 stream.write_json_packet(&msg);
                 ActorMessageStatus::Processed


### PR DESCRIPTION
This is one of three pull requests that allows the DevTools Debugger to render.

The two related prs are #21942 and #21943 

In this pr, I introduced the `interrupt` method to the threadActor. This is arguably a carry-over from the firefox devtools, where the debugger server is running in the same event loop as the content scripts, and it can only update itself when the debugger server is paused. Depending on how debugging is, or how debugging will be implemented on servo, this method may need to be adjusted for "debugger events" and "script events". 

After all three patches on this topic are merged, you should be able to see the debugger \o/ (but no sources yet)

<img width="900" alt="screen shot 2018-10-14 at 16 57 07" src="https://user-images.githubusercontent.com/26968615/46918408-35f30180-cfd2-11e8-9a98-8e1540adc894.png">

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21944)
<!-- Reviewable:end -->
