### PR TITLE
Ensure async scene is built before capturing reftest output.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1208,6 +1208,9 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             if let Err(result) = self.is_ready_to_paint_image_output() {
                 return Err(UnableToComposite::NotReadyToPaintImage(result));
             }
+
+            // Ensure that all async scene operations are complete.
+            self.webrender_api.flush_scene_builder();
         }
 
         let rt_info = match target {


### PR DESCRIPTION
I strongly suspect that this will solve the underlying cause of #22062 - if the async scene builder isn't done, the compositor will take a screenshot of an empty gl framebuffer, which would be a big back square. I'm going to keep doing my due diligence while bisecting the relevant WR changes, but until then this will definitely not hurt us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22219)
<!-- Reviewable:end -->
