### PR TITLE
Connect to intermittent trackers via https

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -491,7 +491,7 @@ class MachCommands(CommandBase):
         for failure in failures:
             if tracker_api:
                 if tracker_api == 'default':
-                    tracker_api = "http://build.servo.org/intermittent-tracker"
+                    tracker_api = "https://build.servo.org/intermittent-tracker"
                 elif tracker_api.endswith('/'):
                     tracker_api = tracker_api[0:-1]
 
@@ -519,7 +519,7 @@ class MachCommands(CommandBase):
 
         if reporter_api:
             if reporter_api == 'default':
-                reporter_api = "http://build.servo.org/intermittent-failure-tracker"
+                reporter_api = "https://build.servo.org/intermittent-failure-tracker"
             if reporter_api.endswith('/'):
                 reporter_api = reporter_api[0:-1]
             reported = set()


### PR DESCRIPTION
This is the last part of #22088.
Each https url returns the same with curl as its previous http variant, so it should be a safe change.
And https has already been used at this place in the past: https://github.com/servo/servo/commit/38474f8671d17dfce992ebf6b6dda905a5de5b1b

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22127)
<!-- Reviewable:end -->
