### PR TITLE
Fix PromiseRejectionEvent constructor when promise argument is None

### DIFF
--- a/components/script/dom/promiserejectionevent.rs
+++ b/components/script/dom/promiserejectionevent.rs
@@ -5,7 +5,7 @@
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use crate::dom::bindings::codegen::Bindings::PromiseRejectionEventBinding;
 use crate::dom::bindings::codegen::Bindings::PromiseRejectionEventBinding::PromiseRejectionEventMethods;
-use crate::dom::bindings::error::Fallible;
+use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::DomRoot;
@@ -73,7 +73,11 @@ impl PromiseRejectionEvent {
         let reason = init.reason.handle();
         let promise = match init.promise.as_ref() {
             Some(promise) => promise.clone(),
-            None => Promise::new(global),
+            None => {
+                return Err(Error::Type(
+                    "required member promise is undefined.".to_string(),
+                ))
+            },
         };
         let bubbles = EventBubbles::from(init.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.cancelable);

--- a/tests/wpt/metadata/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-event-constructor.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-event-constructor.html.ini
@@ -1,5 +1,0 @@
-[promise-rejection-event-constructor.html]
-  type: testharness
-  [This tests the constructor for the PromiseRejectionEvent DOM class.]
-    expected: FAIL
-


### PR DESCRIPTION
Due to lack of `required` of the `promise` argument in webidl, we need to handle this so that it can be correct behavior. And then the constructor test will be passed!

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22170)
<!-- Reviewable:end -->
