### PR TITLE
Add a workaround for a rustc ICE

### DIFF
--- a/components/script/build.rs
+++ b/components/script/build.rs
@@ -79,9 +79,10 @@ struct Bytes<'a>(&'a str);
 
 impl<'a> fmt::Debug for Bytes<'a> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("b\"")?;
-        formatter.write_str(self.0)?;
-        formatter.write_str("\" as &'static [u8]")
+        // https://github.com/rust-lang/rust/issues/55223
+        // should technically be just `write!(formatter, "b\"{}\"", self.0)
+        // but the referenced issue breaks promotion in the surrounding code
+        write!(formatter, "{{ const FOO: &[u8] = b\"{}\"; FOO }}", self.0)
     }
 }
 


### PR DESCRIPTION
While https://github.com/rust-lang/rust/issues/55223 is being fixed, this workaround will allow servo to compile on the latest nightly rustc

r? @SimonSapin 

---

- [ ] `./mach build -d` does not report any errors
  * I'm getting
  ```
    Collecting voluptuous==0.10.5 (from -r /home/oliver/Projects/rust/servo/python/requirements.txt (line 18))
      Using cached https://files.pythonhosted.org/packages/c3/81/c84f8a3e723b760fdd1c41fc80201cb80cd29c1bce5159d8918c58df7d2a/voluptuous-0.10.5.tar.gz
        Complete output from command python setup.py egg_info:
        Traceback (most recent call last):
          File "<string>", line 1, in <module>
          File "/tmp/pip-install-Qdty2x/voluptuous/setup.py", line 16, in <module>
            f.write(long_description)
        UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 1229: ordinal not in range(128)
    ```
    locally, no clue how to continue from there. The script crate compiles fine with `cargo build`
- [ ] `./mach test-tidy` does not report any errors

- [X] These changes do not require tests because the `script` crate just won't compile without this change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22000)
<!-- Reviewable:end -->
