### PR TITLE
Add support for market:// urls

### DIFF
--- a/ports/libsimpleservo/src/api.rs
+++ b/ports/libsimpleservo/src/api.rs
@@ -63,6 +63,8 @@ pub trait HostTrait {
     fn on_load_ended(&self);
     /// Page title has changed.
     fn on_title_changed(&self, title: String);
+    /// Allow Navigation.
+    fn on_allow_navigation(&self, url: String) -> bool;
     /// Page URL has changed.
     fn on_url_changed(&self, url: String);
     /// Back/forward state has changed.
@@ -364,8 +366,12 @@ impl ServoGlue {
                     let title = format!("{} - Servo", title);
                     self.callbacks.host_callbacks.on_title_changed(title);
                 },
-                EmbedderMsg::AllowNavigation(_url, response_chan) => {
-                    if let Err(e) = response_chan.send(true) {
+                EmbedderMsg::AllowNavigation(url, response_chan) => {
+                    let data: bool = self
+                        .callbacks
+                        .host_callbacks
+                        .on_allow_navigation(url.to_string());
+                    if let Err(e) = response_chan.send(data) {
                         warn!("Failed to send allow_navigation() response: {}", e);
                     };
                 },

--- a/ports/libsimpleservo/src/capi.rs
+++ b/ports/libsimpleservo/src/capi.rs
@@ -35,6 +35,7 @@ pub struct CHostCallbacks {
     pub on_load_started: extern "C" fn(),
     pub on_load_ended: extern "C" fn(),
     pub on_title_changed: extern "C" fn(title: *const c_char),
+    pub on_allow_navigation: extern "C" fn(url: *const c_char) -> bool,
     pub on_url_changed: extern "C" fn(url: *const c_char),
     pub on_history_changed: extern "C" fn(can_go_back: bool, can_go_forward: bool),
     pub on_animating_changed: extern "C" fn(animating: bool),
@@ -300,6 +301,14 @@ impl HostTrait for HostCallbacks {
         let title_ptr = title.as_ptr();
         mem::forget(title);
         (self.0.on_title_changed)(title_ptr);
+    }
+
+    fn on_allow_navigation(&self, url: String) -> bool {
+        debug!("on_allow_navigation");
+        let url = CString::new(url).expect("Can't create string");
+        let url_ptr = url.as_ptr();
+        mem::forget(url);
+        (self.0.on_allow_navigation)(url_ptr)
     }
 
     fn on_url_changed(&self, url: String) {

--- a/ports/libsimpleservo/src/jniapi.rs
+++ b/ports/libsimpleservo/src/jniapi.rs
@@ -395,6 +395,26 @@ impl HostTrait for HostCallbacks {
         .unwrap();
     }
 
+    fn on_allow_navigation(&self, url: String) -> bool {
+        debug!("on_allow_navigation");
+        let env = self.jvm.get_env().unwrap();
+        let s = match new_string(&env, &url) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        let s = JValue::from(JObject::from(s));
+        let allow = env.call_method(
+            self.callbacks.as_obj(),
+            "onAllowNavigation",
+            "(Ljava/lang/String;)Z",
+            &[s],
+        );
+        match allow {
+            Ok(allow) => return allow.z().unwrap(),
+            Err(_) => return true,
+        }
+    }
+
     fn on_url_changed(&self, url: String) {
         debug!("on_url_changed");
         let env = self.jvm.get_env().unwrap();

--- a/support/android/apk/servoapp/src/main/java/org/mozilla/servo/MainActivity.java
+++ b/support/android/apk/servoapp/src/main/java/org/mozilla/servo/MainActivity.java
@@ -20,6 +20,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import android.util.Log;
 
 import org.mozilla.servoview.ServoView;
 import org.mozilla.servoview.Servo;
@@ -160,6 +161,19 @@ public class MainActivity extends Activity implements Servo.Client {
         mBackButton.setEnabled(canGoBack);
         mFwdButton.setEnabled(canGoForward);
         mCanGoBack = canGoBack;
+    }
+
+    @Override
+    public boolean onAllowNavigation(String url) {
+        if (url.startsWith("market://")) {
+            try {
+                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+                return false;
+            } catch (Exception e) {
+                Log.e("onAllowNavigation", e.toString());
+            }
+        }
+        return true;
     }
 
     public void onRedrawing(boolean redrawing) {

--- a/support/android/apk/servoview/src/main/java/org/mozilla/servoview/Servo.java
+++ b/support/android/apk/servoview/src/main/java/org/mozilla/servoview/Servo.java
@@ -128,6 +128,8 @@ public class Servo {
     }
 
     public interface Client {
+        boolean onAllowNavigation(String url);
+
         void onLoadStarted();
 
         void onLoadEnded();
@@ -189,6 +191,10 @@ public class Servo {
 
         public void onAnimatingChanged(boolean animating) {
             mRunCallback.inGLThread(() -> mGfxCb.animationStateChanged(animating));
+        }
+
+        public boolean onAllowNavigation(String url) {
+            return mClient.onAllowNavigation(url);
         }
 
         public void onLoadStarted() {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR (once complete) will support `market://` urls, ie, it will open Playstore instead of displaying `Could not load the requested page: Unexpected scheme`.

---
Currently, I am experiencing the following error
<details>
<summary>ADBLog</summary>

<p>

```
11-02 12:17:18.224 21968-21984/org.mozilla.servo D/simpleservo: reload
11-02 12:17:18.225 21968-21984/org.mozilla.servo I/simpleservo: reload
11-02 12:17:18.225 21968-21984/org.mozilla.servo D/simpleservo: perform_updates
11-02 12:17:18.225 21968-22011/org.mozilla.servo D/simpleservo: constellation got ConstellationMsg::Reload message
11-02 12:17:18.233 21968-22011/org.mozilla.servo D/simpleservo: constellation got ScriptMsg::LoadUrl message from pipeline (1,1)
    wakeup
11-02 12:17:18.236 21968-21984/org.mozilla.servo D/simpleservo: performUpdates
    perform_updates
    on_allow_navigation
11-02 12:17:18.237 21968-22011/org.mozilla.servo D/simpleservo: Loading market://details/?id=org.mozilla.firefox in pipeline (1,1).
    Creating new pipeline (1,2) in browsing context (0,1).
11-02 12:17:18.238 21968-22011/org.mozilla.servo I/simpleservo: ResourceReader::read(rippy.png)
11-02 12:17:18.242 21968-21991/org.mozilla.servo D/simpleservo: thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Error(JavaException, State { next_error: None, backtrace: InternalBacktrace { backtrace: None } })', libcore/result.rs:1009:5
    note: Run with `RUST_BACKTRACE=1` for a backtrace.
11-02 12:17:18.248 21968-22011/org.mozilla.servo D/simpleservo: wakeup
11-02 12:17:18.249 21968-22011/org.mozilla.servo D/simpleservo: wakeup
11-02 12:17:18.272 21968-22011/org.mozilla.servo D/simpleservo: constellation got ScriptMsg::InitiateNavigateRequest message from pipeline (1,2)
11-02 12:17:18.274 21968-22011/org.mozilla.servo D/simpleservo: constellation got ScriptMsg::VisibilityChangeComplete message from pipeline (1,2)
11-02 12:17:18.289 21968-22011/org.mozilla.servo D/simpleservo: constellation got ScriptMsg::SetFinalUrl message from pipeline (1,2)
11-02 12:17:18.294 21968-22011/org.mozilla.servo D/simpleservo: constellation got ScriptMsg::ActivateDocument message from pipeline (1,2)
11-02 12:17:18.295 21968-22011/org.mozilla.servo D/simpleservo: Document ready to activate (1,2)
    Setting browsing context (0,1) to be pipeline (1,2).
    Adding pipeline to existing browsing context.
    Setting activity of (1,1) to be Inactive.
    Setting activity of (1,2) to be FullyActive.
    Closing pipeline PipelineId { namespace_id: PipelineNamespaceId(1), index: PipelineIndex(1) }.
11-02 12:17:18.296 21968-22011/org.mozilla.servo D/simpleservo: wakeup
11-02 12:17:18.299 21968-22044/org.mozilla.servo I/simpleservo: ResourceReader::read(neterror.html)
11-02 12:17:18.350 21968-21973/org.mozilla.servo I/zygote: Do partial code cache collection, code=23KB, data=29KB
11-02 12:17:18.352 21968-21973/org.mozilla.servo I/zygote: After code cache collection, code=23KB, data=29KB
    Increasing code cache capacity to 128KB
11-02 12:17:18.359 21968-22005/org.mozilla.servo D/simpleservo: wakeup
```

</p>
</details>

Also, where can I find Logs from the function I made in MainActivity?


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21992 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22091)
<!-- Reviewable:end -->
