### PR TITLE
Add gstreamer and gstreamer-vaapi to Arch Linux dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ sudo zypper install libX11-devel libexpat-devel libbz2-devel Mesa-libEGL-devel M
 
 ``` sh
 sudo pacman -S --needed base-devel git python2 python2-virtualenv python2-pip mesa cmake bzip2 libxmu glu \
-    pkg-config ttf-fira-sans harfbuzz ccache clang autoconf2.13
+    pkg-config ttf-fira-sans harfbuzz ccache clang autoconf2.13 gstreamer gstreamer-vaapi
 ```
 #### On Gentoo Linux
 


### PR DESCRIPTION
Running `./mach build --dev` on Arch Linux fails with error messages about missing gstreamer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22166)
<!-- Reviewable:end -->
