### PR TITLE
Clear refcounted promise before dropping JSRuntime

### DIFF
--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -224,6 +224,12 @@ impl LiveDOMReferences {
         });
     }
 
+    pub fn destruct() {
+        LIVE_REFERENCES.with(|ref r| {
+            *r.borrow_mut() = None;
+        });
+    }
+
     #[allow(unrooted_must_root)]
     fn addref_promise(&self, promise: Rc<Promise>) {
         let mut table = self.promise_table.borrow_mut();

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -145,7 +145,10 @@ pub struct Runtime(RustRuntime);
 
 impl Drop for Runtime {
     fn drop(&mut self) {
-        THREAD_ACTIVE.with(|t| t.set(false));
+        THREAD_ACTIVE.with(|t| {
+            LiveDOMReferences::destruct();
+            t.set(false);
+        });
     }
 }
 

--- a/tests/wpt/metadata/fetch/cross-origin-resource-policy/fetch-in-iframe.html.ini
+++ b/tests/wpt/metadata/fetch/cross-origin-resource-policy/fetch-in-iframe.html.ini
@@ -1,5 +1,4 @@
 [fetch-in-iframe.html]
-  expected: CRASH
   [Untitled]
     expected: FAIL
 


### PR DESCRIPTION
Not sure if this is the right solution?

I also tried to `impl Drop for LiveDOMReferences` but it's still executed after dropping JSRuntime.
So, maybe we should clear it before dropping the JSRuntime?

cc @jdm @asajeffrey 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21331 .
- [x] There are tests for these changes; the status of `fetch/cross-origin-resource-policy/fetch-in-iframe.html` will be `OK`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/21988)
<!-- Reviewable:end -->
