### PR TITLE
Remove duplicate code

### DIFF
--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -318,7 +318,6 @@ impl Request {
             Referrer::NoReferrer
         };
         req.referrer_policy = init.referrer_policy;
-        req.pipeline_id = init.pipeline_id;
         req.redirect_mode = init.redirect_mode;
         let mut url_list = init.url_list;
         if url_list.is_empty() {


### PR DESCRIPTION
`req.pipeline_id` is already set with `init.pipeline_id` during initialization.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22217)
<!-- Reviewable:end -->
