### PR TITLE
Make android logging work for multiple println calls

### DIFF
--- a/ports/libsimpleservo/src/jniapi.rs
+++ b/ports/libsimpleservo/src/jniapi.rs
@@ -483,7 +483,10 @@ fn redirect_stdout_to_logcat() {
             let end = if result == 0 {
                 return;
             } else if result < 0 {
-                return; /* TODO: report problem */
+                unsafe {
+                    __android_log_write(3, tag, b"error in log thread; closing\0".as_ptr() as *const _);
+                }
+                return;
             } else {
                 result as usize + cursor
             };

--- a/ports/libsimpleservo/src/jniapi.rs
+++ b/ports/libsimpleservo/src/jniapi.rs
@@ -491,6 +491,9 @@ fn redirect_stdout_to_logcat() {
                 result as usize + cursor
             };
 
+            // Only modify the portion of the buffer that contains real data.
+            let buf = &mut buf[0..end];
+
             if let Some(last_newline_pos) = buf.iter().rposition(|&c| c == b'\n' as c_char) {
                 buf[last_newline_pos] = b'\0' as c_char;
                 unsafe {

--- a/ports/libsimpleservo/src/jniapi.rs
+++ b/ports/libsimpleservo/src/jniapi.rs
@@ -509,7 +509,7 @@ fn redirect_stdout_to_logcat() {
                 } else {
                     cursor = 0;
                 }
-            } else if cursor == BUF_AVAILABLE {
+            } else if end == BUF_AVAILABLE {
                 // No newline found but the buffer is full, flush it anyway.
                 // `buf.as_ptr()` is null-terminated by BUF_LENGTH being 1 less than BUF_AVAILABLE.
                 unsafe {


### PR DESCRIPTION
The existing implementation had incorrect calculations for calculating when there was unlogged data sitting in the buffer and when the buffer was full. With these changes I am able to see the expected output for the following testcase:
```html
<script>
  console.log("hi");
  console.log("hi there");
  console.log("hi there again");
  let s = "hi there again x2 ";
  for (var i = 0; i < 10; i++) {
    s += s;
  }
  console.log(s);
  </script>
```

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21875
- [x] These changes do not require tests because no automated tests for behaviour of logcat on android

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21950)
<!-- Reviewable:end -->
