### PR TITLE
Correct select all

### DIFF
--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -583,6 +583,7 @@ impl<T: ClipboardProvider> TextInput<T> {
         let last_line = self.lines.len() - 1;
         self.edit_point.line = last_line;
         self.edit_point.index = self.lines[last_line].len();
+        self.selection_direction = SelectionDirection::Forward;
         self.assert_ok_selection();
     }
 

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -699,3 +699,13 @@ fn test_selection_bounds() {
     assert_eq!(TextPoint { line: 0, index: 0 }, textinput.selection_start());
     assert_eq!(TextPoint { line: 1, index: 0 }, textinput.selection_end());
 }
+
+#[test]
+fn test_select_all() {
+    let mut textinput = text_input(Lines::Single, "abc");
+    textinput.set_selection_range(2, 3, SelectionDirection::Backward);
+    textinput.select_all();
+    assert_eq!(textinput.selection_direction(), SelectionDirection::Forward);
+    assert_eq!(TextPoint { line: 0, index: 0 }, textinput.selection_start());
+    assert_eq!(TextPoint { line: 0, index: 3 }, textinput.selection_end());
+}


### PR DESCRIPTION
Fixes assertion failure.
Set selection direction forward on select all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22136)
<!-- Reviewable:end -->
