### PR TITLE
Ensuring https for Windows Taskcluster

### DIFF
--- a/etc/taskcluster/windows/bootstrap.ps1
+++ b/etc/taskcluster/windows/bootstrap.ps1
@@ -10,13 +10,6 @@
     [EnvironmentVariableTarget]::Machine)
 
 
-# Optional
-$client.DownloadFile(
-    "https://download.tuxfamily.org/dvorak/windows/bepo.exe",
-    "C:\bepo.exe"
-)
-
-
 # use TLS 1.2 (see bug 1443595)
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
@@ -34,6 +27,12 @@ function Expand-ZIPFile($file, $destination, $url)
         $shell.Namespace($destination).copyhere($item)
     }
 }
+
+# Optional
+$client.DownloadFile(
+    "https://download.tuxfamily.org/dvorak/windows/bepo.exe",
+    "C:\bepo.exe"
+)
 
 md C:\git
 Expand-ZIPFile -File "C:\git.zip" -Destination "C:\git" -Url `

--- a/etc/taskcluster/windows/bootstrap.ps1
+++ b/etc/taskcluster/windows/bootstrap.ps1
@@ -12,7 +12,7 @@
 
 # Optional
 $client.DownloadFile(
-    "http://download.tuxfamily.org/dvorak/windows/bepo.exe",
+    "https://download.tuxfamily.org/dvorak/windows/bepo.exe",
     "C:\bepo.exe"
 )
 

--- a/etc/taskcluster/windows/first-boot.ps1
+++ b/etc/taskcluster/windows/first-boot.ps1
@@ -40,7 +40,7 @@ $client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/dow
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download" +
     "/v1.1.0/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")
 Expand-ZIPFile -File "C:\nssm-2.24.zip" -Destination "C:\" `
-    -Url "http://www.nssm.cc/release/nssm-2.24.zip"
+    -Url "https://www.nssm.cc/release/nssm-2.24.zip"
 Start-Process C:\generic-worker\generic-worker.exe -ArgumentList `
     "new-openpgp-keypair --file C:\generic-worker\generic-worker-gpg-signing-key.key" `
     -Wait -NoNewWindow -PassThru `


### PR DESCRIPTION
This should be a safe change as there're already some https downloads on Windows Taskcluster. Examples:
* with `$client.DownloadFile()`: https://github.com/servo/servo/blob/78327fcba5a0bcabc8411327ae1aa175bbaf5f49/etc/taskcluster/windows/bootstrap.ps1#L43
* with `Expand-ZIPFile`: https://github.com/servo/servo/blob/e217672c1ab665a68aca36bb5086956254604e75/etc/taskcluster/windows/bootstrap.ps1#L40

Modern TLS is supported:
https://www.hardenize.com/report/download.tuxfamily.org#www_tls
https://www.hardenize.com/report/nssm.cc#www_tls

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22123)
<!-- Reviewable:end -->
