### PR TITLE
remove useless arguments from prepare_for_composite

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1213,7 +1213,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
     ) -> Result<Option<Image>, UnableToComposite> {
         let width = self.embedder_coordinates.framebuffer.width_typed();
         let height = self.embedder_coordinates.framebuffer.height_typed();
-        if !self.window.prepare_for_composite(width, height) {
+        if !self.window.prepare_for_composite() {
             return Err(UnableToComposite::WindowUnprepared);
         }
 

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -11,7 +11,7 @@ use gleam::gl;
 use keyboard_types::KeyboardEvent;
 use msg::constellation_msg::{TopLevelBrowsingContextId, TraversalDirection};
 use script_traits::{MouseButton, TouchEventType, TouchId};
-use servo_geometry::{DeviceIndependentPixel, DeviceUintLength};
+use servo_geometry::DeviceIndependentPixel;
 use servo_url::ServoUrl;
 use std::fmt::{Debug, Error, Formatter};
 #[cfg(feature = "gleam")]
@@ -129,7 +129,7 @@ pub trait WindowMethods {
     /// Requests that the window system prepare a composite. Typically this will involve making
     /// some type of platform-specific graphics context current. Returns true if the composite may
     /// proceed and false if it should not.
-    fn prepare_for_composite(&self, width: DeviceUintLength, height: DeviceUintLength) -> bool;
+    fn prepare_for_composite(&self) -> bool;
     /// Return the GL function pointer trait.
     #[cfg(feature = "gleam")]
     fn gl(&self) -> Rc<gl::Gl>;

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -82,7 +82,6 @@ use constellation::{FromCompositorLogger, FromScriptLogger};
 use constellation::content_process_sandbox_profile;
 use embedder_traits::{EmbedderMsg, EmbedderProxy, EmbedderReceiver, EventLoopWaker};
 use env_logger::Builder as EnvLoggerBuilder;
-use euclid::Length;
 #[cfg(all(not(target_os = "windows"), not(target_os = "ios")))]
 use gaol::sandbox::{ChildSandbox, ChildSandboxMethods};
 use gfx::font_cache_thread::FontCacheThread;
@@ -138,7 +137,7 @@ where
         let opts = opts::get();
 
         // Make sure the gl context is made current.
-        window.prepare_for_composite(Length::new(0), Length::new(0));
+        window.prepare_for_composite();
 
         // Reserving a namespace to create TopLevelBrowserContextId.
         PipelineNamespace::install(PipelineNamespaceId(0));

--- a/ports/libsimpleservo/src/api.rs
+++ b/ports/libsimpleservo/src/api.rs
@@ -7,13 +7,12 @@ use servo::{self, gl, webrender_api, BrowserId, Servo};
 use servo::compositing::windowing::{AnimationState, EmbedderCoordinates, MouseWindowEvent, WindowEvent, WindowMethods};
 use servo::embedder_traits::EmbedderMsg;
 use servo::embedder_traits::resources::{self, Resource};
-use servo::euclid::{Length, TypedPoint2D, TypedScale, TypedSize2D, TypedVector2D};
+use servo::euclid::{TypedPoint2D, TypedScale, TypedSize2D, TypedVector2D};
 use servo::msg::constellation_msg::TraversalDirection;
 use servo::script_traits::{MouseButton, TouchEventType};
 use servo::servo_config::opts;
 use servo::servo_config::prefs::{PrefValue, PREFS};
 use servo::servo_url::ServoUrl;
-use servo::style_traits::DevicePixel;
 use std::cell::{Cell, RefCell};
 use std::mem;
 use std::path::PathBuf;
@@ -433,11 +432,7 @@ struct ServoCallbacks {
 }
 
 impl WindowMethods for ServoCallbacks {
-    fn prepare_for_composite(
-        &self,
-        _width: Length<u32, DevicePixel>,
-        _height: Length<u32, DevicePixel>,
-    ) -> bool {
+    fn prepare_for_composite(&self) -> bool {
         debug!("WindowMethods::prepare_for_composite");
         self.host_callbacks.make_current();
         true

--- a/ports/servo/glutin_app/window.rs
+++ b/ports/servo/glutin_app/window.rs
@@ -4,7 +4,7 @@
 
 //! A windowing implementation using winit.
 
-use euclid::{Length, TypedPoint2D, TypedVector2D, TypedScale, TypedSize2D};
+use euclid::{TypedPoint2D, TypedVector2D, TypedScale, TypedSize2D};
 #[cfg(target_os = "windows")]
 use gdi32;
 use gleam::gl;
@@ -776,11 +776,12 @@ impl WindowMethods for Window {
         self.animation_state.set(state);
     }
 
-    fn prepare_for_composite(
-        &self,
-        _width: Length<u32, DevicePixel>,
-        _height: Length<u32, DevicePixel>,
-    ) -> bool {
+    fn prepare_for_composite(&self) -> bool {
+        if let WindowKind::Window(ref window, ..) = self.kind {
+            if let Err(err) = unsafe { window.context().make_current() } {
+                warn!("Couldn't make window current: {}", err);
+            }
+        };
         true
     }
 }


### PR DESCRIPTION
Accidentally fixes #22009

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22009 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22048)
<!-- Reviewable:end -->
