### PR TITLE
Enable old glyph assertion

### DIFF
--- a/components/gfx/text/glyph.rs
+++ b/components/gfx/text/glyph.rs
@@ -223,16 +223,7 @@ impl<'a> DetailedGlyphStore {
             entry_offset, glyphs
         );
 
-        // TODO: don't actually assert this until asserts are compiled
-        // in/out based on severity, debug/release, etc. This assertion
-        // would wreck the complexity of the lookup.
-        //
-        // See Rust Issue #3647, #2228, #3627 for related information.
-        //
-        // do self.detail_lookup.borrow |arr| {
-        //     assert !arr.contains(entry)
-        // }
-
+        debug_assert!(!self.detail_lookup.contains(&entry));
         self.detail_lookup.push(entry);
         self.detail_buffer.extend_from_slice(glyphs);
         self.lookup_is_sorted = false;


### PR DESCRIPTION
The assertion had a note that it should be enabled
when something like debug_assert is available.

This must have been disabled since before Rust 1.0 as it uses invalid syntax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22165)
<!-- Reviewable:end -->
