### PR TITLE
Add support for touch events on Android

### DIFF
--- a/ports/libsimpleservo/src/api.rs
+++ b/ports/libsimpleservo/src/api.rs
@@ -9,7 +9,7 @@ use servo::embedder_traits::resources::{self, Resource};
 use servo::embedder_traits::EmbedderMsg;
 use servo::euclid::{TypedPoint2D, TypedScale, TypedSize2D, TypedVector2D};
 use servo::msg::constellation_msg::TraversalDirection;
-use servo::script_traits::{MouseButton, TouchEventType};
+use servo::script_traits::{MouseButton, TouchEventType, TouchId};
 use servo::servo_config::opts;
 use servo::servo_config::prefs::{PrefValue, PREFS};
 use servo::servo_url::ServoUrl;
@@ -308,6 +308,46 @@ impl ServoGlue {
             scroll_location,
             TypedPoint2D::new(x as i32, y as i32),
             TouchEventType::Up,
+        );
+        self.process_event(event)
+    }
+
+    /// Touch event: press down
+    pub fn touch_down(&mut self, x: f32, y: f32, pointer_id: i32) -> Result<(), &'static str> {
+        let event = WindowEvent::Touch(
+            TouchEventType::Down,
+            TouchId(pointer_id),
+            TypedPoint2D::new(x as f32, y as f32),
+        );
+        self.process_event(event)
+    }
+
+    /// Touch event: move touching finger
+    pub fn touch_move(&mut self, x: f32, y: f32, pointer_id: i32) -> Result<(), &'static str> {
+        let event = WindowEvent::Touch(
+            TouchEventType::Move,
+            TouchId(pointer_id),
+            TypedPoint2D::new(x as f32, y as f32),
+        );
+        self.process_event(event)
+    }
+
+    /// Touch event: Lift touching finger
+    pub fn touch_up(&mut self, x: f32, y: f32, pointer_id: i32) -> Result<(), &'static str> {
+        let event = WindowEvent::Touch(
+            TouchEventType::Up,
+            TouchId(pointer_id),
+            TypedPoint2D::new(x as f32, y as f32),
+        );
+        self.process_event(event)
+    }
+
+    /// Cancel touch event
+    pub fn touch_cancel(&mut self, x: f32, y: f32, pointer_id: i32) -> Result<(), &'static str> {
+        let event = WindowEvent::Touch(
+            TouchEventType::Cancel,
+            TouchId(pointer_id),
+            TypedPoint2D::new(x as f32, y as f32),
         );
         self.process_event(event)
     }

--- a/ports/libsimpleservo/src/capi.rs
+++ b/ports/libsimpleservo/src/capi.rs
@@ -206,6 +206,30 @@ pub extern "C" fn scroll(dx: i32, dy: i32, x: i32, y: i32) {
 }
 
 #[no_mangle]
+pub extern "C" fn touch_down(x: f32, y: f32, pointer_id: i32) {
+    debug!("touch down");
+    call(|s| s.touch_down(x, y, pointer_id));
+}
+
+#[no_mangle]
+pub extern "C" fn touch_up(x: f32, y: f32, pointer_id: i32) {
+    debug!("touch up");
+    call(|s| s.touch_up(x, y, pointer_id));
+}
+
+#[no_mangle]
+pub extern "C" fn touch_move(x: f32, y: f32, pointer_id: i32) {
+    debug!("touch move");
+    call(|s| s.touch_move(x, y, pointer_id));
+}
+
+#[no_mangle]
+pub extern "C" fn touch_cancel(x: f32, y: f32, pointer_id: i32) {
+    debug!("touch cancel");
+    call(|s| s.touch_cancel(x, y, pointer_id));
+}
+
+#[no_mangle]
 pub extern "C" fn pinchzoom_start(factor: f32, x: i32, y: i32) {
     debug!("pinchzoom_start");
     call(|s| s.pinchzoom_start(factor, x as u32, y as u32));

--- a/ports/libsimpleservo/src/jniapi.rs
+++ b/ports/libsimpleservo/src/jniapi.rs
@@ -231,6 +231,54 @@ pub fn Java_org_mozilla_servoview_JNIServo_scroll(
 }
 
 #[no_mangle]
+pub fn Java_org_mozilla_servoview_JNIServo_touchDown(
+    env: JNIEnv,
+    _: JClass,
+    x: jfloat,
+    y: jfloat,
+    pointer_id: jint,
+) {
+    debug!("touchDown");
+    call(&env, |s| s.touch_down(x, y, pointer_id as i32));
+}
+
+#[no_mangle]
+pub fn Java_org_mozilla_servoview_JNIServo_touchUp(
+    env: JNIEnv,
+    _: JClass,
+    x: jfloat,
+    y: jfloat,
+    pointer_id: jint,
+) {
+    debug!("touchUp");
+    call(&env, |s| s.touch_up(x, y, pointer_id as i32));
+}
+
+#[no_mangle]
+pub fn Java_org_mozilla_servoview_JNIServo_touchMove(
+    env: JNIEnv,
+    _: JClass,
+    x: jfloat,
+    y: jfloat,
+    pointer_id: jint,
+) {
+    debug!("touchMove");
+    call(&env, |s| s.touch_move(x, y, pointer_id as i32));
+}
+
+#[no_mangle]
+pub fn Java_org_mozilla_servoview_JNIServo_touchCancel(
+    env: JNIEnv,
+    _: JClass,
+    x: jfloat,
+    y: jfloat,
+    pointer_id: jint,
+) {
+    debug!("touchCancel");
+    call(&env, |s| s.touch_cancel(x, y, pointer_id as i32));
+}
+
+#[no_mangle]
 pub fn Java_org_mozilla_servoview_JNIServo_pinchZoomStart(
     env: JNIEnv,
     _: JClass,

--- a/support/android/apk/servoview/src/main/java/org/mozilla/servoview/JNIServo.java
+++ b/support/android/apk/servoview/src/main/java/org/mozilla/servoview/JNIServo.java
@@ -50,6 +50,14 @@ public class JNIServo {
 
     public native void scrollEnd(int dx, int dy, int x, int y);
 
+    public native void touchDown(float x, float y, int pointer_id);
+
+    public native void touchMove(float x, float y, int pointer_id);
+
+    public native void touchUp(float x, float y, int pointer_id);
+
+    public native void touchCancel(float x, float y, int pointer_id);
+
     public native void pinchZoomStart(float factor, int x, int y);
 
     public native void pinchZoom(float factor, int x, int y);

--- a/support/android/apk/servoview/src/main/java/org/mozilla/servoview/Servo.java
+++ b/support/android/apk/servoview/src/main/java/org/mozilla/servoview/Servo.java
@@ -107,6 +107,22 @@ public class Servo {
         mRunCallback.inGLThread(() -> mJNI.scrollEnd(dx, dy, x, y));
     }
 
+    public void touchDown(float x, float y, int pointerId) {
+        mRunCallback.inGLThread(() -> mJNI.touchDown(x, y, pointerId));
+    }
+
+    public void touchMove(float x, float y, int pointerId) {
+        mRunCallback.inGLThread(() -> mJNI.touchMove(x, y, pointerId));
+    }
+
+    public void touchUp(float x, float y, int pointerId) {
+        mRunCallback.inGLThread(() -> mJNI.touchUp(x, y, pointerId));
+    }
+
+    public void touchCancel(float x, float y, int pointerId) {
+        mRunCallback.inGLThread(() -> mJNI.touchCancel(x, y, pointerId));
+    }
+
     public void pinchZoomStart(float factor, int x, int y) {
         mRunCallback.inGLThread(() -> mJNI.pinchZoomStart(factor, x, y));
     }


### PR DESCRIPTION
Currently on Android we treat all touch events as scroll events. Servo is already capable of distinguishing between scroll-touches and regular touch events (see `on_touch_move` in `components/compositor/touch.rs`), so we should just be passing touch events through.

Servo however does not natively support fling gestures, so we continue to use `GestureDetector` for that.


With this PR, the [Three.js cloth animation](https://threejs.org/examples/webgl_animation_cloth.html) can be panned around.

r? @paulrouget

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22229)
<!-- Reviewable:end -->
