### PR TITLE
Handle open URL intent on Android

### DIFF
--- a/support/android/apk/servoapp/src/main/java/org/mozilla/servo/MainActivity.java
+++ b/support/android/apk/servoapp/src/main/java/org/mozilla/servo/MainActivity.java
@@ -7,6 +7,7 @@ package org.mozilla.servo;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.system.ErrnoException;
@@ -70,10 +71,14 @@ public class MainActivity extends Activity implements Servo.Client {
           }
         }
 
-        String args = getIntent().getStringExtra("servoargs");
-        String log = getIntent().getStringExtra("servolog");
+        Intent intent = getIntent();
+        String args = intent.getStringExtra("servoargs");
+        String log = intent.getStringExtra("servolog");
         mServoView.setServoArgs(args, log);
 
+        if (Intent.ACTION_VIEW.equals(intent.getAction())) {
+          mServoView.loadUri(intent.getData());
+        }
         setupUrlField();
     }
 


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #21997

This makes it easier to use Servo as the default browser.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22013)
<!-- Reviewable:end -->
