### PR TITLE
Add GetShaderPrecisionFormat argument validation

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -2588,6 +2588,14 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         shader_type: u32,
         precision_type: u32,
     ) -> Option<DomRoot<WebGLShaderPrecisionFormat>> {
+        match shader_type {
+            constants::FRAGMENT_SHADER | constants::VERTEX_SHADER => (),
+            _ => {
+                self.webgl_error(InvalidEnum);
+                return None;
+            },
+        }
+
         match precision_type {
             constants::LOW_FLOAT |
             constants::MEDIUM_FLOAT |


### PR DESCRIPTION
This patch adds a check on the shader_type argument. If it is not one either
FRAGMENT_SHADER or VERTEX_SHADER, we return INVALID_ENUM.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix  #22080 
<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because @jdm wants to wait until the PR is open to test.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22214)
<!-- Reviewable:end -->
