### PR TITLE
Prepare stylo crates for switching to the 2018 edition

### DIFF
--- a/components/hashglobe/src/fake.rs
+++ b/components/hashglobe/src/fake.rs
@@ -26,7 +26,7 @@ pub use std::collections::hash_set::{IntoIter as SetIntoIter, Iter as SetIter};
 #[derive(Clone)]
 pub struct HashMap<K, V, S = RandomState>(StdMap<K, V, S>);
 
-use FailedAllocationError;
+use crate::FailedAllocationError;
 
 impl<K, V, S> Deref for HashMap<K, V, S> {
     type Target = StdMap<K, V, S>;

--- a/components/hashglobe/src/hash_map.rs
+++ b/components/hashglobe/src/hash_map.rs
@@ -23,7 +23,7 @@ use std::ops::{Deref, Index};
 use super::table::BucketState::{Empty, Full};
 use super::table::{self, Bucket, EmptyBucket, FullBucket, FullBucketMut, RawTable, SafeHash};
 
-use FailedAllocationError;
+use crate::FailedAllocationError;
 
 const MIN_NONZERO_RAW_CAPACITY: usize = 32; // must be a power of two
 

--- a/components/hashglobe/src/table.rs
+++ b/components/hashglobe/src/table.rs
@@ -8,8 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use alloc::{alloc, dealloc};
-use shim::{Shared, Unique};
+use crate::alloc::{alloc, dealloc};
+use crate::shim::{Shared, Unique};
 use std::cmp;
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::marker;
@@ -18,7 +18,7 @@ use std::ops::{Deref, DerefMut};
 use std::ptr;
 
 use self::BucketState::*;
-use FailedAllocationError;
+use crate::FailedAllocationError;
 
 /// Integer type used for stored hash values.
 ///
@@ -795,7 +795,7 @@ impl<K, V> RawTable<K, V> {
         let buffer = alloc(size, alignment);
 
         if buffer.is_null() {
-            use AllocationInfo;
+            use crate::AllocationInfo;
             return Err(FailedAllocationError {
                 reason: "out of memory when allocating RawTable",
                 allocation_info: Some(AllocationInfo { size, alignment }),

--- a/components/selectors/attr.rs
+++ b/components/selectors/attr.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::parser::SelectorImpl;
 use cssparser::ToCss;
-use parser::SelectorImpl;
 use std::fmt;
 
 #[derive(Clone, Eq, PartialEq)]

--- a/components/selectors/builder.rs
+++ b/components/selectors/builder.rs
@@ -17,9 +17,9 @@
 //! is non-trivial. This module encapsulates those details and presents an
 //! easy-to-use API for the parser.
 
-use parser::{Combinator, Component, SelectorImpl};
+use crate::parser::{Combinator, Component, SelectorImpl};
+use crate::sink::Push;
 use servo_arc::{Arc, HeaderWithLength, ThinArc};
-use sink::Push;
 use smallvec::{self, SmallVec};
 use std::cmp;
 use std::iter;

--- a/components/selectors/context.rs
+++ b/components/selectors/context.rs
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use attr::CaseSensitivity;
-use bloom::BloomFilter;
-use nth_index_cache::NthIndexCache;
-use parser::SelectorImpl;
-use tree::{Element, OpaqueElement};
+use crate::attr::CaseSensitivity;
+use crate::bloom::BloomFilter;
+use crate::nth_index_cache::NthIndexCache;
+use crate::parser::SelectorImpl;
+use crate::tree::{Element, OpaqueElement};
 
 /// What kind of selector matching mode we should use.
 ///

--- a/components/selectors/lib.rs
+++ b/components/selectors/lib.rs
@@ -31,6 +31,6 @@ pub mod sink;
 mod tree;
 pub mod visitor;
 
-pub use nth_index_cache::NthIndexCache;
-pub use parser::{Parser, SelectorImpl, SelectorList};
-pub use tree::{Element, OpaqueElement};
+pub use crate::nth_index_cache::NthIndexCache;
+pub use crate::parser::{Parser, SelectorImpl, SelectorList};
+pub use crate::tree::{Element, OpaqueElement};

--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -2,16 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use attr::{AttrSelectorOperation, NamespaceConstraint, ParsedAttrSelectorOperation};
-use bloom::{BloomFilter, BLOOM_HASH_MASK};
-use nth_index_cache::NthIndexCacheInner;
-use parser::{AncestorHashes, Combinator, Component, LocalName};
-use parser::{NonTSPseudoClass, Selector, SelectorImpl, SelectorIter, SelectorList};
+use crate::attr::{AttrSelectorOperation, NamespaceConstraint, ParsedAttrSelectorOperation};
+use crate::bloom::{BloomFilter, BLOOM_HASH_MASK};
+use crate::nth_index_cache::NthIndexCacheInner;
+use crate::parser::{AncestorHashes, Combinator, Component, LocalName};
+use crate::parser::{NonTSPseudoClass, Selector, SelectorImpl, SelectorIter, SelectorList};
+use crate::tree::Element;
 use std::borrow::Borrow;
 use std::iter;
-use tree::Element;
 
-pub use context::*;
+pub use crate::context::*;
 
 // The bloom filter for descendant CSS selectors will have a <1% false
 // positive rate until it has this many selectors in it, then it will
@@ -678,7 +678,7 @@ where
             element.namespace() == url.borrow()
         },
         Component::ExplicitNoNamespace => {
-            let ns = ::parser::namespace_empty_string::<E::Impl>();
+            let ns = crate::parser::namespace_empty_string::<E::Impl>();
             element.namespace() == ns.borrow()
         },
         Component::ID(ref id) => {
@@ -693,7 +693,7 @@ where
         } => {
             let is_html = element.is_html_element_in_html_document();
             element.attr_matches(
-                &NamespaceConstraint::Specific(&::parser::namespace_empty_string::<E::Impl>()),
+                &NamespaceConstraint::Specific(&crate::parser::namespace_empty_string::<E::Impl>()),
                 select_name(is_html, local_name, local_name_lower),
                 &AttrSelectorOperation::Exists,
             )
@@ -710,7 +710,7 @@ where
             }
             let is_html = element.is_html_element_in_html_document();
             element.attr_matches(
-                &NamespaceConstraint::Specific(&::parser::namespace_empty_string::<E::Impl>()),
+                &NamespaceConstraint::Specific(&crate::parser::namespace_empty_string::<E::Impl>()),
                 local_name,
                 &AttrSelectorOperation::WithValue {
                     operator: operator,
@@ -728,7 +728,7 @@ where
             let namespace = match attr_sel.namespace() {
                 Some(ns) => ns,
                 None => {
-                    empty_string = ::parser::namespace_empty_string::<E::Impl>();
+                    empty_string = crate::parser::namespace_empty_string::<E::Impl>();
                     NamespaceConstraint::Specific(&empty_string)
                 },
             };

--- a/components/selectors/nth_index_cache.rs
+++ b/components/selectors/nth_index_cache.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::tree::OpaqueElement;
 use fxhash::FxHashMap;
-use tree::OpaqueElement;
 
 /// A cache to speed up matching of nth-index-like selectors.
 ///

--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -2,26 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use attr::{AttrSelectorOperator, AttrSelectorWithOptionalNamespace};
-use attr::{NamespaceConstraint, ParsedAttrSelectorOperation};
-use attr::{ParsedCaseSensitivity, SELECTOR_WHITESPACE};
-use bloom::BLOOM_HASH_MASK;
-use builder::{SelectorBuilder, SpecificityAndFlags};
-use context::QuirksMode;
+use crate::attr::{AttrSelectorOperator, AttrSelectorWithOptionalNamespace};
+use crate::attr::{NamespaceConstraint, ParsedAttrSelectorOperation};
+use crate::attr::{ParsedCaseSensitivity, SELECTOR_WHITESPACE};
+use crate::bloom::BLOOM_HASH_MASK;
+use crate::builder::{SelectorBuilder, SpecificityAndFlags};
+use crate::context::QuirksMode;
+use crate::sink::Push;
+pub use crate::visitor::{SelectorVisitor, Visit};
 use cssparser::{parse_nth, serialize_identifier};
 use cssparser::{BasicParseError, BasicParseErrorKind, ParseError, ParseErrorKind};
 use cssparser::{CowRcStr, Delimiter, SourceLocation};
 use cssparser::{CssStringWriter, Parser as CssParser, ToCss, Token};
 use precomputed_hash::PrecomputedHash;
 use servo_arc::ThinArc;
-use sink::Push;
 use smallvec::SmallVec;
 use std::borrow::{Borrow, Cow};
 use std::fmt::{self, Debug, Display, Write};
 use std::iter::Rev;
 use std::slice;
 use thin_slice::ThinBoxedSlice;
-pub use visitor::{SelectorVisitor, Visit};
 
 /// A trait that represents a pseudo-element.
 pub trait PseudoElement: Sized + ToCss {
@@ -465,7 +465,7 @@ where
                 let namespace = match attr_selector.namespace() {
                     Some(ns) => ns,
                     None => {
-                        empty_string = ::parser::namespace_empty_string::<Impl>();
+                        empty_string = crate::parser::namespace_empty_string::<Impl>();
                         NamespaceConstraint::Specific(&empty_string)
                     },
                 };
@@ -2147,9 +2147,9 @@ where
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use builder::HAS_PSEUDO_BIT;
+    use crate::builder::HAS_PSEUDO_BIT;
+    use crate::parser;
     use cssparser::{serialize_identifier, Parser as CssParser, ParserInput, ToCss};
-    use parser;
     use std::collections::HashMap;
     use std::fmt;
 

--- a/components/selectors/tree.rs
+++ b/components/selectors/tree.rs
@@ -5,9 +5,9 @@
 //! Traits that nodes must implement. Breaks the otherwise-cyclic dependency
 //! between layout and style.
 
-use attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
-use matching::{ElementSelectorFlags, MatchingContext};
-use parser::SelectorImpl;
+use crate::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
+use crate::matching::{ElementSelectorFlags, MatchingContext};
+use crate::parser::SelectorImpl;
 use std::fmt::Debug;
 use std::ptr::NonNull;
 

--- a/components/selectors/visitor.rs
+++ b/components/selectors/visitor.rs
@@ -6,8 +6,8 @@
 
 #![deny(missing_docs)]
 
-use attr::NamespaceConstraint;
-use parser::{Combinator, Component, SelectorImpl};
+use crate::attr::NamespaceConstraint;
+use crate::parser::{Combinator, Component, SelectorImpl};
 
 /// A trait to visit selector properties.
 ///

--- a/components/servo_arc/lib.rs
+++ b/components/servo_arc/lib.rs
@@ -1060,7 +1060,7 @@ unsafe impl<A: Sync + Send, B: Send + Sync> Sync for ArcUnion<A, B> {}
 
 impl<A: PartialEq, B: PartialEq> PartialEq for ArcUnion<A, B> {
     fn eq(&self, other: &Self) -> bool {
-        use ArcUnionBorrow::*;
+        use crate::ArcUnionBorrow::*;
         match (self.borrow(), other.borrow()) {
             (First(x), First(y)) => x == y,
             (Second(x), Second(y)) => x == y,

--- a/components/style/animation.rs
+++ b/components/style/animation.rs
@@ -8,29 +8,29 @@
 // compile it out so that people remember it exists, thus the cfg'd Sender
 // import.
 
-use bezier::Bezier;
-use context::SharedStyleContext;
-use dom::{OpaqueNode, TElement};
-use font_metrics::FontMetricsProvider;
-use properties::animated_properties::AnimatedProperty;
-use properties::longhands::animation_direction::computed_value::single_value::T as AnimationDirection;
-use properties::longhands::animation_play_state::computed_value::single_value::T as AnimationPlayState;
-use properties::{self, CascadeMode, ComputedValues, LonghandId};
-use rule_tree::CascadeLevel;
+use crate::bezier::Bezier;
+use crate::context::SharedStyleContext;
+use crate::dom::{OpaqueNode, TElement};
+use crate::font_metrics::FontMetricsProvider;
+use crate::properties::animated_properties::AnimatedProperty;
+use crate::properties::longhands::animation_direction::computed_value::single_value::T as AnimationDirection;
+use crate::properties::longhands::animation_play_state::computed_value::single_value::T as AnimationPlayState;
+use crate::properties::{self, CascadeMode, ComputedValues, LonghandId};
+use crate::rule_tree::CascadeLevel;
+use crate::stylesheets::keyframes_rule::{KeyframesAnimation, KeyframesStep, KeyframesStepValue};
+use crate::timer::Timer;
+use crate::values::computed::box_::TransitionProperty;
+use crate::values::computed::Time;
+use crate::values::computed::TimingFunction;
+use crate::values::generics::box_::AnimationIterationCount;
+use crate::values::generics::easing::{StepPosition, TimingFunction as GenericTimingFunction};
+use crate::Atom;
 use servo_arc::Arc;
 #[cfg(feature = "servo")]
 use servo_channel::Sender;
 use std::fmt;
 #[cfg(feature = "gecko")]
 use std::sync::mpsc::Sender;
-use stylesheets::keyframes_rule::{KeyframesAnimation, KeyframesStep, KeyframesStepValue};
-use timer::Timer;
-use values::computed::box_::TransitionProperty;
-use values::computed::Time;
-use values::computed::TimingFunction;
-use values::generics::box_::AnimationIterationCount;
-use values::generics::easing::{StepPosition, TimingFunction as GenericTimingFunction};
-use Atom;
 
 /// This structure represents a keyframes animation current iteration state.
 ///

--- a/components/style/applicable_declarations.rs
+++ b/components/style/applicable_declarations.rs
@@ -4,10 +4,10 @@
 
 //! Applicable declarations management.
 
-use properties::PropertyDeclarationBlock;
-use rule_tree::{CascadeLevel, ShadowCascadeOrder, StyleSource};
+use crate::properties::PropertyDeclarationBlock;
+use crate::rule_tree::{CascadeLevel, ShadowCascadeOrder, StyleSource};
+use crate::shared_lock::Locked;
 use servo_arc::Arc;
-use shared_lock::Locked;
 use smallvec::SmallVec;
 use std::fmt::{self, Debug};
 

--- a/components/style/attr.rs
+++ b/components/style/attr.rs
@@ -7,20 +7,20 @@
 //! [attr]: https://dom.spec.whatwg.org/#interface-attr
 
 use app_units::Au;
+use crate::properties::PropertyDeclarationBlock;
+use crate::shared_lock::Locked;
+use crate::str::str_join;
+use crate::str::{read_exponent, read_fraction, HTML_SPACE_CHARACTERS};
+use crate::str::{read_numbers, split_commas, split_html_space_chars};
+use crate::values::specified::Length;
+use crate::{Atom, LocalName, Namespace, Prefix};
 use cssparser::{self, Color, RGBA};
 use euclid::num::Zero;
 use num_traits::ToPrimitive;
-use properties::PropertyDeclarationBlock;
 use selectors::attr::AttrSelectorOperation;
 use servo_arc::Arc;
 use servo_url::ServoUrl;
-use shared_lock::Locked;
 use std::str::FromStr;
-use str::str_join;
-use str::{read_exponent, read_fraction, HTML_SPACE_CHARACTERS};
-use str::{read_numbers, split_commas, split_html_space_chars};
-use values::specified::Length;
-use {Atom, LocalName, Namespace, Prefix};
 
 // Duplicated from script::dom::values.
 const UNSIGNED_LONG_MAX: u32 = 2147483647;

--- a/components/style/author_styles.rs
+++ b/components/style/author_styles.rs
@@ -5,16 +5,16 @@
 //! A set of author stylesheets and their computed representation, such as the
 //! ones used for ShadowRoot and XBL.
 
-use context::QuirksMode;
-use dom::TElement;
+use crate::context::QuirksMode;
+use crate::dom::TElement;
+use crate::invalidation::media_queries::ToMediaListKey;
+use crate::media_queries::Device;
+use crate::shared_lock::SharedRwLockReadGuard;
+use crate::stylesheet_set::AuthorStylesheetSet;
+use crate::stylesheets::StylesheetInDocument;
+use crate::stylist::CascadeData;
 #[cfg(feature = "gecko")]
 use gecko_bindings::sugar::ownership::{HasBoxFFI, HasFFI, HasSimpleFFI};
-use invalidation::media_queries::ToMediaListKey;
-use media_queries::Device;
-use shared_lock::SharedRwLockReadGuard;
-use stylesheet_set::AuthorStylesheetSet;
-use stylesheets::StylesheetInDocument;
-use stylist::CascadeData;
 
 /// A set of author stylesheets and their computed representation, such as the
 /// ones used for ShadowRoot and XBL.

--- a/components/style/author_styles.rs
+++ b/components/style/author_styles.rs
@@ -7,14 +7,14 @@
 
 use crate::context::QuirksMode;
 use crate::dom::TElement;
+#[cfg(feature = "gecko")]
+use crate::gecko_bindings::sugar::ownership::{HasBoxFFI, HasFFI, HasSimpleFFI};
 use crate::invalidation::media_queries::ToMediaListKey;
 use crate::media_queries::Device;
 use crate::shared_lock::SharedRwLockReadGuard;
 use crate::stylesheet_set::AuthorStylesheetSet;
 use crate::stylesheets::StylesheetInDocument;
 use crate::stylist::CascadeData;
-#[cfg(feature = "gecko")]
-use gecko_bindings::sugar::ownership::{HasBoxFFI, HasFFI, HasSimpleFFI};
 
 /// A set of author stylesheets and their computed representation, such as the
 /// ones used for ShadowRoot and XBL.
@@ -76,10 +76,10 @@ where
 }
 
 #[cfg(feature = "gecko")]
-unsafe impl HasFFI for AuthorStyles<::gecko::data::GeckoStyleSheet> {
-    type FFIType = ::gecko_bindings::bindings::RawServoAuthorStyles;
+unsafe impl HasFFI for AuthorStyles<crate::gecko::data::GeckoStyleSheet> {
+    type FFIType = crate::gecko_bindings::bindings::RawServoAuthorStyles;
 }
 #[cfg(feature = "gecko")]
-unsafe impl HasSimpleFFI for AuthorStyles<::gecko::data::GeckoStyleSheet> {}
+unsafe impl HasSimpleFFI for AuthorStyles<crate::gecko::data::GeckoStyleSheet> {}
 #[cfg(feature = "gecko")]
-unsafe impl HasBoxFFI for AuthorStyles<::gecko::data::GeckoStyleSheet> {}
+unsafe impl HasBoxFFI for AuthorStyles<crate::gecko::data::GeckoStyleSheet> {}

--- a/components/style/bezier.rs
+++ b/components/style/bezier.rs
@@ -8,7 +8,7 @@
 
 #![deny(missing_docs)]
 
-use values::CSSFloat;
+use crate::values::CSSFloat;
 
 const NEWTON_METHOD_ITERATIONS: u8 = 8;
 

--- a/components/style/bloom.rs
+++ b/components/style/bloom.rs
@@ -8,7 +8,7 @@
 #![deny(missing_docs)]
 
 use atomic_refcell::{AtomicRefCell, AtomicRefMut};
-use dom::{SendElement, TElement};
+use crate::dom::{SendElement, TElement};
 use owning_ref::OwningHandle;
 use selectors::bloom::BloomFilter;
 use servo_arc::Arc;

--- a/components/style/context.rs
+++ b/components/style/context.rs
@@ -13,6 +13,8 @@ use crate::data::{EagerPseudoStyles, ElementData};
 use crate::dom::OpaqueNode;
 use crate::dom::{SendElement, TElement};
 use crate::font_metrics::FontMetricsProvider;
+#[cfg(feature = "gecko")]
+use crate::gecko_bindings::structs;
 use crate::parallel::{STACK_SAFETY_MARGIN_KB, STYLE_THREAD_STACK_SIZE_KB};
 use crate::properties::ComputedValues;
 #[cfg(feature = "servo")]
@@ -30,8 +32,6 @@ use crate::traversal_flags::TraversalFlags;
 use euclid::Size2D;
 use euclid::TypedScale;
 use fxhash::FxHashMap;
-#[cfg(feature = "gecko")]
-use gecko_bindings::structs;
 #[cfg(feature = "servo")]
 use parking_lot::RwLock;
 use selectors::matching::ElementSelectorFlags;

--- a/components/style/custom_properties.rs
+++ b/components/style/custom_properties.rs
@@ -6,11 +6,12 @@
 //!
 //! [custom]: https://drafts.csswg.org/css-variables/
 
+use crate::hash::map::Entry;
+use crate::properties::{CSSWideKeyword, CustomDeclarationValue};
+use crate::selector_map::{PrecomputedHashMap, PrecomputedHashSet};
+use crate::Atom;
 use cssparser::{Delimiter, Parser, ParserInput, SourcePosition, Token, TokenSerializationType};
-use hash::map::Entry;
 use precomputed_hash::PrecomputedHash;
-use properties::{CSSWideKeyword, CustomDeclarationValue};
-use selector_map::{PrecomputedHashMap, PrecomputedHashSet};
 use selectors::parser::SelectorParseErrorKind;
 use servo_arc::Arc;
 use smallvec::SmallVec;
@@ -19,7 +20,6 @@ use std::cmp;
 use std::fmt::{self, Write};
 use std::hash::Hash;
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
-use Atom;
 
 /// The environment from which to get `env` function values.
 ///
@@ -553,7 +553,7 @@ fn parse_var_function<'i, 't>(
     let name = parse_name(&name).map_err(|()| {
         input.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(name.clone()))
     })?;
-    if input.try(|input| input.expect_comma()).is_ok() {
+    if input.r#try(|input| input.expect_comma()).is_ok() {
         parse_fallback(input)?;
     }
     if let Some(refs) = references {
@@ -569,7 +569,7 @@ fn parse_env_function<'i, 't>(
     // TODO(emilio): This should be <custom-ident> per spec, but no other
     // browser does that, see https://github.com/w3c/csswg-drafts/issues/3262.
     input.expect_ident()?;
-    if input.try(|input| input.expect_comma()).is_ok() {
+    if input.r#try(|input| input.expect_comma()).is_ok() {
         parse_fallback(input)?;
     }
     if let Some(references) = references {

--- a/components/style/data.rs
+++ b/components/style/data.rs
@@ -4,22 +4,22 @@
 
 //! Per-node data used in style calculation.
 
-use context::{SharedStyleContext, StackLimitChecker};
-use dom::TElement;
-use invalidation::element::invalidator::InvalidationResult;
-use invalidation::element::restyle_hints::RestyleHint;
+use crate::context::{SharedStyleContext, StackLimitChecker};
+use crate::dom::TElement;
+use crate::invalidation::element::invalidator::InvalidationResult;
+use crate::invalidation::element::restyle_hints::RestyleHint;
+use crate::properties::ComputedValues;
+use crate::rule_tree::StrongRuleNode;
+use crate::selector_parser::{PseudoElement, RestyleDamage, EAGER_PSEUDO_COUNT};
+use crate::shared_lock::StylesheetGuards;
+use crate::style_resolver::{PrimaryStyle, ResolvedElementStyles, ResolvedStyle};
 #[cfg(feature = "gecko")]
 use malloc_size_of::MallocSizeOfOps;
-use properties::ComputedValues;
-use rule_tree::StrongRuleNode;
-use selector_parser::{PseudoElement, RestyleDamage, EAGER_PSEUDO_COUNT};
 use selectors::NthIndexCache;
 use servo_arc::Arc;
-use shared_lock::StylesheetGuards;
 use std::fmt;
 use std::mem;
 use std::ops::{Deref, DerefMut};
-use style_resolver::{PrimaryStyle, ResolvedElementStyles, ResolvedStyle};
 
 bitflags! {
     /// Various flags stored on ElementData.
@@ -255,8 +255,8 @@ impl ElementData {
             return InvalidationResult::empty();
         }
 
-        use invalidation::element::invalidator::TreeStyleInvalidator;
-        use invalidation::element::state_and_attributes::StateAndAttrInvalidationProcessor;
+        use crate::invalidation::element::invalidator::TreeStyleInvalidator;
+        use crate::invalidation::element::state_and_attributes::StateAndAttrInvalidationProcessor;
 
         debug!(
             "invalidate_style_if_needed: {:?}, flags: {:?}, has_snapshot: {}, \

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -7,30 +7,30 @@
 #![allow(unsafe_code)]
 #![deny(missing_docs)]
 
-use applicable_declarations::ApplicableDeclarationBlock;
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
 #[cfg(feature = "gecko")]
 use context::PostAnimationTasks;
 #[cfg(feature = "gecko")]
 use context::UpdateAnimationsTasks;
-use data::ElementData;
-use element_state::ElementState;
-use font_metrics::FontMetricsProvider;
-use media_queries::Device;
-use properties::{AnimationRules, ComputedValues, PropertyDeclarationBlock};
-use selector_parser::{AttrValue, Lang, PseudoElement, SelectorImpl};
+use crate::applicable_declarations::ApplicableDeclarationBlock;
+use crate::data::ElementData;
+use crate::element_state::ElementState;
+use crate::font_metrics::FontMetricsProvider;
+use crate::media_queries::Device;
+use crate::properties::{AnimationRules, ComputedValues, PropertyDeclarationBlock};
+use crate::selector_parser::{AttrValue, Lang, PseudoElement, SelectorImpl};
+use crate::shared_lock::Locked;
+use crate::stylist::CascadeData;
+use crate::traversal_flags::TraversalFlags;
+use crate::{Atom, LocalName, Namespace, WeakAtom};
 use selectors::matching::{ElementSelectorFlags, QuirksMode, VisitedHandlingMode};
 use selectors::sink::Push;
 use selectors::Element as SelectorsElement;
 use servo_arc::{Arc, ArcBorrow};
-use shared_lock::Locked;
 use std::fmt;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Deref;
-use stylist::CascadeData;
-use traversal_flags::TraversalFlags;
-use {Atom, LocalName, Namespace, WeakAtom};
 
 /// An opaque handle to a node, which, unlike UnsafeNode, cannot be transformed
 /// back into a non-opaque representation. The only safe operation that can be

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -8,11 +8,11 @@
 #![deny(missing_docs)]
 
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
-#[cfg(feature = "gecko")]
-use context::PostAnimationTasks;
-#[cfg(feature = "gecko")]
-use context::UpdateAnimationsTasks;
 use crate::applicable_declarations::ApplicableDeclarationBlock;
+#[cfg(feature = "gecko")]
+use crate::context::PostAnimationTasks;
+#[cfg(feature = "gecko")]
+use crate::context::UpdateAnimationsTasks;
 use crate::data::ElementData;
 use crate::element_state::ElementState;
 use crate::font_metrics::FontMetricsProvider;

--- a/components/style/dom_apis.rs
+++ b/components/style/dom_apis.rs
@@ -5,17 +5,17 @@
 //! Generic implementations of some DOM APIs so they can be shared between Servo
 //! and Gecko.
 
-use context::QuirksMode;
-use dom::{TDocument, TElement, TNode, TShadowRoot};
-use invalidation::element::invalidator::{DescendantInvalidationLists, Invalidation};
-use invalidation::element::invalidator::{InvalidationProcessor, InvalidationVector};
+use crate::context::QuirksMode;
+use crate::dom::{TDocument, TElement, TNode, TShadowRoot};
+use crate::invalidation::element::invalidator::{DescendantInvalidationLists, Invalidation};
+use crate::invalidation::element::invalidator::{InvalidationProcessor, InvalidationVector};
+use crate::Atom;
 use selectors::attr::CaseSensitivity;
 use selectors::matching::{self, MatchingContext, MatchingMode};
 use selectors::parser::{Combinator, Component, LocalName, SelectorImpl};
 use selectors::{Element, NthIndexCache, SelectorList};
 use smallvec::SmallVec;
 use std::borrow::Borrow;
-use Atom;
 
 /// <https://dom.spec.whatwg.org/#dom-element-matches>
 pub fn element_matches<E>(
@@ -594,7 +594,7 @@ pub fn query_selector<E, Q>(
     E: TElement,
     Q: SelectorQuery<E>,
 {
-    use invalidation::element::invalidator::TreeStyleInvalidator;
+    use crate::invalidation::element::invalidator::TreeStyleInvalidator;
 
     let quirks_mode = root.owner_doc().quirks_mode();
 

--- a/components/style/driver.rs
+++ b/components/style/driver.rs
@@ -26,7 +26,7 @@ fn should_report_statistics() -> bool {
 
 #[cfg(feature = "gecko")]
 fn should_report_statistics() -> bool {
-    unsafe { ::gecko_bindings::structs::ServoTraversalStatistics_sActive }
+    unsafe { crate::gecko_bindings::structs::ServoTraversalStatistics_sActive }
 }
 
 #[cfg(feature = "servo")]
@@ -38,9 +38,9 @@ fn report_statistics(_stats: &PerThreadTraversalStatistics) {
 fn report_statistics(stats: &PerThreadTraversalStatistics) {
     // This should only be called in the main thread, or it may be racy
     // to update the statistics in a global variable.
-    debug_assert!(unsafe { ::gecko_bindings::bindings::Gecko_IsMainThread() });
+    debug_assert!(unsafe { crate::gecko_bindings::bindings::Gecko_IsMainThread() });
     let gecko_stats =
-        unsafe { &mut ::gecko_bindings::structs::ServoTraversalStatistics_sSingleton };
+        unsafe { &mut crate::gecko_bindings::structs::ServoTraversalStatistics_sSingleton };
     gecko_stats.mElementsTraversed += stats.elements_traversed;
     gecko_stats.mElementsStyled += stats.elements_styled;
     gecko_stats.mElementsMatched += stats.elements_matched;

--- a/components/style/driver.rs
+++ b/components/style/driver.rs
@@ -7,17 +7,17 @@
 
 #![deny(missing_docs)]
 
-use context::{PerThreadTraversalStatistics, StyleContext};
-use context::{ThreadLocalStyleContext, TraversalStatistics};
-use dom::{SendNode, TElement, TNode};
-use parallel;
-use parallel::{DispatchMode, WORK_UNIT_MAX};
+use crate::context::{PerThreadTraversalStatistics, StyleContext};
+use crate::context::{ThreadLocalStyleContext, TraversalStatistics};
+use crate::dom::{SendNode, TElement, TNode};
+use crate::parallel;
+use crate::parallel::{DispatchMode, WORK_UNIT_MAX};
+use crate::scoped_tls::ScopedTLS;
+use crate::traversal::{DomTraversal, PerLevelTraversalData, PreTraverseToken};
 use rayon;
-use scoped_tls::ScopedTLS;
 use std::collections::VecDeque;
 use std::mem;
 use time;
-use traversal::{DomTraversal, PerLevelTraversalData, PreTraverseToken};
 
 #[cfg(feature = "servo")]
 fn should_report_statistics() -> bool {

--- a/components/style/encoding_support.rs
+++ b/components/style/encoding_support.rs
@@ -6,15 +6,15 @@
 
 extern crate encoding_rs;
 
-use context::QuirksMode;
+use crate::context::QuirksMode;
+use crate::error_reporting::ParseErrorReporter;
+use crate::media_queries::MediaList;
+use crate::shared_lock::SharedRwLock;
+use crate::stylesheets::{Origin, Stylesheet, StylesheetLoader, UrlExtraData};
 use cssparser::{stylesheet_encoding, EncodingSupport};
-use error_reporting::ParseErrorReporter;
-use media_queries::MediaList;
 use servo_arc::Arc;
-use shared_lock::SharedRwLock;
 use std::borrow::Cow;
 use std::str;
-use stylesheets::{Origin, Stylesheet, StylesheetLoader, UrlExtraData};
 
 struct EncodingRs;
 

--- a/components/style/error_reporting.rs
+++ b/components/style/error_reporting.rs
@@ -6,10 +6,10 @@
 
 #![deny(missing_docs)]
 
+use crate::stylesheets::UrlExtraData;
 use cssparser::{BasicParseErrorKind, ParseErrorKind, SourceLocation, Token};
 use std::fmt;
 use style_traits::ParseError;
-use stylesheets::UrlExtraData;
 
 /// Errors that can be encountered while parsing CSS.
 #[derive(Debug)]

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -8,27 +8,29 @@
 
 use crate::error_reporting::ContextualParseError;
 use crate::parser::{Parse, ParserContext};
+#[cfg(feature = "gecko")]
+use crate::properties::longhands::font_language_override;
 use crate::shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use crate::str::CssStringWriter;
 use crate::values::computed::font::FamilyName;
 use crate::values::generics::font::FontStyle as GenericFontStyle;
 use crate::values::specified::font::SpecifiedFontStyle;
 use crate::values::specified::font::{AbsoluteFontWeight, FontStretch};
+#[cfg(feature = "gecko")]
+use crate::values::specified::font::{
+    SpecifiedFontFeatureSettings, SpecifiedFontVariationSettings,
+};
 use crate::values::specified::url::SpecifiedUrl;
 use crate::values::specified::Angle;
 #[cfg(feature = "gecko")]
 use cssparser::UnicodeRange;
 use cssparser::{AtRuleParser, DeclarationListParser, DeclarationParser, Parser};
 use cssparser::{CowRcStr, SourceLocation};
-#[cfg(feature = "gecko")]
-use properties::longhands::font_language_override;
 use selectors::parser::SelectorParseErrorKind;
 use std::fmt::{self, Write};
 use style_traits::values::SequenceWriter;
 use style_traits::{Comma, CssWriter, OneOrMoreSeparated, ParseError};
 use style_traits::{StyleParseErrorKind, ToCss};
-#[cfg(feature = "gecko")]
-use values::specified::font::{SpecifiedFontFeatureSettings, SpecifiedFontVariationSettings};
 
 /// A source for a font-face rule.
 #[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
@@ -53,8 +55,8 @@ impl OneOrMoreSeparated for Source {
 #[repr(u8)]
 #[allow(missing_docs)]
 pub enum FontFaceSourceListComponent {
-    Url(*const ::gecko_bindings::structs::mozilla::css::URLValue),
-    Local(*mut ::gecko_bindings::structs::nsAtom),
+    Url(*const crate::gecko_bindings::structs::mozilla::css::URLValue),
+    Local(*mut crate::gecko_bindings::structs::nsAtom),
     FormatHint {
         length: usize,
         utf8_bytes: *const u8,
@@ -410,13 +412,13 @@ impl Parse for Source {
 macro_rules! is_descriptor_enabled {
     ("font-display") => {
         unsafe {
-            use gecko_bindings::structs::mozilla;
+            use crate::gecko_bindings::structs::mozilla;
             mozilla::StaticPrefs_sVarCache_layout_css_font_display_enabled
         }
     };
     ("font-variation-settings") => {
         unsafe {
-            use gecko_bindings::structs::mozilla;
+            use crate::gecko_bindings::structs::mozilla;
             mozilla::StaticPrefs_sVarCache_layout_css_font_variations_enabled != 0
         }
     };

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -6,29 +6,29 @@
 //!
 //! [ff]: https://drafts.csswg.org/css-fonts/#at-font-face-rule
 
+use crate::error_reporting::ContextualParseError;
+use crate::parser::{Parse, ParserContext};
+use crate::shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
+use crate::str::CssStringWriter;
+use crate::values::computed::font::FamilyName;
+use crate::values::generics::font::FontStyle as GenericFontStyle;
+use crate::values::specified::font::SpecifiedFontStyle;
+use crate::values::specified::font::{AbsoluteFontWeight, FontStretch};
+use crate::values::specified::url::SpecifiedUrl;
+use crate::values::specified::Angle;
 #[cfg(feature = "gecko")]
 use cssparser::UnicodeRange;
 use cssparser::{AtRuleParser, DeclarationListParser, DeclarationParser, Parser};
 use cssparser::{CowRcStr, SourceLocation};
-use error_reporting::ContextualParseError;
-use parser::{Parse, ParserContext};
 #[cfg(feature = "gecko")]
 use properties::longhands::font_language_override;
 use selectors::parser::SelectorParseErrorKind;
-use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt::{self, Write};
-use str::CssStringWriter;
 use style_traits::values::SequenceWriter;
 use style_traits::{Comma, CssWriter, OneOrMoreSeparated, ParseError};
 use style_traits::{StyleParseErrorKind, ToCss};
-use values::computed::font::FamilyName;
-use values::generics::font::FontStyle as GenericFontStyle;
-use values::specified::font::SpecifiedFontStyle;
-use values::specified::font::{AbsoluteFontWeight, FontStretch};
 #[cfg(feature = "gecko")]
 use values::specified::font::{SpecifiedFontFeatureSettings, SpecifiedFontVariationSettings};
-use values::specified::url::SpecifiedUrl;
-use values::specified::Angle;
 
 /// A source for a font-face rule.
 #[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
@@ -118,7 +118,7 @@ macro_rules! impl_range {
             ) -> Result<Self, ParseError<'i>> {
                 let first = $component::parse(context, input)?;
                 let second = input
-                    .try(|input| $component::parse(context, input))
+                    .r#try(|input| $component::parse(context, input))
                     .unwrap_or_else(|_| first.clone());
                 Ok($range(first, second))
             }
@@ -232,7 +232,7 @@ impl Parse for FontStyle {
             GenericFontStyle::Italic => FontStyle::Italic,
             GenericFontStyle::Oblique(angle) => {
                 let second_angle = input
-                    .try(|input| SpecifiedFontStyle::parse_angle(context, input))
+                    .r#try(|input| SpecifiedFontStyle::parse_angle(context, input))
                     .unwrap_or_else(|_| angle.clone());
 
                 FontStyle::Oblique(angle, second_angle)
@@ -378,7 +378,7 @@ impl Parse for Source {
         input: &mut Parser<'i, 't>,
     ) -> Result<Source, ParseError<'i>> {
         if input
-            .try(|input| input.expect_function_matching("local"))
+            .r#try(|input| input.expect_function_matching("local"))
             .is_ok()
         {
             return input
@@ -390,7 +390,7 @@ impl Parse for Source {
 
         // Parsing optional format()
         let format_hints = if input
-            .try(|input| input.expect_function_matching("format"))
+            .r#try(|input| input.expect_function_matching("format"))
             .is_ok()
         {
             input.parse_nested_block(|input| {

--- a/components/style/font_metrics.rs
+++ b/components/style/font_metrics.rs
@@ -86,8 +86,8 @@ impl FontMetricsProvider for ServoMetricsProvider {
 
 #[cfg(feature = "gecko")]
 /// Construct a font metrics provider for the current product
-pub fn get_metrics_provider_for_product() -> ::gecko::wrapper::GeckoFontMetricsProvider {
-    ::gecko::wrapper::GeckoFontMetricsProvider::new()
+pub fn get_metrics_provider_for_product() -> crate::gecko::wrapper::GeckoFontMetricsProvider {
+    crate::gecko::wrapper::GeckoFontMetricsProvider::new()
 }
 
 #[cfg(feature = "servo")]

--- a/components/style/font_metrics.rs
+++ b/components/style/font_metrics.rs
@@ -7,11 +7,11 @@
 #![deny(missing_docs)]
 
 use app_units::Au;
-use context::SharedStyleContext;
-use logical_geometry::WritingMode;
-use media_queries::Device;
-use properties::style_structs::Font;
-use Atom;
+use crate::context::SharedStyleContext;
+use crate::logical_geometry::WritingMode;
+use crate::media_queries::Device;
+use crate::properties::style_structs::Font;
+use crate::Atom;
 
 /// Represents the font metrics that style needs from a font to compute the
 /// value of certain CSS units like `ex`.

--- a/components/style/gecko/arc_types.rs
+++ b/components/style/gecko/arc_types.rs
@@ -8,40 +8,42 @@
 
 #![allow(non_snake_case, missing_docs)]
 
-use gecko::url::CssUrlData;
-use gecko_bindings::bindings::RawServoCounterStyleRule;
-use gecko_bindings::bindings::RawServoFontFeatureValuesRule;
-use gecko_bindings::bindings::RawServoImportRule;
-use gecko_bindings::bindings::RawServoKeyframe;
-use gecko_bindings::bindings::RawServoKeyframesRule;
-use gecko_bindings::bindings::RawServoMediaRule;
-use gecko_bindings::bindings::RawServoMozDocumentRule;
-use gecko_bindings::bindings::RawServoNamespaceRule;
-use gecko_bindings::bindings::RawServoPageRule;
-use gecko_bindings::bindings::RawServoRuleNode;
-use gecko_bindings::bindings::RawServoRuleNodeStrong;
-use gecko_bindings::bindings::RawServoSupportsRule;
-use gecko_bindings::bindings::ServoCssRules;
-use gecko_bindings::structs::RawServoAnimationValue;
-use gecko_bindings::structs::RawServoCssUrlData;
-use gecko_bindings::structs::RawServoDeclarationBlock;
-use gecko_bindings::structs::RawServoFontFaceRule;
-use gecko_bindings::structs::RawServoMediaList;
-use gecko_bindings::structs::RawServoQuotes;
-use gecko_bindings::structs::RawServoStyleRule;
-use gecko_bindings::structs::RawServoStyleSheetContents;
-use gecko_bindings::sugar::ownership::{HasArcFFI, HasFFI, Strong};
-use media_queries::MediaList;
-use properties::animated_properties::AnimationValue;
-use properties::{ComputedValues, PropertyDeclarationBlock};
-use rule_tree::StrongRuleNode;
+use crate::gecko::url::CssUrlData;
+use crate::gecko_bindings::bindings::RawServoCounterStyleRule;
+use crate::gecko_bindings::bindings::RawServoFontFeatureValuesRule;
+use crate::gecko_bindings::bindings::RawServoImportRule;
+use crate::gecko_bindings::bindings::RawServoKeyframe;
+use crate::gecko_bindings::bindings::RawServoKeyframesRule;
+use crate::gecko_bindings::bindings::RawServoMediaRule;
+use crate::gecko_bindings::bindings::RawServoMozDocumentRule;
+use crate::gecko_bindings::bindings::RawServoNamespaceRule;
+use crate::gecko_bindings::bindings::RawServoPageRule;
+use crate::gecko_bindings::bindings::RawServoRuleNode;
+use crate::gecko_bindings::bindings::RawServoRuleNodeStrong;
+use crate::gecko_bindings::bindings::RawServoSupportsRule;
+use crate::gecko_bindings::bindings::ServoCssRules;
+use crate::gecko_bindings::structs::RawServoAnimationValue;
+use crate::gecko_bindings::structs::RawServoCssUrlData;
+use crate::gecko_bindings::structs::RawServoDeclarationBlock;
+use crate::gecko_bindings::structs::RawServoFontFaceRule;
+use crate::gecko_bindings::structs::RawServoMediaList;
+use crate::gecko_bindings::structs::RawServoQuotes;
+use crate::gecko_bindings::structs::RawServoStyleRule;
+use crate::gecko_bindings::structs::RawServoStyleSheetContents;
+use crate::gecko_bindings::sugar::ownership::{HasArcFFI, HasFFI, Strong};
+use crate::media_queries::MediaList;
+use crate::properties::animated_properties::AnimationValue;
+use crate::properties::{ComputedValues, PropertyDeclarationBlock};
+use crate::rule_tree::StrongRuleNode;
+use crate::shared_lock::Locked;
+use crate::stylesheets::keyframes_rule::Keyframe;
+use crate::stylesheets::{CounterStyleRule, CssRules, FontFaceRule, FontFeatureValuesRule};
+use crate::stylesheets::{
+    DocumentRule, ImportRule, KeyframesRule, MediaRule, NamespaceRule, PageRule,
+};
+use crate::stylesheets::{StyleRule, StylesheetContents, SupportsRule};
 use servo_arc::{Arc, ArcBorrow};
-use shared_lock::Locked;
 use std::{mem, ptr};
-use stylesheets::keyframes_rule::Keyframe;
-use stylesheets::{CounterStyleRule, CssRules, FontFaceRule, FontFeatureValuesRule};
-use stylesheets::{DocumentRule, ImportRule, KeyframesRule, MediaRule, NamespaceRule, PageRule};
-use stylesheets::{StyleRule, StylesheetContents, SupportsRule};
 use values::computed::QuotePair;
 
 macro_rules! impl_arc_ffi {

--- a/components/style/gecko/conversions.rs
+++ b/components/style/gecko/conversions.rs
@@ -9,24 +9,24 @@
 #![allow(unsafe_code)]
 
 use app_units::Au;
-use gecko::values::GeckoStyleCoordConvertible;
-use gecko_bindings::bindings;
-use gecko_bindings::structs::{self, nsStyleCoord_CalcValue};
-use gecko_bindings::structs::{nsStyleImage, nsresult, SheetType};
-use gecko_bindings::sugar::ns_style_coord::{CoordData, CoordDataMut, CoordDataValue};
-use std::f32::consts::PI;
-use stylesheets::{Origin, RulesMutateError};
-use values::computed::image::LineDirection;
-use values::computed::url::ComputedImageUrl;
-use values::computed::{Angle, CalcLengthOrPercentage, Gradient, Image};
-use values::computed::{
+use crate::gecko::values::GeckoStyleCoordConvertible;
+use crate::gecko_bindings::bindings;
+use crate::gecko_bindings::structs::{self, nsStyleCoord_CalcValue};
+use crate::gecko_bindings::structs::{nsStyleImage, nsresult, SheetType};
+use crate::gecko_bindings::sugar::ns_style_coord::{CoordData, CoordDataMut, CoordDataValue};
+use crate::stylesheets::{Origin, RulesMutateError};
+use crate::values::computed::image::LineDirection;
+use crate::values::computed::url::ComputedImageUrl;
+use crate::values::computed::{Angle, CalcLengthOrPercentage, Gradient, Image};
+use crate::values::computed::{
     Integer, LengthOrPercentage, LengthOrPercentageOrAuto, NonNegativeLengthOrPercentageOrAuto,
 };
-use values::computed::{Percentage, TextAlign};
-use values::generics::box_::VerticalAlign;
-use values::generics::grid::{TrackListValue, TrackSize};
-use values::generics::image::{CompatMode, GradientItem, Image as GenericImage};
-use values::generics::rect::Rect;
+use crate::values::computed::{Percentage, TextAlign};
+use crate::values::generics::box_::VerticalAlign;
+use crate::values::generics::grid::{TrackListValue, TrackSize};
+use crate::values::generics::image::{CompatMode, GradientItem, Image as GenericImage};
+use crate::values::generics::rect::Rect;
+use std::f32::consts::PI;
 
 impl From<CalcLengthOrPercentage> for nsStyleCoord_CalcValue {
     fn from(other: CalcLengthOrPercentage) -> nsStyleCoord_CalcValue {
@@ -112,8 +112,8 @@ impl From<nsStyleCoord_CalcValue> for LengthOrPercentageOrAuto {
 // disappear as we move more stuff to cbindgen.
 impl From<nsStyleCoord_CalcValue> for NonNegativeLengthOrPercentageOrAuto {
     fn from(other: nsStyleCoord_CalcValue) -> Self {
+        use crate::values::generics::NonNegative;
         use style_traits::values::specified::AllowedNumericType;
-        use values::generics::NonNegative;
         NonNegative(if other.mLength < 0 || other.mPercent < 0. {
             LengthOrPercentageOrAuto::Calc(CalcLengthOrPercentage::with_clamping_mode(
                 Au(other.mLength).into(),
@@ -137,8 +137,8 @@ impl From<Angle> for CoordDataValue {
 }
 
 fn line_direction(horizontal: LengthOrPercentage, vertical: LengthOrPercentage) -> LineDirection {
-    use values::computed::position::Position;
-    use values::specified::position::{X, Y};
+    use crate::values::computed::position::Position;
+    use crate::values::specified::position::{X, Y};
 
     let horizontal_percentage = match horizontal {
         LengthOrPercentage::Percentage(percentage) => Some(percentage.0),
@@ -240,8 +240,10 @@ impl nsStyleImage {
         use self::structs::NS_STYLE_GRADIENT_SIZE_CLOSEST_SIDE as CLOSEST_SIDE;
         use self::structs::NS_STYLE_GRADIENT_SIZE_FARTHEST_CORNER as FARTHEST_CORNER;
         use self::structs::NS_STYLE_GRADIENT_SIZE_FARTHEST_SIDE as FARTHEST_SIDE;
-        use values::generics::image::{Circle, Ellipse, EndingShape, GradientKind, ShapeExtent};
-        use values::specified::position::{X, Y};
+        use crate::values::generics::image::{
+            Circle, Ellipse, EndingShape, GradientKind, ShapeExtent,
+        };
+        use crate::values::specified::position::{X, Y};
 
         let stop_count = gradient.items.len();
         if stop_count >= ::std::u32::MAX as usize {
@@ -437,8 +439,8 @@ impl nsStyleImage {
 
     /// Converts into Image.
     pub unsafe fn into_image(self: &nsStyleImage) -> Option<Image> {
-        use gecko_bindings::structs::nsStyleImageType;
-        use values::computed::{MozImageRect, NumberOrPercentage};
+        use crate::gecko_bindings::structs::nsStyleImageType;
+        use crate::values::computed::{MozImageRect, NumberOrPercentage};
 
         match self.mType {
             nsStyleImageType::eStyleImageType_Null => None,
@@ -477,7 +479,7 @@ impl nsStyleImage {
                 Some(GenericImage::Gradient(self.get_gradient()))
             },
             nsStyleImageType::eStyleImageType_Element => {
-                use gecko_string_cache::Atom;
+                use crate::gecko_string_cache::Atom;
                 let atom = bindings::Gecko_GetImageElement(self);
                 Some(GenericImage::Element(Atom::from_raw(atom)))
             },
@@ -497,11 +499,11 @@ impl nsStyleImage {
         use self::structs::NS_STYLE_GRADIENT_SIZE_CLOSEST_SIDE as CLOSEST_SIDE;
         use self::structs::NS_STYLE_GRADIENT_SIZE_FARTHEST_CORNER as FARTHEST_CORNER;
         use self::structs::NS_STYLE_GRADIENT_SIZE_FARTHEST_SIDE as FARTHEST_SIDE;
-        use values::computed::image::LineDirection;
-        use values::computed::position::Position;
-        use values::computed::Length;
-        use values::generics::image::{Circle, ColorStop, CompatMode, Ellipse};
-        use values::generics::image::{EndingShape, GradientKind, ShapeExtent};
+        use crate::values::computed::image::LineDirection;
+        use crate::values::computed::position::Position;
+        use crate::values::computed::Length;
+        use crate::values::generics::image::{Circle, ColorStop, CompatMode, Ellipse};
+        use crate::values::generics::image::{EndingShape, GradientKind, ShapeExtent};
 
         let gecko_gradient = bindings::Gecko_GetGradientImageValue(self)
             .as_ref()
@@ -652,26 +654,32 @@ impl nsStyleImage {
 pub mod basic_shape {
     //! Conversions from and to CSS shape representations.
 
-    use gecko::values::GeckoStyleCoordConvertible;
-    use gecko_bindings::structs;
-    use gecko_bindings::structs::{nsStyleCoord, nsStyleCorners};
-    use gecko_bindings::structs::{StyleBasicShape, StyleBasicShapeType};
-    use gecko_bindings::structs::{StyleGeometryBox, StyleShapeSource, StyleShapeSourceType};
-    use gecko_bindings::sugar::ns_style_coord::{CoordDataMut, CoordDataValue};
-    use gecko_bindings::sugar::refptr::RefPtr;
+    use crate::gecko::values::GeckoStyleCoordConvertible;
+    use crate::gecko_bindings::structs;
+    use crate::gecko_bindings::structs::{nsStyleCoord, nsStyleCorners};
+    use crate::gecko_bindings::structs::{StyleBasicShape, StyleBasicShapeType};
+    use crate::gecko_bindings::structs::{
+        StyleGeometryBox, StyleShapeSource, StyleShapeSourceType,
+    };
+    use crate::gecko_bindings::sugar::ns_style_coord::{CoordDataMut, CoordDataValue};
+    use crate::gecko_bindings::sugar::refptr::RefPtr;
+    use crate::values::computed::basic_shape::{
+        BasicShape, ClippingShape, FloatAreaShape, ShapeRadius,
+    };
+    use crate::values::computed::border::{BorderCornerRadius, BorderRadius};
+    use crate::values::computed::length::LengthOrPercentage;
+    use crate::values::computed::motion::OffsetPath;
+    use crate::values::computed::position;
+    use crate::values::computed::url::ComputedUrl;
+    use crate::values::generics::basic_shape::{
+        BasicShape as GenericBasicShape, InsetRect, Polygon,
+    };
+    use crate::values::generics::basic_shape::{Circle, Ellipse, Path, PolygonCoord};
+    use crate::values::generics::basic_shape::{GeometryBox, ShapeBox, ShapeSource};
+    use crate::values::generics::border::BorderRadius as GenericBorderRadius;
+    use crate::values::generics::rect::Rect;
+    use crate::values::specified::SVGPathData;
     use std::borrow::Borrow;
-    use values::computed::basic_shape::{BasicShape, ClippingShape, FloatAreaShape, ShapeRadius};
-    use values::computed::border::{BorderCornerRadius, BorderRadius};
-    use values::computed::length::LengthOrPercentage;
-    use values::computed::motion::OffsetPath;
-    use values::computed::position;
-    use values::computed::url::ComputedUrl;
-    use values::generics::basic_shape::{BasicShape as GenericBasicShape, InsetRect, Polygon};
-    use values::generics::basic_shape::{Circle, Ellipse, Path, PolygonCoord};
-    use values::generics::basic_shape::{GeometryBox, ShapeBox, ShapeSource};
-    use values::generics::border::BorderRadius as GenericBorderRadius;
-    use values::generics::rect::Rect;
-    use values::specified::SVGPathData;
 
     impl StyleShapeSource {
         /// Convert StyleShapeSource to ShapeSource except URL and Image
@@ -706,7 +714,7 @@ pub mod basic_shape {
 
         /// Generate a SVGPathData from StyleShapeSource if possible.
         fn to_svg_path(&self) -> Option<SVGPathData> {
-            use values::specified::svg_path::PathCommand;
+            use crate::values::specified::svg_path::PathCommand;
             match self.mType {
                 StyleShapeSourceType::Path => {
                     let gecko_path = unsafe { &*self.__bindgen_anon_1.mSVGPath.as_ref().mPtr };
@@ -908,7 +916,7 @@ pub mod basic_shape {
 
     impl From<ShapeBox> for StyleGeometryBox {
         fn from(reference: ShapeBox) -> Self {
-            use gecko_bindings::structs::StyleGeometryBox::*;
+            use crate::gecko_bindings::structs::StyleGeometryBox::*;
             match reference {
                 ShapeBox::ContentBox => ContentBox,
                 ShapeBox::PaddingBox => PaddingBox,
@@ -920,7 +928,7 @@ pub mod basic_shape {
 
     impl From<GeometryBox> for StyleGeometryBox {
         fn from(reference: GeometryBox) -> Self {
-            use gecko_bindings::structs::StyleGeometryBox::*;
+            use crate::gecko_bindings::structs::StyleGeometryBox::*;
             match reference {
                 GeometryBox::ShapeBox(shape_box) => From::from(shape_box),
                 GeometryBox::FillBox => FillBox,
@@ -935,7 +943,7 @@ pub mod basic_shape {
     // but coherence doesn't like that and TryFrom isn't stable
     impl From<StyleGeometryBox> for GeometryBox {
         fn from(reference: StyleGeometryBox) -> Self {
-            use gecko_bindings::structs::StyleGeometryBox::*;
+            use crate::gecko_bindings::structs::StyleGeometryBox::*;
             match reference {
                 ContentBox => GeometryBox::ShapeBox(ShapeBox::ContentBox),
                 PaddingBox => GeometryBox::ShapeBox(ShapeBox::PaddingBox),
@@ -951,7 +959,7 @@ pub mod basic_shape {
 
     impl From<StyleGeometryBox> for ShapeBox {
         fn from(reference: StyleGeometryBox) -> Self {
-            use gecko_bindings::structs::StyleGeometryBox::*;
+            use crate::gecko_bindings::structs::StyleGeometryBox::*;
             match reference {
                 ContentBox => ShapeBox::ContentBox,
                 PaddingBox => ShapeBox::PaddingBox,
@@ -987,9 +995,9 @@ impl From<Origin> for SheetType {
 impl TrackSize<LengthOrPercentage> {
     /// Return TrackSize from given two nsStyleCoord
     pub fn from_gecko_style_coords<T: CoordData>(gecko_min: &T, gecko_max: &T) -> Self {
-        use gecko_bindings::structs::root::nsStyleUnit;
-        use values::computed::length::LengthOrPercentage;
-        use values::generics::grid::{TrackBreadth, TrackSize};
+        use crate::gecko_bindings::structs::root::nsStyleUnit;
+        use crate::values::computed::length::LengthOrPercentage;
+        use crate::values::generics::grid::{TrackBreadth, TrackSize};
 
         if gecko_min.unit() == nsStyleUnit::eStyleUnit_None {
             debug_assert!(
@@ -1016,7 +1024,7 @@ impl TrackSize<LengthOrPercentage> {
 
     /// Save TrackSize to given gecko fields.
     pub fn to_gecko_style_coords<T: CoordDataMut>(&self, gecko_min: &mut T, gecko_max: &mut T) {
-        use values::generics::grid::TrackSize;
+        use crate::values::generics::grid::TrackSize;
 
         match *self {
             TrackSize::FitContent(ref lop) => {
@@ -1047,7 +1055,7 @@ impl TrackListValue<LengthOrPercentage, Integer> {
 
     /// Save TrackSize to given gecko fields.
     pub fn to_gecko_style_coords<T: CoordDataMut>(&self, gecko_min: &mut T, gecko_max: &mut T) {
-        use values::generics::grid::TrackListValue;
+        use crate::values::generics::grid::TrackListValue;
 
         match *self {
             TrackListValue::TrackSize(ref size) => size.to_gecko_style_coords(gecko_min, gecko_max),
@@ -1061,7 +1069,7 @@ where
     T: GeckoStyleCoordConvertible,
 {
     /// Convert this generic Rect to given Gecko fields.
-    pub fn to_gecko_rect(&self, sides: &mut ::gecko_bindings::structs::nsStyleSides) {
+    pub fn to_gecko_rect(&self, sides: &mut crate::gecko_bindings::structs::nsStyleSides) {
         self.0.to_gecko_style_coord(&mut sides.data_at_mut(0));
         self.1.to_gecko_style_coord(&mut sides.data_at_mut(1));
         self.2.to_gecko_style_coord(&mut sides.data_at_mut(2));
@@ -1070,9 +1078,9 @@ where
 
     /// Convert from given Gecko data to generic Rect.
     pub fn from_gecko_rect(
-        sides: &::gecko_bindings::structs::nsStyleSides,
-    ) -> Option<::values::generics::rect::Rect<T>> {
-        use values::generics::rect::Rect;
+        sides: &crate::gecko_bindings::structs::nsStyleSides,
+    ) -> Option<crate::values::generics::rect::Rect<T>> {
+        use crate::values::generics::rect::Rect;
 
         Some(Rect::new(
             T::from_gecko_style_coord(&sides.data_at(0)).expect("coord[0] cound not convert"),

--- a/components/style/gecko/data.rs
+++ b/components/style/gecko/data.rs
@@ -5,23 +5,23 @@
 //! Data needed to style a Gecko document.
 
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
-use context::QuirksMode;
-use dom::TElement;
-use gecko_bindings::bindings::{self, RawServoStyleSet};
-use gecko_bindings::structs::StyleSheet as DomStyleSheet;
-use gecko_bindings::structs::{nsIDocument, StyleSheetInfo};
-use gecko_bindings::structs::{RawGeckoPresContextBorrowed, ServoStyleSetSizes};
-use gecko_bindings::sugar::ownership::{HasArcFFI, HasBoxFFI, HasFFI, HasSimpleFFI};
-use invalidation::media_queries::{MediaListKey, ToMediaListKey};
+use crate::context::QuirksMode;
+use crate::dom::TElement;
+use crate::gecko_bindings::bindings::{self, RawServoStyleSet};
+use crate::gecko_bindings::structs::StyleSheet as DomStyleSheet;
+use crate::gecko_bindings::structs::{nsIDocument, StyleSheetInfo};
+use crate::gecko_bindings::structs::{RawGeckoPresContextBorrowed, ServoStyleSetSizes};
+use crate::gecko_bindings::sugar::ownership::{HasArcFFI, HasBoxFFI, HasFFI, HasSimpleFFI};
+use crate::invalidation::media_queries::{MediaListKey, ToMediaListKey};
+use crate::media_queries::{Device, MediaList};
+use crate::properties::ComputedValues;
+use crate::selector_parser::SnapshotMap;
+use crate::shared_lock::{Locked, SharedRwLockReadGuard, StylesheetGuards};
+use crate::stylesheets::{CssRule, Origin, StylesheetContents, StylesheetInDocument};
+use crate::stylist::Stylist;
 use malloc_size_of::MallocSizeOfOps;
-use media_queries::{Device, MediaList};
-use properties::ComputedValues;
-use selector_parser::SnapshotMap;
 use servo_arc::Arc;
-use shared_lock::{Locked, SharedRwLockReadGuard, StylesheetGuards};
 use std::fmt;
-use stylesheets::{CssRule, Origin, StylesheetContents, StylesheetInDocument};
-use stylist::Stylist;
 
 /// Little wrapper to a Gecko style sheet.
 #[derive(Eq, PartialEq)]
@@ -38,7 +38,7 @@ impl fmt::Debug for GeckoStyleSheet {
     }
 }
 
-impl ToMediaListKey for ::gecko::data::GeckoStyleSheet {
+impl ToMediaListKey for crate::gecko::data::GeckoStyleSheet {
     fn to_media_list_key(&self) -> MediaListKey {
         use std::mem;
         unsafe { MediaListKey::from_raw(mem::transmute(self.0)) }
@@ -105,7 +105,7 @@ impl StylesheetInDocument for GeckoStyleSheet {
     }
 
     fn media<'a>(&'a self, guard: &'a SharedRwLockReadGuard) -> Option<&'a MediaList> {
-        use gecko_bindings::structs::mozilla::dom::MediaList as DomMediaList;
+        use crate::gecko_bindings::structs::mozilla::dom::MediaList as DomMediaList;
         use std::mem;
 
         unsafe {

--- a/components/style/gecko/global_style_data.rs
+++ b/components/style/gecko/global_style_data.rs
@@ -4,17 +4,19 @@
 
 //! Global style data
 
-use context::StyleSystemOptions;
-use gecko_bindings::bindings::Gecko_SetJemallocThreadLocalArena;
-use gecko_bindings::bindings::{Gecko_RegisterProfilerThread, Gecko_UnregisterProfilerThread};
+use crate::context::StyleSystemOptions;
+use crate::gecko_bindings::bindings::Gecko_SetJemallocThreadLocalArena;
+use crate::gecko_bindings::bindings::{
+    Gecko_RegisterProfilerThread, Gecko_UnregisterProfilerThread,
+};
+use crate::parallel::STYLE_THREAD_STACK_SIZE_KB;
+use crate::shared_lock::SharedRwLock;
+use crate::thread_state;
 use num_cpus;
-use parallel::STYLE_THREAD_STACK_SIZE_KB;
 use rayon;
-use shared_lock::SharedRwLock;
 use std::cmp;
 use std::env;
 use std::ffi::CString;
-use thread_state;
 
 /// Global style data
 pub struct GlobalStyleData {

--- a/components/style/gecko/media_features.rs
+++ b/components/style/gecko/media_features.rs
@@ -5,16 +5,16 @@
 //! Gecko's media feature list and evaluator.
 
 use app_units::Au;
+use crate::gecko_bindings::bindings;
+use crate::gecko_bindings::structs;
+use crate::media_queries::media_feature::{AllowsRanges, ParsingRequirements};
+use crate::media_queries::media_feature::{Evaluator, MediaFeatureDescription};
+use crate::media_queries::media_feature_expression::{AspectRatio, RangeOrOperator};
+use crate::media_queries::Device;
+use crate::values::computed::CSSPixelLength;
+use crate::values::computed::Resolution;
+use crate::Atom;
 use euclid::Size2D;
-use gecko_bindings::bindings;
-use gecko_bindings::structs;
-use media_queries::media_feature::{AllowsRanges, ParsingRequirements};
-use media_queries::media_feature::{Evaluator, MediaFeatureDescription};
-use media_queries::media_feature_expression::{AspectRatio, RangeOrOperator};
-use media_queries::Device;
-use values::computed::CSSPixelLength;
-use values::computed::Resolution;
-use Atom;
 
 fn viewport_size(device: &Device) -> Size2D<Au> {
     let pc = device.pres_context();

--- a/components/style/gecko/media_queries.rs
+++ b/components/style/gecko/media_queries.rs
@@ -6,24 +6,24 @@
 
 use app_units::Au;
 use app_units::AU_PER_PX;
+use crate::custom_properties::CssEnvironment;
+use crate::gecko::values::{convert_nscolor_to_rgba, convert_rgba_to_nscolor};
+use crate::gecko_bindings::bindings;
+use crate::gecko_bindings::structs;
+use crate::gecko_bindings::structs::{nsPresContext, RawGeckoPresContextBorrowed};
+use crate::media_queries::MediaType;
+use crate::properties::ComputedValues;
+use crate::string_cache::Atom;
+use crate::values::computed::font::FontSize;
+use crate::values::{CustomIdent, KeyframesName};
 use cssparser::RGBA;
-use custom_properties::CssEnvironment;
 use euclid::Size2D;
 use euclid::TypedScale;
-use gecko::values::{convert_nscolor_to_rgba, convert_rgba_to_nscolor};
-use gecko_bindings::bindings;
-use gecko_bindings::structs;
-use gecko_bindings::structs::{nsPresContext, RawGeckoPresContextBorrowed};
-use media_queries::MediaType;
-use properties::ComputedValues;
 use servo_arc::Arc;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicUsize, Ordering};
-use string_cache::Atom;
 use style_traits::viewport::ViewportConstraints;
 use style_traits::{CSSPixel, DevicePixel};
-use values::computed::font::FontSize;
-use values::{CustomIdent, KeyframesName};
 
 /// The `Device` in Gecko wraps a pres context, has a default values computed,
 /// and contains all the viewport rule state.

--- a/components/style/gecko/pseudo_element.rs
+++ b/components/style/gecko/pseudo_element.rs
@@ -8,16 +8,16 @@
 //! `pseudo_element_definition.mako.rs`. If you touch that file, you probably
 //! need to update the checked-in files for Servo.
 
+use crate::gecko_bindings::structs::{self, CSSPseudoElementType};
+use crate::properties::longhands::display::computed_value::T as Display;
+use crate::properties::{ComputedValues, PropertyFlags};
+use crate::selector_parser::{NonTSPseudoClass, PseudoElementCascadeType, SelectorImpl};
+use crate::str::{starts_with_ignore_ascii_case, string_as_ascii_lowercase};
+use crate::string_cache::Atom;
+use crate::values::serialize_atom_identifier;
 use cssparser::ToCss;
-use gecko_bindings::structs::{self, CSSPseudoElementType};
-use properties::longhands::display::computed_value::T as Display;
-use properties::{ComputedValues, PropertyFlags};
-use selector_parser::{NonTSPseudoClass, PseudoElementCascadeType, SelectorImpl};
 use std::fmt;
-use str::{starts_with_ignore_ascii_case, string_as_ascii_lowercase};
-use string_cache::Atom;
 use thin_slice::ThinBoxedSlice;
-use values::serialize_atom_identifier;
 
 include!(concat!(
     env!("OUT_DIR"),

--- a/components/style/gecko/pseudo_element_definition.mako.rs
+++ b/components/style/gecko/pseudo_element_definition.mako.rs
@@ -156,7 +156,7 @@ impl PseudoElement {
     /// Construct a `CSSPseudoElementType` from a pseudo-element
     #[inline]
     fn pseudo_type(&self) -> CSSPseudoElementType {
-        use gecko_bindings::structs::CSSPseudoElementType_InheritingAnonBox;
+        use crate::gecko_bindings::structs::CSSPseudoElementType_InheritingAnonBox;
 
         match *self {
             % for pseudo in PSEUDOS:

--- a/components/style/gecko/restyle_damage.rs
+++ b/components/style/gecko/restyle_damage.rs
@@ -4,11 +4,11 @@
 
 //! Gecko's restyle damage computation (aka change hints, aka `nsChangeHint`).
 
-use gecko_bindings::bindings;
-use gecko_bindings::structs;
-use gecko_bindings::structs::nsChangeHint;
-use matching::{StyleChange, StyleDifference};
-use properties::ComputedValues;
+use crate::gecko_bindings::bindings;
+use crate::gecko_bindings::structs;
+use crate::gecko_bindings::structs::nsChangeHint;
+use crate::matching::{StyleChange, StyleDifference};
+use crate::properties::ComputedValues;
 use std::ops::{BitAnd, BitOr, BitOrAssign, Not};
 
 /// The representation of Gecko's restyle damage is just a wrapper over

--- a/components/style/gecko/rules.rs
+++ b/components/style/gecko/rules.rs
@@ -4,13 +4,13 @@
 
 //! Bindings for CSS Rule objects
 
-use counter_style::{self, CounterBound};
-use gecko_bindings::structs::{self, nsCSSValue};
-use gecko_bindings::sugar::ns_css_value::ToNsCssValue;
+use crate::counter_style::{self, CounterBound};
+use crate::gecko_bindings::structs::{self, nsCSSValue};
+use crate::gecko_bindings::sugar::ns_css_value::ToNsCssValue;
 
 impl<'a> ToNsCssValue for &'a counter_style::System {
     fn convert(self, nscssvalue: &mut nsCSSValue) {
-        use counter_style::System::*;
+        use crate::counter_style::System::*;
         match *self {
             Cyclic => nscssvalue.set_enum(structs::NS_STYLE_COUNTER_SYSTEM_CYCLIC as i32),
             Numeric => nscssvalue.set_enum(structs::NS_STYLE_COUNTER_SYSTEM_NUMERIC as i32),
@@ -123,7 +123,7 @@ impl<'a> ToNsCssValue for &'a counter_style::AdditiveSymbols {
 
 impl<'a> ToNsCssValue for &'a counter_style::SpeakAs {
     fn convert(self, nscssvalue: &mut nsCSSValue) {
-        use counter_style::SpeakAs::*;
+        use crate::counter_style::SpeakAs::*;
         match *self {
             Auto => nscssvalue.set_auto(),
             Bullets => nscssvalue.set_enum(structs::NS_STYLE_COUNTER_SPEAKAS_BULLETS as i32),

--- a/components/style/gecko/selector_parser.rs
+++ b/components/style/gecko/selector_parser.rs
@@ -4,27 +4,29 @@
 
 //! Gecko-specific bits for selector-parsing.
 
+use crate::element_state::{DocumentState, ElementState};
+use crate::gecko_bindings::structs;
+use crate::gecko_bindings::structs::RawServoSelectorList;
+use crate::gecko_bindings::sugar::ownership::{HasBoxFFI, HasFFI, HasSimpleFFI};
+use crate::invalidation::element::document_state::InvalidationMatchingData;
+use crate::selector_parser::{Direction, SelectorParser};
+use crate::str::starts_with_ignore_ascii_case;
+use crate::string_cache::{Atom, Namespace, WeakAtom, WeakNamespace};
+use crate::values::serialize_atom_identifier;
 use cssparser::{BasicParseError, BasicParseErrorKind, Parser};
 use cssparser::{CowRcStr, SourceLocation, ToCss, Token};
-use element_state::{DocumentState, ElementState};
-use gecko_bindings::structs;
-use gecko_bindings::structs::RawServoSelectorList;
-use gecko_bindings::sugar::ownership::{HasBoxFFI, HasFFI, HasSimpleFFI};
-use invalidation::element::document_state::InvalidationMatchingData;
-use selector_parser::{Direction, SelectorParser};
 use selectors::parser::{self as selector_parser, Selector};
 use selectors::parser::{SelectorParseErrorKind, Visit};
 use selectors::visitor::SelectorVisitor;
 use selectors::SelectorList;
 use std::fmt;
-use str::starts_with_ignore_ascii_case;
-use string_cache::{Atom, Namespace, WeakAtom, WeakNamespace};
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss as ToCss_};
 use thin_slice::ThinBoxedSlice;
-use values::serialize_atom_identifier;
 
-pub use gecko::pseudo_element::{PseudoElement, EAGER_PSEUDOS, EAGER_PSEUDO_COUNT, PSEUDO_COUNT};
-pub use gecko::snapshot::SnapshotMap;
+pub use crate::gecko::pseudo_element::{
+    PseudoElement, EAGER_PSEUDOS, EAGER_PSEUDO_COUNT, PSEUDO_COUNT,
+};
+pub use crate::gecko::snapshot::SnapshotMap;
 
 bitflags! {
     // See NonTSPseudoClass::is_enabled_in()
@@ -169,7 +171,7 @@ impl NonTSPseudoClass {
 
     /// Returns whether the pseudo-class is enabled in content sheets.
     fn is_enabled_in_content(&self) -> bool {
-        use gecko_bindings::structs::mozilla;
+        use crate::gecko_bindings::structs::mozilla;
         match *self {
             // For pseudo-classes with pref, the availability in content
             // depends on the pref.

--- a/components/style/gecko/snapshot.rs
+++ b/components/style/gecko/snapshot.rs
@@ -5,19 +5,19 @@
 //! A gecko snapshot, that stores the element attributes and state before they
 //! change in order to properly calculate restyle hints.
 
-use dom::TElement;
-use element_state::ElementState;
-use gecko::snapshot_helpers;
-use gecko::wrapper::{GeckoElement, NamespaceConstraintHelpers};
-use gecko_bindings::bindings;
-use gecko_bindings::structs::ServoElementSnapshot;
-use gecko_bindings::structs::ServoElementSnapshotFlags as Flags;
-use gecko_bindings::structs::ServoElementSnapshotTable;
-use invalidation::element::element_wrapper::ElementSnapshot;
+use crate::dom::TElement;
+use crate::element_state::ElementState;
+use crate::gecko::snapshot_helpers;
+use crate::gecko::wrapper::{GeckoElement, NamespaceConstraintHelpers};
+use crate::gecko_bindings::bindings;
+use crate::gecko_bindings::structs::ServoElementSnapshot;
+use crate::gecko_bindings::structs::ServoElementSnapshotFlags as Flags;
+use crate::gecko_bindings::structs::ServoElementSnapshotTable;
+use crate::invalidation::element::element_wrapper::ElementSnapshot;
+use crate::string_cache::{Atom, Namespace};
+use crate::WeakAtom;
 use selectors::attr::{AttrSelectorOperation, AttrSelectorOperator};
 use selectors::attr::{CaseSensitivity, NamespaceConstraint};
-use string_cache::{Atom, Namespace};
-use WeakAtom;
 
 /// A snapshot of a Gecko element.
 pub type GeckoElementSnapshot = ServoElementSnapshot;

--- a/components/style/gecko/snapshot_helpers.rs
+++ b/components/style/gecko/snapshot_helpers.rs
@@ -4,11 +4,11 @@
 
 //! Element an snapshot common logic.
 
-use gecko_bindings::bindings;
-use gecko_bindings::structs::{self, nsAtom};
+use crate::gecko_bindings::bindings;
+use crate::gecko_bindings::structs::{self, nsAtom};
+use crate::string_cache::{Atom, WeakAtom};
+use crate::CaseSensitivityExt;
 use selectors::attr::CaseSensitivity;
-use string_cache::{Atom, WeakAtom};
-use CaseSensitivityExt;
 
 /// A function that, given an element of type `T`, allows you to get a single
 /// class or a class list.

--- a/components/style/gecko/traversal.rs
+++ b/components/style/gecko/traversal.rs
@@ -4,10 +4,10 @@
 
 //! Gecko-specific bits for the styling DOM traversal.
 
-use context::{SharedStyleContext, StyleContext};
-use dom::{TElement, TNode};
-use gecko::wrapper::{GeckoElement, GeckoNode};
-use traversal::{recalc_style_at, DomTraversal, PerLevelTraversalData};
+use crate::context::{SharedStyleContext, StyleContext};
+use crate::dom::{TElement, TNode};
+use crate::gecko::wrapper::{GeckoElement, GeckoNode};
+use crate::traversal::{recalc_style_at, DomTraversal, PerLevelTraversalData};
 
 /// This is the simple struct that Gecko uses to encapsulate a DOM traversal for
 /// styling.

--- a/components/style/gecko/url.rs
+++ b/components/style/gecko/url.rs
@@ -4,21 +4,21 @@
 
 //! Common handling for the specified value CSS url() values.
 
+use crate::gecko_bindings::bindings;
+use crate::gecko_bindings::structs::root::mozilla::css::URLValue;
+use crate::gecko_bindings::structs::root::mozilla::CORSMode;
+use crate::gecko_bindings::structs::root::nsStyleImageRequest;
+use crate::gecko_bindings::sugar::ownership::{FFIArcHelpers, HasArcFFI};
+use crate::gecko_bindings::sugar::refptr::RefPtr;
+use crate::parser::{Parse, ParserContext};
+use crate::stylesheets::UrlExtraData;
+use crate::values::computed::{Context, ToComputedValue};
 use cssparser::Parser;
-use gecko_bindings::bindings;
-use gecko_bindings::structs::root::mozilla::css::URLValue;
-use gecko_bindings::structs::root::mozilla::CORSMode;
-use gecko_bindings::structs::root::nsStyleImageRequest;
-use gecko_bindings::sugar::ownership::{FFIArcHelpers, HasArcFFI};
-use gecko_bindings::sugar::refptr::RefPtr;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use nsstring::nsCString;
-use parser::{Parse, ParserContext};
 use servo_arc::Arc;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, ToCss};
-use stylesheets::UrlExtraData;
-use values::computed::{Context, ToComputedValue};
 
 /// A CSS url() value for gecko.
 #[css(function = "url")]
@@ -132,12 +132,12 @@ impl SpecifiedUrl {
     }
 
     fn from_css_url(url: CssUrl) -> Self {
-        use gecko_bindings::structs::root::mozilla::CORSMode_CORS_NONE;
+        use crate::gecko_bindings::structs::root::mozilla::CORSMode_CORS_NONE;
         Self::from_css_url_with_cors(url, CORSMode_CORS_NONE)
     }
 
     fn from_css_url_with_cors_anonymous(url: CssUrl) -> Self {
-        use gecko_bindings::structs::root::mozilla::CORSMode_CORS_ANONYMOUS;
+        use crate::gecko_bindings::structs::root::mozilla::CORSMode_CORS_ANONYMOUS;
         Self::from_css_url_with_cors(url, CORSMode_CORS_ANONYMOUS)
     }
 }

--- a/components/style/gecko/values.rs
+++ b/components/style/gecko/values.rs
@@ -7,30 +7,32 @@
 //! Different kind of helpers to interact with Gecko values.
 
 use app_units::Au;
-use counter_style::{Symbol, Symbols};
+use crate::counter_style::{Symbol, Symbols};
+use crate::gecko_bindings::structs::{self, nsStyleCoord, CounterStylePtr};
+use crate::gecko_bindings::structs::{StyleGridTrackBreadth, StyleShapeRadius};
+use crate::gecko_bindings::sugar::ns_style_coord::{CoordData, CoordDataMut, CoordDataValue};
+use crate::media_queries::Device;
+use crate::values::computed::basic_shape::ShapeRadius as ComputedShapeRadius;
+use crate::values::computed::FlexBasis as ComputedFlexBasis;
+use crate::values::computed::{Angle, ExtremumLength, Length, LengthOrPercentage};
+use crate::values::computed::{LengthOrPercentageOrAuto, Percentage};
+use crate::values::computed::{LengthOrPercentageOrNone, Number, NumberOrPercentage};
+use crate::values::computed::{MaxLength as ComputedMaxLength, MozLength as ComputedMozLength};
+use crate::values::computed::{
+    NonNegativeLength, NonNegativeLengthOrPercentage, NonNegativeNumber,
+};
+use crate::values::generics::basic_shape::ShapeRadius;
+use crate::values::generics::box_::Perspective;
+use crate::values::generics::flex::FlexBasis;
+use crate::values::generics::gecko::ScrollSnapPoint;
+use crate::values::generics::grid::{TrackBreadth, TrackKeyword};
+use crate::values::generics::length::{MaxLength, MozLength};
+use crate::values::generics::{CounterStyleOrNone, NonNegative};
+use crate::values::{Auto, Either, None_, Normal};
+use crate::Atom;
 use cssparser::RGBA;
-use gecko_bindings::structs::{self, nsStyleCoord, CounterStylePtr};
-use gecko_bindings::structs::{StyleGridTrackBreadth, StyleShapeRadius};
-use gecko_bindings::sugar::ns_style_coord::{CoordData, CoordDataMut, CoordDataValue};
-use media_queries::Device;
 use nsstring::{nsACString, nsCStr};
 use std::cmp::max;
-use values::computed::basic_shape::ShapeRadius as ComputedShapeRadius;
-use values::computed::FlexBasis as ComputedFlexBasis;
-use values::computed::{Angle, ExtremumLength, Length, LengthOrPercentage};
-use values::computed::{LengthOrPercentageOrAuto, Percentage};
-use values::computed::{LengthOrPercentageOrNone, Number, NumberOrPercentage};
-use values::computed::{MaxLength as ComputedMaxLength, MozLength as ComputedMozLength};
-use values::computed::{NonNegativeLength, NonNegativeLengthOrPercentage, NonNegativeNumber};
-use values::generics::basic_shape::ShapeRadius;
-use values::generics::box_::Perspective;
-use values::generics::flex::FlexBasis;
-use values::generics::gecko::ScrollSnapPoint;
-use values::generics::grid::{TrackBreadth, TrackKeyword};
-use values::generics::length::{MaxLength, MozLength};
-use values::generics::{CounterStyleOrNone, NonNegative};
-use values::{Auto, Either, None_, Normal};
-use Atom;
 
 /// A trait that defines an interface to convert from and to `nsStyleCoord`s.
 pub trait GeckoStyleCoordConvertible: Sized {
@@ -377,8 +379,12 @@ impl GeckoStyleCoordConvertible for Normal {
 
 impl GeckoStyleCoordConvertible for ExtremumLength {
     fn to_gecko_style_coord<T: CoordDataMut>(&self, coord: &mut T) {
-        use gecko_bindings::structs::{NS_STYLE_WIDTH_AVAILABLE, NS_STYLE_WIDTH_FIT_CONTENT};
-        use gecko_bindings::structs::{NS_STYLE_WIDTH_MAX_CONTENT, NS_STYLE_WIDTH_MIN_CONTENT};
+        use crate::gecko_bindings::structs::{
+            NS_STYLE_WIDTH_AVAILABLE, NS_STYLE_WIDTH_FIT_CONTENT,
+        };
+        use crate::gecko_bindings::structs::{
+            NS_STYLE_WIDTH_MAX_CONTENT, NS_STYLE_WIDTH_MIN_CONTENT,
+        };
         coord.set_value(CoordDataValue::Enumerated(match *self {
             ExtremumLength::MozMaxContent => NS_STYLE_WIDTH_MAX_CONTENT,
             ExtremumLength::MozMinContent => NS_STYLE_WIDTH_MIN_CONTENT,
@@ -388,8 +394,12 @@ impl GeckoStyleCoordConvertible for ExtremumLength {
     }
 
     fn from_gecko_style_coord<T: CoordData>(coord: &T) -> Option<Self> {
-        use gecko_bindings::structs::{NS_STYLE_WIDTH_AVAILABLE, NS_STYLE_WIDTH_FIT_CONTENT};
-        use gecko_bindings::structs::{NS_STYLE_WIDTH_MAX_CONTENT, NS_STYLE_WIDTH_MIN_CONTENT};
+        use crate::gecko_bindings::structs::{
+            NS_STYLE_WIDTH_AVAILABLE, NS_STYLE_WIDTH_FIT_CONTENT,
+        };
+        use crate::gecko_bindings::structs::{
+            NS_STYLE_WIDTH_MAX_CONTENT, NS_STYLE_WIDTH_MIN_CONTENT,
+        };
         match coord.as_value() {
             CoordDataValue::Enumerated(NS_STYLE_WIDTH_MAX_CONTENT) => {
                 Some(ExtremumLength::MozMaxContent)
@@ -451,8 +461,8 @@ impl GeckoStyleCoordConvertible for ScrollSnapPoint<LengthOrPercentage> {
     }
 
     fn from_gecko_style_coord<T: CoordData>(coord: &T) -> Option<Self> {
-        use gecko_bindings::structs::root::nsStyleUnit;
-        use values::generics::gecko::ScrollSnapPoint;
+        use crate::gecko_bindings::structs::root::nsStyleUnit;
+        use crate::values::generics::gecko::ScrollSnapPoint;
 
         Some(match coord.unit() {
             nsStyleUnit::eStyleUnit_None => ScrollSnapPoint::None,
@@ -476,7 +486,7 @@ where
     }
 
     fn from_gecko_style_coord<T: CoordData>(coord: &T) -> Option<Self> {
-        use gecko_bindings::structs::root::nsStyleUnit;
+        use crate::gecko_bindings::structs::root::nsStyleUnit;
 
         if coord.unit() == nsStyleUnit::eStyleUnit_None {
             return Some(Perspective::None);
@@ -521,8 +531,8 @@ pub fn round_border_to_device_pixels(width: Au, au_per_device_px: Au) -> Au {
 impl CounterStyleOrNone {
     /// Convert this counter style to a Gecko CounterStylePtr.
     pub fn to_gecko_value(self, gecko_value: &mut CounterStylePtr, device: &Device) {
-        use gecko_bindings::bindings::Gecko_SetCounterStyleToName as set_name;
-        use gecko_bindings::bindings::Gecko_SetCounterStyleToSymbols as set_symbols;
+        use crate::gecko_bindings::bindings::Gecko_SetCounterStyleToName as set_name;
+        use crate::gecko_bindings::bindings::Gecko_SetCounterStyleToSymbols as set_symbols;
         let pres_context = device.pres_context();
         match self {
             CounterStyleOrNone::None => unsafe {
@@ -558,9 +568,9 @@ impl CounterStyleOrNone {
 
     /// Convert Gecko CounterStylePtr to CounterStyleOrNone or String.
     pub fn from_gecko_value(gecko_value: &CounterStylePtr) -> Either<Self, String> {
-        use gecko_bindings::bindings;
-        use values::generics::SymbolsType;
-        use values::CustomIdent;
+        use crate::gecko_bindings::bindings;
+        use crate::values::generics::SymbolsType;
+        use crate::values::CustomIdent;
 
         let name = unsafe { bindings::Gecko_CounterStyle_GetName(gecko_value) };
         if !name.is_null() {

--- a/components/style/gecko_bindings/sugar/ns_com_ptr.rs
+++ b/components/style/gecko_bindings/sugar/ns_com_ptr.rs
@@ -4,7 +4,7 @@
 
 //! Little helpers for `nsCOMPtr`.
 
-use gecko_bindings::structs::nsCOMPtr;
+use crate::gecko_bindings::structs::nsCOMPtr;
 
 #[cfg(feature = "gecko_debug")]
 impl<T> nsCOMPtr<T> {

--- a/components/style/gecko_bindings/sugar/ns_compatibility.rs
+++ b/components/style/gecko_bindings/sugar/ns_compatibility.rs
@@ -4,8 +4,8 @@
 
 //! Little helper for `nsCompatibility`.
 
-use context::QuirksMode;
-use gecko_bindings::structs::nsCompatibility;
+use crate::context::QuirksMode;
+use crate::gecko_bindings::structs::nsCompatibility;
 
 impl From<nsCompatibility> for QuirksMode {
     #[inline]

--- a/components/style/gecko_bindings/sugar/ns_css_shadow_array.rs
+++ b/components/style/gecko_bindings/sugar/ns_css_shadow_array.rs
@@ -4,10 +4,10 @@
 
 //! Rust helpers for Gecko's `nsCSSShadowArray`.
 
-use gecko_bindings::bindings::Gecko_AddRefCSSShadowArrayArbitraryThread;
-use gecko_bindings::bindings::Gecko_NewCSSShadowArray;
-use gecko_bindings::bindings::Gecko_ReleaseCSSShadowArrayArbitraryThread;
-use gecko_bindings::structs::{nsCSSShadowArray, nsCSSShadowItem, RefPtr};
+use crate::gecko_bindings::bindings::Gecko_AddRefCSSShadowArrayArbitraryThread;
+use crate::gecko_bindings::bindings::Gecko_NewCSSShadowArray;
+use crate::gecko_bindings::bindings::Gecko_ReleaseCSSShadowArrayArbitraryThread;
+use crate::gecko_bindings::structs::{nsCSSShadowArray, nsCSSShadowItem, RefPtr};
 use std::ops::{Deref, DerefMut};
 use std::{ptr, slice};
 

--- a/components/style/gecko_bindings/sugar/ns_css_shadow_item.rs
+++ b/components/style/gecko_bindings/sugar/ns_css_shadow_item.rs
@@ -5,8 +5,8 @@
 //! Rust helpers for Gecko's `nsCSSShadowItem`.
 
 use app_units::Au;
-use gecko_bindings::structs::nsCSSShadowItem;
-use values::computed::effects::{BoxShadow, SimpleShadow};
+use crate::gecko_bindings::structs::nsCSSShadowItem;
+use crate::values::computed::effects::{BoxShadow, SimpleShadow};
 
 impl nsCSSShadowItem {
     /// Sets this item from the given box shadow.

--- a/components/style/gecko_bindings/sugar/ns_css_value.rs
+++ b/components/style/gecko_bindings/sugar/ns_css_value.rs
@@ -4,16 +4,16 @@
 
 //! Little helpers for `nsCSSValue`.
 
-use gecko_bindings::bindings;
-use gecko_bindings::structs;
-use gecko_bindings::structs::{nsCSSUnit, nsCSSValue};
-use gecko_bindings::structs::{nsCSSValueList, nsCSSValue_Array};
-use gecko_string_cache::Atom;
+use crate::gecko_bindings::bindings;
+use crate::gecko_bindings::structs;
+use crate::gecko_bindings::structs::{nsCSSUnit, nsCSSValue};
+use crate::gecko_bindings::structs::{nsCSSValueList, nsCSSValue_Array};
+use crate::gecko_string_cache::Atom;
+use crate::values::computed::{Angle, Length, LengthOrPercentage, Percentage};
 use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Index, IndexMut};
 use std::slice;
-use values::computed::{Angle, Length, LengthOrPercentage, Percentage};
 
 impl nsCSSValue {
     /// Create a CSSValue with null unit, useful to be used as a return value.

--- a/components/style/gecko_bindings/sugar/ns_style_auto_array.rs
+++ b/components/style/gecko_bindings/sugar/ns_style_auto_array.rs
@@ -4,10 +4,10 @@
 
 //! Rust helpers for Gecko's `nsStyleAutoArray`.
 
-use gecko_bindings::bindings::Gecko_EnsureStyleAnimationArrayLength;
-use gecko_bindings::bindings::Gecko_EnsureStyleTransitionArrayLength;
-use gecko_bindings::structs::nsStyleAutoArray;
-use gecko_bindings::structs::{StyleAnimation, StyleTransition};
+use crate::gecko_bindings::bindings::Gecko_EnsureStyleAnimationArrayLength;
+use crate::gecko_bindings::bindings::Gecko_EnsureStyleTransitionArrayLength;
+use crate::gecko_bindings::structs::nsStyleAutoArray;
+use crate::gecko_bindings::structs::{StyleAnimation, StyleTransition};
 use std::iter::{once, Chain, IntoIterator, Once};
 use std::ops::{Index, IndexMut};
 use std::slice::{Iter, IterMut};

--- a/components/style/gecko_bindings/sugar/ns_style_coord.rs
+++ b/components/style/gecko_bindings/sugar/ns_style_coord.rs
@@ -4,9 +4,11 @@
 
 //! Rust helpers for Gecko's `nsStyleCoord`.
 
-use gecko_bindings::bindings;
-use gecko_bindings::structs::{nsStyleCoord, nsStyleCoord_Calc, nsStyleCoord_CalcValue};
-use gecko_bindings::structs::{nsStyleCorners, nsStyleSides, nsStyleUnion, nsStyleUnit, nscoord};
+use crate::gecko_bindings::bindings;
+use crate::gecko_bindings::structs::{nsStyleCoord, nsStyleCoord_Calc, nsStyleCoord_CalcValue};
+use crate::gecko_bindings::structs::{
+    nsStyleCorners, nsStyleSides, nsStyleUnion, nsStyleUnit, nscoord,
+};
 use std::mem;
 
 impl nsStyleCoord {
@@ -266,7 +268,7 @@ pub unsafe trait CoordDataMut: CoordData {
     /// Useful for initializing uninits, given that `set_value` may segfault on
     /// uninits.
     fn leaky_set_null(&mut self) {
-        use gecko_bindings::structs::nsStyleUnit::*;
+        use crate::gecko_bindings::structs::nsStyleUnit::*;
         unsafe {
             let (unit, union) = self.values_mut();
             *unit = eStyleUnit_Null;
@@ -278,7 +280,7 @@ pub unsafe trait CoordDataMut: CoordData {
     /// Sets the inner value.
     fn set_value(&mut self, value: CoordDataValue) {
         use self::CoordDataValue::*;
-        use gecko_bindings::structs::nsStyleUnit::*;
+        use crate::gecko_bindings::structs::nsStyleUnit::*;
         self.reset();
         unsafe {
             let (unit, union) = self.values_mut();
@@ -365,7 +367,7 @@ pub unsafe trait CoordData {
     /// Get the appropriate value for this object.
     fn as_value(&self) -> CoordDataValue {
         use self::CoordDataValue::*;
-        use gecko_bindings::structs::nsStyleUnit::*;
+        use crate::gecko_bindings::structs::nsStyleUnit::*;
         unsafe {
             match self.unit() {
                 eStyleUnit_Null => Null,
@@ -387,7 +389,7 @@ pub unsafe trait CoordData {
     #[inline]
     /// Pretend inner value is a float; obtain it.
     unsafe fn get_float(&self) -> f32 {
-        use gecko_bindings::structs::nsStyleUnit::*;
+        use crate::gecko_bindings::structs::nsStyleUnit::*;
         debug_assert!(
             self.unit() == eStyleUnit_Percent ||
                 self.unit() == eStyleUnit_Factor ||
@@ -400,7 +402,7 @@ pub unsafe trait CoordData {
     #[inline]
     /// Pretend inner value is an int; obtain it.
     unsafe fn get_integer(&self) -> i32 {
-        use gecko_bindings::structs::nsStyleUnit::*;
+        use crate::gecko_bindings::structs::nsStyleUnit::*;
         debug_assert!(
             self.unit() == eStyleUnit_Coord ||
                 self.unit() == eStyleUnit_Integer ||

--- a/components/style/gecko_bindings/sugar/ns_t_array.rs
+++ b/components/style/gecko_bindings/sugar/ns_t_array.rs
@@ -4,8 +4,8 @@
 
 //! Rust helpers for Gecko's nsTArray.
 
-use gecko_bindings::bindings;
-use gecko_bindings::structs::{nsTArray, nsTArrayHeader};
+use crate::gecko_bindings::bindings;
+use crate::gecko_bindings::structs::{nsTArray, nsTArrayHeader};
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::slice;

--- a/components/style/gecko_bindings/sugar/origin_flags.rs
+++ b/components/style/gecko_bindings/sugar/origin_flags.rs
@@ -4,15 +4,15 @@
 
 //! Helper to iterate over `OriginFlags` bits.
 
-use gecko_bindings::structs::OriginFlags;
-use gecko_bindings::structs::OriginFlags_Author;
-use gecko_bindings::structs::OriginFlags_User;
-use gecko_bindings::structs::OriginFlags_UserAgent;
-use stylesheets::OriginSet;
+use crate::gecko_bindings::structs::OriginFlags;
+use crate::gecko_bindings::structs::OriginFlags_Author;
+use crate::gecko_bindings::structs::OriginFlags_User;
+use crate::gecko_bindings::structs::OriginFlags_UserAgent;
+use crate::stylesheets::OriginSet;
 
 /// Checks that the values for OriginFlags are the ones we expect.
 pub fn assert_flags_match() {
-    use stylesheets::origin::*;
+    use crate::stylesheets::origin::*;
     debug_assert_eq!(OriginFlags_UserAgent.0, OriginSet::ORIGIN_USER_AGENT.bits());
     debug_assert_eq!(OriginFlags_Author.0, OriginSet::ORIGIN_AUTHOR.bits());
     debug_assert_eq!(OriginFlags_User.0, OriginSet::ORIGIN_USER.bits());

--- a/components/style/gecko_bindings/sugar/refptr.rs
+++ b/components/style/gecko_bindings/sugar/refptr.rs
@@ -4,13 +4,13 @@
 
 //! A rust helper to ease the use of Gecko's refcounted types.
 
-use gecko_bindings::sugar::ownership::HasArcFFI;
-use gecko_bindings::{bindings, structs};
+use crate::gecko_bindings::sugar::ownership::HasArcFFI;
+use crate::gecko_bindings::{bindings, structs};
+use crate::Atom;
 use servo_arc::Arc;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::{fmt, mem, ptr};
-use Atom;
 
 /// Trait for all objects that have Addref() and Release
 /// methods and can be placed inside RefPtr<T>

--- a/components/style/gecko_bindings/sugar/style_complex_color.rs
+++ b/components/style/gecko_bindings/sugar/style_complex_color.rs
@@ -4,13 +4,13 @@
 
 //! Rust helpers to interact with Gecko's StyleComplexColor.
 
-use gecko::values::{convert_nscolor_to_rgba, convert_rgba_to_nscolor};
-use gecko_bindings::structs::StyleComplexColor;
-use gecko_bindings::structs::StyleComplexColor_Tag as Tag;
-use values::computed::ui::ColorOrAuto;
-use values::computed::{Color as ComputedColor, RGBAColor as ComputedRGBA};
-use values::generics::color::{Color as GenericColor, ComplexColorRatios};
-use values::{Auto, Either};
+use crate::gecko::values::{convert_nscolor_to_rgba, convert_rgba_to_nscolor};
+use crate::gecko_bindings::structs::StyleComplexColor;
+use crate::gecko_bindings::structs::StyleComplexColor_Tag as Tag;
+use crate::values::computed::ui::ColorOrAuto;
+use crate::values::computed::{Color as ComputedColor, RGBAColor as ComputedRGBA};
+use crate::values::generics::color::{Color as GenericColor, ComplexColorRatios};
+use crate::values::{Auto, Either};
 
 impl StyleComplexColor {
     /// Create a `StyleComplexColor` value that represents `currentColor`.

--- a/components/style/gecko_string_cache/mod.rs
+++ b/components/style/gecko_string_cache/mod.rs
@@ -10,11 +10,11 @@
 
 //! A drop-in replacement for string_cache, but backed by Gecko `nsAtom`s.
 
-use gecko_bindings::bindings::Gecko_AddRefAtom;
-use gecko_bindings::bindings::Gecko_Atomize;
-use gecko_bindings::bindings::Gecko_Atomize16;
-use gecko_bindings::bindings::Gecko_ReleaseAtom;
-use gecko_bindings::structs::{nsAtom, nsAtom_AtomKind, nsDynamicAtom, nsStaticAtom};
+use crate::gecko_bindings::bindings::Gecko_AddRefAtom;
+use crate::gecko_bindings::bindings::Gecko_Atomize;
+use crate::gecko_bindings::bindings::Gecko_Atomize16;
+use crate::gecko_bindings::bindings::Gecko_ReleaseAtom;
+use crate::gecko_bindings::structs::{nsAtom, nsAtom_AtomKind, nsDynamicAtom, nsStaticAtom};
 use nsstring::{nsAString, nsStr};
 use precomputed_hash::PrecomputedHash;
 use std::borrow::{Borrow, Cow};

--- a/components/style/gecko_string_cache/namespace.rs
+++ b/components/style/gecko_string_cache/namespace.rs
@@ -4,12 +4,12 @@
 
 //! A type to represent a namespace.
 
-use gecko_bindings::structs::nsAtom;
+use crate::gecko_bindings::structs::nsAtom;
+use crate::string_cache::{Atom, WeakAtom};
 use precomputed_hash::PrecomputedHash;
 use std::borrow::Borrow;
 use std::fmt;
 use std::ops::Deref;
-use string_cache::{Atom, WeakAtom};
 
 #[macro_export]
 macro_rules! ns {

--- a/components/style/invalidation/element/document_state.rs
+++ b/components/style/invalidation/element/document_state.rs
@@ -4,13 +4,13 @@
 
 //! An invalidation processor for style changes due to document state changes.
 
-use dom::TElement;
-use element_state::DocumentState;
-use invalidation::element::invalidator::{DescendantInvalidationLists, InvalidationVector};
-use invalidation::element::invalidator::{Invalidation, InvalidationProcessor};
-use invalidation::element::state_and_attributes;
+use crate::dom::TElement;
+use crate::element_state::DocumentState;
+use crate::invalidation::element::invalidator::{DescendantInvalidationLists, InvalidationVector};
+use crate::invalidation::element::invalidator::{Invalidation, InvalidationProcessor};
+use crate::invalidation::element::state_and_attributes;
+use crate::stylist::CascadeData;
 use selectors::matching::{MatchingContext, MatchingMode, QuirksMode, VisitedHandlingMode};
-use stylist::CascadeData;
 
 /// A struct holding the members necessary to invalidate document state
 /// selectors.

--- a/components/style/invalidation/element/element_wrapper.rs
+++ b/components/style/invalidation/element/element_wrapper.rs
@@ -5,16 +5,16 @@
 //! A wrapper over an element and a snapshot, that allows us to selector-match
 //! against a past state of the element.
 
-use dom::TElement;
-use element_state::ElementState;
-use selector_parser::{AttrValue, NonTSPseudoClass, PseudoElement, SelectorImpl};
-use selector_parser::{Snapshot, SnapshotMap};
+use crate::dom::TElement;
+use crate::element_state::ElementState;
+use crate::selector_parser::{AttrValue, NonTSPseudoClass, PseudoElement, SelectorImpl};
+use crate::selector_parser::{Snapshot, SnapshotMap};
+use crate::{Atom, CaseSensitivityExt, LocalName, Namespace, WeakAtom};
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
 use selectors::matching::{ElementSelectorFlags, MatchingContext};
 use selectors::{Element, OpaqueElement};
 use std::cell::Cell;
 use std::fmt;
-use {Atom, CaseSensitivityExt, LocalName, Namespace, WeakAtom};
 
 /// In order to compute restyle hints, we perform a selector match against a
 /// list of partial selectors whose rightmost simple selector may be sensitive
@@ -60,7 +60,7 @@ pub trait ElementSnapshot: Sized {
 
     /// A callback that should be called for each class of the snapshot. Should
     /// only be called if `has_attrs()` returns true.
-    fn each_class<F>(&self, F)
+    fn each_class<F>(&self, _: F)
     where
         F: FnMut(&Atom);
 

--- a/components/style/invalidation/element/invalidation_map.rs
+++ b/components/style/invalidation/element/invalidation_map.rs
@@ -4,18 +4,18 @@
 
 //! Code for invalidations due to state or attribute changes.
 
-use context::QuirksMode;
-use element_state::{DocumentState, ElementState};
+use crate::context::QuirksMode;
+use crate::element_state::{DocumentState, ElementState};
+use crate::selector_map::{MaybeCaseInsensitiveHashMap, SelectorMap, SelectorMapEntry};
+use crate::selector_parser::SelectorImpl;
+use crate::{Atom, LocalName, Namespace};
 use fallible::FallibleVec;
 use hashglobe::FailedAllocationError;
-use selector_map::{MaybeCaseInsensitiveHashMap, SelectorMap, SelectorMapEntry};
-use selector_parser::SelectorImpl;
 use selectors::attr::NamespaceConstraint;
 use selectors::parser::{Combinator, Component};
 use selectors::parser::{Selector, SelectorIter, Visit};
 use selectors::visitor::SelectorVisitor;
 use smallvec::SmallVec;
-use {Atom, LocalName, Namespace};
 
 /// Mapping between (partial) CompoundSelectors (and the combinator to their
 /// right) and the states and attributes they depend on.

--- a/components/style/invalidation/element/invalidation_map.rs
+++ b/components/style/invalidation/element/invalidation_map.rs
@@ -358,7 +358,7 @@ impl<'a> SelectorVisitor for CompoundSelectorDependencyCollector<'a> {
 
     fn visit_simple_selector(&mut self, s: &Component<SelectorImpl>) -> bool {
         #[cfg(feature = "gecko")]
-        use selector_parser::NonTSPseudoClass;
+        use crate::selector_parser::NonTSPseudoClass;
 
         match *s {
             Component::ID(ref id) => {

--- a/components/style/invalidation/element/invalidator.rs
+++ b/components/style/invalidation/element/invalidator.rs
@@ -5,9 +5,9 @@
 //! The struct that takes care of encapsulating all the logic on where and how
 //! element styles need to be invalidated.
 
-use context::StackLimitChecker;
-use dom::{TElement, TNode, TShadowRoot};
-use selector_parser::SelectorImpl;
+use crate::context::StackLimitChecker;
+use crate::dom::{TElement, TNode, TShadowRoot};
+use crate::selector_parser::SelectorImpl;
 use selectors::matching::matches_compound_selector_from;
 use selectors::matching::{CompoundSelectorMatchingResult, MatchingContext};
 use selectors::parser::{Combinator, Component, Selector};

--- a/components/style/invalidation/element/restyle_hints.rs
+++ b/components/style/invalidation/element/restyle_hints.rs
@@ -4,9 +4,9 @@
 
 //! Restyle hints: an optimization to avoid unnecessarily matching selectors.
 
-use crate::traversal_flags::TraversalFlags;
 #[cfg(feature = "gecko")]
-use gecko_bindings::structs::nsRestyleHint;
+use crate::gecko_bindings::structs::nsRestyleHint;
+use crate::traversal_flags::TraversalFlags;
 
 bitflags! {
     /// The kind of restyle we need to do for a given element.
@@ -193,12 +193,12 @@ impl Default for RestyleHint {
 #[cfg(feature = "gecko")]
 impl From<nsRestyleHint> for RestyleHint {
     fn from(mut raw: nsRestyleHint) -> Self {
-        use gecko_bindings::structs::nsRestyleHint_eRestyle_Force as eRestyle_Force;
-        use gecko_bindings::structs::nsRestyleHint_eRestyle_ForceDescendants as eRestyle_ForceDescendants;
-        use gecko_bindings::structs::nsRestyleHint_eRestyle_LaterSiblings as eRestyle_LaterSiblings;
-        use gecko_bindings::structs::nsRestyleHint_eRestyle_Self as eRestyle_Self;
-        use gecko_bindings::structs::nsRestyleHint_eRestyle_SomeDescendants as eRestyle_SomeDescendants;
-        use gecko_bindings::structs::nsRestyleHint_eRestyle_Subtree as eRestyle_Subtree;
+        use crate::gecko_bindings::structs::nsRestyleHint_eRestyle_Force as eRestyle_Force;
+        use crate::gecko_bindings::structs::nsRestyleHint_eRestyle_ForceDescendants as eRestyle_ForceDescendants;
+        use crate::gecko_bindings::structs::nsRestyleHint_eRestyle_LaterSiblings as eRestyle_LaterSiblings;
+        use crate::gecko_bindings::structs::nsRestyleHint_eRestyle_Self as eRestyle_Self;
+        use crate::gecko_bindings::structs::nsRestyleHint_eRestyle_SomeDescendants as eRestyle_SomeDescendants;
+        use crate::gecko_bindings::structs::nsRestyleHint_eRestyle_Subtree as eRestyle_Subtree;
 
         let mut hint = RestyleHint::empty();
 
@@ -241,7 +241,7 @@ malloc_size_of_is_0!(RestyleHint);
 #[cfg(feature = "gecko")]
 #[inline]
 pub fn assert_restyle_hints_match() {
-    use gecko_bindings::structs;
+    use crate::gecko_bindings::structs;
 
     macro_rules! check_restyle_hints {
         ( $( $a:ident => $b:path),*, ) => {

--- a/components/style/invalidation/element/restyle_hints.rs
+++ b/components/style/invalidation/element/restyle_hints.rs
@@ -4,9 +4,9 @@
 
 //! Restyle hints: an optimization to avoid unnecessarily matching selectors.
 
+use crate::traversal_flags::TraversalFlags;
 #[cfg(feature = "gecko")]
 use gecko_bindings::structs::nsRestyleHint;
-use traversal_flags::TraversalFlags;
 
 bitflags! {
     /// The kind of restyle we need to do for a given element.

--- a/components/style/invalidation/element/state_and_attributes.rs
+++ b/components/style/invalidation/element/state_and_attributes.rs
@@ -5,24 +5,24 @@
 //! An invalidation processor for style changes due to state and attribute
 //! changes.
 
-use context::SharedStyleContext;
-use data::ElementData;
-use dom::TElement;
-use element_state::ElementState;
-use invalidation::element::element_wrapper::{ElementSnapshot, ElementWrapper};
-use invalidation::element::invalidation_map::*;
-use invalidation::element::invalidator::{DescendantInvalidationLists, InvalidationVector};
-use invalidation::element::invalidator::{Invalidation, InvalidationProcessor};
-use invalidation::element::restyle_hints::RestyleHint;
-use selector_map::SelectorMap;
-use selector_parser::Snapshot;
+use crate::context::SharedStyleContext;
+use crate::data::ElementData;
+use crate::dom::TElement;
+use crate::element_state::ElementState;
+use crate::invalidation::element::element_wrapper::{ElementSnapshot, ElementWrapper};
+use crate::invalidation::element::invalidation_map::*;
+use crate::invalidation::element::invalidator::{DescendantInvalidationLists, InvalidationVector};
+use crate::invalidation::element::invalidator::{Invalidation, InvalidationProcessor};
+use crate::invalidation::element::restyle_hints::RestyleHint;
+use crate::selector_map::SelectorMap;
+use crate::selector_parser::Snapshot;
+use crate::stylesheets::origin::{Origin, OriginSet};
+use crate::{Atom, WeakAtom};
 use selectors::attr::CaseSensitivity;
 use selectors::matching::matches_selector;
 use selectors::matching::{MatchingContext, MatchingMode, VisitedHandlingMode};
 use selectors::NthIndexCache;
 use smallvec::SmallVec;
-use stylesheets::origin::{Origin, OriginSet};
-use {Atom, WeakAtom};
 
 /// The collector implementation.
 struct Collector<'a, 'b: 'a, 'selectors: 'a, E>

--- a/components/style/invalidation/media_queries.rs
+++ b/components/style/invalidation/media_queries.rs
@@ -4,12 +4,12 @@
 
 //! Code related to the invalidation of media-query-affected rules.
 
-use context::QuirksMode;
+use crate::context::QuirksMode;
+use crate::media_queries::Device;
+use crate::shared_lock::SharedRwLockReadGuard;
+use crate::stylesheets::{DocumentRule, ImportRule, MediaRule};
+use crate::stylesheets::{NestedRuleIterationCondition, Stylesheet, SupportsRule};
 use fxhash::FxHashSet;
-use media_queries::Device;
-use shared_lock::SharedRwLockReadGuard;
-use stylesheets::{DocumentRule, ImportRule, MediaRule};
-use stylesheets::{NestedRuleIterationCondition, Stylesheet, SupportsRule};
 
 /// A key for a given media query result.
 ///
@@ -115,7 +115,7 @@ impl NestedRuleIterationCondition for PotentiallyEffectiveMediaRules {
         quirks_mode: QuirksMode,
         rule: &DocumentRule,
     ) -> bool {
-        use stylesheets::EffectiveRules;
+        use crate::stylesheets::EffectiveRules;
         EffectiveRules::process_document(guard, device, quirks_mode, rule)
     }
 
@@ -126,7 +126,7 @@ impl NestedRuleIterationCondition for PotentiallyEffectiveMediaRules {
         quirks_mode: QuirksMode,
         rule: &SupportsRule,
     ) -> bool {
-        use stylesheets::EffectiveRules;
+        use crate::stylesheets::EffectiveRules;
         EffectiveRules::process_supports(guard, device, quirks_mode, rule)
     }
 }

--- a/components/style/invalidation/stylesheets.rs
+++ b/components/style/invalidation/stylesheets.rs
@@ -7,19 +7,19 @@
 
 #![deny(unsafe_code)]
 
-use dom::{TDocument, TElement, TNode};
+use crate::dom::{TDocument, TElement, TNode};
+use crate::invalidation::element::element_wrapper::{ElementSnapshot, ElementWrapper};
+use crate::invalidation::element::restyle_hints::RestyleHint;
+use crate::media_queries::Device;
+use crate::selector_parser::{SelectorImpl, Snapshot, SnapshotMap};
+use crate::shared_lock::SharedRwLockReadGuard;
+use crate::stylesheets::{CssRule, StylesheetInDocument};
+use crate::Atom;
+use crate::CaseSensitivityExt;
+use crate::LocalName as SelectorLocalName;
 use fxhash::FxHashSet;
-use invalidation::element::element_wrapper::{ElementSnapshot, ElementWrapper};
-use invalidation::element::restyle_hints::RestyleHint;
-use media_queries::Device;
-use selector_parser::{SelectorImpl, Snapshot, SnapshotMap};
 use selectors::attr::CaseSensitivity;
 use selectors::parser::{Component, LocalName, Selector};
-use shared_lock::SharedRwLockReadGuard;
-use stylesheets::{CssRule, StylesheetInDocument};
-use Atom;
-use CaseSensitivityExt;
-use LocalName as SelectorLocalName;
 
 /// A style sheet invalidation represents a kind of element or subtree that may
 /// need to be restyled. Whether it represents a whole subtree or just a single
@@ -419,7 +419,7 @@ impl StylesheetInvalidationSet {
         guard: &SharedRwLockReadGuard,
         device: &Device,
     ) {
-        use stylesheets::CssRule::*;
+        use crate::stylesheets::CssRule::*;
         debug!("StylesheetInvalidationSet::collect_invalidations_for_rule");
         debug_assert!(!self.fully_invalid, "Not worth to be here!");
 

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -215,10 +215,10 @@ macro_rules! reexport_computed_values {
         /// [computed]: https://drafts.csswg.org/css-cascade/#computed
         pub mod computed_values {
             $(
-                pub use properties::longhands::$name::computed_value as $name;
+                pub use crate::properties::longhands::$name::computed_value as $name;
             )+
             // Don't use a side-specific name needlessly:
-            pub use properties::longhands::border_top_style::computed_value as border_style;
+            pub use crate::properties::longhands::border_top_style::computed_value as border_style;
         }
     }
 }

--- a/components/style/lib.rs
+++ b/components/style/lib.rs
@@ -165,15 +165,15 @@ pub mod use_counters;
 pub mod values;
 
 #[cfg(feature = "gecko")]
-pub use gecko_string_cache as string_cache;
+pub use crate::gecko_string_cache as string_cache;
 #[cfg(feature = "gecko")]
-pub use gecko_string_cache::Atom;
+pub use crate::gecko_string_cache::Atom;
 #[cfg(feature = "gecko")]
-pub use gecko_string_cache::Atom as Prefix;
+pub use crate::gecko_string_cache::Atom as Prefix;
 #[cfg(feature = "gecko")]
-pub use gecko_string_cache::Atom as LocalName;
+pub use crate::gecko_string_cache::Atom as LocalName;
 #[cfg(feature = "gecko")]
-pub use gecko_string_cache::Namespace;
+pub use crate::gecko_string_cache::Namespace;
 
 #[cfg(feature = "servo")]
 pub use html5ever::LocalName;
@@ -225,7 +225,7 @@ macro_rules! reexport_computed_values {
 longhand_properties_idents!(reexport_computed_values);
 
 #[cfg(feature = "gecko")]
-use gecko_string_cache::WeakAtom;
+use crate::gecko_string_cache::WeakAtom;
 #[cfg(feature = "servo")]
 use servo_atoms::Atom as WeakAtom;
 

--- a/components/style/logical_geometry.rs
+++ b/components/style/logical_geometry.rs
@@ -4,9 +4,9 @@
 
 //! Geometry in flow-relative space.
 
+use crate::properties::style_structs;
 use euclid::num::Zero;
 use euclid::{Point2D, Rect, SideOffsets2D, Size2D};
-use properties::style_structs;
 use std::cmp::{max, min};
 use std::fmt::{self, Debug, Error, Formatter};
 use std::ops::{Add, Sub};
@@ -42,8 +42,8 @@ bitflags!(
 impl WritingMode {
     /// Return a WritingMode bitflags from the relevant CSS properties.
     pub fn new(inheritedbox_style: &style_structs::InheritedBox) -> Self {
-        use properties::longhands::direction::computed_value::T as Direction;
-        use properties::longhands::writing_mode::computed_value::T as SpecifiedWritingMode;
+        use crate::properties::longhands::direction::computed_value::T as Direction;
+        use crate::properties::longhands::writing_mode::computed_value::T as SpecifiedWritingMode;
 
         let mut flags = WritingMode::empty();
 

--- a/components/style/logical_geometry.rs
+++ b/components/style/logical_geometry.rs
@@ -79,7 +79,7 @@ impl WritingMode {
 
         #[cfg(feature = "gecko")]
         {
-            use properties::longhands::text_orientation::computed_value::T as TextOrientation;
+            use crate::properties::longhands::text_orientation::computed_value::T as TextOrientation;
 
             // If FLAG_SIDEWAYS is already set, this means writing-mode is
             // either sideways-rl or sideways-lr, and for both of these values,

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -7,19 +7,19 @@
 #![allow(unsafe_code)]
 #![deny(missing_docs)]
 
-use context::{ElementCascadeInputs, QuirksMode, SelectorFlagsMap};
-use context::{SharedStyleContext, StyleContext};
-use data::ElementData;
-use dom::TElement;
-use invalidation::element::restyle_hints::RestyleHint;
-use properties::longhands::display::computed_value::T as Display;
-use properties::ComputedValues;
-use rule_tree::{CascadeLevel, StrongRuleNode};
-use selector_parser::{PseudoElement, RestyleDamage};
+use crate::context::{ElementCascadeInputs, QuirksMode, SelectorFlagsMap};
+use crate::context::{SharedStyleContext, StyleContext};
+use crate::data::ElementData;
+use crate::dom::TElement;
+use crate::invalidation::element::restyle_hints::RestyleHint;
+use crate::properties::longhands::display::computed_value::T as Display;
+use crate::properties::ComputedValues;
+use crate::rule_tree::{CascadeLevel, StrongRuleNode};
+use crate::selector_parser::{PseudoElement, RestyleDamage};
+use crate::style_resolver::ResolvedElementStyles;
+use crate::traversal_flags::TraversalFlags;
 use selectors::matching::ElementSelectorFlags;
 use servo_arc::{Arc, ArcBorrow};
-use style_resolver::ResolvedElementStyles;
-use traversal_flags::TraversalFlags;
 
 /// Represents the result of comparing an element's old and new style.
 #[derive(Debug)]
@@ -93,8 +93,8 @@ trait PrivateMatchMethods: TElement {
         cascade_visited: CascadeVisitedMode,
         cascade_inputs: &mut ElementCascadeInputs,
     ) -> bool {
-        use properties::PropertyDeclarationBlock;
-        use shared_lock::Locked;
+        use crate::properties::PropertyDeclarationBlock;
+        use crate::shared_lock::Locked;
 
         debug_assert!(
             replacements.intersects(RestyleHint::replacements()) &&
@@ -419,8 +419,8 @@ trait PrivateMatchMethods: TElement {
         _restyle_hint: RestyleHint,
         _important_rules_changed: bool,
     ) {
-        use animation;
-        use dom::TNode;
+        use crate::animation;
+        use crate::dom::TNode;
 
         let mut possibly_expired_animations = vec![];
         let shared_context = context.shared;
@@ -583,11 +583,11 @@ trait PrivateMatchMethods: TElement {
         &self,
         context: &SharedStyleContext,
         style: &mut Arc<ComputedValues>,
-        possibly_expired_animations: &mut Vec<::animation::PropertyAnimation>,
-        font_metrics: &::font_metrics::FontMetricsProvider,
+        possibly_expired_animations: &mut Vec<crate::animation::PropertyAnimation>,
+        font_metrics: &crate::font_metrics::FontMetricsProvider,
     ) {
-        use animation::{self, Animation, AnimationUpdate};
-        use dom::TNode;
+        use crate::animation::{self, Animation, AnimationUpdate};
+        use crate::dom::TNode;
 
         // Finish any expired transitions.
         let this_opaque = self.as_node().opaque();

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -195,9 +195,9 @@ trait PrivateMatchMethods: TElement {
         context: &mut StyleContext<Self>,
         primary_style: &Arc<ComputedValues>,
     ) -> Option<Arc<ComputedValues>> {
-        use context::CascadeInputs;
-        use style_resolver::{PseudoElementResolution, StyleResolverForElement};
-        use stylist::RuleInclusion;
+        use crate::context::CascadeInputs;
+        use crate::style_resolver::{PseudoElementResolution, StyleResolverForElement};
+        use crate::stylist::RuleInclusion;
 
         let rule_node = primary_style.rules();
         let without_transition_rules = context
@@ -307,7 +307,7 @@ trait PrivateMatchMethods: TElement {
         new_values: &ComputedValues,
         restyle_hints: RestyleHint,
     ) {
-        use context::PostAnimationTasks;
+        use crate::context::PostAnimationTasks;
 
         if !restyle_hints.intersects(RestyleHint::RESTYLE_SMIL) {
             return;
@@ -337,7 +337,7 @@ trait PrivateMatchMethods: TElement {
         restyle_hint: RestyleHint,
         important_rules_changed: bool,
     ) {
-        use context::UpdateAnimationsTasks;
+        use crate::context::UpdateAnimationsTasks;
 
         if context.shared.traversal_flags.for_animation_only() {
             self.handle_display_change_for_smil_if_needed(
@@ -538,7 +538,7 @@ trait PrivateMatchMethods: TElement {
         // seems not common enough to care about.
         #[cfg(feature = "gecko")]
         {
-            use values::specified::align::AlignFlags;
+            use crate::values::specified::align::AlignFlags;
 
             let old_justify_items = old_values.get_position().clone_justify_items();
             let new_justify_items = new_values.get_position().clone_justify_items();

--- a/components/style/media_queries/media_condition.rs
+++ b/components/style/media_queries/media_condition.rs
@@ -7,9 +7,9 @@
 //! https://drafts.csswg.org/mediaqueries-4/#typedef-media-condition
 
 use super::{Device, MediaFeatureExpression};
-use context::QuirksMode;
+use crate::context::QuirksMode;
+use crate::parser::ParserContext;
 use cssparser::{Parser, Token};
-use parser::ParserContext;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
 
@@ -114,7 +114,7 @@ impl MediaCondition {
 
         // ParenthesisBlock.
         let first_condition = Self::parse_paren_block(context, input)?;
-        let operator = match input.try(Operator::parse) {
+        let operator = match input.r#try(Operator::parse) {
             Ok(op) => op,
             Err(..) => return Ok(first_condition),
         };
@@ -133,7 +133,7 @@ impl MediaCondition {
         };
 
         loop {
-            if input.try(|i| i.expect_ident_matching(delim)).is_err() {
+            if input.r#try(|i| i.expect_ident_matching(delim)).is_err() {
                 return Ok(MediaCondition::Operation(
                     conditions.into_boxed_slice(),
                     operator,
@@ -159,7 +159,7 @@ impl MediaCondition {
     ) -> Result<Self, ParseError<'i>> {
         input.parse_nested_block(|input| {
             // Base case.
-            if let Ok(inner) = input.try(|i| Self::parse(context, i)) {
+            if let Ok(inner) = input.r#try(|i| Self::parse(context, i)) {
                 return Ok(MediaCondition::InParens(Box::new(inner)));
             }
             let expr = MediaFeatureExpression::parse_in_parenthesis_block(context, input)?;

--- a/components/style/media_queries/media_feature.rs
+++ b/components/style/media_queries/media_feature.rs
@@ -6,12 +6,12 @@
 
 use super::media_feature_expression::{AspectRatio, RangeOrOperator};
 use super::Device;
+use crate::parser::ParserContext;
+use crate::values::computed::{CSSPixelLength, Resolution};
+use crate::Atom;
 use cssparser::Parser;
-use parser::ParserContext;
 use std::fmt;
 use style_traits::ParseError;
-use values::computed::{CSSPixelLength, Resolution};
-use Atom;
 
 /// A generic discriminant for an enum value.
 pub type KeywordDiscriminant = u8;

--- a/components/style/media_queries/media_feature_expression.rs
+++ b/components/style/media_queries/media_feature_expression.rs
@@ -9,6 +9,8 @@ use super::media_feature::{Evaluator, MediaFeatureDescription};
 use super::media_feature::{KeywordDiscriminant, ParsingRequirements};
 use super::Device;
 use crate::context::QuirksMode;
+#[cfg(feature = "gecko")]
+use crate::gecko_bindings::structs;
 use crate::parser::{Parse, ParserContext};
 use crate::str::{starts_with_ignore_ascii_case, string_as_ascii_lowercase};
 use crate::stylesheets::Origin;
@@ -17,8 +19,6 @@ use crate::values::specified::{Integer, Length, Number, Resolution};
 use crate::values::{serialize_atom_identifier, CSSFloat};
 use crate::Atom;
 use cssparser::{Parser, Token};
-#[cfg(feature = "gecko")]
-use gecko_bindings::structs;
 use num_traits::Zero;
 use std::cmp::{Ordering, PartialOrd};
 use std::fmt::{self, Write};
@@ -270,10 +270,10 @@ impl MediaFeatureExpression {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
+        #[cfg(feature = "gecko")]
+        use crate::gecko::media_features::MEDIA_FEATURES;
         #[cfg(feature = "servo")]
         use crate::servo::media_queries::MEDIA_FEATURES;
-        #[cfg(feature = "gecko")]
-        use gecko::media_features::MEDIA_FEATURES;
 
         // FIXME: remove extra indented block when lifetimes are non-lexical
         let feature;

--- a/components/style/media_queries/media_feature_expression.rs
+++ b/components/style/media_queries/media_feature_expression.rs
@@ -8,21 +8,21 @@
 use super::media_feature::{Evaluator, MediaFeatureDescription};
 use super::media_feature::{KeywordDiscriminant, ParsingRequirements};
 use super::Device;
-use context::QuirksMode;
+use crate::context::QuirksMode;
+use crate::parser::{Parse, ParserContext};
+use crate::str::{starts_with_ignore_ascii_case, string_as_ascii_lowercase};
+use crate::stylesheets::Origin;
+use crate::values::computed::{self, ToComputedValue};
+use crate::values::specified::{Integer, Length, Number, Resolution};
+use crate::values::{serialize_atom_identifier, CSSFloat};
+use crate::Atom;
 use cssparser::{Parser, Token};
 #[cfg(feature = "gecko")]
 use gecko_bindings::structs;
 use num_traits::Zero;
-use parser::{Parse, ParserContext};
 use std::cmp::{Ordering, PartialOrd};
 use std::fmt::{self, Write};
-use str::{starts_with_ignore_ascii_case, string_as_ascii_lowercase};
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
-use stylesheets::Origin;
-use values::computed::{self, ToComputedValue};
-use values::specified::{Integer, Length, Number, Resolution};
-use values::{serialize_atom_identifier, CSSFloat};
-use Atom;
 
 /// An aspect ratio, with a numerator and denominator.
 #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq)]
@@ -221,14 +221,14 @@ fn consume_operation_or_colon(input: &mut Parser) -> Result<Option<Operator>, ()
     Ok(Some(match first_delim {
         '=' => Operator::Equal,
         '>' => {
-            if input.try(|i| i.expect_delim('=')).is_ok() {
+            if input.r#try(|i| i.expect_delim('=')).is_ok() {
                 Operator::GreaterThanEqual
             } else {
                 Operator::GreaterThan
             }
         },
         '<' => {
-            if input.try(|i| i.expect_delim('=')).is_ok() {
+            if input.r#try(|i| i.expect_delim('=')).is_ok() {
                 Operator::LessThanEqual
             } else {
                 Operator::LessThan
@@ -270,10 +270,10 @@ impl MediaFeatureExpression {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
+        #[cfg(feature = "servo")]
+        use crate::servo::media_queries::MEDIA_FEATURES;
         #[cfg(feature = "gecko")]
         use gecko::media_features::MEDIA_FEATURES;
-        #[cfg(feature = "servo")]
-        use servo::media_queries::MEDIA_FEATURES;
 
         // FIXME: remove extra indented block when lifetimes are non-lexical
         let feature;
@@ -350,7 +350,7 @@ impl MediaFeatureExpression {
             }
         }
 
-        let operator = input.try(consume_operation_or_colon);
+        let operator = input.r#try(consume_operation_or_colon);
         let operator = match operator {
             Err(..) => {
                 // If there's no colon, this is a media query of the

--- a/components/style/media_queries/media_list.rs
+++ b/components/style/media_queries/media_list.rs
@@ -7,11 +7,11 @@
 //! https://drafts.csswg.org/mediaqueries/#typedef-media-query-list
 
 use super::{Device, MediaQuery, Qualifier};
-use context::QuirksMode;
+use crate::context::QuirksMode;
+use crate::error_reporting::ContextualParseError;
+use crate::parser::ParserContext;
 use cssparser::{Delimiter, Parser};
 use cssparser::{ParserInput, Token};
-use error_reporting::ContextualParseError;
-use parser::ParserContext;
 
 /// A type that encapsulates a media query list.
 #[css(comma, derive_debug)]

--- a/components/style/media_queries/media_query.rs
+++ b/components/style/media_queries/media_query.rs
@@ -7,13 +7,13 @@
 //! https://drafts.csswg.org/mediaqueries/#typedef-media-query
 
 use super::media_condition::MediaCondition;
+use crate::parser::ParserContext;
+use crate::str::string_as_ascii_lowercase;
+use crate::values::CustomIdent;
+use crate::Atom;
 use cssparser::Parser;
-use parser::ParserContext;
 use std::fmt::{self, Write};
-use str::string_as_ascii_lowercase;
 use style_traits::{CssWriter, ParseError, ToCss};
-use values::CustomIdent;
-use Atom;
 
 /// <https://drafts.csswg.org/mediaqueries/#mq-prefix>
 #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, Parse, PartialEq, ToCss)]
@@ -125,8 +125,8 @@ impl MediaQuery {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         let (qualifier, explicit_media_type) = input
-            .try(|input| -> Result<_, ()> {
-                let qualifier = input.try(Qualifier::parse).ok();
+            .r#try(|input| -> Result<_, ()> {
+                let qualifier = input.r#try(Qualifier::parse).ok();
                 let ident = input.expect_ident().map_err(|_| ())?;
                 let media_type = MediaQueryType::parse(&ident)?;
                 Ok((qualifier, Some(media_type)))
@@ -135,7 +135,7 @@ impl MediaQuery {
 
         let condition = if explicit_media_type.is_none() {
             Some(MediaCondition::parse(context, input)?)
-        } else if input.try(|i| i.expect_ident_matching("and")).is_ok() {
+        } else if input.r#try(|i| i.expect_ident_matching("and")).is_ok() {
             Some(MediaCondition::parse_disallow_or(context, input)?)
         } else {
             None

--- a/components/style/media_queries/mod.rs
+++ b/components/style/media_queries/mod.rs
@@ -18,7 +18,7 @@ pub use self::media_feature_expression::MediaFeatureExpression;
 pub use self::media_list::MediaList;
 pub use self::media_query::{MediaQuery, MediaQueryType, MediaType, Qualifier};
 
+#[cfg(feature = "servo")]
+pub use crate::servo::media_queries::Device;
 #[cfg(feature = "gecko")]
 pub use gecko::media_queries::Device;
-#[cfg(feature = "servo")]
-pub use servo::media_queries::Device;

--- a/components/style/media_queries/mod.rs
+++ b/components/style/media_queries/mod.rs
@@ -18,7 +18,7 @@ pub use self::media_feature_expression::MediaFeatureExpression;
 pub use self::media_list::MediaList;
 pub use self::media_query::{MediaQuery, MediaQueryType, MediaType, Qualifier};
 
+#[cfg(feature = "gecko")]
+pub use crate::gecko::media_queries::Device;
 #[cfg(feature = "servo")]
 pub use crate::servo::media_queries::Device;
-#[cfg(feature = "gecko")]
-pub use gecko::media_queries::Device;

--- a/components/style/parallel.rs
+++ b/components/style/parallel.rs
@@ -23,13 +23,13 @@
 #![deny(missing_docs)]
 
 use arrayvec::ArrayVec;
-use context::{StyleContext, ThreadLocalStyleContext};
-use dom::{OpaqueNode, SendNode, TElement};
+use crate::context::{StyleContext, ThreadLocalStyleContext};
+use crate::dom::{OpaqueNode, SendNode, TElement};
+use crate::scoped_tls::ScopedTLS;
+use crate::traversal::{DomTraversal, PerLevelTraversalData};
 use itertools::Itertools;
 use rayon;
-use scoped_tls::ScopedTLS;
 use smallvec::SmallVec;
-use traversal::{DomTraversal, PerLevelTraversalData};
 
 /// The minimum stack size for a thread in the styling pool, in kilobytes.
 pub const STYLE_THREAD_STACK_SIZE_KB: usize = 256;

--- a/components/style/parser.rs
+++ b/components/style/parser.rs
@@ -15,7 +15,7 @@ use style_traits::{OneOrMoreSeparated, ParseError, ParsingMode, Separator};
 #[cfg(feature = "gecko")]
 #[inline]
 pub fn assert_parsing_mode_match() {
-    use gecko_bindings::structs;
+    use crate::gecko_bindings::structs;
 
     macro_rules! check_parsing_modes {
         ( $( $a:ident => $b:path ),*, ) => {

--- a/components/style/parser.rs
+++ b/components/style/parser.rs
@@ -4,12 +4,12 @@
 
 //! The context within which CSS code is parsed.
 
-use context::QuirksMode;
+use crate::context::QuirksMode;
+use crate::error_reporting::{ContextualParseError, ParseErrorReporter};
+use crate::stylesheets::{CssRuleType, Namespaces, Origin, UrlExtraData};
+use crate::use_counters::UseCounters;
 use cssparser::{Parser, SourceLocation, UnicodeRange};
-use error_reporting::{ContextualParseError, ParseErrorReporter};
 use style_traits::{OneOrMoreSeparated, ParseError, ParsingMode, Separator};
-use stylesheets::{CssRuleType, Namespaces, Origin, UrlExtraData};
-use use_counters::UseCounters;
 
 /// Asserts that all ParsingMode flags have a matching ParsingMode value in gecko.
 #[cfg(feature = "gecko")]

--- a/components/style/properties/cascade.rs
+++ b/components/style/properties/cascade.rs
@@ -745,7 +745,7 @@ impl<'a, 'b: 'a> Cascade<'a, 'b> {
                 let gecko_font = self.context.builder.mutate_font().gecko_mut();
                 gecko_font.mGenericID = generic;
                 unsafe {
-                    ::gecko_bindings::bindings::Gecko_nsStyleFont_PrefillDefaultForGeneric(
+                    crate::gecko_bindings::bindings::Gecko_nsStyleFont_PrefillDefaultForGeneric(
                         gecko_font,
                         pres_context,
                         generic,
@@ -796,7 +796,7 @@ impl<'a, 'b: 'a> Cascade<'a, 'b> {
                     self.seen.contains(LonghandId::MozMinFontSizeRatio) ||
                     self.seen.contains(LonghandId::FontFamily)
                 {
-                    use properties::{CSSWideKeyword, WideKeywordDeclaration};
+                    use crate::properties::{CSSWideKeyword, WideKeywordDeclaration};
 
                     // font-size must be explicitly inherited to handle lang
                     // changes and scriptlevel changes.

--- a/components/style/properties/cascade.rs
+++ b/components/style/properties/cascade.rs
@@ -4,27 +4,27 @@
 
 //! The main cascading algorithm of the style system.
 
-use context::QuirksMode;
-use custom_properties::CustomPropertiesBuilder;
-use dom::TElement;
-use font_metrics::FontMetricsProvider;
-use logical_geometry::WritingMode;
-use media_queries::Device;
-use properties::{ComputedValues, StyleBuilder};
-use properties::{LonghandId, LonghandIdSet};
-use properties::{PropertyDeclaration, PropertyDeclarationId, DeclarationImportanceIterator};
-use properties::CASCADE_PROPERTY;
-use rule_cache::{RuleCache, RuleCacheConditions};
-use rule_tree::{CascadeLevel, StrongRuleNode};
-use selector_parser::PseudoElement;
+use crate::context::QuirksMode;
+use crate::custom_properties::CustomPropertiesBuilder;
+use crate::dom::TElement;
+use crate::font_metrics::FontMetricsProvider;
+use crate::logical_geometry::WritingMode;
+use crate::media_queries::Device;
+use crate::properties::{ComputedValues, StyleBuilder};
+use crate::properties::{LonghandId, LonghandIdSet};
+use crate::properties::{PropertyDeclaration, PropertyDeclarationId, DeclarationImportanceIterator};
+use crate::properties::CASCADE_PROPERTY;
+use crate::rule_cache::{RuleCache, RuleCacheConditions};
+use crate::rule_tree::{CascadeLevel, StrongRuleNode};
+use crate::selector_parser::PseudoElement;
 use servo_arc::Arc;
-use shared_lock::StylesheetGuards;
+use crate::shared_lock::StylesheetGuards;
 use smallbitvec::SmallBitVec;
 use smallvec::SmallVec;
 use std::borrow::Cow;
 use std::cell::RefCell;
-use style_adjuster::StyleAdjuster;
-use values::computed;
+use crate::style_adjuster::StyleAdjuster;
+use crate::values::computed;
 
 /// We split the cascade in two phases: 'early' properties, and 'late'
 /// properties.

--- a/components/style/properties/data.py
+++ b/components/style/properties/data.py
@@ -270,12 +270,12 @@ class Longhand(object):
 
     def base_type(self):
         if self.predefined_type and not self.is_vector:
-            return "::values::specified::{}".format(self.predefined_type)
+            return "crate::values::specified::{}".format(self.predefined_type)
         return "longhands::{}::SpecifiedValue".format(self.ident)
 
     def specified_type(self):
         if self.predefined_type and not self.is_vector:
-            ty = "::values::specified::{}".format(self.predefined_type)
+            ty = "crate::values::specified::{}".format(self.predefined_type)
         else:
             ty = "longhands::{}::SpecifiedValue".format(self.ident)
         if self.boxed:

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -6,25 +6,25 @@
 
 #![deny(missing_docs)]
 
-use context::QuirksMode;
+use crate::context::QuirksMode;
 use cssparser::{DeclarationListParser, parse_important, ParserInput, CowRcStr};
 use cssparser::{Parser, AtRuleParser, DeclarationParser, Delimiter, ParseErrorKind};
-use custom_properties::{CustomPropertiesBuilder, CssEnvironment};
-use error_reporting::{ParseErrorReporter, ContextualParseError};
+use crate::custom_properties::{CustomPropertiesBuilder, CssEnvironment};
+use crate::error_reporting::{ParseErrorReporter, ContextualParseError};
 use itertools::Itertools;
-use parser::ParserContext;
-use properties::animated_properties::{AnimationValue, AnimationValueMap};
-use shared_lock::Locked;
+use crate::parser::ParserContext;
+use crate::properties::animated_properties::{AnimationValue, AnimationValueMap};
+use crate::shared_lock::Locked;
 use smallbitvec::{self, SmallBitVec};
 use smallvec::SmallVec;
 use std::fmt::{self, Write};
 use std::iter::{DoubleEndedIterator, Zip};
 use std::slice::Iter;
-use str::{CssString, CssStringBorrow, CssStringWriter};
+use crate::str::{CssString, CssStringBorrow, CssStringWriter};
 use style_traits::{CssWriter, ParseError, ParsingMode, StyleParseErrorKind, ToCss};
-use stylesheets::{CssRuleType, Origin, UrlExtraData};
+use crate::stylesheets::{CssRuleType, Origin, UrlExtraData};
 use super::*;
-use values::computed::Context;
+use crate::values::computed::Context;
 
 /// The animation rules.
 ///
@@ -144,7 +144,7 @@ pub struct AnimationValueIterator<'a, 'cx, 'cx_a:'cx> {
     context: &'cx mut Context<'cx_a>,
     default_values: &'a ComputedValues,
     /// Custom properties in a keyframe if exists.
-    extra_custom_properties: Option<&'a Arc<::custom_properties::CustomPropertiesMap>>,
+    extra_custom_properties: Option<&'a Arc<crate::custom_properties::CustomPropertiesMap>>,
 }
 
 impl<'a, 'cx, 'cx_a:'cx> AnimationValueIterator<'a, 'cx, 'cx_a> {
@@ -152,7 +152,7 @@ impl<'a, 'cx, 'cx_a:'cx> AnimationValueIterator<'a, 'cx, 'cx_a> {
         declarations: &'a PropertyDeclarationBlock,
         context: &'cx mut Context<'cx_a>,
         default_values: &'a ComputedValues,
-        extra_custom_properties: Option<&'a Arc<::custom_properties::CustomPropertiesMap>>,
+        extra_custom_properties: Option<&'a Arc<crate::custom_properties::CustomPropertiesMap>>,
     ) -> AnimationValueIterator<'a, 'cx, 'cx_a> {
         AnimationValueIterator {
             iter: declarations.declaration_importance_iter(),
@@ -258,7 +258,7 @@ impl PropertyDeclarationBlock {
         &'a self,
         context: &'cx mut Context<'cx_a>,
         default_values: &'a ComputedValues,
-        extra_custom_properties: Option<&'a Arc<::custom_properties::CustomPropertiesMap>>,
+        extra_custom_properties: Option<&'a Arc<crate::custom_properties::CustomPropertiesMap>>,
     ) -> AnimationValueIterator<'a, 'cx, 'cx_a> {
         AnimationValueIterator::new(self, context, default_values, extra_custom_properties)
     }
@@ -467,7 +467,7 @@ impl PropertyDeclarationBlock {
                 //
                 // TODO(emilio): Unship.
                 if let PropertyDeclaration::Display(old_display) = *slot {
-                    use properties::longhands::display::computed_value::T as display;
+                    use crate::properties::longhands::display::computed_value::T as display;
 
                     if let PropertyDeclaration::Display(new_display) = declaration {
                         if display::should_ignore_parsed_value(old_display, new_display) {
@@ -841,7 +841,7 @@ impl PropertyDeclarationBlock {
     pub fn cascade_custom_properties_with_context(
         &self,
         context: &Context,
-    ) -> Option<Arc<::custom_properties::CustomPropertiesMap>> {
+    ) -> Option<Arc<crate::custom_properties::CustomPropertiesMap>> {
         self.cascade_custom_properties(
             context.style().custom_properties(),
             context.device().environment(),
@@ -853,9 +853,9 @@ impl PropertyDeclarationBlock {
     /// properties.
     fn cascade_custom_properties(
         &self,
-        inherited_custom_properties: Option<&Arc<::custom_properties::CustomPropertiesMap>>,
+        inherited_custom_properties: Option<&Arc<crate::custom_properties::CustomPropertiesMap>>,
         environment: &CssEnvironment,
-    ) -> Option<Arc<::custom_properties::CustomPropertiesMap>> {
+    ) -> Option<Arc<crate::custom_properties::CustomPropertiesMap>> {
         let mut builder = CustomPropertiesBuilder::new(
             inherited_custom_properties,
             environment,

--- a/components/style/properties/gecko.mako.rs
+++ b/components/style/properties/gecko.mako.rs
@@ -10,63 +10,63 @@
 %>
 <%namespace name="helpers" file="/helpers.mako.rs" />
 
-use Atom;
+use crate::Atom;
 use app_units::Au;
-use custom_properties::CustomPropertiesMap;
-use gecko_bindings::bindings;
+use crate::custom_properties::CustomPropertiesMap;
+use crate::gecko_bindings::bindings;
 % for style_struct in data.style_structs:
-use gecko_bindings::structs::${style_struct.gecko_ffi_name};
-use gecko_bindings::bindings::Gecko_Construct_Default_${style_struct.gecko_ffi_name};
-use gecko_bindings::bindings::Gecko_CopyConstruct_${style_struct.gecko_ffi_name};
-use gecko_bindings::bindings::Gecko_Destroy_${style_struct.gecko_ffi_name};
+use crate::gecko_bindings::structs::${style_struct.gecko_ffi_name};
+use crate::gecko_bindings::bindings::Gecko_Construct_Default_${style_struct.gecko_ffi_name};
+use crate::gecko_bindings::bindings::Gecko_CopyConstruct_${style_struct.gecko_ffi_name};
+use crate::gecko_bindings::bindings::Gecko_Destroy_${style_struct.gecko_ffi_name};
 % endfor
-use gecko_bindings::bindings::Gecko_CopyCounterStyle;
-use gecko_bindings::bindings::Gecko_CopyCursorArrayFrom;
-use gecko_bindings::bindings::Gecko_CopyFontFamilyFrom;
-use gecko_bindings::bindings::Gecko_CopyImageValueFrom;
-use gecko_bindings::bindings::Gecko_CopyListStyleImageFrom;
-use gecko_bindings::bindings::Gecko_EnsureImageLayersLength;
-use gecko_bindings::bindings::Gecko_SetCursorArrayLength;
-use gecko_bindings::bindings::Gecko_SetCursorImageValue;
-use gecko_bindings::bindings::Gecko_NewCSSShadowArray;
-use gecko_bindings::bindings::Gecko_nsStyleFont_SetLang;
-use gecko_bindings::bindings::Gecko_nsStyleFont_CopyLangFrom;
-use gecko_bindings::bindings::Gecko_SetListStyleImageNone;
-use gecko_bindings::bindings::Gecko_SetListStyleImageImageValue;
-use gecko_bindings::bindings::Gecko_SetNullImageValue;
-use gecko_bindings::bindings::{Gecko_ResetFilters, Gecko_CopyFiltersFrom};
-use gecko_bindings::bindings::RawGeckoPresContextBorrowed;
-use gecko_bindings::structs;
-use gecko_bindings::structs::nsCSSPropertyID;
-use gecko_bindings::structs::mozilla::CSSPseudoElementType;
-use gecko_bindings::structs::mozilla::CSSPseudoElementType_InheritingAnonBox;
-use gecko_bindings::sugar::ns_style_coord::{CoordDataValue, CoordData, CoordDataMut};
-use gecko_bindings::sugar::refptr::RefPtr;
-use gecko::values::convert_nscolor_to_rgba;
-use gecko::values::convert_rgba_to_nscolor;
-use gecko::values::GeckoStyleCoordConvertible;
-use gecko::values::round_border_to_device_pixels;
-use logical_geometry::WritingMode;
-use media_queries::Device;
-use properties::computed_value_flags::*;
-use properties::longhands;
-use rule_tree::StrongRuleNode;
-use selector_parser::PseudoElement;
+use crate::gecko_bindings::bindings::Gecko_CopyCounterStyle;
+use crate::gecko_bindings::bindings::Gecko_CopyCursorArrayFrom;
+use crate::gecko_bindings::bindings::Gecko_CopyFontFamilyFrom;
+use crate::gecko_bindings::bindings::Gecko_CopyImageValueFrom;
+use crate::gecko_bindings::bindings::Gecko_CopyListStyleImageFrom;
+use crate::gecko_bindings::bindings::Gecko_EnsureImageLayersLength;
+use crate::gecko_bindings::bindings::Gecko_SetCursorArrayLength;
+use crate::gecko_bindings::bindings::Gecko_SetCursorImageValue;
+use crate::gecko_bindings::bindings::Gecko_NewCSSShadowArray;
+use crate::gecko_bindings::bindings::Gecko_nsStyleFont_SetLang;
+use crate::gecko_bindings::bindings::Gecko_nsStyleFont_CopyLangFrom;
+use crate::gecko_bindings::bindings::Gecko_SetListStyleImageNone;
+use crate::gecko_bindings::bindings::Gecko_SetListStyleImageImageValue;
+use crate::gecko_bindings::bindings::Gecko_SetNullImageValue;
+use crate::gecko_bindings::bindings::{Gecko_ResetFilters, Gecko_CopyFiltersFrom};
+use crate::gecko_bindings::bindings::RawGeckoPresContextBorrowed;
+use crate::gecko_bindings::structs;
+use crate::gecko_bindings::structs::nsCSSPropertyID;
+use crate::gecko_bindings::structs::mozilla::CSSPseudoElementType;
+use crate::gecko_bindings::structs::mozilla::CSSPseudoElementType_InheritingAnonBox;
+use crate::gecko_bindings::sugar::ns_style_coord::{CoordDataValue, CoordData, CoordDataMut};
+use crate::gecko_bindings::sugar::refptr::RefPtr;
+use crate::gecko::values::convert_nscolor_to_rgba;
+use crate::gecko::values::convert_rgba_to_nscolor;
+use crate::gecko::values::GeckoStyleCoordConvertible;
+use crate::gecko::values::round_border_to_device_pixels;
+use crate::logical_geometry::WritingMode;
+use crate::media_queries::Device;
+use crate::properties::computed_value_flags::*;
+use crate::properties::longhands;
+use crate::rule_tree::StrongRuleNode;
+use crate::selector_parser::PseudoElement;
 use servo_arc::{Arc, RawOffsetArc};
 use std::marker::PhantomData;
 use std::mem::{forget, uninitialized, transmute, zeroed};
 use std::{cmp, ops, ptr};
-use values::{self, CustomIdent, Either, KeyframesName, None_};
-use values::computed::{NonNegativeLength, Percentage, TransitionProperty};
-use values::computed::font::FontSize;
-use values::computed::effects::{BoxShadow, Filter, SimpleShadow};
-use values::computed::outline::OutlineStyle;
-use values::generics::column::ColumnCount;
-use values::generics::position::ZIndex;
-use values::generics::text::MozTabSize;
-use values::generics::transform::TransformStyle;
-use values::generics::url::UrlOrNone;
-use computed_values::border_style;
+use crate::values::{self, CustomIdent, Either, KeyframesName, None_};
+use crate::values::computed::{NonNegativeLength, Percentage, TransitionProperty};
+use crate::values::computed::font::FontSize;
+use crate::values::computed::effects::{BoxShadow, Filter, SimpleShadow};
+use crate::values::computed::outline::OutlineStyle;
+use crate::values::generics::column::ColumnCount;
+use crate::values::generics::position::ZIndex;
+use crate::values::generics::text::MozTabSize;
+use crate::values::generics::transform::TransformStyle;
+use crate::values::generics::url::UrlOrNone;
+use crate::computed_values::border_style;
 
 pub mod style_structs {
     % for style_struct in data.style_structs:
@@ -75,10 +75,10 @@ pub mod style_structs {
 }
 
 /// FIXME(emilio): This is completely duplicated with the other properties code.
-pub type ComputedValuesInner = ::gecko_bindings::structs::ServoComputedData;
+pub type ComputedValuesInner = crate::gecko_bindings::structs::ServoComputedData;
 
 #[repr(C)]
-pub struct ComputedValues(::gecko_bindings::structs::mozilla::ComputedStyle);
+pub struct ComputedValues(crate::gecko_bindings::structs::mozilla::ComputedStyle);
 
 impl ComputedValues {
     pub fn new(
@@ -148,7 +148,7 @@ impl ComputedValues {
         &self,
         old_values: Option<<&ComputedValues>
     ) -> bool {
-        use properties::longhands::display::computed_value::T as Display;
+        use crate::properties::longhands::display::computed_value::T as Display;
 
         old_values.map_or(false, |old| {
             let old_display_style = old.get_box().clone_display();
@@ -308,7 +308,7 @@ impl ComputedValuesInner {
 }
 
 <%def name="declare_style_struct(style_struct)">
-pub use ::gecko_bindings::structs::mozilla::Gecko${style_struct.gecko_name} as ${style_struct.gecko_struct_name};
+pub use crate::gecko_bindings::structs::mozilla::Gecko${style_struct.gecko_name} as ${style_struct.gecko_struct_name};
 impl ${style_struct.gecko_struct_name} {
     pub fn gecko(&self) -> &${style_struct.gecko_ffi_name} {
         &self.gecko
@@ -371,7 +371,7 @@ def set_gecko_property(ffi_name, expr):
 <%def name="impl_keyword_setter(ident, gecko_ffi_name, keyword, cast_type='u8', on_set=None)">
     #[allow(non_snake_case)]
     pub fn set_${ident}(&mut self, v: longhands::${ident}::computed_value::T) {
-        use properties::longhands::${ident}::computed_value::T as Keyword;
+        use crate::properties::longhands::${ident}::computed_value::T as Keyword;
         // FIXME(bholley): Align binary representations and ditch |match| for cast + static_asserts
         let result = match v {
             % for value in keyword.values_for('gecko'):
@@ -392,7 +392,7 @@ def set_gecko_property(ffi_name, expr):
     //        We should remove this after fix bug 1371809.
     #[allow(non_snake_case, non_upper_case_globals)]
     pub fn clone_${ident}(&self) -> longhands::${ident}::computed_value::T {
-        use properties::longhands::${ident}::computed_value::T as Keyword;
+        use crate::properties::longhands::${ident}::computed_value::T as Keyword;
         // FIXME(bholley): Align binary representations and ditch |match| for cast + static_asserts
 
         // Some constant macros in the gecko are defined as negative integer(e.g. font-stretch).
@@ -518,8 +518,8 @@ def set_gecko_property(ffi_name, expr):
     // set on mContextFlags, and the length field is set to the initial value.
 
     pub fn set_${ident}(&mut self, v: longhands::${ident}::computed_value::T) {
-        use values::generics::svg::{SVGLength, SvgLengthOrPercentageOrNumber};
-        use gecko_bindings::structs::nsStyleSVG_${ident.upper()}_CONTEXT as CONTEXT_VALUE;
+        use crate::values::generics::svg::{SVGLength, SvgLengthOrPercentageOrNumber};
+        use crate::gecko_bindings::structs::nsStyleSVG_${ident.upper()}_CONTEXT as CONTEXT_VALUE;
         let length = match v {
             SVGLength::Length(length) => {
                 self.gecko.mContextFlags &= !CONTEXT_VALUE;
@@ -542,7 +542,7 @@ def set_gecko_property(ffi_name, expr):
     }
 
     pub fn copy_${ident}_from(&mut self, other: &Self) {
-        use gecko_bindings::structs::nsStyleSVG_${ident.upper()}_CONTEXT as CONTEXT_VALUE;
+        use crate::gecko_bindings::structs::nsStyleSVG_${ident.upper()}_CONTEXT as CONTEXT_VALUE;
         self.gecko.${gecko_ffi_name}.copy_from(&other.gecko.${gecko_ffi_name});
         self.gecko.mContextFlags =
             (self.gecko.mContextFlags & !CONTEXT_VALUE) |
@@ -554,9 +554,9 @@ def set_gecko_property(ffi_name, expr):
     }
 
     pub fn clone_${ident}(&self) -> longhands::${ident}::computed_value::T {
-        use values::generics::svg::{SVGLength, SvgLengthOrPercentageOrNumber};
-        use values::computed::LengthOrPercentage;
-        use gecko_bindings::structs::nsStyleSVG_${ident.upper()}_CONTEXT as CONTEXT_VALUE;
+        use crate::values::generics::svg::{SVGLength, SvgLengthOrPercentageOrNumber};
+        use crate::values::computed::LengthOrPercentage;
+        use crate::gecko_bindings::structs::nsStyleSVG_${ident.upper()}_CONTEXT as CONTEXT_VALUE;
         if (self.gecko.mContextFlags & CONTEXT_VALUE) != 0 {
             return SVGLength::ContextValue;
         }
@@ -589,10 +589,10 @@ def set_gecko_property(ffi_name, expr):
     <% source_prefix = ident.split("_")[0].upper() + "_OPACITY_SOURCE" %>
 
     pub fn set_${ident}(&mut self, v: longhands::${ident}::computed_value::T) {
-        use gecko_bindings::structs::nsStyleSVG_${source_prefix}_MASK as MASK;
-        use gecko_bindings::structs::nsStyleSVG_${source_prefix}_SHIFT as SHIFT;
-        use gecko_bindings::structs::nsStyleSVGOpacitySource::*;
-        use values::generics::svg::SVGOpacity;
+        use crate::gecko_bindings::structs::nsStyleSVG_${source_prefix}_MASK as MASK;
+        use crate::gecko_bindings::structs::nsStyleSVG_${source_prefix}_SHIFT as SHIFT;
+        use crate::gecko_bindings::structs::nsStyleSVGOpacitySource::*;
+        use crate::values::generics::svg::SVGOpacity;
         self.gecko.mContextFlags &= !MASK;
         match v {
             SVGOpacity::Opacity(opacity) => {
@@ -614,7 +614,7 @@ def set_gecko_property(ffi_name, expr):
     }
 
     pub fn copy_${ident}_from(&mut self, other: &Self) {
-        use gecko_bindings::structs::nsStyleSVG_${source_prefix}_MASK as MASK;
+        use crate::gecko_bindings::structs::nsStyleSVG_${source_prefix}_MASK as MASK;
         self.gecko.${gecko_ffi_name} = other.gecko.${gecko_ffi_name};
         self.gecko.mContextFlags =
             (self.gecko.mContextFlags & !MASK) |
@@ -626,10 +626,10 @@ def set_gecko_property(ffi_name, expr):
     }
 
     pub fn clone_${ident}(&self) -> longhands::${ident}::computed_value::T {
-        use gecko_bindings::structs::nsStyleSVG_${source_prefix}_MASK as MASK;
-        use gecko_bindings::structs::nsStyleSVG_${source_prefix}_SHIFT as SHIFT;
-        use gecko_bindings::structs::nsStyleSVGOpacitySource::*;
-        use values::generics::svg::SVGOpacity;
+        use crate::gecko_bindings::structs::nsStyleSVG_${source_prefix}_MASK as MASK;
+        use crate::gecko_bindings::structs::nsStyleSVG_${source_prefix}_SHIFT as SHIFT;
+        use crate::gecko_bindings::structs::nsStyleSVGOpacitySource::*;
+        use crate::values::generics::svg::SVGOpacity;
 
         let source = (self.gecko.mContextFlags & MASK) >> SHIFT;
         if source == eStyleSVGOpacitySource_Normal as u8 {
@@ -649,7 +649,7 @@ def set_gecko_property(ffi_name, expr):
 <%def name="impl_svg_paint(ident, gecko_ffi_name)">
     #[allow(non_snake_case)]
     pub fn set_${ident}(&mut self, mut v: longhands::${ident}::computed_value::T) {
-        use values::generics::svg::SVGPaintKind;
+        use crate::values::generics::svg::SVGPaintKind;
         use self::structs::nsStyleSVGPaintType;
         use self::structs::nsStyleSVGFallbackType;
 
@@ -711,8 +711,8 @@ def set_gecko_property(ffi_name, expr):
 
     #[allow(non_snake_case)]
     pub fn clone_${ident}(&self) -> longhands::${ident}::computed_value::T {
-        use values::computed::url::ComputedUrl;
-        use values::generics::svg::{SVGPaint, SVGPaintKind};
+        use crate::values::computed::url::ComputedUrl;
+        use crate::values::generics::svg::{SVGPaint, SVGPaintKind};
         use self::structs::nsStyleSVGPaintType;
         use self::structs::nsStyleSVGFallbackType;
         let ref paint = ${get_gecko_property(gecko_ffi_name)};
@@ -813,7 +813,7 @@ def set_gecko_property(ffi_name, expr):
 
     #[allow(non_snake_case)]
     pub fn clone_${ident}(&self) -> longhands::${ident}::computed_value::T {
-        use properties::longhands::${ident}::computed_value::T;
+        use crate::properties::longhands::${ident}::computed_value::T;
         T::from_gecko_style_coord(&self.gecko.${gecko_ffi_name}.data_at(${index}))
             .expect("clone for ${ident} failed")
     }
@@ -835,7 +835,7 @@ def set_gecko_property(ffi_name, expr):
 
     #[allow(non_snake_case)]
     pub fn clone_${ident}(&self) -> longhands::${ident}::computed_value::T {
-        use properties::longhands::${ident}::computed_value::T;
+        use crate::properties::longhands::${ident}::computed_value::T;
         T::from_gecko_style_coord(&self.gecko.${gecko_ffi_name})
             .expect("clone for ${ident} failed")
     }
@@ -895,7 +895,7 @@ def set_gecko_property(ffi_name, expr):
 
     #[allow(non_snake_case)]
     pub fn clone_${ident}(&self) -> longhands::${ident}::computed_value::T {
-        use values::computed::border::BorderCornerRadius;
+        use crate::values::computed::border::BorderCornerRadius;
         let width = GeckoStyleCoordConvertible::from_gecko_style_coord(
                         &self.gecko.${gecko_ffi_name}.data_at(${x_index}))
                         .expect("Failed to clone ${ident}");
@@ -933,7 +933,7 @@ def set_gecko_property(ffi_name, expr):
 
     #[allow(non_snake_case)]
     pub fn clone_${ident}(&self) -> longhands::${ident}::computed_value::T {
-        use values::computed::url::ComputedUrl;
+        use crate::values::computed::url::ComputedUrl;
 
         if self.gecko.${gecko_ffi_name}.mRawPtr.is_null() {
             return UrlOrNone::none()
@@ -1012,7 +1012,7 @@ transform_functions = [
             "list" : "%s.set_shared_list(%s.0.iter().map(&convert_to_ns_css_value));",
         }
     %>
-    ::values::generics::transform::TransformOperation::${name}${pattern} => {
+    crate::values::generics::transform::TransformOperation::${name}${pattern} => {
         % if has_optional:
             let optional_present = ${items[-1] + str(len(items))}.is_some();
             let len = if optional_present {
@@ -1082,7 +1082,7 @@ transform_functions = [
 
     %>
     structs::nsCSSKeyword::eCSSKeyword_${keyword} => {
-        ::values::generics::transform::TransformOperation::${name}${pre_symbols}
+        crate::values::generics::transform::TransformOperation::${name}${pre_symbols}
         % for index, item in enumerate(items):
             % if keyword == "matrix3d":
                 m${index / 4 + 1}${index % 4 + 1}:
@@ -1115,8 +1115,8 @@ fn set_single_transform_function(
     servo_value: &values::computed::TransformOperation,
     gecko_value: &mut structs::nsCSSValue /* output */
 ) {
-    use values::computed::TransformOperation;
-    use values::generics::transform::{Matrix, Matrix3D};
+    use crate::values::computed::TransformOperation;
+    use crate::values::generics::transform::{Matrix, Matrix3D};
 
     let convert_to_ns_css_value = |item: &TransformOperation| -> structs::nsCSSValue {
         let mut value = structs::nsCSSValue::null();
@@ -1137,7 +1137,7 @@ pub fn convert_transform(
     input: &[values::computed::TransformOperation],
     output: &mut structs::root::RefPtr<structs::root::nsCSSValueSharedList>
 ) {
-    use gecko_bindings::sugar::refptr::RefPtr;
+    use crate::gecko_bindings::sugar::refptr::RefPtr;
 
     unsafe { output.clear() };
 
@@ -1156,9 +1156,9 @@ pub fn convert_transform(
 fn clone_single_transform_function(
     gecko_value: &structs::nsCSSValue
 ) -> values::computed::TransformOperation {
-    use values::computed::{Length, Percentage, TransformOperation};
-    use values::generics::transform::{Matrix, Matrix3D};
-    use values::generics::transform::Transform;
+    use crate::values::computed::{Length, Percentage, TransformOperation};
+    use crate::values::generics::transform::{Matrix, Matrix3D};
+    use crate::values::generics::transform::Transform;
 
     let convert_shared_list_to_operations = |value: &structs::nsCSSValue|
                                             -> Vec<TransformOperation> {
@@ -1190,7 +1190,7 @@ fn clone_single_transform_function(
 pub fn clone_transform_from_list(
     list: Option< &structs::root::nsCSSValueList>
 ) -> values::computed::Transform {
-    use values::generics::transform::Transform;
+    use crate::values::generics::transform::Transform;
 
     let result = match list {
         Some(list) => {
@@ -1213,7 +1213,7 @@ pub fn clone_transform_from_list(
 <%def name="impl_transform(ident, gecko_ffi_name)">
     #[allow(non_snake_case)]
     pub fn set_${ident}(&mut self, other: values::computed::Transform) {
-        use gecko_properties::convert_transform;
+        use crate::gecko_properties::convert_transform;
         if other.0.is_empty() {
             unsafe {
                 self.gecko.${gecko_ffi_name}.clear();
@@ -1235,8 +1235,8 @@ pub fn clone_transform_from_list(
 
     #[allow(non_snake_case)]
     pub fn clone_${ident}(&self) -> values::computed::Transform {
-        use gecko_properties::clone_transform_from_list;
-        use values::generics::transform::Transform;
+        use crate::gecko_properties::clone_transform_from_list;
+        use crate::values::generics::transform::Transform;
 
         if self.gecko.${gecko_ffi_name}.mRawPtr.is_null() {
             return Transform(vec!());
@@ -1279,7 +1279,7 @@ pub fn clone_transform_from_list(
 
     #[allow(non_snake_case)]
     pub fn clone_${ident}(&self) -> values::computed::TransformOrigin {
-        use values::computed::{Length, LengthOrPercentage, TransformOrigin};
+        use crate::values::computed::{Length, LengthOrPercentage, TransformOrigin};
         TransformOrigin {
             horizontal: LengthOrPercentage::from_gecko_style_coord(&self.gecko.${gecko_ffi_name}[0])
                 .expect("clone for LengthOrPercentage failed"),
@@ -1375,7 +1375,7 @@ impl Clone for ${style_struct.gecko_struct_name} {
     }
 
     pub fn clone_${ident}(&self) -> longhands::${ident}::computed_value::T {
-        use values::generics::font::{FontSettings, FontTag, ${tag_type}};
+        use crate::values::generics::font::{FontSettings, FontTag, ${tag_type}};
 
         FontSettings(
             self.gecko.mFont.${gecko_ffi_name}.iter().map(|gecko_font_setting| {
@@ -1601,7 +1601,7 @@ fn static_assert() {
     }
 
     pub fn clone_border_image_source(&self) -> longhands::border_image_source::computed_value::T {
-        use values::None_;
+        use crate::values::None_;
 
         match unsafe { self.gecko.mBorderImageSource.into_image() } {
             Some(image) => Either::Second(image),
@@ -1616,8 +1616,8 @@ fn static_assert() {
     %>
 
     pub fn set_border_image_repeat(&mut self, v: longhands::border_image_repeat::computed_value::T) {
-        use values::specified::border::BorderImageRepeatKeyword;
-        use gecko_bindings::structs::StyleBorderImageRepeat;
+        use crate::values::specified::border::BorderImageRepeatKeyword;
+        use crate::gecko_bindings::structs::StyleBorderImageRepeat;
 
         % for i, side in enumerate(["H", "V"]):
             self.gecko.mBorderImageRepeat${side} = match v.${i} {
@@ -1638,8 +1638,8 @@ fn static_assert() {
     }
 
     pub fn clone_border_image_repeat(&self) -> longhands::border_image_repeat::computed_value::T {
-        use values::specified::border::BorderImageRepeatKeyword;
-        use gecko_bindings::structs::StyleBorderImageRepeat;
+        use crate::values::specified::border::BorderImageRepeatKeyword;
+        use crate::gecko_bindings::structs::StyleBorderImageRepeat;
 
         % for side in ["H", "V"]:
         let servo_${side.lower()} = match self.gecko.mBorderImageRepeat${side} {
@@ -1654,7 +1654,7 @@ fn static_assert() {
     <% impl_style_sides("border_image_width") %>
 
     pub fn set_border_image_slice(&mut self, v: longhands::border_image_slice::computed_value::T) {
-        use gecko_bindings::structs::{NS_STYLE_BORDER_IMAGE_SLICE_NOFILL, NS_STYLE_BORDER_IMAGE_SLICE_FILL};
+        use crate::gecko_bindings::structs::{NS_STYLE_BORDER_IMAGE_SLICE_NOFILL, NS_STYLE_BORDER_IMAGE_SLICE_FILL};
 
         v.offsets.to_gecko_rect(&mut self.gecko.mBorderImageSlice);
 
@@ -1671,9 +1671,9 @@ fn static_assert() {
     </%self:copy_sides_style_coord>
 
     pub fn clone_border_image_slice(&self) -> longhands::border_image_slice::computed_value::T {
-        use gecko_bindings::structs::NS_STYLE_BORDER_IMAGE_SLICE_FILL;
-        use values::computed::{BorderImageSlice, NumberOrPercentage};
-        type NumberOrPercentageRect = ::values::generics::rect::Rect<NumberOrPercentage>;
+        use crate::gecko_bindings::structs::NS_STYLE_BORDER_IMAGE_SLICE_FILL;
+        use crate::values::computed::{BorderImageSlice, NumberOrPercentage};
+        type NumberOrPercentageRect = crate::values::generics::rect::Rect<NumberOrPercentage>;
 
         BorderImageSlice {
             offsets:
@@ -1726,7 +1726,7 @@ fn static_assert() {
     }
 
     pub fn copy_z_index_from(&mut self, other: &Self) {
-        use gecko_bindings::structs::nsStyleUnit;
+        use crate::gecko_bindings::structs::nsStyleUnit;
         // z-index is never a calc(). If it were, we'd be leaking here, so
         // assert that it isn't.
         debug_assert_ne!(self.gecko.mZIndex.unit(), nsStyleUnit::eStyleUnit_Calc);
@@ -1762,7 +1762,7 @@ fn static_assert() {
     }
 
     pub fn set_computed_justify_items(&mut self, v: values::specified::JustifyItems) {
-        debug_assert_ne!(v.0, ::values::specified::align::AlignFlags::LEGACY);
+        debug_assert_ne!(v.0, crate::values::specified::align::AlignFlags::LEGACY);
         self.gecko.mJustifyItems = v.into();
     }
 
@@ -1795,7 +1795,7 @@ fn static_assert() {
 
     % for value in GRID_LINES:
     pub fn set_${value.name}(&mut self, v: longhands::${value.name}::computed_value::T) {
-        use gecko_bindings::structs::{nsStyleGridLine_kMinLine, nsStyleGridLine_kMaxLine};
+        use crate::gecko_bindings::structs::{nsStyleGridLine_kMinLine, nsStyleGridLine_kMaxLine};
 
         let ident = v.ident.as_ref().map_or(&[] as &[_], |ident| ident.0.as_slice());
         self.gecko.${value.gecko}.mLineName.assign(ident);
@@ -1818,7 +1818,7 @@ fn static_assert() {
     }
 
     pub fn clone_${value.name}(&self) -> longhands::${value.name}::computed_value::T {
-        use gecko_bindings::structs::{nsStyleGridLine_kMinLine, nsStyleGridLine_kMaxLine};
+        use crate::gecko_bindings::structs::{nsStyleGridLine_kMinLine, nsStyleGridLine_kMaxLine};
 
         longhands::${value.name}::computed_value::T {
             is_span: self.gecko.${value.gecko}.mHasSpan,
@@ -1858,18 +1858,18 @@ fn static_assert() {
     }
 
     pub fn clone_grid_auto_${kind}(&self) -> longhands::grid_auto_${kind}::computed_value::T {
-        ::values::generics::grid::TrackSize::from_gecko_style_coords(&self.gecko.mGridAuto${kind.title()}Min,
+        crate::values::generics::grid::TrackSize::from_gecko_style_coords(&self.gecko.mGridAuto${kind.title()}Min,
                                                                      &self.gecko.mGridAuto${kind.title()}Max)
     }
 
     pub fn set_grid_template_${kind}(&mut self, v: longhands::grid_template_${kind}::computed_value::T) {
         <% self_grid = "self.gecko.mGridTemplate%s" % kind.title() %>
-        use gecko_bindings::structs::{nsTArray, nsStyleGridLine_kMaxLine};
+        use crate::gecko_bindings::structs::{nsTArray, nsStyleGridLine_kMaxLine};
         use nsstring::nsStringRepr;
         use std::usize;
-        use values::CustomIdent;
-        use values::generics::grid::TrackListType::Auto;
-        use values::generics::grid::{GridTemplateComponent, RepeatCount};
+        use crate::values::CustomIdent;
+        use crate::values::generics::grid::TrackListType::Auto;
+        use crate::values::generics::grid::{GridTemplateComponent, RepeatCount};
 
         #[inline]
         fn set_line_names(servo_names: &[CustomIdent], gecko_names: &mut nsTArray<nsStringRepr>) {
@@ -1991,11 +1991,11 @@ fn static_assert() {
 
     pub fn clone_grid_template_${kind}(&self) -> longhands::grid_template_${kind}::computed_value::T {
         <% self_grid = "self.gecko.mGridTemplate%s" % kind.title() %>
-        use gecko_bindings::structs::nsTArray;
+        use crate::gecko_bindings::structs::nsTArray;
         use nsstring::nsStringRepr;
-        use values::CustomIdent;
-        use values::generics::grid::{GridTemplateComponent, LineNameList, RepeatCount};
-        use values::generics::grid::{TrackList, TrackListType, TrackListValue, TrackRepeat, TrackSize};
+        use crate::values::CustomIdent;
+        use crate::values::generics::grid::{GridTemplateComponent, LineNameList, RepeatCount};
+        use crate::values::generics::grid::{TrackList, TrackListType, TrackListValue, TrackRepeat, TrackSize};
 
         let value = match unsafe { ${self_grid}.mPtr.as_ref() } {
             None => return GridTemplateComponent::None,
@@ -2077,8 +2077,8 @@ fn static_assert() {
     ${impl_simple_type_with_conversion("grid_auto_flow")}
 
     pub fn set_grid_template_areas(&mut self, v: values::computed::position::GridTemplateAreas) {
-        use gecko_bindings::bindings::Gecko_NewGridTemplateAreasValue;
-        use gecko_bindings::sugar::refptr::UniqueRefPtr;
+        use crate::gecko_bindings::bindings::Gecko_NewGridTemplateAreasValue;
+        use crate::gecko_bindings::sugar::refptr::UniqueRefPtr;
 
         let v = match v {
             Either::First(areas) => areas,
@@ -2118,8 +2118,8 @@ fn static_assert() {
 
     pub fn clone_grid_template_areas(&self) -> values::computed::position::GridTemplateAreas {
         use std::ops::Range;
-        use values::None_;
-        use values::specified::position::{NamedArea, TemplateAreas, TemplateAreasArc};
+        use crate::values::None_;
+        use crate::values::specified::position::{NamedArea, TemplateAreas, TemplateAreasArc};
 
         if self.gecko.mGridTemplateAreas.mRawPtr.is_null() {
             return Either::Second(None_);
@@ -2276,8 +2276,8 @@ fn static_assert() {
     }
 
     pub fn clone_font_family(&self) -> longhands::font_family::computed_value::T {
-        use gecko_bindings::structs::FontFamilyType;
-        use values::computed::font::{FontFamily, SingleFontFamily, FontFamilyList};
+        use crate::gecko_bindings::structs::FontFamilyType;
+        use crate::values::computed::font::{FontFamily, SingleFontFamily, FontFamilyList};
 
         let fontlist = &self.gecko.mFont.fontlist;
         let shared_fontlist = unsafe { fontlist.mFontlist.mBasePtr.to_safe() };
@@ -2316,7 +2316,7 @@ fn static_assert() {
     }
 
     pub fn set_font_size(&mut self, v: FontSize) {
-        use values::generics::font::KeywordSize;
+        use crate::values::generics::font::KeywordSize;
         self.gecko.mSize = v.size().0;
         self.gecko.mScriptUnconstrainedSize = v.size().0;
         if let Some(info) = v.keyword_info {
@@ -2530,7 +2530,7 @@ fn static_assert() {
     }
 
     pub fn clone_font_size(&self) -> FontSize {
-        use values::generics::font::{KeywordInfo, KeywordSize};
+        use crate::values::generics::font::{KeywordInfo, KeywordSize};
         let size = Au(self.gecko.mSize).into();
         let kw = match self.gecko.mFontSizeKeyword as u32 {
             structs::NS_STYLE_FONT_SIZE_XXSMALL => KeywordSize::XXSmall,
@@ -2581,9 +2581,9 @@ fn static_assert() {
     }
     ${impl_simple_copy('font_stretch', 'mFont.stretch')}
     pub fn clone_font_stretch(&self) -> longhands::font_stretch::computed_value::T {
-        use values::computed::font::FontStretch;
-        use values::computed::Percentage;
-        use values::generics::NonNegative;
+        use crate::values::computed::font::FontStretch;
+        use crate::values::computed::Percentage;
+        use crate::values::generics::NonNegative;
 
         let stretch =
             unsafe { bindings::Gecko_FontStretch_ToFloat(self.gecko.mFont.stretch) };
@@ -2593,7 +2593,7 @@ fn static_assert() {
     }
 
     pub fn set_font_style(&mut self, v: longhands::font_style::computed_value::T) {
-        use values::generics::font::FontStyle;
+        use crate::values::generics::font::FontStyle;
         let s = &mut self.gecko.mFont.style;
         unsafe {
             match v {
@@ -2607,14 +2607,14 @@ fn static_assert() {
     }
     ${impl_simple_copy('font_style', 'mFont.style')}
     pub fn clone_font_style(&self) -> longhands::font_style::computed_value::T {
-        use values::computed::font::FontStyle;
+        use crate::values::computed::font::FontStyle;
         FontStyle::from_gecko(self.gecko.mFont.style)
     }
 
     ${impl_simple_type_with_conversion("font_synthesis", "mFont.synthesis")}
 
     pub fn set_font_size_adjust(&mut self, v: longhands::font_size_adjust::computed_value::T) {
-        use properties::longhands::font_size_adjust::computed_value::T;
+        use crate::properties::longhands::font_size_adjust::computed_value::T;
         match v {
             T::None => self.gecko.mFont.sizeAdjust = -1.0 as f32,
             T::Number(n) => self.gecko.mFont.sizeAdjust = n,
@@ -2630,7 +2630,7 @@ fn static_assert() {
     }
 
     pub fn clone_font_size_adjust(&self) -> longhands::font_size_adjust::computed_value::T {
-        use properties::longhands::font_size_adjust::computed_value::T;
+        use crate::properties::longhands::font_size_adjust::computed_value::T;
         T::from_gecko_adjust(self.gecko.mFont.sizeAdjust)
     }
 
@@ -2688,13 +2688,13 @@ fn static_assert() {
     pub fn set_font_variant_alternates(&mut self,
                                        v: values::computed::font::FontVariantAlternates,
                                        device: &Device) {
-        use gecko_bindings::bindings::{Gecko_ClearAlternateValues, Gecko_AppendAlternateValues};
-        use gecko_bindings::bindings::Gecko_nsFont_ResetFontFeatureValuesLookup;
-        use gecko_bindings::bindings::Gecko_nsFont_SetFontFeatureValuesLookup;
+        use crate::gecko_bindings::bindings::{Gecko_ClearAlternateValues, Gecko_AppendAlternateValues};
+        use crate::gecko_bindings::bindings::Gecko_nsFont_ResetFontFeatureValuesLookup;
+        use crate::gecko_bindings::bindings::Gecko_nsFont_SetFontFeatureValuesLookup;
         % for value in "normal swash stylistic ornaments annotation styleset character_variant historical".split():
-            use gecko_bindings::structs::NS_FONT_VARIANT_ALTERNATES_${value.upper()};
+            use crate::gecko_bindings::structs::NS_FONT_VARIANT_ALTERNATES_${value.upper()};
         % endfor
-        use values::specified::font::VariantAlternates;
+        use crate::values::specified::font::VariantAlternates;
 
         unsafe {
             Gecko_ClearAlternateValues(&mut self.gecko.mFont, v.len());
@@ -2743,7 +2743,7 @@ fn static_assert() {
 
     #[allow(non_snake_case)]
     pub fn copy_font_variant_alternates_from(&mut self, other: &Self) {
-        use gecko_bindings::bindings::Gecko_CopyAlternateValuesFrom;
+        use crate::gecko_bindings::bindings::Gecko_CopyAlternateValuesFrom;
 
         self.gecko.mFont.variantAlternates = other.gecko.mFont.variantAlternates;
         unsafe {
@@ -2757,11 +2757,11 @@ fn static_assert() {
 
     pub fn clone_font_variant_alternates(&self) -> values::computed::font::FontVariantAlternates {
         % for value in "normal swash stylistic ornaments annotation styleset character_variant historical".split():
-            use gecko_bindings::structs::NS_FONT_VARIANT_ALTERNATES_${value.upper()};
+            use crate::gecko_bindings::structs::NS_FONT_VARIANT_ALTERNATES_${value.upper()};
         % endfor
-        use values::specified::font::VariantAlternates;
-        use values::specified::font::VariantAlternatesList;
-        use values::CustomIdent;
+        use crate::values::specified::font::VariantAlternates;
+        use crate::values::specified::font::VariantAlternatesList;
+        use crate::values::CustomIdent;
 
         if self.gecko.mFont.variantAlternates == NS_FONT_VARIANT_ALTERNATES_NORMAL as u16 {
             return VariantAlternatesList(vec![].into_boxed_slice());
@@ -2888,7 +2888,7 @@ fn static_assert() {
     #[allow(non_snake_case)]
     pub fn ${type}_${ident}_at(&self, index: usize)
         -> longhands::${type}_${ident}::computed_value::SingleComputedValue {
-        use values::computed::Time;
+        use crate::values::computed::Time;
         Time::from_seconds(self.gecko.m${type.capitalize()}s[index].m${gecko_ffi_name} / 1000.)
     }
     ${impl_animation_or_transition_count(type, ident, gecko_ffi_name)}
@@ -2952,7 +2952,7 @@ fn static_assert() {
         where I: IntoIterator<Item = longhands::animation_${ident}::computed_value::single_value::T>,
               I::IntoIter: ExactSizeIterator + Clone
     {
-        use properties::longhands::animation_${ident}::single_value::computed_value::T as Keyword;
+        use crate::properties::longhands::animation_${ident}::single_value::computed_value::T as Keyword;
 
         let v = v.into_iter();
 
@@ -2975,7 +2975,7 @@ fn static_assert() {
     #[allow(non_snake_case)]
     pub fn animation_${ident}_at(&self, index: usize)
         -> longhands::animation_${ident}::computed_value::SingleComputedValue {
-        use properties::longhands::animation_${ident}::single_value::computed_value::T as Keyword;
+        use crate::properties::longhands::animation_${ident}::single_value::computed_value::T as Keyword;
         match self.gecko.mAnimations[index].m${gecko_ffi_name} ${keyword.maybe_cast("u32")} {
             % for value in keyword.gecko_values():
                 structs::${keyword.gecko_constant(value)} => Keyword::${to_camel_case(value)},
@@ -3007,7 +3007,7 @@ fn static_assert() {
     }
 
     pub fn clone_${ident}(&self) -> values::computed::${type} {
-        use values::generics::transform::${type};
+        use crate::values::generics::transform::${type};
 
         if self.gecko.${gecko_ffi_name}.mRawPtr.is_null() {
             return ${type}::None;
@@ -3086,7 +3086,7 @@ fn static_assert() {
 
     <% overflow_x = data.longhands_by_name["overflow-x"] %>
     pub fn set_overflow_y(&mut self, v: longhands::overflow_y::computed_value::T) {
-        use properties::longhands::overflow_x::computed_value::T as BaseType;
+        use crate::properties::longhands::overflow_x::computed_value::T as BaseType;
         // FIXME(bholley): Align binary representations and ditch |match| for cast + static_asserts
         self.gecko.mOverflowY = match v {
             % for value in overflow_x.keyword.values_for('gecko'):
@@ -3096,7 +3096,7 @@ fn static_assert() {
     }
     ${impl_simple_copy('overflow_y', 'mOverflowY')}
     pub fn clone_overflow_y(&self) -> longhands::overflow_y::computed_value::T {
-        use properties::longhands::overflow_x::computed_value::T as BaseType;
+        use crate::properties::longhands::overflow_x::computed_value::T as BaseType;
         // FIXME(bholley): Align binary representations and ditch |match| for cast + static_asserts
         match self.gecko.mOverflowY as u32 {
             % for value in overflow_x.keyword.values_for('gecko'):
@@ -3107,7 +3107,7 @@ fn static_assert() {
     }
 
     pub fn set_vertical_align(&mut self, v: longhands::vertical_align::computed_value::T) {
-        use values::generics::box_::VerticalAlign;
+        use crate::values::generics::box_::VerticalAlign;
         let value = match v {
             VerticalAlign::Baseline => structs::NS_STYLE_VERTICAL_ALIGN_BASELINE,
             VerticalAlign::Sub => structs::NS_STYLE_VERTICAL_ALIGN_SUB,
@@ -3129,8 +3129,8 @@ fn static_assert() {
     }
 
     pub fn clone_vertical_align(&self) -> longhands::vertical_align::computed_value::T {
-        use values::computed::LengthOrPercentage;
-        use values::generics::box_::VerticalAlign;
+        use crate::values::computed::LengthOrPercentage;
+        use crate::values::generics::box_::VerticalAlign;
 
         let gecko = &self.gecko.mVerticalAlign;
         match gecko.as_value() {
@@ -3153,7 +3153,7 @@ fn static_assert() {
     // "A conforming user agent may interpret the values 'left' and 'right'
     // as 'always'." - CSS2.1, section 13.3.1
     pub fn set_page_break_${kind}(&mut self, v: longhands::page_break_${kind}::computed_value::T) {
-        use computed_values::page_break_${kind}::T;
+        use crate::computed_values::page_break_${kind}::T;
 
         let result = match v {
             T::Auto   => false,
@@ -3170,7 +3170,7 @@ fn static_assert() {
     // Temp fix for Bugzilla bug 24000.
     // See set_page_break_before/after for detail.
     pub fn clone_page_break_${kind}(&self) -> longhands::page_break_${kind}::computed_value::T {
-        use computed_values::page_break_${kind}::T;
+        use crate::computed_values::page_break_${kind}::T;
 
         if self.gecko.mBreak${kind.title()} { T::Always } else { T::Auto }
     }
@@ -3220,9 +3220,9 @@ fn static_assert() {
         where I: IntoIterator<Item = longhands::transition_property::computed_value::single_value::T>,
               I::IntoIter: ExactSizeIterator
     {
-        use gecko_bindings::structs::nsCSSPropertyID::eCSSPropertyExtra_no_properties;
-        use gecko_bindings::structs::nsCSSPropertyID::eCSSPropertyExtra_variable;
-        use gecko_bindings::structs::nsCSSPropertyID::eCSSProperty_UNKNOWN;
+        use crate::gecko_bindings::structs::nsCSSPropertyID::eCSSPropertyExtra_no_properties;
+        use crate::gecko_bindings::structs::nsCSSPropertyID::eCSSPropertyExtra_variable;
+        use crate::gecko_bindings::structs::nsCSSPropertyID::eCSSProperty_UNKNOWN;
 
         let v = v.into_iter();
 
@@ -3253,7 +3253,7 @@ fn static_assert() {
 
     /// Returns whether there are any transitions specified.
     pub fn specifies_transitions(&self) -> bool {
-        use gecko_bindings::structs::nsCSSPropertyID::eCSSPropertyExtra_all_properties;
+        use crate::gecko_bindings::structs::nsCSSPropertyID::eCSSPropertyExtra_all_properties;
         if self.gecko.mTransitionPropertyCount == 1 &&
             self.gecko.mTransitions[0].mProperty == eCSSPropertyExtra_all_properties &&
             self.transition_combined_duration_at(0) <= 0.0f32 {
@@ -3265,9 +3265,9 @@ fn static_assert() {
 
     pub fn transition_property_at(&self, index: usize)
         -> longhands::transition_property::computed_value::SingleComputedValue {
-        use gecko_bindings::structs::nsCSSPropertyID::eCSSPropertyExtra_no_properties;
-        use gecko_bindings::structs::nsCSSPropertyID::eCSSPropertyExtra_variable;
-        use gecko_bindings::structs::nsCSSPropertyID::eCSSProperty_UNKNOWN;
+        use crate::gecko_bindings::structs::nsCSSPropertyID::eCSSPropertyExtra_no_properties;
+        use crate::gecko_bindings::structs::nsCSSPropertyID::eCSSPropertyExtra_variable;
+        use crate::gecko_bindings::structs::nsCSSPropertyID::eCSSProperty_UNKNOWN;
 
         let property = self.gecko.mTransitions[index].mProperty;
         if property == eCSSProperty_UNKNOWN {
@@ -3299,8 +3299,8 @@ fn static_assert() {
     }
 
     pub fn copy_transition_property_from(&mut self, other: &Self) {
-        use gecko_bindings::structs::nsCSSPropertyID::eCSSPropertyExtra_variable;
-        use gecko_bindings::structs::nsCSSPropertyID::eCSSProperty_UNKNOWN;
+        use crate::gecko_bindings::structs::nsCSSPropertyID::eCSSPropertyExtra_variable;
+        use crate::gecko_bindings::structs::nsCSSPropertyID::eCSSProperty_UNKNOWN;
         self.gecko.mTransitions.ensure_len(other.gecko.mTransitions.len());
 
         let count = other.gecko.mTransitionPropertyCount;
@@ -3374,7 +3374,7 @@ fn static_assert() {
     }
     pub fn animation_name_at(&self, index: usize)
         -> longhands::animation_name::computed_value::SingleComputedValue {
-        use properties::longhands::animation_name::single_value::SpecifiedValue as AnimationName;
+        use crate::properties::longhands::animation_name::single_value::SpecifiedValue as AnimationName;
 
         let atom = self.gecko.mAnimations[index].mName.mRawPtr;
         if atom == atom!("").as_ptr() {
@@ -3409,7 +3409,7 @@ fn static_assert() {
         I::IntoIter: ExactSizeIterator + Clone
     {
         use std::f32;
-        use values::generics::box_::AnimationIterationCount;
+        use crate::values::generics::box_::AnimationIterationCount;
 
         let v = v.into_iter();
 
@@ -3430,7 +3430,7 @@ fn static_assert() {
         &self,
         index: usize,
     ) -> values::computed::AnimationIterationCount {
-        use values::generics::box_::AnimationIterationCount;
+        use crate::values::generics::box_::AnimationIterationCount;
 
         if self.gecko.mAnimations[index].mIterationCount.is_infinite() {
             AnimationIterationCount::Infinite
@@ -3472,8 +3472,8 @@ fn static_assert() {
     }
 
     pub fn clone_perspective_origin(&self) -> longhands::perspective_origin::computed_value::T {
-        use properties::longhands::perspective_origin::computed_value::T;
-        use values::computed::LengthOrPercentage;
+        use crate::properties::longhands::perspective_origin::computed_value::T;
+        use crate::values::computed::LengthOrPercentage;
         T {
             horizontal: LengthOrPercentage::from_gecko_style_coord(&self.gecko.mPerspectiveOrigin[0])
                 .expect("Expected length or percentage for horizontal value of perspective-origin"),
@@ -3487,8 +3487,8 @@ fn static_assert() {
     ${impl_individual_transform('scale', 'Scale', 'mSpecifiedScale')}
 
     pub fn set_will_change(&mut self, v: longhands::will_change::computed_value::T) {
-        use gecko_bindings::bindings::{Gecko_AppendWillChange, Gecko_ClearWillChange};
-        use properties::longhands::will_change::computed_value::T;
+        use crate::gecko_bindings::bindings::{Gecko_AppendWillChange, Gecko_ClearWillChange};
+        use crate::properties::longhands::will_change::computed_value::T;
 
         match v {
             T::AnimateableFeatures { features, bits } => {
@@ -3514,7 +3514,7 @@ fn static_assert() {
     }
 
     pub fn copy_will_change_from(&mut self, other: &Self) {
-        use gecko_bindings::bindings::Gecko_CopyWillChangeFrom;
+        use crate::gecko_bindings::bindings::Gecko_CopyWillChangeFrom;
 
         self.gecko.mWillChangeBitField = other.gecko.mWillChangeBitField;
         unsafe {
@@ -3527,10 +3527,10 @@ fn static_assert() {
     }
 
     pub fn clone_will_change(&self) -> longhands::will_change::computed_value::T {
-        use properties::longhands::will_change::computed_value::T;
-        use gecko_bindings::structs::nsAtom;
-        use values::CustomIdent;
-        use values::specified::box_::WillChangeBits;
+        use crate::properties::longhands::will_change::computed_value::T;
+        use crate::gecko_bindings::structs::nsAtom;
+        use crate::values::CustomIdent;
+        use crate::values::specified::box_::WillChangeBits;
 
         if self.gecko.mWillChange.len() == 0 {
             return T::Auto
@@ -3551,16 +3551,16 @@ fn static_assert() {
     <% impl_shape_source("shape_outside", "mShapeOutside") %>
 
     pub fn set_contain(&mut self, v: longhands::contain::computed_value::T) {
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_NONE;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_STRICT;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_CONTENT;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_SIZE;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_LAYOUT;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_STYLE;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_PAINT;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_ALL_BITS;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_CONTENT_BITS;
-        use properties::longhands::contain::SpecifiedValue;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_NONE;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_STRICT;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_CONTENT;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_SIZE;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_LAYOUT;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_STYLE;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_PAINT;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_ALL_BITS;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_CONTENT_BITS;
+        use crate::properties::longhands::contain::SpecifiedValue;
 
         if v.is_empty() {
             self.gecko.mContain = NS_STYLE_CONTAIN_NONE as u8;
@@ -3594,15 +3594,15 @@ fn static_assert() {
     }
 
     pub fn clone_contain(&self) -> longhands::contain::computed_value::T {
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_STRICT;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_CONTENT;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_SIZE;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_LAYOUT;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_STYLE;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_PAINT;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_ALL_BITS;
-        use gecko_bindings::structs::NS_STYLE_CONTAIN_CONTENT_BITS;
-        use properties::longhands::contain::{self, SpecifiedValue};
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_STRICT;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_CONTENT;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_SIZE;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_LAYOUT;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_STYLE;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_PAINT;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_ALL_BITS;
+        use crate::gecko_bindings::structs::NS_STYLE_CONTAIN_CONTENT_BITS;
+        use crate::properties::longhands::contain::{self, SpecifiedValue};
 
         let mut servo_flags = contain::computed_value::T::empty();
         let gecko_flags = self.gecko.mContain;
@@ -3646,10 +3646,10 @@ fn static_assert() {
     ${impl_simple_type_with_conversion("touch_action")}
 
     pub fn set_offset_path(&mut self, v: longhands::offset_path::computed_value::T) {
-        use gecko_bindings::bindings::{Gecko_NewStyleMotion, Gecko_SetStyleMotion};
-        use gecko_bindings::structs::StyleShapeSourceType;
-        use values::generics::basic_shape::FillRule;
-        use values::specified::OffsetPath;
+        use crate::gecko_bindings::bindings::{Gecko_NewStyleMotion, Gecko_SetStyleMotion};
+        use crate::gecko_bindings::structs::StyleShapeSourceType;
+        use crate::values::generics::basic_shape::FillRule;
+        use crate::values::specified::OffsetPath;
 
         let motion = unsafe { Gecko_NewStyleMotion().as_mut().unwrap() };
         match v {
@@ -3662,7 +3662,7 @@ fn static_assert() {
     }
 
     pub fn clone_offset_path(&self) -> longhands::offset_path::computed_value::T {
-        use values::specified::OffsetPath;
+        use crate::values::specified::OffsetPath;
         match unsafe { self.gecko.mMotion.mPtr.as_ref() } {
             None => OffsetPath::none(),
             Some(v) => (&v.mOffsetPath).into()
@@ -3670,7 +3670,7 @@ fn static_assert() {
     }
 
     pub fn copy_offset_path_from(&mut self, other: &Self) {
-        use gecko_bindings::bindings::Gecko_CopyStyleMotions;
+        use crate::gecko_bindings::bindings::Gecko_CopyStyleMotions;
         unsafe { Gecko_CopyStyleMotions(&mut self.gecko.mMotion, other.gecko.mMotion.mPtr) };
     }
 
@@ -3690,7 +3690,7 @@ fn static_assert() {
         where I: IntoIterator<Item=longhands::${shorthand}_${name}::computed_value::single_value::T>,
               I::IntoIter: ExactSizeIterator
     {
-        use gecko_bindings::structs::nsStyleImageLayers_LayerType as LayerType;
+        use crate::gecko_bindings::structs::nsStyleImageLayers_LayerType as LayerType;
         let v = v.into_iter();
 
         unsafe {
@@ -3709,7 +3709,7 @@ fn static_assert() {
 
 <%def name="copy_simple_image_array_property(name, shorthand, layers_field_name, field_name)">
     pub fn copy_${shorthand}_${name}_from(&mut self, other: &Self) {
-        use gecko_bindings::structs::nsStyleImageLayers_LayerType as LayerType;
+        use crate::gecko_bindings::structs::nsStyleImageLayers_LayerType as LayerType;
 
         let count = other.gecko.${layers_field_name}.${field_name}Count;
         unsafe {
@@ -3746,8 +3746,8 @@ fn static_assert() {
         I: IntoIterator<Item=longhands::${ident}::computed_value::single_value::T>,
         I::IntoIter: ExactSizeIterator,
     {
-        use properties::longhands::${ident}::single_value::computed_value::T as Keyword;
-        use gecko_bindings::structs::nsStyleImageLayers_LayerType as LayerType;
+        use crate::properties::longhands::${ident}::single_value::computed_value::T as Keyword;
+        use crate::gecko_bindings::structs::nsStyleImageLayers_LayerType as LayerType;
 
         let v = v.into_iter();
 
@@ -3770,7 +3770,7 @@ fn static_assert() {
     }
 
     pub fn clone_${ident}(&self) -> longhands::${ident}::computed_value::T {
-        use properties::longhands::${ident}::single_value::computed_value::T as Keyword;
+        use crate::properties::longhands::${ident}::single_value::computed_value::T as Keyword;
 
         % if keyword.needs_cast():
         % for value in keyword.values_for('gecko'):
@@ -3812,9 +3812,9 @@ fn static_assert() {
     %>
 
     <%self:simple_image_array_property name="repeat" shorthand="${shorthand}" field_name="mRepeat">
-        use values::specified::background::BackgroundRepeatKeyword;
-        use gecko_bindings::structs::nsStyleImageLayers_Repeat;
-        use gecko_bindings::structs::StyleImageLayerRepeat;
+        use crate::values::specified::background::BackgroundRepeatKeyword;
+        use crate::gecko_bindings::structs::nsStyleImageLayers_Repeat;
+        use crate::gecko_bindings::structs::StyleImageLayerRepeat;
 
         fn to_ns(repeat: BackgroundRepeatKeyword) -> StyleImageLayerRepeat {
             match repeat {
@@ -3834,9 +3834,9 @@ fn static_assert() {
     </%self:simple_image_array_property>
 
     pub fn clone_${shorthand}_repeat(&self) -> longhands::${shorthand}_repeat::computed_value::T {
-        use properties::longhands::${shorthand}_repeat::single_value::computed_value::T;
-        use values::specified::background::BackgroundRepeatKeyword;
-        use gecko_bindings::structs::StyleImageLayerRepeat;
+        use crate::properties::longhands::${shorthand}_repeat::single_value::computed_value::T;
+        use crate::values::specified::background::BackgroundRepeatKeyword;
+        use crate::gecko_bindings::structs::StyleImageLayerRepeat;
 
         fn to_servo(repeat: StyleImageLayerRepeat) -> BackgroundRepeatKeyword {
             match repeat {
@@ -3862,7 +3862,7 @@ fn static_assert() {
 
     % for orientation in ["x", "y"]:
     pub fn copy_${shorthand}_position_${orientation}_from(&mut self, other: &Self) {
-        use gecko_bindings::structs::nsStyleImageLayers_LayerType as LayerType;
+        use crate::gecko_bindings::structs::nsStyleImageLayers_LayerType as LayerType;
 
         let count = other.gecko.${image_layers_field}.mPosition${orientation.upper()}Count;
 
@@ -3901,7 +3901,7 @@ fn static_assert() {
                                               ::computed_value::single_value::T>,
               I::IntoIter: ExactSizeIterator
     {
-        use gecko_bindings::structs::nsStyleImageLayers_LayerType as LayerType;
+        use crate::gecko_bindings::structs::nsStyleImageLayers_LayerType as LayerType;
 
         let v = v.into_iter();
 
@@ -3919,10 +3919,10 @@ fn static_assert() {
     % endfor
 
     <%self:simple_image_array_property name="size" shorthand="${shorthand}" field_name="mSize">
-        use gecko_bindings::structs::nsStyleImageLayers_Size_Dimension;
-        use gecko_bindings::structs::nsStyleImageLayers_Size_DimensionType;
-        use gecko_bindings::structs::{nsStyleCoord_CalcValue, nsStyleImageLayers_Size};
-        use values::generics::background::BackgroundSize;
+        use crate::gecko_bindings::structs::nsStyleImageLayers_Size_Dimension;
+        use crate::gecko_bindings::structs::nsStyleImageLayers_Size_DimensionType;
+        use crate::gecko_bindings::structs::{nsStyleCoord_CalcValue, nsStyleImageLayers_Size};
+        use crate::values::generics::background::BackgroundSize;
 
         let mut width = nsStyleCoord_CalcValue::new();
         let mut height = nsStyleCoord_CalcValue::new();
@@ -3964,10 +3964,10 @@ fn static_assert() {
     </%self:simple_image_array_property>
 
     pub fn clone_${shorthand}_size(&self) -> longhands::${shorthand}_size::computed_value::T {
-        use gecko_bindings::structs::nsStyleCoord_CalcValue as CalcValue;
-        use gecko_bindings::structs::nsStyleImageLayers_Size_DimensionType as DimensionType;
-        use values::computed::NonNegativeLengthOrPercentageOrAuto;
-        use values::generics::background::BackgroundSize;
+        use crate::gecko_bindings::structs::nsStyleCoord_CalcValue as CalcValue;
+        use crate::gecko_bindings::structs::nsStyleImageLayers_Size_DimensionType as DimensionType;
+        use crate::values::computed::NonNegativeLengthOrPercentageOrAuto;
+        use crate::values::generics::background::BackgroundSize;
 
         fn to_servo(value: CalcValue, ty: u8) -> NonNegativeLengthOrPercentageOrAuto {
             if ty == DimensionType::eAuto as u8 {
@@ -3997,7 +3997,7 @@ fn static_assert() {
     }
 
     pub fn copy_${shorthand}_image_from(&mut self, other: &Self) {
-        use gecko_bindings::structs::nsStyleImageLayers_LayerType as LayerType;
+        use crate::gecko_bindings::structs::nsStyleImageLayers_LayerType as LayerType;
         unsafe {
             let count = other.gecko.${image_layers_field}.mImageCount;
             Gecko_EnsureImageLayersLength(&mut self.gecko.${image_layers_field},
@@ -4022,7 +4022,7 @@ fn static_assert() {
         where I: IntoIterator<Item = longhands::${shorthand}_image::computed_value::single_value::T>,
               I::IntoIter: ExactSizeIterator
     {
-        use gecko_bindings::structs::nsStyleImageLayers_LayerType as LayerType;
+        use crate::gecko_bindings::structs::nsStyleImageLayers_LayerType as LayerType;
 
         let images = images.into_iter();
 
@@ -4047,7 +4047,7 @@ fn static_assert() {
     }
 
     pub fn clone_${shorthand}_image(&self) -> longhands::${shorthand}_image::computed_value::T {
-        use values::None_;
+        use crate::values::None_;
 
         longhands::${shorthand}_image::computed_value::List(
             self.gecko.${image_layers_field}.mLayers.iter()
@@ -4070,7 +4070,7 @@ fn static_assert() {
             fill_fields += " mMaskMode mComposite"
     %>
     pub fn fill_arrays(&mut self) {
-        use gecko_bindings::bindings::Gecko_FillAllImageLayers;
+        use crate::gecko_bindings::bindings::Gecko_FillAllImageLayers;
         use std::cmp;
         let mut max_len = 1;
         % for member in fill_fields.split():
@@ -4132,7 +4132,7 @@ fn static_assert() {
     }
 
     pub fn clone_list_style_image(&self) -> longhands::list_style_image::computed_value::T {
-        use values::computed::url::ComputedImageUrl;
+        use crate::values::computed::url::ComputedImageUrl;
 
         if self.gecko.mListStyleImage.mRawPtr.is_null() {
             return UrlOrNone::None;
@@ -4145,7 +4145,7 @@ fn static_assert() {
     }
 
     pub fn set_list_style_type(&mut self, v: longhands::list_style_type::computed_value::T, device: &Device) {
-        use gecko_bindings::bindings::Gecko_SetCounterStyleToString;
+        use crate::gecko_bindings::bindings::Gecko_SetCounterStyleToString;
         use nsstring::{nsACString, nsCStr};
         use self::longhands::list_style_type::computed_value::T;
         match v {
@@ -4169,8 +4169,8 @@ fn static_assert() {
 
     pub fn clone_list_style_type(&self) -> longhands::list_style_type::computed_value::T {
         use self::longhands::list_style_type::computed_value::T;
-        use values::Either;
-        use values::generics::CounterStyleOrNone;
+        use crate::values::Either;
+        use crate::values::generics::CounterStyleOrNone;
 
         let result = CounterStyleOrNone::from_gecko_value(&self.gecko.mCounterStyle);
         match result {
@@ -4203,7 +4203,7 @@ fn static_assert() {
 
     #[allow(non_snake_case)]
     pub fn set__moz_image_region(&mut self, v: longhands::_moz_image_region::computed_value::T) {
-        use values::Either;
+        use crate::values::Either;
 
         match v {
             Either::Second(_auto) => {
@@ -4229,8 +4229,8 @@ fn static_assert() {
 
     #[allow(non_snake_case)]
     pub fn clone__moz_image_region(&self) -> longhands::_moz_image_region::computed_value::T {
-        use values::{Auto, Either};
-        use values::computed::ClipRect;
+        use crate::values::{Auto, Either};
+        use crate::values::computed::ClipRect;
 
         // There is no ideal way to detect auto type for structs::nsRect and its components, so
         // if all components are zero, we use Auto.
@@ -4296,13 +4296,13 @@ fn static_assert() {
     }
 
     pub fn set_clip(&mut self, v: longhands::clip::computed_value::T) {
-        use gecko_bindings::structs::NS_STYLE_CLIP_AUTO;
-        use gecko_bindings::structs::NS_STYLE_CLIP_RECT;
-        use gecko_bindings::structs::NS_STYLE_CLIP_LEFT_AUTO;
-        use gecko_bindings::structs::NS_STYLE_CLIP_TOP_AUTO;
-        use gecko_bindings::structs::NS_STYLE_CLIP_RIGHT_AUTO;
-        use gecko_bindings::structs::NS_STYLE_CLIP_BOTTOM_AUTO;
-        use values::Either;
+        use crate::gecko_bindings::structs::NS_STYLE_CLIP_AUTO;
+        use crate::gecko_bindings::structs::NS_STYLE_CLIP_RECT;
+        use crate::gecko_bindings::structs::NS_STYLE_CLIP_LEFT_AUTO;
+        use crate::gecko_bindings::structs::NS_STYLE_CLIP_TOP_AUTO;
+        use crate::gecko_bindings::structs::NS_STYLE_CLIP_RIGHT_AUTO;
+        use crate::gecko_bindings::structs::NS_STYLE_CLIP_BOTTOM_AUTO;
+        use crate::values::Either;
 
         match v {
             Either::First(rect) => {
@@ -4355,13 +4355,13 @@ fn static_assert() {
     }
 
     pub fn clone_clip(&self) -> longhands::clip::computed_value::T {
-        use gecko_bindings::structs::NS_STYLE_CLIP_AUTO;
-        use gecko_bindings::structs::NS_STYLE_CLIP_BOTTOM_AUTO;
-        use gecko_bindings::structs::NS_STYLE_CLIP_LEFT_AUTO;
-        use gecko_bindings::structs::NS_STYLE_CLIP_RIGHT_AUTO;
-        use gecko_bindings::structs::NS_STYLE_CLIP_TOP_AUTO;
-        use values::computed::{ClipRect, ClipRectOrAuto};
-        use values::Either;
+        use crate::gecko_bindings::structs::NS_STYLE_CLIP_AUTO;
+        use crate::gecko_bindings::structs::NS_STYLE_CLIP_BOTTOM_AUTO;
+        use crate::gecko_bindings::structs::NS_STYLE_CLIP_LEFT_AUTO;
+        use crate::gecko_bindings::structs::NS_STYLE_CLIP_RIGHT_AUTO;
+        use crate::gecko_bindings::structs::NS_STYLE_CLIP_TOP_AUTO;
+        use crate::values::computed::{ClipRect, ClipRectOrAuto};
+        use crate::values::Either;
 
         if self.gecko.mClipFlags == NS_STYLE_CLIP_AUTO as u8 {
             ClipRectOrAuto::auto()
@@ -4412,19 +4412,19 @@ fn static_assert() {
         I: IntoIterator<Item = Filter>,
         I::IntoIter: ExactSizeIterator,
     {
-        use values::generics::effects::Filter::*;
-        use gecko_bindings::structs::nsCSSShadowArray;
-        use gecko_bindings::structs::nsStyleFilter;
-        use gecko_bindings::structs::NS_STYLE_FILTER_BLUR;
-        use gecko_bindings::structs::NS_STYLE_FILTER_BRIGHTNESS;
-        use gecko_bindings::structs::NS_STYLE_FILTER_CONTRAST;
-        use gecko_bindings::structs::NS_STYLE_FILTER_GRAYSCALE;
-        use gecko_bindings::structs::NS_STYLE_FILTER_INVERT;
-        use gecko_bindings::structs::NS_STYLE_FILTER_OPACITY;
-        use gecko_bindings::structs::NS_STYLE_FILTER_SATURATE;
-        use gecko_bindings::structs::NS_STYLE_FILTER_SEPIA;
-        use gecko_bindings::structs::NS_STYLE_FILTER_HUE_ROTATE;
-        use gecko_bindings::structs::NS_STYLE_FILTER_DROP_SHADOW;
+        use crate::values::generics::effects::Filter::*;
+        use crate::gecko_bindings::structs::nsCSSShadowArray;
+        use crate::gecko_bindings::structs::nsStyleFilter;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_BLUR;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_BRIGHTNESS;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_CONTRAST;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_GRAYSCALE;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_INVERT;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_OPACITY;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_SATURATE;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_SEPIA;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_HUE_ROTATE;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_DROP_SHADOW;
 
         fn fill_filter(m_type: u32, value: CoordDataValue, gecko_filter: &mut nsStyleFilter){
             gecko_filter.mType = m_type;
@@ -4488,19 +4488,19 @@ fn static_assert() {
     }
 
     pub fn clone_filter(&self) -> longhands::filter::computed_value::T {
-        use values::generics::effects::Filter;
-        use values::computed::url::ComputedUrl;
-        use gecko_bindings::structs::NS_STYLE_FILTER_BLUR;
-        use gecko_bindings::structs::NS_STYLE_FILTER_BRIGHTNESS;
-        use gecko_bindings::structs::NS_STYLE_FILTER_CONTRAST;
-        use gecko_bindings::structs::NS_STYLE_FILTER_GRAYSCALE;
-        use gecko_bindings::structs::NS_STYLE_FILTER_INVERT;
-        use gecko_bindings::structs::NS_STYLE_FILTER_OPACITY;
-        use gecko_bindings::structs::NS_STYLE_FILTER_SATURATE;
-        use gecko_bindings::structs::NS_STYLE_FILTER_SEPIA;
-        use gecko_bindings::structs::NS_STYLE_FILTER_HUE_ROTATE;
-        use gecko_bindings::structs::NS_STYLE_FILTER_DROP_SHADOW;
-        use gecko_bindings::structs::NS_STYLE_FILTER_URL;
+        use crate::values::generics::effects::Filter;
+        use crate::values::computed::url::ComputedUrl;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_BLUR;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_BRIGHTNESS;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_CONTRAST;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_GRAYSCALE;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_INVERT;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_OPACITY;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_SATURATE;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_SEPIA;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_HUE_ROTATE;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_DROP_SHADOW;
+        use crate::gecko_bindings::structs::NS_STYLE_FILTER_URL;
 
         let mut filters = Vec::new();
         for filter in self.gecko.mFilters.iter(){
@@ -4605,7 +4605,7 @@ fn static_assert() {
     }
 
     pub fn set_line_height(&mut self, v: longhands::line_height::computed_value::T) {
-        use values::generics::text::LineHeight;
+        use crate::values::generics::text::LineHeight;
         // FIXME: Align binary representations and ditch |match| for cast + static_asserts
         let en = match v {
             LineHeight::Normal => CoordDataValue::Normal,
@@ -4618,7 +4618,7 @@ fn static_assert() {
     }
 
     pub fn clone_line_height(&self) -> longhands::line_height::computed_value::T {
-        use values::generics::text::LineHeight;
+        use crate::values::generics::text::LineHeight;
         return match self.gecko.mLineHeight.as_value() {
             CoordDataValue::Normal => LineHeight::Normal,
             CoordDataValue::Coord(coord) => LineHeight::Length(Au(coord).into()),
@@ -4632,7 +4632,7 @@ fn static_assert() {
     <%call expr="impl_coord_copy('line_height', 'mLineHeight')"></%call>
 
     pub fn set_letter_spacing(&mut self, v: longhands::letter_spacing::computed_value::T) {
-        use values::generics::text::Spacing;
+        use crate::values::generics::text::Spacing;
         match v {
             Spacing::Value(value) => self.gecko.mLetterSpacing.set(value),
             Spacing::Normal => self.gecko.mLetterSpacing.set_value(CoordDataValue::Normal)
@@ -4640,8 +4640,8 @@ fn static_assert() {
     }
 
     pub fn clone_letter_spacing(&self) -> longhands::letter_spacing::computed_value::T {
-        use values::computed::Length;
-        use values::generics::text::Spacing;
+        use crate::values::computed::Length;
+        use crate::values::generics::text::Spacing;
         debug_assert!(
             matches!(self.gecko.mLetterSpacing.as_value(),
                      CoordDataValue::Normal |
@@ -4653,7 +4653,7 @@ fn static_assert() {
     <%call expr="impl_coord_copy('letter_spacing', 'mLetterSpacing')"></%call>
 
     pub fn set_word_spacing(&mut self, v: longhands::word_spacing::computed_value::T) {
-        use values::generics::text::Spacing;
+        use crate::values::generics::text::Spacing;
         match v {
             Spacing::Value(lop) => self.gecko.mWordSpacing.set(lop),
             // https://drafts.csswg.org/css-text-3/#valdef-word-spacing-normal
@@ -4662,8 +4662,8 @@ fn static_assert() {
     }
 
     pub fn clone_word_spacing(&self) -> longhands::word_spacing::computed_value::T {
-        use values::computed::LengthOrPercentage;
-        use values::generics::text::Spacing;
+        use crate::values::computed::LengthOrPercentage;
+        use crate::values::generics::text::Spacing;
         debug_assert!(
             matches!(self.gecko.mWordSpacing.as_value(),
                      CoordDataValue::Normal |
@@ -4686,8 +4686,8 @@ fn static_assert() {
     ${impl_simple_type_with_conversion("text_emphasis_position")}
 
     pub fn set_text_emphasis_style(&mut self, v: values::computed::TextEmphasisStyle) {
-        use values::computed::TextEmphasisStyle;
-        use values::specified::text::{TextEmphasisFillMode, TextEmphasisShapeKeyword};
+        use crate::values::computed::TextEmphasisStyle;
+        use crate::values::specified::text::{TextEmphasisFillMode, TextEmphasisShapeKeyword};
 
         self.clear_text_emphasis_style_if_string();
         let (te, s) = match v {
@@ -4729,9 +4729,9 @@ fn static_assert() {
     }
 
     pub fn clone_text_emphasis_style(&self) -> values::computed::TextEmphasisStyle {
-        use values::computed::TextEmphasisStyle;
-        use values::computed::text::TextEmphasisKeywordValue;
-        use values::specified::text::{TextEmphasisFillMode, TextEmphasisShapeKeyword};
+        use crate::values::computed::TextEmphasisStyle;
+        use crate::values::computed::text::TextEmphasisKeywordValue;
+        use crate::values::specified::text::{TextEmphasisFillMode, TextEmphasisShapeKeyword};
 
         if self.gecko.mTextEmphasisStyle == structs::NS_STYLE_TEXT_EMPHASIS_STYLE_NONE as u8 {
             return TextEmphasisStyle::None;
@@ -4792,7 +4792,7 @@ fn static_assert() {
     ${impl_simple_type_with_conversion("text_decoration_line")}
 
     fn clear_overflow_sides_if_string(&mut self) {
-        use gecko_bindings::structs::nsStyleTextOverflowSide;
+        use crate::gecko_bindings::structs::nsStyleTextOverflowSide;
         fn clear_if_string(side: &mut nsStyleTextOverflowSide) {
             if side.mType == structs::NS_STYLE_TEXT_OVERFLOW_STRING as u8 {
                 side.mString.truncate();
@@ -4804,8 +4804,8 @@ fn static_assert() {
     }
 
     pub fn set_text_overflow(&mut self, v: longhands::text_overflow::computed_value::T) {
-        use gecko_bindings::structs::nsStyleTextOverflowSide;
-        use values::specified::text::TextOverflowSide;
+        use crate::gecko_bindings::structs::nsStyleTextOverflowSide;
+        use crate::values::specified::text::TextOverflowSide;
 
         fn set(side: &mut nsStyleTextOverflowSide, value: &TextOverflowSide) {
             let ty = match *value {
@@ -4827,7 +4827,7 @@ fn static_assert() {
     }
 
     pub fn copy_text_overflow_from(&mut self, other: &Self) {
-        use gecko_bindings::structs::nsStyleTextOverflowSide;
+        use crate::gecko_bindings::structs::nsStyleTextOverflowSide;
         fn set(side: &mut nsStyleTextOverflowSide, other: &nsStyleTextOverflowSide) {
             if other.mType == structs::NS_STYLE_TEXT_OVERFLOW_STRING as u8 {
                 side.mString.assign(&*other.mString)
@@ -4845,8 +4845,8 @@ fn static_assert() {
     }
 
     pub fn clone_text_overflow(&self) -> longhands::text_overflow::computed_value::T {
-        use gecko_bindings::structs::nsStyleTextOverflowSide;
-        use values::specified::text::TextOverflowSide;
+        use crate::gecko_bindings::structs::nsStyleTextOverflowSide;
+        use crate::values::specified::text::TextOverflowSide;
 
         fn to_servo(side: &nsStyleTextOverflowSide) -> TextOverflowSide {
             match side.mType as u32 {
@@ -4866,7 +4866,7 @@ fn static_assert() {
     }
 
     pub fn set_initial_letter(&mut self, v: longhands::initial_letter::computed_value::T) {
-        use values::generics::text::InitialLetter;
+        use crate::values::generics::text::InitialLetter;
         match v {
             InitialLetter::Normal => {
                 self.gecko.mInitialLetterSize = 0.;
@@ -4893,7 +4893,7 @@ fn static_assert() {
     }
 
     pub fn clone_initial_letter(&self) -> longhands::initial_letter::computed_value::T {
-        use values::generics::text::InitialLetter;
+        use crate::values::generics::text::InitialLetter;
 
         if self.gecko.mInitialLetterSize == 0. && self.gecko.mInitialLetterSink == 0 {
             InitialLetter::Normal
@@ -4926,8 +4926,8 @@ fn set_style_svg_path(
     servo_path: &values::specified::svg_path::SVGPathData,
     fill: values::generics::basic_shape::FillRule,
 ) {
-    use gecko_bindings::bindings::Gecko_NewStyleSVGPath;
-    use gecko_bindings::structs::StyleShapeSourceType;
+    use crate::gecko_bindings::bindings::Gecko_NewStyleSVGPath;
+    use crate::gecko_bindings::structs::StyleShapeSourceType;
 
     // Setup type.
     shape_source.mType = StyleShapeSourceType::Path;
@@ -4946,12 +4946,12 @@ fn set_style_svg_path(
 
 <%def name="impl_shape_source(ident, gecko_ffi_name)">
     pub fn set_${ident}(&mut self, v: longhands::${ident}::computed_value::T) {
-        use gecko_bindings::bindings::{Gecko_NewBasicShape, Gecko_DestroyShapeSource};
-        use gecko_bindings::structs::{StyleBasicShape, StyleBasicShapeType, StyleShapeSourceType};
-        use gecko_bindings::structs::{StyleGeometryBox, StyleShapeSource};
-        use gecko::conversions::basic_shape::set_corners_from_radius;
-        use gecko::values::GeckoStyleCoordConvertible;
-        use values::generics::basic_shape::{BasicShape, ShapeSource};
+        use crate::gecko_bindings::bindings::{Gecko_NewBasicShape, Gecko_DestroyShapeSource};
+        use crate::gecko_bindings::structs::{StyleBasicShape, StyleBasicShapeType, StyleShapeSourceType};
+        use crate::gecko_bindings::structs::{StyleGeometryBox, StyleShapeSource};
+        use crate::gecko::conversions::basic_shape::set_corners_from_radius;
+        use crate::gecko::values::GeckoStyleCoordConvertible;
+        use crate::values::generics::basic_shape::{BasicShape, ShapeSource};
 
         let ref mut ${ident} = self.gecko.${gecko_ffi_name};
 
@@ -5063,7 +5063,7 @@ fn set_style_svg_path(
     }
 
     pub fn copy_${ident}_from(&mut self, other: &Self) {
-        use gecko_bindings::bindings::Gecko_CopyShapeSourceFrom;
+        use crate::gecko_bindings::bindings::Gecko_CopyShapeSourceFrom;
         unsafe {
             Gecko_CopyShapeSourceFrom(&mut self.gecko.${gecko_ffi_name}, &other.gecko.${gecko_ffi_name});
         }
@@ -5097,13 +5097,13 @@ clip-path
     ${impl_simple_copy('paint_order', 'mPaintOrder')}
 
     pub fn clone_paint_order(&self) -> longhands::paint_order::computed_value::T {
-        use properties::longhands::paint_order::computed_value::T;
+        use crate::properties::longhands::paint_order::computed_value::T;
         T(self.gecko.mPaintOrder)
     }
 
     pub fn set_stroke_dasharray(&mut self, v: longhands::stroke_dasharray::computed_value::T) {
-        use gecko_bindings::structs::nsStyleSVG_STROKE_DASHARRAY_CONTEXT as CONTEXT_VALUE;
-        use values::generics::svg::{SVGStrokeDashArray, SvgLengthOrPercentageOrNumber};
+        use crate::gecko_bindings::structs::nsStyleSVG_STROKE_DASHARRAY_CONTEXT as CONTEXT_VALUE;
+        use crate::values::generics::svg::{SVGStrokeDashArray, SvgLengthOrPercentageOrNumber};
 
         match v {
             SVGStrokeDashArray::Values(v) => {
@@ -5131,7 +5131,7 @@ clip-path
     }
 
     pub fn copy_stroke_dasharray_from(&mut self, other: &Self) {
-        use gecko_bindings::structs::nsStyleSVG_STROKE_DASHARRAY_CONTEXT as CONTEXT_VALUE;
+        use crate::gecko_bindings::structs::nsStyleSVG_STROKE_DASHARRAY_CONTEXT as CONTEXT_VALUE;
         unsafe {
             bindings::Gecko_nsStyleSVG_CopyDashArray(&mut self.gecko, &other.gecko);
         }
@@ -5145,9 +5145,9 @@ clip-path
     }
 
     pub fn clone_stroke_dasharray(&self) -> longhands::stroke_dasharray::computed_value::T {
-        use gecko_bindings::structs::nsStyleSVG_STROKE_DASHARRAY_CONTEXT as CONTEXT_VALUE;
-        use values::computed::LengthOrPercentage;
-        use values::generics::svg::{SVGStrokeDashArray, SvgLengthOrPercentageOrNumber};
+        use crate::gecko_bindings::structs::nsStyleSVG_STROKE_DASHARRAY_CONTEXT as CONTEXT_VALUE;
+        use crate::values::computed::LengthOrPercentage;
+        use crate::values::generics::svg::{SVGStrokeDashArray, SvgLengthOrPercentageOrNumber};
 
         if self.gecko.mContextFlags & CONTEXT_VALUE != 0 {
             debug_assert_eq!(self.gecko.mStrokeDasharray.len(), 0);
@@ -5329,8 +5329,8 @@ clip-path
     }
 
     pub fn clone_cursor(&self) -> longhands::cursor::computed_value::T {
-        use values::computed::ui::CursorImage;
-        use values::computed::url::ComputedImageUrl;
+        use crate::values::computed::ui::CursorImage;
+        use crate::values::computed::url::ComputedImageUrl;
         use style_traits::cursor::CursorKind;
 
         let keyword = match self.gecko.mCursor as u32 {
@@ -5393,8 +5393,8 @@ clip-path
     }
 
     pub fn set_scrollbar_color(&mut self, v: longhands::scrollbar_color::computed_value::T) {
-        use gecko_bindings::structs::StyleComplexColor;
-        use values::generics::ui::ScrollbarColor;
+        use crate::gecko_bindings::structs::StyleComplexColor;
+        use crate::values::generics::ui::ScrollbarColor;
         match v {
             ScrollbarColor::Auto => {
                 self.gecko.mScrollbarFaceColor = StyleComplexColor::auto();
@@ -5417,8 +5417,8 @@ clip-path
     }
 
     pub fn clone_scrollbar_color(&self) -> longhands::scrollbar_color::computed_value::T {
-        use gecko_bindings::structs::StyleComplexColor_Tag as Tag;
-        use values::generics::ui::ScrollbarColor;
+        use crate::gecko_bindings::structs::StyleComplexColor_Tag as Tag;
+        use crate::values::generics::ui::ScrollbarColor;
         debug_assert!(
             (self.gecko.mScrollbarFaceColor.mTag == Tag::eAuto) ==
             (self.gecko.mScrollbarTrackColor.mTag == Tag::eAuto),
@@ -5440,7 +5440,7 @@ clip-path
 
     #[allow(unused_unsafe)]
     pub fn set_column_count(&mut self, v: longhands::column_count::computed_value::T) {
-        use gecko_bindings::structs::{nsStyleColumn_kColumnCountAuto, nsStyleColumn_kMaxColumnCount};
+        use crate::gecko_bindings::structs::{nsStyleColumn_kColumnCountAuto, nsStyleColumn_kMaxColumnCount};
 
         self.gecko.mColumnCount = match v {
             ColumnCount::Integer(integer) => {
@@ -5453,7 +5453,7 @@ clip-path
     ${impl_simple_copy('column_count', 'mColumnCount')}
 
     pub fn clone_column_count(&self) -> longhands::column_count::computed_value::T {
-        use gecko_bindings::structs::{nsStyleColumn_kColumnCountAuto, nsStyleColumn_kMaxColumnCount};
+        use crate::gecko_bindings::structs::{nsStyleColumn_kColumnCountAuto, nsStyleColumn_kMaxColumnCount};
         if self.gecko.mColumnCount != nsStyleColumn_kColumnCountAuto {
             debug_assert!(self.gecko.mColumnCount >= 1 &&
                           self.gecko.mColumnCount <= nsStyleColumn_kMaxColumnCount);
@@ -5474,13 +5474,13 @@ clip-path
     }
 
     pub fn set_content(&mut self, v: longhands::content::computed_value::T, device: &Device) {
-        use values::CustomIdent;
-        use values::generics::counters::{Content, ContentItem};
-        use values::generics::CounterStyleOrNone;
-        use gecko_bindings::structs::nsStyleContentData;
-        use gecko_bindings::structs::nsStyleContentAttr;
-        use gecko_bindings::structs::StyleContentType;
-        use gecko_bindings::bindings::Gecko_ClearAndResizeStyleContents;
+        use crate::values::CustomIdent;
+        use crate::values::generics::counters::{Content, ContentItem};
+        use crate::values::generics::CounterStyleOrNone;
+        use crate::gecko_bindings::structs::nsStyleContentData;
+        use crate::gecko_bindings::structs::nsStyleContentAttr;
+        use crate::gecko_bindings::structs::StyleContentType;
+        use crate::gecko_bindings::bindings::Gecko_ClearAndResizeStyleContents;
 
         // Converts a string as utf16, and returns an owned, zero-terminated raw buffer.
         fn as_utf16_and_forget(s: &str) -> *mut u16 {
@@ -5612,7 +5612,7 @@ clip-path
     }
 
     pub fn copy_content_from(&mut self, other: &Self) {
-        use gecko_bindings::bindings::Gecko_CopyStyleContentsFrom;
+        use crate::gecko_bindings::bindings::Gecko_CopyStyleContentsFrom;
         unsafe {
             Gecko_CopyStyleContentsFrom(&mut self.gecko, &other.gecko)
         }
@@ -5624,13 +5624,13 @@ clip-path
 
     pub fn clone_content(&self) -> longhands::content::computed_value::T {
         use {Atom, Namespace};
-        use gecko::conversions::string_from_chars_pointer;
-        use gecko_bindings::structs::StyleContentType;
-        use values::generics::counters::{Content, ContentItem};
-        use values::computed::url::ComputedImageUrl;
-        use values::{CustomIdent, Either};
-        use values::generics::CounterStyleOrNone;
-        use values::specified::Attr;
+        use crate::gecko::conversions::string_from_chars_pointer;
+        use crate::gecko_bindings::structs::StyleContentType;
+        use crate::values::generics::counters::{Content, ContentItem};
+        use crate::values::computed::url::ComputedImageUrl;
+        use crate::values::{CustomIdent, Either};
+        use crate::values::generics::CounterStyleOrNone;
+        use crate::values::specified::Attr;
 
         if self.gecko.mContents.is_empty() {
             return Content::None;
@@ -5727,8 +5727,8 @@ clip-path
         pub fn clone_counter_${counter_property.lower()}(
             &self
         ) -> longhands::counter_${counter_property.lower()}::computed_value::T {
-            use values::generics::counters::CounterPair;
-            use values::CustomIdent;
+            use crate::values::generics::counters::CounterPair;
+            use crate::values::CustomIdent;
 
             longhands::counter_${counter_property.lower()}::computed_value::T::new(
                 self.gecko.m${counter_property}s.iter().map(|ref gecko_counter| {

--- a/components/style/properties/helpers.mako.rs
+++ b/components/style/properties/helpers.mako.rs
@@ -17,15 +17,15 @@
         #[allow(unused_imports)]
         use cssparser::{Color as CSSParserColor, RGBA};
         #[allow(unused_imports)]
-        use values::specified::AllowQuirks;
+        use crate::values::specified::AllowQuirks;
         #[allow(unused_imports)]
         use smallvec::SmallVec;
-        pub use values::specified::${type} as SpecifiedValue;
+        pub use crate::values::specified::${type} as SpecifiedValue;
         pub mod computed_value {
             % if computed_type:
             pub use ${computed_type} as T;
             % else:
-            pub use values::computed::${type} as T;
+            pub use crate::values::computed::${type} as T;
             % endif
         }
         % if initial_value:
@@ -91,19 +91,19 @@
             #[allow(unused_imports)]
             use cssparser::{Parser, BasicParseError};
             #[allow(unused_imports)]
-            use parser::{Parse, ParserContext};
+            use crate::parser::{Parse, ParserContext};
             #[allow(unused_imports)]
-            use properties::ShorthandId;
+            use crate::properties::ShorthandId;
             #[allow(unused_imports)]
             use selectors::parser::SelectorParseErrorKind;
             #[allow(unused_imports)]
             use style_traits::{ParseError, StyleParseErrorKind};
             #[allow(unused_imports)]
-            use values::computed::{Context, ToComputedValue};
+            use crate::values::computed::{Context, ToComputedValue};
             #[allow(unused_imports)]
-            use values::{computed, specified};
+            use crate::values::{computed, specified};
             #[allow(unused_imports)]
-            use values::{Auto, Either, None_, Normal};
+            use crate::values::{Auto, Either, None_, Normal};
             ${caller.body()}
         }
 
@@ -116,7 +116,7 @@
             % else:
             use smallvec::{IntoIter, SmallVec};
             % endif
-            use values::computed::ComputedVecIter;
+            use crate::values::computed::ComputedVecIter;
 
             /// The generic type defining the value for this property.
             ///
@@ -148,9 +148,9 @@
                 Sorry, this is stupid but needed for now.
             % endif
 
-            use properties::animated_properties::ListAnimation;
-            use values::animated::{Animate, ToAnimatedValue, ToAnimatedZero, Procedure};
-            use values::distance::{SquaredDistance, ComputeSquaredDistance};
+            use crate::properties::animated_properties::ListAnimation;
+            use crate::values::animated::{Animate, ToAnimatedValue, ToAnimatedZero, Procedure};
+            use crate::values::distance::{SquaredDistance, ComputeSquaredDistance};
 
             // FIXME(emilio): For some reason rust thinks that this alias is
             // unused, even though it's clearly used below?
@@ -235,7 +235,7 @@
                 }
             % endif
 
-            ::style_traits::${separator}::parse(input, |parser| {
+            style_traits::${separator}::parse(input, |parser| {
                 single_value::parse(context, parser)
             }).map(SpecifiedValue)
         }
@@ -279,21 +279,21 @@
         #[allow(unused_imports)]
         use cssparser::{Parser, BasicParseError, Token};
         #[allow(unused_imports)]
-        use parser::{Parse, ParserContext};
+        use crate::parser::{Parse, ParserContext};
         #[allow(unused_imports)]
-        use properties::{UnparsedValue, ShorthandId};
+        use crate::properties::{UnparsedValue, ShorthandId};
         #[allow(unused_imports)]
-        use values::{Auto, Either, None_, Normal};
+        use crate::values::{Auto, Either, None_, Normal};
         #[allow(unused_imports)]
-        use error_reporting::ParseErrorReporter;
+        use crate::error_reporting::ParseErrorReporter;
         #[allow(unused_imports)]
-        use properties::longhands;
+        use crate::properties::longhands;
         #[allow(unused_imports)]
-        use properties::{LonghandId, LonghandIdSet};
+        use crate::properties::{LonghandId, LonghandIdSet};
         #[allow(unused_imports)]
-        use properties::{CSSWideKeyword, ComputedValues, PropertyDeclaration};
+        use crate::properties::{CSSWideKeyword, ComputedValues, PropertyDeclaration};
         #[allow(unused_imports)]
-        use properties::style_structs;
+        use crate::properties::style_structs;
         #[allow(unused_imports)]
         use selectors::parser::SelectorParseErrorKind;
         #[allow(unused_imports)]
@@ -301,11 +301,11 @@
         #[allow(unused_imports)]
         use style_traits::{ParseError, StyleParseErrorKind};
         #[allow(unused_imports)]
-        use values::computed::{Context, ToComputedValue};
+        use crate::values::computed::{Context, ToComputedValue};
         #[allow(unused_imports)]
-        use values::{computed, generics, specified};
+        use crate::values::{computed, generics, specified};
         #[allow(unused_imports)]
-        use Atom;
+        use crate::Atom;
         ${caller.body()}
         #[allow(unused_variables)]
         pub fn cascade_property(
@@ -428,7 +428,7 @@
         keyword = keyword=Keyword(name, values, **keyword_kwargs)
     %>
     <%call expr="longhand(name, keyword=Keyword(name, values, **keyword_kwargs), **kwargs)">
-        use properties::longhands::system_font::SystemFont;
+        use crate::properties::longhands::system_font::SystemFont;
 
         pub mod computed_value {
             #[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
@@ -511,7 +511,7 @@
         ///
         /// Intended for use with presentation attributes, not style structs
         pub fn from_gecko_keyword(kw: u32) -> Self {
-            use gecko_bindings::structs;
+            use crate::gecko_bindings::structs;
             % for value in values:
                 // We can't match on enum values if we're matching on a u32
                 const ${to_rust_ident(value).upper()}: ${const_type}
@@ -535,7 +535,7 @@
         /// Intended for use with presentation attributes, not style structs
         pub fn from_gecko_keyword(kw: ${kw_type}) -> Self {
             % for gecko_bit in bit_map.values():
-            use gecko_bindings::structs::${gecko_bit_prefix}${gecko_bit};
+            use crate::gecko_bindings::structs::${gecko_bit_prefix}${gecko_bit};
             % endfor
 
             let mut bits = ${type}::empty();
@@ -549,7 +549,7 @@
 
         pub fn to_gecko_keyword(self) -> ${kw_type} {
             % for gecko_bit in bit_map.values():
-            use gecko_bindings::structs::${gecko_bit_prefix}${gecko_bit};
+            use crate::gecko_bindings::structs::${gecko_bit_prefix}${gecko_bit};
             % endfor
 
             let mut bits: ${kw_type} = 0;
@@ -668,8 +668,8 @@
     /// ${shorthand.spec}
     pub mod ${shorthand.ident} {
         use cssparser::Parser;
-        use parser::ParserContext;
-        use properties::{PropertyDeclaration, SourcePropertyDeclaration, MaybeBoxed, longhands};
+        use crate::parser::ParserContext;
+        use crate::properties::{PropertyDeclaration, SourcePropertyDeclaration, MaybeBoxed, longhands};
         #[allow(unused_imports)]
         use selectors::parser::SelectorParseErrorKind;
         #[allow(unused_imports)]
@@ -772,7 +772,7 @@
             input: &mut Parser<'i, 't>,
         ) -> Result<(), ParseError<'i>> {
             #[allow(unused_imports)]
-            use properties::{NonCustomPropertyId, LonghandId};
+            use crate::properties::{NonCustomPropertyId, LonghandId};
             input.parse_entirely(|input| parse_value(context, input)).map(|longhands| {
                 % for sub_property in shorthand.sub_properties:
                 % if sub_property.may_be_disabled_in(shorthand, product):
@@ -798,9 +798,9 @@
     <% sub_properties=' '.join(sub_property_pattern % side for side in PHYSICAL_SIDES) %>
     <%call expr="self.shorthand(name, sub_properties=sub_properties, **kwargs)">
         #[allow(unused_imports)]
-        use parser::Parse;
-        use values::generics::rect::Rect;
-        use values::specified;
+        use crate::parser::Parse;
+        use crate::values::generics::rect::Rect;
+        use crate::values::specified;
 
         pub fn parse_value<'i, 't>(
             context: &ParserContext,
@@ -852,7 +852,7 @@
             return to_rust_ident(name.replace(side, phy_side).replace("inset-", ""))
     %>
     % if side is not None:
-        use logical_geometry::PhysicalSide;
+        use crate::logical_geometry::PhysicalSide;
         match wm.${to_rust_ident(side)}_physical_side() {
             % for phy_side in PHYSICAL_SIDES:
                 PhysicalSide::${phy_side.title()} => {

--- a/components/style/properties/helpers/animated_properties.mako.rs
+++ b/components/style/properties/helpers/animated_properties.mako.rs
@@ -9,40 +9,40 @@
     from itertools import groupby
 %>
 
-#[cfg(feature = "gecko")] use gecko_bindings::structs::RawServoAnimationValueMap;
-#[cfg(feature = "gecko")] use gecko_bindings::structs::RawGeckoGfxMatrix4x4;
-#[cfg(feature = "gecko")] use gecko_bindings::structs::nsCSSPropertyID;
-#[cfg(feature = "gecko")] use gecko_bindings::sugar::ownership::{HasFFI, HasSimpleFFI};
+#[cfg(feature = "gecko")] use crate::gecko_bindings::structs::RawServoAnimationValueMap;
+#[cfg(feature = "gecko")] use crate::gecko_bindings::structs::RawGeckoGfxMatrix4x4;
+#[cfg(feature = "gecko")] use crate::gecko_bindings::structs::nsCSSPropertyID;
+#[cfg(feature = "gecko")] use crate::gecko_bindings::sugar::ownership::{HasFFI, HasSimpleFFI};
 use itertools::{EitherOrBoth, Itertools};
 use num_traits::Zero;
-use properties::{CSSWideKeyword, PropertyDeclaration};
-use properties::longhands;
-use properties::longhands::visibility::computed_value::T as Visibility;
-use properties::LonghandId;
+use crate::properties::{CSSWideKeyword, PropertyDeclaration};
+use crate::properties::longhands;
+use crate::properties::longhands::visibility::computed_value::T as Visibility;
+use crate::properties::LonghandId;
 use servo_arc::Arc;
 use smallvec::SmallVec;
 use std::{cmp, ptr};
 use std::mem::{self, ManuallyDrop};
-use hash::FxHashMap;
+use crate::hash::FxHashMap;
 use super::ComputedValues;
-use values::CSSFloat;
-use values::animated::{Animate, Procedure, ToAnimatedValue, ToAnimatedZero};
-use values::animated::effects::Filter as AnimatedFilter;
-#[cfg(feature = "gecko")] use values::computed::TransitionProperty;
-use values::computed::Angle;
-use values::computed::{ClipRect, Context};
-use values::computed::{Length, LengthOrPercentage};
-use values::computed::{Number, Percentage};
-use values::computed::ToComputedValue;
-use values::computed::transform::{DirectionVector, Matrix, Matrix3D};
-use values::computed::transform::TransformOperation as ComputedTransformOperation;
-use values::computed::transform::Transform as ComputedTransform;
-use values::computed::transform::Rotate as ComputedRotate;
-use values::computed::transform::Translate as ComputedTranslate;
-use values::computed::transform::Scale as ComputedScale;
-use values::generics::transform::{self, Rotate, Translate, Scale, Transform, TransformOperation};
-use values::distance::{ComputeSquaredDistance, SquaredDistance};
-use values::generics::effects::Filter;
+use crate::values::CSSFloat;
+use crate::values::animated::{Animate, Procedure, ToAnimatedValue, ToAnimatedZero};
+use crate::values::animated::effects::Filter as AnimatedFilter;
+#[cfg(feature = "gecko")] use crate::values::computed::TransitionProperty;
+use crate::values::computed::Angle;
+use crate::values::computed::{ClipRect, Context};
+use crate::values::computed::{Length, LengthOrPercentage};
+use crate::values::computed::{Number, Percentage};
+use crate::values::computed::ToComputedValue;
+use crate::values::computed::transform::{DirectionVector, Matrix, Matrix3D};
+use crate::values::computed::transform::TransformOperation as ComputedTransformOperation;
+use crate::values::computed::transform::Transform as ComputedTransform;
+use crate::values::computed::transform::Rotate as ComputedRotate;
+use crate::values::computed::transform::Translate as ComputedTranslate;
+use crate::values::computed::transform::Scale as ComputedScale;
+use crate::values::generics::transform::{self, Rotate, Translate, Scale, Transform, TransformOperation};
+use crate::values::distance::{ComputeSquaredDistance, SquaredDistance};
+use crate::values::generics::effects::Filter;
 use void::{self, Void};
 
 /// Convert nsCSSPropertyID to TransitionProperty
@@ -357,7 +357,7 @@ impl AnimationValue {
     /// "Uncompute" this animation value in order to be used inside the CSS
     /// cascade.
     pub fn uncompute(&self) -> PropertyDeclaration {
-        use properties::longhands;
+        use crate::properties::longhands;
         use self::AnimationValue::*;
 
         use super::PropertyDeclarationVariantRepr;
@@ -401,7 +401,7 @@ impl AnimationValue {
     pub fn from_declaration(
         decl: &PropertyDeclaration,
         context: &mut Context,
-        extra_custom_properties: Option<<&Arc<::custom_properties::CustomPropertiesMap>>,
+        extra_custom_properties: Option<<&Arc<crate::custom_properties::CustomPropertiesMap>>,
         initial: &ComputedValues
     ) -> Option<Self> {
         use super::PropertyDeclarationVariantRepr;
@@ -815,7 +815,7 @@ impl ToAnimatedZero for Visibility {
 impl Animate for ClipRect {
     #[inline]
     fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
-        use values::computed::Length;
+        use crate::values::computed::Length;
         let animate_component = |this: &Option<Length>, other: &Option<Length>| {
             match (this.animate(other, procedure)?, procedure) {
                 (None, Procedure::Interpolate { .. }) => Ok(None),
@@ -1070,8 +1070,8 @@ impl Animate for ComputedTransformOperation {
                 &TransformOperation::Perspective(ref fd),
                 &TransformOperation::Perspective(ref td),
             ) => {
-                use values::computed::CSSPixelLength;
-                use values::generics::transform::create_perspective_matrix;
+                use crate::values::computed::CSSPixelLength;
+                use crate::values::generics::transform::create_perspective_matrix;
 
                 // From https://drafts.csswg.org/css-transforms-2/#interpolation-of-transform-functions:
                 //
@@ -1246,7 +1246,7 @@ impl ComputeSquaredDistance for MatrixDecomposed2D {
     #[inline]
     fn compute_squared_distance(&self, other: &Self) -> Result<SquaredDistance, ()> {
         // Use Radian to compute the distance.
-        const RAD_PER_DEG: f64 = ::std::f64::consts::PI / 180.0;
+        const RAD_PER_DEG: f64 = std::f64::consts::PI / 180.0;
         let angle1 = self.angle as f64 * RAD_PER_DEG;
         let angle2 = other.angle as f64 * RAD_PER_DEG;
         Ok(self.translate.compute_squared_distance(&other.translate)? +

--- a/components/style/properties/longhands/border.mako.rs
+++ b/components/style/properties/longhands/border.mako.rs
@@ -48,8 +48,8 @@
     ${helpers.predefined_type(
         "border-%s-width" % side_name,
         "BorderSideWidth",
-        "::values::computed::NonNegativeLength::new(3.)",
-        computed_type="::values::computed::NonNegativeLength",
+        "crate::values::computed::NonNegativeLength::new(3.)",
+        computed_type="crate::values::computed::NonNegativeLength",
         alias=maybe_moz_logical_alias(product, side, "-moz-border-%s-width"),
         spec=maybe_logical_spec(side, "width"),
         animation_value_type="NonNegativeLength",
@@ -64,7 +64,7 @@
 ${helpers.gecko_keyword_conversion(
     Keyword('border-style',
     "none solid double dotted dashed hidden groove ridge inset outset"),
-    type="::values::specified::BorderStyle",
+    type="crate::values::specified::BorderStyle",
 )}
 
 // FIXME(#4126): when gfx supports painting it, make this Size2D<LengthOrPercentage>
@@ -160,11 +160,11 @@ ${helpers.predefined_type(
 )}
 
 #[cfg(feature = "gecko")]
-impl ::values::computed::BorderImageWidth {
-    pub fn to_gecko_rect(&self, sides: &mut ::gecko_bindings::structs::nsStyleSides) {
-        use gecko_bindings::sugar::ns_style_coord::{CoordDataMut, CoordDataValue};
-        use gecko::values::GeckoStyleCoordConvertible;
-        use values::generics::border::BorderImageSideWidth;
+impl crate::values::computed::BorderImageWidth {
+    pub fn to_gecko_rect(&self, sides: &mut crate::gecko_bindings::structs::nsStyleSides) {
+        use crate::gecko_bindings::sugar::ns_style_coord::{CoordDataMut, CoordDataValue};
+        use crate::gecko::values::GeckoStyleCoordConvertible;
+        use crate::values::generics::border::BorderImageSideWidth;
 
         % for i in range(0, 4):
         match self.${i} {
@@ -182,16 +182,16 @@ impl ::values::computed::BorderImageWidth {
     }
 
     pub fn from_gecko_rect(
-        sides: &::gecko_bindings::structs::nsStyleSides,
-    ) -> Option<::values::computed::BorderImageWidth> {
-        use gecko_bindings::structs::nsStyleUnit::{eStyleUnit_Factor, eStyleUnit_Auto};
-        use gecko_bindings::sugar::ns_style_coord::CoordData;
-        use gecko::values::GeckoStyleCoordConvertible;
-        use values::computed::{LengthOrPercentage, Number};
-        use values::generics::border::BorderImageSideWidth;
+        sides: &crate::gecko_bindings::structs::nsStyleSides,
+    ) -> Option<crate::values::computed::BorderImageWidth> {
+        use crate::gecko_bindings::structs::nsStyleUnit::{eStyleUnit_Factor, eStyleUnit_Auto};
+        use crate::gecko_bindings::sugar::ns_style_coord::CoordData;
+        use crate::gecko::values::GeckoStyleCoordConvertible;
+        use crate::values::computed::{LengthOrPercentage, Number};
+        use crate::values::generics::border::BorderImageSideWidth;
 
         Some(
-            ::values::computed::BorderImageWidth::new(
+            crate::values::computed::BorderImageWidth::new(
                 % for i in range(0, 4):
                 match sides.data_at(${i}).unit() {
                     eStyleUnit_Auto => {

--- a/components/style/properties/longhands/color.mako.rs
+++ b/components/style/properties/longhands/color.mako.rs
@@ -63,11 +63,11 @@ pub mod system_colors {
                           IMESelectedConvertedTextBackground IMESelectedConvertedTextForeground
                           IMESelectedConvertedTextUnderline SpellCheckerUnderline""".split()
     %>
-    use gecko_bindings::bindings::Gecko_GetLookAndFeelSystemColor;
-    use gecko_bindings::structs::root::mozilla::LookAndFeel_ColorID;
+    use crate::gecko_bindings::bindings::Gecko_GetLookAndFeelSystemColor;
+    use crate::gecko_bindings::structs::root::mozilla::LookAndFeel_ColorID;
     use std::fmt::{self, Write};
     use style_traits::{CssWriter, ToCss};
-    use values::computed::{Context, ToComputedValue};
+    use crate::values::computed::{Context, ToComputedValue};
 
     pub type SystemColor = LookAndFeel_ColorID;
 

--- a/components/style/properties/longhands/column.mako.rs
+++ b/components/style/properties/longhands/column.mako.rs
@@ -43,9 +43,9 @@ ${helpers.single_keyword(
 ${helpers.predefined_type(
     "column-rule-width",
     "BorderSideWidth",
-    "::values::computed::NonNegativeLength::new(3.)",
+    "crate::values::computed::NonNegativeLength::new(3.)",
     initial_specified_value="specified::BorderSideWidth::Medium",
-    computed_type="::values::computed::NonNegativeLength",
+    computed_type="crate::values::computed::NonNegativeLength",
     products="gecko",
     spec="https://drafts.csswg.org/css-multicol/#propdef-column-rule-width",
     animation_value_type="NonNegativeLength",

--- a/components/style/properties/longhands/font.mako.rs
+++ b/components/style/properties/longhands/font.mako.rs
@@ -326,12 +326,12 @@ ${helpers.predefined_type(
 
         use app_units::Au;
         use cssparser::{Parser, ToCss};
-        use gecko_bindings::structs::FontFamilyType;
-        use properties::longhands;
+        use crate::gecko_bindings::structs::FontFamilyType;
+        use crate::properties::longhands;
         use std::fmt;
         use std::hash::{Hash, Hasher};
         use style_traits::ParseError;
-        use values::computed::{ToComputedValue, Context};
+        use crate::values::computed::{ToComputedValue, Context};
 
         <%
             system_fonts = """caption icon menu message-box small-caption status-bar
@@ -375,12 +375,12 @@ ${helpers.predefined_type(
             type ComputedValue = ComputedSystemFont;
 
             fn to_computed_value(&self, cx: &Context) -> Self::ComputedValue {
-                use gecko_bindings::bindings;
-                use gecko_bindings::structs::{LookAndFeel_FontID, nsFont};
+                use crate::gecko_bindings::bindings;
+                use crate::gecko_bindings::structs::{LookAndFeel_FontID, nsFont};
                 use std::mem;
-                use values::computed::Percentage;
-                use values::computed::font::{FontSize, FontStretch, FontStyle, FontFamilyList};
-                use values::generics::NonNegative;
+                use crate::values::computed::Percentage;
+                use crate::values::computed::font::{FontSize, FontStretch, FontStyle, FontFamilyList};
+                use crate::values::generics::NonNegative;
 
                 let id = match *self {
                     % for font in system_fonts:

--- a/components/style/properties/longhands/inherited_svg.mako.rs
+++ b/components/style/properties/longhands/inherited_svg.mako.rs
@@ -39,7 +39,7 @@ ${helpers.single_keyword(
 ${helpers.predefined_type(
     "fill",
     "SVGPaint",
-    "::values::computed::SVGPaint::black()",
+    "crate::values::computed::SVGPaint::black()",
     products="gecko",
     animation_value_type="IntermediateSVGPaint",
     boxed=True,
@@ -87,7 +87,7 @@ ${helpers.predefined_type(
     "stroke-width", "SVGWidth",
     "computed::SVGWidth::one()",
     products="gecko",
-    animation_value_type="::values::computed::SVGWidth",
+    animation_value_type="crate::values::computed::SVGWidth",
     spec="https://www.w3.org/TR/SVG2/painting.html#StrokeWidth",
 )}
 
@@ -112,7 +112,7 @@ ${helpers.predefined_type(
     "GreaterThanOrEqualToOneNumber",
     "From::from(4.0)",
     products="gecko",
-    animation_value_type="::values::computed::GreaterThanOrEqualToOneNumber",
+    animation_value_type="crate::values::computed::GreaterThanOrEqualToOneNumber",
     spec="https://www.w3.org/TR/SVG11/painting.html#StrokeMiterlimitProperty",
 )}
 
@@ -130,7 +130,7 @@ ${helpers.predefined_type(
     "SVGStrokeDashArray",
     "Default::default()",
     products="gecko",
-    animation_value_type="::values::computed::SVGStrokeDashArray",
+    animation_value_type="crate::values::computed::SVGStrokeDashArray",
     spec="https://www.w3.org/TR/SVG2/painting.html#StrokeDashing",
 )}
 

--- a/components/style/properties/longhands/inherited_text.mako.rs
+++ b/components/style/properties/longhands/inherited_text.mako.rs
@@ -293,9 +293,9 @@ ${helpers.predefined_type(
 ${helpers.predefined_type(
     "-webkit-text-stroke-width",
     "BorderSideWidth",
-    "::values::computed::NonNegativeLength::new(0.)",
+    "crate::values::computed::NonNegativeLength::new(0.)",
     initial_specified_value="specified::BorderSideWidth::Length(specified::Length::zero())",
-    computed_type="::values::computed::NonNegativeLength",
+    computed_type="crate::values::computed::NonNegativeLength",
     products="gecko",
     gecko_pref="layout.css.prefixes.webkit",
     flags="APPLIES_TO_FIRST_LETTER APPLIES_TO_FIRST_LINE APPLIES_TO_PLACEHOLDER",

--- a/components/style/properties/longhands/outline.mako.rs
+++ b/components/style/properties/longhands/outline.mako.rs
@@ -32,9 +32,9 @@ ${helpers.predefined_type(
 ${helpers.predefined_type(
     "outline-width",
     "BorderSideWidth",
-    "::values::computed::NonNegativeLength::new(3.)",
+    "crate::values::computed::NonNegativeLength::new(3.)",
     initial_specified_value="specified::BorderSideWidth::Medium",
-    computed_type="::values::computed::NonNegativeLength",
+    computed_type="crate::values::computed::NonNegativeLength",
     animation_value_type="NonNegativeLength",
     spec="https://drafts.csswg.org/css-ui/#propdef-outline-width",
 )}
@@ -55,7 +55,7 @@ ${helpers.predefined_type(
 ${helpers.predefined_type(
     "outline-offset",
     "Length",
-    "::values::computed::Length::new(0.)",
+    "crate::values::computed::Length::new(0.)",
     products="servo gecko",
     animation_value_type="ComputedValue",
     spec="https://drafts.csswg.org/css-ui/#propdef-outline-offset",

--- a/components/style/properties/longhands/position.mako.rs
+++ b/components/style/properties/longhands/position.mako.rs
@@ -42,7 +42,7 @@ macro_rules! impl_align_conversions {
     ($name: path) => {
         impl From<u8> for $name {
             fn from(bits: u8) -> $name {
-                $name(::values::specified::align::AlignFlags::from_bits(bits)
+                $name(crate::values::specified::align::AlignFlags::from_bits(bits)
                       .expect("bits contain valid flag"))
             }
         }
@@ -149,7 +149,7 @@ ${helpers.single_keyword(
     )}
 
     #[cfg(feature = "gecko")]
-    impl_align_conversions!(::values::specified::align::AlignItems);
+    impl_align_conversions!(crate::values::specified::align::AlignItems);
 
     ${helpers.predefined_type(
         "justify-items",
@@ -160,7 +160,7 @@ ${helpers.single_keyword(
     )}
 
     #[cfg(feature = "gecko")]
-    impl_align_conversions!(::values::specified::align::JustifyItems);
+    impl_align_conversions!(crate::values::specified::align::JustifyItems);
 % endif
 
 // Flex item properties
@@ -214,7 +214,7 @@ ${helpers.predefined_type(
     )}
 
     #[cfg(feature = "gecko")]
-    impl_align_conversions!(::values::specified::align::SelfAlignment);
+    impl_align_conversions!(crate::values::specified::align::SelfAlignment);
 % endif
 
 // https://drafts.csswg.org/css-flexbox/#propdef-order

--- a/components/style/properties/shorthands/background.mako.rs
+++ b/components/style/properties/shorthands/background.mako.rs
@@ -10,13 +10,13 @@
                                     background-attachment background-image background-size background-origin
                                     background-clip"
                     spec="https://drafts.csswg.org/css-backgrounds/#the-background">
-    use properties::longhands::{background_position_x, background_position_y, background_repeat};
-    use properties::longhands::{background_attachment, background_image, background_size, background_origin};
-    use properties::longhands::background_clip;
-    use properties::longhands::background_clip::single_value::computed_value::T as Clip;
-    use properties::longhands::background_origin::single_value::computed_value::T as Origin;
-    use values::specified::{Color, Position, PositionComponent};
-    use parser::Parse;
+    use crate::properties::longhands::{background_position_x, background_position_y, background_repeat};
+    use crate::properties::longhands::{background_attachment, background_image, background_size, background_origin};
+    use crate::properties::longhands::background_clip;
+    use crate::properties::longhands::background_clip::single_value::computed_value::T as Clip;
+    use crate::properties::longhands::background_origin::single_value::computed_value::T as Origin;
+    use crate::values::specified::{Color, Position, PositionComponent};
+    use crate::parser::Parse;
 
     // FIXME(emilio): Should be the same type!
     impl From<background_origin::single_value::SpecifiedValue> for background_clip::single_value::SpecifiedValue {
@@ -199,9 +199,9 @@
                     flags="SHORTHAND_IN_GETCS"
                     sub_properties="background-position-x background-position-y"
                     spec="https://drafts.csswg.org/css-backgrounds-4/#the-background-position">
-    use properties::longhands::{background_position_x, background_position_y};
-    use values::specified::AllowQuirks;
-    use values::specified::position::Position;
+    use crate::properties::longhands::{background_position_x, background_position_y};
+    use crate::values::specified::AllowQuirks;
+    use crate::values::specified::position::Position;
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,

--- a/components/style/properties/shorthands/border.mako.rs
+++ b/components/style/properties/shorthands/border.mako.rs
@@ -21,8 +21,8 @@ ${helpers.four_sides_shorthand(
         ' '.join('border-%s-width' % side
                  for side in PHYSICAL_SIDES)}"
     spec="https://drafts.csswg.org/css-backgrounds/#border-width">
-    use values::generics::rect::Rect;
-    use values::specified::{AllowQuirks, BorderSideWidth};
+    use crate::values::generics::rect::Rect;
+    use crate::values::specified::{AllowQuirks, BorderSideWidth};
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,
@@ -54,7 +54,7 @@ pub fn parse_border<'i, 't>(
     context: &ParserContext,
     input: &mut Parser<'i, 't>,
 ) -> Result<(specified::Color, specified::BorderStyle, specified::BorderSideWidth), ParseError<'i>> {
-    use values::specified::{Color, BorderStyle, BorderSideWidth};
+    use crate::values::specified::{Color, BorderStyle, BorderSideWidth};
     let _unused = context;
     let mut color = None;
     let mut style = None;
@@ -147,8 +147,8 @@ pub fn parse_border<'i, 't>(
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Longhands, ParseError<'i>> {
-        use properties::longhands::{border_image_outset, border_image_repeat, border_image_slice};
-        use properties::longhands::{border_image_source, border_image_width};
+        use crate::properties::longhands::{border_image_outset, border_image_repeat, border_image_slice};
+        use crate::properties::longhands::{border_image_source, border_image_width};
 
         let (color, style, width) = super::parse_border(context, input)?;
         Ok(expanded! {
@@ -206,7 +206,7 @@ pub fn parse_border<'i, 't>(
     // Just use the same as border-left. The border shorthand can't accept
     // any value that the sub-shorthand couldn't.
     <%
-        border_left = "<::properties::shorthands::border_left::Longhands as SpecifiedValueInfo>"
+        border_left = "<crate::properties::shorthands::border_left::Longhands as SpecifiedValueInfo>"
     %>
     impl SpecifiedValueInfo for Longhands {
         const SUPPORTED_TYPES: u8 = ${border_left}::SUPPORTED_TYPES;
@@ -220,10 +220,10 @@ pub fn parse_border<'i, 't>(
     'border-%s-radius' % (corner)
      for corner in ['top-left', 'top-right', 'bottom-right', 'bottom-left']
 )}" extra_prefixes="webkit" spec="https://drafts.csswg.org/css-backgrounds/#border-radius">
-    use values::generics::rect::Rect;
-    use values::generics::border::BorderCornerRadius;
-    use values::specified::border::BorderRadius;
-    use parser::Parse;
+    use crate::values::generics::rect::Rect;
+    use crate::values::generics::border::BorderCornerRadius;
+    use crate::values::specified::border::BorderRadius;
+    use crate::parser::Parse;
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,
@@ -260,8 +260,8 @@ pub fn parse_border<'i, 't>(
     border-image-repeat border-image-slice border-image-source border-image-width"
     extra_prefixes="moz:layout.css.prefixes.border-image webkit"
     spec="https://drafts.csswg.org/css-backgrounds-3/#border-image">
-    use properties::longhands::{border_image_outset, border_image_repeat, border_image_slice};
-    use properties::longhands::{border_image_source, border_image_width};
+    use crate::properties::longhands::{border_image_outset, border_image_repeat, border_image_slice};
+    use crate::properties::longhands::{border_image_source, border_image_width};
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,

--- a/components/style/properties/shorthands/box.mako.rs
+++ b/components/style/properties/shorthands/box.mako.rs
@@ -10,9 +10,9 @@
     sub_properties="overflow-x overflow-y"
     spec="https://drafts.csswg.org/css-overflow/#propdef-overflow"
 >
-    use properties::longhands::overflow_x::parse as parse_overflow;
+    use crate::properties::longhands::overflow_x::parse as parse_overflow;
     % if product == "gecko":
-        use properties::longhands::overflow_x::SpecifiedValue;
+        use crate::properties::longhands::overflow_x::SpecifiedValue;
     % endif
 
     pub fn parse_value<'i, 't>(
@@ -20,7 +20,7 @@
         input: &mut Parser<'i, 't>,
     ) -> Result<Longhands, ParseError<'i>> {
         % if product == "gecko":
-            use gecko_bindings::structs;
+            use crate::gecko_bindings::structs;
             let moz_kw_enabled = unsafe {
                 structs::StaticPrefs_sVarCache_layout_css_overflow_moz_scrollbars_enabled
             };
@@ -82,7 +82,7 @@
          "(https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-clip-box)"
     products="gecko"
 >
-    use values::specified::OverflowClipBox;
+    use crate::values::specified::OverflowClipBox;
     pub fn parse_value<'i, 't>(
         _: &ParserContext,
         input: &mut Parser<'i, 't>,
@@ -130,11 +130,11 @@ macro_rules! try_parse_one {
                                     transition-timing-function
                                     transition-delay"
                     spec="https://drafts.csswg.org/css-transitions/#propdef-transition">
-    use parser::Parse;
+    use crate::parser::Parse;
     % for prop in "delay duration property timing_function".split():
-    use properties::longhands::transition_${prop};
+    use crate::properties::longhands::transition_${prop};
     % endfor
-    use values::specified::TransitionProperty;
+    use crate::values::specified::TransitionProperty;
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,
@@ -282,7 +282,7 @@ macro_rules! try_parse_one {
                  direction fill_mode play_state".split()
     %>
     % for prop in props:
-    use properties::longhands::animation_${prop};
+    use crate::properties::longhands::animation_${prop};
     % endfor
 
     pub fn parse_value<'i, 't>(
@@ -391,7 +391,7 @@ macro_rules! try_parse_one {
                     gecko_pref="layout.css.scroll-snap.enabled"
                     sub_properties="scroll-snap-type-x scroll-snap-type-y"
                     spec="https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-snap-type">
-    use properties::longhands::scroll_snap_type_x;
+    use crate::properties::longhands::scroll_snap_type_x;
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,
@@ -425,7 +425,7 @@ macro_rules! try_parse_one {
         _: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Longhands, ParseError<'i>> {
-        use values::specified::OverscrollBehavior;
+        use crate::values::specified::OverscrollBehavior;
         let behavior_x = OverscrollBehavior::parse(input)?;
         let behavior_y = input.try(OverscrollBehavior::parse).unwrap_or(behavior_x);
         Ok(expanded! {

--- a/components/style/properties/shorthands/column.mako.rs
+++ b/components/style/properties/shorthands/column.mako.rs
@@ -9,7 +9,7 @@
                     servo_pref="layout.columns.enabled",
                     derive_serialize="True"
                     extra_prefixes="moz" spec="https://drafts.csswg.org/css-multicol/#propdef-columns">
-    use properties::longhands::{column_count, column_width};
+    use crate::properties::longhands::{column_count, column_width};
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,
@@ -59,8 +59,8 @@
     sub_properties="column-rule-width column-rule-style column-rule-color"
     derive_serialize="True"
     spec="https://drafts.csswg.org/css-multicol/#propdef-column-rule">
-    use properties::longhands::{column_rule_width, column_rule_style};
-    use properties::longhands::column_rule_color;
+    use crate::properties::longhands::{column_rule_width, column_rule_style};
+    use crate::properties::longhands::column_rule_color;
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,

--- a/components/style/properties/shorthands/font.mako.rs
+++ b/components/style/properties/shorthands/font.mako.rs
@@ -21,14 +21,14 @@
                                     ${'font-variation-settings' if product == 'gecko' else ''}"
                     derive_value_info="False"
                     spec="https://drafts.csswg.org/css-fonts-3/#propdef-font">
-    use parser::Parse;
-    use properties::longhands::{font_family, font_style, font_weight, font_stretch};
-    use properties::longhands::font_variant_caps;
+    use crate::parser::Parse;
+    use crate::properties::longhands::{font_family, font_style, font_weight, font_stretch};
+    use crate::properties::longhands::font_variant_caps;
     #[cfg(feature = "gecko")]
-    use properties::longhands::system_font::SystemFont;
-    use values::specified::text::LineHeight;
-    use values::specified::FontSize;
-    use values::specified::font::{FontStretch, FontStretchKeyword};
+    use crate::properties::longhands::system_font::SystemFont;
+    use crate::values::specified::text::LineHeight;
+    use crate::values::specified::FontSize;
+    use crate::values::specified::font::{FontStretch, FontStretchKeyword};
 
     <%
         gecko_sub_properties = "kerning language_override size_adjust \
@@ -39,7 +39,7 @@
     %>
     % if product == "gecko":
         % for prop in gecko_sub_properties:
-            use properties::longhands::font_${prop};
+            use crate::properties::longhands::font_${prop};
         % endfor
     % endif
     use self::font_family::SpecifiedValue as FontFamily;
@@ -301,10 +301,10 @@
     %>
 
 % for prop in sub_properties:
-    use properties::longhands::font_variant_${prop};
+    use crate::properties::longhands::font_variant_${prop};
 % endfor
     #[allow(unused_imports)]
-    use values::specified::FontVariantLigatures;
+    use crate::values::specified::FontVariantLigatures;
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,

--- a/components/style/properties/shorthands/inherited_svg.mako.rs
+++ b/components/style/properties/shorthands/inherited_svg.mako.rs
@@ -7,13 +7,13 @@
 <%helpers:shorthand name="marker" products="gecko"
     sub_properties="marker-start marker-end marker-mid"
     spec="https://www.w3.org/TR/SVG2/painting.html#MarkerShorthand">
-    use values::specified::url::UrlOrNone;
+    use crate::values::specified::url::UrlOrNone;
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Longhands, ParseError<'i>> {
-        use parser::Parse;
+        use crate::parser::Parse;
         let url = UrlOrNone::parse(context, input)?;
 
         Ok(expanded! {

--- a/components/style/properties/shorthands/inherited_text.mako.rs
+++ b/components/style/properties/shorthands/inherited_text.mako.rs
@@ -8,7 +8,7 @@
     sub_properties="text-emphasis-style text-emphasis-color"
     derive_serialize="True"
     spec="https://drafts.csswg.org/css-text-decor-3/#text-emphasis-property">
-    use properties::longhands::{text_emphasis_color, text_emphasis_style};
+    use crate::properties::longhands::{text_emphasis_color, text_emphasis_style};
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,
@@ -52,7 +52,7 @@
                     products="gecko"
                     derive_serialize="True"
                     spec="https://compat.spec.whatwg.org/#the-webkit-text-stroke">
-    use properties::longhands::{_webkit_text_stroke_color, _webkit_text_stroke_width};
+    use crate::properties::longhands::{_webkit_text_stroke_color, _webkit_text_stroke_width};
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,

--- a/components/style/properties/shorthands/list.mako.rs
+++ b/components/style/properties/shorthands/list.mako.rs
@@ -8,8 +8,8 @@
                     sub_properties="list-style-position list-style-image list-style-type"
                     derive_serialize="True"
                     spec="https://drafts.csswg.org/css-lists/#propdef-list-style">
-    use properties::longhands::{list_style_image, list_style_position, list_style_type};
-    use values::specified::url::ImageUrlOrNone;
+    use crate::properties::longhands::{list_style_image, list_style_position, list_style_type};
+    use crate::values::specified::url::ImageUrlOrNone;
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,
@@ -64,7 +64,7 @@
             % if product == "servo":
             list_style_type::SpecifiedValue::None
             % else:
-            use values::generics::CounterStyleOrNone;
+            use crate::values::generics::CounterStyleOrNone;
             list_style_type::SpecifiedValue::CounterStyle(CounterStyleOrNone::None)
             % endif
         }

--- a/components/style/properties/shorthands/outline.mako.rs
+++ b/components/style/properties/shorthands/outline.mako.rs
@@ -8,9 +8,9 @@
                     sub_properties="outline-color outline-style outline-width"
                     derive_serialize="True"
                     spec="https://drafts.csswg.org/css-ui/#propdef-outline">
-    use properties::longhands::{outline_color, outline_width, outline_style};
-    use values::specified;
-    use parser::Parse;
+    use crate::properties::longhands::{outline_color, outline_width, outline_style};
+    use crate::values::specified;
+    use crate::parser::Parse;
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,
@@ -62,9 +62,9 @@
     '-moz-outline-radius-%s' % corner
     for corner in ['topleft', 'topright', 'bottomright', 'bottomleft']
 )}" products="gecko" spec="Nonstandard (https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-outline-radius)">
-    use values::generics::rect::Rect;
-    use values::specified::border::BorderRadius;
-    use parser::Parse;
+    use crate::values::generics::rect::Rect;
+    use crate::values::specified::border::BorderRadius;
+    use crate::parser::Parse;
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,
@@ -81,7 +81,7 @@
 
     impl<'a> ToCss for LonghandsToSerialize<'a>  {
         fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result where W: fmt::Write {
-            use values::generics::border::BorderCornerRadius;
+            use crate::values::generics::border::BorderCornerRadius;
 
             let LonghandsToSerialize {
                 _moz_outline_radius_topleft: &BorderCornerRadius(ref tl),

--- a/components/style/properties/shorthands/position.mako.rs
+++ b/components/style/properties/shorthands/position.mako.rs
@@ -9,7 +9,7 @@
                     extra_prefixes="webkit"
                     derive_serialize="True"
                     spec="https://drafts.csswg.org/css-flexbox/#flex-flow-property">
-    use properties::longhands::{flex_direction, flex_wrap};
+    use crate::properties::longhands::{flex_direction, flex_wrap};
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,
@@ -48,9 +48,9 @@
                     extra_prefixes="webkit"
                     derive_serialize="True"
                     spec="https://drafts.csswg.org/css-flexbox/#flex-property">
-    use parser::Parse;
-    use values::specified::NonNegativeNumber;
-    use properties::longhands::flex_basis::SpecifiedValue as FlexBasis;
+    use crate::parser::Parse;
+    use crate::values::specified::NonNegativeNumber;
+    use crate::properties::longhands::flex_basis::SpecifiedValue as FlexBasis;
 
     fn parse_flexibility<'i, 't>(
         context: &ParserContext,
@@ -111,7 +111,7 @@
 <%helpers:shorthand name="gap" alias="grid-gap" sub_properties="row-gap column-gap"
                     spec="https://drafts.csswg.org/css-align-3/#gap-shorthand"
                     products="gecko">
-  use properties::longhands::{row_gap, column_gap};
+  use crate::properties::longhands::{row_gap, column_gap};
 
   pub fn parse_value<'i, 't>(context: &ParserContext, input: &mut Parser<'i, 't>)
                              -> Result<Longhands, ParseError<'i>> {
@@ -142,8 +142,8 @@
 <%helpers:shorthand name="grid-${kind}" sub_properties="grid-${kind}-start grid-${kind}-end"
                     spec="https://drafts.csswg.org/css-grid/#propdef-grid-${kind}"
                     products="gecko">
-    use values::specified::GridLine;
-    use parser::Parse;
+    use crate::values::specified::GridLine;
+    use crate::parser::Parse;
 
     // NOTE: Since both the shorthands have the same code, we should (re-)use code from one to implement
     // the other. This might not be a big deal for now, but we should consider looking into this in the future
@@ -184,8 +184,8 @@
                     sub_properties="grid-row-start grid-row-end grid-column-start grid-column-end"
                     spec="https://drafts.csswg.org/css-grid/#propdef-grid-area"
                     products="gecko">
-    use values::specified::GridLine;
-    use parser::Parse;
+    use crate::values::specified::GridLine;
+    use crate::parser::Parse;
 
     // The code is the same as `grid-{row,column}` except that this can have four values at most.
     pub fn parse_value<'i, 't>(
@@ -251,14 +251,14 @@
                     sub_properties="grid-template-rows grid-template-columns grid-template-areas"
                     spec="https://drafts.csswg.org/css-grid/#propdef-grid-template"
                     products="gecko">
-    use parser::Parse;
+    use crate::parser::Parse;
     use servo_arc::Arc;
-    use values::{Either, None_};
-    use values::generics::grid::{LineNameList, TrackSize, TrackList, TrackListType};
-    use values::generics::grid::{TrackListValue, concat_serialize_idents};
-    use values::specified::{GridTemplateComponent, GenericGridTemplateComponent};
-    use values::specified::grid::parse_line_names;
-    use values::specified::position::{TemplateAreas, TemplateAreasArc};
+    use crate::values::{Either, None_};
+    use crate::values::generics::grid::{LineNameList, TrackSize, TrackList, TrackListType};
+    use crate::values::generics::grid::{TrackListValue, concat_serialize_idents};
+    use crate::values::specified::{GridTemplateComponent, GenericGridTemplateComponent};
+    use crate::values::specified::grid::parse_line_names;
+    use crate::values::specified::position::{TemplateAreas, TemplateAreasArc};
 
     /// Parsing for `<grid-template>` shorthand (also used by `grid` shorthand).
     pub fn parse_grid_template<'i, 't>(
@@ -484,12 +484,12 @@
                                     grid-auto-rows grid-auto-columns grid-auto-flow"
                     spec="https://drafts.csswg.org/css-grid/#propdef-grid"
                     products="gecko">
-    use parser::Parse;
-    use properties::longhands::{grid_auto_columns, grid_auto_rows, grid_auto_flow};
-    use values::{Either, None_};
-    use values::generics::grid::{GridTemplateComponent, TrackListType};
-    use values::specified::{GenericGridTemplateComponent, TrackSize};
-    use values::specified::position::{AutoFlow, GridAutoFlow};
+    use crate::parser::Parse;
+    use crate::properties::longhands::{grid_auto_columns, grid_auto_rows, grid_auto_flow};
+    use crate::values::{Either, None_};
+    use crate::values::generics::grid::{GridTemplateComponent, TrackListType};
+    use crate::values::specified::{GenericGridTemplateComponent, TrackSize};
+    use crate::values::specified::position::{AutoFlow, GridAutoFlow};
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,
@@ -636,7 +636,7 @@
 <%helpers:shorthand name="place-content" sub_properties="align-content justify-content"
                     spec="https://drafts.csswg.org/css-align/#propdef-place-content"
                     products="gecko">
-    use values::specified::align::{AlignContent, JustifyContent, ContentDistribution, AxisDirection};
+    use crate::values::specified::align::{AlignContent, JustifyContent, ContentDistribution, AxisDirection};
 
     pub fn parse_value<'i, 't>(
         _: &ParserContext,
@@ -688,7 +688,7 @@
 <%helpers:shorthand name="place-self" sub_properties="align-self justify-self"
                     spec="https://drafts.csswg.org/css-align/#place-self-property"
                     products="gecko">
-    use values::specified::align::{AlignSelf, JustifySelf, SelfAlignment, AxisDirection};
+    use crate::values::specified::align::{AlignSelf, JustifySelf, SelfAlignment, AxisDirection};
 
     pub fn parse_value<'i, 't>(
         _: &ParserContext,
@@ -726,8 +726,8 @@
 <%helpers:shorthand name="place-items" sub_properties="align-items justify-items"
                     spec="https://drafts.csswg.org/css-align/#place-items-property"
                     products="gecko">
-    use values::specified::align::{AlignItems, JustifyItems};
-    use parser::Parse;
+    use crate::values::specified::align::{AlignItems, JustifyItems};
+    use crate::parser::Parse;
 
     impl From<AlignItems> for JustifyItems {
         fn from(align: AlignItems) -> JustifyItems {

--- a/components/style/properties/shorthands/svg.mako.rs
+++ b/components/style/properties/shorthands/svg.mako.rs
@@ -9,11 +9,11 @@
                     sub_properties="mask-mode mask-repeat mask-clip mask-origin mask-composite mask-position-x
                                     mask-position-y mask-size mask-image"
                     spec="https://drafts.fxtf.org/css-masking/#propdef-mask">
-    use properties::longhands::{mask_mode, mask_repeat, mask_clip, mask_origin, mask_composite, mask_position_x,
+    use crate::properties::longhands::{mask_mode, mask_repeat, mask_clip, mask_origin, mask_composite, mask_position_x,
                                 mask_position_y};
-    use properties::longhands::{mask_size, mask_image};
-    use values::specified::{Position, PositionComponent};
-    use parser::Parse;
+    use crate::properties::longhands::{mask_size, mask_image};
+    use crate::values::specified::{Position, PositionComponent};
+    use crate::parser::Parse;
 
     // FIXME(emilio): These two mask types should be the same!
     impl From<mask_origin::single_value::SpecifiedValue> for mask_clip::single_value::SpecifiedValue {
@@ -125,8 +125,8 @@
 
     impl<'a> ToCss for LonghandsToSerialize<'a>  {
         fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result where W: fmt::Write {
-            use properties::longhands::mask_origin::single_value::computed_value::T as Origin;
-            use properties::longhands::mask_clip::single_value::computed_value::T as Clip;
+            use crate::properties::longhands::mask_origin::single_value::computed_value::T as Origin;
+            use crate::properties::longhands::mask_clip::single_value::computed_value::T as Clip;
 
             let len = self.mask_image.0.len();
             if len == 0 {
@@ -186,9 +186,9 @@
                     flags="SHORTHAND_IN_GETCS"
                     sub_properties="mask-position-x mask-position-y"
                     spec="https://drafts.csswg.org/css-masks-4/#the-mask-position">
-    use properties::longhands::{mask_position_x,mask_position_y};
-    use values::specified::position::Position;
-    use parser::Parse;
+    use crate::properties::longhands::{mask_position_x,mask_position_y};
+    use crate::values::specified::position::Position;
+    use crate::parser::Parse;
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,

--- a/components/style/properties/shorthands/text.mako.rs
+++ b/components/style/properties/shorthands/text.mako.rs
@@ -11,10 +11,10 @@
                     spec="https://drafts.csswg.org/css-text-decor/#propdef-text-decoration">
 
     % if product == "gecko":
-        use values::specified;
-        use properties::longhands::{text_decoration_line, text_decoration_style, text_decoration_color};
+        use crate::values::specified;
+        use crate::properties::longhands::{text_decoration_line, text_decoration_style, text_decoration_color};
     % else:
-        use properties::longhands::text_decoration_line;
+        use crate::properties::longhands::text_decoration_line;
     % endif
 
     pub fn parse_value<'i, 't>(

--- a/components/style/rule_cache.rs
+++ b/components/style/rule_cache.rs
@@ -5,15 +5,15 @@
 //! A cache from rule node to computed values, in order to cache reset
 //! properties.
 
+use crate::logical_geometry::WritingMode;
+use crate::properties::{ComputedValues, StyleBuilder};
+use crate::rule_tree::StrongRuleNode;
+use crate::selector_parser::PseudoElement;
+use crate::shared_lock::StylesheetGuards;
+use crate::values::computed::NonNegativeLength;
 use fxhash::FxHashMap;
-use logical_geometry::WritingMode;
-use properties::{ComputedValues, StyleBuilder};
-use rule_tree::StrongRuleNode;
-use selector_parser::PseudoElement;
 use servo_arc::Arc;
-use shared_lock::StylesheetGuards;
 use smallvec::SmallVec;
-use values::computed::NonNegativeLength;
 
 /// The conditions for caching and matching a style in the rule cache.
 #[derive(Clone, Debug, Default)]

--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -6,21 +6,21 @@
 
 //! The rule tree.
 
-use applicable_declarations::ApplicableDeclarationList;
+use crate::applicable_declarations::ApplicableDeclarationList;
+use crate::properties::{Importance, LonghandIdSet, PropertyDeclarationBlock};
+use crate::shared_lock::{Locked, SharedRwLockReadGuard, StylesheetGuards};
+use crate::stylesheets::StyleRule;
+use crate::thread_state;
 #[cfg(feature = "gecko")]
 use gecko::selector_parser::PseudoElement;
 #[cfg(feature = "gecko")]
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
-use properties::{Importance, LonghandIdSet, PropertyDeclarationBlock};
 use servo_arc::{Arc, ArcBorrow, ArcUnion, ArcUnionBorrow};
-use shared_lock::{Locked, SharedRwLockReadGuard, StylesheetGuards};
 use smallvec::SmallVec;
 use std::io::{self, Write};
 use std::mem;
 use std::ptr;
 use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
-use stylesheets::StyleRule;
-use thread_state;
 
 /// The rule tree, the structure servo uses to preserve the results of selector
 /// matching.
@@ -1149,7 +1149,7 @@ impl StrongRuleNode {
 
     unsafe fn assert_free_list_has_no_duplicates_or_null(&self) {
         assert!(cfg!(debug_assertions), "This is an expensive check!");
-        use hash::FxHashSet;
+        use crate::hash::FxHashSet;
 
         let me = &*self.ptr();
         assert!(me.is_root());
@@ -1430,7 +1430,7 @@ impl StrongRuleNode {
         &self,
         guards: &StylesheetGuards,
     ) -> (LonghandIdSet, bool) {
-        use properties::PropertyDeclarationId;
+        use crate::properties::PropertyDeclarationId;
 
         // We want to iterate over cascade levels that override the animations
         // level, i.e.  !important levels and the transitions level.

--- a/components/style/rule_tree/mod.rs
+++ b/components/style/rule_tree/mod.rs
@@ -7,12 +7,12 @@
 //! The rule tree.
 
 use crate::applicable_declarations::ApplicableDeclarationList;
+#[cfg(feature = "gecko")]
+use crate::gecko::selector_parser::PseudoElement;
 use crate::properties::{Importance, LonghandIdSet, PropertyDeclarationBlock};
 use crate::shared_lock::{Locked, SharedRwLockReadGuard, StylesheetGuards};
 use crate::stylesheets::StyleRule;
 use crate::thread_state;
-#[cfg(feature = "gecko")]
-use gecko::selector_parser::PseudoElement;
 #[cfg(feature = "gecko")]
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use servo_arc::{Arc, ArcBorrow, ArcUnion, ArcUnionBorrow};
@@ -1214,15 +1214,15 @@ impl StrongRuleNode {
         author_colors_allowed: bool,
     ) -> bool
     where
-        E: ::dom::TElement,
+        E: crate::dom::TElement,
     {
-        use gecko_bindings::structs::NS_AUTHOR_SPECIFIED_BACKGROUND;
-        use gecko_bindings::structs::NS_AUTHOR_SPECIFIED_BORDER;
-        use gecko_bindings::structs::NS_AUTHOR_SPECIFIED_PADDING;
-        use properties::{CSSWideKeyword, LonghandId, LonghandIdSet};
-        use properties::{PropertyDeclaration, PropertyDeclarationId};
+        use crate::gecko_bindings::structs::NS_AUTHOR_SPECIFIED_BACKGROUND;
+        use crate::gecko_bindings::structs::NS_AUTHOR_SPECIFIED_BORDER;
+        use crate::gecko_bindings::structs::NS_AUTHOR_SPECIFIED_PADDING;
+        use crate::properties::{CSSWideKeyword, LonghandId, LonghandIdSet};
+        use crate::properties::{PropertyDeclaration, PropertyDeclarationId};
+        use crate::values::specified::Color;
         use std::borrow::Cow;
-        use values::specified::Color;
 
         // Reset properties:
         const BACKGROUND_PROPS: &'static [LonghandId] =

--- a/components/style/selector_map.rs
+++ b/components/style/selector_map.rs
@@ -5,22 +5,22 @@
 //! A data structure to efficiently index structs containing selectors by local
 //! name, ids and hash.
 
-use applicable_declarations::ApplicableDeclarationList;
-use context::QuirksMode;
-use dom::TElement;
+use crate::applicable_declarations::ApplicableDeclarationList;
+use crate::context::QuirksMode;
+use crate::dom::TElement;
+use crate::hash::map as hash_map;
+use crate::hash::{HashMap, HashSet};
+use crate::rule_tree::{CascadeLevel, ShadowCascadeOrder};
+use crate::selector_parser::SelectorImpl;
+use crate::stylist::Rule;
+use crate::{Atom, LocalName, Namespace, WeakAtom};
 use fallible::FallibleVec;
-use hash::map as hash_map;
-use hash::{HashMap, HashSet};
 use hashglobe::FailedAllocationError;
 use precomputed_hash::PrecomputedHash;
-use rule_tree::{CascadeLevel, ShadowCascadeOrder};
-use selector_parser::SelectorImpl;
 use selectors::matching::{matches_selector, ElementSelectorFlags, MatchingContext};
 use selectors::parser::{Combinator, Component, SelectorIter};
 use smallvec::SmallVec;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
-use stylist::Rule;
-use {Atom, LocalName, Namespace, WeakAtom};
 
 /// A hasher implementation that doesn't hash anything, because it expects its
 /// input to be a suitable u32 hash.

--- a/components/style/selector_parser.rs
+++ b/components/style/selector_parser.rs
@@ -23,19 +23,19 @@ pub type AttrValue = <SelectorImpl as ::selectors::SelectorImpl>::AttrValue;
 pub use crate::servo::selector_parser::*;
 
 #[cfg(feature = "gecko")]
-pub use gecko::selector_parser::*;
+pub use crate::gecko::selector_parser::*;
 
 #[cfg(feature = "servo")]
 pub use crate::servo::selector_parser::ServoElementSnapshot as Snapshot;
 
 #[cfg(feature = "gecko")]
-pub use gecko::snapshot::GeckoElementSnapshot as Snapshot;
+pub use crate::gecko::snapshot::GeckoElementSnapshot as Snapshot;
 
 #[cfg(feature = "servo")]
 pub use crate::servo::restyle_damage::ServoRestyleDamage as RestyleDamage;
 
 #[cfg(feature = "gecko")]
-pub use gecko::restyle_damage::GeckoRestyleDamage as RestyleDamage;
+pub use crate::gecko::restyle_damage::GeckoRestyleDamage as RestyleDamage;
 
 /// Servo's selector parser.
 #[cfg_attr(feature = "servo", derive(MallocSizeOf))]

--- a/components/style/selector_parser.rs
+++ b/components/style/selector_parser.rs
@@ -6,33 +6,33 @@
 
 #![deny(missing_docs)]
 
+use crate::element_state::ElementState;
+use crate::stylesheets::{Namespaces, Origin, UrlExtraData};
+use crate::values::serialize_atom_identifier;
+use crate::Atom;
 use cssparser::{Parser as CssParser, ParserInput};
-use element_state::ElementState;
 use selectors::parser::SelectorList;
 use std::fmt::{self, Debug, Write};
 use style_traits::{CssWriter, ParseError, ToCss};
-use stylesheets::{Namespaces, Origin, UrlExtraData};
-use values::serialize_atom_identifier;
-use Atom;
 
 /// A convenient alias for the type that represents an attribute value used for
 /// selector parser implementation.
 pub type AttrValue = <SelectorImpl as ::selectors::SelectorImpl>::AttrValue;
 
 #[cfg(feature = "servo")]
-pub use servo::selector_parser::*;
+pub use crate::servo::selector_parser::*;
 
 #[cfg(feature = "gecko")]
 pub use gecko::selector_parser::*;
 
 #[cfg(feature = "servo")]
-pub use servo::selector_parser::ServoElementSnapshot as Snapshot;
+pub use crate::servo::selector_parser::ServoElementSnapshot as Snapshot;
 
 #[cfg(feature = "gecko")]
 pub use gecko::snapshot::GeckoElementSnapshot as Snapshot;
 
 #[cfg(feature = "servo")]
-pub use servo::restyle_damage::ServoRestyleDamage as RestyleDamage;
+pub use crate::servo::restyle_damage::ServoRestyleDamage as RestyleDamage;
 
 #[cfg(feature = "gecko")]
 pub use gecko::restyle_damage::GeckoRestyleDamage as RestyleDamage;

--- a/components/style/servo/media_queries.rs
+++ b/components/style/servo/media_queries.rs
@@ -5,20 +5,20 @@
 //! Servo's media-query device and expression representation.
 
 use app_units::Au;
+use crate::custom_properties::CssEnvironment;
+use crate::media_queries::media_feature::{AllowsRanges, ParsingRequirements};
+use crate::media_queries::media_feature::{Evaluator, MediaFeatureDescription};
+use crate::media_queries::media_feature_expression::RangeOrOperator;
+use crate::media_queries::MediaType;
+use crate::properties::ComputedValues;
+use crate::values::computed::font::FontSize;
+use crate::values::computed::CSSPixelLength;
+use crate::values::KeyframesName;
 use cssparser::RGBA;
-use custom_properties::CssEnvironment;
 use euclid::{Size2D, TypedScale, TypedSize2D};
-use media_queries::media_feature::{AllowsRanges, ParsingRequirements};
-use media_queries::media_feature::{Evaluator, MediaFeatureDescription};
-use media_queries::media_feature_expression::RangeOrOperator;
-use media_queries::MediaType;
-use properties::ComputedValues;
 use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
 use style_traits::viewport::ViewportConstraints;
 use style_traits::{CSSPixel, DevicePixel};
-use values::computed::font::FontSize;
-use values::computed::CSSPixelLength;
-use values::KeyframesName;
 
 /// A device is a structure that represents the current media a given document
 /// is displayed in.

--- a/components/style/servo/restyle_damage.rs
+++ b/components/style/servo/restyle_damage.rs
@@ -5,9 +5,9 @@
 //! The restyle damage is a hint that tells layout which kind of operations may
 //! be needed in presence of incremental style changes.
 
-use computed_values::display::T as Display;
-use matching::{StyleChange, StyleDifference};
-use properties::ComputedValues;
+use crate::computed_values::display::T as Display;
+use crate::matching::{StyleChange, StyleDifference};
+use crate::properties::ComputedValues;
 use std::fmt;
 
 bitflags! {

--- a/components/style/servo/selector_parser.rs
+++ b/components/style/servo/selector_parser.rs
@@ -6,16 +6,19 @@
 
 //! Servo's selector parser.
 
-use attr::{AttrIdentifier, AttrValue};
+use crate::attr::{AttrIdentifier, AttrValue};
+use crate::dom::{OpaqueNode, TElement, TNode};
+use crate::element_state::{DocumentState, ElementState};
+use crate::invalidation::element::document_state::InvalidationMatchingData;
+use crate::invalidation::element::element_wrapper::ElementSnapshot;
+use crate::properties::longhands::display::computed_value::T as Display;
+use crate::properties::{ComputedValues, PropertyFlags};
+use crate::selector_parser::{
+    AttrValue as SelectorAttrValue, PseudoElementCascadeType, SelectorParser,
+};
+use crate::{Atom, CaseSensitivityExt, LocalName, Namespace, Prefix};
 use cssparser::{serialize_identifier, CowRcStr, Parser as CssParser, SourceLocation, ToCss};
-use dom::{OpaqueNode, TElement, TNode};
-use element_state::{DocumentState, ElementState};
 use fxhash::FxHashMap;
-use invalidation::element::document_state::InvalidationMatchingData;
-use invalidation::element::element_wrapper::ElementSnapshot;
-use properties::longhands::display::computed_value::T as Display;
-use properties::{ComputedValues, PropertyFlags};
-use selector_parser::{AttrValue as SelectorAttrValue, PseudoElementCascadeType, SelectorParser};
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
 use selectors::parser::{SelectorParseErrorKind, Visit};
 use selectors::visitor::SelectorVisitor;
@@ -23,7 +26,6 @@ use std::fmt;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use style_traits::{ParseError, StyleParseErrorKind};
-use {Atom, CaseSensitivityExt, LocalName, Namespace, Prefix};
 
 /// A pseudo-element, both public and private.
 ///
@@ -349,7 +351,7 @@ impl NonTSPseudoClass {
     /// selector matching, and it's set from the DOM.
     pub fn state_flag(&self) -> ElementState {
         use self::NonTSPseudoClass::*;
-        use element_state::ElementState;
+        use crate::element_state::ElementState;
         match *self {
             Active => ElementState::IN_ACTIVE_STATE,
             Focus => ElementState::IN_FOCUS_STATE,

--- a/components/style/servo/url.rs
+++ b/components/style/servo/url.rs
@@ -4,16 +4,16 @@
 
 //! Common handling for the specified value CSS url() values.
 
+use crate::parser::{Parse, ParserContext};
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use servo_url::ServoUrl;
 use std::fmt::{self, Write};
 // Note: We use std::sync::Arc rather than servo_arc::Arc here because the
 // nonzero optimization is important in keeping the size of SpecifiedUrl below
 // the threshold.
+use crate::values::computed::{Context, ToComputedValue};
 use std::sync::Arc;
 use style_traits::{CssWriter, ParseError, ToCss};
-use values::computed::{Context, ToComputedValue};
 
 /// A CSS url() value for servo.
 ///

--- a/components/style/shared_lock.rs
+++ b/components/style/shared_lock.rs
@@ -239,7 +239,7 @@ pub trait ToCssWithGuard {
 #[cfg(feature = "gecko")]
 pub struct DeepCloneParams {
     /// The new sheet we're cloning rules into.
-    pub reference_sheet: *const ::gecko_bindings::structs::StyleSheet,
+    pub reference_sheet: *const crate::gecko_bindings::structs::StyleSheet,
 }
 
 /// Parameters needed for deep clones.

--- a/components/style/shared_lock.rs
+++ b/components/style/shared_lock.rs
@@ -6,6 +6,8 @@
 
 #[cfg(feature = "gecko")]
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
+use crate::str::{CssString, CssStringWriter};
+use crate::stylesheets::Origin;
 #[cfg(feature = "servo")]
 use parking_lot::RwLock;
 use servo_arc::Arc;
@@ -15,8 +17,6 @@ use std::fmt;
 use std::mem;
 #[cfg(feature = "gecko")]
 use std::ptr;
-use str::{CssString, CssStringWriter};
-use stylesheets::Origin;
 
 /// A shared read/write lock that can protect multiple objects.
 ///

--- a/components/style/sharing/checks.rs
+++ b/components/style/sharing/checks.rs
@@ -6,11 +6,11 @@
 //! quickly whether it's worth to share style, and whether two different
 //! elements can indeed share the same style.
 
-use bloom::StyleBloom;
-use context::{SelectorFlagsMap, SharedStyleContext};
-use dom::TElement;
+use crate::bloom::StyleBloom;
+use crate::context::{SelectorFlagsMap, SharedStyleContext};
+use crate::dom::TElement;
+use crate::sharing::{StyleSharingCandidate, StyleSharingTarget};
 use selectors::NthIndexCache;
-use sharing::{StyleSharingCandidate, StyleSharingTarget};
 
 /// Determines whether a target and a candidate have compatible parents for
 /// sharing.

--- a/components/style/sharing/mod.rs
+++ b/components/style/sharing/mod.rs
@@ -64,15 +64,18 @@
 //! selectors are effectively stripped off, so that matching them all against
 //! elements makes sense.
 
-use applicable_declarations::ApplicableDeclarationBlock;
 use atomic_refcell::{AtomicRefCell, AtomicRefMut};
-use bloom::StyleBloom;
-use context::{SelectorFlagsMap, SharedStyleContext, StyleContext};
-use dom::{SendElement, TElement};
-use matching::MatchMethods;
+use crate::applicable_declarations::ApplicableDeclarationBlock;
+use crate::bloom::StyleBloom;
+use crate::context::{SelectorFlagsMap, SharedStyleContext, StyleContext};
+use crate::dom::{SendElement, TElement};
+use crate::matching::MatchMethods;
+use crate::properties::ComputedValues;
+use crate::rule_tree::StrongRuleNode;
+use crate::style_resolver::{PrimaryStyle, ResolvedElementStyles};
+use crate::stylist::Stylist;
+use crate::Atom;
 use owning_ref::OwningHandle;
-use properties::ComputedValues;
-use rule_tree::StrongRuleNode;
 use selectors::matching::{ElementSelectorFlags, VisitedHandlingMode};
 use selectors::NthIndexCache;
 use servo_arc::Arc;
@@ -82,10 +85,7 @@ use std::marker::PhantomData;
 use std::mem;
 use std::ops::Deref;
 use std::ptr::NonNull;
-use style_resolver::{PrimaryStyle, ResolvedElementStyles};
-use stylist::Stylist;
 use uluru::{Entry, LRUCache};
-use Atom;
 
 mod checks;
 

--- a/components/style/style_adjuster.rs
+++ b/components/style/style_adjuster.rs
@@ -59,7 +59,7 @@ fn is_effective_display_none_for_display_contents<E>(element: E) -> bool
 where
     E: TElement,
 {
-    use Atom;
+    use crate::Atom;
 
     // FIXME(emilio): This should be an actual static.
     lazy_static! {
@@ -272,8 +272,8 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
     /// mutating writing-mode change the potential physical sides chosen?
     #[cfg(feature = "gecko")]
     fn adjust_for_text_combine_upright(&mut self) {
-        use computed_values::text_combine_upright::T as TextCombineUpright;
-        use computed_values::writing_mode::T as WritingMode;
+        use crate::computed_values::text_combine_upright::T as TextCombineUpright;
+        use crate::computed_values::writing_mode::T as WritingMode;
 
         let writing_mode = self.style.get_inherited_box().clone_writing_mode();
         let text_combine_upright = self.style.get_inherited_text().clone_text_combine_upright();
@@ -346,9 +346,9 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
     /// both forced to "normal".
     #[cfg(feature = "gecko")]
     fn adjust_for_mathvariant(&mut self) {
-        use properties::longhands::_moz_math_variant::computed_value::T as MozMathVariant;
-        use properties::longhands::font_weight::computed_value::T as FontWeight;
-        use values::generics::font::FontStyle;
+        use crate::properties::longhands::_moz_math_variant::computed_value::T as MozMathVariant;
+        use crate::properties::longhands::font_weight::computed_value::T as FontWeight;
+        use crate::values::generics::font::FontStyle;
         if self.style.get_font().clone__moz_math_variant() != MozMathVariant::None {
             let font_style = self.style.mutate_font();
             font_style.set_font_weight(FontWeight::normal());
@@ -512,7 +512,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
     /// table.
     #[cfg(feature = "gecko")]
     fn adjust_for_table_text_align(&mut self) {
-        use properties::longhands::text_align::computed_value::T as TextAlign;
+        use crate::properties::longhands::text_align::computed_value::T as TextAlign;
         if self.style.get_box().clone_display() != Display::Table {
             return;
         }
@@ -587,7 +587,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
     where
         E: TElement,
     {
-        use properties::longhands::unicode_bidi::computed_value::T as UnicodeBidi;
+        use crate::properties::longhands::unicode_bidi::computed_value::T as UnicodeBidi;
 
         let self_display = self.style.get_box().clone_display();
         // Check whether line break should be suppressed for this element.
@@ -669,7 +669,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
     /// <https://drafts.csswg.org/css-align/#valdef-justify-items-legacy>
     #[cfg(feature = "gecko")]
     fn adjust_for_justify_items(&mut self) {
-        use values::specified::align;
+        use crate::values::specified::align;
         let justify_items = self.style.get_position().clone_justify_items();
         if justify_items.specified.0 != align::AlignFlags::LEGACY {
             return;
@@ -703,8 +703,8 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
     where
         E: TElement,
     {
-        use properties::longhands::_moz_appearance::computed_value::T as Appearance;
-        use properties::longhands::line_height::computed_value::T as LineHeight;
+        use crate::properties::longhands::_moz_appearance::computed_value::T as Appearance;
+        use crate::properties::longhands::line_height::computed_value::T as LineHeight;
 
         if self.style.get_box().clone__moz_appearance() == Appearance::Menulist {
             if self.style.get_inherited_text().clone_line_height() == LineHeight::normal() {

--- a/components/style/style_adjuster.rs
+++ b/components/style/style_adjuster.rs
@@ -6,13 +6,13 @@
 //! a computed style needs in order for it to adhere to the CSS spec.
 
 use app_units::Au;
-use dom::TElement;
-use properties::computed_value_flags::ComputedValueFlags;
-use properties::longhands::display::computed_value::T as Display;
-use properties::longhands::float::computed_value::T as Float;
-use properties::longhands::overflow_x::computed_value::T as Overflow;
-use properties::longhands::position::computed_value::T as Position;
-use properties::{self, ComputedValues, StyleBuilder};
+use crate::dom::TElement;
+use crate::properties::computed_value_flags::ComputedValueFlags;
+use crate::properties::longhands::display::computed_value::T as Display;
+use crate::properties::longhands::float::computed_value::T as Float;
+use crate::properties::longhands::overflow_x::computed_value::T as Overflow;
+use crate::properties::longhands::position::computed_value::T as Position;
+use crate::properties::{self, ComputedValues, StyleBuilder};
 
 /// A struct that implements all the adjustment methods.
 ///
@@ -362,8 +362,8 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
     /// See https://github.com/servo/servo/issues/15229
     #[cfg(feature = "servo")]
     fn adjust_for_alignment(&mut self, layout_parent_style: &ComputedValues) {
-        use computed_values::align_items::T as AlignItems;
-        use computed_values::align_self::T as AlignSelf;
+        use crate::computed_values::align_items::T as AlignItems;
+        use crate::computed_values::align_self::T as AlignSelf;
 
         if self.style.get_position().clone_align_self() == AlignSelf::Auto &&
             !self.style.out_of_flow_positioned()
@@ -534,7 +534,7 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
     /// and Blink have with this very same thing.
     #[cfg(feature = "servo")]
     fn adjust_for_text_decorations_in_effect(&mut self) {
-        use values::computed::text::TextDecorationsInEffect;
+        use crate::values::computed::text::TextDecorationsInEffect;
 
         let decorations_in_effect = TextDecorationsInEffect::from_style(&self.style);
         if self.style.get_inherited_text().text_decorations_in_effect != decorations_in_effect {

--- a/components/style/style_resolver.rs
+++ b/components/style/style_resolver.rs
@@ -4,21 +4,21 @@
 
 //! Style resolution for a given element or pseudo-element.
 
-use applicable_declarations::ApplicableDeclarationList;
-use context::{CascadeInputs, ElementCascadeInputs, StyleContext};
-use data::{EagerPseudoStyles, ElementStyles};
-use dom::TElement;
+use crate::applicable_declarations::ApplicableDeclarationList;
+use crate::context::{CascadeInputs, ElementCascadeInputs, StyleContext};
+use crate::data::{EagerPseudoStyles, ElementStyles};
+use crate::dom::TElement;
+use crate::matching::MatchMethods;
+use crate::properties::longhands::display::computed_value::T as Display;
+use crate::properties::{AnimationRules, ComputedValues};
+use crate::rule_tree::StrongRuleNode;
+use crate::selector_parser::{PseudoElement, SelectorImpl};
+use crate::stylist::RuleInclusion;
 use log::Level::Trace;
-use matching::MatchMethods;
-use properties::longhands::display::computed_value::T as Display;
-use properties::{AnimationRules, ComputedValues};
-use rule_tree::StrongRuleNode;
-use selector_parser::{PseudoElement, SelectorImpl};
 use selectors::matching::{
     ElementSelectorFlags, MatchingContext, MatchingMode, VisitedHandlingMode,
 };
 use servo_arc::Arc;
-use stylist::RuleInclusion;
 
 /// Whether pseudo-elements should be resolved or not.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -111,7 +111,7 @@ fn eager_pseudo_is_definitely_not_generated(
     pseudo: &PseudoElement,
     style: &ComputedValues,
 ) -> bool {
-    use properties::computed_value_flags::ComputedValueFlags;
+    use crate::properties::computed_value_flags::ComputedValueFlags;
 
     if !pseudo.is_before_or_after() {
         return false;

--- a/components/style/stylesheet_set.rs
+++ b/components/style/stylesheet_set.rs
@@ -4,13 +4,13 @@
 
 //! A centralized set of stylesheets for a document.
 
-use dom::TElement;
-use invalidation::stylesheets::StylesheetInvalidationSet;
-use media_queries::Device;
-use selector_parser::SnapshotMap;
-use shared_lock::SharedRwLockReadGuard;
+use crate::dom::TElement;
+use crate::invalidation::stylesheets::StylesheetInvalidationSet;
+use crate::media_queries::Device;
+use crate::selector_parser::SnapshotMap;
+use crate::shared_lock::SharedRwLockReadGuard;
+use crate::stylesheets::{Origin, OriginSet, OriginSetIterator, PerOrigin, StylesheetInDocument};
 use std::{mem, slice};
-use stylesheets::{Origin, OriginSet, OriginSetIterator, PerOrigin, StylesheetInDocument};
 
 /// Entry for a StylesheetSet.
 #[derive(MallocSizeOf)]

--- a/components/style/stylesheets/counter_style_rule.rs
+++ b/components/style/stylesheets/counter_style_rule.rs
@@ -4,4 +4,4 @@
 
 #![allow(missing_docs)]
 
-pub use counter_style::CounterStyleRuleData as CounterStyleRule;
+pub use crate::counter_style::CounterStyleRuleData as CounterStyleRule;

--- a/components/style/stylesheets/document_rule.rs
+++ b/components/style/stylesheets/document_rule.rs
@@ -172,8 +172,8 @@ impl DocumentMatchingFunction {
     #[cfg(feature = "gecko")]
     /// Evaluate a URL matching function.
     pub fn evaluate(&self, device: &Device) -> bool {
-        use gecko_bindings::bindings::Gecko_DocumentRule_UseForPresentation;
-        use gecko_bindings::structs::DocumentMatchingFunction as GeckoDocumentMatchingFunction;
+        use crate::gecko_bindings::bindings::Gecko_DocumentRule_UseForPresentation;
+        use crate::gecko_bindings::structs::DocumentMatchingFunction as GeckoDocumentMatchingFunction;
         use nsstring::nsCStr;
 
         let func = match *self {
@@ -253,8 +253,8 @@ impl DocumentCondition {
 
     #[cfg(feature = "gecko")]
     fn allowed_in(&self, context: &ParserContext) -> bool {
-        use gecko_bindings::structs;
-        use stylesheets::Origin;
+        use crate::gecko_bindings::structs;
+        use crate::stylesheets::Origin;
 
         if context.stylesheet_origin != Origin::Author {
             return true;

--- a/components/style/stylesheets/document_rule.rs
+++ b/components/style/stylesheets/document_rule.rs
@@ -6,19 +6,19 @@
 //! initially in CSS Conditional Rules Module Level 3, @document has been postponed to the level 4.
 //! We implement the prefixed `@-moz-document`.
 
+use crate::media_queries::Device;
+use crate::parser::{Parse, ParserContext};
+use crate::shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked};
+use crate::shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
+use crate::str::CssStringWriter;
+use crate::stylesheets::CssRules;
+use crate::values::CssUrl;
 use cssparser::{Parser, SourceLocation};
 #[cfg(feature = "gecko")]
 use malloc_size_of::{MallocSizeOfOps, MallocUnconditionalShallowSizeOf};
-use media_queries::Device;
-use parser::{Parse, ParserContext};
 use servo_arc::Arc;
-use shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked};
-use shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt::{self, Write};
-use str::CssStringWriter;
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
-use stylesheets::CssRules;
-use values::CssUrl;
 
 #[derive(Debug)]
 /// A @-moz-document rule
@@ -135,7 +135,7 @@ impl DocumentMatchingFunction {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(url) = input.try(|input| CssUrl::parse(context, input)) {
+        if let Ok(url) = input.r#try(|input| CssUrl::parse(context, input)) {
             return Ok(DocumentMatchingFunction::Url(url));
         }
 

--- a/components/style/stylesheets/font_face_rule.rs
+++ b/components/style/stylesheets/font_face_rule.rs
@@ -4,4 +4,4 @@
 
 #![allow(missing_docs)]
 
-pub use font_face::FontFaceRuleData as FontFaceRule;
+pub use crate::font_face::FontFaceRuleData as FontFaceRule;

--- a/components/style/stylesheets/font_feature_values_rule.rs
+++ b/components/style/stylesheets/font_feature_values_rule.rs
@@ -7,6 +7,10 @@
 //! [font-feature-values]: https://drafts.csswg.org/css-fonts-3/#at-font-feature-values-rule
 
 use crate::error_reporting::ContextualParseError;
+#[cfg(feature = "gecko")]
+use crate::gecko_bindings::bindings::Gecko_AppendFeatureValueHashEntry;
+#[cfg(feature = "gecko")]
+use crate::gecko_bindings::structs::{self, gfxFontFeatureValueSet, nsTArray};
 use crate::parser::{Parse, ParserContext};
 use crate::shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use crate::str::CssStringWriter;
@@ -17,10 +21,6 @@ use crate::Atom;
 use cssparser::{AtRuleParser, AtRuleType, BasicParseErrorKind, CowRcStr};
 use cssparser::{DeclarationListParser, DeclarationParser, Parser};
 use cssparser::{QualifiedRuleParser, RuleListParser, SourceLocation, Token};
-#[cfg(feature = "gecko")]
-use gecko_bindings::bindings::Gecko_AppendFeatureValueHashEntry;
-#[cfg(feature = "gecko")]
-use gecko_bindings::structs::{self, gfxFontFeatureValueSet, nsTArray};
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
 

--- a/components/style/stylesheets/font_feature_values_rule.rs
+++ b/components/style/stylesheets/font_feature_values_rule.rs
@@ -6,23 +6,23 @@
 //!
 //! [font-feature-values]: https://drafts.csswg.org/css-fonts-3/#at-font-feature-values-rule
 
+use crate::error_reporting::ContextualParseError;
+use crate::parser::{Parse, ParserContext};
+use crate::shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
+use crate::str::CssStringWriter;
+use crate::stylesheets::CssRuleType;
+use crate::values::computed::font::FamilyName;
+use crate::values::serialize_atom_identifier;
+use crate::Atom;
 use cssparser::{AtRuleParser, AtRuleType, BasicParseErrorKind, CowRcStr};
 use cssparser::{DeclarationListParser, DeclarationParser, Parser};
 use cssparser::{QualifiedRuleParser, RuleListParser, SourceLocation, Token};
-use error_reporting::ContextualParseError;
 #[cfg(feature = "gecko")]
 use gecko_bindings::bindings::Gecko_AppendFeatureValueHashEntry;
 #[cfg(feature = "gecko")]
 use gecko_bindings::structs::{self, gfxFontFeatureValueSet, nsTArray};
-use parser::{Parse, ParserContext};
-use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt::{self, Write};
-use str::CssStringWriter;
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
-use stylesheets::CssRuleType;
-use values::computed::font::FamilyName;
-use values::serialize_atom_identifier;
-use Atom;
 
 /// A @font-feature-values block declaration.
 /// It is `<ident>: <integer>+`.

--- a/components/style/stylesheets/import_rule.rs
+++ b/components/style/stylesheets/import_rule.rs
@@ -6,16 +6,16 @@
 //!
 //! [import]: https://drafts.csswg.org/css-cascade-3/#at-import
 
-use context::QuirksMode;
+use crate::context::QuirksMode;
+use crate::media_queries::MediaList;
+use crate::shared_lock::{DeepCloneParams, DeepCloneWithLock};
+use crate::shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
+use crate::str::CssStringWriter;
+use crate::stylesheets::{CssRule, Origin, StylesheetInDocument};
+use crate::values::CssUrl;
 use cssparser::SourceLocation;
-use media_queries::MediaList;
-use shared_lock::{DeepCloneParams, DeepCloneWithLock};
-use shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt::{self, Write};
-use str::CssStringWriter;
 use style_traits::{CssWriter, ToCss};
-use stylesheets::{CssRule, Origin, StylesheetInDocument};
-use values::CssUrl;
 
 /// With asynchronous stylesheet parsing, we can't synchronously create a
 /// GeckoStyleSheet. So we use this placeholder instead.
@@ -124,7 +124,7 @@ impl StylesheetInDocument for ImportSheet {
 /// A sheet that is held from an import rule.
 #[cfg(feature = "servo")]
 #[derive(Debug)]
-pub struct ImportSheet(pub ::servo_arc::Arc<::stylesheets::Stylesheet>);
+pub struct ImportSheet(pub ::servo_arc::Arc<crate::stylesheets::Stylesheet>);
 
 #[cfg(feature = "servo")]
 impl StylesheetInDocument for ImportSheet {

--- a/components/style/stylesheets/import_rule.rs
+++ b/components/style/stylesheets/import_rule.rs
@@ -30,7 +30,7 @@ pub struct PendingSheet {
 #[derive(Debug)]
 pub enum ImportSheet {
     /// A bonafide stylesheet.
-    Sheet(::gecko::data::GeckoStyleSheet),
+    Sheet(crate::gecko::data::GeckoStyleSheet),
     /// An @import created while parsing off-main-thread, whose Gecko sheet has
     /// yet to be created and attached.
     Pending(PendingSheet),
@@ -39,7 +39,7 @@ pub enum ImportSheet {
 #[cfg(feature = "gecko")]
 impl ImportSheet {
     /// Creates a new ImportSheet from a GeckoStyleSheet.
-    pub fn new(sheet: ::gecko::data::GeckoStyleSheet) -> Self {
+    pub fn new(sheet: crate::gecko::data::GeckoStyleSheet) -> Self {
         ImportSheet::Sheet(sheet)
     }
 
@@ -53,7 +53,7 @@ impl ImportSheet {
 
     /// Returns a reference to the GeckoStyleSheet in this ImportSheet, if it
     /// exists.
-    pub fn as_sheet(&self) -> Option<&::gecko::data::GeckoStyleSheet> {
+    pub fn as_sheet(&self) -> Option<&crate::gecko::data::GeckoStyleSheet> {
         match *self {
             ImportSheet::Sheet(ref s) => Some(s),
             ImportSheet::Pending(_) => None,
@@ -69,8 +69,8 @@ impl DeepCloneWithLock for ImportSheet {
         _guard: &SharedRwLockReadGuard,
         params: &DeepCloneParams,
     ) -> Self {
-        use gecko::data::GeckoStyleSheet;
-        use gecko_bindings::bindings;
+        use crate::gecko::data::GeckoStyleSheet;
+        use crate::gecko_bindings::bindings;
         match *self {
             ImportSheet::Sheet(ref s) => {
                 let clone = unsafe {

--- a/components/style/stylesheets/keyframes_rule.rs
+++ b/components/style/stylesheets/keyframes_rule.rs
@@ -4,24 +4,24 @@
 
 //! Keyframes: https://drafts.csswg.org/css-animations/#keyframes
 
+use crate::error_reporting::ContextualParseError;
+use crate::parser::ParserContext;
+use crate::properties::longhands::transition_timing_function::single_value::SpecifiedValue as SpecifiedTimingFunction;
+use crate::properties::LonghandIdSet;
+use crate::properties::{Importance, PropertyDeclaration};
+use crate::properties::{LonghandId, PropertyDeclarationBlock, PropertyId};
+use crate::properties::{PropertyDeclarationId, SourcePropertyDeclaration};
+use crate::shared_lock::{DeepCloneParams, DeepCloneWithLock, SharedRwLock, SharedRwLockReadGuard};
+use crate::shared_lock::{Locked, ToCssWithGuard};
+use crate::str::CssStringWriter;
+use crate::stylesheets::rule_parser::VendorPrefix;
+use crate::stylesheets::{CssRuleType, StylesheetContents};
+use crate::values::{serialize_percentage, KeyframesName};
 use cssparser::{parse_one_rule, DeclarationListParser, DeclarationParser, SourceLocation, Token};
 use cssparser::{AtRuleParser, CowRcStr, Parser, ParserInput, QualifiedRuleParser, RuleListParser};
-use error_reporting::ContextualParseError;
-use parser::ParserContext;
-use properties::longhands::transition_timing_function::single_value::SpecifiedValue as SpecifiedTimingFunction;
-use properties::LonghandIdSet;
-use properties::{Importance, PropertyDeclaration};
-use properties::{LonghandId, PropertyDeclarationBlock, PropertyId};
-use properties::{PropertyDeclarationId, SourcePropertyDeclaration};
 use servo_arc::Arc;
-use shared_lock::{DeepCloneParams, DeepCloneWithLock, SharedRwLock, SharedRwLockReadGuard};
-use shared_lock::{Locked, ToCssWithGuard};
 use std::fmt::{self, Write};
-use str::CssStringWriter;
 use style_traits::{CssWriter, ParseError, ParsingMode, StyleParseErrorKind, ToCss};
-use stylesheets::rule_parser::VendorPrefix;
-use stylesheets::{CssRuleType, StylesheetContents};
-use values::{serialize_percentage, KeyframesName};
 
 /// A [`@keyframes`][keyframes] rule.
 ///

--- a/components/style/stylesheets/loader.rs
+++ b/components/style/stylesheets/loader.rs
@@ -5,13 +5,13 @@
 //! The stylesheet loader is the abstraction used to trigger network requests
 //! for `@import` rules.
 
+use crate::media_queries::MediaList;
+use crate::parser::ParserContext;
+use crate::shared_lock::{Locked, SharedRwLock};
+use crate::stylesheets::import_rule::ImportRule;
+use crate::values::CssUrl;
 use cssparser::SourceLocation;
-use media_queries::MediaList;
-use parser::ParserContext;
 use servo_arc::Arc;
-use shared_lock::{Locked, SharedRwLock};
-use stylesheets::import_rule::ImportRule;
-use values::CssUrl;
 
 /// The stylesheet loader is the abstraction used to trigger network requests
 /// for `@import` rules.

--- a/components/style/stylesheets/media_rule.rs
+++ b/components/style/stylesheets/media_rule.rs
@@ -6,17 +6,17 @@
 //!
 //! [media]: https://drafts.csswg.org/css-conditional/#at-ruledef-media
 
+use crate::media_queries::MediaList;
+use crate::shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked};
+use crate::shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
+use crate::str::CssStringWriter;
+use crate::stylesheets::CssRules;
 use cssparser::SourceLocation;
 #[cfg(feature = "gecko")]
 use malloc_size_of::{MallocSizeOfOps, MallocUnconditionalShallowSizeOf};
-use media_queries::MediaList;
 use servo_arc::Arc;
-use shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked};
-use shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt::{self, Write};
-use str::CssStringWriter;
 use style_traits::{CssWriter, ToCss};
-use stylesheets::CssRules;
 
 /// An [`@media`][media] urle.
 ///

--- a/components/style/stylesheets/mod.rs
+++ b/components/style/stylesheets/mod.rs
@@ -63,7 +63,7 @@ pub type UrlExtraData = ::servo_url::ServoUrl;
 #[cfg(feature = "gecko")]
 #[derive(Clone, PartialEq)]
 pub struct UrlExtraData(
-    pub ::gecko_bindings::sugar::refptr::RefPtr<::gecko_bindings::structs::URLExtraData>,
+    pub crate::gecko_bindings::sugar::refptr::RefPtr<crate::gecko_bindings::structs::URLExtraData>,
 );
 
 #[cfg(feature = "gecko")]
@@ -80,7 +80,7 @@ impl UrlExtraData {
     ///
     /// This method doesn't touch refcount.
     #[inline]
-    pub unsafe fn from_ptr_ref(ptr: &*mut ::gecko_bindings::structs::URLExtraData) -> &Self {
+    pub unsafe fn from_ptr_ref(ptr: &*mut crate::gecko_bindings::structs::URLExtraData) -> &Self {
         ::std::mem::transmute(ptr)
     }
 }
@@ -88,7 +88,7 @@ impl UrlExtraData {
 #[cfg(feature = "gecko")]
 impl fmt::Debug for UrlExtraData {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        use gecko_bindings::{bindings, structs};
+        use crate::gecko_bindings::{bindings, structs};
 
         struct DebugURI(*mut structs::nsIURI);
         impl fmt::Debug for DebugURI {

--- a/components/style/stylesheets/mod.rs
+++ b/components/style/stylesheets/mod.rs
@@ -23,15 +23,15 @@ mod stylesheet;
 pub mod supports_rule;
 pub mod viewport_rule;
 
+use crate::parser::ParserContext;
+use crate::shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked};
+use crate::shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
+use crate::str::CssStringWriter;
 use cssparser::{parse_one_rule, Parser, ParserInput};
 #[cfg(feature = "gecko")]
 use malloc_size_of::{MallocSizeOfOps, MallocUnconditionalShallowSizeOf};
-use parser::ParserContext;
 use servo_arc::Arc;
-use shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked};
-use shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt;
-use str::CssStringWriter;
 use style_traits::ParsingMode;
 
 pub use self::counter_style_rule::CounterStyleRule;

--- a/components/style/stylesheets/namespace_rule.rs
+++ b/components/style/stylesheets/namespace_rule.rs
@@ -4,11 +4,11 @@
 
 //! The `@namespace` at-rule.
 
+use crate::shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
+use crate::str::CssStringWriter;
+use crate::{Namespace, Prefix};
 use cssparser::SourceLocation;
-use shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt::{self, Write};
-use str::CssStringWriter;
-use {Namespace, Prefix};
 
 /// A `@namespace` rule.
 #[derive(Clone, Debug, PartialEq)]

--- a/components/style/stylesheets/page_rule.rs
+++ b/components/style/stylesheets/page_rule.rs
@@ -6,15 +6,15 @@
 //!
 //! [page]: https://drafts.csswg.org/css2/page.html#page-box
 
+use crate::properties::PropertyDeclarationBlock;
+use crate::shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked};
+use crate::shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
+use crate::str::CssStringWriter;
 use cssparser::SourceLocation;
 #[cfg(feature = "gecko")]
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps, MallocUnconditionalShallowSizeOf};
-use properties::PropertyDeclarationBlock;
 use servo_arc::Arc;
-use shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked};
-use shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt::{self, Write};
-use str::CssStringWriter;
 
 /// A [`@page`][page] rule.
 ///

--- a/components/style/stylesheets/rule_list.rs
+++ b/components/style/stylesheets/rule_list.rs
@@ -4,17 +4,17 @@
 
 //! A list of CSS rules.
 
+use crate::shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked};
+use crate::shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
+use crate::str::CssStringWriter;
+use crate::stylesheets::loader::StylesheetLoader;
+use crate::stylesheets::rule_parser::{InsertRuleContext, State};
+use crate::stylesheets::stylesheet::StylesheetContents;
+use crate::stylesheets::{CssRule, RulesMutateError};
 #[cfg(feature = "gecko")]
 use malloc_size_of::{MallocShallowSizeOf, MallocSizeOfOps};
 use servo_arc::{Arc, RawOffsetArc};
-use shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked};
-use shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt::{self, Write};
-use str::CssStringWriter;
-use stylesheets::loader::StylesheetLoader;
-use stylesheets::rule_parser::{InsertRuleContext, State};
-use stylesheets::stylesheet::StylesheetContents;
-use stylesheets::{CssRule, RulesMutateError};
 
 /// A list of CSS rules.
 #[derive(Debug)]

--- a/components/style/stylesheets/rule_parser.rs
+++ b/components/style/stylesheets/rule_parser.rs
@@ -4,32 +4,32 @@
 
 //! Parsing of the stylesheet contents.
 
-use counter_style::{parse_counter_style_body, parse_counter_style_name_definition};
+use crate::counter_style::{parse_counter_style_body, parse_counter_style_name_definition};
+use crate::error_reporting::ContextualParseError;
+use crate::font_face::parse_font_face_block;
+use crate::media_queries::MediaList;
+use crate::parser::{Parse, ParserContext};
+use crate::properties::parse_property_declaration_list;
+use crate::selector_parser::{SelectorImpl, SelectorParser};
+use crate::shared_lock::{Locked, SharedRwLock};
+use crate::str::starts_with_ignore_ascii_case;
+use crate::stylesheets::document_rule::DocumentCondition;
+use crate::stylesheets::font_feature_values_rule::parse_family_name_list;
+use crate::stylesheets::keyframes_rule::parse_keyframe_list;
+use crate::stylesheets::stylesheet::Namespaces;
+use crate::stylesheets::supports_rule::SupportsCondition;
+use crate::stylesheets::viewport_rule;
+use crate::stylesheets::{CssRule, CssRuleType, CssRules, RulesMutateError, StylesheetLoader};
+use crate::stylesheets::{DocumentRule, FontFeatureValuesRule, KeyframesRule, MediaRule};
+use crate::stylesheets::{NamespaceRule, PageRule, StyleRule, SupportsRule, ViewportRule};
+use crate::values::computed::font::FamilyName;
+use crate::values::{CssUrl, CustomIdent, KeyframesName};
+use crate::{Namespace, Prefix};
 use cssparser::{AtRuleParser, AtRuleType, Parser, QualifiedRuleParser, RuleListParser};
 use cssparser::{BasicParseError, BasicParseErrorKind, CowRcStr, SourceLocation};
-use error_reporting::ContextualParseError;
-use font_face::parse_font_face_block;
-use media_queries::MediaList;
-use parser::{Parse, ParserContext};
-use properties::parse_property_declaration_list;
-use selector_parser::{SelectorImpl, SelectorParser};
 use selectors::SelectorList;
 use servo_arc::Arc;
-use shared_lock::{Locked, SharedRwLock};
-use str::starts_with_ignore_ascii_case;
 use style_traits::{ParseError, StyleParseErrorKind};
-use stylesheets::document_rule::DocumentCondition;
-use stylesheets::font_feature_values_rule::parse_family_name_list;
-use stylesheets::keyframes_rule::parse_keyframe_list;
-use stylesheets::stylesheet::Namespaces;
-use stylesheets::supports_rule::SupportsCondition;
-use stylesheets::viewport_rule;
-use stylesheets::{CssRule, CssRuleType, CssRules, RulesMutateError, StylesheetLoader};
-use stylesheets::{DocumentRule, FontFeatureValuesRule, KeyframesRule, MediaRule};
-use stylesheets::{NamespaceRule, PageRule, StyleRule, SupportsRule, ViewportRule};
-use values::computed::font::FamilyName;
-use values::{CssUrl, CustomIdent, KeyframesName};
-use {Namespace, Prefix};
 
 /// The information we need particularly to do CSSOM insertRule stuff.
 pub struct InsertRuleContext<'a> {
@@ -202,7 +202,7 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
                     return Err(input.new_custom_error(StyleParseErrorKind::UnexpectedNamespaceRule))
                 }
 
-                let prefix = input.try(|i| i.expect_ident_cloned())
+                let prefix = input.r#try(|i| i.expect_ident_cloned())
                                   .map(|s| Prefix::from(s.as_ref())).ok();
                 let maybe_namespace = match input.expect_url_or_string() {
                     Ok(url_or_string) => url_or_string,

--- a/components/style/stylesheets/rules_iterator.rs
+++ b/components/style/stylesheets/rules_iterator.rs
@@ -4,13 +4,13 @@
 
 //! An iterator over a list of rules.
 
-use context::QuirksMode;
-use media_queries::Device;
-use shared_lock::SharedRwLockReadGuard;
+use crate::context::QuirksMode;
+use crate::media_queries::Device;
+use crate::shared_lock::SharedRwLockReadGuard;
+use crate::stylesheets::StylesheetInDocument;
+use crate::stylesheets::{CssRule, DocumentRule, ImportRule, MediaRule, SupportsRule};
 use smallvec::SmallVec;
 use std::slice;
-use stylesheets::StylesheetInDocument;
-use stylesheets::{CssRule, DocumentRule, ImportRule, MediaRule, SupportsRule};
 
 /// An iterator over a list of rules.
 pub struct RulesIterator<'a, 'b, C>

--- a/components/style/stylesheets/style_rule.rs
+++ b/components/style/stylesheets/style_rule.rs
@@ -4,19 +4,19 @@
 
 //! A style rule.
 
+use crate::properties::PropertyDeclarationBlock;
+use crate::selector_parser::SelectorImpl;
+use crate::shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked};
+use crate::shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
+use crate::str::CssStringWriter;
 use cssparser::SourceLocation;
 #[cfg(feature = "gecko")]
 use malloc_size_of::MallocUnconditionalShallowSizeOf;
 #[cfg(feature = "gecko")]
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
-use properties::PropertyDeclarationBlock;
-use selector_parser::SelectorImpl;
 use selectors::SelectorList;
 use servo_arc::Arc;
-use shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked};
-use shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
 use std::fmt::{self, Write};
-use str::CssStringWriter;
 
 /// A style rule, with selectors and declarations.
 #[derive(Debug)]

--- a/components/style/stylesheets/stylesheet.rs
+++ b/components/style/stylesheets/stylesheet.rs
@@ -2,31 +2,31 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use context::QuirksMode;
-use cssparser::{Parser, ParserInput, RuleListParser};
-use error_reporting::{ContextualParseError, ParseErrorReporter};
-use fallible::FallibleVec;
-use fxhash::FxHashMap;
-use invalidation::media_queries::{MediaListKey, ToMediaListKey};
-#[cfg(feature = "gecko")]
-use malloc_size_of::{MallocSizeOfOps, MallocUnconditionalShallowSizeOf};
-use media_queries::{Device, MediaList};
-use parking_lot::RwLock;
-use parser::ParserContext;
-use servo_arc::Arc;
-use shared_lock::{
+use crate::context::QuirksMode;
+use crate::error_reporting::{ContextualParseError, ParseErrorReporter};
+use crate::invalidation::media_queries::{MediaListKey, ToMediaListKey};
+use crate::media_queries::{Device, MediaList};
+use crate::parser::ParserContext;
+use crate::shared_lock::{
     DeepCloneParams, DeepCloneWithLock, Locked, SharedRwLock, SharedRwLockReadGuard,
 };
+use crate::stylesheets::loader::StylesheetLoader;
+use crate::stylesheets::rule_parser::{State, TopLevelRuleParser};
+use crate::stylesheets::rules_iterator::{EffectiveRules, EffectiveRulesIterator};
+use crate::stylesheets::rules_iterator::{NestedRuleIterationCondition, RulesIterator};
+use crate::stylesheets::{CssRule, CssRules, Origin, UrlExtraData};
+use crate::use_counters::UseCounters;
+use crate::{Namespace, Prefix};
+use cssparser::{Parser, ParserInput, RuleListParser};
+use fallible::FallibleVec;
+use fxhash::FxHashMap;
+#[cfg(feature = "gecko")]
+use malloc_size_of::{MallocSizeOfOps, MallocUnconditionalShallowSizeOf};
+use parking_lot::RwLock;
+use servo_arc::Arc;
 use std::mem;
 use std::sync::atomic::{AtomicBool, Ordering};
 use style_traits::ParsingMode;
-use stylesheets::loader::StylesheetLoader;
-use stylesheets::rule_parser::{State, TopLevelRuleParser};
-use stylesheets::rules_iterator::{EffectiveRules, EffectiveRulesIterator};
-use stylesheets::rules_iterator::{NestedRuleIterationCondition, RulesIterator};
-use stylesheets::{CssRule, CssRules, Origin, UrlExtraData};
-use use_counters::UseCounters;
-use {Namespace, Prefix};
 
 /// This structure holds the user-agent and user stylesheets.
 pub struct UserAgentStylesheets {
@@ -166,9 +166,9 @@ macro_rules! rule_filter {
         $(
             #[allow(missing_docs)]
             fn $method<F>(&self, device: &Device, guard: &SharedRwLockReadGuard, mut f: F)
-                where F: FnMut(&::stylesheets::$rule_type),
+                where F: FnMut(&crate::stylesheets::$rule_type),
             {
-                use stylesheets::CssRule;
+                use crate::stylesheets::CssRule;
 
                 for rule in self.effective_rules(device, guard) {
                     if let CssRule::$variant(ref lock) = *rule {

--- a/components/style/stylesheets/supports_rule.rs
+++ b/components/style/stylesheets/supports_rule.rs
@@ -4,24 +4,24 @@
 
 //! [@supports rules](https://drafts.csswg.org/css-conditional-3/#at-supports)
 
+use crate::parser::ParserContext;
+use crate::properties::{PropertyDeclaration, PropertyId, SourcePropertyDeclaration};
+use crate::selector_parser::{SelectorImpl, SelectorParser};
+use crate::shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked};
+use crate::shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
+use crate::str::CssStringWriter;
+use crate::stylesheets::{CssRuleType, CssRules, Namespaces};
 use cssparser::parse_important;
 use cssparser::{Delimiter, Parser, SourceLocation, Token};
 use cssparser::{ParseError as CssParseError, ParserInput};
 #[cfg(feature = "gecko")]
 use malloc_size_of::{MallocSizeOfOps, MallocUnconditionalShallowSizeOf};
-use parser::ParserContext;
-use properties::{PropertyDeclaration, PropertyId, SourcePropertyDeclaration};
-use selector_parser::{SelectorImpl, SelectorParser};
 use selectors::parser::{Selector, SelectorParseErrorKind};
 use servo_arc::Arc;
-use shared_lock::{DeepCloneParams, DeepCloneWithLock, Locked};
-use shared_lock::{SharedRwLock, SharedRwLockReadGuard, ToCssWithGuard};
 use std::ffi::{CStr, CString};
 use std::fmt::{self, Write};
 use std::str;
-use str::CssStringWriter;
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
-use stylesheets::{CssRuleType, CssRules, Namespaces};
 
 /// An [`@supports`][supports] rule.
 ///
@@ -103,7 +103,7 @@ impl SupportsCondition {
     ///
     /// <https://drafts.csswg.org/css-conditional/#supports_condition>
     pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
-        if input.try(|i| i.expect_ident_matching("not")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("not")).is_ok() {
             let inner = SupportsCondition::parse_in_parens(input)?;
             return Ok(SupportsCondition::Not(Box::new(inner)));
         }
@@ -129,7 +129,7 @@ impl SupportsCondition {
         loop {
             conditions.push(SupportsCondition::parse_in_parens(input)?);
             if input
-                .try(|input| input.expect_ident_matching(keyword))
+                .r#try(|input| input.expect_ident_matching(keyword))
                 .is_err()
             {
                 // Did not find the expected keyword.
@@ -175,20 +175,20 @@ impl SupportsCondition {
     fn parse_in_parens<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
         // Whitespace is normally taken care of in `Parser::next`,
         // but we want to not include it in `pos` for the SupportsCondition::FutureSyntax cases.
-        while input.try(Parser::expect_whitespace).is_ok() {}
+        while input.r#try(Parser::expect_whitespace).is_ok() {}
         let pos = input.position();
         let location = input.current_source_location();
         // FIXME: remove clone() when lifetimes are non-lexical
         match input.next()?.clone() {
             Token::ParenthesisBlock => {
                 let nested =
-                    input.try(|input| input.parse_nested_block(parse_condition_or_declaration));
+                    input.r#try(|input| input.parse_nested_block(parse_condition_or_declaration));
                 if nested.is_ok() {
                     return nested;
                 }
             },
             Token::Function(ident) => {
-                let nested = input.try(|input| {
+                let nested = input.r#try(|input| {
                     input.parse_nested_block(|input| {
                         SupportsCondition::parse_functional(&ident, input)
                     })
@@ -240,7 +240,7 @@ fn eval_moz_bool_pref(_: &CStr, _: &ParserContext) -> bool {
 pub fn parse_condition_or_declaration<'i, 't>(
     input: &mut Parser<'i, 't>,
 ) -> Result<SupportsCondition, ParseError<'i>> {
-    if let Ok(condition) = input.try(SupportsCondition::parse) {
+    if let Ok(condition) = input.r#try(SupportsCondition::parse) {
         Ok(SupportsCondition::Parenthesized(Box::new(condition)))
     } else {
         Declaration::parse(input).map(SupportsCondition::Declaration)
@@ -418,7 +418,7 @@ impl Declaration {
                     PropertyDeclaration::parse_into(&mut declarations, id, &context, input)
                         .map_err(|_| input.new_custom_error(()))
                 })?;
-                let _ = input.try(parse_important);
+                let _ = input.r#try(parse_important);
                 Ok(())
             })
             .is_ok()

--- a/components/style/stylesheets/supports_rule.rs
+++ b/components/style/stylesheets/supports_rule.rs
@@ -222,8 +222,8 @@ impl SupportsCondition {
 
 #[cfg(feature = "gecko")]
 fn eval_moz_bool_pref(name: &CStr, cx: &ParserContext) -> bool {
-    use gecko_bindings::bindings;
-    use stylesheets::Origin;
+    use crate::gecko_bindings::bindings;
+    use crate::stylesheets::Origin;
     if cx.stylesheet_origin != Origin::UserAgent && !cx.chrome_rules_enabled() {
         return false;
     }
@@ -325,7 +325,7 @@ impl RawSelector {
         #[cfg(feature = "gecko")]
         {
             if unsafe {
-                !::gecko_bindings::structs::StaticPrefs_sVarCache_layout_css_supports_selector_enabled
+                !crate::gecko_bindings::structs::StaticPrefs_sVarCache_layout_css_supports_selector_enabled
             } {
                 return false;
             }
@@ -347,7 +347,7 @@ impl RawSelector {
 
                 #[cfg(feature = "gecko")]
                 {
-                    use selector_parser::PseudoElement;
+                    use crate::selector_parser::PseudoElement;
                     use selectors::parser::Component;
 
                     let has_any_unknown_webkit_pseudo = selector.has_pseudo_element() && selector

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -4,27 +4,37 @@
 
 //! Selector matching.
 
-use applicable_declarations::{ApplicableDeclarationBlock, ApplicableDeclarationList};
-use context::{CascadeInputs, QuirksMode};
-use dom::{TElement, TShadowRoot};
-use element_state::{DocumentState, ElementState};
-use font_metrics::FontMetricsProvider;
+use crate::applicable_declarations::{ApplicableDeclarationBlock, ApplicableDeclarationList};
+use crate::context::{CascadeInputs, QuirksMode};
+use crate::dom::{TElement, TShadowRoot};
+use crate::element_state::{DocumentState, ElementState};
+use crate::font_metrics::FontMetricsProvider;
+use crate::invalidation::element::invalidation_map::InvalidationMap;
+use crate::invalidation::media_queries::{EffectiveMediaQueryResults, ToMediaListKey};
+use crate::media_queries::Device;
+use crate::properties::{self, CascadeMode, ComputedValues};
+use crate::properties::{AnimationRules, PropertyDeclarationBlock};
+use crate::rule_cache::{RuleCache, RuleCacheConditions};
+use crate::rule_tree::{CascadeLevel, RuleTree, ShadowCascadeOrder, StrongRuleNode, StyleSource};
+use crate::selector_map::{PrecomputedHashMap, PrecomputedHashSet, SelectorMap, SelectorMapEntry};
+use crate::selector_parser::{PerPseudoElementMap, PseudoElement, SelectorImpl, SnapshotMap};
+use crate::shared_lock::{Locked, SharedRwLockReadGuard, StylesheetGuards};
+use crate::stylesheet_set::{DataValidity, DocumentStylesheetSet, SheetRebuildKind};
+use crate::stylesheet_set::{DocumentStylesheetFlusher, SheetCollectionFlusher};
+use crate::stylesheets::keyframes_rule::KeyframesAnimation;
+use crate::stylesheets::viewport_rule::{self, MaybeNew, ViewportRule};
+use crate::stylesheets::StyleRule;
+use crate::stylesheets::StylesheetInDocument;
+use crate::stylesheets::{CssRule, Origin, OriginSet, PerOrigin, PerOriginIter};
+use crate::thread_state::{self, ThreadState};
+use crate::{Atom, LocalName, Namespace, WeakAtom};
 #[cfg(feature = "gecko")]
 use gecko_bindings::structs::{ServoStyleSetSizes, StyleRuleInclusion};
 use hashglobe::FailedAllocationError;
-use invalidation::element::invalidation_map::InvalidationMap;
-use invalidation::media_queries::{EffectiveMediaQueryResults, ToMediaListKey};
 #[cfg(feature = "gecko")]
 use malloc_size_of::MallocUnconditionalShallowSizeOf;
 #[cfg(feature = "gecko")]
 use malloc_size_of::{MallocShallowSizeOf, MallocSizeOf, MallocSizeOfOps};
-use media_queries::Device;
-use properties::{self, CascadeMode, ComputedValues};
-use properties::{AnimationRules, PropertyDeclarationBlock};
-use rule_cache::{RuleCache, RuleCacheConditions};
-use rule_tree::{CascadeLevel, RuleTree, ShadowCascadeOrder, StrongRuleNode, StyleSource};
-use selector_map::{PrecomputedHashMap, PrecomputedHashSet, SelectorMap, SelectorMapEntry};
-use selector_parser::{PerPseudoElementMap, PseudoElement, SelectorImpl, SnapshotMap};
 use selectors::attr::{CaseSensitivity, NamespaceConstraint};
 use selectors::bloom::BloomFilter;
 use selectors::matching::VisitedHandlingMode;
@@ -34,27 +44,17 @@ use selectors::parser::{SelectorIter, Visit};
 use selectors::visitor::SelectorVisitor;
 use selectors::NthIndexCache;
 use servo_arc::{Arc, ArcBorrow};
-use shared_lock::{Locked, SharedRwLockReadGuard, StylesheetGuards};
 use smallbitvec::SmallBitVec;
 use smallvec::SmallVec;
 use std::ops;
 use std::sync::Mutex;
 use style_traits::viewport::ViewportConstraints;
-use stylesheet_set::{DataValidity, DocumentStylesheetSet, SheetRebuildKind};
-use stylesheet_set::{DocumentStylesheetFlusher, SheetCollectionFlusher};
-use stylesheets::keyframes_rule::KeyframesAnimation;
-use stylesheets::viewport_rule::{self, MaybeNew, ViewportRule};
-use stylesheets::StyleRule;
-use stylesheets::StylesheetInDocument;
 #[cfg(feature = "gecko")]
 use stylesheets::{CounterStyleRule, FontFaceRule, FontFeatureValuesRule, PageRule};
-use stylesheets::{CssRule, Origin, OriginSet, PerOrigin, PerOriginIter};
-use thread_state::{self, ThreadState};
-use {Atom, LocalName, Namespace, WeakAtom};
 
 /// The type of the stylesheets that the stylist contains.
 #[cfg(feature = "servo")]
-pub type StylistSheet = ::stylesheets::DocumentStyleSheet;
+pub type StylistSheet = crate::stylesheets::DocumentStyleSheet;
 
 /// The type of the stylesheets that the stylist contains.
 #[cfg(feature = "gecko")]
@@ -719,7 +719,7 @@ impl Stylist {
     where
         E: TElement,
     {
-        use font_metrics::ServoMetricsProvider;
+        use crate::font_metrics::ServoMetricsProvider;
         self.precomputed_values_for_pseudo::<E>(
             guards,
             &pseudo,
@@ -1556,7 +1556,7 @@ impl Stylist {
     where
         E: TElement,
     {
-        use font_metrics::get_metrics_provider_for_product;
+        use crate::font_metrics::get_metrics_provider_for_product;
 
         let block = declarations.read_with(guards.author);
         let iter_declarations = || {
@@ -2333,7 +2333,7 @@ impl CascadeData {
     where
         S: StylesheetInDocument + ToMediaListKey + 'static,
     {
-        use invalidation::media_queries::PotentiallyEffectiveMediaRules;
+        use crate::invalidation::media_queries::PotentiallyEffectiveMediaRules;
 
         let effective_now = stylesheet.is_effective_for_device(device, guard);
 

--- a/components/style/stylist.rs
+++ b/components/style/stylist.rs
@@ -9,6 +9,8 @@ use crate::context::{CascadeInputs, QuirksMode};
 use crate::dom::{TElement, TShadowRoot};
 use crate::element_state::{DocumentState, ElementState};
 use crate::font_metrics::FontMetricsProvider;
+#[cfg(feature = "gecko")]
+use crate::gecko_bindings::structs::{ServoStyleSetSizes, StyleRuleInclusion};
 use crate::invalidation::element::invalidation_map::InvalidationMap;
 use crate::invalidation::media_queries::{EffectiveMediaQueryResults, ToMediaListKey};
 use crate::media_queries::Device;
@@ -25,11 +27,11 @@ use crate::stylesheets::keyframes_rule::KeyframesAnimation;
 use crate::stylesheets::viewport_rule::{self, MaybeNew, ViewportRule};
 use crate::stylesheets::StyleRule;
 use crate::stylesheets::StylesheetInDocument;
+#[cfg(feature = "gecko")]
+use crate::stylesheets::{CounterStyleRule, FontFaceRule, FontFeatureValuesRule, PageRule};
 use crate::stylesheets::{CssRule, Origin, OriginSet, PerOrigin, PerOriginIter};
 use crate::thread_state::{self, ThreadState};
 use crate::{Atom, LocalName, Namespace, WeakAtom};
-#[cfg(feature = "gecko")]
-use gecko_bindings::structs::{ServoStyleSetSizes, StyleRuleInclusion};
 use hashglobe::FailedAllocationError;
 #[cfg(feature = "gecko")]
 use malloc_size_of::MallocUnconditionalShallowSizeOf;
@@ -49,8 +51,6 @@ use smallvec::SmallVec;
 use std::ops;
 use std::sync::Mutex;
 use style_traits::viewport::ViewportConstraints;
-#[cfg(feature = "gecko")]
-use stylesheets::{CounterStyleRule, FontFaceRule, FontFeatureValuesRule, PageRule};
 
 /// The type of the stylesheets that the stylist contains.
 #[cfg(feature = "servo")]
@@ -58,7 +58,7 @@ pub type StylistSheet = crate::stylesheets::DocumentStyleSheet;
 
 /// The type of the stylesheets that the stylist contains.
 #[cfg(feature = "gecko")]
-pub type StylistSheet = ::gecko::data::GeckoStyleSheet;
+pub type StylistSheet = crate::gecko::data::GeckoStyleSheet;
 
 /// A cache of computed user-agent data, to be shared across documents.
 lazy_static! {

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -4,18 +4,18 @@
 
 //! Traversing the DOM tree; the bloom filter.
 
-use context::{ElementCascadeInputs, SharedStyleContext, StyleContext};
-use data::{ElementData, ElementStyles};
-use dom::{NodeInfo, OpaqueNode, TElement, TNode};
-use invalidation::element::restyle_hints::RestyleHint;
-use matching::{ChildCascadeRequirement, MatchMethods};
-use selector_parser::PseudoElement;
+use crate::context::{ElementCascadeInputs, SharedStyleContext, StyleContext};
+use crate::data::{ElementData, ElementStyles};
+use crate::dom::{NodeInfo, OpaqueNode, TElement, TNode};
+use crate::invalidation::element::restyle_hints::RestyleHint;
+use crate::matching::{ChildCascadeRequirement, MatchMethods};
+use crate::selector_parser::PseudoElement;
+use crate::sharing::StyleSharingTarget;
+use crate::style_resolver::{PseudoElementResolution, StyleResolverForElement};
+use crate::stylist::RuleInclusion;
+use crate::traversal_flags::TraversalFlags;
 use selectors::NthIndexCache;
-use sharing::StyleSharingTarget;
 use smallvec::SmallVec;
-use style_resolver::{PseudoElementResolution, StyleResolverForElement};
-use stylist::RuleInclusion;
-use traversal_flags::TraversalFlags;
 
 /// A per-traversal-level chunk of data. This is sent down by the traversal, and
 /// currently only holds the dom depth for the bloom filter.
@@ -307,7 +307,7 @@ pub fn resolve_style<E>(
 where
     E: TElement,
 {
-    use style_resolver::StyleResolverForElement;
+    use crate::style_resolver::StyleResolverForElement;
 
     debug_assert!(
         rule_inclusion == RuleInclusion::DefaultOnly ||
@@ -406,8 +406,8 @@ pub fn recalc_style_at<E, D, F>(
     D: DomTraversal<E>,
     F: FnMut(E::ConcreteNode),
 {
+    use crate::traversal_flags::TraversalFlags;
     use std::cmp;
-    use traversal_flags::TraversalFlags;
 
     let flags = context.shared.traversal_flags;
     let is_initial_style = !data.has_styles();
@@ -586,7 +586,7 @@ fn compute_style<E>(
 where
     E: TElement,
 {
-    use data::RestyleKind::*;
+    use crate::data::RestyleKind::*;
 
     context.thread_local.statistics.elements_styled += 1;
     let kind = data.restyle_kind(context.shared);
@@ -719,9 +719,9 @@ fn notify_paint_worklet<E>(context: &StyleContext<E>, data: &ElementData)
 where
     E: TElement,
 {
+    use crate::values::generics::image::Image;
+    use crate::values::Either;
     use style_traits::ToCss;
-    use values::generics::image::Image;
-    use values::Either;
 
     // We speculatively evaluate any paint worklets during styling.
     // This allows us to run paint worklets in parallel with style and layout.
@@ -811,7 +811,7 @@ fn note_children<E, D, F>(
                     child_hint |= RestyleHint::RECASCADE_SELF | RestyleHint::RECASCADE_DESCENDANTS;
                 },
                 ChildCascadeRequirement::MustCascadeChildrenIfInheritResetStyle => {
-                    use properties::computed_value_flags::ComputedValueFlags;
+                    use crate::properties::computed_value_flags::ComputedValueFlags;
                     if child_data
                         .styles
                         .primary()

--- a/components/style/traversal_flags.rs
+++ b/components/style/traversal_flags.rs
@@ -40,7 +40,7 @@ bitflags! {
 #[cfg(feature = "gecko")]
 #[inline]
 pub fn assert_traversal_flags_match() {
-    use gecko_bindings::structs;
+    use crate::gecko_bindings::structs;
 
     macro_rules! check_traversal_flags {
         ( $( $a:ident => $b:path ),*, ) => {

--- a/components/style/use_counters/mod.rs
+++ b/components/style/use_counters/mod.rs
@@ -4,9 +4,9 @@
 
 //! Various stuff for CSS property use counters.
 
+use crate::properties::{NonCustomPropertyId, NON_CUSTOM_PROPERTY_ID_COUNT};
 #[cfg(feature = "gecko")]
 use gecko_bindings::sugar::ownership::{HasBoxFFI, HasFFI, HasSimpleFFI};
-use properties::{NonCustomPropertyId, NON_CUSTOM_PROPERTY_ID_COUNT};
 use std::cell::Cell;
 
 #[cfg(target_pointer_width = "64")]

--- a/components/style/use_counters/mod.rs
+++ b/components/style/use_counters/mod.rs
@@ -4,9 +4,9 @@
 
 //! Various stuff for CSS property use counters.
 
-use crate::properties::{NonCustomPropertyId, NON_CUSTOM_PROPERTY_ID_COUNT};
 #[cfg(feature = "gecko")]
-use gecko_bindings::sugar::ownership::{HasBoxFFI, HasFFI, HasSimpleFFI};
+use crate::gecko_bindings::sugar::ownership::{HasBoxFFI, HasFFI, HasSimpleFFI};
+use crate::properties::{NonCustomPropertyId, NON_CUSTOM_PROPERTY_ID_COUNT};
 use std::cell::Cell;
 
 #[cfg(target_pointer_width = "64")]
@@ -78,7 +78,7 @@ impl UseCounters {
 
 #[cfg(feature = "gecko")]
 unsafe impl HasFFI for UseCounters {
-    type FFIType = ::gecko_bindings::structs::StyleUseCounters;
+    type FFIType = crate::gecko_bindings::structs::StyleUseCounters;
 }
 
 #[cfg(feature = "gecko")]

--- a/components/style/values/animated/color.rs
+++ b/components/style/values/animated/color.rs
@@ -4,9 +4,9 @@
 
 //! Animated types for CSS colors.
 
-use values::animated::{Animate, Procedure, ToAnimatedZero};
-use values::distance::{ComputeSquaredDistance, SquaredDistance};
-use values::generics::color::{Color as GenericColor, ComplexColorRatios};
+use crate::values::animated::{Animate, Procedure, ToAnimatedZero};
+use crate::values::distance::{ComputeSquaredDistance, SquaredDistance};
+use crate::values::generics::color::{Color as GenericColor, ComplexColorRatios};
 
 /// An animated RGBA color.
 ///

--- a/components/style/values/animated/effects.rs
+++ b/components/style/values/animated/effects.rs
@@ -4,16 +4,16 @@
 
 //! Animated types for CSS values related to effects.
 
-use values::animated::color::Color;
-use values::computed::length::Length;
+use crate::values::animated::color::Color;
+use crate::values::computed::length::Length;
+use crate::values::computed::{Angle, Number};
+use crate::values::generics::effects::BoxShadow as GenericBoxShadow;
+use crate::values::generics::effects::Filter as GenericFilter;
+use crate::values::generics::effects::SimpleShadow as GenericSimpleShadow;
+#[cfg(not(feature = "gecko"))]
+use crate::values::Impossible;
 #[cfg(feature = "gecko")]
 use values::computed::url::ComputedUrl;
-use values::computed::{Angle, Number};
-use values::generics::effects::BoxShadow as GenericBoxShadow;
-use values::generics::effects::Filter as GenericFilter;
-use values::generics::effects::SimpleShadow as GenericSimpleShadow;
-#[cfg(not(feature = "gecko"))]
-use values::Impossible;
 
 /// An animated value for a single `box-shadow`.
 pub type BoxShadow = GenericBoxShadow<Color, Length, Length, Length>;

--- a/components/style/values/animated/effects.rs
+++ b/components/style/values/animated/effects.rs
@@ -6,14 +6,14 @@
 
 use crate::values::animated::color::Color;
 use crate::values::computed::length::Length;
+#[cfg(feature = "gecko")]
+use crate::values::computed::url::ComputedUrl;
 use crate::values::computed::{Angle, Number};
 use crate::values::generics::effects::BoxShadow as GenericBoxShadow;
 use crate::values::generics::effects::Filter as GenericFilter;
 use crate::values::generics::effects::SimpleShadow as GenericSimpleShadow;
 #[cfg(not(feature = "gecko"))]
 use crate::values::Impossible;
-#[cfg(feature = "gecko")]
-use values::computed::url::ComputedUrl;
 
 /// An animated value for a single `box-shadow`.
 pub type BoxShadow = GenericBoxShadow<Color, Length, Length, Length>;

--- a/components/style/values/animated/font.rs
+++ b/components/style/values/animated/font.rs
@@ -5,10 +5,10 @@
 //! Animation implementation for various font-related types.
 
 use super::{Animate, Procedure, ToAnimatedZero};
-use values::computed::font::{FontVariationSettings, FontWeight};
-use values::computed::Number;
-use values::distance::{ComputeSquaredDistance, SquaredDistance};
-use values::generics::font::{FontSettings as GenericFontSettings, FontTag, VariationValue};
+use crate::values::computed::font::{FontVariationSettings, FontWeight};
+use crate::values::computed::Number;
+use crate::values::distance::{ComputeSquaredDistance, SquaredDistance};
+use crate::values::generics::font::{FontSettings as GenericFontSettings, FontTag, VariationValue};
 
 impl ToAnimatedZero for FontWeight {
     #[inline]

--- a/components/style/values/animated/length.rs
+++ b/components/style/values/animated/length.rs
@@ -5,11 +5,11 @@
 //! Animation implementation for various length-related types.
 
 use super::{Animate, Procedure, ToAnimatedValue, ToAnimatedZero};
-use values::computed::length::{CalcLengthOrPercentage, Length};
-use values::computed::length::{LengthOrPercentageOrAuto, LengthOrPercentageOrNone};
-use values::computed::MaxLength as ComputedMaxLength;
-use values::computed::MozLength as ComputedMozLength;
-use values::computed::Percentage;
+use crate::values::computed::length::{CalcLengthOrPercentage, Length};
+use crate::values::computed::length::{LengthOrPercentageOrAuto, LengthOrPercentageOrNone};
+use crate::values::computed::MaxLength as ComputedMaxLength;
+use crate::values::computed::MozLength as ComputedMozLength;
+use crate::values::computed::Percentage;
 
 /// <https://drafts.csswg.org/css-transitions/#animtype-lpcalc>
 impl Animate for CalcLengthOrPercentage {
@@ -74,8 +74,8 @@ impl ToAnimatedValue for ComputedMaxLength {
 
     #[inline]
     fn from_animated_value(animated: Self::AnimatedValue) -> Self {
-        use values::computed::{Length, LengthOrPercentageOrNone, Percentage};
-        use values::generics::length::MaxLength as GenericMaxLength;
+        use crate::values::computed::{Length, LengthOrPercentageOrNone, Percentage};
+        use crate::values::generics::length::MaxLength as GenericMaxLength;
         match animated {
             GenericMaxLength::LengthOrPercentageOrNone(lopn) => {
                 let result = match lopn {
@@ -104,8 +104,8 @@ impl ToAnimatedValue for ComputedMozLength {
 
     #[inline]
     fn from_animated_value(animated: Self::AnimatedValue) -> Self {
-        use values::computed::{Length, LengthOrPercentageOrAuto, Percentage};
-        use values::generics::length::MozLength as GenericMozLength;
+        use crate::values::computed::{Length, LengthOrPercentageOrAuto, Percentage};
+        use crate::values::generics::length::MozLength as GenericMozLength;
         match animated {
             GenericMozLength::LengthOrPercentageOrAuto(lopa) => {
                 let result = match lopa {

--- a/components/style/values/animated/mod.rs
+++ b/components/style/values/animated/mod.rs
@@ -9,14 +9,14 @@
 //! module's raison d'être is to ultimately contain all these types.
 
 use app_units::Au;
+use crate::properties::PropertyId;
+use crate::values::computed::length::CalcLengthOrPercentage;
+use crate::values::computed::url::ComputedUrl;
+use crate::values::computed::Angle as ComputedAngle;
+use crate::values::computed::BorderCornerRadius as ComputedBorderCornerRadius;
 use euclid::{Point2D, Size2D};
-use properties::PropertyId;
 use smallvec::SmallVec;
 use std::cmp;
-use values::computed::length::CalcLengthOrPercentage;
-use values::computed::url::ComputedUrl;
-use values::computed::Angle as ComputedAngle;
-use values::computed::BorderCornerRadius as ComputedBorderCornerRadius;
 
 pub mod color;
 pub mod effects;

--- a/components/style/values/animated/svg.rs
+++ b/components/style/values/animated/svg.rs
@@ -5,13 +5,13 @@
 //! Animation implementations for various SVG-related types.
 
 use super::{Animate, Procedure, ToAnimatedZero};
-use properties::animated_properties::ListAnimation;
-use values::animated::color::Color as AnimatedColor;
-use values::computed::url::ComputedUrl;
-use values::computed::{LengthOrPercentage, Number, NumberOrPercentage};
-use values::distance::{ComputeSquaredDistance, SquaredDistance};
-use values::generics::svg::{SVGLength, SVGPaint, SvgLengthOrPercentageOrNumber};
-use values::generics::svg::{SVGOpacity, SVGStrokeDashArray};
+use crate::properties::animated_properties::ListAnimation;
+use crate::values::animated::color::Color as AnimatedColor;
+use crate::values::computed::url::ComputedUrl;
+use crate::values::computed::{LengthOrPercentage, Number, NumberOrPercentage};
+use crate::values::distance::{ComputeSquaredDistance, SquaredDistance};
+use crate::values::generics::svg::{SVGLength, SVGPaint, SvgLengthOrPercentageOrNumber};
+use crate::values::generics::svg::{SVGOpacity, SVGStrokeDashArray};
 
 /// Animated SVGPaint.
 pub type IntermediateSVGPaint = SVGPaint<AnimatedColor, ComputedUrl>;

--- a/components/style/values/computed/align.rs
+++ b/components/style/values/computed/align.rs
@@ -6,8 +6,8 @@
 //!
 //! https://drafts.csswg.org/css-align/
 
-use values::computed::{Context, ToComputedValue};
-use values::specified;
+use crate::values::computed::{Context, ToComputedValue};
+use crate::values::specified;
 
 pub use super::specified::{AlignContent, AlignItems, JustifyContent, SelfAlignment};
 pub use super::specified::{AlignSelf, JustifySelf};
@@ -60,7 +60,7 @@ impl ToComputedValue for specified::JustifyItems {
 
     /// <https://drafts.csswg.org/css-align/#valdef-justify-items-legacy>
     fn to_computed_value(&self, _context: &Context) -> JustifyItems {
-        use values::specified::align;
+        use crate::values::specified::align;
         let specified = *self;
         let computed = if self.0 != align::AlignFlags::LEGACY {
             *self

--- a/components/style/values/computed/angle.rs
+++ b/components/style/values/computed/angle.rs
@@ -4,14 +4,14 @@
 
 //! Computed angles.
 
+use crate::values::distance::{ComputeSquaredDistance, SquaredDistance};
+use crate::values::CSSFloat;
 use num_traits::Zero;
 use std::f64::consts::PI;
 use std::fmt::{self, Write};
 use std::ops::Add;
 use std::{f32, f64};
 use style_traits::{CssWriter, ToCss};
-use values::distance::{ComputeSquaredDistance, SquaredDistance};
-use values::CSSFloat;
 
 /// A computed angle in degrees.
 #[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]

--- a/components/style/values/computed/background.rs
+++ b/components/style/values/computed/background.rs
@@ -4,13 +4,13 @@
 
 //! Computed types for CSS values related to backgrounds.
 
+use crate::values::computed::length::NonNegativeLengthOrPercentageOrAuto;
+use crate::values::computed::{Context, ToComputedValue};
+use crate::values::generics::background::BackgroundSize as GenericBackgroundSize;
+use crate::values::specified::background::BackgroundRepeat as SpecifiedBackgroundRepeat;
+use crate::values::specified::background::BackgroundRepeatKeyword;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ToCss};
-use values::computed::length::NonNegativeLengthOrPercentageOrAuto;
-use values::computed::{Context, ToComputedValue};
-use values::generics::background::BackgroundSize as GenericBackgroundSize;
-use values::specified::background::BackgroundRepeat as SpecifiedBackgroundRepeat;
-use values::specified::background::BackgroundRepeatKeyword;
 
 /// A computed value for the `background-size` property.
 pub type BackgroundSize = GenericBackgroundSize<NonNegativeLengthOrPercentageOrAuto>;

--- a/components/style/values/computed/basic_shape.rs
+++ b/components/style/values/computed/basic_shape.rs
@@ -7,14 +7,14 @@
 //!
 //! [basic-shape]: https://drafts.csswg.org/css-shapes/#typedef-basic-shape
 
+use crate::values::computed::url::ComputedUrl;
+use crate::values::computed::{Image, LengthOrPercentage};
+use crate::values::generics::basic_shape as generic;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ToCss};
-use values::computed::url::ComputedUrl;
-use values::computed::{Image, LengthOrPercentage};
-use values::generics::basic_shape as generic;
 
 /// A computed alias for FillRule.
-pub use values::generics::basic_shape::FillRule;
+pub use crate::values::generics::basic_shape::FillRule;
 
 /// A computed clipping shape.
 pub type ClippingShape = generic::ClippingShape<BasicShape, ComputedUrl>;

--- a/components/style/values/computed/border.rs
+++ b/components/style/values/computed/border.rs
@@ -5,18 +5,18 @@
 //! Computed types for CSS values related to borders.
 
 use app_units::Au;
-use values::animated::ToAnimatedZero;
-use values::computed::length::{LengthOrPercentage, NonNegativeLength};
-use values::computed::{Number, NumberOrPercentage};
-use values::generics::border::BorderCornerRadius as GenericBorderCornerRadius;
-use values::generics::border::BorderImageSideWidth as GenericBorderImageSideWidth;
-use values::generics::border::BorderImageSlice as GenericBorderImageSlice;
-use values::generics::border::BorderRadius as GenericBorderRadius;
-use values::generics::border::BorderSpacing as GenericBorderSpacing;
-use values::generics::rect::Rect;
-use values::generics::size::Size;
+use crate::values::animated::ToAnimatedZero;
+use crate::values::computed::length::{LengthOrPercentage, NonNegativeLength};
+use crate::values::computed::{Number, NumberOrPercentage};
+use crate::values::generics::border::BorderCornerRadius as GenericBorderCornerRadius;
+use crate::values::generics::border::BorderImageSideWidth as GenericBorderImageSideWidth;
+use crate::values::generics::border::BorderImageSlice as GenericBorderImageSlice;
+use crate::values::generics::border::BorderRadius as GenericBorderRadius;
+use crate::values::generics::border::BorderSpacing as GenericBorderSpacing;
+use crate::values::generics::rect::Rect;
+use crate::values::generics::size::Size;
 
-pub use values::specified::border::BorderImageRepeat;
+pub use crate::values::specified::border::BorderImageRepeat;
 
 /// A computed value for the `border-image-width` property.
 pub type BorderImageWidth = Rect<BorderImageSideWidth>;

--- a/components/style/values/computed/box.rs
+++ b/components/style/values/computed/box.rs
@@ -4,16 +4,18 @@
 
 //! Computed types for box properties.
 
-use values::computed::length::{LengthOrPercentage, NonNegativeLength};
-use values::computed::{Context, Number, ToComputedValue};
-use values::generics::box_::AnimationIterationCount as GenericAnimationIterationCount;
-use values::generics::box_::Perspective as GenericPerspective;
-use values::generics::box_::VerticalAlign as GenericVerticalAlign;
-use values::specified::box_ as specified;
+use crate::values::computed::length::{LengthOrPercentage, NonNegativeLength};
+use crate::values::computed::{Context, Number, ToComputedValue};
+use crate::values::generics::box_::AnimationIterationCount as GenericAnimationIterationCount;
+use crate::values::generics::box_::Perspective as GenericPerspective;
+use crate::values::generics::box_::VerticalAlign as GenericVerticalAlign;
+use crate::values::specified::box_ as specified;
 
-pub use values::specified::box_::{AnimationName, Appearance, Contain, Display, OverflowClipBox};
-pub use values::specified::box_::{Clear as SpecifiedClear, Float as SpecifiedFloat};
-pub use values::specified::box_::{
+pub use crate::values::specified::box_::{
+    AnimationName, Appearance, Contain, Display, OverflowClipBox,
+};
+pub use crate::values::specified::box_::{Clear as SpecifiedClear, Float as SpecifiedFloat};
+pub use crate::values::specified::box_::{
     OverscrollBehavior, ScrollSnapType, TouchAction, TransitionProperty, WillChange,
 };
 

--- a/components/style/values/computed/color.rs
+++ b/components/style/values/computed/color.rs
@@ -4,12 +4,12 @@
 
 //! Computed color values.
 
+use crate::values::animated::color::RGBA as AnimatedRGBA;
+use crate::values::animated::ToAnimatedValue;
+use crate::values::generics::color::Color as GenericColor;
 use cssparser::{Color as CSSParserColor, RGBA};
 use std::fmt;
 use style_traits::{CssWriter, ToCss};
-use values::animated::color::RGBA as AnimatedRGBA;
-use values::animated::ToAnimatedValue;
-use values::generics::color::Color as GenericColor;
 
 /// Computed value type for the specified RGBAColor.
 pub type RGBAColor = RGBA;

--- a/components/style/values/computed/column.rs
+++ b/components/style/values/computed/column.rs
@@ -4,8 +4,8 @@
 
 //! Computed types for the column properties.
 
-use values::computed::PositiveInteger;
-use values::generics::column::ColumnCount as GenericColumnCount;
+use crate::values::computed::PositiveInteger;
+use crate::values::generics::column::ColumnCount as GenericColumnCount;
 
 /// A computed type for `column-count` values.
 pub type ColumnCount = GenericColumnCount<PositiveInteger>;

--- a/components/style/values/computed/counters.rs
+++ b/components/style/values/computed/counters.rs
@@ -4,10 +4,10 @@
 
 //! Computed values for counter properties
 
-use values::computed::url::ComputedImageUrl;
-use values::generics::counters as generics;
-use values::generics::counters::CounterIncrement as GenericCounterIncrement;
-use values::generics::counters::CounterReset as GenericCounterReset;
+use crate::values::computed::url::ComputedImageUrl;
+use crate::values::generics::counters as generics;
+use crate::values::generics::counters::CounterIncrement as GenericCounterIncrement;
+use crate::values::generics::counters::CounterReset as GenericCounterReset;
 
 /// A computed value for the `counter-increment` property.
 pub type CounterIncrement = GenericCounterIncrement<i32>;

--- a/components/style/values/computed/easing.rs
+++ b/components/style/values/computed/easing.rs
@@ -4,8 +4,8 @@
 
 //! Computed types for CSS Easing functions.
 
-use values::computed::{Integer, Number};
-use values::generics::easing;
+use crate::values::computed::{Integer, Number};
+use crate::values::generics::easing;
 
 /// A computed timing function.
 pub type ComputedTimingFunction = easing::TimingFunction<Integer, Number>;

--- a/components/style/values/computed/effects.rs
+++ b/components/style/values/computed/effects.rs
@@ -6,14 +6,14 @@
 
 use crate::values::computed::color::Color;
 use crate::values::computed::length::{Length, NonNegativeLength};
+#[cfg(feature = "gecko")]
+use crate::values::computed::url::ComputedUrl;
 use crate::values::computed::{Angle, NonNegativeNumber};
 use crate::values::generics::effects::BoxShadow as GenericBoxShadow;
 use crate::values::generics::effects::Filter as GenericFilter;
 use crate::values::generics::effects::SimpleShadow as GenericSimpleShadow;
 #[cfg(not(feature = "gecko"))]
 use crate::values::Impossible;
-#[cfg(feature = "gecko")]
-use values::computed::url::ComputedUrl;
 
 /// A computed value for a single shadow of the `box-shadow` property.
 pub type BoxShadow = GenericBoxShadow<Color, Length, NonNegativeLength, Length>;

--- a/components/style/values/computed/effects.rs
+++ b/components/style/values/computed/effects.rs
@@ -4,16 +4,16 @@
 
 //! Computed types for CSS values related to effects.
 
-use values::computed::color::Color;
-use values::computed::length::{Length, NonNegativeLength};
+use crate::values::computed::color::Color;
+use crate::values::computed::length::{Length, NonNegativeLength};
+use crate::values::computed::{Angle, NonNegativeNumber};
+use crate::values::generics::effects::BoxShadow as GenericBoxShadow;
+use crate::values::generics::effects::Filter as GenericFilter;
+use crate::values::generics::effects::SimpleShadow as GenericSimpleShadow;
+#[cfg(not(feature = "gecko"))]
+use crate::values::Impossible;
 #[cfg(feature = "gecko")]
 use values::computed::url::ComputedUrl;
-use values::computed::{Angle, NonNegativeNumber};
-use values::generics::effects::BoxShadow as GenericBoxShadow;
-use values::generics::effects::Filter as GenericFilter;
-use values::generics::effects::SimpleShadow as GenericSimpleShadow;
-#[cfg(not(feature = "gecko"))]
-use values::Impossible;
 
 /// A computed value for a single shadow of the `box-shadow` property.
 pub type BoxShadow = GenericBoxShadow<Color, Length, NonNegativeLength, Length>;

--- a/components/style/values/computed/flex.rs
+++ b/components/style/values/computed/flex.rs
@@ -4,11 +4,11 @@
 
 //! Computed types for CSS values related to flexbox.
 
-use values::generics::flex::FlexBasis as GenericFlexBasis;
+use crate::values::generics::flex::FlexBasis as GenericFlexBasis;
 
 /// The `width` value type.
 #[cfg(feature = "servo")]
-pub type Width = ::values::computed::NonNegativeLengthOrPercentageOrAuto;
+pub type Width = crate::values::computed::NonNegativeLengthOrPercentageOrAuto;
 
 /// The `width` value type.
 #[cfg(feature = "gecko")]

--- a/components/style/values/computed/flex.rs
+++ b/components/style/values/computed/flex.rs
@@ -12,7 +12,7 @@ pub type Width = crate::values::computed::NonNegativeLengthOrPercentageOrAuto;
 
 /// The `width` value type.
 #[cfg(feature = "gecko")]
-pub type Width = ::values::computed::MozLength;
+pub type Width = crate::values::computed::MozLength;
 
 /// A computed value for the `flex-basis` property.
 pub type FlexBasis = GenericFlexBasis<Width>;

--- a/components/style/values/computed/font.rs
+++ b/components/style/values/computed/font.rs
@@ -6,6 +6,10 @@
 
 use app_units::Au;
 use byteorder::{BigEndian, ByteOrder};
+#[cfg(feature = "gecko")]
+use crate::gecko_bindings::sugar::refptr::RefPtr;
+#[cfg(feature = "gecko")]
+use crate::gecko_bindings::{bindings, structs};
 use crate::values::animated::{ToAnimatedValue, ToAnimatedZero};
 use crate::values::computed::{Angle, Context, Integer, NonNegativeLength, NonNegativePercentage};
 use crate::values::computed::{Number, Percentage, ToComputedValue};
@@ -17,10 +21,6 @@ use crate::values::specified::length::{FontBaseSize, NoCalcLength};
 use crate::values::CSSFloat;
 use crate::Atom;
 use cssparser::{serialize_identifier, CssStringWriter, Parser};
-#[cfg(feature = "gecko")]
-use gecko_bindings::sugar::refptr::RefPtr;
-#[cfg(feature = "gecko")]
-use gecko_bindings::{bindings, structs};
 #[cfg(feature = "gecko")]
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use std::fmt::{self, Write};
@@ -441,7 +441,7 @@ impl SingleFontFamily {
     #[cfg(feature = "gecko")]
     /// Return the generic ID for a given generic font name
     pub fn generic(name: &Atom) -> (structs::FontFamilyType, u8) {
-        use gecko_bindings::structs::FontFamilyType;
+        use crate::gecko_bindings::structs::FontFamilyType;
         if *name == atom!("serif") {
             (FontFamilyType::eFamily_serif, structs::kGenericFont_serif)
         } else if *name == atom!("sans-serif") {
@@ -477,7 +477,7 @@ impl SingleFontFamily {
     #[cfg(feature = "gecko")]
     /// Get the corresponding font-family with family name
     fn from_font_family_name(family: &structs::FontFamilyName) -> SingleFontFamily {
-        use gecko_bindings::structs::FontFamilyType;
+        use crate::gecko_bindings::structs::FontFamilyType;
 
         match family.mType {
             FontFamilyType::eFamily_sans_serif => SingleFontFamily::Generic(atom!("sans-serif")),
@@ -545,7 +545,7 @@ impl Hash for FontFamilyList {
     where
         H: Hasher,
     {
-        use string_cache::WeakAtom;
+        use crate::string_cache::WeakAtom;
 
         for name in self.0.mNames.iter() {
             name.mType.hash(state);
@@ -827,7 +827,7 @@ impl ToComputedValue for specified::MozScriptLevel {
     type ComputedValue = MozScriptLevel;
 
     fn to_computed_value(&self, cx: &Context) -> i8 {
-        use properties::longhands::_moz_math_display::SpecifiedValue as DisplayValue;
+        use crate::properties::longhands::_moz_math_display::SpecifiedValue as DisplayValue;
         use std::{cmp, i8};
 
         let int = match *self {

--- a/components/style/values/computed/font.rs
+++ b/components/style/values/computed/font.rs
@@ -6,6 +6,16 @@
 
 use app_units::Au;
 use byteorder::{BigEndian, ByteOrder};
+use crate::values::animated::{ToAnimatedValue, ToAnimatedZero};
+use crate::values::computed::{Angle, Context, Integer, NonNegativeLength, NonNegativePercentage};
+use crate::values::computed::{Number, Percentage, ToComputedValue};
+use crate::values::generics::font::{
+    self as generics, FeatureTagValue, FontSettings, VariationValue,
+};
+use crate::values::specified::font::{self as specified, MAX_FONT_WEIGHT, MIN_FONT_WEIGHT};
+use crate::values::specified::length::{FontBaseSize, NoCalcLength};
+use crate::values::CSSFloat;
+use crate::Atom;
 use cssparser::{serialize_identifier, CssStringWriter, Parser};
 #[cfg(feature = "gecko")]
 use gecko_bindings::sugar::refptr::RefPtr;
@@ -18,17 +28,11 @@ use std::hash::{Hash, Hasher};
 #[cfg(feature = "servo")]
 use std::slice;
 use style_traits::{CssWriter, ParseError, ToCss};
-use values::animated::{ToAnimatedValue, ToAnimatedZero};
-use values::computed::{Angle, Context, Integer, NonNegativeLength, NonNegativePercentage};
-use values::computed::{Number, Percentage, ToComputedValue};
-use values::generics::font::{self as generics, FeatureTagValue, FontSettings, VariationValue};
-use values::specified::font::{self as specified, MAX_FONT_WEIGHT, MIN_FONT_WEIGHT};
-use values::specified::length::{FontBaseSize, NoCalcLength};
-use values::CSSFloat;
-use Atom;
 
-pub use values::computed::Length as MozScriptMinSize;
-pub use values::specified::font::{FontSynthesis, MozScriptSizeMultiplier, XLang, XTextZoom};
+pub use crate::values::computed::Length as MozScriptMinSize;
+pub use crate::values::specified::font::{
+    FontSynthesis, MozScriptSizeMultiplier, XLang, XTextZoom,
+};
 
 /// A value for the font-weight property per:
 ///
@@ -370,7 +374,7 @@ impl SingleFontFamily {
 
     /// Parse a font-family value
     pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Self, ParseError<'i>> {
-        if let Ok(value) = input.try(|i| i.expect_string_cloned()) {
+        if let Ok(value) = input.r#try(|i| i.expect_string_cloned()) {
             return Ok(SingleFontFamily::FamilyName(FamilyName {
                 name: Atom::from(&*value),
                 syntax: FamilyNameSyntax::Quoted,
@@ -415,7 +419,7 @@ impl SingleFontFamily {
             value.push(' ');
             value.push_str(&ident);
         }
-        while let Ok(ident) = input.try(|i| i.expect_ident_cloned()) {
+        while let Ok(ident) = input.r#try(|i| i.expect_ident_cloned()) {
             value.push(' ');
             value.push_str(&ident);
         }

--- a/components/style/values/computed/gecko.rs
+++ b/components/style/values/computed/gecko.rs
@@ -4,8 +4,8 @@
 
 //! Computed types for legacy Gecko-only properties.
 
-use values::computed::length::LengthOrPercentage;
-use values::generics::gecko::ScrollSnapPoint as GenericScrollSnapPoint;
+use crate::values::computed::length::LengthOrPercentage;
+use crate::values::generics::gecko::ScrollSnapPoint as GenericScrollSnapPoint;
 
 /// A computed type for scroll snap points.
 pub type ScrollSnapPoint = GenericScrollSnapPoint<LengthOrPercentage>;

--- a/components/style/values/computed/image.rs
+++ b/components/style/values/computed/image.rs
@@ -7,19 +7,19 @@
 //!
 //! [image]: https://drafts.csswg.org/css-images/#image-values
 
+use crate::values::computed::position::Position;
+use crate::values::computed::url::ComputedImageUrl;
+use crate::values::computed::{Angle, Color, Context};
+use crate::values::computed::{Length, LengthOrPercentage, NumberOrPercentage, ToComputedValue};
+use crate::values::generics::image::{self as generic, CompatMode};
+use crate::values::specified::image::LineDirection as SpecifiedLineDirection;
+use crate::values::specified::position::{X, Y};
+use crate::values::{Either, None_};
 use std::f32::consts::PI;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ToCss};
-use values::computed::position::Position;
-use values::computed::url::ComputedImageUrl;
 #[cfg(feature = "gecko")]
 use values::computed::Percentage;
-use values::computed::{Angle, Color, Context};
-use values::computed::{Length, LengthOrPercentage, NumberOrPercentage, ToComputedValue};
-use values::generics::image::{self as generic, CompatMode};
-use values::specified::image::LineDirection as SpecifiedLineDirection;
-use values::specified::position::{X, Y};
-use values::{Either, None_};
 
 /// A computed image layer.
 pub type ImageLayer = Either<None_, Image>;

--- a/components/style/values/computed/image.rs
+++ b/components/style/values/computed/image.rs
@@ -9,6 +9,8 @@
 
 use crate::values::computed::position::Position;
 use crate::values::computed::url::ComputedImageUrl;
+#[cfg(feature = "gecko")]
+use crate::values::computed::Percentage;
 use crate::values::computed::{Angle, Color, Context};
 use crate::values::computed::{Length, LengthOrPercentage, NumberOrPercentage, ToComputedValue};
 use crate::values::generics::image::{self as generic, CompatMode};
@@ -18,8 +20,6 @@ use crate::values::{Either, None_};
 use std::f32::consts::PI;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ToCss};
-#[cfg(feature = "gecko")]
-use values::computed::Percentage;
 
 /// A computed image layer.
 pub type ImageLayer = Either<None_, Image>;

--- a/components/style/values/computed/length.rs
+++ b/components/style/values/computed/length.rs
@@ -6,22 +6,24 @@
 
 use super::{Context, Number, Percentage, ToComputedValue};
 use app_units::Au;
+use crate::values::animated::{Animate, Procedure, ToAnimatedValue, ToAnimatedZero};
+use crate::values::distance::{ComputeSquaredDistance, SquaredDistance};
+use crate::values::generics::length::{
+    MaxLength as GenericMaxLength, MozLength as GenericMozLength,
+};
+use crate::values::generics::NonNegative;
+use crate::values::specified::length::ViewportPercentageLength;
+use crate::values::specified::length::{AbsoluteLength, FontBaseSize, FontRelativeLength};
+use crate::values::{specified, Auto, CSSFloat, Either, IsAuto, Normal};
 use ordered_float::NotNan;
 use std::fmt::{self, Write};
 use std::ops::{Add, Neg};
 use style_traits::values::specified::AllowedNumericType;
 use style_traits::{CssWriter, ToCss};
-use values::animated::{Animate, Procedure, ToAnimatedValue, ToAnimatedZero};
-use values::distance::{ComputeSquaredDistance, SquaredDistance};
-use values::generics::length::{MaxLength as GenericMaxLength, MozLength as GenericMozLength};
-use values::generics::NonNegative;
-use values::specified::length::ViewportPercentageLength;
-use values::specified::length::{AbsoluteLength, FontBaseSize, FontRelativeLength};
-use values::{specified, Auto, CSSFloat, Either, IsAuto, Normal};
 
 pub use super::image::Image;
-pub use values::specified::url::UrlOrNone;
-pub use values::specified::{Angle, BorderStyle, Time};
+pub use crate::values::specified::url::UrlOrNone;
+pub use crate::values::specified::{Angle, BorderStyle, Time};
 
 impl ToComputedValue for specified::NoCalcLength {
     type ComputedValue = CSSPixelLength;

--- a/components/style/values/computed/list.rs
+++ b/components/style/values/computed/list.rs
@@ -4,9 +4,9 @@
 
 //! `list` computed values.
 
-pub use crate::values::specified::list::{QuotePair, Quotes};
 #[cfg(feature = "gecko")]
-pub use values::specified::list::ListStyleType;
+pub use crate::values::specified::list::ListStyleType;
+pub use crate::values::specified::list::{QuotePair, Quotes};
 
 use servo_arc::Arc;
 

--- a/components/style/values/computed/list.rs
+++ b/components/style/values/computed/list.rs
@@ -4,9 +4,9 @@
 
 //! `list` computed values.
 
+pub use crate::values::specified::list::{QuotePair, Quotes};
 #[cfg(feature = "gecko")]
 pub use values::specified::list::ListStyleType;
-pub use values::specified::list::{QuotePair, Quotes};
 
 use servo_arc::Arc;
 

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -11,23 +11,23 @@ use super::generics::grid::{TrackList as GenericTrackList, TrackSize as GenericT
 use super::generics::{GreaterThanOrEqualToOne, NonNegative};
 use super::specified;
 use super::{CSSFloat, CSSInteger};
-use context::QuirksMode;
+use crate::context::QuirksMode;
+use crate::font_metrics::{get_metrics_provider_for_product, FontMetricsProvider};
+use crate::media_queries::Device;
+use crate::properties::{ComputedValues, LonghandId, StyleBuilder};
+use crate::rule_cache::RuleCacheConditions;
+use crate::Atom;
+#[cfg(feature = "servo")]
+use crate::Prefix;
 use euclid::Size2D;
-use font_metrics::{get_metrics_provider_for_product, FontMetricsProvider};
-use media_queries::Device;
 #[cfg(feature = "gecko")]
 use properties;
-use properties::{ComputedValues, LonghandId, StyleBuilder};
-use rule_cache::RuleCacheConditions;
 use std::cell::RefCell;
 use std::cmp;
 use std::f32;
 use std::fmt::{self, Write};
 use style_traits::cursor::CursorKind;
 use style_traits::{CssWriter, ToCss};
-use Atom;
-#[cfg(feature = "servo")]
-use Prefix;
 
 #[cfg(feature = "gecko")]
 pub use self::align::{AlignContent, AlignItems, JustifyContent, JustifyItems, SelfAlignment};

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -14,14 +14,14 @@ use super::{CSSFloat, CSSInteger};
 use crate::context::QuirksMode;
 use crate::font_metrics::{get_metrics_provider_for_product, FontMetricsProvider};
 use crate::media_queries::Device;
+#[cfg(feature = "gecko")]
+use crate::properties;
 use crate::properties::{ComputedValues, LonghandId, StyleBuilder};
 use crate::rule_cache::RuleCacheConditions;
 use crate::Atom;
 #[cfg(feature = "servo")]
 use crate::Prefix;
 use euclid::Size2D;
-#[cfg(feature = "gecko")]
-use properties;
 use std::cell::RefCell;
 use std::cmp;
 use std::f32;

--- a/components/style/values/computed/motion.rs
+++ b/components/style/values/computed/motion.rs
@@ -7,4 +7,4 @@
 /// A computed offset-path. The computed value is as specified value.
 ///
 /// https://drafts.fxtf.org/motion-1/#offset-path-property
-pub use values::specified::motion::OffsetPath;
+pub use crate::values::specified::motion::OffsetPath;

--- a/components/style/values/computed/outline.rs
+++ b/components/style/values/computed/outline.rs
@@ -4,4 +4,4 @@
 
 //! Computed values for outline properties
 
-pub use values::specified::OutlineStyle;
+pub use crate::values::specified::OutlineStyle;

--- a/components/style/values/computed/percentage.rs
+++ b/components/style/values/computed/percentage.rs
@@ -4,11 +4,11 @@
 
 //! Computed percentages.
 
+use crate::values::animated::ToAnimatedValue;
+use crate::values::generics::NonNegative;
+use crate::values::{serialize_percentage, CSSFloat};
 use std::fmt;
 use style_traits::{CssWriter, ToCss};
-use values::animated::ToAnimatedValue;
-use values::generics::NonNegative;
-use values::{serialize_percentage, CSSFloat};
 
 /// A computed percentage.
 #[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]

--- a/components/style/values/computed/position.rs
+++ b/components/style/values/computed/position.rs
@@ -7,12 +7,12 @@
 //!
 //! [position]: https://drafts.csswg.org/css-backgrounds-3/#position
 
+use crate::values::computed::{Integer, LengthOrPercentage, Percentage};
+use crate::values::generics::position::Position as GenericPosition;
+use crate::values::generics::position::ZIndex as GenericZIndex;
+pub use crate::values::specified::position::{GridAutoFlow, GridTemplateAreas};
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ToCss};
-use values::computed::{Integer, LengthOrPercentage, Percentage};
-use values::generics::position::Position as GenericPosition;
-use values::generics::position::ZIndex as GenericZIndex;
-pub use values::specified::position::{GridAutoFlow, GridTemplateAreas};
 
 /// The computed value of a CSS `<position>`
 pub type Position = GenericPosition<HorizontalPosition, VerticalPosition>;

--- a/components/style/values/computed/rect.rs
+++ b/components/style/values/computed/rect.rs
@@ -4,8 +4,8 @@
 
 //! Computed types for CSS borders.
 
-use values::computed::length::LengthOrNumber;
-use values::generics::rect::Rect;
+use crate::values::computed::length::LengthOrNumber;
+use crate::values::generics::rect::Rect;
 
 /// A specified rectangle made of four `<length-or-number>` values.
 pub type LengthOrNumberRect = Rect<LengthOrNumber>;

--- a/components/style/values/computed/resolution.rs
+++ b/components/style/values/computed/resolution.rs
@@ -6,11 +6,11 @@
 //!
 //! https://drafts.csswg.org/css-values/#resolution
 
+use crate::values::computed::{Context, ToComputedValue};
+use crate::values::specified;
+use crate::values::CSSFloat;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ToCss};
-use values::computed::{Context, ToComputedValue};
-use values::specified;
-use values::CSSFloat;
 
 /// A computed `<resolution>`.
 pub struct Resolution(CSSFloat);

--- a/components/style/values/computed/svg.rs
+++ b/components/style/values/computed/svg.rs
@@ -4,16 +4,16 @@
 
 //! Computed types for SVG properties.
 
-use values::computed::color::Color;
-use values::computed::url::ComputedUrl;
-use values::computed::{LengthOrPercentage, NonNegativeLengthOrPercentage};
-use values::computed::{NonNegativeNumber, Number, Opacity};
-use values::generics::svg as generic;
-use values::RGBA;
+use crate::values::computed::color::Color;
+use crate::values::computed::url::ComputedUrl;
+use crate::values::computed::{LengthOrPercentage, NonNegativeLengthOrPercentage};
+use crate::values::computed::{NonNegativeNumber, Number, Opacity};
+use crate::values::generics::svg as generic;
+use crate::values::RGBA;
 
-pub use values::specified::SVGPaintOrder;
+pub use crate::values::specified::SVGPaintOrder;
 
-pub use values::specified::MozContextProperties;
+pub use crate::values::specified::MozContextProperties;
 
 /// Computed SVG Paint value
 pub type SVGPaint = generic::SVGPaint<Color, ComputedUrl>;
@@ -83,7 +83,7 @@ pub type SVGWidth = generic::SVGLength<NonNegativeSvgLengthOrPercentageOrNumber>
 impl SVGWidth {
     /// `1px`.
     pub fn one() -> Self {
-        use values::generics::NonNegative;
+        use crate::values::generics::NonNegative;
         generic::SVGLength::Length(generic::SvgLengthOrPercentageOrNumber::LengthOrPercentage(
             NonNegative(LengthOrPercentage::one()),
         ))

--- a/components/style/values/computed/table.rs
+++ b/components/style/values/computed/table.rs
@@ -4,4 +4,4 @@
 
 //! Computed types for table properties.
 
-pub use values::specified::table::XSpan;
+pub use crate::values::specified::table::XSpan;

--- a/components/style/values/computed/text.rs
+++ b/components/style/values/computed/text.rs
@@ -5,20 +5,22 @@
 //! Computed types for text properties.
 
 #[cfg(feature = "servo")]
-use properties::StyleBuilder;
+use crate::properties::StyleBuilder;
+use crate::values::computed::length::{Length, LengthOrPercentage};
+use crate::values::computed::{NonNegativeLength, NonNegativeNumber};
+use crate::values::generics::text::InitialLetter as GenericInitialLetter;
+use crate::values::generics::text::LineHeight as GenericLineHeight;
+use crate::values::generics::text::MozTabSize as GenericMozTabSize;
+use crate::values::generics::text::Spacing;
+use crate::values::specified::text::{
+    TextEmphasisFillMode, TextEmphasisShapeKeyword, TextOverflowSide,
+};
+use crate::values::{CSSFloat, CSSInteger};
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ToCss};
-use values::computed::length::{Length, LengthOrPercentage};
-use values::computed::{NonNegativeLength, NonNegativeNumber};
-use values::generics::text::InitialLetter as GenericInitialLetter;
-use values::generics::text::LineHeight as GenericLineHeight;
-use values::generics::text::MozTabSize as GenericMozTabSize;
-use values::generics::text::Spacing;
-use values::specified::text::{TextEmphasisFillMode, TextEmphasisShapeKeyword, TextOverflowSide};
-use values::{CSSFloat, CSSInteger};
 
-pub use values::specified::TextAlignKeyword as TextAlign;
-pub use values::specified::TextEmphasisPosition;
+pub use crate::values::specified::TextAlignKeyword as TextAlign;
+pub use crate::values::specified::TextEmphasisPosition;
 
 /// A computed value for the `initial-letter` property.
 pub type InitialLetter = GenericInitialLetter<CSSFloat, CSSInteger>;
@@ -99,7 +101,7 @@ impl TextDecorationsInEffect {
     /// Computes the text-decorations in effect for a given style.
     #[cfg(feature = "servo")]
     pub fn from_style(style: &StyleBuilder) -> Self {
-        use values::computed::Display;
+        use crate::values::computed::Display;
 
         // Start with no declarations if this is an atomic inline-level box;
         // otherwise, start with the declarations in effect and add in the text

--- a/components/style/values/computed/time.rs
+++ b/components/style/values/computed/time.rs
@@ -4,9 +4,9 @@
 
 //! Computed time values.
 
+use crate::values::CSSFloat;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ToCss};
-use values::CSSFloat;
 
 /// A computed `<time>` value.
 #[derive(Clone, Copy, Debug, MallocSizeOf, PartialEq, PartialOrd)]

--- a/components/style/values/computed/transform.rs
+++ b/components/style/values/computed/transform.rs
@@ -5,13 +5,13 @@
 //! Computed types for CSS values that are related to transformations.
 
 use super::CSSFloat;
+use crate::values::animated::ToAnimatedZero;
+use crate::values::computed::{Angle, Integer, Length, LengthOrPercentage, Number, Percentage};
+use crate::values::generics::transform as generic;
 use euclid::{Transform3D, Vector3D};
 use num_traits::Zero;
-use values::animated::ToAnimatedZero;
-use values::computed::{Angle, Integer, Length, LengthOrPercentage, Number, Percentage};
-use values::generics::transform as generic;
 
-pub use values::generics::transform::TransformStyle;
+pub use crate::values::generics::transform::TransformStyle;
 
 /// A single operation in a computed CSS `transform`
 pub type TransformOperation =

--- a/components/style/values/computed/ui.rs
+++ b/components/style/values/computed/ui.rs
@@ -4,13 +4,13 @@
 
 //! Computed values for UI properties
 
-use values::computed::color::Color;
-use values::computed::url::ComputedImageUrl;
-use values::computed::Number;
-use values::generics::ui as generics;
-use values::{Auto, Either};
+use crate::values::computed::color::Color;
+use crate::values::computed::url::ComputedImageUrl;
+use crate::values::computed::Number;
+use crate::values::generics::ui as generics;
+use crate::values::{Auto, Either};
 
-pub use values::specified::ui::MozForceBrokenImageIcon;
+pub use crate::values::specified::ui::MozForceBrokenImageIcon;
 
 /// auto | <color>
 pub type ColorOrAuto = Either<Color, Auto>;

--- a/components/style/values/computed/url.rs
+++ b/components/style/values/computed/url.rs
@@ -4,12 +4,12 @@
 
 //! Common handling for the computed value CSS url() values.
 
-use values::generics::url::UrlOrNone as GenericUrlOrNone;
+use crate::values::generics::url::UrlOrNone as GenericUrlOrNone;
 
+#[cfg(feature = "servo")]
+pub use crate::servo::url::{ComputedImageUrl, ComputedUrl};
 #[cfg(feature = "gecko")]
 pub use gecko::url::{ComputedImageUrl, ComputedUrl};
-#[cfg(feature = "servo")]
-pub use servo::url::{ComputedImageUrl, ComputedUrl};
 
 /// Computed <url> | <none>
 pub type UrlOrNone = GenericUrlOrNone<ComputedUrl>;

--- a/components/style/values/computed/url.rs
+++ b/components/style/values/computed/url.rs
@@ -6,10 +6,10 @@
 
 use crate::values::generics::url::UrlOrNone as GenericUrlOrNone;
 
+#[cfg(feature = "gecko")]
+pub use crate::gecko::url::{ComputedImageUrl, ComputedUrl};
 #[cfg(feature = "servo")]
 pub use crate::servo::url::{ComputedImageUrl, ComputedUrl};
-#[cfg(feature = "gecko")]
-pub use gecko::url::{ComputedImageUrl, ComputedUrl};
 
 /// Computed <url> | <none>
 pub type UrlOrNone = GenericUrlOrNone<ComputedUrl>;

--- a/components/style/values/generics/basic_shape.rs
+++ b/components/style/values/generics/basic_shape.rs
@@ -5,14 +5,14 @@
 //! CSS handling for the [`basic-shape`](https://drafts.csswg.org/css-shapes/#typedef-basic-shape)
 //! types that are generic over their `ToCss` implementations.
 
+use crate::values::animated::{Animate, Procedure, ToAnimatedZero};
+use crate::values::distance::{ComputeSquaredDistance, SquaredDistance};
+use crate::values::generics::border::BorderRadius;
+use crate::values::generics::position::Position;
+use crate::values::generics::rect::Rect;
+use crate::values::specified::SVGPathData;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ToCss};
-use values::animated::{Animate, Procedure, ToAnimatedZero};
-use values::distance::{ComputeSquaredDistance, SquaredDistance};
-use values::generics::border::BorderRadius;
-use values::generics::position::Position;
-use values::generics::rect::Rect;
-use values::specified::SVGPathData;
 
 /// A clipping shape, for `clip-path`.
 pub type ClippingShape<BasicShape, Url> = ShapeSource<BasicShape, GeometryBox, Url>;

--- a/components/style/values/generics/border.rs
+++ b/components/style/values/generics/border.rs
@@ -4,10 +4,10 @@
 
 //! Generic types for CSS values related to borders.
 
+use crate::values::generics::rect::Rect;
+use crate::values::generics::size::Size;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ToCss};
-use values::generics::rect::Rect;
-use values::generics::size::Size;
 
 /// A generic value for a single side of a `border-image-width` property.
 #[derive(

--- a/components/style/values/generics/box.rs
+++ b/components/style/values/generics/box.rs
@@ -4,7 +4,7 @@
 
 //! Generic types for box properties.
 
-use values::animated::ToAnimatedZero;
+use crate::values::animated::ToAnimatedZero;
 
 /// A generic value for the `vertical-align` property.
 #[derive(

--- a/components/style/values/generics/counters.rs
+++ b/components/style/values/generics/counters.rs
@@ -6,12 +6,12 @@
 
 #[cfg(feature = "servo")]
 use crate::computed_values::list_style_type::T as ListStyleType;
+#[cfg(feature = "gecko")]
+use crate::values::generics::CounterStyleOrNone;
+#[cfg(feature = "gecko")]
+use crate::values::specified::Attr;
 use crate::values::CustomIdent;
 use std::ops::Deref;
-#[cfg(feature = "gecko")]
-use values::generics::CounterStyleOrNone;
-#[cfg(feature = "gecko")]
-use values::specified::Attr;
 
 /// A name / value pair for counters.
 #[derive(Clone, Debug, MallocSizeOf, PartialEq, SpecifiedValueInfo, ToComputedValue, ToCss)]

--- a/components/style/values/generics/counters.rs
+++ b/components/style/values/generics/counters.rs
@@ -5,13 +5,13 @@
 //! Generic types for counters-related CSS values.
 
 #[cfg(feature = "servo")]
-use computed_values::list_style_type::T as ListStyleType;
+use crate::computed_values::list_style_type::T as ListStyleType;
+use crate::values::CustomIdent;
 use std::ops::Deref;
 #[cfg(feature = "gecko")]
 use values::generics::CounterStyleOrNone;
 #[cfg(feature = "gecko")]
 use values::specified::Attr;
-use values::CustomIdent;
 
 /// A name / value pair for counters.
 #[derive(Clone, Debug, MallocSizeOf, PartialEq, SpecifiedValueInfo, ToComputedValue, ToCss)]

--- a/components/style/values/generics/easing.rs
+++ b/components/style/values/generics/easing.rs
@@ -58,7 +58,7 @@ pub enum TimingKeyword {
 
 #[cfg(feature = "gecko")]
 fn step_position_jump_enabled(_context: &ParserContext) -> bool {
-    use gecko_bindings::structs;
+    use crate::gecko_bindings::structs;
     unsafe { structs::StaticPrefs_sVarCache_layout_css_step_position_jump_enabled }
 }
 

--- a/components/style/values/generics/easing.rs
+++ b/components/style/values/generics/easing.rs
@@ -5,8 +5,8 @@
 //! Generic types for CSS Easing Functions.
 //! https://drafts.csswg.org/css-easing/#timing-functions
 
-use parser::ParserContext;
-use values::CSSFloat;
+use crate::parser::ParserContext;
+use crate::values::CSSFloat;
 
 /// A generic easing function.
 #[derive(

--- a/components/style/values/generics/font.rs
+++ b/components/style/values/generics/font.rs
@@ -6,9 +6,9 @@
 
 use app_units::Au;
 use byteorder::{BigEndian, ReadBytesExt};
+use crate::parser::{Parse, ParserContext};
 use cssparser::Parser;
 use num_traits::One;
-use parser::{Parse, ParserContext};
 use std::fmt::{self, Write};
 use std::io::Cursor;
 use style_traits::{CssWriter, KeywordsCollectFn, ParseError};
@@ -85,7 +85,7 @@ impl<T: Parse> Parse for FontSettings<T> {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if input.try(|i| i.expect_ident_matching("normal")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("normal")).is_ok() {
             return Ok(Self::normal());
         }
 

--- a/components/style/values/generics/image.rs
+++ b/components/style/values/generics/image.rs
@@ -6,12 +6,12 @@
 //!
 //! [images]: https://drafts.csswg.org/css-images/#image-values
 
-use custom_properties;
+use crate::custom_properties;
+use crate::values::serialize_atom_identifier;
+use crate::Atom;
 use servo_arc::Arc;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ToCss};
-use values::serialize_atom_identifier;
-use Atom;
 
 /// An [image].
 ///

--- a/components/style/values/generics/length.rs
+++ b/components/style/values/generics/length.rs
@@ -4,7 +4,7 @@
 
 //! Generic types for CSS values related to length.
 
-use values::computed::ExtremumLength;
+use crate::values::computed::ExtremumLength;
 
 /// A generic value for the `width`, `height`, `min-width`, or `min-height` property.
 ///

--- a/components/style/values/generics/mod.rs
+++ b/components/style/values/generics/mod.rs
@@ -6,9 +6,9 @@
 //! for both specified and computed values.
 
 use super::CustomIdent;
-use counter_style::{parse_counter_style_name, Symbols};
+use crate::counter_style::{parse_counter_style_name, Symbols};
+use crate::parser::{Parse, ParserContext};
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use style_traits::{KeywordsCollectFn, ParseError};
 use style_traits::{SpecifiedValueInfo, StyleParseErrorKind};
 
@@ -111,16 +111,19 @@ impl Parse for CounterStyleOrNone {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(name) = input.try(|i| parse_counter_style_name(i)) {
+        if let Ok(name) = input.r#try(|i| parse_counter_style_name(i)) {
             return Ok(CounterStyleOrNone::Name(name));
         }
-        if input.try(|i| i.expect_ident_matching("none")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("none")).is_ok() {
             return Ok(CounterStyleOrNone::None);
         }
-        if input.try(|i| i.expect_function_matching("symbols")).is_ok() {
+        if input
+            .r#try(|i| i.expect_function_matching("symbols"))
+            .is_ok()
+        {
             return input.parse_nested_block(|input| {
                 let symbols_type = input
-                    .try(|i| SymbolsType::parse(i))
+                    .r#try(|i| SymbolsType::parse(i))
                     .unwrap_or(SymbolsType::Symbolic);
                 let symbols = Symbols::parse(context, input)?;
                 // There must be at least two symbols for alphabetic or

--- a/components/style/values/generics/mod.rs
+++ b/components/style/values/generics/mod.rs
@@ -54,7 +54,7 @@ pub enum SymbolsType {
 impl SymbolsType {
     /// Convert symbols type to their corresponding Gecko values.
     pub fn to_gecko_keyword(self) -> u8 {
-        use gecko_bindings::structs;
+        use crate::gecko_bindings::structs;
         match self {
             SymbolsType::Cyclic => structs::NS_STYLE_COUNTER_SYSTEM_CYCLIC as u8,
             SymbolsType::Numeric => structs::NS_STYLE_COUNTER_SYSTEM_NUMERIC as u8,
@@ -66,7 +66,7 @@ impl SymbolsType {
 
     /// Convert Gecko value to symbol type.
     pub fn from_gecko_keyword(gecko_value: u32) -> SymbolsType {
-        use gecko_bindings::structs;
+        use crate::gecko_bindings::structs;
         match gecko_value {
             structs::NS_STYLE_COUNTER_SYSTEM_CYCLIC => SymbolsType::Cyclic,
             structs::NS_STYLE_COUNTER_SYSTEM_NUMERIC => SymbolsType::Numeric,

--- a/components/style/values/generics/rect.rs
+++ b/components/style/values/generics/rect.rs
@@ -4,8 +4,8 @@
 
 //! Generic types for CSS values that are composed of four sides.
 
+use crate::parser::{Parse, ParserContext};
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, ToCss};
 
@@ -50,7 +50,7 @@ where
         Parse: Fn(&ParserContext, &mut Parser<'i, 't>) -> Result<T, ParseError<'i>>,
     {
         let first = parse(context, input)?;
-        let second = if let Ok(second) = input.try(|i| parse(context, i)) {
+        let second = if let Ok(second) = input.r#try(|i| parse(context, i)) {
             second
         } else {
             // <first>
@@ -61,13 +61,13 @@ where
                 first,
             ));
         };
-        let third = if let Ok(third) = input.try(|i| parse(context, i)) {
+        let third = if let Ok(third) = input.r#try(|i| parse(context, i)) {
             third
         } else {
             // <first> <second>
             return Ok(Self::new(first.clone(), second.clone(), first, second));
         };
-        let fourth = if let Ok(fourth) = input.try(|i| parse(context, i)) {
+        let fourth = if let Ok(fourth) = input.r#try(|i| parse(context, i)) {
             fourth
         } else {
             // <first> <second> <third>

--- a/components/style/values/generics/size.rs
+++ b/components/style/values/generics/size.rs
@@ -4,12 +4,12 @@
 
 //! Generic type for CSS properties that are composed by two dimensions.
 
+use crate::parser::ParserContext;
+use crate::values::animated::ToAnimatedValue;
 use cssparser::Parser;
 use euclid::Size2D;
-use parser::ParserContext;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, SpecifiedValueInfo, ToCss};
-use values::animated::ToAnimatedValue;
 
 /// A generic size, for `border-*-radius` longhand properties, or
 /// `border-spacing`.
@@ -55,7 +55,7 @@ impl<L> Size<L> {
     {
         let first = parse_one(context, input)?;
         let second = input
-            .try(|i| parse_one(context, i))
+            .r#try(|i| parse_one(context, i))
             .unwrap_or_else(|_| first.clone());
         Ok(Self::new(first, second))
     }

--- a/components/style/values/generics/svg.rs
+++ b/components/style/values/generics/svg.rs
@@ -4,10 +4,10 @@
 
 //! Generic types for CSS values in SVG
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::{Either, None_};
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use style_traits::{ParseError, StyleParseErrorKind};
-use values::{Either, None_};
 
 /// An SVG paint value
 ///
@@ -84,10 +84,10 @@ fn parse_fallback<'i, 't, ColorType: Parse>(
     context: &ParserContext,
     input: &mut Parser<'i, 't>,
 ) -> Option<Either<ColorType, None_>> {
-    if input.try(|i| i.expect_ident_matching("none")).is_ok() {
+    if input.r#try(|i| i.expect_ident_matching("none")).is_ok() {
         Some(Either::Second(None_))
     } else {
-        if let Ok(color) = input.try(|i| ColorType::parse(context, i)) {
+        if let Ok(color) = input.r#try(|i| ColorType::parse(context, i)) {
             Some(Either::First(color))
         } else {
             None
@@ -100,12 +100,12 @@ impl<ColorType: Parse, UrlPaintServer: Parse> Parse for SVGPaint<ColorType, UrlP
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(url) = input.try(|i| UrlPaintServer::parse(context, i)) {
+        if let Ok(url) = input.r#try(|i| UrlPaintServer::parse(context, i)) {
             Ok(SVGPaint {
                 kind: SVGPaintKind::PaintServer(url),
                 fallback: parse_fallback(context, input),
             })
-        } else if let Ok(kind) = input.try(SVGPaintKind::parse_ident) {
+        } else if let Ok(kind) = input.r#try(SVGPaintKind::parse_ident) {
             if let SVGPaintKind::None = kind {
                 Ok(SVGPaint {
                     kind: kind,
@@ -117,7 +117,7 @@ impl<ColorType: Parse, UrlPaintServer: Parse> Parse for SVGPaint<ColorType, UrlP
                     fallback: parse_fallback(context, input),
                 })
             }
-        } else if let Ok(color) = input.try(|i| ColorType::parse(context, i)) {
+        } else if let Ok(color) = input.r#try(|i| ColorType::parse(context, i)) {
             Ok(SVGPaint {
                 kind: SVGPaintKind::Color(color),
                 fallback: None,
@@ -158,7 +158,7 @@ impl<LengthOrPercentageType: Parse, NumberType: Parse> Parse
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(num) = input.try(|i| NumberType::parse(context, i)) {
+        if let Ok(num) = input.r#try(|i| NumberType::parse(context, i)) {
             return Ok(SvgLengthOrPercentageOrNumber::Number(num));
         }
 

--- a/components/style/values/generics/text.rs
+++ b/components/style/values/generics/text.rs
@@ -5,11 +5,11 @@
 //! Generic types for text properties.
 
 use app_units::Au;
+use crate::parser::ParserContext;
+use crate::values::animated::{Animate, Procedure, ToAnimatedZero};
+use crate::values::distance::{ComputeSquaredDistance, SquaredDistance};
 use cssparser::Parser;
-use parser::ParserContext;
 use style_traits::ParseError;
-use values::animated::{Animate, Procedure, ToAnimatedZero};
-use values::distance::{ComputeSquaredDistance, SquaredDistance};
 
 /// A generic value for the `initial-letter` property.
 #[derive(
@@ -58,7 +58,7 @@ impl<Value> Spacing<Value> {
     where
         F: FnOnce(&ParserContext, &mut Parser<'i, 't>) -> Result<Value, ParseError<'i>>,
     {
-        if input.try(|i| i.expect_ident_matching("normal")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("normal")).is_ok() {
             return Ok(Spacing::Normal);
         }
         parse(context, input).map(Spacing::Value)

--- a/components/style/values/generics/transform.rs
+++ b/components/style/values/generics/transform.rs
@@ -5,16 +5,16 @@
 //! Generic types for CSS values that are related to transformations.
 
 use app_units::Au;
+use crate::values::computed::length::Length as ComputedLength;
+use crate::values::computed::length::LengthOrPercentage as ComputedLengthOrPercentage;
+use crate::values::specified::angle::Angle as SpecifiedAngle;
+use crate::values::specified::length::Length as SpecifiedLength;
+use crate::values::specified::length::LengthOrPercentage as SpecifiedLengthOrPercentage;
+use crate::values::{computed, CSSFloat};
 use euclid::{self, Rect, Transform3D};
 use num_traits::Zero;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ToCss};
-use values::computed::length::Length as ComputedLength;
-use values::computed::length::LengthOrPercentage as ComputedLengthOrPercentage;
-use values::specified::angle::Angle as SpecifiedAngle;
-use values::specified::length::Length as SpecifiedLength;
-use values::specified::length::LengthOrPercentage as SpecifiedLengthOrPercentage;
-use values::{computed, CSSFloat};
 
 /// A generic 2D transformation matrix.
 #[allow(missing_docs)]
@@ -514,8 +514,8 @@ pub fn get_normalized_vector_and_angle<T: Zero>(
     z: CSSFloat,
     angle: T,
 ) -> (CSSFloat, CSSFloat, CSSFloat, T) {
+    use crate::values::computed::transform::DirectionVector;
     use euclid::approxeq::ApproxEq;
-    use values::computed::transform::DirectionVector;
     let vector = DirectionVector::new(x, y, z);
     if vector.square_length().approx_eq(&f32::zero()) {
         // https://www.w3.org/TR/css-transforms-1/#funcdef-rotate3d

--- a/components/style/values/generics/url.rs
+++ b/components/style/values/generics/url.rs
@@ -4,8 +4,8 @@
 
 //! Generic types for url properties.
 
+use crate::parser::{Parse, ParserContext};
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use style_traits::ParseError;
 
 /// An image url or none, used for example in list-style-image
@@ -44,7 +44,7 @@ where
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<UrlOrNone<Url>, ParseError<'i>> {
-        if let Ok(url) = input.try(|input| Url::parse(context, input)) {
+        if let Ok(url) = input.r#try(|input| Url::parse(context, input)) {
             return Ok(UrlOrNone::Url(url));
         }
         input.expect_ident_matching("none")?;

--- a/components/style/values/mod.rs
+++ b/components/style/values/mod.rs
@@ -8,20 +8,20 @@
 
 #![deny(missing_docs)]
 
-pub use cssparser::{serialize_identifier, serialize_name, CowRcStr, Parser};
-pub use cssparser::{SourceLocation, Token, RGBA};
-use crate::Atom;
 use crate::parser::{Parse, ParserContext};
 use crate::values::distance::{ComputeSquaredDistance, SquaredDistance};
+use crate::Atom;
+pub use cssparser::{serialize_identifier, serialize_name, CowRcStr, Parser};
+pub use cssparser::{SourceLocation, Token, RGBA};
 use selectors::parser::SelectorParseErrorKind;
 use std::fmt::{self, Debug, Write};
 use std::hash;
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
 
+#[cfg(feature = "gecko")]
+pub use crate::gecko::url::CssUrl;
 #[cfg(feature = "servo")]
 pub use crate::servo::url::CssUrl;
-#[cfg(feature = "gecko")]
-pub use gecko::url::CssUrl;
 
 pub mod animated;
 pub mod computed;

--- a/components/style/values/mod.rs
+++ b/components/style/values/mod.rs
@@ -10,18 +10,18 @@
 
 pub use cssparser::{serialize_identifier, serialize_name, CowRcStr, Parser};
 pub use cssparser::{SourceLocation, Token, RGBA};
-use parser::{Parse, ParserContext};
+use crate::Atom;
+use crate::parser::{Parse, ParserContext};
+use crate::values::distance::{ComputeSquaredDistance, SquaredDistance};
 use selectors::parser::SelectorParseErrorKind;
 use std::fmt::{self, Debug, Write};
 use std::hash;
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
-use values::distance::{ComputeSquaredDistance, SquaredDistance};
-use Atom;
 
+#[cfg(feature = "servo")]
+pub use crate::servo::url::CssUrl;
 #[cfg(feature = "gecko")]
 pub use gecko::url::CssUrl;
-#[cfg(feature = "servo")]
-pub use servo::url::CssUrl;
 
 pub mod animated;
 pub mod computed;
@@ -155,7 +155,7 @@ impl<A: Parse, B: Parse> Parse for Either<A, B> {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Either<A, B>, ParseError<'i>> {
-        if let Ok(v) = input.try(|i| A::parse(context, i)) {
+        if let Ok(v) = input.r#try(|i| A::parse(context, i)) {
             Ok(Either::First(v))
         } else {
             B::parse(context, input).map(Either::Second)

--- a/components/style/values/specified/align.rs
+++ b/components/style/values/specified/align.rs
@@ -6,9 +6,9 @@
 //!
 //! https://drafts.csswg.org/css-align/
 
+use crate::gecko_bindings::structs;
+use crate::parser::{Parse, ParserContext};
 use cssparser::Parser;
-use gecko_bindings::structs;
-use parser::{Parse, ParserContext};
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, KeywordsCollectFn, ParseError, SpecifiedValueInfo, ToCss};
 
@@ -195,25 +195,25 @@ impl ContentDistribution {
         //      when this function is updated.
 
         // Try to parse normal first
-        if input.try(|i| i.expect_ident_matching("normal")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("normal")).is_ok() {
             return Ok(ContentDistribution::normal());
         }
 
         // Parse <baseline-position>, but only on the block axis.
         if axis == AxisDirection::Block {
-            if let Ok(value) = input.try(parse_baseline) {
+            if let Ok(value) = input.r#try(parse_baseline) {
                 return Ok(ContentDistribution::new(value));
             }
         }
 
         // <content-distribution>
-        if let Ok(value) = input.try(parse_content_distribution) {
+        if let Ok(value) = input.r#try(parse_content_distribution) {
             return Ok(ContentDistribution::new(value));
         }
 
         // <overflow-position>? <content-position>
         let overflow_position = input
-            .try(parse_overflow_position)
+            .r#try(parse_overflow_position)
             .unwrap_or(AlignFlags::empty());
 
         let content_position = try_match_ident_ignore_ascii_case! { input,
@@ -358,18 +358,18 @@ impl SelfAlignment {
         //
         // It's weird that this accepts <baseline-position>, but not
         // justify-content...
-        if let Ok(value) = input.try(parse_baseline) {
+        if let Ok(value) = input.r#try(parse_baseline) {
             return Ok(SelfAlignment(value));
         }
 
         // auto | normal | stretch
-        if let Ok(value) = input.try(parse_auto_normal_stretch) {
+        if let Ok(value) = input.r#try(parse_auto_normal_stretch) {
             return Ok(SelfAlignment(value));
         }
 
         // <overflow-position>? <self-position>
         let overflow_position = input
-            .try(parse_overflow_position)
+            .r#try(parse_overflow_position)
             .unwrap_or(AlignFlags::empty());
         let self_position = parse_self_position(input, axis)?;
         Ok(SelfAlignment(overflow_position | self_position))
@@ -484,17 +484,17 @@ impl Parse for AlignItems {
         //      this function is updated.
 
         // <baseline-position>
-        if let Ok(baseline) = input.try(parse_baseline) {
+        if let Ok(baseline) = input.r#try(parse_baseline) {
             return Ok(AlignItems(baseline));
         }
 
         // normal | stretch
-        if let Ok(value) = input.try(parse_normal_stretch) {
+        if let Ok(value) = input.r#try(parse_normal_stretch) {
             return Ok(AlignItems(value));
         }
         // <overflow-position>? <self-position>
         let overflow = input
-            .try(parse_overflow_position)
+            .r#try(parse_overflow_position)
             .unwrap_or(AlignFlags::empty());
         let self_position = parse_self_position(input, AxisDirection::Block)?;
         Ok(AlignItems(self_position | overflow))
@@ -542,23 +542,23 @@ impl Parse for JustifyItems {
         //
         // It's weird that this accepts <baseline-position>, but not
         // justify-content...
-        if let Ok(baseline) = input.try(parse_baseline) {
+        if let Ok(baseline) = input.r#try(parse_baseline) {
             return Ok(JustifyItems(baseline));
         }
 
         // normal | stretch
-        if let Ok(value) = input.try(parse_normal_stretch) {
+        if let Ok(value) = input.r#try(parse_normal_stretch) {
             return Ok(JustifyItems(value));
         }
 
         // legacy | [ legacy && [ left | right | center ] ]
-        if let Ok(value) = input.try(parse_legacy) {
+        if let Ok(value) = input.r#try(parse_legacy) {
             return Ok(JustifyItems(value));
         }
 
         // <overflow-position>? <self-position>
         let overflow = input
-            .try(parse_overflow_position)
+            .r#try(parse_overflow_position)
             .unwrap_or(AlignFlags::empty());
         let self_position = parse_self_position(input, AxisDirection::Inline)?;
         Ok(JustifyItems(overflow | self_position))
@@ -714,7 +714,7 @@ fn parse_legacy<'i, 't>(input: &mut Parser<'i, 't>) -> Result<AlignFlags, ParseE
     //      when this function is updated.
     let flags = try_match_ident_ignore_ascii_case! { input,
         "legacy" => {
-            let flags = input.try(parse_left_right_center)
+            let flags = input.r#try(parse_left_right_center)
                 .unwrap_or(AlignFlags::empty());
 
             return Ok(AlignFlags::LEGACY | flags)

--- a/components/style/values/specified/angle.rs
+++ b/components/style/values/specified/angle.rs
@@ -4,15 +4,15 @@
 
 //! Specified angles.
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::computed::angle::Angle as ComputedAngle;
+use crate::values::computed::{Context, ToComputedValue};
+use crate::values::specified::calc::CalcNode;
+use crate::values::CSSFloat;
 use cssparser::{Parser, Token};
-use parser::{Parse, ParserContext};
 use std::f32::consts::PI;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, SpecifiedValueInfo, ToCss};
-use values::computed::angle::Angle as ComputedAngle;
-use values::computed::{Context, ToComputedValue};
-use values::specified::calc::CalcNode;
-use values::CSSFloat;
 
 /// A specified angle dimension.
 #[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]

--- a/components/style/values/specified/background.rs
+++ b/components/style/values/specified/background.rs
@@ -4,12 +4,12 @@
 
 //! Specified types for CSS values related to backgrounds.
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::generics::background::BackgroundSize as GenericBackgroundSize;
+use crate::values::specified::length::NonNegativeLengthOrPercentageOrAuto;
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use selectors::parser::SelectorParseErrorKind;
 use style_traits::ParseError;
-use values::generics::background::BackgroundSize as GenericBackgroundSize;
-use values::specified::length::NonNegativeLengthOrPercentageOrAuto;
 
 /// A specified value for the `background-size` property.
 pub type BackgroundSize = GenericBackgroundSize<NonNegativeLengthOrPercentageOrAuto>;
@@ -19,9 +19,9 @@ impl Parse for BackgroundSize {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(width) = input.try(|i| NonNegativeLengthOrPercentageOrAuto::parse(context, i)) {
+        if let Ok(width) = input.r#try(|i| NonNegativeLengthOrPercentageOrAuto::parse(context, i)) {
             let height = input
-                .try(|i| NonNegativeLengthOrPercentageOrAuto::parse(context, i))
+                .r#try(|i| NonNegativeLengthOrPercentageOrAuto::parse(context, i))
                 .unwrap_or(NonNegativeLengthOrPercentageOrAuto::auto());
             return Ok(GenericBackgroundSize::Explicit { width, height });
         }
@@ -106,7 +106,7 @@ impl Parse for BackgroundRepeat {
             },
         };
 
-        let vertical = input.try(BackgroundRepeatKeyword::parse).ok();
+        let vertical = input.r#try(BackgroundRepeatKeyword::parse).ok();
         Ok(BackgroundRepeat::Keywords(horizontal, vertical))
     }
 }

--- a/components/style/values/specified/basic_shape.rs
+++ b/components/style/values/specified/basic_shape.rs
@@ -54,7 +54,7 @@ pub type Polygon = generic::Polygon<LengthOrPercentage>;
 
 #[cfg(feature = "gecko")]
 fn is_clip_path_path_enabled(context: &ParserContext) -> bool {
-    use gecko_bindings::structs::mozilla;
+    use crate::gecko_bindings::structs::mozilla;
     context.chrome_rules_enabled() ||
         unsafe { mozilla::StaticPrefs_sVarCache_layout_css_clip_path_path_enabled }
 }

--- a/components/style/values/specified/basic_shape.rs
+++ b/components/style/values/specified/basic_shape.rs
@@ -7,26 +7,26 @@
 //!
 //! [basic-shape]: https://drafts.csswg.org/css-shapes/#typedef-basic-shape
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::computed::Percentage;
+use crate::values::generics::basic_shape as generic;
+use crate::values::generics::basic_shape::{GeometryBox, Path, PolygonCoord};
+use crate::values::generics::basic_shape::{ShapeBox, ShapeSource};
+use crate::values::generics::rect::Rect;
+use crate::values::specified::border::BorderRadius;
+use crate::values::specified::image::Image;
+use crate::values::specified::position::{HorizontalPosition, Position, PositionComponent};
+use crate::values::specified::position::{Side, VerticalPosition};
+use crate::values::specified::url::SpecifiedUrl;
+use crate::values::specified::LengthOrPercentage;
+use crate::values::specified::SVGPathData;
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use std::borrow::Cow;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
-use values::computed::Percentage;
-use values::generics::basic_shape as generic;
-use values::generics::basic_shape::{GeometryBox, Path, PolygonCoord};
-use values::generics::basic_shape::{ShapeBox, ShapeSource};
-use values::generics::rect::Rect;
-use values::specified::border::BorderRadius;
-use values::specified::image::Image;
-use values::specified::position::{HorizontalPosition, Position, PositionComponent};
-use values::specified::position::{Side, VerticalPosition};
-use values::specified::url::SpecifiedUrl;
-use values::specified::LengthOrPercentage;
-use values::specified::SVGPathData;
 
 /// A specified alias for FillRule.
-pub use values::generics::basic_shape::FillRule;
+pub use crate::values::generics::basic_shape::FillRule;
 
 /// A specified clipping shape.
 pub type ClippingShape = generic::ClippingShape<BasicShape, SpecifiedUrl>;
@@ -70,12 +70,12 @@ impl Parse for ClippingShape {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         if is_clip_path_path_enabled(context) {
-            if let Ok(p) = input.try(|i| Path::parse(context, i)) {
+            if let Ok(p) = input.r#try(|i| Path::parse(context, i)) {
                 return Ok(ShapeSource::Path(p));
             }
         }
 
-        if let Ok(url) = input.try(|i| SpecifiedUrl::parse(context, i)) {
+        if let Ok(url) = input.r#try(|i| SpecifiedUrl::parse(context, i)) {
             return Ok(ShapeSource::ImageOrUrl(url));
         }
 
@@ -89,7 +89,7 @@ impl Parse for FloatAreaShape {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(image) = input.try(|i| Image::parse_with_cors_anonymous(context, i)) {
+        if let Ok(image) = input.r#try(|i| Image::parse_with_cors_anonymous(context, i)) {
             return Ok(ShapeSource::ImageOrUrl(image));
         }
 
@@ -106,7 +106,7 @@ where
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if input.try(|i| i.expect_ident_matching("none")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("none")).is_ok() {
             return Ok(ShapeSource::None);
         }
 
@@ -119,7 +119,7 @@ where
                 return false; // already parsed this component
             }
 
-            *component = input.try(|i| U::parse(context, i)).ok();
+            *component = input.r#try(|i| U::parse(context, i)).ok();
             component.is_some()
         }
 
@@ -147,7 +147,7 @@ impl Parse for GeometryBox {
         _context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(shape_box) = input.try(|i| ShapeBox::parse(i)) {
+        if let Ok(shape_box) = input.r#try(|i| ShapeBox::parse(i)) {
             return Ok(GeometryBox::ShapeBox(shape_box));
         }
 
@@ -197,7 +197,7 @@ impl InsetRect {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         let rect = Rect::parse_with(context, input, LengthOrPercentage::parse)?;
-        let round = if input.try(|i| i.expect_ident_matching("round")).is_ok() {
+        let round = if input.r#try(|i| i.expect_ident_matching("round")).is_ok() {
             Some(BorderRadius::parse(context, input)?)
         } else {
             None
@@ -225,9 +225,9 @@ impl Circle {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         let radius = input
-            .try(|i| ShapeRadius::parse(context, i))
+            .r#try(|i| ShapeRadius::parse(context, i))
             .unwrap_or_default();
-        let position = if input.try(|i| i.expect_ident_matching("at")).is_ok() {
+        let position = if input.r#try(|i| i.expect_ident_matching("at")).is_ok() {
             Position::parse(context, input)?
         } else {
             Position::center()
@@ -270,14 +270,14 @@ impl Ellipse {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         let (a, b) = input
-            .try(|i| -> Result<_, ParseError> {
+            .r#try(|i| -> Result<_, ParseError> {
                 Ok((
                     ShapeRadius::parse(context, i)?,
                     ShapeRadius::parse(context, i)?,
                 ))
             })
             .unwrap_or_default();
-        let position = if input.try(|i| i.expect_ident_matching("at")).is_ok() {
+        let position = if input.r#try(|i| i.expect_ident_matching("at")).is_ok() {
             Position::parse(context, input)?
         } else {
             Position::center()
@@ -315,7 +315,7 @@ impl Parse for ShapeRadius {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(lop) = input.try(|i| LengthOrPercentage::parse_non_negative(context, i)) {
+        if let Ok(lop) = input.r#try(|i| LengthOrPercentage::parse_non_negative(context, i)) {
             return Ok(generic::ShapeRadius::Length(lop));
         }
 
@@ -419,7 +419,7 @@ impl Polygon {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         let fill = input
-            .try(|i| -> Result<_, ParseError> {
+            .r#try(|i| -> Result<_, ParseError> {
                 let fill = FillRule::parse(i)?;
                 i.expect_comma()?; // only eat the comma if there is something before it
                 Ok(fill)
@@ -457,7 +457,7 @@ impl Path {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         let fill = input
-            .try(|i| -> Result<_, ParseError> {
+            .r#try(|i| -> Result<_, ParseError> {
                 let fill = FillRule::parse(i)?;
                 i.expect_comma()?;
                 Ok(fill)

--- a/components/style/values/specified/border.rs
+++ b/components/style/values/specified/border.rs
@@ -4,20 +4,20 @@
 
 //! Specified types for CSS values related to borders.
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::computed::{self, Context, ToComputedValue};
+use crate::values::generics::border::BorderCornerRadius as GenericBorderCornerRadius;
+use crate::values::generics::border::BorderImageSideWidth as GenericBorderImageSideWidth;
+use crate::values::generics::border::BorderImageSlice as GenericBorderImageSlice;
+use crate::values::generics::border::BorderRadius as GenericBorderRadius;
+use crate::values::generics::border::BorderSpacing as GenericBorderSpacing;
+use crate::values::generics::rect::Rect;
+use crate::values::generics::size::Size;
+use crate::values::specified::length::{Length, LengthOrPercentage, NonNegativeLength};
+use crate::values::specified::{AllowQuirks, Number, NumberOrPercentage};
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, ToCss};
-use values::computed::{self, Context, ToComputedValue};
-use values::generics::border::BorderCornerRadius as GenericBorderCornerRadius;
-use values::generics::border::BorderImageSideWidth as GenericBorderImageSideWidth;
-use values::generics::border::BorderImageSlice as GenericBorderImageSlice;
-use values::generics::border::BorderRadius as GenericBorderRadius;
-use values::generics::border::BorderSpacing as GenericBorderSpacing;
-use values::generics::rect::Rect;
-use values::generics::size::Size;
-use values::specified::length::{Length, LengthOrPercentage, NonNegativeLength};
-use values::specified::{AllowQuirks, Number, NumberOrPercentage};
 
 /// A specified value for a single side of the `border-width` property.
 #[derive(Clone, Debug, MallocSizeOf, PartialEq, SpecifiedValueInfo, ToCss)]
@@ -58,7 +58,7 @@ impl BorderSideWidth {
         allow_quirks: AllowQuirks,
     ) -> Result<Self, ParseError<'i>> {
         if let Ok(length) =
-            input.try(|i| Length::parse_non_negative_quirky(context, i, allow_quirks))
+            input.r#try(|i| Length::parse_non_negative_quirky(context, i, allow_quirks))
         {
             return Ok(BorderSideWidth::Length(length));
         }
@@ -115,11 +115,11 @@ impl Parse for BorderImageSideWidth {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if input.try(|i| i.expect_ident_matching("auto")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("auto")).is_ok() {
             return Ok(GenericBorderImageSideWidth::Auto);
         }
 
-        if let Ok(len) = input.try(|i| LengthOrPercentage::parse_non_negative(context, i)) {
+        if let Ok(len) = input.r#try(|i| LengthOrPercentage::parse_non_negative(context, i)) {
             return Ok(GenericBorderImageSideWidth::Length(len));
         }
 
@@ -133,10 +133,10 @@ impl Parse for BorderImageSlice {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        let mut fill = input.try(|i| i.expect_ident_matching("fill")).is_ok();
+        let mut fill = input.r#try(|i| i.expect_ident_matching("fill")).is_ok();
         let offsets = Rect::parse_with(context, input, NumberOrPercentage::parse_non_negative)?;
         if !fill {
-            fill = input.try(|i| i.expect_ident_matching("fill")).is_ok();
+            fill = input.r#try(|i| i.expect_ident_matching("fill")).is_ok();
         }
         Ok(GenericBorderImageSlice {
             offsets: offsets,
@@ -151,7 +151,7 @@ impl Parse for BorderRadius {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         let widths = Rect::parse_with(context, input, LengthOrPercentage::parse_non_negative)?;
-        let heights = if input.try(|i| i.expect_delim('/')).is_ok() {
+        let heights = if input.r#try(|i| i.expect_delim('/')).is_ok() {
             Rect::parse_with(context, input, LengthOrPercentage::parse_non_negative)?
         } else {
             widths.clone()
@@ -236,7 +236,7 @@ impl Parse for BorderImageRepeat {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         let horizontal = BorderImageRepeatKeyword::parse(input)?;
-        let vertical = input.try(BorderImageRepeatKeyword::parse).ok();
+        let vertical = input.r#try(BorderImageRepeatKeyword::parse).ok();
         Ok(BorderImageRepeat(
             horizontal,
             vertical.unwrap_or(horizontal),

--- a/components/style/values/specified/box.rs
+++ b/components/style/values/specified/box.rs
@@ -4,24 +4,26 @@
 
 //! Specified types for box properties.
 
+use crate::custom_properties::Name as CustomPropertyName;
+use crate::parser::{Parse, ParserContext};
+use crate::properties::{
+    LonghandId, PropertyDeclarationId, PropertyFlags, PropertyId, ShorthandId,
+};
+use crate::values::generics::box_::AnimationIterationCount as GenericAnimationIterationCount;
+use crate::values::generics::box_::Perspective as GenericPerspective;
+use crate::values::generics::box_::VerticalAlign as GenericVerticalAlign;
+use crate::values::specified::length::{LengthOrPercentage, NonNegativeLength};
+use crate::values::specified::{AllowQuirks, Number};
+use crate::values::{CustomIdent, KeyframesName};
+use crate::Atom;
 use cssparser::Parser;
-use custom_properties::Name as CustomPropertyName;
-use parser::{Parse, ParserContext};
-use properties::{LonghandId, PropertyDeclarationId, PropertyFlags, PropertyId, ShorthandId};
 use selectors::parser::SelectorParseErrorKind;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, KeywordsCollectFn, ParseError};
 use style_traits::{SpecifiedValueInfo, StyleParseErrorKind, ToCss};
-use values::generics::box_::AnimationIterationCount as GenericAnimationIterationCount;
-use values::generics::box_::Perspective as GenericPerspective;
-use values::generics::box_::VerticalAlign as GenericVerticalAlign;
-use values::specified::length::{LengthOrPercentage, NonNegativeLength};
-use values::specified::{AllowQuirks, Number};
-use values::{CustomIdent, KeyframesName};
-use Atom;
 
 fn in_ua_or_chrome_sheet(context: &ParserContext) -> bool {
-    use stylesheets::Origin;
+    use crate::stylesheets::Origin;
     context.stylesheet_origin == Origin::UserAgent || context.chrome_rules_enabled()
 }
 
@@ -308,7 +310,7 @@ impl Parse for VerticalAlign {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         if let Ok(lop) =
-            input.try(|i| LengthOrPercentage::parse_quirky(context, i, AllowQuirks::Yes))
+            input.r#try(|i| LengthOrPercentage::parse_quirky(context, i, AllowQuirks::Yes))
         {
             return Ok(GenericVerticalAlign::Length(lop));
         }
@@ -339,7 +341,7 @@ impl Parse for AnimationIterationCount {
         input: &mut ::cssparser::Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         if input
-            .try(|input| input.expect_ident_matching("infinite"))
+            .r#try(|input| input.expect_ident_matching("infinite"))
             .is_ok()
         {
             return Ok(GenericAnimationIterationCount::Infinite);
@@ -392,7 +394,7 @@ impl Parse for AnimationName {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(name) = input.try(|input| KeyframesName::parse(context, input)) {
+        if let Ok(name) = input.r#try(|input| KeyframesName::parse(context, input)) {
             return Ok(AnimationName(Some(name)));
         }
 
@@ -555,7 +557,7 @@ impl Parse for WillChange {
         input: &mut Parser<'i, 't>,
     ) -> Result<WillChange, ParseError<'i>> {
         if input
-            .try(|input| input.expect_ident_matching("auto"))
+            .r#try(|input| input.expect_ident_matching("auto"))
             .is_ok()
         {
             return Ok(WillChange::Auto);
@@ -644,14 +646,14 @@ impl Parse for TouchAction {
             "none" => Ok(TouchAction::TOUCH_ACTION_NONE),
             "manipulation" => Ok(TouchAction::TOUCH_ACTION_MANIPULATION),
             "pan-x" => {
-                if input.try(|i| i.expect_ident_matching("pan-y")).is_ok() {
+                if input.r#try(|i| i.expect_ident_matching("pan-y")).is_ok() {
                     Ok(TouchAction::TOUCH_ACTION_PAN_X | TouchAction::TOUCH_ACTION_PAN_Y)
                 } else {
                     Ok(TouchAction::TOUCH_ACTION_PAN_X)
                 }
             },
             "pan-y" => {
-                if input.try(|i| i.expect_ident_matching("pan-x")).is_ok() {
+                if input.r#try(|i| i.expect_ident_matching("pan-x")).is_ok() {
                     Ok(TouchAction::TOUCH_ACTION_PAN_X | TouchAction::TOUCH_ACTION_PAN_Y)
                 } else {
                     Ok(TouchAction::TOUCH_ACTION_PAN_Y)
@@ -755,7 +757,7 @@ impl Parse for Contain {
         input: &mut Parser<'i, 't>,
     ) -> Result<Contain, ParseError<'i>> {
         let mut result = Contain::empty();
-        while let Ok(name) = input.try(|i| i.expect_ident_cloned()) {
+        while let Ok(name) = input.r#try(|i| i.expect_ident_cloned()) {
             let flag = match_ignore_ascii_case! { &name,
                 "size" => Some(Contain::SIZE),
                 "layout" => Some(Contain::LAYOUT),
@@ -792,7 +794,7 @@ impl Parse for Perspective {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if input.try(|i| i.expect_ident_matching("none")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("none")).is_ok() {
             return Ok(GenericPerspective::None);
         }
         Ok(GenericPerspective::Length(NonNegativeLength::parse(
@@ -821,7 +823,7 @@ impl ToCss for TransitionProperty {
     where
         W: Write,
     {
-        use values::serialize_atom_name;
+        use crate::values::serialize_atom_name;
         match *self {
             TransitionProperty::Shorthand(ref s) => s.to_css(dest),
             TransitionProperty::Longhand(ref l) => l.to_css(dest),

--- a/components/style/values/specified/box.rs
+++ b/components/style/values/specified/box.rs
@@ -29,14 +29,14 @@ fn in_ua_or_chrome_sheet(context: &ParserContext) -> bool {
 
 #[cfg(feature = "gecko")]
 fn moz_display_values_enabled(context: &ParserContext) -> bool {
-    use gecko_bindings::structs;
+    use crate::gecko_bindings::structs;
     in_ua_or_chrome_sheet(context) ||
         unsafe { structs::StaticPrefs_sVarCache_layout_css_xul_display_values_content_enabled }
 }
 
 #[cfg(feature = "gecko")]
 fn moz_box_display_values_enabled(context: &ParserContext) -> bool {
-    use gecko_bindings::structs;
+    use crate::gecko_bindings::structs;
     in_ua_or_chrome_sheet(context) ||
         unsafe {
             structs::StaticPrefs_sVarCache_layout_css_xul_box_display_values_content_enabled
@@ -670,7 +670,7 @@ impl_bitflags_conversions!(TouchAction);
 #[cfg(feature = "gecko")]
 #[inline]
 pub fn assert_touch_action_matches() {
-    use gecko_bindings::structs;
+    use crate::gecko_bindings::structs;
 
     macro_rules! check_touch_action {
         ( $( $a:ident => $b:path),*, ) => {
@@ -883,10 +883,12 @@ impl TransitionProperty {
 
     /// Convert TransitionProperty to nsCSSPropertyID.
     #[cfg(feature = "gecko")]
-    pub fn to_nscsspropertyid(&self) -> Result<::gecko_bindings::structs::nsCSSPropertyID, ()> {
+    pub fn to_nscsspropertyid(
+        &self,
+    ) -> Result<crate::gecko_bindings::structs::nsCSSPropertyID, ()> {
         Ok(match *self {
             TransitionProperty::Shorthand(ShorthandId::All) => {
-                ::gecko_bindings::structs::nsCSSPropertyID::eCSSPropertyExtra_all_properties
+                crate::gecko_bindings::structs::nsCSSPropertyID::eCSSPropertyExtra_all_properties
             },
             TransitionProperty::Shorthand(ref id) => id.to_nscsspropertyid(),
             TransitionProperty::Longhand(ref id) => id.to_nscsspropertyid(),

--- a/components/style/values/specified/calc.rs
+++ b/components/style/values/specified/calc.rs
@@ -6,16 +6,16 @@
 //!
 //! [calc]: https://drafts.csswg.org/css-values/#calc-notation
 
+use crate::parser::ParserContext;
+use crate::values::computed;
+use crate::values::specified::length::ViewportPercentageLength;
+use crate::values::specified::length::{AbsoluteLength, FontRelativeLength, NoCalcLength};
+use crate::values::specified::{Angle, Time};
+use crate::values::{CSSFloat, CSSInteger};
 use cssparser::{AngleOrNumber, NumberOrPercentage, Parser, Token};
-use parser::ParserContext;
 use std::fmt::{self, Write};
 use style_traits::values::specified::AllowedNumericType;
 use style_traits::{CssWriter, ParseError, SpecifiedValueInfo, StyleParseErrorKind, ToCss};
-use values::computed;
-use values::specified::length::ViewportPercentageLength;
-use values::specified::length::{AbsoluteLength, FontRelativeLength, NoCalcLength};
-use values::specified::{Angle, Time};
-use values::{CSSFloat, CSSInteger};
 
 /// A node inside a `Calc` expression's AST.
 #[derive(Clone, Debug)]

--- a/components/style/values/specified/color.rs
+++ b/components/style/values/specified/color.rs
@@ -5,17 +5,17 @@
 //! Specified color values.
 
 use super::AllowQuirks;
+#[cfg(feature = "gecko")]
+use crate::gecko_bindings::structs::nscolor;
 use crate::parser::{Parse, ParserContext};
+#[cfg(feature = "gecko")]
+use crate::properties::longhands::system_colors::SystemColor;
 use crate::values::computed::{Color as ComputedColor, Context, ToComputedValue};
 use crate::values::generics::color::Color as GenericColor;
 use crate::values::specified::calc::CalcNode;
 use cssparser::{AngleOrNumber, Color as CSSParserColor, Parser, Token, RGBA};
 use cssparser::{BasicParseErrorKind, NumberOrPercentage, ParseErrorKind};
-#[cfg(feature = "gecko")]
-use gecko_bindings::structs::nscolor;
 use itoa;
-#[cfg(feature = "gecko")]
-use properties::longhands::system_colors::SystemColor;
 use std::fmt::{self, Write};
 use std::io::Write as IoWrite;
 use style_traits::{CssType, CssWriter, KeywordsCollectFn, ParseError, StyleParseErrorKind};
@@ -329,7 +329,7 @@ impl Color {
 
 #[cfg(feature = "gecko")]
 fn convert_nscolor_to_computedcolor(color: nscolor) -> ComputedColor {
-    use gecko::values::convert_nscolor_to_rgba;
+    use crate::gecko::values::convert_nscolor_to_rgba;
     ComputedColor::rgba(convert_nscolor_to_rgba(color))
 }
 

--- a/components/style/values/specified/color.rs
+++ b/components/style/values/specified/color.rs
@@ -5,21 +5,21 @@
 //! Specified color values.
 
 use super::AllowQuirks;
+use crate::parser::{Parse, ParserContext};
+use crate::values::computed::{Color as ComputedColor, Context, ToComputedValue};
+use crate::values::generics::color::Color as GenericColor;
+use crate::values::specified::calc::CalcNode;
 use cssparser::{AngleOrNumber, Color as CSSParserColor, Parser, Token, RGBA};
 use cssparser::{BasicParseErrorKind, NumberOrPercentage, ParseErrorKind};
 #[cfg(feature = "gecko")]
 use gecko_bindings::structs::nscolor;
 use itoa;
-use parser::{Parse, ParserContext};
 #[cfg(feature = "gecko")]
 use properties::longhands::system_colors::SystemColor;
 use std::fmt::{self, Write};
 use std::io::Write as IoWrite;
 use style_traits::{CssType, CssWriter, KeywordsCollectFn, ParseError, StyleParseErrorKind};
 use style_traits::{SpecifiedValueInfo, ToCss, ValueParseErrorKind};
-use values::computed::{Color as ComputedColor, Context, ToComputedValue};
-use values::generics::color::Color as GenericColor;
-use values::specified::calc::CalcNode;
 
 /// Specified color value
 #[derive(Clone, Debug, MallocSizeOf, PartialEq)]
@@ -73,7 +73,7 @@ impl<'a, 'b: 'a, 'i: 'a> ::cssparser::ColorComponentParser<'i> for ColorComponen
         &self,
         input: &mut Parser<'i, 't>,
     ) -> Result<AngleOrNumber, ParseError<'i>> {
-        use values::specified::Angle;
+        use crate::values::specified::Angle;
 
         let location = input.current_source_location();
         let token = input.next()?.clone();
@@ -99,13 +99,13 @@ impl<'a, 'b: 'a, 'i: 'a> ::cssparser::ColorComponentParser<'i> for ColorComponen
     }
 
     fn parse_percentage<'t>(&self, input: &mut Parser<'i, 't>) -> Result<f32, ParseError<'i>> {
-        use values::specified::Percentage;
+        use crate::values::specified::Percentage;
 
         Ok(Percentage::parse(self.0, input)?.get())
     }
 
     fn parse_number<'t>(&self, input: &mut Parser<'i, 't>) -> Result<f32, ParseError<'i>> {
-        use values::specified::Number;
+        use crate::values::specified::Number;
 
         Ok(Number::parse(self.0, input)?.get())
     }
@@ -142,7 +142,7 @@ impl Parse for Color {
         input.reset(&start);
 
         let compontent_parser = ColorComponentParser(&*context);
-        match input.try(|i| CSSParserColor::parse_with(&compontent_parser, i)) {
+        match input.r#try(|i| CSSParserColor::parse_with(&compontent_parser, i)) {
             Ok(value) => Ok(match value {
                 CSSParserColor::CurrentColor => Color::CurrentColor,
                 CSSParserColor::RGBA(rgba) => Color::Numeric {
@@ -245,7 +245,7 @@ impl Color {
         input: &mut Parser<'i, 't>,
         allow_quirks: AllowQuirks,
     ) -> Result<Self, ParseError<'i>> {
-        input.try(|i| Self::parse(context, i)).or_else(|e| {
+        input.r#try(|i| Self::parse(context, i)).or_else(|e| {
             if !allow_quirks.allowed(context.quirks_mode) {
                 return Err(e);
             }

--- a/components/style/values/specified/column.rs
+++ b/components/style/values/specified/column.rs
@@ -4,11 +4,11 @@
 
 //! Specified types for the column properties.
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::generics::column::ColumnCount as GenericColumnCount;
+use crate::values::specified::PositiveInteger;
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use style_traits::ParseError;
-use values::generics::column::ColumnCount as GenericColumnCount;
-use values::specified::PositiveInteger;
 
 /// A specified type for `column-count` values.
 pub type ColumnCount = GenericColumnCount<PositiveInteger>;
@@ -18,7 +18,7 @@ impl Parse for ColumnCount {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if input.try(|i| i.expect_ident_matching("auto")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("auto")).is_ok() {
             return Ok(GenericColumnCount::Auto);
         }
         Ok(GenericColumnCount::Integer(PositiveInteger::parse(

--- a/components/style/values/specified/counters.rs
+++ b/components/style/values/specified/counters.rs
@@ -5,22 +5,22 @@
 //! Specified types for counter properties.
 
 #[cfg(feature = "servo")]
-use computed_values::list_style_type::T as ListStyleType;
+use crate::computed_values::list_style_type::T as ListStyleType;
+use crate::parser::{Parse, ParserContext};
+use crate::values::generics::counters as generics;
+use crate::values::generics::counters::CounterIncrement as GenericCounterIncrement;
+use crate::values::generics::counters::CounterPair;
+use crate::values::generics::counters::CounterReset as GenericCounterReset;
+use crate::values::specified::url::SpecifiedImageUrl;
+use crate::values::specified::Integer;
+use crate::values::CustomIdent;
 use cssparser::{Parser, Token};
-use parser::{Parse, ParserContext};
 use selectors::parser::SelectorParseErrorKind;
 use style_traits::{ParseError, StyleParseErrorKind};
-use values::generics::counters as generics;
-use values::generics::counters::CounterIncrement as GenericCounterIncrement;
-use values::generics::counters::CounterPair;
-use values::generics::counters::CounterReset as GenericCounterReset;
 #[cfg(feature = "gecko")]
 use values::generics::CounterStyleOrNone;
-use values::specified::url::SpecifiedImageUrl;
 #[cfg(feature = "gecko")]
 use values::specified::Attr;
-use values::specified::Integer;
-use values::CustomIdent;
 
 /// A specified value for the `counter-increment` property.
 pub type CounterIncrement = GenericCounterIncrement<Integer>;
@@ -52,7 +52,7 @@ fn parse_counters<'i, 't>(
     default_value: i32,
 ) -> Result<Vec<CounterPair<Integer>>, ParseError<'i>> {
     if input
-        .try(|input| input.expect_ident_matching("none"))
+        .r#try(|input| input.expect_ident_matching("none"))
         .is_ok()
     {
         return Ok(vec![]);
@@ -68,7 +68,7 @@ fn parse_counters<'i, 't>(
         };
 
         let value = input
-            .try(|input| Integer::parse(context, input))
+            .r#try(|input| Integer::parse(context, input))
             .unwrap_or(Integer::new(default_value));
         counters.push(CounterPair { name, value });
     }
@@ -90,7 +90,7 @@ impl Content {
     #[cfg(feature = "servo")]
     fn parse_counter_style(_: &ParserContext, input: &mut Parser) -> ListStyleType {
         input
-            .try(|input| {
+            .r#try(|input| {
                 input.expect_comma()?;
                 ListStyleType::parse(input)
             })
@@ -100,7 +100,7 @@ impl Content {
     #[cfg(feature = "gecko")]
     fn parse_counter_style(context: &ParserContext, input: &mut Parser) -> CounterStyleOrNone {
         input
-            .try(|input| {
+            .r#try(|input| {
                 input.expect_comma()?;
                 CounterStyleOrNone::parse(context, input)
             })
@@ -117,13 +117,13 @@ impl Parse for Content {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         if input
-            .try(|input| input.expect_ident_matching("normal"))
+            .r#try(|input| input.expect_ident_matching("normal"))
             .is_ok()
         {
             return Ok(generics::Content::Normal);
         }
         if input
-            .try(|input| input.expect_ident_matching("none"))
+            .r#try(|input| input.expect_ident_matching("none"))
             .is_ok()
         {
             return Ok(generics::Content::None);
@@ -131,7 +131,7 @@ impl Parse for Content {
         #[cfg(feature = "gecko")]
         {
             if input
-                .try(|input| input.expect_ident_matching("-moz-alt-content"))
+                .r#try(|input| input.expect_ident_matching("-moz-alt-content"))
                 .is_ok()
             {
                 return Ok(generics::Content::MozAltContent);
@@ -142,7 +142,7 @@ impl Parse for Content {
         loop {
             #[cfg(feature = "gecko")]
             {
-                if let Ok(url) = input.try(|i| SpecifiedImageUrl::parse(context, i)) {
+                if let Ok(url) = input.r#try(|i| SpecifiedImageUrl::parse(context, i)) {
                     content.push(generics::ContentItem::Url(url));
                     continue;
                 }

--- a/components/style/values/specified/counters.rs
+++ b/components/style/values/specified/counters.rs
@@ -11,16 +11,16 @@ use crate::values::generics::counters as generics;
 use crate::values::generics::counters::CounterIncrement as GenericCounterIncrement;
 use crate::values::generics::counters::CounterPair;
 use crate::values::generics::counters::CounterReset as GenericCounterReset;
+#[cfg(feature = "gecko")]
+use crate::values::generics::CounterStyleOrNone;
 use crate::values::specified::url::SpecifiedImageUrl;
+#[cfg(feature = "gecko")]
+use crate::values::specified::Attr;
 use crate::values::specified::Integer;
 use crate::values::CustomIdent;
 use cssparser::{Parser, Token};
 use selectors::parser::SelectorParseErrorKind;
 use style_traits::{ParseError, StyleParseErrorKind};
-#[cfg(feature = "gecko")]
-use values::generics::CounterStyleOrNone;
-#[cfg(feature = "gecko")]
-use values::specified::Attr;
 
 /// A specified value for the `counter-increment` property.
 pub type CounterIncrement = GenericCounterIncrement<Integer>;

--- a/components/style/values/specified/easing.rs
+++ b/components/style/values/specified/easing.rs
@@ -4,14 +4,14 @@
 
 //! Specified types for CSS Easing functions.
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::computed::easing::TimingFunction as ComputedTimingFunction;
+use crate::values::generics::easing::TimingFunction as GenericTimingFunction;
+use crate::values::generics::easing::{StepPosition, TimingKeyword};
+use crate::values::specified::{Integer, Number};
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use selectors::parser::SelectorParseErrorKind;
 use style_traits::{ParseError, StyleParseErrorKind};
-use values::computed::easing::TimingFunction as ComputedTimingFunction;
-use values::generics::easing::TimingFunction as GenericTimingFunction;
-use values::generics::easing::{StepPosition, TimingKeyword};
-use values::specified::{Integer, Number};
 
 /// A specified timing function.
 pub type TimingFunction = GenericTimingFunction<Integer, Number>;
@@ -21,10 +21,10 @@ impl Parse for TimingFunction {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(keyword) = input.try(TimingKeyword::parse) {
+        if let Ok(keyword) = input.r#try(TimingKeyword::parse) {
             return Ok(GenericTimingFunction::Keyword(keyword));
         }
-        if let Ok(ident) = input.try(|i| i.expect_ident_cloned()) {
+        if let Ok(ident) = input.r#try(|i| i.expect_ident_cloned()) {
             let position = match_ignore_ascii_case! { &ident,
                 "step-start" => StepPosition::Start,
                 "step-end" => StepPosition::End,
@@ -57,7 +57,7 @@ impl Parse for TimingFunction {
                 },
                 "steps" => {
                     let steps = Integer::parse_positive(context, i)?;
-                    let position = i.try(|i| {
+                    let position = i.r#try(|i| {
                         i.expect_comma()?;
                         StepPosition::parse(context, i)
                     }).unwrap_or(StepPosition::End);

--- a/components/style/values/specified/effects.rs
+++ b/components/style/values/specified/effects.rs
@@ -16,13 +16,13 @@ use crate::values::generics::effects::SimpleShadow as GenericSimpleShadow;
 use crate::values::generics::NonNegative;
 use crate::values::specified::color::Color;
 use crate::values::specified::length::{Length, NonNegativeLength};
+#[cfg(feature = "gecko")]
+use crate::values::specified::url::SpecifiedUrl;
 use crate::values::specified::{Angle, NumberOrPercentage};
 #[cfg(not(feature = "gecko"))]
 use crate::values::Impossible;
 use cssparser::{self, BasicParseErrorKind, Parser, Token};
 use style_traits::{ParseError, StyleParseErrorKind, ValueParseErrorKind};
-#[cfg(feature = "gecko")]
-use values::specified::url::SpecifiedUrl;
 
 /// A specified value for a single shadow of the `box-shadow` property.
 pub type BoxShadow =

--- a/components/style/values/specified/flex.rs
+++ b/components/style/values/specified/flex.rs
@@ -4,14 +4,14 @@
 
 //! Specified types for CSS values related to flexbox.
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::generics::flex::FlexBasis as GenericFlexBasis;
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use style_traits::ParseError;
-use values::generics::flex::FlexBasis as GenericFlexBasis;
 
 /// The `width` value type.
 #[cfg(feature = "servo")]
-pub type Width = ::values::specified::NonNegativeLengthOrPercentageOrAuto;
+pub type Width = crate::values::specified::NonNegativeLengthOrPercentageOrAuto;
 
 /// The `width` value type.
 #[cfg(feature = "gecko")]
@@ -25,7 +25,7 @@ impl Parse for FlexBasis {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(width) = input.try(|i| Width::parse(context, i)) {
+        if let Ok(width) = input.r#try(|i| Width::parse(context, i)) {
             return Ok(GenericFlexBasis::Width(width));
         }
         try_match_ident_ignore_ascii_case! { input,

--- a/components/style/values/specified/flex.rs
+++ b/components/style/values/specified/flex.rs
@@ -15,7 +15,7 @@ pub type Width = crate::values::specified::NonNegativeLengthOrPercentageOrAuto;
 
 /// The `width` value type.
 #[cfg(feature = "gecko")]
-pub type Width = ::values::specified::MozLength;
+pub type Width = crate::values::specified::MozLength;
 
 /// A specified value for the `flex-basis` property.
 pub type FlexBasis = GenericFlexBasis<Width>;

--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -6,28 +6,31 @@
 
 use app_units::Au;
 use byteorder::{BigEndian, ByteOrder};
+use crate::parser::{Parse, ParserContext};
+use crate::properties::longhands::system_font::SystemFont;
+use crate::values::computed::font::{FamilyName, FontFamilyList, FontStyleAngle, SingleFontFamily};
+use crate::values::computed::{
+    font as computed, Context, Length, NonNegativeLength, ToComputedValue,
+};
+use crate::values::computed::{Angle as ComputedAngle, Percentage as ComputedPercentage};
+use crate::values::generics::font::{self as generics, FeatureTagValue, FontSettings, FontTag};
+use crate::values::generics::font::{KeywordSize, VariationValue};
+use crate::values::generics::NonNegative;
+use crate::values::specified::length::{FontBaseSize, AU_PER_PT, AU_PER_PX};
+use crate::values::specified::{AllowQuirks, Angle, Integer, LengthOrPercentage};
+use crate::values::specified::{NoCalcLength, Number, Percentage};
+use crate::values::CustomIdent;
+use crate::Atom;
 use cssparser::{Parser, Token};
 #[cfg(feature = "gecko")]
 use gecko_bindings::bindings;
 #[cfg(feature = "gecko")]
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
-use parser::{Parse, ParserContext};
-use properties::longhands::system_font::SystemFont;
 use std::fmt::{self, Write};
 use style_traits::values::SequenceWriter;
 use style_traits::{CssWriter, KeywordsCollectFn, ParseError};
 use style_traits::{SpecifiedValueInfo, StyleParseErrorKind, ToCss};
-use values::computed::font::{FamilyName, FontFamilyList, FontStyleAngle, SingleFontFamily};
-use values::computed::{font as computed, Context, Length, NonNegativeLength, ToComputedValue};
-use values::computed::{Angle as ComputedAngle, Percentage as ComputedPercentage};
-use values::generics::font::{self as generics, FeatureTagValue, FontSettings, FontTag};
-use values::generics::font::{KeywordSize, VariationValue};
-use values::generics::NonNegative;
-use values::specified::length::{FontBaseSize, AU_PER_PT, AU_PER_PX};
-use values::specified::{AllowQuirks, Angle, Integer, LengthOrPercentage};
-use values::specified::{NoCalcLength, Number, Percentage};
-use values::CustomIdent;
-use Atom;
+
 
 // FIXME(emilio): The system font code is copy-pasta, and should be cleaned up.
 macro_rules! system_font_methods {
@@ -115,7 +118,7 @@ impl Parse for FontWeight {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<FontWeight, ParseError<'i>> {
-        if let Ok(absolute) = input.try(|input| AbsoluteFontWeight::parse(context, input)) {
+        if let Ok(absolute) = input.r#try(|input| AbsoluteFontWeight::parse(context, input)) {
             return Ok(FontWeight::Absolute(absolute));
         }
 
@@ -188,7 +191,7 @@ impl Parse for AbsoluteFontWeight {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(number) = input.try(|input| Number::parse(context, input)) {
+        if let Ok(number) = input.r#try(|input| Number::parse(context, input)) {
             // We could add another AllowedNumericType value, but it doesn't
             // seem worth it just for a single property with such a weird range,
             // so we do the clamping here manually.
@@ -240,7 +243,7 @@ impl Parse for SpecifiedFontStyle {
             "normal" => generics::FontStyle::Normal,
             "italic" => generics::FontStyle::Italic,
             "oblique" => {
-                let angle = input.try(|input| Self::parse_angle(context, input))
+                let angle = input.r#try(|input| Self::parse_angle(context, input))
                     .unwrap_or_else(|_| Self::default_angle());
 
                 generics::FontStyle::Oblique(angle)
@@ -479,7 +482,8 @@ impl Parse for FontStretch {
         //
         //    Values less than 0% are not allowed and are treated as parse
         //    errors.
-        if let Ok(percentage) = input.try(|input| Percentage::parse_non_negative(context, input)) {
+        if let Ok(percentage) = input.r#try(|input| Percentage::parse_non_negative(context, input))
+        {
             return Ok(FontStretch::Stretch(percentage));
         }
 
@@ -679,7 +683,7 @@ impl Parse for FontSizeAdjust {
         input: &mut Parser<'i, 't>,
     ) -> Result<FontSizeAdjust, ParseError<'i>> {
         if input
-            .try(|input| input.expect_ident_matching("none"))
+            .r#try(|input| input.expect_ident_matching("none"))
             .is_ok()
         {
             return Ok(FontSizeAdjust::None);
@@ -850,7 +854,7 @@ impl FontSize {
         context: &Context,
         base_size: FontBaseSize,
     ) -> computed::FontSize {
-        use values::specified::length::FontRelativeLength;
+        use crate::values::specified::length::FontRelativeLength;
 
         let compose_keyword = |factor| {
             context
@@ -987,12 +991,12 @@ impl FontSize {
         allow_quirks: AllowQuirks,
     ) -> Result<FontSize, ParseError<'i>> {
         if let Ok(lop) =
-            input.try(|i| LengthOrPercentage::parse_non_negative_quirky(context, i, allow_quirks))
+            input.r#try(|i| LengthOrPercentage::parse_non_negative_quirky(context, i, allow_quirks))
         {
             return Ok(FontSize::Length(lop));
         }
 
-        if let Ok(kw) = input.try(KeywordSize::parse) {
+        if let Ok(kw) = input.r#try(KeywordSize::parse) {
             return Ok(FontSize::Keyword(kw.into()));
         }
 
@@ -1174,7 +1178,7 @@ impl Parse for FontVariantAlternates {
     ) -> Result<FontVariantAlternates, ParseError<'i>> {
         let mut alternates = Vec::new();
         if input
-            .try(|input| input.expect_ident_matching("normal"))
+            .r#try(|input| input.expect_ident_matching("normal"))
             .is_ok()
         {
             return Ok(FontVariantAlternates::Value(VariantAlternatesList(
@@ -1191,7 +1195,7 @@ impl Parse for FontVariantAlternates {
                 parsed_alternates |= $flag;
             )
         );
-        while let Ok(_) = input.try(|input| {
+        while let Ok(_) = input.r#try(|input| {
             // FIXME: remove clone() when lifetimes are non-lexical
             match input.next()?.clone() {
                 Token::Ident(ref value) if value.eq_ignore_ascii_case("historical-forms") => {
@@ -1406,13 +1410,13 @@ impl Parse for FontVariantEastAsian {
         let mut result = VariantEastAsian::empty();
 
         if input
-            .try(|input| input.expect_ident_matching("normal"))
+            .r#try(|input| input.expect_ident_matching("normal"))
             .is_ok()
         {
             return Ok(FontVariantEastAsian::Value(result));
         }
 
-        while let Ok(flag) = input.try(|input| {
+        while let Ok(flag) = input.r#try(|input| {
             Ok(
                 match_ignore_ascii_case! { &input.expect_ident().map_err(|_| ())?,
                     "jis78" =>
@@ -1630,19 +1634,19 @@ impl Parse for FontVariantLigatures {
         let mut result = VariantLigatures::empty();
 
         if input
-            .try(|input| input.expect_ident_matching("normal"))
+            .r#try(|input| input.expect_ident_matching("normal"))
             .is_ok()
         {
             return Ok(FontVariantLigatures::Value(result));
         }
         if input
-            .try(|input| input.expect_ident_matching("none"))
+            .r#try(|input| input.expect_ident_matching("none"))
             .is_ok()
         {
             return Ok(FontVariantLigatures::Value(VariantLigatures::NONE));
         }
 
-        while let Ok(flag) = input.try(|input| {
+        while let Ok(flag) = input.r#try(|input| {
             Ok(
                 match_ignore_ascii_case! { &input.expect_ident().map_err(|_| ())?,
                     "common-ligatures" =>
@@ -1839,13 +1843,13 @@ impl Parse for FontVariantNumeric {
         let mut result = VariantNumeric::empty();
 
         if input
-            .try(|input| input.expect_ident_matching("normal"))
+            .r#try(|input| input.expect_ident_matching("normal"))
             .is_ok()
         {
             return Ok(FontVariantNumeric::Value(result));
         }
 
-        while let Ok(flag) = input.try(|input| {
+        while let Ok(flag) = input.r#try(|input| {
             Ok(
                 match_ignore_ascii_case! { &input.expect_ident().map_err(|_| ())?,
                     "ordinal" =>
@@ -1979,14 +1983,14 @@ impl Parse for FontSynthesis {
             "none" => Ok(result),
             "weight" => {
                 result.weight = true;
-                if input.try(|input| input.expect_ident_matching("style")).is_ok() {
+                if input.r#try(|input| input.expect_ident_matching("style")).is_ok() {
                     result.style = true;
                 }
                 Ok(result)
             },
             "style" => {
                 result.style = true;
-                if input.try(|input| input.expect_ident_matching("weight")).is_ok() {
+                if input.r#try(|input| input.expect_ident_matching("weight")).is_ok() {
                     result.weight = true;
                 }
                 Ok(result)
@@ -2125,7 +2129,7 @@ impl Parse for FontLanguageOverride {
         input: &mut Parser<'i, 't>,
     ) -> Result<FontLanguageOverride, ParseError<'i>> {
         if input
-            .try(|input| input.expect_ident_matching("normal"))
+            .r#try(|input| input.expect_ident_matching("normal"))
             .is_ok()
         {
             return Ok(FontLanguageOverride::Normal);
@@ -2192,7 +2196,7 @@ fn parse_one_feature_value<'i, 't>(
     context: &ParserContext,
     input: &mut Parser<'i, 't>,
 ) -> Result<Integer, ParseError<'i>> {
-    if let Ok(integer) = input.try(|i| Integer::parse_non_negative(context, i)) {
+    if let Ok(integer) = input.r#try(|i| Integer::parse_non_negative(context, i)) {
         return Ok(integer);
     }
 
@@ -2210,7 +2214,7 @@ impl Parse for FeatureTagValue<Integer> {
     ) -> Result<Self, ParseError<'i>> {
         let tag = FontTag::parse(context, input)?;
         let value = input
-            .try(|i| parse_one_feature_value(context, i))
+            .r#try(|i| parse_one_feature_value(context, i))
             .unwrap_or_else(|_| Integer::new(1));
 
         Ok(Self { tag, value })
@@ -2328,7 +2332,7 @@ impl Parse for MozScriptLevel {
         input: &mut Parser<'i, 't>,
     ) -> Result<MozScriptLevel, ParseError<'i>> {
         // We don't bother to handle calc here.
-        if let Ok(i) = input.try(|i| i.expect_integer()) {
+        if let Ok(i) = input.r#try(|i| i.expect_integer()) {
             return Ok(MozScriptLevel::Relative(i));
         }
         input.expect_ident_matching("auto")?;

--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -6,6 +6,8 @@
 
 use app_units::Au;
 use byteorder::{BigEndian, ByteOrder};
+#[cfg(feature = "gecko")]
+use crate::gecko_bindings::bindings;
 use crate::parser::{Parse, ParserContext};
 use crate::properties::longhands::system_font::SystemFont;
 use crate::values::computed::font::{FamilyName, FontFamilyList, FontStyleAngle, SingleFontFamily};
@@ -23,14 +25,11 @@ use crate::values::CustomIdent;
 use crate::Atom;
 use cssparser::{Parser, Token};
 #[cfg(feature = "gecko")]
-use gecko_bindings::bindings;
-#[cfg(feature = "gecko")]
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use std::fmt::{self, Write};
 use style_traits::values::SequenceWriter;
 use style_traits::{CssWriter, KeywordsCollectFn, ParseError};
 use style_traits::{SpecifiedValueInfo, StyleParseErrorKind, ToCss};
-
 
 // FIXME(emilio): The system font code is copy-pasta, and should be cleaned up.
 macro_rules! system_font_methods {
@@ -753,8 +752,8 @@ impl ToComputedValue for KeywordSize {
     type ComputedValue = NonNegativeLength;
     #[inline]
     fn to_computed_value(&self, cx: &Context) -> NonNegativeLength {
-        use context::QuirksMode;
-        use values::specified::length::au_to_int_px;
+        use crate::context::QuirksMode;
+        use crate::values::specified::length::au_to_int_px;
 
         // The tables in this function are originally from
         // nsRuleNode::CalcFontPointSize in Gecko:
@@ -1310,7 +1309,7 @@ macro_rules! impl_variant_east_asian {
         #[cfg(feature = "gecko")]
         #[inline]
         pub fn assert_variant_east_asian_matches() {
-            use gecko_bindings::structs;
+            use crate::gecko_bindings::structs;
             $(
                 debug_assert_eq!(structs::$gecko as u16, VariantEastAsian::$ident.bits());
             )+
@@ -1520,7 +1519,7 @@ macro_rules! impl_variant_ligatures {
         #[cfg(feature = "gecko")]
         #[inline]
         pub fn assert_variant_ligatures_matches() {
-            use gecko_bindings::structs;
+            use crate::gecko_bindings::structs;
             $(
                 debug_assert_eq!(structs::$gecko as u16, VariantLigatures::$ident.bits());
             )+
@@ -1739,7 +1738,7 @@ macro_rules! impl_variant_numeric {
         #[cfg(feature = "gecko")]
         #[inline]
         pub fn assert_variant_numeric_matches() {
-            use gecko_bindings::structs;
+            use crate::gecko_bindings::structs;
             $(
                 debug_assert_eq!(structs::$gecko as u8, VariantNumeric::$ident.bits());
             )+
@@ -2019,7 +2018,7 @@ impl ToCss for FontSynthesis {
 #[cfg(feature = "gecko")]
 impl From<u8> for FontSynthesis {
     fn from(bits: u8) -> FontSynthesis {
-        use gecko_bindings::structs;
+        use crate::gecko_bindings::structs;
 
         FontSynthesis {
             weight: bits & structs::NS_FONT_SYNTHESIS_WEIGHT as u8 != 0,
@@ -2031,7 +2030,7 @@ impl From<u8> for FontSynthesis {
 #[cfg(feature = "gecko")]
 impl From<FontSynthesis> for u8 {
     fn from(v: FontSynthesis) -> u8 {
-        use gecko_bindings::structs;
+        use crate::gecko_bindings::structs;
 
         let mut bits: u8 = 0;
         if v.weight {

--- a/components/style/values/specified/gecko.rs
+++ b/components/style/values/specified/gecko.rs
@@ -4,18 +4,18 @@
 
 //! Specified types for legacy Gecko-only properties.
 
+use crate::gecko::values::GeckoStyleCoordConvertible;
+use crate::gecko_bindings::sugar::ns_style_coord::{CoordData, CoordDataMut};
+use crate::parser::{Parse, ParserContext};
+use crate::values::computed;
+use crate::values::computed::length::CSSPixelLength;
+use crate::values::generics::gecko::ScrollSnapPoint as GenericScrollSnapPoint;
+use crate::values::generics::rect::Rect;
+use crate::values::specified::length::LengthOrPercentage;
 use cssparser::{Parser, Token};
-use gecko::values::GeckoStyleCoordConvertible;
-use gecko_bindings::sugar::ns_style_coord::{CoordData, CoordDataMut};
-use parser::{Parse, ParserContext};
 use std::fmt;
 use style_traits::values::SequenceWriter;
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
-use values::computed;
-use values::computed::length::CSSPixelLength;
-use values::generics::gecko::ScrollSnapPoint as GenericScrollSnapPoint;
-use values::generics::rect::Rect;
-use values::specified::length::LengthOrPercentage;
 
 /// A specified type for scroll snap points.
 pub type ScrollSnapPoint = GenericScrollSnapPoint<LengthOrPercentage>;
@@ -25,7 +25,7 @@ impl Parse for ScrollSnapPoint {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if input.try(|i| i.expect_ident_matching("none")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("none")).is_ok() {
             return Ok(GenericScrollSnapPoint::None);
         }
         input.expect_function_matching("repeat")?;

--- a/components/style/values/specified/grid.rs
+++ b/components/style/values/specified/grid.rs
@@ -388,7 +388,7 @@ impl ToComputedValue for TrackList<LengthOrPercentage, Integer> {
 #[cfg(feature = "gecko")]
 #[inline]
 fn allow_grid_template_subgrids() -> bool {
-    use gecko_bindings::structs::mozilla;
+    use crate::gecko_bindings::structs::mozilla;
     unsafe { mozilla::StaticPrefs_sVarCache_layout_css_grid_template_subgrid_value_enabled }
 }
 

--- a/components/style/values/specified/grid.rs
+++ b/components/style/values/specified/grid.rs
@@ -5,16 +5,16 @@
 //! CSS handling for the computed value of
 //! [grids](https://drafts.csswg.org/css-grid/)
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::computed::{self, Context, ToComputedValue};
+use crate::values::generics::grid::{GridTemplateComponent, RepeatCount, TrackBreadth};
+use crate::values::generics::grid::{LineNameList, TrackKeyword, TrackRepeat, TrackSize};
+use crate::values::generics::grid::{TrackList, TrackListType, TrackListValue};
+use crate::values::specified::{Integer, LengthOrPercentage};
+use crate::values::{CSSFloat, CustomIdent};
 use cssparser::{ParseError as CssParseError, Parser, Token};
-use parser::{Parse, ParserContext};
 use std::mem;
 use style_traits::{ParseError, StyleParseErrorKind};
-use values::computed::{self, Context, ToComputedValue};
-use values::generics::grid::{GridTemplateComponent, RepeatCount, TrackBreadth};
-use values::generics::grid::{LineNameList, TrackKeyword, TrackRepeat, TrackSize};
-use values::generics::grid::{TrackList, TrackListType, TrackListValue};
-use values::specified::{Integer, LengthOrPercentage};
-use values::{CSSFloat, CustomIdent};
 
 /// Parse a single flexible length.
 pub fn parse_flex<'i, 't>(input: &mut Parser<'i, 't>) -> Result<CSSFloat, ParseError<'i>> {
@@ -36,11 +36,11 @@ impl Parse for TrackBreadth<LengthOrPercentage> {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(lop) = input.try(|i| LengthOrPercentage::parse_non_negative(context, i)) {
+        if let Ok(lop) = input.r#try(|i| LengthOrPercentage::parse_non_negative(context, i)) {
             return Ok(TrackBreadth::Breadth(lop));
         }
 
-        if let Ok(f) = input.try(parse_flex) {
+        if let Ok(f) = input.r#try(parse_flex) {
             return Ok(TrackBreadth::Fr(f));
         }
 
@@ -53,14 +53,17 @@ impl Parse for TrackSize<LengthOrPercentage> {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(b) = input.try(|i| TrackBreadth::parse(context, i)) {
+        if let Ok(b) = input.r#try(|i| TrackBreadth::parse(context, i)) {
             return Ok(TrackSize::Breadth(b));
         }
 
-        if input.try(|i| i.expect_function_matching("minmax")).is_ok() {
+        if input
+            .r#try(|i| i.expect_function_matching("minmax"))
+            .is_ok()
+        {
             return input.parse_nested_block(|input| {
                 let inflexible_breadth =
-                    match input.try(|i| LengthOrPercentage::parse_non_negative(context, i)) {
+                    match input.r#try(|i| LengthOrPercentage::parse_non_negative(context, i)) {
                         Ok(lop) => TrackBreadth::Breadth(lop),
                         Err(..) => {
                             let keyword = TrackKeyword::parse(input)?;
@@ -92,7 +95,7 @@ pub fn parse_line_names<'i, 't>(
     input.expect_square_bracket_block()?;
     input.parse_nested_block(|input| {
         let mut values = vec![];
-        while let Ok((loc, ident)) = input.try(|i| -> Result<_, CssParseError<()>> {
+        while let Ok((loc, ident)) = input.r#try(|i| -> Result<_, CssParseError<()>> {
             Ok((i.current_source_location(), i.expect_ident_cloned()?))
         }) {
             let ident = CustomIdent::from_ident(loc, &ident, &["span", "auto"])?;
@@ -123,7 +126,7 @@ impl TrackRepeat<LengthOrPercentage, Integer> {
         input: &mut Parser<'i, 't>,
     ) -> Result<(Self, RepeatType), ParseError<'i>> {
         input
-            .try(|i| i.expect_function_matching("repeat").map_err(|e| e.into()))
+            .r#try(|i| i.expect_function_matching("repeat").map_err(|e| e.into()))
             .and_then(|_| {
                 input.parse_nested_block(|input| {
                     let count = RepeatCount::parse(context, input)?;
@@ -143,9 +146,9 @@ impl TrackRepeat<LengthOrPercentage, Integer> {
 
                     loop {
                         current_names = input
-                            .try(parse_line_names)
+                            .r#try(parse_line_names)
                             .unwrap_or(vec![].into_boxed_slice());
-                        if let Ok(track_size) = input.try(|i| TrackSize::parse(context, i)) {
+                        if let Ok(track_size) = input.r#try(|i| TrackSize::parse(context, i)) {
                             if !track_size.is_fixed() {
                                 if is_auto {
                                     // should be <fixed-size> for <auto-repeat>
@@ -169,7 +172,7 @@ impl TrackRepeat<LengthOrPercentage, Integer> {
                                 // gecko implements new spec.
                                 names.push(
                                     input
-                                        .try(parse_line_names)
+                                        .r#try(parse_line_names)
                                         .unwrap_or(vec![].into_boxed_slice()),
                                 );
                                 break;
@@ -223,10 +226,10 @@ impl Parse for TrackList<LengthOrPercentage, Integer> {
         loop {
             current_names.extend_from_slice(
                 &mut input
-                    .try(parse_line_names)
+                    .r#try(parse_line_names)
                     .unwrap_or(vec![].into_boxed_slice()),
             );
-            if let Ok(track_size) = input.try(|i| TrackSize::parse(context, i)) {
+            if let Ok(track_size) = input.r#try(|i| TrackSize::parse(context, i)) {
                 if !track_size.is_fixed() {
                     atleast_one_not_fixed = true;
                     if auto_repeat.is_some() {
@@ -239,7 +242,7 @@ impl Parse for TrackList<LengthOrPercentage, Integer> {
                 names.push(vec.into_boxed_slice());
                 values.push(TrackListValue::TrackSize(track_size));
             } else if let Ok((repeat, type_)) =
-                input.try(|i| TrackRepeat::parse_with_repeat_type(context, i))
+                input.r#try(|i| TrackRepeat::parse_with_repeat_type(context, i))
             {
                 if list_type == TrackListType::Explicit {
                     list_type = TrackListType::Normal; // <explicit-track-list> doesn't contain repeat()
@@ -401,7 +404,7 @@ impl Parse for GridTemplateComponent<LengthOrPercentage, Integer> {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if input.try(|i| i.expect_ident_matching("none")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("none")).is_ok() {
             return Ok(GridTemplateComponent::None);
         }
 
@@ -416,7 +419,7 @@ impl GridTemplateComponent<LengthOrPercentage, Integer> {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         if allow_grid_template_subgrids() {
-            if let Ok(t) = input.try(|i| LineNameList::parse(context, i)) {
+            if let Ok(t) = input.r#try(|i| LineNameList::parse(context, i)) {
                 return Ok(GridTemplateComponent::Subgrid(t));
             }
         }

--- a/components/style/values/specified/image.rs
+++ b/components/style/values/specified/image.rs
@@ -7,9 +7,18 @@
 //!
 //! [image]: https://drafts.csswg.org/css-images/#image-values
 
+use crate::custom_properties::SpecifiedValue;
+use crate::parser::{Parse, ParserContext};
+use crate::values::generics::image::PaintWorklet;
+use crate::values::generics::image::{self as generic, Circle, CompatMode, Ellipse, ShapeExtent};
+use crate::values::generics::position::Position as GenericPosition;
+use crate::values::specified::position::{LegacyPosition, Position, PositionComponent, Side, X, Y};
+use crate::values::specified::url::SpecifiedImageUrl;
+use crate::values::specified::{Angle, Color, Length, LengthOrPercentage};
+use crate::values::specified::{Number, NumberOrPercentage, Percentage};
+use crate::values::{Either, None_};
+use crate::Atom;
 use cssparser::{Delimiter, Parser, Token};
-use custom_properties::SpecifiedValue;
-use parser::{Parse, ParserContext};
 use selectors::parser::SelectorParseErrorKind;
 #[cfg(feature = "servo")]
 use servo_url::ServoUrl;
@@ -19,15 +28,6 @@ use style_traits::{CssType, CssWriter, KeywordsCollectFn, ParseError};
 use style_traits::{SpecifiedValueInfo, StyleParseErrorKind, ToCss};
 #[cfg(feature = "gecko")]
 use values::computed::{Context, Position as ComputedPosition, ToComputedValue};
-use values::generics::image::PaintWorklet;
-use values::generics::image::{self as generic, Circle, CompatMode, Ellipse, ShapeExtent};
-use values::generics::position::Position as GenericPosition;
-use values::specified::position::{LegacyPosition, Position, PositionComponent, Side, X, Y};
-use values::specified::url::SpecifiedImageUrl;
-use values::specified::{Angle, Color, Length, LengthOrPercentage};
-use values::specified::{Number, NumberOrPercentage, Percentage};
-use values::{Either, None_};
-use Atom;
 
 /// A specified image layer.
 pub type ImageLayer = Either<None_, Image>;
@@ -39,7 +39,7 @@ impl ImageLayer {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(v) = input.try(|i| None_::parse(context, i)) {
+        if let Ok(v) = input.r#try(|i| None_::parse(context, i)) {
             return Ok(Either::First(v));
         }
         Image::parse_with_cors_anonymous(context, input).map(Either::Second)
@@ -142,19 +142,19 @@ impl Parse for Image {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Image, ParseError<'i>> {
-        if let Ok(url) = input.try(|input| SpecifiedImageUrl::parse(context, input)) {
+        if let Ok(url) = input.r#try(|input| SpecifiedImageUrl::parse(context, input)) {
             return Ok(generic::Image::Url(url));
         }
-        if let Ok(gradient) = input.try(|i| Gradient::parse(context, i)) {
+        if let Ok(gradient) = input.r#try(|i| Gradient::parse(context, i)) {
             return Ok(generic::Image::Gradient(Box::new(gradient)));
         }
         #[cfg(feature = "servo")]
         {
-            if let Ok(paint_worklet) = input.try(|i| PaintWorklet::parse(context, i)) {
+            if let Ok(paint_worklet) = input.r#try(|i| PaintWorklet::parse(context, i)) {
                 return Ok(generic::Image::PaintWorklet(paint_worklet));
             }
         }
-        if let Ok(image_rect) = input.try(|input| MozImageRect::parse(context, input)) {
+        if let Ok(image_rect) = input.r#try(|input| MozImageRect::parse(context, input)) {
             return Ok(generic::Image::Rect(Box::new(image_rect)));
         }
         Ok(generic::Image::Element(Image::parse_element(input)?))
@@ -166,13 +166,13 @@ impl Image {
     /// for insertion in the cascade.
     #[cfg(feature = "servo")]
     pub fn for_cascade(url: ServoUrl) -> Self {
-        use values::CssUrl;
+        use crate::values::CssUrl;
         generic::Image::Url(CssUrl::for_cascade(url))
     }
 
     /// Parses a `-moz-element(# <element-id>)`.
     fn parse_element<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Atom, ParseError<'i>> {
-        input.try(|i| i.expect_function_matching("-moz-element"))?;
+        input.r#try(|i| i.expect_function_matching("-moz-element"))?;
         let location = input.current_source_location();
         input.parse_nested_block(|i| match *i.next()? {
             Token::IDHash(ref id) => Ok(Atom::from(id.as_ref())),
@@ -190,7 +190,7 @@ impl Image {
         input: &mut Parser<'i, 't>,
     ) -> Result<Image, ParseError<'i>> {
         if let Ok(url) =
-            input.try(|input| SpecifiedImageUrl::parse_with_cors_anonymous(context, input))
+            input.r#try(|input| SpecifiedImageUrl::parse_with_cors_anonymous(context, input))
         {
             return Ok(generic::Image::Url(url));
         }
@@ -350,7 +350,7 @@ impl Gradient {
                 context: &ParserContext,
                 input: &mut Parser<'i, 't>,
             ) -> Result<Self, ParseError<'i>> {
-                input.try(|i| {
+                input.r#try(|i| {
                     let x = Component::parse(context, i)?;
                     let y = Component::parse(context, i)?;
 
@@ -413,13 +413,13 @@ impl Gradient {
                 context: &ParserContext,
                 input: &mut Parser<'i, 't>,
             ) -> Result<Self, ParseError<'i>> {
-                if let Ok(side) = input.try(|i| S::parse(context, i)) {
+                if let Ok(side) = input.r#try(|i| S::parse(context, i)) {
                     return Ok(Component::Side(side));
                 }
-                if let Ok(number) = input.try(|i| NumberOrPercentage::parse(context, i)) {
+                if let Ok(number) = input.r#try(|i| NumberOrPercentage::parse(context, i)) {
                     return Ok(Component::Number(number));
                 }
-                input.try(|i| i.expect_ident_matching("center"))?;
+                input.r#try(|i| i.expect_ident_matching("center"))?;
                 Ok(Component::Center)
             }
         }
@@ -477,7 +477,7 @@ impl Gradient {
         };
 
         let mut items = input
-            .try(|i| {
+            .r#try(|i| {
                 i.expect_comma()?;
                 i.parse_comma_separated(|i| {
                     let function = i.expect_function()?.clone();
@@ -572,16 +572,16 @@ impl GradientKind {
         input: &mut Parser<'i, 't>,
         compat_mode: &mut CompatMode,
     ) -> Result<Self, ParseError<'i>> {
-        let direction = if let Ok(d) = input.try(|i| LineDirection::parse(context, i, compat_mode))
-        {
-            input.expect_comma()?;
-            d
-        } else {
-            match *compat_mode {
-                CompatMode::Modern => LineDirection::Vertical(Y::Bottom),
-                _ => LineDirection::Vertical(Y::Top),
-            }
-        };
+        let direction =
+            if let Ok(d) = input.r#try(|i| LineDirection::parse(context, i, compat_mode)) {
+                input.expect_comma()?;
+                d
+            } else {
+                match *compat_mode {
+                    CompatMode::Modern => LineDirection::Vertical(Y::Bottom),
+                    _ => LineDirection::Vertical(Y::Top),
+                }
+            };
         Ok(generic::GradientKind::Linear(direction))
     }
 
@@ -592,16 +592,16 @@ impl GradientKind {
     ) -> Result<Self, ParseError<'i>> {
         let (shape, position, angle, moz_position) = match *compat_mode {
             CompatMode::Modern => {
-                let shape = input.try(|i| EndingShape::parse(context, i, *compat_mode));
-                let position = input.try(|i| {
+                let shape = input.r#try(|i| EndingShape::parse(context, i, *compat_mode));
+                let position = input.r#try(|i| {
                     i.expect_ident_matching("at")?;
                     Position::parse(context, i)
                 });
                 (shape, position.ok(), None, None)
             },
             CompatMode::WebKit => {
-                let position = input.try(|i| Position::parse(context, i));
-                let shape = input.try(|i| {
+                let position = input.r#try(|i| Position::parse(context, i));
+                let shape = input.r#try(|i| {
                     if position.is_ok() {
                         i.expect_comma()?;
                     }
@@ -620,13 +620,13 @@ impl GradientKind {
             //                          cover | contain
             // and <color-stop>     = <color> [ <percentage> | <length> ]?
             CompatMode::Moz => {
-                let mut position = input.try(|i| LegacyPosition::parse(context, i));
-                let angle = input.try(|i| Angle::parse(context, i)).ok();
+                let mut position = input.r#try(|i| LegacyPosition::parse(context, i));
+                let angle = input.r#try(|i| Angle::parse(context, i)).ok();
                 if position.is_err() {
-                    position = input.try(|i| LegacyPosition::parse(context, i));
+                    position = input.r#try(|i| LegacyPosition::parse(context, i));
                 }
 
-                let shape = input.try(|i| {
+                let shape = input.r#try(|i| {
                     if position.is_ok() || angle.is_some() {
                         i.expect_comma()?;
                     }
@@ -768,18 +768,18 @@ impl LineDirection {
         compat_mode: &mut CompatMode,
     ) -> Result<Self, ParseError<'i>> {
         let mut _angle = if *compat_mode == CompatMode::Moz {
-            input.try(|i| Angle::parse(context, i)).ok()
+            input.r#try(|i| Angle::parse(context, i)).ok()
         } else {
             // Gradients allow unitless zero angles as an exception, see:
             // https://github.com/w3c/csswg-drafts/issues/1162
-            if let Ok(angle) = input.try(|i| Angle::parse_with_unitless(context, i)) {
+            if let Ok(angle) = input.r#try(|i| Angle::parse_with_unitless(context, i)) {
                 return Ok(LineDirection::Angle(angle));
             }
             None
         };
 
-        input.try(|i| {
-            let to_ident = i.try(|i| i.expect_ident_matching("to"));
+        input.r#try(|i| {
+            let to_ident = i.r#try(|i| i.expect_ident_matching("to"));
             match *compat_mode {
                 // `to` keyword is mandatory in modern syntax.
                 CompatMode::Modern => to_ident?,
@@ -801,9 +801,9 @@ impl LineDirection {
             {
                 // `-moz-` prefixed linear gradient can be both Angle and Position.
                 if *compat_mode == CompatMode::Moz {
-                    let position = i.try(|i| LegacyPosition::parse(context, i)).ok();
+                    let position = i.r#try(|i| LegacyPosition::parse(context, i)).ok();
                     if _angle.is_none() {
-                        _angle = i.try(|i| Angle::parse(context, i)).ok();
+                        _angle = i.r#try(|i| Angle::parse(context, i)).ok();
                     };
 
                     if _angle.is_none() && position.is_none() {
@@ -813,14 +813,14 @@ impl LineDirection {
                 }
             }
 
-            if let Ok(x) = i.try(X::parse) {
-                if let Ok(y) = i.try(Y::parse) {
+            if let Ok(x) = i.r#try(X::parse) {
+                if let Ok(y) = i.r#try(Y::parse) {
                     return Ok(LineDirection::Corner(x, y));
                 }
                 return Ok(LineDirection::Horizontal(x));
             }
             let y = Y::parse(i)?;
-            if let Ok(x) = i.try(X::parse) {
+            if let Ok(x) = i.r#try(X::parse) {
                 return Ok(LineDirection::Corner(x, y));
             }
             Ok(LineDirection::Vertical(y))
@@ -850,19 +850,20 @@ impl EndingShape {
         input: &mut Parser<'i, 't>,
         compat_mode: CompatMode,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(extent) = input.try(|i| ShapeExtent::parse_with_compat_mode(i, compat_mode)) {
-            if input.try(|i| i.expect_ident_matching("circle")).is_ok() {
+        if let Ok(extent) = input.r#try(|i| ShapeExtent::parse_with_compat_mode(i, compat_mode)) {
+            if input.r#try(|i| i.expect_ident_matching("circle")).is_ok() {
                 return Ok(generic::EndingShape::Circle(Circle::Extent(extent)));
             }
-            let _ = input.try(|i| i.expect_ident_matching("ellipse"));
+            let _ = input.r#try(|i| i.expect_ident_matching("ellipse"));
             return Ok(generic::EndingShape::Ellipse(Ellipse::Extent(extent)));
         }
-        if input.try(|i| i.expect_ident_matching("circle")).is_ok() {
-            if let Ok(extent) = input.try(|i| ShapeExtent::parse_with_compat_mode(i, compat_mode)) {
+        if input.r#try(|i| i.expect_ident_matching("circle")).is_ok() {
+            if let Ok(extent) = input.r#try(|i| ShapeExtent::parse_with_compat_mode(i, compat_mode))
+            {
                 return Ok(generic::EndingShape::Circle(Circle::Extent(extent)));
             }
             if compat_mode == CompatMode::Modern {
-                if let Ok(length) = input.try(|i| Length::parse(context, i)) {
+                if let Ok(length) = input.r#try(|i| Length::parse(context, i)) {
                     return Ok(generic::EndingShape::Circle(Circle::Radius(length)));
                 }
             }
@@ -870,12 +871,13 @@ impl EndingShape {
                 ShapeExtent::FarthestCorner,
             )));
         }
-        if input.try(|i| i.expect_ident_matching("ellipse")).is_ok() {
-            if let Ok(extent) = input.try(|i| ShapeExtent::parse_with_compat_mode(i, compat_mode)) {
+        if input.r#try(|i| i.expect_ident_matching("ellipse")).is_ok() {
+            if let Ok(extent) = input.r#try(|i| ShapeExtent::parse_with_compat_mode(i, compat_mode))
+            {
                 return Ok(generic::EndingShape::Ellipse(Ellipse::Extent(extent)));
             }
             if compat_mode == CompatMode::Modern {
-                let pair: Result<_, ParseError> = input.try(|i| {
+                let pair: Result<_, ParseError> = input.r#try(|i| {
                     let x = LengthOrPercentage::parse(context, i)?;
                     let y = LengthOrPercentage::parse(context, i)?;
                     Ok((x, y))
@@ -891,10 +893,10 @@ impl EndingShape {
         // -moz- prefixed radial gradient doesn't allow EndingShape's Length or LengthOrPercentage
         // to come before shape keyword. Otherwise it conflicts with <position>.
         if compat_mode != CompatMode::Moz {
-            if let Ok(length) = input.try(|i| Length::parse(context, i)) {
-                if let Ok(y) = input.try(|i| LengthOrPercentage::parse(context, i)) {
+            if let Ok(length) = input.r#try(|i| Length::parse(context, i)) {
+                if let Ok(y) = input.r#try(|i| LengthOrPercentage::parse(context, i)) {
                     if compat_mode == CompatMode::Modern {
-                        let _ = input.try(|i| i.expect_ident_matching("ellipse"));
+                        let _ = input.r#try(|i| i.expect_ident_matching("ellipse"));
                     }
                     return Ok(generic::EndingShape::Ellipse(Ellipse::Radii(
                         length.into(),
@@ -902,7 +904,7 @@ impl EndingShape {
                     )));
                 }
                 if compat_mode == CompatMode::Modern {
-                    let y = input.try(|i| {
+                    let y = input.r#try(|i| {
                         i.expect_ident_matching("ellipse")?;
                         LengthOrPercentage::parse(context, i)
                     });
@@ -912,17 +914,17 @@ impl EndingShape {
                             y,
                         )));
                     }
-                    let _ = input.try(|i| i.expect_ident_matching("circle"));
+                    let _ = input.r#try(|i| i.expect_ident_matching("circle"));
                 }
 
                 return Ok(generic::EndingShape::Circle(Circle::Radius(length)));
             }
         }
-        input.try(|i| {
+        input.r#try(|i| {
             let x = Percentage::parse(context, i)?;
-            let y = if let Ok(y) = i.try(|i| LengthOrPercentage::parse(context, i)) {
+            let y = if let Ok(y) = i.r#try(|i| LengthOrPercentage::parse(context, i)) {
                 if compat_mode == CompatMode::Modern {
-                    let _ = i.try(|i| i.expect_ident_matching("ellipse"));
+                    let _ = i.r#try(|i| i.expect_ident_matching("ellipse"));
                 }
                 y
             } else {
@@ -963,7 +965,7 @@ impl GradientItem {
         loop {
             input.parse_until_before(Delimiter::Comma, |input| {
                 if seen_stop {
-                    if let Ok(hint) = input.try(|i| LengthOrPercentage::parse(context, i)) {
+                    if let Ok(hint) = input.r#try(|i| LengthOrPercentage::parse(context, i)) {
                         seen_stop = false;
                         items.push(generic::GradientItem::InterpolationHint(hint));
                         return Ok(());
@@ -972,7 +974,7 @@ impl GradientItem {
 
                 let stop = ColorStop::parse(context, input)?;
 
-                if let Ok(multi_position) = input.try(|i| LengthOrPercentage::parse(context, i)) {
+                if let Ok(multi_position) = input.r#try(|i| LengthOrPercentage::parse(context, i)) {
                     let stop_color = stop.color.clone();
                     items.push(generic::GradientItem::ColorStop(stop));
                     items.push(generic::GradientItem::ColorStop(ColorStop {
@@ -1008,7 +1010,7 @@ impl Parse for ColorStop {
     ) -> Result<Self, ParseError<'i>> {
         Ok(ColorStop {
             color: Color::parse(context, input)?,
-            position: input.try(|i| LengthOrPercentage::parse(context, i)).ok(),
+            position: input.r#try(|i| LengthOrPercentage::parse(context, i)).ok(),
         })
     }
 }
@@ -1022,7 +1024,7 @@ impl Parse for PaintWorklet {
         input.parse_nested_block(|input| {
             let name = Atom::from(&**input.expect_ident()?);
             let arguments = input
-                .try(|input| {
+                .r#try(|input| {
                     input.expect_comma()?;
                     input.parse_comma_separated(|input| SpecifiedValue::parse(input))
                 })
@@ -1037,7 +1039,7 @@ impl Parse for MozImageRect {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        input.try(|i| i.expect_function_matching("-moz-image-rect"))?;
+        input.r#try(|i| i.expect_function_matching("-moz-image-rect"))?;
         input.parse_nested_block(|i| {
             let string = i.expect_url_or_string()?;
             let url = SpecifiedImageUrl::parse_from_string(string.as_ref().to_owned(), context);

--- a/components/style/values/specified/image.rs
+++ b/components/style/values/specified/image.rs
@@ -9,6 +9,8 @@
 
 use crate::custom_properties::SpecifiedValue;
 use crate::parser::{Parse, ParserContext};
+#[cfg(feature = "gecko")]
+use crate::values::computed::{Context, Position as ComputedPosition, ToComputedValue};
 use crate::values::generics::image::PaintWorklet;
 use crate::values::generics::image::{self as generic, Circle, CompatMode, Ellipse, ShapeExtent};
 use crate::values::generics::position::Position as GenericPosition;
@@ -26,8 +28,6 @@ use std::cmp::Ordering;
 use std::fmt::{self, Write};
 use style_traits::{CssType, CssWriter, KeywordsCollectFn, ParseError};
 use style_traits::{SpecifiedValueInfo, StyleParseErrorKind, ToCss};
-#[cfg(feature = "gecko")]
-use values::computed::{Context, Position as ComputedPosition, ToComputedValue};
 
 /// A specified image layer.
 pub type ImageLayer = Either<None_, Image>;
@@ -268,7 +268,7 @@ impl Parse for Gradient {
 
         #[cfg(feature = "gecko")]
         {
-            use gecko_bindings::structs;
+            use crate::gecko_bindings::structs;
             if compat_mode == CompatMode::Moz &&
                 !unsafe { structs::StaticPrefs_sVarCache_layout_css_prefixes_gradients }
             {
@@ -691,8 +691,8 @@ impl generic::LineDirection for LineDirection {
                 }),
                 None,
             ) => {
-                use values::computed::Percentage as ComputedPercentage;
-                use values::specified::transform::OriginComponent;
+                use crate::values::computed::Percentage as ComputedPercentage;
+                use crate::values::specified::transform::OriginComponent;
 
                 // `50% 0%` is the default value for line direction.
                 // These percentage values can also be keywords.

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -8,23 +8,25 @@
 
 use super::{AllowQuirks, Number, Percentage, ToComputedValue};
 use app_units::Au;
+use crate::font_metrics::FontMetricsQueryResult;
+use crate::parser::{Parse, ParserContext};
+use crate::values::computed::{self, CSSPixelLength, Context, ExtremumLength};
+use crate::values::generics::length::{
+    MaxLength as GenericMaxLength, MozLength as GenericMozLength,
+};
+use crate::values::generics::NonNegative;
+use crate::values::specified::calc::CalcNode;
+use crate::values::{Auto, CSSFloat, Either, IsAuto, Normal};
 use cssparser::{Parser, Token};
 use euclid::Size2D;
-use font_metrics::FontMetricsQueryResult;
-use parser::{Parse, ParserContext};
 use std::cmp;
 use std::ops::{Add, Mul};
 use style_traits::values::specified::AllowedNumericType;
 use style_traits::{ParseError, SpecifiedValueInfo, StyleParseErrorKind};
-use values::computed::{self, CSSPixelLength, Context, ExtremumLength};
-use values::generics::length::{MaxLength as GenericMaxLength, MozLength as GenericMozLength};
-use values::generics::NonNegative;
-use values::specified::calc::CalcNode;
-use values::{Auto, CSSFloat, Either, IsAuto, Normal};
 
 pub use super::image::{ColorStop, EndingShape as GradientEndingShape, Gradient};
 pub use super::image::{GradientKind, Image};
-pub use values::specified::calc::CalcLengthOrPercentage;
+pub use crate::values::specified::calc::CalcLengthOrPercentage;
 
 /// Number of app units per pixel
 pub const AU_PER_PX: CSSFloat = 60.;
@@ -1182,7 +1184,7 @@ impl LengthOrNumber {
         // We try to parse as a Number first because, for cases like
         // LengthOrNumber, we want "0" to be parsed as a plain Number rather
         // than a Length (0px); this matches the behaviour of all major browsers
-        if let Ok(v) = input.try(|i| Number::parse_non_negative(context, i)) {
+        if let Ok(v) = input.r#try(|i| Number::parse_non_negative(context, i)) {
             return Ok(Either::Second(v));
         }
 
@@ -1226,7 +1228,7 @@ impl MozLength {
         input: &mut Parser<'i, 't>,
         allow_quirks: AllowQuirks,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(l) = input.try(ExtremumLength::parse) {
+        if let Ok(l) = input.r#try(ExtremumLength::parse) {
             return Ok(GenericMozLength::ExtremumLength(l));
         }
 
@@ -1278,7 +1280,7 @@ impl MaxLength {
         input: &mut Parser<'i, 't>,
         allow_quirks: AllowQuirks,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(l) = input.try(ExtremumLength::parse) {
+        if let Ok(l) = input.r#try(ExtremumLength::parse) {
             return Ok(GenericMaxLength::ExtremumLength(l));
         }
 

--- a/components/style/values/specified/list.rs
+++ b/components/style/values/specified/list.rs
@@ -4,8 +4,8 @@
 
 //! `list` specified values.
 
+use crate::parser::{Parse, ParserContext};
 use cssparser::{Parser, Token};
-use parser::{Parse, ParserContext};
 use servo_arc::Arc;
 use style_traits::{ParseError, StyleParseErrorKind};
 #[cfg(feature = "gecko")]
@@ -63,7 +63,7 @@ impl Parse for ListStyleType {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(style) = input.try(|i| CounterStyleOrNone::parse(context, i)) {
+        if let Ok(style) = input.r#try(|i| CounterStyleOrNone::parse(context, i)) {
             return Ok(ListStyleType::CounterStyle(style));
         }
 
@@ -97,7 +97,7 @@ impl Parse for Quotes {
         input: &mut Parser<'i, 't>,
     ) -> Result<Quotes, ParseError<'i>> {
         if input
-            .try(|input| input.expect_ident_matching("none"))
+            .r#try(|input| input.expect_ident_matching("none"))
             .is_ok()
         {
             return Ok(Quotes(Arc::new(Box::new([]))));

--- a/components/style/values/specified/list.rs
+++ b/components/style/values/specified/list.rs
@@ -5,13 +5,13 @@
 //! `list` specified values.
 
 use crate::parser::{Parse, ParserContext};
+#[cfg(feature = "gecko")]
+use crate::values::generics::CounterStyleOrNone;
+#[cfg(feature = "gecko")]
+use crate::values::CustomIdent;
 use cssparser::{Parser, Token};
 use servo_arc::Arc;
 use style_traits::{ParseError, StyleParseErrorKind};
-#[cfg(feature = "gecko")]
-use values::generics::CounterStyleOrNone;
-#[cfg(feature = "gecko")]
-use values::CustomIdent;
 
 /// Specified and computed `list-style-type` property.
 #[cfg(feature = "gecko")]
@@ -37,7 +37,7 @@ impl ListStyleType {
     /// list-style-type, and thus only values possible in that
     /// attribute is considered here.
     pub fn from_gecko_keyword(value: u32) -> Self {
-        use gecko_bindings::structs;
+        use crate::gecko_bindings::structs;
 
         if value == structs::NS_STYLE_LIST_STYLE_NONE {
             return ListStyleType::CounterStyle(CounterStyleOrNone::None);

--- a/components/style/values/specified/mod.rs
+++ b/components/style/values/specified/mod.rs
@@ -11,17 +11,17 @@ use super::generics::grid::{GridLine as GenericGridLine, TrackBreadth as Generic
 use super::generics::grid::{TrackList as GenericTrackList, TrackSize as GenericTrackSize};
 use super::generics::{GreaterThanOrEqualToOne, NonNegative};
 use super::{Auto, CSSFloat, CSSInteger, Either};
-use context::QuirksMode;
+use crate::context::QuirksMode;
+use crate::parser::{Parse, ParserContext};
+use crate::values::serialize_atom_identifier;
+use crate::values::specified::calc::CalcNode;
+use crate::{Atom, Namespace, Prefix};
 use cssparser::{Parser, Token};
 use num_traits::One;
-use parser::{Parse, ParserContext};
 use std::f32;
 use std::fmt::{self, Write};
 use style_traits::values::specified::AllowedNumericType;
 use style_traits::{CssWriter, ParseError, SpecifiedValueInfo, StyleParseErrorKind, ToCss};
-use values::serialize_atom_identifier;
-use values::specified::calc::CalcNode;
-use {Atom, Namespace, Prefix};
 
 #[cfg(feature = "gecko")]
 pub use self::align::{AlignContent, AlignItems, AlignSelf, ContentDistribution};
@@ -359,7 +359,7 @@ impl NumberOrPercentage {
         input: &mut Parser<'i, 't>,
         type_: AllowedNumericType,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(per) = input.try(|i| Percentage::parse_with_clamping_mode(context, i, type_)) {
+        if let Ok(per) = input.r#try(|i| Percentage::parse_with_clamping_mode(context, i, type_)) {
             return Ok(NumberOrPercentage::Percentage(per));
         }
 
@@ -695,7 +695,7 @@ impl ClipRect {
         input: &mut Parser<'i, 't>,
         allow_quirks: AllowQuirks,
     ) -> Result<Self, ParseError<'i>> {
-        use values::specified::Length;
+        use crate::values::specified::Length;
 
         fn parse_argument<'i, 't>(
             context: &ParserContext,
@@ -703,7 +703,7 @@ impl ClipRect {
             allow_quirks: AllowQuirks,
         ) -> Result<Option<Length>, ParseError<'i>> {
             if input
-                .try(|input| input.expect_ident_matching("auto"))
+                .r#try(|input| input.expect_ident_matching("auto"))
                 .is_ok()
             {
                 Ok(None)
@@ -720,7 +720,7 @@ impl ClipRect {
             let bottom;
             let left;
 
-            if input.try(|input| input.expect_comma()).is_ok() {
+            if input.r#try(|input| input.expect_comma()).is_ok() {
                 right = parse_argument(context, input, allow_quirks)?;
                 input.expect_comma()?;
                 bottom = parse_argument(context, input, allow_quirks)?;
@@ -751,7 +751,7 @@ impl ClipRectOrAuto {
         input: &mut Parser<'i, 't>,
         allow_quirks: AllowQuirks,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(v) = input.try(|i| ClipRect::parse_quirky(context, i, allow_quirks)) {
+        if let Ok(v) = input.r#try(|i| ClipRect::parse_quirky(context, i, allow_quirks)) {
             Ok(Either::First(v))
         } else {
             Auto::parse(context, input).map(Either::Second)
@@ -816,8 +816,8 @@ impl Attr {
     ) -> Result<Attr, ParseError<'i>> {
         // Syntax is `[namespace? `|`]? ident`
         // no spaces allowed
-        let first = input.try(|i| i.expect_ident_cloned()).ok();
-        if let Ok(token) = input.try(|i| i.next_including_whitespace().map(|t| t.clone())) {
+        let first = input.r#try(|i| i.expect_ident_cloned()).ok();
+        if let Ok(token) = input.r#try(|i| i.next_including_whitespace().map(|t| t.clone())) {
             match token {
                 Token::Delim('|') => {
                     let location = input.current_source_location();

--- a/components/style/values/specified/motion.rs
+++ b/components/style/values/specified/motion.rs
@@ -4,10 +4,10 @@
 
 //! Specified types for CSS values that are related to motion path.
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::specified::SVGPathData;
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use style_traits::{ParseError, StyleParseErrorKind};
-use values::specified::SVGPathData;
 
 /// The offset-path value.
 ///
@@ -50,7 +50,7 @@ impl Parse for OffsetPath {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         // Parse none.
-        if input.try(|i| i.expect_ident_matching("none")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("none")).is_ok() {
             return Ok(OffsetPath::none());
         }
 

--- a/components/style/values/specified/outline.rs
+++ b/components/style/values/specified/outline.rs
@@ -4,11 +4,11 @@
 
 //! Specified values for outline properties
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::specified::BorderStyle;
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use selectors::parser::SelectorParseErrorKind;
 use style_traits::ParseError;
-use values::specified::BorderStyle;
 
 #[derive(
     Clone,
@@ -53,7 +53,7 @@ impl Parse for OutlineStyle {
         _context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<OutlineStyle, ParseError<'i>> {
-        if let Ok(border_style) = input.try(BorderStyle::parse) {
+        if let Ok(border_style) = input.r#try(BorderStyle::parse) {
             if let BorderStyle::Hidden = border_style {
                 return Err(input
                     .new_custom_error(SelectorParseErrorKind::UnexpectedIdent("hidden".into())));

--- a/components/style/values/specified/percentage.rs
+++ b/components/style/values/specified/percentage.rs
@@ -4,15 +4,15 @@
 
 //! Specified percentages.
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::computed::percentage::Percentage as ComputedPercentage;
+use crate::values::computed::{Context, ToComputedValue};
+use crate::values::specified::calc::CalcNode;
+use crate::values::{serialize_percentage, CSSFloat};
 use cssparser::{Parser, Token};
-use parser::{Parse, ParserContext};
 use std::fmt::{self, Write};
 use style_traits::values::specified::AllowedNumericType;
 use style_traits::{CssWriter, ParseError, SpecifiedValueInfo, ToCss};
-use values::computed::percentage::Percentage as ComputedPercentage;
-use values::computed::{Context, ToComputedValue};
-use values::specified::calc::CalcNode;
-use values::{serialize_percentage, CSSFloat};
 
 /// A percentage value.
 #[derive(Clone, Copy, Debug, Default, MallocSizeOf, PartialEq)]

--- a/components/style/values/specified/position.rs
+++ b/components/style/values/specified/position.rs
@@ -7,22 +7,24 @@
 //!
 //! [position]: https://drafts.csswg.org/css-backgrounds-3/#position
 
+use crate::hash::FxHashMap;
+use crate::parser::{Parse, ParserContext};
+use crate::str::HTML_SPACE_CHARACTERS;
+use crate::values::computed::{
+    CalcLengthOrPercentage, LengthOrPercentage as ComputedLengthOrPercentage,
+};
+use crate::values::computed::{Context, Percentage, ToComputedValue};
+use crate::values::generics::position::Position as GenericPosition;
+use crate::values::generics::position::ZIndex as GenericZIndex;
+use crate::values::specified::transform::OriginComponent;
+use crate::values::specified::{AllowQuirks, Integer, LengthOrPercentage};
+use crate::values::{Either, None_};
 use cssparser::Parser;
-use hash::FxHashMap;
-use parser::{Parse, ParserContext};
 use selectors::parser::SelectorParseErrorKind;
 use servo_arc::Arc;
 use std::fmt::{self, Write};
 use std::ops::Range;
-use str::HTML_SPACE_CHARACTERS;
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
-use values::computed::{CalcLengthOrPercentage, LengthOrPercentage as ComputedLengthOrPercentage};
-use values::computed::{Context, Percentage, ToComputedValue};
-use values::generics::position::Position as GenericPosition;
-use values::generics::position::ZIndex as GenericZIndex;
-use values::specified::transform::OriginComponent;
-use values::specified::{AllowQuirks, Integer, LengthOrPercentage};
-use values::{Either, None_};
 
 /// The specified value of a CSS `<position>`
 pub type Position = GenericPosition<HorizontalPosition, VerticalPosition>;
@@ -100,28 +102,28 @@ impl Position {
         input: &mut Parser<'i, 't>,
         allow_quirks: AllowQuirks,
     ) -> Result<Self, ParseError<'i>> {
-        match input.try(|i| PositionComponent::parse_quirky(context, i, allow_quirks)) {
+        match input.r#try(|i| PositionComponent::parse_quirky(context, i, allow_quirks)) {
             Ok(x_pos @ PositionComponent::Center) => {
                 if let Ok(y_pos) =
-                    input.try(|i| PositionComponent::parse_quirky(context, i, allow_quirks))
+                    input.r#try(|i| PositionComponent::parse_quirky(context, i, allow_quirks))
                 {
                     return Ok(Self::new(x_pos, y_pos));
                 }
                 let x_pos = input
-                    .try(|i| PositionComponent::parse_quirky(context, i, allow_quirks))
+                    .r#try(|i| PositionComponent::parse_quirky(context, i, allow_quirks))
                     .unwrap_or(x_pos);
                 let y_pos = PositionComponent::Center;
                 return Ok(Self::new(x_pos, y_pos));
             },
             Ok(PositionComponent::Side(x_keyword, lop)) => {
-                if input.try(|i| i.expect_ident_matching("center")).is_ok() {
+                if input.r#try(|i| i.expect_ident_matching("center")).is_ok() {
                     let x_pos = PositionComponent::Side(x_keyword, lop);
                     let y_pos = PositionComponent::Center;
                     return Ok(Self::new(x_pos, y_pos));
                 }
-                if let Ok(y_keyword) = input.try(Y::parse) {
+                if let Ok(y_keyword) = input.r#try(Y::parse) {
                     let y_lop = input
-                        .try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
+                        .r#try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
                         .ok();
                     let x_pos = PositionComponent::Side(x_keyword, lop);
                     let y_pos = PositionComponent::Side(y_keyword, y_lop);
@@ -132,30 +134,30 @@ impl Position {
                 return Ok(Self::new(x_pos, y_pos));
             },
             Ok(x_pos @ PositionComponent::Length(_)) => {
-                if let Ok(y_keyword) = input.try(Y::parse) {
+                if let Ok(y_keyword) = input.r#try(Y::parse) {
                     let y_pos = PositionComponent::Side(y_keyword, None);
                     return Ok(Self::new(x_pos, y_pos));
                 }
                 if let Ok(y_lop) =
-                    input.try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
+                    input.r#try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
                 {
                     let y_pos = PositionComponent::Length(y_lop);
                     return Ok(Self::new(x_pos, y_pos));
                 }
                 let y_pos = PositionComponent::Center;
-                let _ = input.try(|i| i.expect_ident_matching("center"));
+                let _ = input.r#try(|i| i.expect_ident_matching("center"));
                 return Ok(Self::new(x_pos, y_pos));
             },
             Err(_) => {},
         }
         let y_keyword = Y::parse(input)?;
-        let lop_and_x_pos: Result<_, ParseError> = input.try(|i| {
+        let lop_and_x_pos: Result<_, ParseError> = input.r#try(|i| {
             let y_lop = i
-                .try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
+                .r#try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
                 .ok();
-            if let Ok(x_keyword) = i.try(X::parse) {
+            if let Ok(x_keyword) = i.r#try(X::parse) {
                 let x_lop = i
-                    .try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
+                    .r#try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
                     .ok();
                 let x_pos = PositionComponent::Side(x_keyword, x_lop);
                 return Ok((y_lop, x_pos));
@@ -228,15 +230,16 @@ impl<S: Parse> PositionComponent<S> {
         input: &mut Parser<'i, 't>,
         allow_quirks: AllowQuirks,
     ) -> Result<Self, ParseError<'i>> {
-        if input.try(|i| i.expect_ident_matching("center")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("center")).is_ok() {
             return Ok(PositionComponent::Center);
         }
-        if let Ok(lop) = input.try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks)) {
+        if let Ok(lop) = input.r#try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
+        {
             return Ok(PositionComponent::Length(lop));
         }
         let keyword = S::parse(context, input)?;
         let lop = input
-            .try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
+            .r#try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
             .ok();
         Ok(PositionComponent::Side(keyword, lop))
     }
@@ -357,51 +360,51 @@ impl LegacyPosition {
         input: &mut Parser<'i, 't>,
         allow_quirks: AllowQuirks,
     ) -> Result<Self, ParseError<'i>> {
-        match input.try(|i| OriginComponent::parse(context, i)) {
+        match input.r#try(|i| OriginComponent::parse(context, i)) {
             Ok(x_pos @ OriginComponent::Center) => {
-                if let Ok(y_pos) = input.try(|i| OriginComponent::parse(context, i)) {
+                if let Ok(y_pos) = input.r#try(|i| OriginComponent::parse(context, i)) {
                     return Ok(Self::new(x_pos, y_pos));
                 }
                 let x_pos = input
-                    .try(|i| OriginComponent::parse(context, i))
+                    .r#try(|i| OriginComponent::parse(context, i))
                     .unwrap_or(x_pos);
                 let y_pos = OriginComponent::Center;
                 return Ok(Self::new(x_pos, y_pos));
             },
             Ok(OriginComponent::Side(x_keyword)) => {
-                if let Ok(y_keyword) = input.try(Y::parse) {
+                if let Ok(y_keyword) = input.r#try(Y::parse) {
                     let x_pos = OriginComponent::Side(x_keyword);
                     let y_pos = OriginComponent::Side(y_keyword);
                     return Ok(Self::new(x_pos, y_pos));
                 }
                 let x_pos = OriginComponent::Side(x_keyword);
                 if let Ok(y_lop) =
-                    input.try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
+                    input.r#try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
                 {
                     return Ok(Self::new(x_pos, OriginComponent::Length(y_lop)));
                 }
-                let _ = input.try(|i| i.expect_ident_matching("center"));
+                let _ = input.r#try(|i| i.expect_ident_matching("center"));
                 return Ok(Self::new(x_pos, OriginComponent::Center));
             },
             Ok(x_pos @ OriginComponent::Length(_)) => {
-                if let Ok(y_keyword) = input.try(Y::parse) {
+                if let Ok(y_keyword) = input.r#try(Y::parse) {
                     let y_pos = OriginComponent::Side(y_keyword);
                     return Ok(Self::new(x_pos, y_pos));
                 }
                 if let Ok(y_lop) =
-                    input.try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
+                    input.r#try(|i| LengthOrPercentage::parse_quirky(context, i, allow_quirks))
                 {
                     let y_pos = OriginComponent::Length(y_lop);
                     return Ok(Self::new(x_pos, y_pos));
                 }
-                let _ = input.try(|i| i.expect_ident_matching("center"));
+                let _ = input.r#try(|i| i.expect_ident_matching("center"));
                 return Ok(Self::new(x_pos, OriginComponent::Center));
             },
             Err(_) => {},
         }
         let y_keyword = Y::parse(input)?;
-        let x_pos: Result<_, ParseError> = input.try(|i| {
-            if let Ok(x_keyword) = i.try(X::parse) {
+        let x_pos: Result<_, ParseError> = input.r#try(|i| {
+            if let Ok(x_keyword) = i.r#try(X::parse) {
                 let x_pos = OriginComponent::Side(x_keyword);
                 return Ok(x_pos);
             }
@@ -646,7 +649,7 @@ impl Parse for TemplateAreas {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         let mut strings = vec![];
-        while let Ok(string) = input.try(|i| i.expect_string().map(|s| s.as_ref().into())) {
+        while let Ok(string) = input.r#try(|i| i.expect_string().map(|s| s.as_ref().into())) {
             strings.push(string);
         }
 
@@ -740,7 +743,7 @@ impl Parse for ZIndex {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if input.try(|i| i.expect_ident_matching("auto")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("auto")).is_ok() {
             return Ok(GenericZIndex::Auto);
         }
         Ok(GenericZIndex::Integer(Integer::parse(context, input)?))

--- a/components/style/values/specified/position.rs
+++ b/components/style/values/specified/position.rs
@@ -522,7 +522,7 @@ impl Parse for GridAutoFlow {
 #[cfg(feature = "gecko")]
 impl From<u8> for GridAutoFlow {
     fn from(bits: u8) -> GridAutoFlow {
-        use gecko_bindings::structs;
+        use crate::gecko_bindings::structs;
 
         GridAutoFlow {
             autoflow: if bits & structs::NS_STYLE_GRID_AUTO_FLOW_ROW as u8 != 0 {
@@ -538,7 +538,7 @@ impl From<u8> for GridAutoFlow {
 #[cfg(feature = "gecko")]
 impl From<GridAutoFlow> for u8 {
     fn from(v: GridAutoFlow) -> u8 {
-        use gecko_bindings::structs;
+        use crate::gecko_bindings::structs;
 
         let mut result: u8 = match v.autoflow {
             AutoFlow::Row => structs::NS_STYLE_GRID_AUTO_FLOW_ROW as u8,

--- a/components/style/values/specified/rect.rs
+++ b/components/style/values/specified/rect.rs
@@ -4,11 +4,11 @@
 
 //! Specified types for CSS borders.
 
+use crate::parser::ParserContext;
+use crate::values::generics::rect::Rect;
+use crate::values::specified::length::LengthOrNumber;
 use cssparser::Parser;
-use parser::ParserContext;
 use style_traits::ParseError;
-use values::generics::rect::Rect;
-use values::specified::length::LengthOrNumber;
 
 /// A specified rectangle made of four `<length-or-number>` values.
 pub type LengthOrNumberRect = Rect<LengthOrNumber>;

--- a/components/style/values/specified/resolution.rs
+++ b/components/style/values/specified/resolution.rs
@@ -6,10 +6,10 @@
 //!
 //! https://drafts.csswg.org/css-values/#resolution
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::CSSFloat;
 use cssparser::{Parser, Token};
-use parser::{Parse, ParserContext};
 use style_traits::{ParseError, StyleParseErrorKind};
-use values::CSSFloat;
 
 /// A specified resolution.
 #[derive(Clone, Debug, MallocSizeOf, PartialEq, ToCss)]

--- a/components/style/values/specified/source_size_list.rs
+++ b/components/style/values/specified/source_size_list.rs
@@ -5,15 +5,15 @@
 //! https://html.spec.whatwg.org/multipage/#source-size-list
 
 use app_units::Au;
+use crate::media_queries::{Device, MediaCondition};
+use crate::parser::{Parse, ParserContext};
+use crate::values::computed::{self, ToComputedValue};
+use crate::values::specified::{Length, NoCalcLength, ViewportPercentageLength};
 use cssparser::{Delimiter, Parser, Token};
 #[cfg(feature = "gecko")]
 use gecko_bindings::sugar::ownership::{HasBoxFFI, HasFFI, HasSimpleFFI};
-use media_queries::{Device, MediaCondition};
-use parser::{Parse, ParserContext};
 use selectors::context::QuirksMode;
 use style_traits::ParseError;
-use values::computed::{self, ToComputedValue};
-use values::specified::{Length, NoCalcLength, ViewportPercentageLength};
 
 /// A value for a `<source-size>`:
 ///
@@ -92,7 +92,7 @@ impl Parse for SourceSizeOrLength {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(size) = input.try(|input| SourceSize::parse(context, input)) {
+        if let Ok(size) = input.r#try(|input| SourceSize::parse(context, input)) {
             return Ok(SourceSizeOrLength::SourceSize(size));
         }
 

--- a/components/style/values/specified/source_size_list.rs
+++ b/components/style/values/specified/source_size_list.rs
@@ -5,13 +5,13 @@
 //! https://html.spec.whatwg.org/multipage/#source-size-list
 
 use app_units::Au;
+#[cfg(feature = "gecko")]
+use crate::gecko_bindings::sugar::ownership::{HasBoxFFI, HasFFI, HasSimpleFFI};
 use crate::media_queries::{Device, MediaCondition};
 use crate::parser::{Parse, ParserContext};
 use crate::values::computed::{self, ToComputedValue};
 use crate::values::specified::{Length, NoCalcLength, ViewportPercentageLength};
 use cssparser::{Delimiter, Parser, Token};
-#[cfg(feature = "gecko")]
-use gecko_bindings::sugar::ownership::{HasBoxFFI, HasFFI, HasSimpleFFI};
 use selectors::context::QuirksMode;
 use style_traits::ParseError;
 
@@ -142,7 +142,7 @@ impl SourceSizeList {
 
 #[cfg(feature = "gecko")]
 unsafe impl HasFFI for SourceSizeList {
-    type FFIType = ::gecko_bindings::structs::RawServoSourceSizeList;
+    type FFIType = crate::gecko_bindings::structs::RawServoSourceSizeList;
 }
 #[cfg(feature = "gecko")]
 unsafe impl HasSimpleFFI for SourceSizeList {}

--- a/components/style/values/specified/svg.rs
+++ b/components/style/values/specified/svg.rs
@@ -29,7 +29,7 @@ fn is_context_value_enabled() -> bool {
     // The prefs can only be mutated on the main thread, so it is safe
     // to read whenever we are on the main thread or the main thread is
     // blocked.
-    use gecko_bindings::structs::mozilla;
+    use crate::gecko_bindings::structs::mozilla;
     unsafe { mozilla::StaticPrefs_sVarCache_gfx_font_rendering_opentype_svg_enabled }
 }
 #[cfg(not(feature = "gecko"))]

--- a/components/style/values/specified/svg.rs
+++ b/components/style/values/specified/svg.rs
@@ -4,17 +4,19 @@
 
 //! Specified types for SVG properties.
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::generics::svg as generic;
+use crate::values::specified::color::Color;
+use crate::values::specified::url::SpecifiedUrl;
+use crate::values::specified::{
+    LengthOrPercentage, NonNegativeLengthOrPercentage, NonNegativeNumber,
+};
+use crate::values::specified::{Number, Opacity};
+use crate::values::CustomIdent;
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use std::fmt::{self, Write};
 use style_traits::{CommaWithSpace, CssWriter, ParseError, Separator};
 use style_traits::{StyleParseErrorKind, ToCss};
-use values::generics::svg as generic;
-use values::specified::color::Color;
-use values::specified::url::SpecifiedUrl;
-use values::specified::{LengthOrPercentage, NonNegativeLengthOrPercentage, NonNegativeNumber};
-use values::specified::{Number, Opacity};
-use values::CustomIdent;
 
 /// Specified SVG Paint value
 pub type SVGPaint = generic::SVGPaint<Color, SpecifiedUrl>;
@@ -61,7 +63,7 @@ impl Parse for SVGLength {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         input
-            .try(|i| SvgLengthOrPercentageOrNumber::parse(context, i))
+            .r#try(|i| SvgLengthOrPercentageOrNumber::parse(context, i))
             .map(Into::into)
             .or_else(|_| parse_context_value(input, generic::SVGLength::ContextValue))
     }
@@ -87,7 +89,7 @@ impl Parse for SVGWidth {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         input
-            .try(|i| NonNegativeSvgLengthOrPercentageOrNumber::parse(context, i))
+            .r#try(|i| NonNegativeSvgLengthOrPercentageOrNumber::parse(context, i))
             .map(Into::into)
             .or_else(|_| parse_context_value(input, generic::SVGLength::ContextValue))
     }
@@ -107,13 +109,13 @@ impl Parse for SVGStrokeDashArray {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(values) = input.try(|i| {
+        if let Ok(values) = input.r#try(|i| {
             CommaWithSpace::parse(i, |i| {
                 NonNegativeSvgLengthOrPercentageOrNumber::parse(context, i)
             })
         }) {
             Ok(generic::SVGStrokeDashArray::Values(values))
-        } else if let Ok(_) = input.try(|i| i.expect_ident_matching("none")) {
+        } else if let Ok(_) = input.r#try(|i| i.expect_ident_matching("none")) {
             Ok(generic::SVGStrokeDashArray::Values(vec![]))
         } else {
             parse_context_value(input, generic::SVGStrokeDashArray::ContextValue)
@@ -129,7 +131,7 @@ impl Parse for SVGOpacity {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(opacity) = input.try(|i| Opacity::parse(context, i)) {
+        if let Ok(opacity) = input.r#try(|i| Opacity::parse(context, i)) {
             return Ok(generic::SVGOpacity::Opacity(opacity));
         }
 
@@ -194,7 +196,7 @@ impl Parse for SVGPaintOrder {
         _context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<SVGPaintOrder, ParseError<'i>> {
-        if let Ok(()) = input.try(|i| i.expect_ident_matching("normal")) {
+        if let Ok(()) = input.r#try(|i| i.expect_ident_matching("normal")) {
             return Ok(SVGPaintOrder::normal());
         }
 
@@ -205,7 +207,7 @@ impl Parse for SVGPaintOrder {
         let mut pos = 0;
 
         loop {
-            let result: Result<_, ParseError> = input.try(|input| {
+            let result: Result<_, ParseError> = input.r#try(|input| {
                 try_match_ident_ignore_ascii_case! { input,
                     "fill" => Ok(PaintOrder::Fill),
                     "stroke" => Ok(PaintOrder::Stroke),

--- a/components/style/values/specified/svg_path.rs
+++ b/components/style/values/specified/svg_path.rs
@@ -4,17 +4,17 @@
 
 //! Specified types for SVG Path.
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::animated::{Animate, Procedure, ToAnimatedZero};
+use crate::values::distance::{ComputeSquaredDistance, SquaredDistance};
+use crate::values::CSSFloat;
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use std::fmt::{self, Write};
 use std::iter::{Cloned, Peekable};
 use std::ops::AddAssign;
 use std::slice;
 use style_traits::values::SequenceWriter;
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
-use values::animated::{Animate, Procedure, ToAnimatedZero};
-use values::distance::{ComputeSquaredDistance, SquaredDistance};
-use values::CSSFloat;
 
 /// The SVG path data.
 ///

--- a/components/style/values/specified/table.rs
+++ b/components/style/values/specified/table.rs
@@ -4,8 +4,8 @@
 
 //! Specified types for table properties.
 
+use crate::parser::{Parse, ParserContext};
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use style_traits::{ParseError, StyleParseErrorKind};
 
 #[derive(

--- a/components/style/values/specified/text.rs
+++ b/components/style/values/specified/text.rs
@@ -793,7 +793,7 @@ impl TextEmphasisPosition {
     #[cfg(feature = "gecko")]
     /// Converts an enumerated value coming from Gecko to a `TextEmphasisPosition`.
     pub fn from_gecko_keyword(kw: u32) -> Self {
-        use gecko_bindings::structs;
+        use crate::gecko_bindings::structs;
 
         let vert = if kw & structs::NS_STYLE_TEXT_EMPHASIS_POSITION_RIGHT != 0 {
             TextEmphasisVerticalWritingModeValue::Right
@@ -839,7 +839,7 @@ impl From<u8> for TextEmphasisPosition {
 #[cfg(feature = "gecko")]
 impl From<TextEmphasisPosition> for u8 {
     fn from(v: TextEmphasisPosition) -> u8 {
-        use gecko_bindings::structs;
+        use crate::gecko_bindings::structs;
 
         let mut result = match v.0 {
             TextEmphasisHorizontalWritingModeValue::Over => {

--- a/components/style/values/specified/text.rs
+++ b/components/style/values/specified/text.rs
@@ -4,27 +4,29 @@
 
 //! Specified types for text properties.
 
+use crate::parser::{Parse, ParserContext};
+use crate::properties::longhands::writing_mode::computed_value::T as SpecifiedWritingMode;
+use crate::values::computed::text::LineHeight as ComputedLineHeight;
+use crate::values::computed::text::TextEmphasisKeywordValue as ComputedTextEmphasisKeywordValue;
+use crate::values::computed::text::TextEmphasisStyle as ComputedTextEmphasisStyle;
+use crate::values::computed::text::TextOverflow as ComputedTextOverflow;
+use crate::values::computed::{Context, ToComputedValue};
+use crate::values::generics::text::InitialLetter as GenericInitialLetter;
+use crate::values::generics::text::LineHeight as GenericLineHeight;
+use crate::values::generics::text::MozTabSize as GenericMozTabSize;
+use crate::values::generics::text::Spacing;
+use crate::values::specified::length::{
+    FontRelativeLength, Length, LengthOrPercentage, NoCalcLength,
+};
+use crate::values::specified::length::{NonNegativeLength, NonNegativeLengthOrPercentage};
+use crate::values::specified::{AllowQuirks, Integer, NonNegativeNumber, Number};
 use cssparser::{Parser, Token};
-use parser::{Parse, ParserContext};
-use properties::longhands::writing_mode::computed_value::T as SpecifiedWritingMode;
 use selectors::parser::SelectorParseErrorKind;
 use std::fmt::{self, Write};
 use style_traits::values::SequenceWriter;
 use style_traits::{CssWriter, KeywordsCollectFn, ParseError};
 use style_traits::{SpecifiedValueInfo, StyleParseErrorKind, ToCss};
 use unicode_segmentation::UnicodeSegmentation;
-use values::computed::text::LineHeight as ComputedLineHeight;
-use values::computed::text::TextEmphasisKeywordValue as ComputedTextEmphasisKeywordValue;
-use values::computed::text::TextEmphasisStyle as ComputedTextEmphasisStyle;
-use values::computed::text::TextOverflow as ComputedTextOverflow;
-use values::computed::{Context, ToComputedValue};
-use values::generics::text::InitialLetter as GenericInitialLetter;
-use values::generics::text::LineHeight as GenericLineHeight;
-use values::generics::text::MozTabSize as GenericMozTabSize;
-use values::generics::text::Spacing;
-use values::specified::length::{FontRelativeLength, Length, LengthOrPercentage, NoCalcLength};
-use values::specified::length::{NonNegativeLength, NonNegativeLengthOrPercentage};
-use values::specified::{AllowQuirks, Integer, NonNegativeNumber, Number};
 
 /// A specified type for the `initial-letter` property.
 pub type InitialLetter = GenericInitialLetter<Number, Integer>;
@@ -43,11 +45,11 @@ impl Parse for InitialLetter {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if input.try(|i| i.expect_ident_matching("normal")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("normal")).is_ok() {
             return Ok(GenericInitialLetter::Normal);
         }
         let size = Number::parse_at_least_one(context, input)?;
-        let sink = input.try(|i| Integer::parse_positive(context, i)).ok();
+        let sink = input.r#try(|i| Integer::parse_positive(context, i)).ok();
         Ok(GenericInitialLetter::Specified(size, sink))
     }
 }
@@ -79,10 +81,10 @@ impl Parse for LineHeight {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(number) = input.try(|i| NonNegativeNumber::parse(context, i)) {
+        if let Ok(number) = input.r#try(|i| NonNegativeNumber::parse(context, i)) {
             return Ok(GenericLineHeight::Number(number));
         }
-        if let Ok(nlop) = input.try(|i| NonNegativeLengthOrPercentage::parse(context, i)) {
+        if let Ok(nlop) = input.r#try(|i| NonNegativeLengthOrPercentage::parse(context, i)) {
             return Ok(GenericLineHeight::Length(nlop));
         }
         let location = input.current_source_location();
@@ -107,8 +109,8 @@ impl ToComputedValue for LineHeight {
 
     #[inline]
     fn to_computed_value(&self, context: &Context) -> Self::ComputedValue {
-        use values::computed::Length as ComputedLength;
-        use values::specified::length::FontBaseSize;
+        use crate::values::computed::Length as ComputedLength;
+        use crate::values::specified::length::FontBaseSize;
         match *self {
             GenericLineHeight::Normal => GenericLineHeight::Normal,
             #[cfg(feature = "gecko")]
@@ -213,7 +215,7 @@ impl Parse for TextOverflow {
     ) -> Result<TextOverflow, ParseError<'i>> {
         let first = TextOverflowSide::parse(context, input)?;
         let second = input
-            .try(|input| TextOverflowSide::parse(context, input))
+            .r#try(|input| TextOverflowSide::parse(context, input))
             .ok();
         Ok(TextOverflow { first, second })
     }
@@ -293,14 +295,14 @@ macro_rules! impl_text_decoration_line {
             ) -> Result<TextDecorationLine, ParseError<'i>> {
                 let mut result = TextDecorationLine::NONE;
                 if input
-                    .try(|input| input.expect_ident_matching("none"))
+                    .r#try(|input| input.expect_ident_matching("none"))
                     .is_ok()
                 {
                     return Ok(result);
                 }
 
                 loop {
-                    let result = input.try(|input| {
+                    let result = input.r#try(|input| {
                         let ident = input.expect_ident().map_err(|_| ())?;
                         match_ignore_ascii_case! { ident,
                             $(
@@ -469,7 +471,7 @@ impl Parse for TextAlign {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         // MozCenterOrInherit cannot be parsed, only set directly on the elements
-        if let Ok(key) = input.try(TextAlignKeyword::parse) {
+        if let Ok(key) = input.r#try(TextAlignKeyword::parse) {
             return Ok(TextAlign::Keyword(key));
         }
         #[cfg(feature = "gecko")]
@@ -700,22 +702,22 @@ impl Parse for TextEmphasisStyle {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         if input
-            .try(|input| input.expect_ident_matching("none"))
+            .r#try(|input| input.expect_ident_matching("none"))
             .is_ok()
         {
             return Ok(TextEmphasisStyle::None);
         }
 
-        if let Ok(s) = input.try(|i| i.expect_string().map(|s| s.as_ref().to_owned())) {
+        if let Ok(s) = input.r#try(|i| i.expect_string().map(|s| s.as_ref().to_owned())) {
             // Handle <string>
             return Ok(TextEmphasisStyle::String(s));
         }
 
         // Handle a pair of keywords
-        let mut shape = input.try(TextEmphasisShapeKeyword::parse).ok();
-        let fill = input.try(TextEmphasisFillMode::parse).ok();
+        let mut shape = input.r#try(TextEmphasisShapeKeyword::parse).ok();
+        let fill = input.r#try(TextEmphasisFillMode::parse).ok();
         if shape.is_none() {
-            shape = input.try(TextEmphasisShapeKeyword::parse).ok();
+            shape = input.r#try(TextEmphasisShapeKeyword::parse).ok();
         }
 
         // At least one of shape or fill must be handled
@@ -815,7 +817,7 @@ impl Parse for TextEmphasisPosition {
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
         if let Ok(horizontal) =
-            input.try(|input| TextEmphasisHorizontalWritingModeValue::parse(input))
+            input.r#try(|input| TextEmphasisHorizontalWritingModeValue::parse(input))
         {
             let vertical = TextEmphasisVerticalWritingModeValue::parse(input)?;
             Ok(TextEmphasisPosition(horizontal, vertical))
@@ -867,7 +869,7 @@ impl Parse for MozTabSize {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if let Ok(number) = input.try(|i| NonNegativeNumber::parse(context, i)) {
+        if let Ok(number) = input.r#try(|i| NonNegativeNumber::parse(context, i)) {
             // Numbers need to be parsed first because `0` must be recognised
             // as the number `0` and not the length `0px`.
             return Ok(GenericMozTabSize::Number(number));

--- a/components/style/values/specified/time.rs
+++ b/components/style/values/specified/time.rs
@@ -4,15 +4,15 @@
 
 //! Specified time values.
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::computed::time::Time as ComputedTime;
+use crate::values::computed::{Context, ToComputedValue};
+use crate::values::specified::calc::CalcNode;
+use crate::values::CSSFloat;
 use cssparser::{Parser, Token};
-use parser::{Parse, ParserContext};
 use std::fmt::{self, Write};
 use style_traits::values::specified::AllowedNumericType;
 use style_traits::{CssWriter, ParseError, SpecifiedValueInfo, StyleParseErrorKind, ToCss};
-use values::computed::time::Time as ComputedTime;
-use values::computed::{Context, ToComputedValue};
-use values::specified::calc::CalcNode;
-use values::CSSFloat;
 
 /// A time value according to CSS-VALUES § 6.2.
 #[derive(Clone, Copy, Debug, MallocSizeOf, PartialEq)]

--- a/components/style/values/specified/ui.rs
+++ b/components/style/values/specified/ui.rs
@@ -4,16 +4,16 @@
 
 //! Specified types for UI properties.
 
+use crate::parser::{Parse, ParserContext};
+use crate::values::generics::ui as generics;
+use crate::values::specified::color::Color;
+use crate::values::specified::url::SpecifiedImageUrl;
+use crate::values::specified::Number;
+use crate::values::{Auto, Either};
 use cssparser::Parser;
-use parser::{Parse, ParserContext};
 use std::fmt::{self, Write};
 use style_traits::cursor::CursorKind;
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
-use values::generics::ui as generics;
-use values::specified::color::Color;
-use values::specified::url::SpecifiedImageUrl;
-use values::specified::Number;
-use values::{Auto, Either};
 
 /// auto | <color>
 pub type ColorOrAuto = Either<Color, Auto>;
@@ -32,7 +32,7 @@ impl Parse for Cursor {
     ) -> Result<Self, ParseError<'i>> {
         let mut images = vec![];
         loop {
-            match input.try(|input| CursorImage::parse(context, input)) {
+            match input.r#try(|input| CursorImage::parse(context, input)) {
                 Ok(image) => images.push(image),
                 Err(_) => break,
             }
@@ -64,7 +64,7 @@ impl Parse for CursorImage {
     ) -> Result<Self, ParseError<'i>> {
         Ok(Self {
             url: SpecifiedImageUrl::parse(context, input)?,
-            hotspot: match input.try(|input| Number::parse(context, input)) {
+            hotspot: match input.r#try(|input| Number::parse(context, input)) {
                 Ok(number) => Some((number, Number::parse(context, input)?)),
                 Err(_) => None,
             },
@@ -131,7 +131,7 @@ impl Parse for ScrollbarColor {
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        if input.try(|i| i.expect_ident_matching("auto")).is_ok() {
+        if input.r#try(|i| i.expect_ident_matching("auto")).is_ok() {
             return Ok(generics::ScrollbarColor::Auto);
         }
         Ok(generics::ScrollbarColor::Colors {

--- a/components/style/values/specified/url.rs
+++ b/components/style/values/specified/url.rs
@@ -4,12 +4,12 @@
 
 //! Common handling for the specified value CSS url() values.
 
-use values::generics::url::UrlOrNone as GenericUrlOrNone;
+use crate::values::generics::url::UrlOrNone as GenericUrlOrNone;
 
+#[cfg(feature = "servo")]
+pub use crate::servo::url::{SpecifiedImageUrl, SpecifiedUrl};
 #[cfg(feature = "gecko")]
 pub use gecko::url::{SpecifiedImageUrl, SpecifiedUrl};
-#[cfg(feature = "servo")]
-pub use servo::url::{SpecifiedImageUrl, SpecifiedUrl};
 
 /// Specified <url> | <none>
 pub type UrlOrNone = GenericUrlOrNone<SpecifiedUrl>;

--- a/components/style/values/specified/url.rs
+++ b/components/style/values/specified/url.rs
@@ -6,10 +6,10 @@
 
 use crate::values::generics::url::UrlOrNone as GenericUrlOrNone;
 
+#[cfg(feature = "gecko")]
+pub use crate::gecko::url::{SpecifiedImageUrl, SpecifiedUrl};
 #[cfg(feature = "servo")]
 pub use crate::servo::url::{SpecifiedImageUrl, SpecifiedUrl};
-#[cfg(feature = "gecko")]
-pub use gecko::url::{SpecifiedImageUrl, SpecifiedUrl};
 
 /// Specified <url> | <none>
 pub type UrlOrNone = GenericUrlOrNone<SpecifiedUrl>;

--- a/components/style_derive/animate.rs
+++ b/components/style_derive/animate.rs
@@ -16,7 +16,7 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
         if !no_bound.contains(&param.ident) {
             cg::add_predicate(
                 &mut where_clause,
-                parse_quote!(#param: ::values::animated::Animate),
+                parse_quote!(#param: crate::values::animated::Animate),
             );
         }
     }
@@ -51,13 +51,13 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     quote! {
-        impl #impl_generics ::values::animated::Animate for #name #ty_generics #where_clause {
+        impl #impl_generics crate::values::animated::Animate for #name #ty_generics #where_clause {
             #[allow(unused_variables, unused_imports)]
             #[inline]
             fn animate(
                 &self,
                 other: &Self,
-                procedure: ::values::animated::Procedure,
+                procedure: crate::values::animated::Procedure,
             ) -> Result<Self, ()> {
                 match (self, other) {
                     #match_body
@@ -84,12 +84,12 @@ fn derive_variant_arm(variant: &VariantInfo) -> Result<Tokens, ()> {
                 if #this != #other {
                     return Err(());
                 }
-                let #result = ::std::clone::Clone::clone(#this);
+                let #result = std::clone::Clone::clone(#this);
             }
         } else {
             quote! {
                 let #result =
-                    ::values::animated::Animate::animate(#this, #other, procedure)?;
+                    crate::values::animated::Animate::animate(#this, #other, procedure)?;
             }
         }
     }));

--- a/components/style_derive/animate.rs
+++ b/components/style_derive/animate.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use cg;
+use crate::cg;
 use darling::util::IdentList;
 use quote::Tokens;
 use syn::{DeriveInput, Path};

--- a/components/style_derive/cg.rs
+++ b/components/style_derive/cg.rs
@@ -53,9 +53,7 @@ pub fn fmap_trait_output(input: &DeriveInput, trait_path: &Path, trait_output: I
                     },
                     &GenericParam::Type(ref data) => {
                         let ident = data.ident;
-                        GenericArgument::Type(
-                            parse_quote!(<#ident as #trait_path>::#trait_output),
-                        )
+                        GenericArgument::Type(parse_quote!(<#ident as #trait_path>::#trait_output))
                     },
                     ref arg => panic!("arguments {:?} cannot be mapped yet", arg),
                 })

--- a/components/style_derive/cg.rs
+++ b/components/style_derive/cg.rs
@@ -54,7 +54,7 @@ pub fn fmap_trait_output(input: &DeriveInput, trait_path: &Path, trait_output: I
                     &GenericParam::Type(ref data) => {
                         let ident = data.ident;
                         GenericArgument::Type(
-                            parse_quote!(<#ident as ::#trait_path>::#trait_output),
+                            parse_quote!(<#ident as #trait_path>::#trait_output),
                         )
                     },
                     ref arg => panic!("arguments {:?} cannot be mapped yet", arg),

--- a/components/style_derive/compute_squared_distance.rs
+++ b/components/style_derive/compute_squared_distance.rs
@@ -16,7 +16,7 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
         if !no_bound.contains(&param.ident) {
             cg::add_predicate(
                 &mut where_clause,
-                parse_quote!(#param: ::values::distance::ComputeSquaredDistance),
+                parse_quote!(#param: crate::values::distance::ComputeSquaredDistance),
             );
         }
     }
@@ -35,7 +35,7 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
             let (this_pattern, this_info) = cg::ref_pattern(&variant, "this");
             let (other_pattern, other_info) = cg::ref_pattern(&variant, "other");
             let sum = if this_info.is_empty() {
-                quote! { ::values::distance::SquaredDistance::from_sqrt(0.) }
+                quote! { crate::values::distance::SquaredDistance::from_sqrt(0.) }
             } else {
                 let mut sum = quote!();
                 sum.append_separated(this_info.iter().zip(&other_info).map(|(this, other)| {
@@ -44,7 +44,7 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
                         let ty = &this.ast().ty;
                         cg::add_predicate(
                             &mut where_clause,
-                            parse_quote!(#ty: ::values::distance::ComputeSquaredDistance),
+                            parse_quote!(#ty: crate::values::distance::ComputeSquaredDistance),
                         );
                     }
 
@@ -57,12 +57,12 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
                                 if #this != #other {
                                     return Err(());
                                 }
-                                ::values::distance::SquaredDistance::from_sqrt(0.)
+                                crate::values::distance::SquaredDistance::from_sqrt(0.)
                             }
                         }
                     } else {
                         quote! {
-                            ::values::distance::ComputeSquaredDistance::compute_squared_distance(#this, #other)?
+                            crate::values::distance::ComputeSquaredDistance::compute_squared_distance(#this, #other)?
                         }
                     }
                 }), quote!(+));
@@ -95,13 +95,13 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     quote! {
-        impl #impl_generics ::values::distance::ComputeSquaredDistance for #name #ty_generics #where_clause {
+        impl #impl_generics crate::values::distance::ComputeSquaredDistance for #name #ty_generics #where_clause {
             #[allow(unused_variables, unused_imports)]
             #[inline]
             fn compute_squared_distance(
                 &self,
                 other: &Self,
-            ) -> Result<::values::distance::SquaredDistance, ()> {
+            ) -> Result<crate::values::distance::SquaredDistance, ()> {
                 match (self, other) {
                     #match_body
                 }

--- a/components/style_derive/compute_squared_distance.rs
+++ b/components/style_derive/compute_squared_distance.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use animate::{AnimationFieldAttrs, AnimationInputAttrs, AnimationVariantAttrs};
-use cg;
+use crate::animate::{AnimationFieldAttrs, AnimationInputAttrs, AnimationVariantAttrs};
+use crate::cg;
 use quote::Tokens;
 use syn::{DeriveInput, Path};
 use synstructure;

--- a/components/style_derive/parse.rs
+++ b/components/style_derive/parse.rs
@@ -79,7 +79,7 @@ pub fn derive(input: DeriveInput) -> Tokens {
             match_ignore_ascii_case! { &ident,
                 #match_body
                 _ => Err(location.new_unexpected_token_error(
-                    ::cssparser::Token::Ident(ident.clone())
+                    cssparser::Token::Ident(ident.clone())
                 ))
             }
         }
@@ -88,12 +88,12 @@ pub fn derive(input: DeriveInput) -> Tokens {
     };
 
     let parse_trait_impl = quote! {
-        impl ::parser::Parse for #name {
+        impl crate::parser::Parse for #name {
             #[inline]
             fn parse<'i, 't>(
-                #context_ident: &::parser::ParserContext,
-                input: &mut ::cssparser::Parser<'i, 't>,
-            ) -> Result<Self, ::style_traits::ParseError<'i>> {
+                #context_ident: &crate::parser::ParserContext,
+                input: &mut cssparser::Parser<'i, 't>,
+            ) -> Result<Self, style_traits::ParseError<'i>> {
                 #parse_body
             }
         }
@@ -110,13 +110,13 @@ pub fn derive(input: DeriveInput) -> Tokens {
             /// Parse this keyword.
             #[inline]
             pub fn parse<'i, 't>(
-                input: &mut ::cssparser::Parser<'i, 't>,
-            ) -> Result<Self, ::style_traits::ParseError<'i>> {
+                input: &mut cssparser::Parser<'i, 't>,
+            ) -> Result<Self, style_traits::ParseError<'i>> {
                 let location = input.current_source_location();
                 let ident = input.expect_ident()?;
                 Self::from_ident(ident.as_ref()).map_err(|()| {
                     location.new_unexpected_token_error(
-                        ::cssparser::Token::Ident(ident.clone())
+                        cssparser::Token::Ident(ident.clone())
                     )
                 })
             }

--- a/components/style_derive/parse.rs
+++ b/components/style_derive/parse.rs
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use cg;
+use crate::cg;
+use crate::to_css::CssVariantAttrs;
 use quote::Tokens;
 use syn::{DeriveInput, Path};
 use synstructure;
-use to_css::CssVariantAttrs;
 
 #[darling(attributes(parse), default)]
 #[derive(Default, FromVariant)]

--- a/components/style_derive/specified_value_info.rs
+++ b/components/style_derive/specified_value_info.rs
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use cg;
-use parse::ParseVariantAttrs;
+use crate::cg;
+use crate::parse::ParseVariantAttrs;
+use crate::to_css::{CssFieldAttrs, CssInputAttrs, CssVariantAttrs};
 use quote::Tokens;
 use syn::{Data, DeriveInput, Fields, Ident, Type};
-use to_css::{CssFieldAttrs, CssInputAttrs, CssVariantAttrs};
 
 pub fn derive(mut input: DeriveInput) -> Tokens {
     let css_attrs = cg::parse_input_attrs::<CssInputAttrs>(&input);

--- a/components/style_derive/specified_value_info.rs
+++ b/components/style_derive/specified_value_info.rs
@@ -24,7 +24,7 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
         for param in input.generics.type_params() {
             cg::add_predicate(
                 &mut where_clause,
-                parse_quote!(#param: ::style_traits::SpecifiedValueInfo),
+                parse_quote!(#param: style_traits::SpecifiedValueInfo),
             );
         }
         input.generics.where_clause = where_clause;
@@ -86,20 +86,20 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
     let mut types_value = quote!(0);
     types_value.append_all(types.iter().map(|ty| {
         quote! {
-            | <#ty as ::style_traits::SpecifiedValueInfo>::SUPPORTED_TYPES
+            | <#ty as style_traits::SpecifiedValueInfo>::SUPPORTED_TYPES
         }
     }));
 
     let mut nested_collects = quote!();
     nested_collects.append_all(types.iter().map(|ty| {
         quote! {
-            <#ty as ::style_traits::SpecifiedValueInfo>::collect_completion_keywords(_f);
+            <#ty as style_traits::SpecifiedValueInfo>::collect_completion_keywords(_f);
         }
     }));
 
     if let Some(ty) = info_attrs.ty {
         types_value.append_all(quote! {
-            | ::style_traits::CssType::#ty
+            | style_traits::CssType::#ty
         });
     }
 
@@ -114,7 +114,7 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
     let name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     quote! {
-        impl #impl_generics ::style_traits::SpecifiedValueInfo for #name #ty_generics
+        impl #impl_generics style_traits::SpecifiedValueInfo for #name #ty_generics
         #where_clause
         {
             const SUPPORTED_TYPES: u8 = #types_value;

--- a/components/style_derive/to_animated_value.rs
+++ b/components/style_derive/to_animated_value.rs
@@ -12,19 +12,19 @@ pub fn derive(mut input: DeriveInput) -> quote::Tokens {
     for param in input.generics.type_params() {
         cg::add_predicate(
             &mut where_clause,
-            parse_quote!(#param: ::values::animated::ToAnimatedValue),
+            parse_quote!(#param: crate::values::animated::ToAnimatedValue),
         );
     }
 
     let to_body = cg::fmap_match(
         &input,
         BindStyle::Move,
-        |binding| quote!(::values::animated::ToAnimatedValue::to_animated_value(#binding)),
+        |binding| quote!(crate::values::animated::ToAnimatedValue::to_animated_value(#binding)),
     );
     let from_body = cg::fmap_match(
         &input,
         BindStyle::Move,
-        |binding| quote!(::values::animated::ToAnimatedValue::from_animated_value(#binding)),
+        |binding| quote!(crate::values::animated::ToAnimatedValue::from_animated_value(#binding)),
     );
 
     input.generics.where_clause = where_clause;
@@ -32,12 +32,12 @@ pub fn derive(mut input: DeriveInput) -> quote::Tokens {
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let animated_value_type = cg::fmap_trait_output(
         &input,
-        &parse_quote!(values::animated::ToAnimatedValue),
+        &parse_quote!(crate::values::animated::ToAnimatedValue),
         "AnimatedValue".into(),
     );
 
     quote! {
-        impl #impl_generics ::values::animated::ToAnimatedValue for #name #ty_generics #where_clause {
+        impl #impl_generics crate::values::animated::ToAnimatedValue for #name #ty_generics #where_clause {
             type AnimatedValue = #animated_value_type;
 
             #[allow(unused_variables)]

--- a/components/style_derive/to_animated_value.rs
+++ b/components/style_derive/to_animated_value.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use cg;
+use crate::cg;
 use quote;
 use syn::DeriveInput;
 use synstructure::BindStyle;

--- a/components/style_derive/to_animated_zero.rs
+++ b/components/style_derive/to_animated_zero.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use animate::{AnimationFieldAttrs, AnimationInputAttrs, AnimationVariantAttrs};
-use cg;
+use crate::animate::{AnimationFieldAttrs, AnimationInputAttrs, AnimationVariantAttrs};
+use crate::cg;
 use quote;
 use syn;
 use synstructure;

--- a/components/style_derive/to_animated_zero.rs
+++ b/components/style_derive/to_animated_zero.rs
@@ -16,7 +16,7 @@ pub fn derive(mut input: syn::DeriveInput) -> quote::Tokens {
         if !no_bound.contains(&param.ident) {
             cg::add_predicate(
                 &mut where_clause,
-                parse_quote!(#param: ::values::animated::ToAnimatedZero),
+                parse_quote!(#param: crate::values::animated::ToAnimatedZero),
             );
         }
     }
@@ -33,12 +33,12 @@ pub fn derive(mut input: syn::DeriveInput) -> quote::Tokens {
             let field_attrs = cg::parse_field_attrs::<AnimationFieldAttrs>(&binding.ast());
             if field_attrs.constant {
                 quote! {
-                    let #mapped_binding = ::std::clone::Clone::clone(#binding);
+                    let #mapped_binding = std::clone::Clone::clone(#binding);
                 }
             } else {
                 quote! {
                     let #mapped_binding =
-                        ::values::animated::ToAnimatedZero::to_animated_zero(#binding)?;
+                        crate::values::animated::ToAnimatedZero::to_animated_zero(#binding)?;
                 }
             }
         }));
@@ -51,7 +51,7 @@ pub fn derive(mut input: syn::DeriveInput) -> quote::Tokens {
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     quote! {
-        impl #impl_generics ::values::animated::ToAnimatedZero for #name #ty_generics #where_clause {
+        impl #impl_generics crate::values::animated::ToAnimatedZero for #name #ty_generics #where_clause {
             #[allow(unused_variables)]
             #[inline]
             fn to_animated_zero(&self) -> Result<Self, ()> {

--- a/components/style_derive/to_computed_value.rs
+++ b/components/style_derive/to_computed_value.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use cg;
+use crate::cg;
 use quote::Tokens;
 use syn::DeriveInput;
 use synstructure::BindStyle;

--- a/components/style_derive/to_computed_value.rs
+++ b/components/style_derive/to_computed_value.rs
@@ -14,7 +14,7 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
         for param in &params {
             cg::add_predicate(
                 &mut where_clause,
-                parse_quote!(#param: ::values::computed::ToComputedValue),
+                parse_quote!(#param: crate::values::computed::ToComputedValue),
             );
         }
 
@@ -26,23 +26,23 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
                 let output_type = cg::map_type_params(
                     ty,
                     &params,
-                    &mut |ident| parse_quote!(<#ident as ::values::computed::ToComputedValue>::ComputedValue),
+                    &mut |ident| parse_quote!(<#ident as crate::values::computed::ToComputedValue>::ComputedValue),
                 );
 
                 cg::add_predicate(
                     &mut where_clause,
                     parse_quote!(
-                        #ty: ::values::computed::ToComputedValue<ComputedValue = #output_type>
+                        #ty: crate::values::computed::ToComputedValue<ComputedValue = #output_type>
                     ),
                 );
             }
             quote! {
-                ::values::computed::ToComputedValue::to_computed_value(#binding, context)
+                crate::values::computed::ToComputedValue::to_computed_value(#binding, context)
             }
         });
         let from_body = cg::fmap_match(&input, BindStyle::Ref, |binding| {
             quote! {
-                ::values::computed::ToComputedValue::from_computed_value(#binding)
+                crate::values::computed::ToComputedValue::from_computed_value(#binding)
             }
         });
 
@@ -55,7 +55,7 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
 
     if input.generics.type_params().next().is_none() {
         return quote! {
-            impl #impl_generics ::values::computed::ToComputedValue for #name #ty_generics
+            impl #impl_generics crate::values::computed::ToComputedValue for #name #ty_generics
             #where_clause
             {
                 type ComputedValue = Self;
@@ -63,14 +63,14 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
                 #[inline]
                 fn to_computed_value(
                     &self,
-                    _context: &::values::computed::Context,
+                    _context: &crate::values::computed::Context,
                 ) -> Self::ComputedValue {
-                    ::std::clone::Clone::clone(self)
+                    std::clone::Clone::clone(self)
                 }
 
                 #[inline]
                 fn from_computed_value(computed: &Self::ComputedValue) -> Self {
-                    ::std::clone::Clone::clone(computed)
+                    std::clone::Clone::clone(computed)
                 }
             }
         };
@@ -78,17 +78,17 @@ pub fn derive(mut input: DeriveInput) -> Tokens {
 
     let computed_value_type = cg::fmap_trait_output(
         &input,
-        &parse_quote!(values::computed::ToComputedValue),
+        &parse_quote!(crate::values::computed::ToComputedValue),
         "ComputedValue".into(),
     );
 
     quote! {
-        impl #impl_generics ::values::computed::ToComputedValue for #name #ty_generics #where_clause {
+        impl #impl_generics crate::values::computed::ToComputedValue for #name #ty_generics #where_clause {
             type ComputedValue = #computed_value_type;
 
             #[allow(unused_variables)]
             #[inline]
-            fn to_computed_value(&self, context: &::values::computed::Context) -> Self::ComputedValue {
+            fn to_computed_value(&self, context: &crate::values::computed::Context) -> Self::ComputedValue {
                 match *self {
                     #to_body
                 }

--- a/components/style_derive/to_css.rs
+++ b/components/style_derive/to_css.rs
@@ -13,7 +13,7 @@ pub fn derive(mut input: syn::DeriveInput) -> Tokens {
     for param in input.generics.type_params() {
         cg::add_predicate(
             &mut where_clause,
-            parse_quote!(#param: ::style_traits::ToCss),
+            parse_quote!(#param: style_traits::ToCss),
         );
     }
 
@@ -36,15 +36,15 @@ pub fn derive(mut input: syn::DeriveInput) -> Tokens {
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     let mut impls = quote! {
-        impl #impl_generics ::style_traits::ToCss for #name #ty_generics #where_clause {
+        impl #impl_generics style_traits::ToCss for #name #ty_generics #where_clause {
             #[allow(unused_variables)]
             #[inline]
             fn to_css<W>(
                 &self,
-                dest: &mut ::style_traits::CssWriter<W>,
-            ) -> ::std::fmt::Result
+                dest: &mut style_traits::CssWriter<W>,
+            ) -> std::fmt::Result
             where
-                W: ::std::fmt::Write,
+                W: std::fmt::Write,
             {
                 match *self {
                     #match_body
@@ -55,11 +55,11 @@ pub fn derive(mut input: syn::DeriveInput) -> Tokens {
 
     if input_attrs.derive_debug {
         impls.append_all(quote! {
-            impl #impl_generics ::std::fmt::Debug for #name #ty_generics #where_clause {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                    ::style_traits::ToCss::to_css(
+            impl #impl_generics std::fmt::Debug for #name #ty_generics #where_clause {
+                fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    style_traits::ToCss::to_css(
                         self,
-                        &mut ::style_traits::CssWriter::new(f),
+                        &mut style_traits::CssWriter::new(f),
                     )
                 }
             }
@@ -90,28 +90,28 @@ fn derive_variant_arm(variant: &VariantInfo, generics: &mut Option<WhereClause>)
     let mut expr = if let Some(keyword) = variant_attrs.keyword {
         assert!(bindings.is_empty());
         quote! {
-            ::std::fmt::Write::write_str(dest, #keyword)
+            std::fmt::Write::write_str(dest, #keyword)
         }
     } else if !bindings.is_empty() {
         derive_variant_fields_expr(bindings, generics, separator)
     } else {
         quote! {
-            ::std::fmt::Write::write_str(dest, #identifier)
+            std::fmt::Write::write_str(dest, #identifier)
         }
     };
 
     if variant_attrs.dimension {
         expr = quote! {
             #expr?;
-            ::std::fmt::Write::write_str(dest, #identifier)
+            std::fmt::Write::write_str(dest, #identifier)
         }
     } else if let Some(function) = variant_attrs.function {
         let mut identifier = function.explicit().map_or(identifier, |name| name);
         identifier.push_str("(");
         expr = quote! {
-            ::std::fmt::Write::write_str(dest, #identifier)?;
+            std::fmt::Write::write_str(dest, #identifier)?;
             #expr?;
-            ::std::fmt::Write::write_str(dest, ")")
+            std::fmt::Write::write_str(dest, ")")
         }
     }
     expr
@@ -140,9 +140,9 @@ fn derive_variant_fields_expr(
     if !attrs.iterable && iter.peek().is_none() {
         if attrs.field_bound {
             let ty = &first.ast().ty;
-            cg::add_predicate(where_clause, parse_quote!(#ty: ::style_traits::ToCss));
+            cg::add_predicate(where_clause, parse_quote!(#ty: style_traits::ToCss));
         }
-        let mut expr = quote! { ::style_traits::ToCss::to_css(#first, dest) };
+        let mut expr = quote! { style_traits::ToCss::to_css(#first, dest) };
         if let Some(condition) = attrs.skip_if {
             expr = quote! {
                 if !#condition(#first) {
@@ -159,7 +159,7 @@ fn derive_variant_fields_expr(
     }
 
     quote! {{
-        let mut writer = ::style_traits::values::SequenceWriter::new(dest, #separator);
+        let mut writer = style_traits::values::SequenceWriter::new(dest, #separator);
         #expr
         Ok(())
     }}
@@ -205,7 +205,7 @@ fn derive_single_field_expr(
     } else {
         if attrs.field_bound {
             let ty = &field.ast().ty;
-            cg::add_predicate(where_clause, parse_quote!(#ty: ::style_traits::ToCss));
+            cg::add_predicate(where_clause, parse_quote!(#ty: style_traits::ToCss));
         }
         quote! { writer.item(#field)?; }
     };

--- a/components/style_derive/to_css.rs
+++ b/components/style_derive/to_css.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use cg;
+use crate::cg;
 use darling::util::Override;
 use quote::{ToTokens, Tokens};
 use syn::{self, Data, Path, WhereClause};
@@ -11,10 +11,7 @@ use synstructure::{BindingInfo, Structure, VariantInfo};
 pub fn derive(mut input: syn::DeriveInput) -> Tokens {
     let mut where_clause = input.generics.where_clause.take();
     for param in input.generics.type_params() {
-        cg::add_predicate(
-            &mut where_clause,
-            parse_quote!(#param: style_traits::ToCss),
-        );
+        cg::add_predicate(&mut where_clause, parse_quote!(#param: style_traits::ToCss));
     }
 
     let input_attrs = cg::parse_input_attrs::<CssInputAttrs>(&input);

--- a/components/style_traits/lib.rs
+++ b/components/style_traits/lib.rs
@@ -91,8 +91,10 @@ pub mod values;
 #[macro_use]
 pub mod viewport;
 
-pub use specified_value_info::{CssType, KeywordsCollectFn, SpecifiedValueInfo};
-pub use values::{Comma, CommaWithSpace, CssWriter, OneOrMoreSeparated, Separator, Space, ToCss};
+pub use crate::specified_value_info::{CssType, KeywordsCollectFn, SpecifiedValueInfo};
+pub use crate::values::{
+    Comma, CommaWithSpace, CssWriter, OneOrMoreSeparated, Separator, Space, ToCss,
+};
 
 /// The error type for all CSS parsing routines.
 pub type ParseError<'i> = cssparser::ParseError<'i, StyleParseErrorKind<'i>>;

--- a/components/style_traits/values.rs
+++ b/components/style_traits/values.rs
@@ -324,7 +324,7 @@ impl Separator for Space {
         let mut results = vec![parse_one(input)?];
         loop {
             input.skip_whitespace(); // Unnecessary for correctness, but may help try() rewind less.
-            if let Ok(item) = input.try(&mut parse_one) {
+            if let Ok(item) = input.r#try(&mut parse_one) {
                 results.push(item);
             } else {
                 return Ok(results);
@@ -350,9 +350,9 @@ impl Separator for CommaWithSpace {
         loop {
             input.skip_whitespace(); // Unnecessary for correctness, but may help try() rewind less.
             let comma_location = input.current_source_location();
-            let comma = input.try(|i| i.expect_comma()).is_ok();
+            let comma = input.r#try(|i| i.expect_comma()).is_ok();
             input.skip_whitespace(); // Unnecessary for correctness, but may help try() rewind less.
-            if let Ok(item) = input.try(&mut parse_one) {
+            if let Ok(item) = input.r#try(&mut parse_one) {
                 results.push(item);
             } else if comma {
                 return Err(comma_location.new_unexpected_token_error(Token::Comma));
@@ -507,7 +507,7 @@ macro_rules! define_css_keyword_enum {
 
 /// Helper types for the handling of specified values.
 pub mod specified {
-    use ParsingMode;
+    use crate::ParsingMode;
 
     /// Whether to allow negative lengths or not.
     #[repr(u8)]

--- a/components/style_traits/viewport.rs
+++ b/components/style_traits/viewport.rs
@@ -4,10 +4,10 @@
 
 //! Helper types for the `@viewport` rule.
 
+use crate::{CSSPixel, CssWriter, ParseError, PinchZoomFactor, ToCss};
 use cssparser::Parser;
 use euclid::TypedSize2D;
 use std::fmt::{self, Write};
-use {CSSPixel, CssWriter, ParseError, PinchZoomFactor, ToCss};
 
 define_css_keyword_enum! {
     pub enum UserZoom {
@@ -115,9 +115,9 @@ impl Zoom {
     ///
     /// <https://drafts.csswg.org/css-device-adapt/#descdef-viewport-zoom>
     pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Zoom, ParseError<'i>> {
+        use crate::values::specified::AllowedNumericType::NonNegative;
+        use crate::ParsingMode;
         use cssparser::Token;
-        use values::specified::AllowedNumericType::NonNegative;
-        use ParsingMode;
 
         let location = input.current_source_location();
         match *input.next()? {

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -327,6 +327,7 @@ def windows_build_task(name):
 
 CONFIG.task_name_template = "Servo: %s"
 CONFIG.index_prefix = "project.servo.servo"
+CONFIG.docker_image_buil_worker_type = "servo-docker-worker"
 CONFIG.docker_images_expire_in = build_dependencies_artifacts_expire_in
 CONFIG.repacked_msi_files_expire_in = build_dependencies_artifacts_expire_in
 

--- a/etc/taskcluster/decisionlib.py
+++ b/etc/taskcluster/decisionlib.py
@@ -40,6 +40,7 @@ class Config:
         self.index_prefix = "garbage.servo-decisionlib"
         self.scopes_for_all_subtasks = []
         self.routes_for_all_subtasks = []
+        self.docker_image_buil_worker_type = None
         self.docker_images_expire_in = "1 month"
         self.repacked_msi_files_expire_in = "1 month"
 
@@ -627,7 +628,7 @@ class DockerWorkerTask(Task):
 
         image_build_task = (
             DockerWorkerTask("Docker image: " + image_name)
-            .with_worker_type(self.worker_type)
+            .with_worker_type(CONFIG.docker_image_buil_worker_type or self.worker_type)
             .with_max_run_time_minutes(30)
             .with_index_and_artifacts_expire_in(CONFIG.docker_images_expire_in)
             .with_features("dind")

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -24,6 +24,6 @@ servo_atoms = {path = "../../../components/atoms"}
 servo_config = {path = "../../../components/config"}
 servo_url = {path = "../../../components/url"}
 size_of_test = {path = "../../../components/size_of_test"}
-style = {path = "../../../components/style"}
+style = {path = "../../../components/style", features = ["servo"]}
 style_traits = {path = "../../../components/style_traits"}
 std_test_override = { path = "../../../components/std_test_override" }

--- a/tests/unit/style/parsing/animation.rs
+++ b/tests/unit/style/parsing/animation.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use parsing::parse;
+use crate::parsing::parse;
 use servo_atoms::Atom;
 use style::parser::Parse;
 use style::properties::longhands::animation_name;

--- a/tests/unit/style/parsing/background.rs
+++ b/tests/unit/style/parsing/background.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use parsing::parse;
+use crate::parsing::parse;
 use style::properties::longhands::background_size;
 use style::properties::longhands::{
     background_attachment, background_clip, background_color, background_image,

--- a/tests/unit/style/parsing/border.rs
+++ b/tests/unit/style/parsing/border.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use parsing::parse;
+use crate::parsing::parse;
 use style::parser::Parse;
 use style::properties::longhands::{border_image_outset, border_image_repeat, border_image_slice};
 use style::properties::longhands::{border_image_source, border_image_width};

--- a/tests/unit/style/parsing/box_.rs
+++ b/tests/unit/style/parsing/box_.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use parsing::parse;
+use crate::parsing::parse;
 use style_traits::ToCss;
 
 #[test]

--- a/tests/unit/style/parsing/column.rs
+++ b/tests/unit/style/parsing/column.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use parsing::parse;
+use crate::parsing::parse;
 use style_traits::ToCss;
 
 #[test]

--- a/tests/unit/style/parsing/effects.rs
+++ b/tests/unit/style/parsing/effects.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use parsing::parse;
+use crate::parsing::parse;
 use style::properties::longhands::{perspective_origin, transform_origin};
 use style_traits::ToCss;
 
@@ -49,7 +49,7 @@ fn test_effects_parser_exhaustion() {
 
 #[test]
 fn test_parse_factor() {
-    use parsing::parse;
+    use crate::parsing::parse;
     use style::properties::longhands::filter;
 
     assert!(parse(filter::parse, "brightness(0)").is_ok());

--- a/tests/unit/style/parsing/inherited_text.rs
+++ b/tests/unit/style/parsing/inherited_text.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use parsing::parse;
+use crate::parsing::parse;
 use style::values::generics::text::Spacing;
 
 #[test]

--- a/tests/unit/style/parsing/outline.rs
+++ b/tests/unit/style/parsing/outline.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use parsing::parse;
+use crate::parsing::parse;
 use style_traits::ToCss;
 
 #[test]

--- a/tests/unit/style/parsing/position.rs
+++ b/tests/unit/style/parsing/position.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use parsing::{parse, parse_entirely};
+use crate::parsing::{parse, parse_entirely};
 use style::parser::Parse;
 use style::values::specified::position::*;
 use style_traits::ToCss;

--- a/tests/unit/style/parsing/text_overflow.rs
+++ b/tests/unit/style/parsing/text_overflow.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use parsing::parse;
+use crate::parsing::parse;
 use style_traits::ToCss;
 
 #[test]

--- a/tests/unit/style/parsing/transition_duration.rs
+++ b/tests/unit/style/parsing/transition_duration.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use parsing::parse;
+use crate::parsing::parse;
 use style::properties::longhands::transition_duration;
 
 #[test]

--- a/tests/unit/style/parsing/transition_timing_function.rs
+++ b/tests/unit/style/parsing/transition_timing_function.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use parsing::parse;
+use crate::parsing::parse;
 use style::properties::longhands::transition_timing_function;
 use style_traits::ToCss;
 

--- a/tests/unit/style/properties/serialization.rs
+++ b/tests/unit/style/properties/serialization.rs
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use properties::{parse, parse_input};
+use crate::properties::{parse, parse_input};
+use crate::stylesheets::block_from;
 use style::computed_values::display::T as Display;
 use style::properties::declaration_block::PropertyDeclarationBlock;
 use style::properties::parse_property_declaration_list;
@@ -13,7 +14,6 @@ use style::values::specified::{BorderSideWidth, BorderStyle, Color};
 use style::values::specified::{Length, LengthOrPercentage, LengthOrPercentageOrAuto};
 use style::values::RGBA;
 use style_traits::ToCss;
-use stylesheets::block_from;
 
 trait ToCssString {
     fn to_css_string(&self) -> String;


### PR DESCRIPTION
This can land when [Gecko requires Rust 1.30](https://bugzilla.mozilla.org/show_bug.cgi?id=1504031). This does not switch the crates yet because the new edition is not yet stable in 1.30.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22083)
<!-- Reviewable:end -->
