### PR TITLE
Don't strip final character of directory name for maven package.

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -552,7 +552,7 @@ class PackageCommands(CommandBase):
                 base_dir = os.path.join(directory, artifact_dir)
                 if not os.path.isdir(base_dir):
                     continue
-                package_upload_base = "{}/{}".format(dest_key_base, artifact_dir[:-1])
+                package_upload_base = "{}/{}".format(dest_key_base, artifact_dir)
                 # Upload all of the files inside the subdirectory.
                 for f in os.listdir(base_dir):
                     file_upload_key = "{}/{}".format(package_upload_base, f)


### PR DESCRIPTION
Right now we're uploading to `servoview-armv7/0.0.1.20181015.532775` when the actual files are called `servoview-armv7-0.0.1.20181015.5327758.aar` (note the extra `8`). This was a mistake caused by trying to remove excess `/` characters during development.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21951)
<!-- Reviewable:end -->
