### PR TITLE
Reduce the amount of EGL buffer swapping the ML port is doing

### DIFF
--- a/ports/libmlservo/src/lib.rs
+++ b/ports/libmlservo/src/lib.rs
@@ -7,6 +7,11 @@ extern crate egl;
 extern crate servo;
 extern crate smallvec;
 
+use egl::egl::EGLContext;
+use egl::egl::EGLDisplay;
+use egl::egl::EGLSurface;
+use egl::egl::MakeCurrent;
+use egl::egl::SwapBuffers;
 use egl::eglext::eglGetProcAddress;
 use servo::BrowserId;
 use servo::Servo;
@@ -36,10 +41,6 @@ use std::os::raw::c_void;
 use std::path::PathBuf;
 use std::rc::Rc;
 
-type EGLContext = *const c_void;
-type EGLSurface = *const c_void;
-type EGLDisplay = *const c_void;
-
 type ServoInstance = *mut c_void;
 
 #[repr(u32)]
@@ -58,9 +59,9 @@ pub struct MLLogger(extern "C" fn (MLLogLevel, *const c_char));
 const LOG_LEVEL: log::LevelFilter = log::LevelFilter::Info;
 
 #[no_mangle]
-pub unsafe extern "C" fn init_servo(_ctxt: EGLContext,
-                                    _surf: EGLSurface,
-                                    _disp: EGLDisplay,
+pub unsafe extern "C" fn init_servo(ctxt: EGLContext,
+                                    surf: EGLSurface,
+                                    disp: EGLDisplay,
                                     logger: MLLogger,
                                     url: *const c_char,
                                     width: u32,
@@ -77,7 +78,15 @@ pub unsafe extern "C" fn init_servo(_ctxt: EGLContext,
     });
 
     info!("OpenGL version {}", gl.get_string(gl::VERSION));
-    let window = Rc::new(WindowInstance::new(gl, width, height, hidpi));
+    let window = Rc::new(WindowInstance {
+        ctxt: ctxt,
+        surf: surf,
+        disp: disp,
+        gl: gl,
+        width: width,
+        height: height,
+        hidpi: hidpi,
+    });
 
     info!("Starting servo");
     let mut servo = Box::new(Servo::new(window));
@@ -110,28 +119,23 @@ pub unsafe extern "C" fn discard_servo(servo: ServoInstance) {
 }
 
 struct WindowInstance {
+    ctxt: EGLContext,
+    surf: EGLSurface,
+    disp: EGLDisplay,
     gl: Rc<Gl>,
     width: u32,
     height: u32,
     hidpi: f32,
 }
 
-impl WindowInstance {
-    fn new(gl: Rc<Gl>, width: u32, height: u32, hidpi: f32) -> WindowInstance {
-        WindowInstance {
-            gl: gl,
-            width: width,
-            height: height,
-            hidpi: hidpi,
-        }
-    }
-}
-
 impl WindowMethods for WindowInstance {
     fn present(&self) {
+        SwapBuffers(self.disp, self.surf);
     }
 
     fn prepare_for_composite(&self, _w: Length<u32, DevicePixel>, _h: Length<u32, DevicePixel>) -> bool {
+        MakeCurrent(self.disp, self.surf, self.surf, self.ctxt);
+        self.gl.viewport(0, 0, self.width as i32, self.height as i32);
         true
     }
 

--- a/support/magicleap/Servo2D/code/src/Servo2D.cpp
+++ b/support/magicleap/Servo2D/code/src/Servo2D.cpp
@@ -113,8 +113,6 @@ int Servo2D::init() {
   EGLContext ctx = plane_->getEGLContext();
   EGLSurface surf = plane_->getEGLSurface();
   EGLDisplay dpy = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-  eglMakeCurrent(dpy, surf, surf, ctx);
-  glViewport(0, 0, VIEWPORT_W, VIEWPORT_H);
 
   // Hook into servo
   servo_ = init_servo(ctx, surf, dpy, logger, "https://servo.org", VIEWPORT_H, VIEWPORT_W, HIDPI);
@@ -124,9 +122,6 @@ int Servo2D::init() {
     return 1;
   }
 
-  // Flush GL
-  glFlush();
-  eglSwapBuffers(dpy, surf);
   return 0;
 }
 
@@ -173,19 +168,8 @@ void Servo2D::instanceInitialScenes() {
 }
 
 bool Servo2D::updateLoop(float fDelta) {
-  // Get the EGL context, surface and display.
-  EGLContext ctx = plane_->getEGLContext();
-  EGLSurface surf = plane_->getEGLSurface();
-  EGLDisplay dpy = eglGetDisplay(EGL_DEFAULT_DISPLAY);
-  eglMakeCurrent(dpy, surf, surf, ctx);
-  glViewport(0, 0, VIEWPORT_W, VIEWPORT_H);
-
   // Hook into servo
   heartbeat_servo(servo_);
-
-  // Flush GL
-  glFlush();
-  eglSwapBuffers(dpy, surf);
 
   // Return true for your app to continue running, false to terminate the app.
   return true;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

At the moment, we're swapping the EGL buffers every heartbeat, which produces a lot of flickering. We should only swap the buffers when needed.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because we have no way to test on ML

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22044)
<!-- Reviewable:end -->
