### PR TITLE
Use GradientBuilder::into_stops

### DIFF
--- a/components/layout/display_list/gradient.rs
+++ b/components/layout/display_list/gradient.rs
@@ -283,7 +283,7 @@ pub fn linear(
             (center + delta).to_layout(),
             extend_mode(repeating),
         ),
-        builder.stops().to_vec(),
+        builder.into_stops(),
     )
 }
 
@@ -322,6 +322,6 @@ pub fn radial(
             radius.to_layout(),
             extend_mode(repeating),
         ),
-        builder.stops().to_vec(),
+        builder.into_stops(),
     )
 }


### PR DESCRIPTION
Avoid cloning gradient stops.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22164)
<!-- Reviewable:end -->
