### PR TITLE
style: Re-enable the rule that was accidentally disabled by a typo in the CSS parser.

### DIFF
--- a/resources/servo.css
+++ b/resources/servo.css
@@ -260,16 +260,10 @@ svg > * {
     margin: 0;
 }
 
-/* The outer fragment wrapper of an inline absolute hypothetical fragment.
- *
- * FIXME(emilio): This was disabled because of a typo in the CSS parser,
- * re-enable or figure out why it's not needed.
-
+/* The outer fragment wrapper of an inline absolute hypothetical fragment. */
 *|*::-servo-inline-absolute {
     clip: auto;
     border: none;
     padding: 0;
     margin: 0;
 }
-
-*/


### PR DESCRIPTION
In #21946 I commented out this rule because before that patch we were
accidentally ignoring it because of a typo in the CSS parser, since that PR
didn't intend to change behavior.

This PR does though, and re-enables the rule.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21983)
<!-- Reviewable:end -->
