### PR TITLE
Update webidl of ServiceWorkerGlobalScope

### DIFF
--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -436,6 +436,9 @@ unsafe extern "C" fn interrupt_callback(cx: *mut JSContext) -> bool {
 }
 
 impl ServiceWorkerGlobalScopeMethods for ServiceWorkerGlobalScope {
-    // https://w3c.github.io/ServiceWorker/#service-worker-global-scope-onmessage-attribute
+    // https://w3c.github.io/ServiceWorker/#dom-serviceworkerglobalscope-onmessage
     event_handler!(message, GetOnmessage, SetOnmessage);
+
+    // https://w3c.github.io/ServiceWorker/#dom-serviceworkerglobalscope-onmessageerror
+    event_handler!(messageerror, GetOnmessageerror, SetOnmessageerror);
 }

--- a/components/script/dom/webidls/ServiceWorkerGlobalScope.webidl
+++ b/components/script/dom/webidls/ServiceWorkerGlobalScope.webidl
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// https://w3c.github.io/ServiceWorker/#service-worker-global-scope
+// https://w3c.github.io/ServiceWorker/#serviceworkerglobalscope
 
 [Global=(Worker,ServiceWorker), Exposed=ServiceWorker,
  Pref="dom.serviceworker.enabled"]
@@ -17,8 +17,8 @@ interface ServiceWorkerGlobalScope : WorkerGlobalScope {
   //attribute EventHandler oninstall;
   //attribute EventHandler onactivate;
   //attribute EventHandler onfetch;
-  //attribute EventHandler onforeignfetch;
 
   // event
   attribute EventHandler onmessage; // event.source of the message events is Client object
+  attribute EventHandler onmessageerror;
 };


### PR DESCRIPTION
Part of #19302.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes are part of #19302  (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they just update the webidl for `ServiceWorkerGlobalScope`; related tests should be updated when we start to implement its functions.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22191)
<!-- Reviewable:end -->
