### PR TITLE
Update webidl of ServiceWorkerRegistration

### DIFF
--- a/components/script/dom/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworkerregistration.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::codegen::Bindings::ServiceWorkerBinding::ServiceWorkerState;
+use crate::dom::bindings::codegen::Bindings::ServiceWorkerRegistrationBinding::ServiceWorkerUpdateViaCache;
 use crate::dom::bindings::codegen::Bindings::ServiceWorkerRegistrationBinding::{
     ServiceWorkerRegistrationMethods, Wrap,
 };
@@ -25,6 +26,7 @@ pub struct ServiceWorkerRegistration {
     installing: Option<Dom<ServiceWorker>>,
     waiting: Option<Dom<ServiceWorker>>,
     scope: ServoUrl,
+    update_via_cache: ServiceWorkerUpdateViaCache,
     uninstalling: Cell<bool>,
 }
 
@@ -36,9 +38,11 @@ impl ServiceWorkerRegistration {
             installing: None,
             waiting: None,
             scope: scope,
+            update_via_cache: ServiceWorkerUpdateViaCache::Imports,
             uninstalling: Cell::new(false),
         }
     }
+
     #[allow(unrooted_must_root)]
     pub fn new(
         global: &GlobalScope,
@@ -137,5 +141,10 @@ impl ServiceWorkerRegistrationMethods for ServiceWorkerRegistration {
     // https://w3c.github.io/ServiceWorker/#service-worker-registration-scope-attribute
     fn Scope(&self) -> USVString {
         USVString(self.scope.as_str().to_owned())
+    }
+
+    // https://w3c.github.io/ServiceWorker/#service-worker-registration-updateviacache
+    fn UpdateViaCache(&self) -> ServiceWorkerUpdateViaCache {
+        self.update_via_cache
     }
 }

--- a/components/script/dom/webidls/ServiceWorkerRegistration.webidl
+++ b/components/script/dom/webidls/ServiceWorkerRegistration.webidl
@@ -2,18 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// https://w3c.github.io/ServiceWorker/#service-worker-registration-obj
-[Pref="dom.serviceworker.enabled", Exposed=(Window,Worker)]
+// https://w3c.github.io/ServiceWorker/#serviceworkerregistration-interface
+[Pref="dom.serviceworker.enabled", SecureContext, Exposed=(Window,Worker)]
 interface ServiceWorkerRegistration : EventTarget {
-  [Unforgeable] readonly attribute ServiceWorker? installing;
-  [Unforgeable] readonly attribute ServiceWorker? waiting;
-  [Unforgeable] readonly attribute ServiceWorker? active;
+  readonly attribute ServiceWorker? installing;
+  readonly attribute ServiceWorker? waiting;
+  readonly attribute ServiceWorker? active;
+  // [SameObject] readonly attribute NavigationPreloadManager navigationPreload;
 
   readonly attribute USVString scope;
+  readonly attribute ServiceWorkerUpdateViaCache updateViaCache;
 
   // [NewObject] Promise<void> update();
   // [NewObject] Promise<boolean> unregister();
 
   // event
   // attribute EventHandler onupdatefound;
+};
+
+enum ServiceWorkerUpdateViaCache {
+  "imports",
+  "all",
+  "none"
 };


### PR DESCRIPTION
I'll start to work on #19302 and I'd like to update these sw related webidl one by one.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes is part of #19302 
- [x] These changes do not require tests because it just updates the webidl for `ServiceWorkerRegistration`; related tests should be updated when we start to implement its functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22171)
<!-- Reviewable:end -->
