### PR TITLE
Update the manifest twice to work around manifest generation issue.

### DIFF
--- a/etc/ci/update-wpt-checkout
+++ b/etc/ci/update-wpt-checkout
@@ -42,7 +42,7 @@ function unsafe_pull_from_upstream() {
 
     # Update the manifest to include the new changes.
     ./mach update-manifest || return 3
-    # Update the manifest again to reach a fixed state (https://github.com/servo/servo/issues/22235).
+    # Update the manifest again to reach a fixed state (https://github.com/servo/servo/issues/22275).
     ./mach update-manifest || return 4
 
     # Amend the existing commit with the new changes from updating the manifest.

--- a/etc/ci/update-wpt-checkout
+++ b/etc/ci/update-wpt-checkout
@@ -42,9 +42,11 @@ function unsafe_pull_from_upstream() {
 
     # Update the manifest to include the new changes.
     ./mach update-manifest || return 3
+    # Update the manifest again to reach a fixed state (https://github.com/servo/servo/issues/22235).
+    ./mach update-manifest || return 4
 
     # Amend the existing commit with the new changes from updating the manifest.
-    git commit -a --amend --no-edit || return 4
+    git commit -a --amend --no-edit || return 5
 }
 
 # Remove all local traces of this sync operation.


### PR DESCRIPTION
My theory is that the new VCS-based cache that's used when generating the manifest gets confused when files that match a gitignore rule are added for the first time. Updating the manifest twice makes the problematic files disappear from the manifest, and I'm not inclined to spend any more time chasing this bug. Fixes #22275.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22274)
<!-- Reviewable:end -->
