### PR TITLE
Put every Android build artefact in target/android/

### DIFF
--- a/etc/ci/check_dynamic_symbols.py
+++ b/etc/ci/check_dynamic_symbols.py
@@ -23,7 +23,7 @@ objdump_output = subprocess.check_output([
         'android-toolchains', 'ndk', 'toolchains', 'arm-linux-androideabi-4.9',
         'prebuilt', 'linux-x86_64', 'bin', 'arm-linux-androideabi-objdump'),
     '-T',
-    'target/armv7-linux-androideabi/debug/libsimpleservo.so']
+    'target/android/armv7-linux-androideabi/debug/libsimpleservo.so']
 ).split(b'\n')
 
 for line in objdump_output:

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -113,8 +113,8 @@ def android_arm32():
         .with_treeherder("Android ARMv7")
         .with_script("./mach build --android --release")
         .with_artifacts(
-            "/repo/target/armv7-linux-androideabi/release/servoapp.apk",
-            "/repo/target/armv7-linux-androideabi/release/servoview.aar",
+            "/repo/target/android/armv7-linux-androideabi/release/servoapp.apk",
+            "/repo/target/android/armv7-linux-androideabi/release/servoview.aar",
         )
         .find_or_create("build.android_armv7_release." + CONFIG.git_sha)
     )
@@ -126,8 +126,8 @@ def android_x86():
         .with_treeherder("Android x86")
         .with_script("./mach build --target i686-linux-android --release")
         .with_artifacts(
-            "/repo/target/i686-linux-android/release/servoapp.apk",
-            "/repo/target/i686-linux-android/release/servoview.aar",
+            "/repo/target/android/i686-linux-android/release/servoapp.apk",
+            "/repo/target/android/i686-linux-android/release/servoview.aar",
         )
         .find_or_create("build.android_x86_release." + CONFIG.git_sha)
     )
@@ -140,7 +140,7 @@ def android_x86():
         .with_scopes("project:servo:docker-worker-kvm:capability:privileged")
         .with_dockerfile(dockerfile_path("run-android-emulator"))
         .with_repo()
-        .with_curl_artifact_script(build_task, "servoapp.apk", "target/i686-linux-android/release")
+        .with_curl_artifact_script(build_task, "servoapp.apk", "target/android/i686-linux-android/release")
         .with_script("""
             ./mach bootstrap-android --accept-all-licences --emulator-x86
             ./mach test-android-startup --release

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -203,7 +203,29 @@ class MachCommands(CommandBase):
             android = self.config["build"]["android"]
         features = features or self.servo_features()
 
-        base_path = self.get_target_dir()
+        if target and android:
+            print("Please specify either --target or --android.")
+            sys.exit(1)
+
+        if android:
+            target = self.config["android"]["target"]
+
+        if not magicleap:
+            features += ["native-bluetooth"]
+
+        if magicleap and not target:
+            target = "aarch64-linux-android"
+
+        if target and not android and not magicleap:
+            android = self.handle_android_target(target)
+
+        target_path = base_path = self.get_target_dir()
+        if android:
+            target_path = path.join(target_path, "android")
+            base_path = path.join(target_path, target)
+        elif magicleap:
+            target_path = path.join(target_path, "magicleap")
+            base_path = path.join(target_path, target)
         release_path = path.join(base_path, "release", "servo")
         dev_path = path.join(base_path, "debug", "servo")
 
@@ -228,10 +250,6 @@ class MachCommands(CommandBase):
             print("Please specify either --dev or --release.")
             sys.exit(1)
 
-        if target and android:
-            print("Please specify either --target or --android.")
-            sys.exit(1)
-
         if release:
             opts += ["--release"]
             servo_path = release_path
@@ -245,15 +263,6 @@ class MachCommands(CommandBase):
         if very_verbose:
             opts += ["-vv"]
 
-        if android:
-            target = self.config["android"]["target"]
-
-        if not magicleap:
-            features += ["native-bluetooth"]
-
-        if magicleap and not target:
-            target = "aarch64-linux-android"
-
         if target:
             if self.config["tools"]["use-rustup"]:
                 # 'rustup target add' fails if the toolchain is not installed at all.
@@ -263,8 +272,6 @@ class MachCommands(CommandBase):
                             "--toolchain", self.toolchain(), target])
 
             opts += ["--target", target]
-            if not android and not magicleap:
-                android = self.handle_android_target(target)
 
         self.ensure_bootstrapped(target=target)
         self.ensure_clobbered()
@@ -284,6 +291,7 @@ class MachCommands(CommandBase):
 
         build_start = time()
         env = self.build_env(target=target, is_build=True)
+        env["CARGO_TARGET_DIR"] = target_path
 
         if with_debug_assertions:
             env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C debug_assertions"
@@ -307,8 +315,7 @@ class MachCommands(CommandBase):
             make_cmd = ["make"]
             if jobs is not None:
                 make_cmd += ["-j" + jobs]
-            android_dir = self.android_build_dir(dev)
-            openssl_dir = path.join(android_dir, "native", "openssl")
+            openssl_dir = path.join(target_path, target, "native", "openssl")
             if not path.exists(openssl_dir):
                 os.makedirs(openssl_dir)
             shutil.copy(path.join(self.android_support_dir(), "openssl.makefile"), openssl_dir)
@@ -428,8 +435,8 @@ class MachCommands(CommandBase):
             # according to the build target.
             gst_lib = "gst-build-{}".format(self.config["android"]["lib"])
             gst_lib_zip = "gstreamer-{}-1.14.3-20181105-103937.zip".format(self.config["android"]["lib"])
-            gst_dir = os.path.join(base_path, "gstreamer")
-            gst_lib_path = os.path.join(base_path, gst_dir, gst_lib)
+            gst_dir = os.path.join(target_path, "gstreamer")
+            gst_lib_path = os.path.join(gst_dir, gst_lib)
             pkg_config_path = os.path.join(gst_lib_path, "pkgconfig")
             env["PKG_CONFIG_PATH"] = pkg_config_path
             if not os.path.exists(gst_lib_path):
@@ -522,7 +529,7 @@ class MachCommands(CommandBase):
             env.setdefault("CMAKE_TOOLCHAIN_FILE", path.join(ml_support, "toolchain.cmake"))
 
             # The Open SSL configuration
-            env.setdefault("OPENSSL_DIR", path.join(self.get_target_dir(), target, "magicleap", "openssl"))
+            env.setdefault("OPENSSL_DIR", path.join(target_path, target, "native", "openssl"))
             env.setdefault("OPENSSL_VERSION", "1.0.2k")
             env.setdefault("OPENSSL_STATIC", "1")
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -345,7 +345,7 @@ class CommandBase(object):
 
     def get_apk_path(self, release):
         base_path = self.get_target_dir()
-        base_path = path.join(base_path, self.config["android"]["target"])
+        base_path = path.join(base_path, "android", self.config["android"]["target"])
         apk_name = "servoapp.apk"
         build_type = "release" if release else "debug"
         return path.join(base_path, build_type, apk_name)
@@ -361,10 +361,10 @@ class CommandBase(object):
         binary_name = "servo" + BIN_SUFFIX
 
         if magicleap:
-            base_path = path.join(base_path, "aarch64-linux-android")
+            base_path = path.join(base_path, "magicleap", "aarch64-linux-android")
             binary_name = "libmlservo.a"
         elif android:
-            base_path = path.join(base_path, self.config["android"]["target"])
+            base_path = path.join(base_path, "android", self.config["android"]["target"])
             binary_name = "libsimpleservo.so"
 
         release_path = path.join(base_path, "release", binary_name)
@@ -700,11 +700,8 @@ install them, let us know by filing a bug!")
     def android_support_dir(self):
         return path.join(self.context.topdir, "support", "android")
 
-    def android_build_dir(self, dev):
-        return path.join(self.get_target_dir(), self.config["android"]["target"], "debug" if dev else "release")
-
     def android_aar_dir(self):
-        return path.join(self.context.topdir, "target", "android_aar")
+        return path.join(self.context.topdir, "target", "android", "aar")
 
     def android_adb_path(self, env):
         if "ANDROID_SDK" in env:

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -44,8 +44,8 @@ from servo.util import delete
 
 PACKAGES = {
     'android': [
-        'target/armv7-linux-androideabi/release/servoapp.apk',
-        'target/armv7-linux-androideabi/release/servoview.aar',
+        'target/android/armv7-linux-androideabi/release/servoapp.apk',
+        'target/android/armv7-linux-androideabi/release/servoview.aar',
     ],
     'linux': [
         'target/release/servo-tech-demo.tar.gz',
@@ -57,11 +57,11 @@ PACKAGES = {
         'target/release/brew/servo.tar.gz',
     ],
     'magicleap': [
-        'target/aarch64-linux-android/release/Servo2D.mpk',
+        'target/magicleap/aarch64-linux-android/release/Servo2D.mpk',
     ],
     'maven': [
-        'target/gradle/servoview/maven/org/mozilla/servoview/servoview-armv7/',
-        'target/gradle/servoview/maven/org/mozilla/servoview/servoview-x86/',
+        'target/android/gradle/servoview/maven/org/mozilla/servoview/servoview-armv7/',
+        'target/android/gradle/servoview/maven/org/mozilla/servoview/servoview-x86/',
     ],
     'windows-msvc': [
         r'target\release\msi\Servo.exe',
@@ -578,7 +578,7 @@ class PackageCommands(CommandBase):
             BUCKET = 'servo-builds'
 
             nightly_dir = 'nightly/maven'
-            dest_key_base = directory.replace("target/gradle/servoview/maven", nightly_dir)
+            dest_key_base = directory.replace("target/android/gradle/servoview/maven", nightly_dir)
             if dest_key_base[-1] == '/':
                 dest_key_base = dest_key_base[:-1]
 

--- a/support/android/apk/build.gradle
+++ b/support/android/apk/build.gradle
@@ -14,7 +14,7 @@ allprojects {
     repositories {
         jcenter()
         flatDir {
-            dirs rootDir.absolutePath + "/../../../target/android_aar"
+            dirs rootDir.absolutePath + "/../../../target/android/aar"
         }
         google()
     }
@@ -23,7 +23,7 @@ allprojects {
 // Utility methods
 String getTargetDir(boolean debug, String arch) {
     def basePath = project.rootDir.getParentFile().getParentFile().getParentFile().absolutePath
-    return basePath + '/target/' + getSubTargetDir(debug, arch)
+    return basePath + '/target/android/' + getSubTargetDir(debug, arch)
 }
 
 String getSubTargetDir(boolean debug, String arch) {

--- a/support/android/apk/servoapp/build.gradle
+++ b/support/android/apk/servoapp/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdkVersion 27
     buildToolsVersion '27.0.3'
 
-    buildDir = rootDir.absolutePath + "/../../../target/gradle/servoapp"
+    buildDir = rootDir.absolutePath + "/../../../target/android/gradle/servoapp"
 
     defaultConfig {
         applicationId "org.mozilla.servo"

--- a/support/android/apk/servoview/build.gradle
+++ b/support/android/apk/servoview/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 27
     buildToolsVersion '27.0.3'
 
-    buildDir = rootDir.absolutePath + "/../../../target/gradle/servoview"
+    buildDir = rootDir.absolutePath + "/../../../target/android/gradle/servoview"
 
     defaultConfig {
         minSdkVersion 18

--- a/support/magicleap/README.md
+++ b/support/magicleap/README.md
@@ -16,7 +16,7 @@ Build the mlservo library:
 ```
 MAGICLEAP_SDK=*directory*  ./mach build -d --magicleap
 ```
-This builds a static library `target/aarch64-linux-android/debug/libmlservo.a`.
+This builds a static library `target/magicleap/aarch64-linux-android/debug/libmlservo.a`.
 
 ## Building the Servo2D application
 

--- a/support/magicleap/Servo2D/Servo2D.mabu
+++ b/support/magicleap/Servo2D/Servo2D.mabu
@@ -9,10 +9,10 @@ SRCS = \
     code/src/Servo2D.cpp
 
 LIBPATHS.debug = \
-    ../../../target/aarch64-linux-android/debug
+    ../../../target/magicleap/aarch64-linux-android/debug
 
 LIBPATHS.release = \
-    ../../../target/aarch64-linux-android/release
+    ../../../target/magicleap/aarch64-linux-android/release
 
 STLIBS = \
     mlservo


### PR DESCRIPTION
This works around #20380 at the cost of rebuilding build-only dependencies twice,
once for normal builds and once for android builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22277)
<!-- Reviewable:end -->
