### PR TITLE
Remove android emulator tests from buildbot CI.

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -207,8 +207,6 @@ android-x86:
   - ./etc/ci/clean_build_artifacts.sh
   - ./mach bootstrap-android --accept-all-licences --build --emulator-x86
   - env --unset ANDROID_NDK --unset ANDROID_SDK ./mach build --target i686-linux-android --release
-  - env --unset ANDROID_NDK --unset ANDROID_SDK ./mach test-android-startup --release
-  - env --unset ANDROID_NDK --unset ANDROID_SDK ./mach test-wpt-android --release /_mozilla/mozilla/DOMParser.html /_mozilla/mozilla/webgl/context_creation_error.html
   - bash ./etc/ci/lockfile_changed.sh
   - ./etc/ci/clean_build_artifacts.sh
 

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -13,12 +13,12 @@ def main(task_for, mock=False):
         if CONFIG.git_ref in ["refs/heads/auto", "refs/heads/try", "refs/heads/try-taskcluster"]:
             linux_tidy_unit()
             android_arm32()
-            #android_x86()
             windows_dev()
             if mock:
                 windows_release()
                 linux_wpt()
                 linux_build_task("Indexed by task definition").find_or_create()
+                android_x86()
 
     # https://tools.taskcluster.net/hooks/project-servo/daily
     elif task_for == "daily":

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -13,7 +13,7 @@ def main(task_for, mock=False):
         if CONFIG.git_ref in ["refs/heads/auto", "refs/heads/try", "refs/heads/try-taskcluster"]:
             linux_tidy_unit()
             android_arm32()
-            android_x86()
+            #android_x86()
             windows_dev()
             if mock:
                 windows_release()


### PR DESCRIPTION
This works around #22187 on CI, since I have not been able to figure out what changed yet. I can reproduce the problem locally, so I can keep poking at it without holding up all the other work going on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22201)
<!-- Reviewable:end -->
