### PR TITLE
DevTools - add Emulation Actor

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -72,6 +72,7 @@ pub struct BrowsingContextActorMsg {
     url: String,
     outerWindowID: u32,
     consoleActor: String,
+    emulationActor: String,
     inspectorActor: String,
     timelineActor: String,
     profilerActor: String,
@@ -84,6 +85,7 @@ pub struct BrowsingContextActor {
     pub title: String,
     pub url: String,
     pub console: String,
+    pub emulation: String,
     pub inspector: String,
     pub timeline: String,
     pub profiler: String,
@@ -192,6 +194,7 @@ impl BrowsingContextActor {
             url: self.url.clone(),
             outerWindowID: 0, //FIXME: this should probably be the pipeline id
             consoleActor: self.console.clone(),
+            emulationActor: self.emulation.clone(),
             inspectorActor: self.inspector.clone(),
             timelineActor: self.timeline.clone(),
             profilerActor: self.profiler.clone(),

--- a/components/devtools/actors/emulation.rs
+++ b/components/devtools/actors/emulation.rs
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use actor::{Actor, ActorMessageStatus, ActorRegistry};
+use serde_json::{Map, Value};
+use std::net::TcpStream;
+
+pub struct EmulationActor {
+    pub name: String,
+}
+
+impl Actor for EmulationActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &self,
+        _registry: &ActorRegistry,
+        msg_type: &str,
+        _msg: &Map<String, Value>,
+        _stream: &mut TcpStream,
+    ) -> Result<ActorMessageStatus, ()> {
+        Ok(match msg_type {
+            _ => ActorMessageStatus::Ignored,
+        })
+    }
+}
+
+impl EmulationActor {
+    pub fn new(name: String) -> EmulationActor {
+        EmulationActor { name: name }
+    }
+}


### PR DESCRIPTION
Last one for today, this one adds the Emulation actor, which allows the netmonitor panel to load. The emulation actor has no methods for now, but will eventually be used by the netmonitor to throttle connections.

Currently the netmonitor shows but doesn't have any values. will get to that soon!

<img width="901" alt="screen shot 2018-10-14 at 19 26 16" src="https://user-images.githubusercontent.com/26968615/46920018-30a0b180-cfe8-11e8-83ec-51ca71f0e8c3.png">

Combined with the changes for the stylesheets actor, the device actor, and the extra methods added in browserContext and threadActor, the devtools are now all loading \o/

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors 
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21945)
<!-- Reviewable:end -->
