### PR TITLE
Replace http with https in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Should you wish to work on an issue, please claim it first by commenting on
 the GitHub issue that you want to work on it. This is to prevent duplicated
 efforts from contributors on the same issue.
 
-Head over to [Servo Starters](http://servo.github.io/servo-starters/) to find
+Head over to [Servo Starters](https://starters.servo.org/) to find
 good tasks to start with. If you come across words or jargon that do not make
 sense, please check [the glossary](docs/glossary.md) first. If there's no
 matching entry, please make a pull request to add one with the content `TODO`
@@ -46,7 +46,7 @@ For specific git instructions, see [GitHub workflow 101](https://github.com/serv
 
 ## Conduct
 
-In all Servo-related forums, we follow the [Rust Code of Conduct](http://www.rust-lang.org/conduct.html). For escalation or moderation issues, please contact Jack (jmoffitt@mozilla.com) and Lars (larsberg@mozilla.com) instead of the Rust moderation team.
+In all Servo-related forums, we follow the [Rust Code of Conduct](https://www.rust-lang.org/conduct.html). For escalation or moderation issues, please contact Jack (jmoffitt@mozilla.com) and Lars (larsberg@mozilla.com) instead of the Rust moderation team.
 
 
 ## Communication

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ list of installed components. It is not on by default. Visual Studio 2017 MUST i
 
 You may experience much faster builds on Windows by following these steps. (Related Rust issue: https://github.com/rust-lang/rust/issues/37543)
 
-1. Download the latest version of LLVM (http://releases.llvm.org/).
+1. Download the latest version of LLVM (https://releases.llvm.org/).
 2. Run the installer and choose to add LLVM to the system PATH.
 3. Add the following to your Cargo config (Found at `%USERPROFILE%\.cargo\config`). You may need to change the triple to match your environment.
 
@@ -358,4 +358,4 @@ There are lots of mach commands you can use. You can list them with `./mach
 --help`.
 
 
-The generated documentation can be found on http://doc.servo.org/servo/index.html
+The generated documentation can be found on https://doc.servo.org/servo/index.html

--- a/components/script/docs/JS-Servos-only-GC.md
+++ b/components/script/docs/JS-Servos-only-GC.md
@@ -31,7 +31,7 @@ the underlying low-level object. If the JavaScript garbage collector determines
 that a reflector is no longer reachable, it destroys the reflector and
 decrements the reference count on the underlying object.
 
-[uaf]: http://cwe.mitre.org/data/definitions/416.html
+[uaf]: https://cwe.mitre.org/data/definitions/416.html
 [refcounting]: https://en.wikipedia.org/wiki/Reference_counting
 [gEBI]: https://developer.mozilla.org/en-US/docs/Web/API/document.getElementById
 
@@ -157,7 +157,7 @@ storing a `Node` struct within a `Document` struct. As in C++, the fields of
 `Node` are included in-line with the fields of `Document`, without any pointer
 indirection, and the auto-generated `trace` method will visit them as well.
 
-[document-spec]: http://dom.spec.whatwg.org/#interface-document
+[document-spec]: https://dom.spec.whatwg.org/#interface-document
 
 A `Document` also has an associated `Window`, but this is not an 'is-a'
 relationship. The `Document` just has a pointer to a `Window`, one of many
@@ -168,7 +168,7 @@ garbage collector about. We do this with a
 above). The implementation of `trace` for `Dom<T>` is not auto-generated; this
 is where we actually call the SpiderMonkey trace hooks:
 
-[dom]: http://doc.servo.org/script/dom/bindings/root/struct.Dom.html
+[dom]: https://doc.servo.org/script/dom/bindings/root/struct.Dom.html
 
 ```rust
 pub fn trace_reflector(tracer: *mut JSTracer, description: &str, reflector: &Reflector) {
@@ -218,7 +218,7 @@ often called from JavaScript through [IDL-based bindings][bindings]. In this
 case, the bindings code constructs a [root][gc-root] for any involved DOM
 objects.
 
-[bindings]: http://doc.servo.org/script/dom/bindings/index.html
+[bindings]: https://doc.servo.org/script/dom/bindings/index.html
 [gc-root]: https://en.wikipedia.org/wiki/Tracing_garbage_collection#Reachability_of_an_object
 
 Another common situation is creating a stack-local root manually. For this
@@ -232,10 +232,10 @@ In some cases, we need to use a DOM object longer than the reference we
 received allows us to; the [`DomRoot::from_ref` associated function][from-ref]
 allows creating a new `DomRoot<T>` struct in that case.
 
-[root]: http://doc.servo.org/script/dom/bindings/root/struct.DomRoot.html
+[root]: https://doc.servo.org/script/dom/bindings/root/struct.DomRoot.html
 [raii]: https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization
-[new]: http://doc.servo.org/script/dom/index.html#construction
-[from-ref]: http://doc.servo.org/script/dom/bindings/root/struct.DomRoot.html#method.from_ref
+[new]: https://doc.servo.org/script/dom/index.html#construction
+[from-ref]: https://doc.servo.org/script/dom/bindings/root/struct.DomRoot.html#method.from_ref
 
 We can then obtain a reference from the `DomRoot<T>` through Rust's built-in
 [`Deref` trait][deref], which exposes a method `deref` with the following
@@ -285,7 +285,7 @@ use-after-free and other dangerous bugs.
 You can check out the [`root` module's documentation][root-docs] for more details
 that didn't make it into this document.
 
-[root-docs]: http://doc.servo.org/script/dom/bindings/root/index.html
+[root-docs]: https://doc.servo.org/script/dom/bindings/root/index.html
 
 Custom static analysis
 ======================
@@ -312,7 +312,7 @@ although in this case we set the default severity to 'error'. There is more
 information about lints in section 4.7 of the paper [<cite>Experience Report:
 Developing the Servo Web Browser Engine using Rust</cite>][lints].
 
-[lints]: http://arxiv.org/pdf/1505.07383v1.pdf
+[lints]: https://arxiv.org/pdf/1505.07383v1.pdf
 
 We have already [implemented a plugin][js-lint] which effectively forbids
 `Dom<T>` from appearing on the [stack][stack]. Because lint plugins are part of
@@ -320,7 +320,7 @@ the usual [warnings infrastructure][warnings], we can use the `allow` attribute
 in places where it's okay to use `Dom<T>`, like DOM struct definitions and the
 implementation of `Dom<T>` itself.
 
-[js-lint]: http://doc.servo.org/plugins/lints/unrooted_must_root/struct.UnrootedPass.html
+[js-lint]: https://doc.servo.org/plugins/lints/unrooted_must_root/struct.UnrootedPass.html
 [stack]: https://en.wikipedia.org/wiki/Stack-based_memory_allocation
 [warnings]: https://doc.rust-lang.org/book/compiler-plugins.html#lint-plugins
 
@@ -329,7 +329,7 @@ this adds only a fraction of a second to the compile time for Servo's largest
 subcomponent, as Rust compile times are dominated by [LLVM][llvm]'s back-end
 optimizations and code generation.
 
-[llvm]: http://llvm.org/
+[llvm]: https://llvm.org/
 
 In the end, the plugin won't necessarily catch every mistake. It's hard to
 achieve full [soundness][soundness] with ad-hoc extensions to a type system.
@@ -351,8 +351,8 @@ a traditional reference-counted DOM. The [Blink][blink] team has also performed
 have Servo's luxury of starting from a clean slate and using a cutting-edge
 language.
 
-[blink]: http://www.chromium.org/blink
-[blink-gc]: http://www.chromium.org/blink/blink-gc
+[blink]: https://www.chromium.org/blink
+[blink-gc]: https://www.chromium.org/blink/blink-gc
 
 In the future, we will likely attempt to merge the allocations of DOM objects
 into the allocations of their JavaScript reflectors. This could produce

--- a/components/style/servo/restyle_damage.rs
+++ b/components/style/servo/restyle_damage.rs
@@ -195,7 +195,7 @@ fn compute_damage(old: &ComputedValues, new: &ComputedValues) -> ServoRestyleDam
     let mut damage = ServoRestyleDamage::empty();
 
     // This should check every CSS property, as enumerated in the fields of
-    // http://doc.servo.org/style/properties/struct.ComputedValues.html
+    // https://doc.servo.org/style/properties/struct.ComputedValues.html
 
     // This uses short-circuiting boolean OR for its side effects and ignores the result.
     let _ = restyle_damage_rebuild_and_reflow!(

--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -26,13 +26,13 @@ You can use and build a release build and a debug build in parallel.
 The servo binary is located in `target/debug/servo` (or `target/release/servo`). You can directly run this binary, but we recommend using `./mach` instead:
 
 ``` shell
-./mach run -d -- http://github.com
+./mach run -d -- https://github.com
 ```
 
 … is equivalent to:
 
 ``` shell
-./target/debug/servo http://github.com
+./target/debug/servo https://github.com
 ```
 
 If you build with `-d`, run with `-d`. If you build with `-r`, run with `-r`.
@@ -61,9 +61,9 @@ This guide only covers the most important options. Be sure to look at all the av
 Even if you have never seen any Rust code, it's not too hard to read Servo's code. But there are some basics things one must know:
 
 - [Match](https://doc.rust-lang.org/book/first-edition/match.html) and [Patterns](https://doc.rust-lang.org/book/first-edition/patterns.html)
-- [Options](http://rustbyexample.com/std/option.html)
-- [Expression](http://rustbyexample.com/expression.html)
-- [Traits](http://rustbyexample.com/trait.html)
+- [Options](https://rustbyexample.com/std/option.html)
+- [Expression](https://rustbyexample.com/expression.html)
+- [Traits](https://rustbyexample.com/trait.html)
 - That doesn't sound important, but be sure to understand how `println!()` works, especially the [formatting traits](https://doc.rust-lang.org/std/fmt/#formatting-traits)
 
 This won't be enough to do any serious work at first, but if you want to navigate the code and fix basic bugs, that should do it. It's a good starting point, and as you dig into Servo source code, you'll learn more.
@@ -71,7 +71,7 @@ This won't be enough to do any serious work at first, but if you want to navigat
 For more exhaustive documentation:
 
 - [doc.rust-lang.org](https://doc.rust-lang.org)
-- [rust by example](http://rustbyexample.com)
+- [rust by example](https://rustbyexample.com)
 
 ## Cargo and Crates
 
@@ -96,13 +96,13 @@ source = "git+https://github.com/servo/rust-stb-image#f4c5380cd586bfe16326e05e25
 
 This file should not be edited by hand. In a normal Rust project, to update the git revision, you would use `cargo update -p stb_image`, but in Servo, use `./mach cargo-update -p stb_image`. Other arguments to cargo are also understood, e.g. use --precise '0.2.3' to update that crate to version 0.2.3.
 
-See [Cargo's documentation about Cargo.toml and Cargo.lock files](http://doc.crates.io/guide.html#cargotoml-vs-cargolock).
+See [Cargo's documentation about Cargo.toml and Cargo.lock files](https://doc.crates.io/guide.html#cargotoml-vs-cargolock).
 
 ## Working on a Crate
 
 As explained above, Servo depends on a lot of libraries, which makes it very modular. While working on a bug in Servo, you'll often end up in one of its dependencies. You will then want to compile your own version of the dependency (and maybe compiling against the HEAD of the library will fix the issue!).
 
-For example, I'm trying to bring some cocoa events to Servo. The Servo window on Desktop is constructed with a library named [Glutin](https://github.com/tomaka/glutin). Glutin itself depends on a cocoa library named [cocoa-rs](http://github.com/servo/cocoa-rs). When building Servo, magically, all these dependencies are downloaded and built for you. But because I want to work on this cocoa event feature, I want Servo to use my own version of *glutin* and *cocoa-rs*.
+For example, I'm trying to bring some cocoa events to Servo. The Servo window on Desktop is constructed with a library named [Glutin](https://github.com/tomaka/glutin). Glutin itself depends on a cocoa library named [cocoa-rs](https://github.com/servo/cocoa-rs). When building Servo, magically, all these dependencies are downloaded and built for you. But because I want to work on this cocoa event feature, I want Servo to use my own version of *glutin* and *cocoa-rs*.
 
 This is how my projects are laid out:
 
@@ -132,7 +132,7 @@ If the output is in the format `https://github.com/rust-lang/crates.io-index#moz
 
 Both will tell any cargo project to not use the online version of the dependency, but your local clone.
 
-For more details about overriding dependencies, see [Cargo's documentation](http://doc.crates.io/specifying-dependencies.html#overriding-dependencies).
+For more details about overriding dependencies, see [Cargo's documentation](https://doc.crates.io/specifying-dependencies.html#overriding-dependencies).
 
 ## Debugging
 
@@ -171,7 +171,7 @@ Using `RUST_LOG="debug"` is usually the very first thing you might want to do if
 RUST_LOG="debug" ./mach run -d -- -i -y 1 -t 1  /tmp/a.html 2>&1 | ts -s "%.S: " | tee /tmp/log.txt
 ```
 
-You can filter by crate or module, for example `RUST_LOG="layout::inline=debug" ./mach run …`. Check the [env_logger](http://doc.rust-lang.org/log/env_logger/index.html) documentation for more details.
+You can filter by crate or module, for example `RUST_LOG="layout::inline=debug" ./mach run …`. Check the [env_logger](https://doc.rust-lang.org/log/env_logger/index.html) documentation for more details.
 
 Use `RUST_BACKTRACE=1` to dump the backtrace when Servo panics.
 
@@ -214,7 +214,7 @@ And to search for a function's full name/regex:
 (gdb) info functions <name> #gdb
 ```
 
-See this [lldb tutorial](http://lldb.llvm.org/tutorial.html) and this [gdb tutorial](http://www.unknownroad.com/rtfm/gdbtut/gdbtoc.html).
+See this [lldb tutorial](https://lldb.llvm.org/tutorial.html) and this [gdb tutorial](http://www.unknownroad.com/rtfm/gdbtut/gdbtoc.html).
 
 To inspect variables and you are new with lldb, we recommend using the `gui` mode (use left/right to expand variables):
 
@@ -276,11 +276,11 @@ See the [debugging guide](./debugging.md) to get started in how to debug Servo.
 ## Documentation:
 
 - Servo's directory structure: [ORGANIZATION.md](./ORGANIZATION.md)
-- http://doc.servo.org/servo/index.html
+- https://doc.servo.org/servo/index.html
 - https://github.com/servo/servo/wiki
-- http://rustbyexample.com
+- https://rustbyexample.com
 - https://doc.rust-lang.org
-- Cargo & crates: http://doc.crates.io/guide.html
+- Cargo & crates: https://doc.crates.io/guide.html
 - mach help: `./mach --help`
 - servo options: `./mach run -- --help`
 - servo debug options: `./mach run -- --debug help`

--- a/docs/components/style.md
+++ b/docs/components/style.md
@@ -134,25 +134,25 @@ pseudo-elements**.
 Feel free to ping @SimonSapin, @mbrubeck or @emilio on irc, and please mention
 that you didn't find it here so it can be added :)
 
-[style-doc]: http://doc.servo.org/style/index.html
+[style-doc]: https://doc.servo.org/style/index.html
 [wiki-styling-overview]: https://github.com/servo/servo/wiki/Styling-overview
 [stylo]: https://public.etherpad-mozilla.org/p/stylo
-[selector-impl]: http://doc.servo.org/selectors/parser/trait.SelectorImpl.html
-[selector-impl-ext]: http://doc.servo.org/style/selector_parser/trait.SelectorImplExt.html
-[servo-selector-impl]: http://doc.servo.org/style/servo/selector_parser/struct.SelectorImpl.html
+[selector-impl]: https://doc.servo.org/selectors/parser/trait.SelectorImpl.html
+[selector-impl-ext]: https://doc.servo.org/style/selector_parser/trait.SelectorImplExt.html
+[servo-selector-impl]: https://doc.servo.org/style/servo/selector_parser/struct.SelectorImpl.html
 [tree-structural-pseudo-classes]: https://www.w3.org/TR/selectors4/#structural-pseudos
-[style-dom-traits]: http://doc.servo.org/style/dom/index.html
-[layout-wrapper]: http://doc.servo.org/layout/wrapper/index.html
-[pseudo-cascade-type]: http://doc.servo.org/style/selector_parser/enum.PseudoElementCascadeType.html
-[servo-pseudo-elements]: http://doc.servo.org/style/selector_parser/enum.PseudoElement.html
+[style-dom-traits]: https://doc.servo.org/style/dom/index.html
+[layout-wrapper]: https://doc.servo.org/layout/wrapper/index.html
+[pseudo-cascade-type]: https://doc.servo.org/style/selector_parser/enum.PseudoElementCascadeType.html
+[servo-pseudo-elements]: https://doc.servo.org/style/selector_parser/enum.PseudoElement.html
 [mdn-pseudo-before]: https://developer.mozilla.org/en/docs/Web/CSS/::before
 [mdn-pseudo-after]: https://developer.mozilla.org/en/docs/Web/CSS/::after
 [mdn-pseudo-selection]: https://developer.mozilla.org/en/docs/Web/CSS/::selection
-[stylist]: http://doc.servo.org/style/stylist/struct.Stylist.html
-[selectors-selectormap]: http://doc.servo.org/style/selector_map/struct.SelectorMap.html
-[selectors-rule]: http://doc.servo.org/style/stylist/struct.Rule.html
-[per-pseudo-selectormap]: http://doc.servo.org/style/selector_parser/struct.PerPseudoElementMap.html
-[per-origin-selectormap]: http://doc.servo.org/style/stylist/struct.PerOriginSelectorMap.html
+[stylist]: https://doc.servo.org/style/stylist/struct.Stylist.html
+[selectors-selectormap]: https://doc.servo.org/style/selector_map/struct.SelectorMap.html
+[selectors-rule]: https://doc.servo.org/style/stylist/struct.Rule.html
+[per-pseudo-selectormap]: https://doc.servo.org/style/selector_parser/struct.PerPseudoElementMap.html
+[per-origin-selectormap]: https://doc.servo.org/style/stylist/struct.PerOriginSelectorMap.html
 [docs-pipeline]: https://github.com/servo/servo/blob/master/docs/glossary.md#pipeline
-[properties-module]: http://doc.servo.org/style/properties/index.html
-[properties-cascade-fn]: http://doc.servo.org/style/properties/fn.cascade.html
+[properties-module]: https://doc.servo.org/style/properties/index.html
+[properties-cascade-fn]: https://doc.servo.org/style/properties/fn.cascade.html

--- a/etc/doc.servo.org/README.md
+++ b/etc/doc.servo.org/README.md
@@ -1,4 +1,4 @@
-[doc.servo.org](http://doc.servo.org)
+[doc.servo.org](https://doc.servo.org)
 =====================================
 
 The Servo documentation.


### PR DESCRIPTION
This PR only changes markdown files and one Rust comment.
Background: [bug 1482947](https://bugzilla.mozilla.org/show_bug.cgi?id=1482947) enabled HSTS for servo.org and its subdomains.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22120)
<!-- Reviewable:end -->
