### PR TITLE
Return the expected response when webdriver requests a session deletion.

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -368,7 +368,7 @@ impl Handler {
 
     fn handle_delete_session(&mut self) -> WebDriverResult<WebDriverResponse> {
         self.session = None;
-        Ok(WebDriverResponse::Void)
+        Ok(WebDriverResponse::DeleteSession)
     }
 
     fn browsing_context_script_command(


### PR DESCRIPTION
This fixes a mistake that I have to deal with every time I try to use our webdriver server implementation for something new. We don't have any automated tests for this functionality yet (#21370) but I want to stop stumbling over it.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because ¯\\\_(ツ)\_/¯

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21965)
<!-- Reviewable:end -->
