### PR TITLE
Count threads at shutdown, warn if not all finished and optionally block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,6 +3210,7 @@ version = "0.0.1"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -226,6 +226,9 @@ pub struct Opts {
 
     /// Print Progressive Web Metrics to console.
     pub print_pwm: bool,
+
+    /// Only shutdown once all theads are finished.
+    pub clean_shutdown: bool,
 }
 
 fn print_usage(app: &str, opts: &Options) {
@@ -600,6 +603,7 @@ pub fn default_opts() -> Opts {
         certificate_path: None,
         unminify_js: false,
         print_pwm: false,
+        clean_shutdown: false,
     }
 }
 
@@ -751,6 +755,11 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         "config-dir",
         "config directory following xdg spec on linux platform",
         "",
+    );
+    opts.optflag(
+        "",
+        "clean-shutdown",
+        "Do not shutdown until all threads have finished (macos only)",
     );
     opts.optflag("v", "version", "Display servo version information");
     opts.optflag("", "unminify-js", "Unminify Javascript");
@@ -1035,6 +1044,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         certificate_path: opt_match.opt_str("certificate-path"),
         unminify_js: opt_match.opt_present("unminify-js"),
         print_pwm: opt_match.opt_present("print-pwm"),
+        clean_shutdown: opt_match.opt_present("clean-shutdown"),
     };
 
     set_defaults(opts);

--- a/ports/servo/Cargo.toml
+++ b/ports/servo/Cargo.toml
@@ -16,6 +16,9 @@ bench = false
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
 
+[target.'cfg(target_os = "macos")'.build-dependencies]
+cc = "1.0"
+
 [package.metadata.winres]
 FileDescription = "Servo"
 LegalCopyright = "© The Servo Project Developers"

--- a/ports/servo/build.rs
+++ b/ports/servo/build.rs
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#[cfg(target_os = "macos")]
+extern crate cc;
+
 #[cfg(windows)]
 extern crate winres;
 
@@ -12,5 +15,11 @@ fn main() {
         res.set_icon("../../resources/Servo.ico");
         res.set_manifest_file("platform/windows/servo.exe.manifest");
         res.compile().unwrap();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        cc::Build::new()
+            .file("platform/macos/count_threads.c")
+            .compile("count_threads");
     }
 }

--- a/ports/servo/platform/macos/count_threads.c
+++ b/ports/servo/platform/macos/count_threads.c
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <mach/mach.h>
+
+int macos_count_running_threads() {
+  task_t task = current_task();
+  thread_act_array_t threads;
+  mach_msg_type_number_t tcnt;
+  task_threads(task, &threads, &tcnt);
+  return tcnt;
+}


### PR DESCRIPTION
On Desktop, after servo shutdown, the process exits, killing all the still-running threads.
On mobile, the process doesn't necessarily shutdown, and we are left with multiple threads failing to use channels, printing warning and panicking.

In the future, we'd like to do a clean shutdown, as in, shutdown only once all the threads have properly finished.

For now, I'm printing a warning if all the threads are not finished, and also add an option to only exit if all the threads have finished.

This only works on MacOS for now, in C, as I haven't found a Rust/multiplatform way to count running threads.

I recommend trying to run servo with `--clean-shutdown` option. Interesting to see how long it takes for other threads to shutdown, and see which threads start panicking.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #__ (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22092)
<!-- Reviewable:end -->
