### PR TITLE
Add magicleap builder

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -229,6 +229,17 @@ android-nightly:
   - ./mach upload-nightly maven
   - ./etc/ci/clean_build_artifacts.sh
 
+magicleap:
+ env:
+  MAGICLEAP_SDK: /Users/servo/magicleap/v0.17.0
+ commands:
+  - ./mach clean-nightlies --keep 3 --force
+  - ./mach clean-cargo-cache --keep 3 --force
+  - ./etc/ci/clean_build_artifacts.sh
+  - ./mach build --magicleap --dev
+  - bash ./etc/ci/lockfile_changed.sh
+  - ./etc/ci/clean_build_artifacts.sh
+
 arm32:
  env:
   AR: /usr/bin/arm-linux-gnueabihf-ar


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Add a magicleap builder to `etc/ci/buildbot_steps.yml` to gate releases on building the magicleap library. This doesn't yet check for building the magicleap app, or add a nightly release. That'll be a later PR.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it's adding a build test

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22117)
<!-- Reviewable:end -->
