### PR TITLE
Fix unused import warning in new Rust Nightly

### DIFF
--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -28,8 +28,6 @@ extern crate deny_public_fields;
 #[macro_use]
 extern crate domobject_derive;
 #[macro_use]
-extern crate enum_iterator;
-#[macro_use]
 extern crate html5ever;
 #[macro_use]
 extern crate js;


### PR DESCRIPTION
https://tools.taskcluster.net/task-inspector/#Zw-1gs3xT4e79Lach3PISg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22231)
<!-- Reviewable:end -->
