### PR TITLE
Fix wrong spec link in align specified value

### DIFF
--- a/components/style/values/specified/align.rs
+++ b/components/style/values/specified/align.rs
@@ -287,7 +287,7 @@ impl From<AlignContent> for u16 {
 
 /// Value for the `justify-content` property.
 ///
-/// <https://drafts.csswg.org/css-align/#propdef-align-content>
+/// <https://drafts.csswg.org/css-align/#propdef-justify-content>
 #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq, ToComputedValue, ToCss)]
 pub struct JustifyContent(pub ContentDistribution);
 
@@ -461,7 +461,7 @@ impl From<JustifySelf> for u8 {
 
 /// Value of the `align-items` property
 ///
-/// <https://drafts.csswg.org/css-align/#self-alignment>
+/// <https://drafts.csswg.org/css-align/#propdef-align-items>
 #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq, ToComputedValue, ToCss)]
 pub struct AlignItems(pub AlignFlags);
 


### PR DESCRIPTION

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it just fixes wrong spec link.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22172)
<!-- Reviewable:end -->
