### PR TITLE
Make the signal handler exit immediately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3640,12 +3640,12 @@ dependencies = [
  "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "keyboard-types 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "libservo 0.0.1",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-src 0.1.0 (git+https://github.com/servo/osmesa-src)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sig 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sig 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinyfiledialogs 3.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3921,8 +3921,11 @@ dependencies = [
 
 [[package]]
 name = "sig"
-version = "0.1.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "signpost"
@@ -5350,7 +5353,7 @@ dependencies = [
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum shared_library 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8254bf098ce4d8d7cc7cc6de438c5488adc5297e5b7ffef88816c0a91bd289c1"
-"checksum sig 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c6649e43c1a1e68d29ed56d0dc3b5b6cf3b901da77cf107c4066b9e3da036df5"
+"checksum sig 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6567e29578f9bfade6a5d94a32b9a4256348358d2a3f448cab0021f9a02614a2"
 "checksum signpost 0.1.0 (git+https://github.com/pcwalton/signpost.git)" = "<none>"
 "checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3640,6 +3640,7 @@ dependencies = [
  "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "keyboard-types 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "libservo 0.0.1",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-src 0.1.0 (git+https://github.com/servo/osmesa-src)",

--- a/ports/servo/Cargo.toml
+++ b/ports/servo/Cargo.toml
@@ -53,10 +53,10 @@ libc = "0.2"
 log = "0.4"
 tinyfiledialogs = "3.0"
 winit = {version = "0.18", features = ["icon_loading"]}
-sig = "0.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 osmesa-sys = "0.1.2"
+sig = "1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11 = "2.0.0"

--- a/ports/servo/Cargo.toml
+++ b/ports/servo/Cargo.toml
@@ -49,6 +49,7 @@ glutin = "0.19"
 keyboard-types = "0.4.3"
 lazy_static = "1"
 libservo = {path = "../../components/servo"}
+libc = "0.2"
 log = "0.4"
 tinyfiledialogs = "3.0"
 winit = {version = "0.18", features = ["icon_loading"]}

--- a/ports/servo/non_android_main.rs
+++ b/ports/servo/non_android_main.rs
@@ -3,7 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #[macro_use] extern crate lazy_static;
-#[cfg(feature = "unstable")] #[macro_use] extern crate sig;
+#[cfg(all(feature = "unstable", any(target_os = "macos", target_os = "linux")))]
+#[macro_use] extern crate sig;
 
 // The window backed by glutin
 mod glutin_app;
@@ -13,7 +14,6 @@ mod resources;
 mod browser;
 
 use backtrace::Backtrace;
-use libc::_exit;
 use servo::{Servo, BrowserId};
 use servo::compositing::windowing::WindowEvent;
 use servo::config::opts::{self, ArgumentParsingResult, parse_url_or_filename};
@@ -36,16 +36,17 @@ pub mod platform {
     pub fn deinit() {}
 }
 
-#[cfg(not(feature = "unstable"))]
+#[cfg(any(not(feature = "unstable"), not(any(target_os = "macos", target_os = "linux"))))]
 fn install_crash_handler() {}
 
-#[cfg(feature = "unstable")]
+#[cfg(all(feature = "unstable", any(target_os = "macos", target_os = "linux")))]
 fn install_crash_handler() {
     use backtrace::Backtrace;
+    use libc::_exit;
     use sig::ffi::Sig;
     use std::thread;
 
-    fn handler(_sig: i32) {
+    extern "C" fn handler(sig: i32) {
         let name = thread::current()
             .name()
             .map(|n| format!(" for thread \"{}\"", n))

--- a/ports/servo/non_android_main.rs
+++ b/ports/servo/non_android_main.rs
@@ -13,6 +13,7 @@ mod resources;
 mod browser;
 
 use backtrace::Backtrace;
+use libc::_exit;
 use servo::{Servo, BrowserId};
 use servo::compositing::windowing::WindowEvent;
 use servo::config::opts::{self, ArgumentParsingResult, parse_url_or_filename};
@@ -42,7 +43,6 @@ fn install_crash_handler() {}
 fn install_crash_handler() {
     use backtrace::Backtrace;
     use sig::ffi::Sig;
-    use std::intrinsics::abort;
     use std::thread;
 
     fn handler(_sig: i32) {
@@ -52,9 +52,7 @@ fn install_crash_handler() {
             .unwrap_or("".to_owned());
         println!("Stack trace{}\n{:?}", name, Backtrace::new());
         unsafe {
-            // N.B. Using process::abort() here causes the crash handler to be
-            //      triggered recursively.
-            abort();
+            _exit(sig);
         }
     }
 

--- a/tests/wpt/mozilla/meta/mozilla/sigsegv.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/sigsegv.html.ini
@@ -1,4 +1,4 @@
 [sigsegv.html]
   type: testharness
   prefs: [dom.testbinding.enabled:true, dom.testable_crash.enabled:true]
-  disabled: https://github.com/servo/servo/issues/14067
+  expected: CRASH


### PR DESCRIPTION
This addresses #22240 by immediately exiting, rather than sometimes triggering a SIGBUS by aborting that can be caught recursively.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22240
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22259)
<!-- Reviewable:end -->
