### PR TITLE
Assign a name to iframes when loading the initial about:blank

### DIFF
--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -217,6 +217,16 @@ impl HTMLIFrameElement {
 
         let window = window_from_node(self);
 
+        // https://html.spec.whatwg.org/multipage/#attr-iframe-name
+        // Note: the spec says to set the name 'when the nested browsing context is created'.
+        // The current implementation sets the name on the window,
+        // when the iframe attributes are first processed.
+        if mode == ProcessingMode::FirstTime {
+            if let Some(window) = self.GetContentWindow() {
+                window.set_name(self.name.borrow().clone())
+            }
+        }
+
         // https://github.com/whatwg/html/issues/490
         if mode == ProcessingMode::FirstTime &&
             !self.upcast::<Element>().has_attribute(&local_name!("src"))
@@ -231,16 +241,6 @@ impl HTMLIFrameElement {
                 window.upcast(),
             );
             return;
-        }
-
-        // https://html.spec.whatwg.org/multipage/#attr-iframe-name
-        // Note: the spec says to set the name 'when the nested browsing context is created'.
-        // The current implementation sets the name on the window,
-        // when the iframe attributes are first processed.
-        if mode == ProcessingMode::FirstTime {
-            if let Some(window) = self.GetContentWindow() {
-                window.set_name(self.name.borrow().clone())
-            }
         }
 
         let url = self.get_url();

--- a/tests/wpt/metadata/html/browsers/windows/targeting-cross-origin-nested-browsing-contexts.html.ini
+++ b/tests/wpt/metadata/html/browsers/windows/targeting-cross-origin-nested-browsing-contexts.html.ini
@@ -1,4 +1,5 @@
 [targeting-cross-origin-nested-browsing-contexts.html]
   type: testharness
+  disabled: https://github.com/servo/servo/issues/10056
   [Targeting nested browsing contexts]
     expected: FAIL

--- a/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-target/form-target-iframe-helper.py
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-target/form-target-iframe-helper.py
@@ -1,0 +1,3 @@
+def main(request, response):
+    return ([("Content-Type", "text/plain")],
+            "OK")

--- a/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-target/form-target-iframe.html
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-target/form-target-iframe.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>Form targetted at iframe</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+async_test(function(t) {
+  window.addEventListener("load", function() {
+    var frame = document.createElement("iframe");
+    frame.name = "frame";
+    document.documentElement.appendChild(frame);
+    var form = document.createElement("form");
+    form.target = "frame";
+    form.action = "form-target-iframe-helper.py";
+    form.method = "POST";
+    var input = document.createElement("input");
+    input.name = "n";
+    form.appendChild(input);
+    document.documentElement.appendChild(form);
+    form.submit();
+    frame.addEventListener("load", function() {
+      if (frame.contentWindow.location.href != "about:blank") {
+        assert_equals(frame.contentWindow.document.body.textContent, "OK");
+        t.done();
+      }
+    });
+  });
+}, "Form targetted at iframe");
+</script>
+<body>

--- a/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-target/form-target-iframe.html
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-target/form-target-iframe.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 async_test(function(t) {
-  window.addEventListener("load", function() {
+  window.addEventListener("load", t.step_func(function() {
     var frame = document.createElement("iframe");
     frame.name = "frame";
     document.documentElement.appendChild(frame);
@@ -17,13 +17,13 @@ async_test(function(t) {
     form.appendChild(input);
     document.documentElement.appendChild(form);
     form.submit();
-    frame.addEventListener("load", function() {
-      if (frame.contentWindow.location.href != "about:blank") {
+    frame.addEventListener("load", t.step_func(function() {
+      if (frame.contentWindow.location.href.includes("form-target-iframe-helper.py")) {
         assert_equals(frame.contentWindow.document.body.textContent, "OK");
         t.done();
       }
-    });
-  });
+    }));
+  }));
 }, "Form targetted at iframe");
 </script>
 <body>


### PR DESCRIPTION
Before, it would assign the name too late, causing scripts (which will not wait for another tick) to accidentally spawn pop-up windows instead of loading into the iframe.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21886
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21976)
<!-- Reviewable:end -->
