### PR TITLE
Fix android GL crash

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -125,11 +125,22 @@ impl<VR: WebVRRenderHandler + 'static> WebGLThread<VR> {
                         let glsl_version = Self::get_glsl_version(&data.ctx);
 
                         // FIXME(nox): Should probably be done by offscreen_gl_context.
-                        if (glsl_version.major, glsl_version.minor) < (3, 1) {
-                            data.ctx.gl().enable(gl::POINT_SPRITE);
-                        }
                         if !is_gles() {
+                            // Points sprites are enabled by default in OpenGL 3.2 core
+                            // and in GLES. Rather than doing version detection, it does
+                            // not hurt to enable them anyways.
+
+                            data.ctx.gl().enable(gl::POINT_SPRITE);
+                            let err = data.ctx.gl().get_error();
+                            if err != 0 {
+                                warn!("Error enabling GL point sprites: {}", err);
+                            }
+
                             data.ctx.gl().enable(gl::PROGRAM_POINT_SIZE);
+                            let err = data.ctx.gl().get_error();
+                            if err != 0 {
+                                warn!("Error enabling GL program point size: {}", err);
+                            }
                         }
 
                         WebGLCreateContextResult {


### PR DESCRIPTION
There were two issues, fundamentally:
1. POINT_SPRITE is not supported on GLES, which was causing the GL_INVALID_ENUM error when using any WebGL API.
2. The version check was using the wrong version value to determine if enabling point sprites was necessary.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22162
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22234)
<!-- Reviewable:end -->
