### PR TITLE
Unused scroll

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -320,7 +320,6 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             time_profiler_chan: state.time_profiler_chan,
             last_composite_time: 0,
             ready_to_save_state: ReadyState::Unknown,
-            scroll_in_progress: false,
             in_scroll_transaction: None,
             webrender: state.webrender,
             webrender_document: state.webrender_document,

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -32,7 +32,6 @@ use std::fs::{File, create_dir_all};
 use std::io::Write;
 use std::num::NonZeroU32;
 use std::rc::Rc;
-use std::time::Instant;
 use style_traits::{CSSPixel, DevicePixel, PinchZoomFactor};
 use style_traits::cursor::CursorKind;
 use style_traits::viewport::ViewportConstraints;
@@ -165,8 +164,6 @@ pub struct IOCompositor<Window: WindowMethods> {
     /// Used by the logic that determines when it is safe to output an
     /// image for the reftest framework.
     ready_to_save_state: ReadyState,
-
-    in_scroll_transaction: Option<Instant>,
 
     /// The webrender renderer.
     webrender: webrender::Renderer,
@@ -320,7 +317,6 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             time_profiler_chan: state.time_profiler_chan,
             last_composite_time: 0,
             ready_to_save_state: ReadyState::Unknown,
-            in_scroll_transaction: None,
             webrender: state.webrender,
             webrender_document: state.webrender_document,
             webrender_api: state.webrender_api,
@@ -843,7 +839,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         &mut self,
         delta: ScrollLocation,
         cursor: DeviceIntPoint,
-        phase: TouchEventType,
+        phase: TouchEventType
     ) {
         match phase {
             TouchEventType::Move => self.on_scroll_window_event(delta, cursor),
@@ -856,8 +852,11 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         }
     }
 
-    fn on_scroll_window_event(&mut self, scroll_location: ScrollLocation, cursor: DeviceIntPoint) {
-        self.in_scroll_transaction = Some(Instant::now());
+    fn on_scroll_window_event(
+        &mut self,
+        scroll_location: ScrollLocation,
+        cursor: DeviceIntPoint
+    ) {
         self.pending_scroll_zoom_events.push(ScrollZoomEvent {
             magnification: 1.0,
             scroll_location: scroll_location,

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -166,9 +166,6 @@ pub struct IOCompositor<Window: WindowMethods> {
     /// image for the reftest framework.
     ready_to_save_state: ReadyState,
 
-    /// Whether a scroll is in progress; i.e. whether the user's fingers are down.
-    scroll_in_progress: bool,
-
     in_scroll_transaction: Option<Instant>,
 
     /// The webrender renderer.
@@ -852,44 +849,16 @@ impl<Window: WindowMethods> IOCompositor<Window> {
         match phase {
             TouchEventType::Move => self.on_scroll_window_event(delta, cursor),
             TouchEventType::Up | TouchEventType::Cancel => {
-                self.on_scroll_end_window_event(delta, cursor);
+                self.on_scroll_window_event(delta, cursor);
             },
             TouchEventType::Down => {
-                self.on_scroll_start_window_event(delta, cursor);
+                self.on_scroll_window_event(delta, cursor);
             },
         }
     }
 
     fn on_scroll_window_event(&mut self, scroll_location: ScrollLocation, cursor: DeviceIntPoint) {
         self.in_scroll_transaction = Some(Instant::now());
-        self.pending_scroll_zoom_events.push(ScrollZoomEvent {
-            magnification: 1.0,
-            scroll_location: scroll_location,
-            cursor: cursor,
-            event_count: 1,
-        });
-    }
-
-    fn on_scroll_start_window_event(
-        &mut self,
-        scroll_location: ScrollLocation,
-        cursor: DeviceIntPoint,
-    ) {
-        self.scroll_in_progress = true;
-        self.pending_scroll_zoom_events.push(ScrollZoomEvent {
-            magnification: 1.0,
-            scroll_location: scroll_location,
-            cursor: cursor,
-            event_count: 1,
-        });
-    }
-
-    fn on_scroll_end_window_event(
-        &mut self,
-        scroll_location: ScrollLocation,
-        cursor: DeviceIntPoint,
-    ) {
-        self.scroll_in_progress = false;
         self.pending_scroll_zoom_events.push(ScrollZoomEvent {
             magnification: 1.0,
             scroll_location: scroll_location,


### PR DESCRIPTION
Combined on_scroll_window_event with on_scroll_start_window_event and on_scroll_end_window_event

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22075  (github issue number if applicable).

<!-- Either: -->
- [X] There are tests for these changes:
- Ran unit-test, test-tidy with no errors,  and tested scrolling on webpages
- [ ] These changes do not require tests

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22097)
<!-- Reviewable:end -->
