### PR TITLE
Download buildbot metadata via https

### DIFF
--- a/etc/ci/performance/download_buildbot_timings.py
+++ b/etc/ci/performance/download_buildbot_timings.py
@@ -24,14 +24,14 @@ def main():
     )
     parser.add_argument("--index-url",
                         type=str,
-                        default='http://build.servo.org/json',
+                        default='https://build.servo.org/json',
                         help="the URL to get the JSON index data index from. "
-                        "Default: http://build.servo.org/json")
+                        "Default: https://build.servo.org/json")
     parser.add_argument("--build-url",
                         type=str,
-                        default='http://build.servo.org/json/builders/{}/builds/{}',
+                        default='https://build.servo.org/json/builders/{}/builds/{}',
                         help="the URL to get the JSON build data from. "
-                        "Default: http://build.servo.org/json/builders/{}/builds/{}")
+                        "Default: https://build.servo.org/json/builders/{}/builds/{}")
     parser.add_argument("--cache-dir",
                         type=str,
                         default=default_cache_dir,


### PR DESCRIPTION
https://build.servo.org/json works.

https://www.hardenize.com/report/build.servo.org#www_tls
Likely ECDHE-RSA-AES128-GCM-SHA256 will be used by any modern client to download the file.

-----
https://docs.python.org/2/library/urllib.html
> For Python versions earlier than 2.7.9, urllib does not attempt to validate the server certificates of HTTPS URIs. Use at your own risk!

python3 is used to run the script: https://github.com/servo/servo/blob/535ea9674f1c80cb911a10c9333194b6c0f919ad/etc/ci/buildbot_steps.yml#L170

-----
https://docs.python.org/3.1/howto/urllib2.html
> Currently urllib.request does not support fetching of https locations through a proxy. However, this can be enabled by extending urllib.request as shown in the recipe [7].

I don't think this will be downloaded through a proxy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22125)
<!-- Reviewable:end -->
