### PR TITLE
mach bootstrap: auto pip install certifi

### DIFF
--- a/python/servo/util.py
+++ b/python/servo/util.py
@@ -21,6 +21,8 @@ import sys
 import time
 import zipfile
 import urllib2
+import subprocess
+import sys
 
 
 try:
@@ -30,6 +32,7 @@ except ImportError:
 
 # The cafile parameter was added in 2.7.9
 if HAS_SNI and sys.version_info >= (2, 7, 9):
+    subprocess.call([sys.executable, "-m", "pip", "install", "certifi"])
     import certifi
     STATIC_RUST_LANG_ORG_DIST = "https://static.rust-lang.org/dist"
     URLOPEN_KWARGS = {"cafile": certifi.where()}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

While trying `mach bootstrap` in new environment of Ubuntu 16.04, found that `certifi` is not a default package for python 2.7
This is a workaround for automatically pip installing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22250)
<!-- Reviewable:end -->
