### PR TITLE
Consistent servo-deps download URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - sudo add-apt-repository 'deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.9 main' -y
         - sudo apt-get update -q
         - sudo apt-get install clang-3.9 llvm-3.9 llvm-3.9-runtime -y
-        - curl -L http://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-x86_64-linux-gnu.tar.gz | tar xz
+        - curl -L https://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-x86_64-linux-gnu.tar.gz | tar xz
         - sed -i "s;prefix=/root/gstreamer;prefix=$PWD/gstreamer;g" $PWD/gstreamer/lib/x86_64-linux-gnu/pkgconfig/*.pc
         - export PKG_CONFIG_PATH=$PWD/gstreamer/lib/x86_64-linux-gnu/pkgconfig
         - export GST_PLUGIN_SYSTEM_PATH=$PWD/gstreamer/lib/x86_64-linux-gnu/gstreamer-1.0

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -437,7 +437,7 @@ class MachCommands(CommandBase):
                 # Follow these instructions to build and deploy new binaries
                 # https://github.com/servo/libgstreamer_android_gen#build
                 print("Downloading GStreamer dependencies")
-                gst_url = "http://servo-deps.s3.amazonaws.com/gstreamer/%s" % gst_lib_zip
+                gst_url = "https://servo-deps.s3.amazonaws.com/gstreamer/%s" % gst_lib_zip
                 print(gst_url)
                 urllib.urlretrieve(gst_url, gst_lib_zip)
                 zip_ref = zipfile.ZipFile(gst_lib_zip, "r")

--- a/support/android/openssl.makefile
+++ b/support/android/openssl.makefile
@@ -2,7 +2,7 @@
 all: openssl
 	@:  # No-op to silence the "make: Nothing to be done for 'all'." message.
 
-# From http://wiki.openssl.org/index.php/Android
+# From https://wiki.openssl.org/index.php/Android
 .PHONY: openssl
 openssl: openssl-${OPENSSL_VERSION}/libssl.so
 
@@ -10,5 +10,5 @@ openssl-${OPENSSL_VERSION}/libssl.so: openssl-${OPENSSL_VERSION}/Configure
 	./openssl.sh ${ANDROID_NDK} ${OPENSSL_VERSION}
 
 openssl-${OPENSSL_VERSION}/Configure:
-	URL=https://s3.amazonaws.com/servo-deps/android-deps/openssl-${OPENSSL_VERSION}.tar.gz; \
+	URL=https://servo-deps.s3.amazonaws.com/android-deps/openssl-${OPENSSL_VERSION}.tar.gz; \
 	curl $$URL | tar xzf -

--- a/support/linux/gstreamer/gstreamer.sh
+++ b/support/linux/gstreamer/gstreamer.sh
@@ -6,7 +6,7 @@
 
 set -o errexit
 
-wget http://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-x86_64-linux-gnu.tar.gz -O gstreamer.tar.gz
+wget https://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-x86_64-linux-gnu.tar.gz -O gstreamer.tar.gz
 tar -zxf gstreamer.tar.gz
 rm gstreamer.tar.gz
 sed -i "s;prefix=/root/gstreamer;prefix=${PWD}/gstreamer;g" ${PWD}/gstreamer/lib/x86_64-linux-gnu/pkgconfig/*.pc

--- a/support/magicleap/openssl.sh
+++ b/support/magicleap/openssl.sh
@@ -25,7 +25,7 @@ fi
 
 echo "Building ${OPENSSL_DIR}/lib/libssl.so"
 
-S3_BUCKET="https://s3.amazonaws.com/servo-deps/android-deps"
+S3_BUCKET="https://servo-deps.s3.amazonaws.com/android-deps"
 S3_URL="${S3_BUCKET}/openssl-${OPENSSL_VERSION}.tar.gz"
 
 if [[ ! -d "${OPENSSL_DIR}/src/openssl-${OPENSSL_VERSION}" ]]; then


### PR DESCRIPTION
This PR ensures consistent https:// downloads for Servo dependencies.

It should be fine because
* https://servo-deps.s3.amazonaws.com is already used for MSVC deps:
https://github.com/servo/servo/blob/e217672c1ab665a68aca36bb5086956254604e75/python/servo/bootstrap.py#L286

* .travis.yml already downloads from [another https url](https://github.com/servo/servo/blob/e217672c1ab665a68aca36bb5086956254604e75/.travis.yml#L28) (https://sh.rustup.rs).
* In #22088 I saw the gstreamer dependency being download via https.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22122)
<!-- Reviewable:end -->
