### PR TITLE
Fixes panic on DOMString::strip_leading_and_trailing_ascii_whitespace

### DIFF
--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -182,16 +182,16 @@ impl DOMString {
             return;
         }
 
-        let last_non_whitespace = match self.0.rfind(|ref c| !char::is_ascii_whitespace(c)) {
-            Some(idx) => idx + 1,
-            None => {
-                self.0.clear();
-                return;
-            },
-        };
-        let first_non_whitespace = self.0.find(|ref c| !char::is_ascii_whitespace(c)).unwrap();
+        let trailing_whitespace_len = self
+            .0
+            .trim_end_matches(|ref c| char::is_ascii_whitespace(c))
+            .len();
+        self.0.truncate(trailing_whitespace_len);
+        if self.0.is_empty() {
+            return;
+        }
 
-        self.0.truncate(last_non_whitespace);
+        let first_non_whitespace = self.0.find(|ref c| !char::is_ascii_whitespace(c)).unwrap();
         let _ = self.0.replace_range(0..first_non_whitespace, "");
     }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14006,6 +14006,12 @@
      {}
     ]
    ],
+   "mozilla/input_value.html": [
+    [
+     "/_mozilla/mozilla/input_value.html",
+     {}
+    ]
+   ],
    "mozilla/interface_member_exposed.html": [
     [
      "/_mozilla/mozilla/interface_member_exposed.html",
@@ -27047,6 +27053,10 @@
   ],
   "mozilla/innerHTML.html": [
    "031e67e0c3bfd25bb32a8c1727864cdcf8bd641b",
+   "testharness"
+  ],
+  "mozilla/input_value.html": [
+   "a2a12d44d0331164651816710eeb2ddcb1738735",
    "testharness"
   ],
   "mozilla/interface_member_exposed.html": [

--- a/tests/wpt/mozilla/tests/mozilla/input_value.html
+++ b/tests/wpt/mozilla/tests/mozilla/input_value.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<head>
+    <meta charset="utf-8">
+    <title></title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+    <input id="0" type="url" value="">
+    <input id="1" type="url" value="  黑aaab">
+    <input id="2" type="url" value="三体!  ">
+    <input id="3" type="url" value="#β">
+    <input id="4" type="url" value="  #β ">
+    <script>
+        // Testing that unicode values are correctly handled in
+        // DOMString::strip_leading_and_trailing_ascii_whitespace
+        test(function() {
+            var expected = ["", "黑aaab", "三体!", "#β", "#β"];
+            for (var i = 0; i < expected.length; i++) {
+                var input = window.document.getElementById(i.toString());
+                assert_equals(input.value, expected[i]);
+            }
+        });
+    </script>
+</body>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This changes `DOMString::strip_leading_and_trailing_ascii_whitespace` to handle multi-byte unicode characters.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #21963 (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21978)
<!-- Reviewable:end -->
