### PR TITLE
Turn on upstream SW wpt tests

### DIFF
--- a/tests/wpt/metadata/service-workers/__dir__.ini
+++ b/tests/wpt/metadata/service-workers/__dir__.ini
@@ -1,0 +1,2 @@
+prefs: ["dom.serviceworker.enabled:true"]
+

--- a/tests/wpt/metadata/service-workers/cache-storage/common.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/common.https.html.ini
@@ -1,0 +1,4 @@
+[common.https.html]
+  [Window sees cache puts by Worker]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-abort.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-abort.https.html.ini
@@ -1,0 +1,4 @@
+[cache-abort.https.html]
+  [Cache Storage: Abort]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-add.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-add.https.html.ini
@@ -1,0 +1,4 @@
+[cache-add.https.html]
+  [Cache.add and Cache.addAll]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-delete.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-delete.https.html.ini
@@ -1,0 +1,4 @@
+[cache-delete.https.html]
+  [Cache.delete]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-keys-attributes-for-service-worker.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-keys-attributes-for-service-worker.https.html.ini
@@ -1,0 +1,7 @@
+[cache-keys-attributes-for-service-worker.https.html]
+  [Request.IsReloadNavigation should persist.]
+    expected: FAIL
+
+  [Request.IsHistoryNavigation should persist.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-keys.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-keys.https.html.ini
@@ -1,0 +1,4 @@
+[cache-keys.https.html]
+  [Cache.keys]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-match.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-match.https.html.ini
@@ -1,0 +1,4 @@
+[cache-match.https.html]
+  [Cache.match]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-matchAll.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-matchAll.https.html.ini
@@ -1,0 +1,4 @@
+[cache-matchAll.https.html]
+  [Cache.matchAll]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-put.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-put.https.html.ini
@@ -1,0 +1,4 @@
+[cache-put.https.html]
+  [Cache.put]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-storage-keys.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-storage-keys.https.html.ini
@@ -1,0 +1,4 @@
+[cache-storage-keys.https.html]
+  [CacheStorage.keys]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-storage-match.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-storage-match.https.html.ini
@@ -1,0 +1,4 @@
+[cache-storage-match.https.html]
+  [CacheStorage.match]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-storage.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/serviceworker/cache-storage.https.html.ini
@@ -1,0 +1,4 @@
+[cache-storage.https.html]
+  [CacheStorage]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/serviceworker/credentials.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/serviceworker/credentials.https.html.ini
@@ -1,0 +1,4 @@
+[credentials.https.html]
+  [Cache API matching includes credentials]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/window/cache-abort.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/window/cache-abort.https.html.ini
@@ -1,0 +1,29 @@
+[cache-abort.https.html]
+  expected: ERROR
+  [put() synchronously followed by abort should reject with AbortError]
+    expected: NOTRUN
+
+  [addAll() on an already-aborted request should reject with AbortError]
+    expected: NOTRUN
+
+  [addAll() synchronously followed by abort should reject with AbortError]
+    expected: NOTRUN
+
+  [add() synchronously followed by abort should reject with AbortError]
+    expected: NOTRUN
+
+  [put() on an already-aborted request should reject with AbortError]
+    expected: FAIL
+
+  [put() followed by abort after headers received should reject with AbortError]
+    expected: NOTRUN
+
+  [add() on an already-aborted request should reject with AbortError]
+    expected: NOTRUN
+
+  [addAll() followed by abort after headers received should reject with AbortError]
+    expected: NOTRUN
+
+  [add() followed by abort after headers received should reject with AbortError]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/cache-storage/window/cache-add.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/window/cache-add.https.html.ini
@@ -1,0 +1,65 @@
+[cache-add.https.html]
+  expected: ERROR
+  [Cache.addAll with no arguments]
+    expected: NOTRUN
+
+  [Cache.addAll with an empty array]
+    expected: NOTRUN
+
+  [Cache.add with request that results in a status of 404]
+    expected: NOTRUN
+
+  [Cache.addAll called with the same Request object specified twice]
+    expected: NOTRUN
+
+  [Cache.add with 206 response]
+    expected: NOTRUN
+
+  [Cache.add called twice with the same Request object]
+    expected: NOTRUN
+
+  [Cache.addAll with Request arguments]
+    expected: NOTRUN
+
+  [Cache.addAll should reject when entries are duplicate by vary header]
+    expected: NOTRUN
+
+  [Cache.addAll should succeed when entries differ by vary header]
+    expected: NOTRUN
+
+  [Cache.add called with relative URL specified as a string]
+    expected: NOTRUN
+
+  [Cache.add called with non-HTTP/HTTPS URL]
+    expected: NOTRUN
+
+  [Cache.addAll with string URL arguments]
+    expected: NOTRUN
+
+  [Cache.add with request that results in a status of 500]
+    expected: NOTRUN
+
+  [Cache.addAll with a mix of succeeding and failing requests]
+    expected: NOTRUN
+
+  [Cache.add called with Request object]
+    expected: NOTRUN
+
+  [Cache.addAll with 206 response]
+    expected: NOTRUN
+
+  [Cache.addAll should reject when one entry has a vary header matching another entry]
+    expected: NOTRUN
+
+  [Cache.add called with no arguments]
+    expected: FAIL
+
+  [Cache.addAll with a mix of valid and undefined arguments]
+    expected: NOTRUN
+
+  [Cache.add called with POST request]
+    expected: NOTRUN
+
+  [Cache.add with request with null body (not consumed)]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/cache-storage/window/cache-delete.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/window/cache-delete.https.html.ini
@@ -1,0 +1,26 @@
+[cache-delete.https.html]
+  expected: ERROR
+  [Cache.delete with no arguments]
+    expected: FAIL
+
+  [Cache.delete called with a Request object]
+    expected: NOTRUN
+
+  [Cache.delete with a non-existent entry]
+    expected: NOTRUN
+
+  [Cache.delete with ignoreSearch option (request with search parameters)]
+    expected: NOTRUN
+
+  [Cache.delete called with a HEAD request]
+    expected: NOTRUN
+
+  [Cache.delete supports ignoreVary]
+    expected: NOTRUN
+
+  [Cache.delete with ignoreSearch option (when it is specified as false)]
+    expected: NOTRUN
+
+  [Cache.delete called with a string URL]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/cache-storage/window/cache-keys.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/window/cache-keys.https.html.ini
@@ -1,0 +1,44 @@
+[cache-keys.https.html]
+  expected: ERROR
+  [Cache.keys with URL containing fragment]
+    expected: NOTRUN
+
+  [Cache.keys with no matching entries]
+    expected: NOTRUN
+
+  [Cache.keys with string fragment "http" as query]
+    expected: NOTRUN
+
+  [Cache.keys with new Request]
+    expected: NOTRUN
+
+  [Cache.keys supports ignoreMethod]
+    expected: NOTRUN
+
+  [Cache.keys with URL]
+    expected: NOTRUN
+
+  [Cache.keys supports ignoreVary]
+    expected: NOTRUN
+
+  [Cache.keys with Request]
+    expected: NOTRUN
+
+  [Cache.keys without parameters]
+    expected: NOTRUN
+
+  [Cache.keys with ignoreSearch option (request with search parameters)]
+    expected: NOTRUN
+
+  [Cache.keys without parameters and VARY entries]
+    expected: NOTRUN
+
+  [Cache.keys with a HEAD Request]
+    expected: NOTRUN
+
+  [Cache.keys with ignoreSearch option (request with no search parameters)]
+    expected: NOTRUN
+
+  [Cache.keys() called on an empty cache]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/window/cache-match.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/window/cache-match.https.html.ini
@@ -1,0 +1,65 @@
+[cache-match.https.html]
+  expected: ERROR
+  [cors-exposed header should be stored correctly.]
+    expected: NOTRUN
+
+  [Cache.match with ignoreSearch option (request with no search parameters)]
+    expected: NOTRUN
+
+  [Cache.match with responses containing "Vary" header]
+    expected: NOTRUN
+
+  [Cache.match with new Request]
+    expected: NOTRUN
+
+  [Cache produces large Responses that can be cloned and read correctly.]
+    expected: NOTRUN
+
+  [Cache.match with string fragment "http" as query]
+    expected: NOTRUN
+
+  [Cache.match with a non-2xx Response]
+    expected: NOTRUN
+
+  [Cache.match with a network error Response]
+    expected: NOTRUN
+
+  [Cache.match with no matching entries]
+    expected: FAIL
+
+  [Cache.match blob should be sliceable]
+    expected: NOTRUN
+
+  [Cache.match supports ignoreMethod]
+    expected: NOTRUN
+
+  [Cache.match with Request and Response objects with different URLs]
+    expected: NOTRUN
+
+  [Cache.match invoked multiple times for the same Request/Response]
+    expected: NOTRUN
+
+  [Cache.match with POST Request]
+    expected: NOTRUN
+
+  [Cache.match with multiple cache hits]
+    expected: NOTRUN
+
+  [Cache.match supports ignoreVary]
+    expected: NOTRUN
+
+  [Cache.match with URL]
+    expected: NOTRUN
+
+  [Cache.match with ignoreSearch option (request with search parameter)]
+    expected: NOTRUN
+
+  [Cache.match with HEAD]
+    expected: NOTRUN
+
+  [Cache.match with URL containing fragment]
+    expected: NOTRUN
+
+  [Cache.match with Request]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/cache-storage/window/cache-matchAll.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/window/cache-matchAll.https.html.ini
@@ -1,0 +1,44 @@
+[cache-matchAll.https.html]
+  expected: ERROR
+  [Cache.matchAll with URL]
+    expected: NOTRUN
+
+  [Cache.matchAll with ignoreSearch option (request with no search parameters)]
+    expected: NOTRUN
+
+  [Cache.matchAll with HEAD]
+    expected: NOTRUN
+
+  [Cache.matchAll without parameters]
+    expected: NOTRUN
+
+  [Cache.matchAll supports ignoreMethod]
+    expected: NOTRUN
+
+  [Cache.matchAll with multiple vary pairs]
+    expected: NOTRUN
+
+  [Cache.matchAll with Request]
+    expected: NOTRUN
+
+  [Cache.matchAll with new Request]
+    expected: NOTRUN
+
+  [Cache.matchAll with ignoreSearch option (request with search parameters)]
+    expected: NOTRUN
+
+  [Cache.matchAll supports ignoreVary]
+    expected: NOTRUN
+
+  [Cache.matchAll with string fragment "http" as query]
+    expected: NOTRUN
+
+  [Cache.matchAll with no matching entries]
+    expected: FAIL
+
+  [Cache.matchAll with URL containing fragment]
+    expected: NOTRUN
+
+  [Cache.matchAll with responses containing "Vary" header]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/cache-storage/window/cache-put.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/window/cache-put.https.html.ini
@@ -1,0 +1,77 @@
+[cache-put.https.html]
+  expected: ERROR
+  [Cache.put with a non-GET request]
+    expected: NOTRUN
+
+  [Cache.put with HTTP 206 response]
+    expected: NOTRUN
+
+  [Cache.put should store Response.redirect() correctly]
+    expected: NOTRUN
+
+  [Cache.put with Response without a body]
+    expected: NOTRUN
+
+  [Cache.put with Request without a body]
+    expected: NOTRUN
+
+  [Cache.put called twice with matching Requests and different Responses]
+    expected: NOTRUN
+
+  [Cache.put called with simple Request and form data Response]
+    expected: NOTRUN
+
+  [Cache.put with a VARY:* Response]
+    expected: NOTRUN
+
+  [Cache.put called with Request and Response from fetch()]
+    expected: NOTRUN
+
+  [Cache.put called with simple Request and blob Response]
+    expected: NOTRUN
+
+  [getReader() after Cache.put]
+    expected: NOTRUN
+
+  [Cache.put called with simple Request and Response]
+    expected: FAIL
+
+  [Cache.put with synthetic 206 response]
+    expected: NOTRUN
+
+  [Cache.put with a non-HTTP/HTTPS request]
+    expected: NOTRUN
+
+  [Cache.put with a POST request]
+    expected: NOTRUN
+
+  [Cache.put with HTTP 500 response]
+    expected: NOTRUN
+
+  [Cache.put called twice with request URLs that differ only by a fragment]
+    expected: NOTRUN
+
+  [Cache.put with an invalid response]
+    expected: NOTRUN
+
+  [Cache.put with an embedded VARY:* Response]
+    expected: NOTRUN
+
+  [Cache.put with a string request]
+    expected: NOTRUN
+
+  [Cache.put with a used response body]
+    expected: NOTRUN
+
+  [Cache.put with a Response containing an empty URL]
+    expected: NOTRUN
+
+  [Cache.put with a relative URL]
+    expected: NOTRUN
+
+  [Cache.put with a null response]
+    expected: NOTRUN
+
+  [Cache.put with an empty response body]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/cache-storage/window/cache-storage-keys.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/window/cache-storage-keys.https.html.ini
@@ -1,0 +1,4 @@
+[cache-storage-keys.https.html]
+  [CacheStorage keys]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/window/cache-storage-match.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/window/cache-storage-match.https.html.ini
@@ -1,0 +1,35 @@
+[cache-storage-match.https.html]
+  expected: ERROR
+  [CacheStorageMatch with empty cache name provided]
+    expected: NOTRUN
+
+  [CacheStorageMatch from one of many caches by name]
+    expected: NOTRUN
+
+  [CacheStorageMatch supports ignoreSearch]
+    expected: NOTRUN
+
+  [Cache.match supports ignoreMethod]
+    expected: NOTRUN
+
+  [CacheStorageMatch from one of many caches]
+    expected: NOTRUN
+
+  [CacheStorageMatch with no cached entry]
+    expected: NOTRUN
+
+  [CacheStorageMatch with no caches available but name provided]
+    expected: NOTRUN
+
+  [CacheStorageMatch supports ignoreVary]
+    expected: NOTRUN
+
+  [CacheStorageMatch with no cache name provided]
+    expected: FAIL
+
+  [CacheStorageMatch a string request]
+    expected: NOTRUN
+
+  [CacheStorageMatch a HEAD request]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/cache-storage/window/cache-storage.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/window/cache-storage.https.html.ini
@@ -1,0 +1,31 @@
+[cache-storage.https.html]
+  [CacheStorage.open with an empty name]
+    expected: FAIL
+
+  [CacheStorage.delete dooms, but does not delete immediately]
+    expected: FAIL
+
+  [CacheStorage.open with no arguments]
+    expected: FAIL
+
+  [CacheStorage names are DOMStrings not USVStrings]
+    expected: FAIL
+
+  [CacheStorage.has with existing cache]
+    expected: FAIL
+
+  [CacheStorage.delete with nonexistent cache]
+    expected: FAIL
+
+  [CacheStorage.open]
+    expected: FAIL
+
+  [CacheStorage.has with nonexistent cache]
+    expected: FAIL
+
+  [CacheStorage.open with existing cache]
+    expected: FAIL
+
+  [CacheStorage.delete with existing cache]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/window/sandboxed-iframes.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/window/sandboxed-iframes.https.html.ini
@@ -1,0 +1,7 @@
+[sandboxed-iframes.https.html]
+  [Sandboxed iframe with allow-same-origin is allowed access]
+    expected: FAIL
+
+  [Sandboxed iframe without allow-same-origin is denied access]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/worker/cache-abort.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/worker/cache-abort.https.html.ini
@@ -1,0 +1,29 @@
+[cache-abort.https.html]
+  expected: ERROR
+  [put() synchronously followed by abort should reject with AbortError]
+    expected: NOTRUN
+
+  [addAll() on an already-aborted request should reject with AbortError]
+    expected: NOTRUN
+
+  [addAll() synchronously followed by abort should reject with AbortError]
+    expected: NOTRUN
+
+  [add() synchronously followed by abort should reject with AbortError]
+    expected: NOTRUN
+
+  [put() on an already-aborted request should reject with AbortError]
+    expected: FAIL
+
+  [put() followed by abort after headers received should reject with AbortError]
+    expected: NOTRUN
+
+  [add() on an already-aborted request should reject with AbortError]
+    expected: NOTRUN
+
+  [addAll() followed by abort after headers received should reject with AbortError]
+    expected: NOTRUN
+
+  [add() followed by abort after headers received should reject with AbortError]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/cache-storage/worker/cache-add.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/worker/cache-add.https.html.ini
@@ -1,0 +1,65 @@
+[cache-add.https.html]
+  expected: ERROR
+  [Cache.addAll with no arguments]
+    expected: NOTRUN
+
+  [Cache.addAll with an empty array]
+    expected: NOTRUN
+
+  [Cache.add with request that results in a status of 404]
+    expected: NOTRUN
+
+  [Cache.addAll called with the same Request object specified twice]
+    expected: NOTRUN
+
+  [Cache.add with 206 response]
+    expected: NOTRUN
+
+  [Cache.add called twice with the same Request object]
+    expected: NOTRUN
+
+  [Cache.addAll with Request arguments]
+    expected: NOTRUN
+
+  [Cache.addAll should reject when entries are duplicate by vary header]
+    expected: NOTRUN
+
+  [Cache.addAll should succeed when entries differ by vary header]
+    expected: NOTRUN
+
+  [Cache.add called with relative URL specified as a string]
+    expected: NOTRUN
+
+  [Cache.add called with non-HTTP/HTTPS URL]
+    expected: NOTRUN
+
+  [Cache.addAll with string URL arguments]
+    expected: NOTRUN
+
+  [Cache.add with request that results in a status of 500]
+    expected: NOTRUN
+
+  [Cache.addAll with a mix of succeeding and failing requests]
+    expected: NOTRUN
+
+  [Cache.add called with Request object]
+    expected: NOTRUN
+
+  [Cache.addAll with 206 response]
+    expected: NOTRUN
+
+  [Cache.addAll should reject when one entry has a vary header matching another entry]
+    expected: NOTRUN
+
+  [Cache.add called with no arguments]
+    expected: FAIL
+
+  [Cache.addAll with a mix of valid and undefined arguments]
+    expected: NOTRUN
+
+  [Cache.add called with POST request]
+    expected: NOTRUN
+
+  [Cache.add with request with null body (not consumed)]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/cache-storage/worker/cache-delete.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/worker/cache-delete.https.html.ini
@@ -1,0 +1,26 @@
+[cache-delete.https.html]
+  expected: ERROR
+  [Cache.delete with no arguments]
+    expected: FAIL
+
+  [Cache.delete called with a Request object]
+    expected: NOTRUN
+
+  [Cache.delete with a non-existent entry]
+    expected: NOTRUN
+
+  [Cache.delete with ignoreSearch option (request with search parameters)]
+    expected: NOTRUN
+
+  [Cache.delete called with a HEAD request]
+    expected: NOTRUN
+
+  [Cache.delete supports ignoreVary]
+    expected: NOTRUN
+
+  [Cache.delete with ignoreSearch option (when it is specified as false)]
+    expected: NOTRUN
+
+  [Cache.delete called with a string URL]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/cache-storage/worker/cache-keys.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/worker/cache-keys.https.html.ini
@@ -1,0 +1,44 @@
+[cache-keys.https.html]
+  expected: ERROR
+  [Cache.keys with URL containing fragment]
+    expected: NOTRUN
+
+  [Cache.keys with no matching entries]
+    expected: NOTRUN
+
+  [Cache.keys with string fragment "http" as query]
+    expected: NOTRUN
+
+  [Cache.keys with new Request]
+    expected: NOTRUN
+
+  [Cache.keys supports ignoreMethod]
+    expected: NOTRUN
+
+  [Cache.keys with URL]
+    expected: NOTRUN
+
+  [Cache.keys supports ignoreVary]
+    expected: NOTRUN
+
+  [Cache.keys with Request]
+    expected: NOTRUN
+
+  [Cache.keys without parameters]
+    expected: NOTRUN
+
+  [Cache.keys with ignoreSearch option (request with search parameters)]
+    expected: NOTRUN
+
+  [Cache.keys without parameters and VARY entries]
+    expected: NOTRUN
+
+  [Cache.keys with a HEAD Request]
+    expected: NOTRUN
+
+  [Cache.keys with ignoreSearch option (request with no search parameters)]
+    expected: NOTRUN
+
+  [Cache.keys() called on an empty cache]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/worker/cache-match.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/worker/cache-match.https.html.ini
@@ -1,0 +1,65 @@
+[cache-match.https.html]
+  expected: ERROR
+  [cors-exposed header should be stored correctly.]
+    expected: NOTRUN
+
+  [Cache.match with ignoreSearch option (request with no search parameters)]
+    expected: NOTRUN
+
+  [Cache.match with responses containing "Vary" header]
+    expected: NOTRUN
+
+  [Cache.match with new Request]
+    expected: NOTRUN
+
+  [Cache produces large Responses that can be cloned and read correctly.]
+    expected: NOTRUN
+
+  [Cache.match with string fragment "http" as query]
+    expected: NOTRUN
+
+  [Cache.match with a non-2xx Response]
+    expected: NOTRUN
+
+  [Cache.match with a network error Response]
+    expected: NOTRUN
+
+  [Cache.match with no matching entries]
+    expected: FAIL
+
+  [Cache.match blob should be sliceable]
+    expected: NOTRUN
+
+  [Cache.match supports ignoreMethod]
+    expected: NOTRUN
+
+  [Cache.match with Request and Response objects with different URLs]
+    expected: NOTRUN
+
+  [Cache.match invoked multiple times for the same Request/Response]
+    expected: NOTRUN
+
+  [Cache.match with POST Request]
+    expected: NOTRUN
+
+  [Cache.match with multiple cache hits]
+    expected: NOTRUN
+
+  [Cache.match supports ignoreVary]
+    expected: NOTRUN
+
+  [Cache.match with URL]
+    expected: NOTRUN
+
+  [Cache.match with ignoreSearch option (request with search parameter)]
+    expected: NOTRUN
+
+  [Cache.match with HEAD]
+    expected: NOTRUN
+
+  [Cache.match with URL containing fragment]
+    expected: NOTRUN
+
+  [Cache.match with Request]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/cache-storage/worker/cache-matchAll.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/worker/cache-matchAll.https.html.ini
@@ -1,0 +1,44 @@
+[cache-matchAll.https.html]
+  expected: ERROR
+  [Cache.matchAll with URL]
+    expected: NOTRUN
+
+  [Cache.matchAll with ignoreSearch option (request with no search parameters)]
+    expected: NOTRUN
+
+  [Cache.matchAll with HEAD]
+    expected: NOTRUN
+
+  [Cache.matchAll without parameters]
+    expected: NOTRUN
+
+  [Cache.matchAll supports ignoreMethod]
+    expected: NOTRUN
+
+  [Cache.matchAll with multiple vary pairs]
+    expected: NOTRUN
+
+  [Cache.matchAll with Request]
+    expected: NOTRUN
+
+  [Cache.matchAll with new Request]
+    expected: NOTRUN
+
+  [Cache.matchAll with ignoreSearch option (request with search parameters)]
+    expected: NOTRUN
+
+  [Cache.matchAll supports ignoreVary]
+    expected: NOTRUN
+
+  [Cache.matchAll with string fragment "http" as query]
+    expected: NOTRUN
+
+  [Cache.matchAll with no matching entries]
+    expected: FAIL
+
+  [Cache.matchAll with URL containing fragment]
+    expected: NOTRUN
+
+  [Cache.matchAll with responses containing "Vary" header]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/cache-storage/worker/cache-put.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/worker/cache-put.https.html.ini
@@ -1,0 +1,74 @@
+[cache-put.https.html]
+  expected: ERROR
+  [Cache.put with a non-GET request]
+    expected: NOTRUN
+
+  [Cache.put with HTTP 206 response]
+    expected: NOTRUN
+
+  [Cache.put should store Response.redirect() correctly]
+    expected: NOTRUN
+
+  [Cache.put with Response without a body]
+    expected: NOTRUN
+
+  [Cache.put with Request without a body]
+    expected: NOTRUN
+
+  [Cache.put called twice with matching Requests and different Responses]
+    expected: NOTRUN
+
+  [Cache.put with a VARY:* Response]
+    expected: NOTRUN
+
+  [Cache.put called with Request and Response from fetch()]
+    expected: NOTRUN
+
+  [Cache.put called with simple Request and blob Response]
+    expected: NOTRUN
+
+  [getReader() after Cache.put]
+    expected: NOTRUN
+
+  [Cache.put called with simple Request and Response]
+    expected: FAIL
+
+  [Cache.put with synthetic 206 response]
+    expected: NOTRUN
+
+  [Cache.put with a non-HTTP/HTTPS request]
+    expected: NOTRUN
+
+  [Cache.put with a POST request]
+    expected: NOTRUN
+
+  [Cache.put with HTTP 500 response]
+    expected: NOTRUN
+
+  [Cache.put called twice with request URLs that differ only by a fragment]
+    expected: NOTRUN
+
+  [Cache.put with an invalid response]
+    expected: NOTRUN
+
+  [Cache.put with an embedded VARY:* Response]
+    expected: NOTRUN
+
+  [Cache.put with a string request]
+    expected: NOTRUN
+
+  [Cache.put with a used response body]
+    expected: NOTRUN
+
+  [Cache.put with a Response containing an empty URL]
+    expected: NOTRUN
+
+  [Cache.put with a relative URL]
+    expected: NOTRUN
+
+  [Cache.put with a null response]
+    expected: NOTRUN
+
+  [Cache.put with an empty response body]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/cache-storage/worker/cache-storage-keys.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/worker/cache-storage-keys.https.html.ini
@@ -1,0 +1,4 @@
+[cache-storage-keys.https.html]
+  [CacheStorage keys]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/cache-storage/worker/cache-storage-match.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/worker/cache-storage-match.https.html.ini
@@ -1,0 +1,35 @@
+[cache-storage-match.https.html]
+  expected: ERROR
+  [CacheStorageMatch with empty cache name provided]
+    expected: NOTRUN
+
+  [CacheStorageMatch from one of many caches by name]
+    expected: NOTRUN
+
+  [CacheStorageMatch supports ignoreSearch]
+    expected: NOTRUN
+
+  [Cache.match supports ignoreMethod]
+    expected: NOTRUN
+
+  [CacheStorageMatch from one of many caches]
+    expected: NOTRUN
+
+  [CacheStorageMatch with no cached entry]
+    expected: NOTRUN
+
+  [CacheStorageMatch with no caches available but name provided]
+    expected: NOTRUN
+
+  [CacheStorageMatch supports ignoreVary]
+    expected: NOTRUN
+
+  [CacheStorageMatch with no cache name provided]
+    expected: FAIL
+
+  [CacheStorageMatch a string request]
+    expected: NOTRUN
+
+  [CacheStorageMatch a HEAD request]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/cache-storage/worker/cache-storage.https.html.ini
+++ b/tests/wpt/metadata/service-workers/cache-storage/worker/cache-storage.https.html.ini
@@ -1,0 +1,31 @@
+[cache-storage.https.html]
+  [CacheStorage.open with an empty name]
+    expected: FAIL
+
+  [CacheStorage.delete dooms, but does not delete immediately]
+    expected: FAIL
+
+  [CacheStorage.open with no arguments]
+    expected: FAIL
+
+  [CacheStorage names are DOMStrings not USVStrings]
+    expected: FAIL
+
+  [CacheStorage.has with existing cache]
+    expected: FAIL
+
+  [CacheStorage.delete with nonexistent cache]
+    expected: FAIL
+
+  [CacheStorage.open]
+    expected: FAIL
+
+  [CacheStorage.has with nonexistent cache]
+    expected: FAIL
+
+  [CacheStorage.open with existing cache]
+    expected: FAIL
+
+  [CacheStorage.delete with existing cache]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/Service-Worker-Allowed-header.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/Service-Worker-Allowed-header.https.html.ini
@@ -1,0 +1,25 @@
+[Service-Worker-Allowed-header.https.html]
+  [Registering within Service-Worker-Allowed path with parent reference]
+    expected: FAIL
+
+  [Service-Worker-Allowed is cross-origin to script, registering on a normally disallowed scope]
+    expected: FAIL
+
+  [Registering within Service-Worker-Allowed path (absolute URL)]
+    expected: FAIL
+
+  [Registering outside Service-Worker-Allowed path with parent reference]
+    expected: FAIL
+
+  [Service-Worker-Allowed is cross-origin to page, same-origin to script]
+    expected: FAIL
+
+  [Service-Worker-Allowed is cross-origin to script, registering on a normally allowed scope]
+    expected: FAIL
+
+  [Registering outside Service-Worker-Allowed path]
+    expected: FAIL
+
+  [Registering within Service-Worker-Allowed path]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/close.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/close.https.html.ini
@@ -1,0 +1,4 @@
+[close.https.html]
+  [ServiceWorkerGlobalScope: close operation]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event-constructor.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event-constructor.https.html.ini
@@ -1,0 +1,4 @@
+[extendable-message-event-constructor.https.html]
+  [ServiceWorkerGlobalScope: ExtendableMessageEvent Constructor]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event.https.html.ini
@@ -1,0 +1,13 @@
+[extendable-message-event.https.html]
+  [Post an extendable message from a nested client]
+    expected: FAIL
+
+  [Post loopback extendable messages]
+    expected: FAIL
+
+  [Post extendable messages among service workers]
+    expected: FAIL
+
+  [Post an extendable message from a top-level client]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/isSecureContext.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/isSecureContext.https.html.ini
@@ -1,0 +1,4 @@
+[isSecureContext.https.html]
+  [Setting up tests]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/postmessage.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/postmessage.https.html.ini
@@ -1,0 +1,7 @@
+[postmessage.https.html]
+  [Post loopback messages]
+    expected: FAIL
+
+  [Post messages among service workers]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/registration-attribute.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/registration-attribute.https.html.ini
@@ -1,0 +1,7 @@
+[registration-attribute.https.html]
+  [Verify registration attributes on ServiceWorkerGlobalScope of the newer worker]
+    expected: FAIL
+
+  [Verify registration attributes on ServiceWorkerGlobalScope]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/service-worker-error-event.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/service-worker-error-event.https.html.ini
@@ -1,0 +1,4 @@
+[service-worker-error-event.https.html]
+  [Error handlers inside serviceworker should see the attributes of ErrorEvent]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/unregister.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/unregister.https.html.ini
@@ -1,0 +1,13 @@
+[unregister.https.html]
+  [Unregister on activate event]
+    expected: FAIL
+
+  [Unregister on installing event]
+    expected: FAIL
+
+  [Unregister controlling service worker]
+    expected: FAIL
+
+  [Unregister on script evaluation]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/update.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/update.https.html.ini
@@ -1,0 +1,4 @@
+[update.https.html]
+  [Update a registration on ServiceWorkerGlobalScope]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/about-blank-replacement.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/about-blank-replacement.https.html.ini
@@ -1,0 +1,22 @@
+[about-blank-replacement.https.html]
+  [Popup initial about:blank is controlled, exposed to clients.matchAll(), and matches final Client.]
+    expected: FAIL
+
+  [Initial about:blank modified by parent is controlled, exposed to clients.matchAll(), and matches final Client.]
+    expected: FAIL
+
+  [Initial about:blank is controlled, exposed to clients.matchAll(), and matches final Client.]
+    expected: FAIL
+
+  [Dynamic about:blank is controlled and is exposed to clients.matchAll().]
+    expected: FAIL
+
+  [Initial about:blank is controlled, exposed to clients.matchAll(), and final Client is not controlled by a service worker.]
+    expected: FAIL
+
+  [Simple about:blank is controlled and is exposed to clients.matchAll().]
+    expected: FAIL
+
+  [Nested about:srcdoc is controlled and is exposed to clients.matchAll().]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/activate-event-after-install-state-change.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/activate-event-after-install-state-change.https.html.ini
@@ -1,0 +1,4 @@
+[activate-event-after-install-state-change.https.html]
+  [installed event should be fired before activating service worker]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/activation-after-registration.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/activation-after-registration.https.html.ini
@@ -1,0 +1,4 @@
+[activation-after-registration.https.html]
+  [activation occurs after registration]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/activation.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/activation.https.html.ini
@@ -1,0 +1,13 @@
+[activation.https.html]
+  [loss of controllees triggers activation]
+    expected: FAIL
+
+  [finishing a request triggers unregister]
+    expected: FAIL
+
+  [skipWaiting bypasses no controllee requirement]
+    expected: FAIL
+
+  [finishing a request triggers activation]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/active.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/active.https.html.ini
@@ -1,0 +1,8 @@
+[active.https.html]
+  expected: ERROR
+  [The ServiceWorker objects returned from active attribute getter that represent the same service worker are the same objects]
+    expected: NOTRUN
+
+  [active is set]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/appcache-ordering-main.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/appcache-ordering-main.https.html.ini
@@ -1,0 +1,4 @@
+[appcache-ordering-main.https.html]
+  [serviceworkers take priority over appcaches]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/claim-affect-other-registration.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/claim-affect-other-registration.https.html.ini
@@ -1,0 +1,4 @@
+[claim-affect-other-registration.https.html]
+  [claim() should affect the originally controlling registration.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/claim-fetch.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/claim-fetch.https.html.ini
@@ -1,0 +1,4 @@
+[claim-fetch.https.html]
+  [fetch() should be intercepted after the client is claimed.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/claim-not-using-registration.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/claim-not-using-registration.https.html.ini
@@ -1,0 +1,7 @@
+[claim-not-using-registration.https.html]
+  [Test claim client which is not using registration]
+    expected: FAIL
+
+  [Test claim client when there's a longer-matched registration not already used by the page]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/claim-shared-worker-fetch.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/claim-shared-worker-fetch.https.html.ini
@@ -1,0 +1,4 @@
+[claim-shared-worker-fetch.https.html]
+  [fetch() in SharedWorker should be intercepted after the client is claimed.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/claim-using-registration.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/claim-using-registration.https.html.ini
@@ -1,0 +1,7 @@
+[claim-using-registration.https.html]
+  [Test for the waiting worker claims a client which is using the the same registration]
+    expected: FAIL
+
+  [Test worker claims client which is using another registration]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/claim-with-redirect.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/claim-with-redirect.https.html.ini
@@ -1,0 +1,2 @@
+[claim-with-redirect.https.html]
+  expected: ERROR

--- a/tests/wpt/metadata/service-workers/service-worker/claim-worker-fetch.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/claim-worker-fetch.https.html.ini
@@ -1,0 +1,7 @@
+[claim-worker-fetch.https.html]
+  [fetch() in Worker should be intercepted after the client is claimed.]
+    expected: FAIL
+
+  [fetch() in nested Worker should be intercepted after the client is claimed.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/client-id.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/client-id.https.html.ini
@@ -1,0 +1,4 @@
+[client-id.https.html]
+  [Client.id returns the client's ID.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/client-navigate.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/client-navigate.https.html.ini
@@ -1,0 +1,16 @@
+[client-navigate.https.html]
+  [Frame location should not be accessible after redirect]
+    expected: FAIL
+
+  [Frame location should not update on failed mixed-content navigation]
+    expected: FAIL
+
+  [Frame location should update on successful navigation]
+    expected: FAIL
+
+  [Frame location should not be accessible after cross-origin navigation]
+    expected: FAIL
+
+  [Frame location should not update on failed about:blank navigation]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/clients-get-client-types.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/clients-get-client-types.https.html.ini
@@ -1,0 +1,4 @@
+[clients-get-client-types.https.html]
+  [Test Clients.get() with window and worker clients]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/clients-get-cross-origin.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/clients-get-cross-origin.https.html.ini
@@ -1,0 +1,4 @@
+[clients-get-cross-origin.https.html]
+  [Test Clients.get() cross origin]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/clients-get.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/clients-get.https.html.ini
@@ -1,0 +1,10 @@
+[clients-get.https.html]
+  [Test Clients.get()]
+    expected: FAIL
+
+  [Test successful Clients.get(FetchEvent.resultingClientId)]
+    expected: FAIL
+
+  [Test unsuccessful Clients.get(FetchEvent.resultingClientId)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/clients-matchall-client-types.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/clients-matchall-client-types.https.html.ini
@@ -1,0 +1,7 @@
+[clients-matchall-client-types.https.html]
+  [Verify matchAll() with window client type]
+    expected: FAIL
+
+  [Verify matchAll() with {window, sharedworker, worker} client types]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/clients-matchall-exact-controller.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/clients-matchall-exact-controller.https.html.ini
@@ -1,0 +1,4 @@
+[clients-matchall-exact-controller.https.html]
+  [Test Clients.matchAll() with exact controller]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/clients-matchall-include-uncontrolled.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/clients-matchall-include-uncontrolled.https.html.ini
@@ -1,0 +1,7 @@
+[clients-matchall-include-uncontrolled.https.html]
+  [Verify matchAll() with windows respect includeUncontrolled]
+    expected: FAIL
+
+  [Verify matchAll() with shared workers respect includeUncontrolled]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/clients-matchall-on-evaluation.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/clients-matchall-on-evaluation.https.html.ini
@@ -1,0 +1,4 @@
+[clients-matchall-on-evaluation.https.html]
+  [Test Clients.matchAll() on script evaluation]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/clients-matchall-order.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/clients-matchall-order.https.html.ini
@@ -1,0 +1,22 @@
+[clients-matchall-order.https.html]
+  [Clients.matchAll() returns non-focused controlled windows in creation order.]
+    expected: FAIL
+
+  [Clients.matchAll() returns uncontrolled windows in focus order.  Case 1.]
+    expected: FAIL
+
+  [Clients.matchAll() returns controlled windows in focus order.  Case 1.]
+    expected: FAIL
+
+  [Clients.matchAll() returns controlled windows and frames in focus order.]
+    expected: FAIL
+
+  [Clients.matchAll() returns uncontrolled windows in focus order.  Case 2.]
+    expected: FAIL
+
+  [Clients.matchAll() returns non-focused uncontrolled windows in creation order.]
+    expected: FAIL
+
+  [Clients.matchAll() returns controlled windows in focus order.  Case 2.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/clients-matchall.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/clients-matchall.https.html.ini
@@ -1,0 +1,4 @@
+[clients-matchall.https.html]
+  [Test Clients.matchAll()]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/controller-on-disconnect.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/controller-on-disconnect.https.html.ini
@@ -1,0 +1,4 @@
+[controller-on-disconnect.https.html]
+  [controller is cleared on disconnected window]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/controller-on-load.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/controller-on-load.https.html.ini
@@ -1,0 +1,4 @@
+[controller-on-load.https.html]
+  [controller is set for a controlled document]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/controller-on-reload.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/controller-on-reload.https.html.ini
@@ -1,0 +1,4 @@
+[controller-on-reload.https.html]
+  [controller is set upon reload after registration]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/controller-with-no-fetch-event-handler.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/controller-with-no-fetch-event-handler.https.html.ini
@@ -1,0 +1,13 @@
+[controller-with-no-fetch-event-handler.https.html]
+  [cross-origin request, cors denied]
+    expected: FAIL
+
+  [global setup]
+    expected: FAIL
+
+  [cross-origin request, cors approved]
+    expected: FAIL
+
+  [cross-origin request, no-cors mode]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/dedicated-worker-service-worker-interception.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/dedicated-worker-service-worker-interception.https.html.ini
@@ -1,0 +1,10 @@
+[dedicated-worker-service-worker-interception.https.html]
+  [Static import should be intercepted by a service worker.]
+    expected: FAIL
+
+  [Dynamic import should be intercepted by a service worker.]
+    expected: FAIL
+
+  [Top-level module loading should be intercepted by a service worker.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/detached-context.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/detached-context.https.html.ini
@@ -1,0 +1,16 @@
+[detached-context.https.html]
+  [accessing navigator on a removed frame]
+    expected: FAIL
+
+  [accessing navigator.serviceWorker on a detached iframe]
+    expected: FAIL
+
+  [accessing a ServiceWorker object from a removed iframe]
+    expected: FAIL
+
+  [accessing navigator.serviceWorker on a removed about:blank frame]
+    expected: FAIL
+
+  [accessing a ServiceWorkerRegistration from a removed iframe]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/embed-and-object-are-not-intercepted.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/embed-and-object-are-not-intercepted.https.html.ini
@@ -1,0 +1,17 @@
+[embed-and-object-are-not-intercepted.https.html]
+  expected: TIMEOUT
+  [requests for EMBED elements of embedded HTML content should not be intercepted by service workers]
+    expected: TIMEOUT
+
+  [requests for EMBED elements of an image should not be intercepted by service workers]
+    expected: NOTRUN
+
+  [requests for OBJECT elements of embedded HTML content should not be intercepted by service workers]
+    expected: NOTRUN
+
+  [requests for OBJECT elements of an image should not be intercepted by service workers]
+    expected: NOTRUN
+
+  [initialize global state]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/extendable-event-async-waituntil.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/extendable-event-async-waituntil.https.html.ini
@@ -1,0 +1,31 @@
+[extendable-event-async-waituntil.https.html]
+  [Test calling waitUntil asynchronously inside microtask of respondWith promise.]
+    expected: FAIL
+
+  [Test calling waitUntil synchronously inside microtask of respondWith promise.]
+    expected: FAIL
+
+  [Test calling waitUntil in a different microtask without an existing extension throws]
+    expected: FAIL
+
+  [Test calling waitUntil asynchronously with pending respondWith promise.]
+    expected: FAIL
+
+  [Test calling waitUntil after the current extension expired in a different task fails]
+    expected: FAIL
+
+  [Test calling waitUntil in a different task with an existing extension succeeds]
+    expected: FAIL
+
+  [Test calling waitUntil in a different task without an existing extension throws]
+    expected: FAIL
+
+  [Test calling waitUntil with an existing extension promise handler succeeds]
+    expected: FAIL
+
+  [Test calling waitUntil at the end of the microtask turn throws]
+    expected: FAIL
+
+  [Test calling waitUntil on a script constructed ExtendableEvent throws exception]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/extendable-event-waituntil.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/extendable-event-waituntil.https.html.ini
@@ -1,0 +1,19 @@
+[extendable-event-waituntil.https.html]
+  [Test activate event waitUntil rejected.]
+    expected: FAIL
+
+  [Test install event waitUntil fulfilled]
+    expected: FAIL
+
+  [Test ExtendableEvent multiple waitUntil fulfilled.]
+    expected: FAIL
+
+  [Test install event waitUntil rejected]
+    expected: FAIL
+
+  [Test activate event waitUntil fulfilled]
+    expected: FAIL
+
+  [Test ExtendableEvent waitUntil reject precedence.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-audio-tainting.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-audio-tainting.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-audio-tainting.https.html]
+  [Verify CORS XHR of fetch() in a Service Worker]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-canvas-tainting-double-write.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-canvas-tainting-double-write.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-canvas-tainting-double-write.https.html]
+  [canvas is tainted after writing both a non-opaque image and an opaque image from the same URL]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-canvas-tainting-image-cache.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-canvas-tainting-image-cache.https.html.ini
@@ -1,0 +1,118 @@
+[fetch-canvas-tainting-image-cache.https.html]
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&reject" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=cors&credentials=same-origin&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&Auth&ACAOrigin=https://web-platform.test:8443&ACACredentials=true&ignore" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&ACAOrigin=https://web-platform.test:8443&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&ACAOrigin=https://web-platform.test:8443&ACACredentials=true&ignore" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&ignore" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&Auth&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&ignore" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&reject" with crossOrigin "" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue%26ACACredentials%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&Auth&ignore" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&reject" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&ACAOrigin=https://web-platform.test:8443&ignore" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&Auth&ignore" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&Auth&ignore" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&ignore" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue%26ACACredentials%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&Auth&ACAOrigin=https://web-platform.test:8443&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=cors&credentials=same-origin&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&cache=true&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26cache%3Dtrue" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [initialize global state]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-canvas-tainting-image.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-canvas-tainting-image.https.html.ini
@@ -1,0 +1,118 @@
+[fetch-canvas-tainting-image.https.html]
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&ignore" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&Auth&ACAOrigin=https://web-platform.test:8443&ACACredentials=true&ignore" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=cors&credentials=same-origin&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&Auth&ignore" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26ACACredentials%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&Auth&ignore" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&reject" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&Auth&ignore" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&reject" with crossOrigin "" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&ACAOrigin=https://web-platform.test:8443&ignore" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&Auth&ACAOrigin=https://web-platform.test:8443&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&ignore" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&ignore" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&ACAOrigin=https://web-platform.test:8443&ACACredentials=true&ignore" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&reject" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&ACAOrigin=https://web-platform.test:8443&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26ACACredentials%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&Auth&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [initialize global state]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=cors&credentials=same-origin&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?PNGIMAGE&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FPNGIMAGE" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-canvas-tainting-video-cache.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-canvas-tainting-video-cache.https.html.ini
@@ -1,0 +1,118 @@
+[fetch-canvas-tainting-video-cache.https.html]
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&Auth&ACAOrigin=https://web-platform.test:8443&ACACredentials=true&ignore" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&ignore" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&reject" with crossOrigin "" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&Auth&ignore" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&reject" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&ignore" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&reject" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&ACAOrigin=https://web-platform.test:8443&ACACredentials=true&ignore" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&Auth&ignore" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=cors&credentials=same-origin&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&Auth&ACAOrigin=https://web-platform.test:8443&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&Auth&ignore" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue%26ACACredentials%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&Auth&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue%26ACACredentials%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=cors&credentials=same-origin&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&ACAOrigin=https://web-platform.test:8443&ignore" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&ACAOrigin=https://web-platform.test:8443&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26cache%3Dtrue" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&cache=true&ignore" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [initialize global state]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-canvas-tainting-video-with-range-request.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-canvas-tainting-video-with-range-request.https.html.ini
@@ -1,0 +1,10 @@
+[fetch-canvas-tainting-video-with-range-request.https.html]
+  [range responses from single origin (same-origin)]
+    expected: FAIL
+
+  [range responses from single origin with both opaque and non-opaque responses]
+    expected: FAIL
+
+  [range responses from multiple origins (cross-origin first)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-canvas-tainting-video.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-canvas-tainting-video.https.html.ini
@@ -1,0 +1,118 @@
+[fetch-canvas-tainting-video.https.html]
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&ACAOrigin=https://web-platform.test:8443&ACACredentials=true&ignore" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&reject" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&ACAOrigin=https://web-platform.test:8443&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&Auth&ignore" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&reject" with crossOrigin "" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=cors&credentials=same-origin&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26ACACredentials%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&Auth&ACAOrigin=https://web-platform.test:8443&ACACredentials=true&ignore" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&ignore" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&Auth&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&ignore" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&ACAOrigin=https://web-platform.test:8443&ignore" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&Auth&ACAOrigin=https://web-platform.test:8443&ignore" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&Auth&ignore" with crossOrigin "" should be TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=cors&credentials=same-origin&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO" with crossOrigin "anonymous" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=no-cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=same-origin&url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&reject" with crossOrigin "use-credentials" should be LOAD_ERROR]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&ignore" with crossOrigin "" should be NOT_TAINTED]
+    expected: FAIL
+
+  [initialize global state]
+    expected: FAIL
+
+  [url "https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&mode=cors&url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FVIDEO%26ACACredentials%3Dtrue%26ACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443" with crossOrigin "use-credentials" should be NOT_TAINTED]
+    expected: FAIL
+
+  [url "https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?VIDEO&Auth&ignore" with crossOrigin "anonymous" should be LOAD_ERROR]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-cors-exposed-header-names.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-cors-exposed-header-names.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-cors-exposed-header-names.https.html]
+  [CORS-exposed header names for a response from sw]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-cors-xhr.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-cors-xhr.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-cors-xhr.https.html]
+  [Verify CORS XHR of fetch() in a Service Worker]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-csp.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-csp.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-csp.https.html]
+  [Verify CSP control of fetch() in a Service Worker]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-after-navigation-within-page.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-after-navigation-within-page.https.html.ini
@@ -1,0 +1,7 @@
+[fetch-event-after-navigation-within-page.https.html]
+  [Service Worker should respond to fetch event after the pushState]
+    expected: FAIL
+
+  [Service Worker should respond to fetch event after the hash changes]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-async-respond-with.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-async-respond-with.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-event-async-respond-with.https.html]
+  [Calling respondWith asynchronously throws an exception]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-network-error.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-network-error.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-event-network-error.https.html]
+  [Rejecting the fetch event or using preventDefault() causes a network error]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-redirect.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-redirect.https.html.ini
@@ -1,0 +1,166 @@
+[fetch-event-redirect.https.html]
+  [Non-navigation, manual redirect, same-origin mode Request redirected to no-cors without credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, no-cors mode Request redirected to same-origin without credentials should succeed interception and response should be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, same-origin mode Request redirected to no-cors without credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, no-cors mode Request redirected to no-cors with credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, same-origin mode Request redirected to cors without credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, same-origin mode Request redirected to no-cors without credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, no-cors mode Request redirected to same-origin with credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, same-origin mode Request redirected to cors with credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, cors mode Request redirected to same-origin without credentials should succeed interception and response should be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, cors mode Request redirected to cors without credentials should succeed interception and response should be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, cors mode Request redirected to same-origin with credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, cors mode Request redirected to same-origin with credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, same-origin mode Request redirected to same-origin with credentials should succeed interception and response should be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, same-origin mode Request redirected to same-origin without credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, cors mode Request redirected to cors without credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, same-origin mode Request redirected to cors with credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, same-origin mode Request redirected to same-origin with credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, same-origin mode Request redirected to no-cors with credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, cors mode Request redirected to cors with credentials should fail interception and response should be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, no-cors mode Request redirected to cors with credentials should succeed interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, same-origin mode Request redirected to cors with credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, cors mode Request redirected to same-origin without credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, no-cors mode Request redirected to cors without credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, cors mode Request redirected to same-origin with credentials should succeed interception and response should be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, same-origin mode Request redirected to cors without credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, cors mode Request redirected to no-cors without credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, same-origin mode Request redirected to same-origin without credentials should succeed interception and response should be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, same-origin mode Request redirected to same-origin without credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, no-cors mode Request redirected to same-origin without credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, same-origin mode Request redirected to same-origin with credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, no-cors mode Request redirected to same-origin with credentials should succeed interception and response should be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, no-cors mode Request redirected to no-cors without credentials should succeed interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, cors mode Request redirected to no-cors with credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, no-cors mode Request redirected to no-cors with credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, no-cors mode Request redirected to same-origin with credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, no-cors mode Request redirected to cors without credentials should succeed interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, cors mode Request redirected to no-cors without credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, same-origin mode Request redirected to cors without credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, no-cors mode Request redirected to cors without credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, no-cors mode Request redirected to cors with credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, cors mode Request redirected to cors with credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, cors mode Request redirected to cors with credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, cors mode Request redirected to no-cors with credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, no-cors mode Request redirected to no-cors without credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, no-cors mode Request redirected to no-cors without credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, same-origin mode Request redirected to no-cors with credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, no-cors mode Request redirected to same-origin without credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, same-origin mode Request redirected to no-cors with credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, follow redirect, no-cors mode Request redirected to no-cors with credentials should succeed interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, cors mode Request redirected to same-origin without credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, cors mode Request redirected to no-cors without credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, no-cors mode Request redirected to cors with credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, error redirect, cors mode Request redirected to no-cors with credentials should fail interception and response should not be redirected]
+    expected: FAIL
+
+  [Non-navigation, manual redirect, cors mode Request redirected to cors without credentials should succeed opaqueredirect interception and response should not be redirected]
+    expected: FAIL
+
+  [initialize global state]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-referrer-policy.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-referrer-policy.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-event-referrer-policy.https.html]
+  [Service Worker responds to fetch event with the referrer policy]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-argument.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-argument.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-event-respond-with-argument.https.html]
+  [respondWith() takes either a Response or a promise that resolves with a Response. Other values should raise a network error.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-body-loaded-in-chunk.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-body-loaded-in-chunk.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-event-respond-with-body-loaded-in-chunk.https.html]
+  [Respond by chunks with a Response being loaded]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-custom-response.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-custom-response.https.html.ini
@@ -1,0 +1,34 @@
+[fetch-event-respond-with-custom-response.https.html]
+  [Subresource built from a blob]
+    expected: FAIL
+
+  [Subresource built from a buffer]
+    expected: FAIL
+
+  [Subresource built from a string]
+    expected: FAIL
+
+  [Subresource built from form-data]
+    expected: FAIL
+
+  [Navigation resource built from a string]
+    expected: FAIL
+
+  [Subresource built from a buffer-view]
+    expected: FAIL
+
+  [Navigation resource built from a buffer]
+    expected: FAIL
+
+  [Navigation resource built from search-params]
+    expected: FAIL
+
+  [Subresource built from search-params]
+    expected: FAIL
+
+  [Navigation resource built from a blob]
+    expected: FAIL
+
+  [Navigation resource built from a buffer-view]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-partial-stream.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-partial-stream.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-event-respond-with-partial-stream.https.html]
+  [respondWith() streams data to an intercepted fetch()]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-readable-stream-chunk.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-readable-stream-chunk.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-event-respond-with-readable-stream-chunk.https.html]
+  [Respond by chunks with a Response built from a ReadableStream]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-readable-stream.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-readable-stream.https.html.ini
@@ -1,0 +1,19 @@
+[fetch-event-respond-with-readable-stream.https.html]
+  [Subresource built from a ReadableStream]
+    expected: FAIL
+
+  [Subresource built from a ReadableStream - delayed]
+    expected: FAIL
+
+  [Subresource built from a ReadableStream - fetch stream]
+    expected: FAIL
+
+  [Main resource built from a ReadableStream - delayed]
+    expected: FAIL
+
+  [Main resource built from a ReadableStream - fetch stream]
+    expected: FAIL
+
+  [Main resource built from a ReadableStream]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-response-body-with-invalid-chunk.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-response-body-with-invalid-chunk.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-event-respond-with-response-body-with-invalid-chunk.https.html]
+  [Response with a ReadableStream having non-Uint8Array chunks should be transferred as errored]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-stops-propagation.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-respond-with-stops-propagation.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-event-respond-with-stops-propagation.https.html]
+  [respondWith() invokes stopImmediatePropagation()]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-throws-after-respond-with.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-throws-after-respond-with.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-event-throws-after-respond-with.https.html]
+  [Fetch event handler throws after a successful respondWith()]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event-within-sw.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event-within-sw.https.html.ini
@@ -1,0 +1,7 @@
+[fetch-event-within-sw.https.html]
+  [Service worker does not intercept fetch/cache requests within service worker]
+    expected: FAIL
+
+  [Service worker intercepts requests from window]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-event.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-event.https.html.ini
@@ -1,0 +1,97 @@
+[fetch-event.https.html]
+  [Service Worker responds to fetch event with the referrer URL]
+    expected: FAIL
+
+  [Service Worker fetches other file in fetch event]
+    expected: FAIL
+
+  [Service Worker event.respondWith must set the used flag]
+    expected: FAIL
+
+  [FetchEvent#request.isReloadNavigation is true (POST + location.reload())]
+    expected: FAIL
+
+  [global setup]
+    expected: FAIL
+
+  [Service Worker responds to fetch event with string]
+    expected: FAIL
+
+  [Service Worker responds to fetch event with an existing client id]
+    expected: FAIL
+
+  [FetchEvent#request.isHistoryNavigation is true (with history.go(1))]
+    expected: FAIL
+
+  [Service Worker responds to fetch event with the correct cache types]
+    expected: FAIL
+
+  [Service Worker should expose FetchEvent URL fragments.]
+    expected: FAIL
+
+  [FetchEvent#request.isHistoryNavigation is false (with location.reload)]
+    expected: FAIL
+
+  [FetchEvent#request.isReloadNavigation is true (with history traversal)]
+    expected: FAIL
+
+  [Multiple calls of respondWith must throw InvalidStateErrors]
+    expected: FAIL
+
+  [FetchEvent#request.isReloadNavigation is true (location.reload())]
+    expected: FAIL
+
+  [Service Worker responds to fetch event with the correct keepalive value]
+    expected: FAIL
+
+  [Service Worker headers in the request of a fetch event]
+    expected: FAIL
+
+  [Service Worker responds to fetch event using request fragment with string]
+    expected: FAIL
+
+  [FetchEvent#request.isHistoryNavigation is true (with history.go(-2))]
+    expected: FAIL
+
+  [FetchEvent#request.isHistoryNavigation is true (with history.go(2))]
+    expected: FAIL
+
+  [Service Worker falls back to network in fetch event with POST form]
+    expected: FAIL
+
+  [FetchEvent#request.isReloadNavigation is true (history.go(0))]
+    expected: FAIL
+
+  [FetchEvent#body is a blob]
+    expected: FAIL
+
+  [FetchEvent#body is a string]
+    expected: FAIL
+
+  [FetchEvent#request.isHistoryNavigation is true (with history.go(-1))]
+    expected: FAIL
+
+  [Service Worker responds to fetch event with blob body]
+    expected: FAIL
+
+  [FetchEvent#request.isHistoryNavigation is false (with history.go(0))]
+    expected: FAIL
+
+  [Service Worker should intercept EventSource]
+    expected: FAIL
+
+  [FetchEvent#request.isHistoryNavigation is true (POST + history.go(-1))]
+    expected: FAIL
+
+  [Service Worker responds to fetch event with null response body]
+    expected: FAIL
+
+  [Service Worker responds to fetch event with the correct integrity_metadata]
+    expected: FAIL
+
+  [Service Worker responds to fetch event with the correct resulting client id]
+    expected: FAIL
+
+  [Service Worker responds to fetch event with POST form]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-frame-resource.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-frame-resource.https.html.ini
@@ -1,0 +1,19 @@
+[fetch-frame-resource.https.html]
+  [CORS type response could be loaded in the new window.]
+    expected: FAIL
+
+  [Opaque type response could not be loaded in the new window.]
+    expected: FAIL
+
+  [CORS type response could be loaded in the iframe.]
+    expected: FAIL
+
+  [Basic type response could be loaded in the new window.]
+    expected: FAIL
+
+  [Opaque type response could not be loaded in the iframe.]
+    expected: FAIL
+
+  [Basic type response could be loaded in the iframe.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-header-visibility.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-header-visibility.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-header-visibility.https.html]
+  [Visibility of defaulted headers during interception]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-mixed-content-to-inscope.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-mixed-content-to-inscope.https.html.ini
@@ -1,0 +1,5 @@
+[fetch-mixed-content-to-inscope.https.html]
+  expected: TIMEOUT
+  [Verify Mixed content of fetch() in a Service Worker]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-mixed-content-to-outscope.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-mixed-content-to-outscope.https.html.ini
@@ -1,0 +1,5 @@
+[fetch-mixed-content-to-outscope.https.html]
+  expected: TIMEOUT
+  [Verify Mixed content of fetch() in a Service Worker]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-request-css-base-url.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-request-css-base-url.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-request-css-base-url.https.html]
+  [CSS's base URL must be the request URL even when fetched from other URL.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-request-css-cross-origin.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-request-css-cross-origin.https.html.ini
@@ -1,0 +1,10 @@
+[fetch-request-css-cross-origin.https.html]
+  [Same-origin policy for access to CSS resources fetched via service worker]
+    expected: FAIL
+
+  [setup global state]
+    expected: FAIL
+
+  [MIME checking of CSS resources fetched via service worker when Content-Type is not set.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-request-css-images.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-request-css-images.https.html.ini
@@ -1,0 +1,13 @@
+[fetch-request-css-images.https.html]
+  [Verify FetchEvent for css image (backgroundImage).]
+    expected: FAIL
+
+  [Verify FetchEvent for css image-set (backgroundImage).]
+    expected: FAIL
+
+  [Verify FetchEvent for css image (shapeOutside).]
+    expected: FAIL
+
+  [Verify FetchEvent for css image-set (shapeOutside).]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-request-fallback.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-request-fallback.https.html.ini
@@ -1,0 +1,49 @@
+[fetch-request-fallback.https.html]
+  [initialize global state]
+    expected: FAIL
+
+  [The SW must intercept only the first request for image resource which is redirected to other origin.]
+    expected: FAIL
+
+  [The SW must intercept only the first request of redirected XHR.]
+    expected: FAIL
+
+  [The SW must intercept only the first request for image resource which is redirected to CORS-unsupported other origin.]
+    expected: FAIL
+
+  [The SW must intercept the request of CORS-supported other origin XHR.]
+    expected: FAIL
+
+  [The SW must intercept only the first request for XHR which is redirected to CORS-unsupported other origin.]
+    expected: FAIL
+
+  [The SW must intercept the request for image.]
+    expected: FAIL
+
+  [The SW must intercept the request for CORS-supported other origin image.]
+    expected: FAIL
+
+  [The SW must intercept only the first request for image resource which is redirected to CORS-supported other origin.]
+    expected: FAIL
+
+  [The SW must intercept only the first request for redirected image resource.]
+    expected: FAIL
+
+  [The SW must intercept only the first request for XHR which is redirected to CORS-supported other origin.]
+    expected: FAIL
+
+  [The SW must intercept the request for other origin image.]
+    expected: FAIL
+
+  [The SW must intercept the request of same origin XHR.]
+    expected: FAIL
+
+  [The SW must intercept the request of CORS-unsupported other origin XHR.]
+    expected: FAIL
+
+  [The SW must intercept the request for CORS-unsupported other origin image.]
+    expected: FAIL
+
+  [The SW must intercept the request for a main resource.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-request-html-imports.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-request-html-imports.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-request-html-imports.https.html]
+  [Verify the FetchEvent for HTMLImports]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-request-no-freshness-headers.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-request-no-freshness-headers.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-request-no-freshness-headers.https.html]
+  [The headers of FetchEvent shouldn't contain freshness headers.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-request-redirect.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-request-redirect.https.html.ini
@@ -1,0 +1,10 @@
+[fetch-request-redirect.https.html]
+  [Verify redirect mode of Fetch API and ServiceWorker FetchEvent.]
+    expected: FAIL
+
+  [Verify redirected of Response(Fetch API), Cache API and ServiceWorker FetchEvent.]
+    expected: FAIL
+
+  [Verify redirected of Response(Fetch API) and ServiceWorker FetchEvent.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-request-resources.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-request-resources.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-request-resources.https.html]
+  [Verify FetchEvent for resources.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-request-xhr-sync-on-worker.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-request-xhr-sync-on-worker.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-request-xhr-sync-on-worker.https.html]
+  [Verify SyncXHR on Worker is intercepted]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-request-xhr-sync.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-request-xhr-sync.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-request-xhr-sync.https.html]
+  [Verify SyncXHR is intercepted]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-request-xhr.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-request-xhr.https.html.ini
@@ -1,0 +1,37 @@
+[fetch-request-xhr.https.html]
+  [event.request has the expected headers for same-origin GET.]
+    expected: FAIL
+
+  [FetchEvent#request.method is set to XHR method]
+    expected: FAIL
+
+  [XHR to data URL]
+    expected: FAIL
+
+  [event.request has the expected headers for cross-origin POST.]
+    expected: FAIL
+
+  [FetchEvent#request.body contains XHR request data (blob)]
+    expected: FAIL
+
+  [XHR with form data]
+    expected: FAIL
+
+  [event.request has the expected headers for cross-origin GET.]
+    expected: FAIL
+
+  [XHR with mode/credentials set]
+    expected: FAIL
+
+  [XHR using OPTIONS method]
+    expected: FAIL
+
+  [FetchEvent#request.body contains XHR request data (string)]
+    expected: FAIL
+
+  [event.request has the expected headers for same-origin POST.]
+    expected: FAIL
+
+  [initialize global state]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-response-taint.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-response-taint.https.html.ini
@@ -1,0 +1,395 @@
+[fetch-response-taint.https.html]
+  expected: TIMEOUT
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"no-cors" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"no-cors" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"same-origin" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"same-origin" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"no-cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"same-origin" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"no-cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"no-cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"cors" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"same-origin" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"no-cors" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"same-origin" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"no-cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"no-cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"cors" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"no-cors" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"same-origin" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"same-origin" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"same-origin" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"no-cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"no-cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"same-origin" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"no-cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"no-cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"same-origin" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"no-cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"no-cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"same-origin" credentials:"omit" should succeed.]
+    expected: TIMEOUT
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"same-origin" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"cors" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?ACAOrigin=*" mode:"cors" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"same-origin" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"no-cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"no-cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"cors" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"cors" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"same-origin" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"same-origin" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"no-cors" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"no-cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"same-origin" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"same-origin" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"cors" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"cors" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"same-origin" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"same-origin" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"same-origin" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"same-origin" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"same-origin" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"same-origin" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"same-origin" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"no-cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"no-cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"cors" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"no-cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"same-origin" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"same-origin" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"same-origin" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"no-cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"cors" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"cors" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"no-cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"no-cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"same-origin" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"no-cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"no-cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"same-origin" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"cors" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"cors" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"same-origin" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"same-origin" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"no-cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"no-cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"no-cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"same-origin" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"no-cors" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [initialize global state]
+    expected: FAIL
+
+  [fetching url:"https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?ACAOrigin=*" mode:"cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"no-cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"no-cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"same-origin" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"no-cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"same-origin" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"same-origin" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"no-cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"same-origin" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?ACAOrigin=*" mode:"cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?ACAOrigin=https://web-platform.test:8443&ACACredentials=true" mode:"cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"same-origin" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"no-cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"cors" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"no-cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"cors" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"cors" credentials:"omit" should fail.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"same-origin" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"same-origin" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"same-origin" credentials:"include" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"no-cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3D*&mode=cors&credentials=omit&" mode:"cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=no-cors&credentials=omit&" mode:"no-cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"same-origin" credentials:"same-origin" should fail.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/service-workers/service-worker/resources/fetch-access-control.py?" mode:"cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"no-cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"cors" credentials:"same-origin" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://www1.web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3FACAOrigin%3Dhttps%3A%2F%2Fweb-platform.test%3A8443%26ACACredentials%3Dtrue&mode=cors&credentials=include&" mode:"no-cors" credentials:"include" should succeed.]
+    expected: NOTRUN
+
+  [fetching url:"https://web-platform.test:8443/?url=https%3A%2F%2Fweb-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=same-origin&" mode:"no-cors" credentials:"omit" should succeed.]
+    expected: NOTRUN
+
+  [url:"https://web-platform.test:8443/?url=https%3A%2F%2Fwww1.web-platform.test%3A8443%2Fservice-workers%2Fservice-worker%2Fresources%2Ffetch-access-control.py%3F&mode=same-origin&credentials=omit&" mode:"same-origin" credentials:"include" should fail.]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-response-xhr.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-response-xhr.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-response-xhr.https.html]
+  [Verify the response of FetchEvent using XMLHttpRequest]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/fetch-waits-for-activate.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/fetch-waits-for-activate.https.html.ini
@@ -1,0 +1,4 @@
+[fetch-waits-for-activate.https.html]
+  [Fetch events should wait for the activate event to complete.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/getregistration.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/getregistration.https.html.ini
@@ -1,0 +1,16 @@
+[getregistration.https.html]
+  [getRegistration]
+    expected: FAIL
+
+  [Register then Unregister then getRegistration]
+    expected: FAIL
+
+  [Register then getRegistration]
+    expected: FAIL
+
+  [Register then getRegistration with a URL having a fragment]
+    expected: FAIL
+
+  [getRegistration with a cross origin URL]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/getregistrations.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/getregistrations.https.html.ini
@@ -1,0 +1,19 @@
+[getregistrations.https.html]
+  [registrations are not returned following unregister]
+    expected: FAIL
+
+  [getRegistrations promise resolves only with same origin registrations.]
+    expected: FAIL
+
+  [Register then Unregister with controlled frame then getRegistrations]
+    expected: FAIL
+
+  [Register multiple times then getRegistrations]
+    expected: FAIL
+
+  [Register then getRegistrations]
+    expected: FAIL
+
+  [Register then Unregister then getRegistrations]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/http-to-https-redirect-and-register.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/http-to-https-redirect-and-register.https.html.ini
@@ -1,0 +1,7 @@
+[http-to-https-redirect-and-register.https.html]
+  [register on a secure page after redirect from an non-secure url]
+    expected: FAIL
+
+  [register on a non-secure page after redirect from an non-secure url]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/immutable-prototype-serviceworker.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/immutable-prototype-serviceworker.https.html.ini
@@ -1,0 +1,4 @@
+[immutable-prototype-serviceworker.https.html]
+  [worker prototype chain should be immutable]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/import-module-scripts.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/import-module-scripts.https.html.ini
@@ -1,0 +1,22 @@
+[import-module-scripts.https.html]
+  [Dynamic import.]
+    expected: FAIL
+
+  [Static import and then dynamic import.]
+    expected: FAIL
+
+  [eval(import()).]
+    expected: FAIL
+
+  [Dynamic import and then static import.]
+    expected: FAIL
+
+  [Static import.]
+    expected: FAIL
+
+  [Nested dynamic import.]
+    expected: FAIL
+
+  [Nested static import.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/import-scripts-mime-types.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/import-scripts-mime-types.https.html.ini
@@ -1,0 +1,7 @@
+[import-scripts-mime-types.https.html]
+  [Fetch importScripts tests from service worker]
+    expected: FAIL
+
+  [Global setup]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/import-scripts-redirect.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/import-scripts-redirect.https.html.ini
@@ -1,0 +1,7 @@
+[import-scripts-redirect.https.html]
+  [importScripts() supports redirects and can be updated]
+    expected: FAIL
+
+  [importScripts() supports redirects]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/import-scripts-resource-map.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/import-scripts-resource-map.https.html.ini
@@ -1,0 +1,4 @@
+[import-scripts-resource-map.https.html]
+  [import the same script URL multiple times]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/import-scripts-updated-flag.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/import-scripts-updated-flag.https.html.ini
@@ -1,0 +1,13 @@
+[import-scripts-updated-flag.https.html]
+  [import script not previously imported]
+    expected: FAIL
+
+  [import script previously imported at worker evaluation time]
+    expected: FAIL
+
+  [import script previously imported at worker install time]
+    expected: FAIL
+
+  [initialize global state]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/indexeddb.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/indexeddb.https.html.ini
@@ -1,0 +1,4 @@
+[indexeddb.https.html]
+  [Verify Indexed DB operation in a Service Worker]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/install-event-type.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/install-event-type.https.html.ini
@@ -1,0 +1,4 @@
+[install-event-type.https.html]
+  [install event type]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/installing.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/installing.https.html.ini
@@ -1,0 +1,8 @@
+[installing.https.html]
+  expected: ERROR
+  [installing is set]
+    expected: FAIL
+
+  [The ServiceWorker objects returned from installing attribute getter that represent the same service worker are the same objects]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/service-worker/interfaces-sw.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/interfaces-sw.https.html.ini
@@ -1,0 +1,4 @@
+[interfaces-sw.https.html]
+  [Interfaces and attributes in ServiceWorkerGlobalScope]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/interfaces-window.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/interfaces-window.https.html.ini
@@ -1,0 +1,7 @@
+[interfaces-window.https.html]
+  [navigator.serviceWorker is not available in a data: iframe]
+    expected: FAIL
+
+  [test setup (worker registration)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/invalid-blobtype.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/invalid-blobtype.https.html.ini
@@ -1,0 +1,4 @@
+[invalid-blobtype.https.html]
+  [Verify the response of FetchEvent using XMLHttpRequest]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/invalid-header.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/invalid-header.https.html.ini
@@ -1,0 +1,4 @@
+[invalid-header.https.html]
+  [Verify the response of FetchEvent using XMLHttpRequest]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/iso-latin1-header.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/iso-latin1-header.https.html.ini
@@ -1,0 +1,4 @@
+[iso-latin1-header.https.html]
+  [Verify the response of FetchEvent using XMLHttpRequest]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/local-url-inherit-controller.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/local-url-inherit-controller.https.html.ini
@@ -1,0 +1,22 @@
+[local-url-inherit-controller.https.html]
+  [Data URL worker should not inherit service worker controller.]
+    expected: FAIL
+
+  [Same-origin blob URL iframe should inherit service worker controller.]
+    expected: FAIL
+
+  [Same-origin blob URL iframe should intercept fetch().]
+    expected: FAIL
+
+  [Same-origin blob URL worker should inherit service worker controller.]
+    expected: FAIL
+
+  [Data URL worker should not intercept fetch().]
+    expected: FAIL
+
+  [Same-origin blob URL worker should intercept fetch().]
+    expected: FAIL
+
+  [Data URL iframe should not intercept fetch().]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/mime-sniffing.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/mime-sniffing.https.html.ini
@@ -1,0 +1,4 @@
+[mime-sniffing.https.html]
+  [The response from service worker should be correctly MIME siniffed.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/multi-globals/url-parsing.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/multi-globals/url-parsing.https.html.ini
@@ -1,0 +1,10 @@
+[url-parsing.https.html]
+  [getRegistration should use the relevant global of the object it was called on to resolve the script URL]
+    expected: FAIL
+
+  [register should use the relevant global of the object it was called on to resolve the script URL and the given scope URL]
+    expected: FAIL
+
+  [register should use the relevant global of the object it was called on to resolve the script URL and the default scope URL]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/multipart-image.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/multipart-image.https.html.ini
@@ -1,0 +1,16 @@
+[multipart-image.https.html]
+  [same-origin multipart image via SW should be readable]
+    expected: FAIL
+
+  [cross-origin multipart image via SW with rejected CORS should fail to load]
+    expected: FAIL
+
+  [cross-origin multipart image via SW with approved CORS should be readable]
+    expected: FAIL
+
+  [cross-origin multipart image with no-cors via SW should not be readable]
+    expected: FAIL
+
+  [initialize global state]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/multiple-register.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/multiple-register.https.html.ini
@@ -1,0 +1,10 @@
+[multiple-register.https.html]
+  [Subsequent registrations resolve to the same registration object]
+    expected: FAIL
+
+  [Concurrent registrations resolve to the same registration object]
+    expected: FAIL
+
+  [Subsequent registrations from a different iframe resolve to the different registration object but they refer to the same registration and workers]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/multiple-update.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/multiple-update.https.html.ini
@@ -1,0 +1,4 @@
+[multiple-update.https.html]
+  [Trigger multiple updates.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/navigate-window.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/navigate-window.https.html.ini
@@ -1,0 +1,7 @@
+[navigate-window.https.html]
+  [Clients.matchAll() should not show an old window after it navigates.]
+    expected: FAIL
+
+  [Clients.matchAll() should not show an old window as controlled after it navigates.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/navigation-preload/broken-chunked-encoding.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/navigation-preload/broken-chunked-encoding.https.html.ini
@@ -1,0 +1,7 @@
+[broken-chunked-encoding.https.html]
+  [FetchEvent#preloadResponse resolves even if the body is sent with broken chunked encoding with some delays]
+    expected: FAIL
+
+  [FetchEvent#preloadResponse resolves even if the body is sent with broken chunked encoding.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/navigation-preload/chunked-encoding.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/navigation-preload/chunked-encoding.https.html.ini
@@ -1,0 +1,4 @@
+[chunked-encoding.https.html]
+  [Navigation Preload must work with chunked encoding.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/navigation-preload/empty-preload-response-body.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/navigation-preload/empty-preload-response-body.https.html.ini
@@ -1,0 +1,4 @@
+[empty-preload-response-body.https.html]
+  [Navigation Preload empty response body.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/navigation-preload/get-state.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/navigation-preload/get-state.https.html.ini
@@ -1,0 +1,10 @@
+[get-state.https.html]
+  [getState from a worker]
+    expected: FAIL
+
+  [getState]
+    expected: FAIL
+
+  [no active worker]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/navigation-preload/navigationPreload.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/navigation-preload/navigationPreload.https.html.ini
@@ -1,0 +1,4 @@
+[navigationPreload.https.html]
+  [The navigationPreload attribute must return service worker registration's NavigationPreloadManager object.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/navigation-preload/redirect.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/navigation-preload/redirect.https.html.ini
@@ -1,0 +1,13 @@
+[redirect.https.html]
+  [Navigation Preload no-location redirect response with body.]
+    expected: FAIL
+
+  [Navigation Preload no-location redirect response.]
+    expected: FAIL
+
+  [Navigation Preload redirect response.]
+    expected: FAIL
+
+  [Navigation Preload redirect to the same scope.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/navigation-preload/request-headers.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/navigation-preload/request-headers.https.html.ini
@@ -1,0 +1,4 @@
+[request-headers.https.html]
+  [Navigation Preload request headers.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/navigation-preload/resource-timing.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/navigation-preload/resource-timing.https.html.ini
@@ -1,0 +1,4 @@
+[resource-timing.https.html]
+  [Navigation Preload Resource Timing.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/navigation-redirect-body.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/navigation-redirect-body.https.html.ini
@@ -1,0 +1,4 @@
+[navigation-redirect-body.https.html]
+  [Navigation redirection must clear body]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/navigation-redirect-to-http.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/navigation-redirect-to-http.https.html.ini
@@ -1,0 +1,5 @@
+[navigation-redirect-to-http.https.html]
+  expected: TIMEOUT
+  [Verify Service Worker can receive HTTP opaqueredirect response.]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/service-workers/service-worker/navigation-redirect.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/navigation-redirect.https.html.ini
@@ -1,0 +1,231 @@
+[navigation-redirect.https.html]
+  [Redirect to other-origin in-scope with opaque redirect response which is passed through Cache.]
+    expected: FAIL
+
+  [SW-fetched redirect to other-origin in-scope.]
+    expected: FAIL
+
+  [SW-generated redirect to same-origin other-scope.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to other-origin and back to same-origin.]
+    expected: FAIL
+
+  [Redirect to other-origin out-scope with opaque redirect response.]
+    expected: FAIL
+
+  [No location redirect response via Cache.]
+    expected: FAIL
+
+  [Normal redirect to same-origin scope.]
+    expected: FAIL
+
+  [SW-generated redirect to other-origin in-scope.]
+    expected: FAIL
+
+  [Normal redirect to same-origin scope with different hash fragments.]
+    expected: FAIL
+
+  [Redirect to same-origin same-scope with opaque redirect response.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to same-origin same-scope with different hash fragments.]
+    expected: FAIL
+
+  [Redirect to same-origin out-scope with opaque redirect response.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to same-origin other-scope.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to same-origin same-scope with a hash fragment.]
+    expected: FAIL
+
+  [SW-generated redirect to other-origin out-scope.]
+    expected: FAIL
+
+  [SW-generated redirect to same-origin out-scope with different hash fragments.]
+    expected: FAIL
+
+  [Redirect to same-origin out-scope with opaque redirect response which is passed through Cache.]
+    expected: FAIL
+
+  [SW-generated redirect to same-origin out-scope.]
+    expected: FAIL
+
+  [Redirect to other-origin out-scope with opaque redirect response which is passed through Cache.]
+    expected: FAIL
+
+  [No location redirect response.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to same-origin out-scope.]
+    expected: FAIL
+
+  [Normal redirect to same-origin scope with a hash fragment.]
+    expected: FAIL
+
+  [Normal redirect to other-origin scope.]
+    expected: FAIL
+
+  [Redirect to same-origin same-scope with opaque redirect response which is passed through Cache.]
+    expected: FAIL
+
+  [Redirect to same-origin other-scope with opaque redirect response.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to same-origin same-scope.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to other-origin out-scope.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to other-origin in-scope.]
+    expected: FAIL
+
+  [clean up global state]
+    expected: FAIL
+
+  [SW-fetched redirect to same-origin same-scope.]
+    expected: FAIL
+
+  [Redirect to other-origin in-scope with opaque redirect response.]
+    expected: FAIL
+
+  [SW-generated redirect to same-origin same-scope.]
+    expected: FAIL
+
+  [SW-fetched redirect to same-origin other-scope.]
+    expected: FAIL
+
+  [SW-fetched redirect to same-origin out-scope.]
+    expected: FAIL
+
+  [SW-generated redirect to same-origin out-scope with a hash fragment.]
+    expected: FAIL
+
+  [SW-fetched redirect to other-origin out-scope.]
+    expected: FAIL
+
+  [Redirect to same-origin other-scope with opaque redirect response which is passed through Cache.]
+    expected: FAIL
+
+  [initialize global state]
+    expected: FAIL
+
+
+[navigation-redirect.https.html?client]
+  [Redirect to other-origin in-scope with opaque redirect response which is passed through Cache.]
+    expected: FAIL
+
+  [SW-fetched redirect to other-origin in-scope.]
+    expected: FAIL
+
+  [SW-generated redirect to same-origin other-scope.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to other-origin and back to same-origin.]
+    expected: FAIL
+
+  [Redirect to other-origin out-scope with opaque redirect response.]
+    expected: FAIL
+
+  [No location redirect response via Cache.]
+    expected: FAIL
+
+  [Normal redirect to same-origin scope.]
+    expected: FAIL
+
+  [SW-generated redirect to other-origin in-scope.]
+    expected: FAIL
+
+  [Normal redirect to same-origin scope with different hash fragments.]
+    expected: FAIL
+
+  [Redirect to same-origin same-scope with opaque redirect response.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to same-origin same-scope with different hash fragments.]
+    expected: FAIL
+
+  [Redirect to same-origin out-scope with opaque redirect response.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to same-origin other-scope.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to same-origin same-scope with a hash fragment.]
+    expected: FAIL
+
+  [SW-generated redirect to other-origin out-scope.]
+    expected: FAIL
+
+  [SW-generated redirect to same-origin out-scope with different hash fragments.]
+    expected: FAIL
+
+  [Redirect to same-origin out-scope with opaque redirect response which is passed through Cache.]
+    expected: FAIL
+
+  [SW-generated redirect to same-origin out-scope.]
+    expected: FAIL
+
+  [Redirect to other-origin out-scope with opaque redirect response which is passed through Cache.]
+    expected: FAIL
+
+  [No location redirect response.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to same-origin out-scope.]
+    expected: FAIL
+
+  [Normal redirect to same-origin scope with a hash fragment.]
+    expected: FAIL
+
+  [Normal redirect to other-origin scope.]
+    expected: FAIL
+
+  [Redirect to same-origin same-scope with opaque redirect response which is passed through Cache.]
+    expected: FAIL
+
+  [Redirect to same-origin other-scope with opaque redirect response.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to same-origin same-scope.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to other-origin out-scope.]
+    expected: FAIL
+
+  [SW-fallbacked redirect to other-origin in-scope.]
+    expected: FAIL
+
+  [clean up global state]
+    expected: FAIL
+
+  [SW-fetched redirect to same-origin same-scope.]
+    expected: FAIL
+
+  [Redirect to other-origin in-scope with opaque redirect response.]
+    expected: FAIL
+
+  [SW-generated redirect to same-origin same-scope.]
+    expected: FAIL
+
+  [SW-fetched redirect to same-origin other-scope.]
+    expected: FAIL
+
+  [SW-fetched redirect to same-origin out-scope.]
+    expected: FAIL
+
+  [SW-generated redirect to same-origin out-scope with a hash fragment.]
+    expected: FAIL
+
+  [SW-fetched redirect to other-origin out-scope.]
+    expected: FAIL
+
+  [Redirect to same-origin other-scope with opaque redirect response which is passed through Cache.]
+    expected: FAIL
+
+  [initialize global state]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/navigation-timing.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/navigation-timing.https.html.ini
@@ -1,0 +1,10 @@
+[navigation-timing.https.html]
+  [Service worker controlled navigation timing network fallback]
+    expected: FAIL
+
+  [Service worker controlled navigation timing]
+    expected: FAIL
+
+  [Service worker controlled navigation timing redirect]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/onactivate-script-error.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/onactivate-script-error.https.html.ini
@@ -1,0 +1,16 @@
+[onactivate-script-error.https.html]
+  [activate handler dispatches an event that throws an error]
+    expected: FAIL
+
+  [activate handler throws an error and prevents default]
+    expected: FAIL
+
+  [activate handler throws an error, error handler does not cancel]
+    expected: FAIL
+
+  [activate handler throws an error]
+    expected: FAIL
+
+  [activate handler throws an error that is cancelled]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/oninstall-script-error.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/oninstall-script-error.https.html.ini
@@ -1,0 +1,19 @@
+[oninstall-script-error.https.html]
+  [install handler throws an error]
+    expected: FAIL
+
+  [install handler throws an error that is cancelled]
+    expected: FAIL
+
+  [install handler throws an error and prevents default]
+    expected: FAIL
+
+  [install handler throws an error, error handler does not cancel]
+    expected: FAIL
+
+  [install handler dispatches an event that throws an error]
+    expected: FAIL
+
+  [install handler throws an error in the waitUntil]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/opaque-response-preloaded.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/opaque-response-preloaded.https.html.ini
@@ -1,0 +1,7 @@
+[opaque-response-preloaded.https.html]
+  [Opaque responses should not be reused for XHRs, loading case]
+    expected: FAIL
+
+  [Opaque responses should not be reused for XHRs, done case]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/performance-timeline.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/performance-timeline.https.html.ini
@@ -1,0 +1,7 @@
+[performance-timeline.https.html]
+  [Test Performance Timeline API in Service Worker]
+    expected: FAIL
+
+  [empty service worker fetch event included in performance timings]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/postmessage-blob-url.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/postmessage-blob-url.https.html.ini
@@ -1,0 +1,4 @@
+[postmessage-blob-url.https.html]
+  [postMessage Blob URL to a ServiceWorker]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/postmessage-from-waiting-serviceworker.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/postmessage-from-waiting-serviceworker.https.html.ini
@@ -1,0 +1,4 @@
+[postmessage-from-waiting-serviceworker.https.html]
+  [Client.postMessage() from waiting serviceworker.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/postmessage-msgport-to-client.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/postmessage-msgport-to-client.https.html.ini
@@ -1,0 +1,4 @@
+[postmessage-msgport-to-client.https.html]
+  [postMessage MessagePorts from ServiceWorker to Client]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/postmessage-to-client-message-queue.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/postmessage-to-client-message-queue.https.html.ini
@@ -1,0 +1,16 @@
+[postmessage-to-client-message-queue.https.html]
+  [Messages from ServiceWorker to Client only received after calling startMessages().]
+    expected: FAIL
+
+  [Microtasks run before dispatching messages after calling startMessages().]
+    expected: FAIL
+
+  [Microtasks run before dispatching messages after setting onmessage.]
+    expected: FAIL
+
+  [Messages from ServiceWorker to Client only received after DOMContentLoaded event.]
+    expected: FAIL
+
+  [Messages from ServiceWorker to Client only received after setting onmessage.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/postmessage-to-client.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/postmessage-to-client.https.html.ini
@@ -1,0 +1,4 @@
+[postmessage-to-client.https.html]
+  [postMessage from ServiceWorker to Client.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/postmessage.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/postmessage.https.html.ini
@@ -1,0 +1,13 @@
+[postmessage.https.html]
+  [postMessage a transferable ArrayBuffer between ServiceWorker and Client]
+    expected: FAIL
+
+  [postMessage with dictionary a transferable ArrayBuffer between ServiceWorker and Client]
+    expected: FAIL
+
+  [postMessage a transferable ArrayBuffer between ServiceWorker and Client over MessagePort]
+    expected: FAIL
+
+  [postMessage to a ServiceWorker (and back via MessagePort)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/ready.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/ready.https.html.ini
@@ -1,0 +1,25 @@
+[ready.https.html]
+  [ready on a controlled document]
+    expected: FAIL
+
+  [ready returns a Promise object in the context of the related document]
+    expected: FAIL
+
+  [access ready after it has been resolved]
+    expected: FAIL
+
+  [ready on a potential controlled document]
+    expected: FAIL
+
+  [ready on an iframe that installs a new service worker]
+    expected: FAIL
+
+  [ready after a longer matched registration registered]
+    expected: FAIL
+
+  [access ready on uninstalling registration that is resurrected]
+    expected: FAIL
+
+  [ready on an iframe whose parent registers a new service worker]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/redirected-response.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/redirected-response.https.html.ini
@@ -1,0 +1,55 @@
+[redirected-response.https.html]
+  [mode: "error", mode change: "follow"]
+    expected: FAIL
+
+  [mode: "manual", generated redirect response]
+    expected: FAIL
+
+  [mode: "follow", no mode change]
+    expected: FAIL
+
+  [The URL for the service worker redirected request should be propagated to response.]
+    expected: FAIL
+
+  [mode: "manual", non-intercepted request]
+    expected: FAIL
+
+  [mode: "error", mode change: "manual"]
+    expected: FAIL
+
+  [mode: "error", generated redirect response]
+    expected: FAIL
+
+  [mode: "follow", no mode change, no server redirect]
+    expected: FAIL
+
+  [mode: "error", non-intercepted request]
+    expected: FAIL
+
+  [mode: "follow", non-intercepted request]
+    expected: FAIL
+
+  [Fetch should follow the redirect response 20 times]
+    expected: FAIL
+
+  [Fetch should not follow the redirect response 21 times.]
+    expected: FAIL
+
+  [mode: "follow", mode change: "manual"]
+    expected: FAIL
+
+  [initialize global state (service worker registration and caches)]
+    expected: FAIL
+
+  [mode: "follow", non-intercepted request, no server redirect]
+    expected: FAIL
+
+  [mode: "follow", generated redirect response]
+    expected: FAIL
+
+  [mode: "manual", no mode change]
+    expected: FAIL
+
+  [mode: "manual", mode change: "follow"]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/referer.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/referer.https.html.ini
@@ -1,0 +1,4 @@
+[referer.https.html]
+  [Verify the referer]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/referrer-policy-header.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/referrer-policy-header.https.html.ini
@@ -1,0 +1,10 @@
+[referrer-policy-header.https.html]
+  [Initialize global state (service worker registration)]
+    expected: FAIL
+
+  [Referrer for a main resource redirected with referrer-policy (origin) should only have origin.]
+    expected: FAIL
+
+  [Referrer for fetch requests initiated from a service worker with referrer-policy (origin) should only have origin.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/register-default-scope.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/register-default-scope.https.html.ini
@@ -1,0 +1,10 @@
+[register-default-scope.https.html]
+  [default scope]
+    expected: FAIL
+
+  [null scope]
+    expected: FAIL
+
+  [undefined scope]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/register-same-scope-different-script-url.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/register-same-scope-different-script-url.https.html.ini
@@ -1,0 +1,16 @@
+[register-same-scope-different-script-url.https.html]
+  [Register same-scope new script url effect on controller]
+    expected: FAIL
+
+  [Register different scripts concurrently]
+    expected: FAIL
+
+  [Register then register new script URL]
+    expected: FAIL
+
+  [Register then register new script that does not install]
+    expected: FAIL
+
+  [Register then register new script URL that 404s]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/register-wait-forever-in-install-worker.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/register-wait-forever-in-install-worker.https.html.ini
@@ -1,0 +1,4 @@
+[register-wait-forever-in-install-worker.https.html]
+  [register worker that calls waitUntil with a promise that never resolves in oninstall]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/registration-basic.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/registration-basic.https.html.ini
@@ -1,0 +1,10 @@
+[registration-basic.https.html]
+  [Registering scope with fragment]
+    expected: FAIL
+
+  [Registering same scope as the script directory]
+    expected: FAIL
+
+  [Registering normal scope]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/registration-end-to-end.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/registration-end-to-end.https.html.ini
@@ -1,0 +1,4 @@
+[registration-end-to-end.https.html]
+  [Registration: end-to-end]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/registration-events.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/registration-events.https.html.ini
@@ -1,0 +1,4 @@
+[registration-events.https.html]
+  [Registration: events]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/registration-iframe.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/registration-iframe.https.html.ini
@@ -1,0 +1,10 @@
+[registration-iframe.https.html]
+  [register method should use the "relevant global object" to parse its scriptURL and scope - normal case]
+    expected: FAIL
+
+  [A scope url should start with the given script url]
+    expected: FAIL
+
+  [register method should use the "relevant global object" to parse its scriptURL and scope - error case]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/registration-mime-types.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/registration-mime-types.https.html.ini
@@ -1,0 +1,103 @@
+[registration-mime-types.https.html]
+  [Registering script with good MIME type application/x-javascript]
+    expected: FAIL
+
+  [Registering script with good MIME type application/javascript]
+    expected: FAIL
+
+  [Registering script with good MIME type application/ecmascript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type application/ecmascript]
+    expected: FAIL
+
+  [Registering script with good MIME type application/x-ecmascript]
+    expected: FAIL
+
+  [Registering script with good MIME type text/ecmascript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/x-javascript]
+    expected: FAIL
+
+  [Registering script with good MIME type text/javascript]
+    expected: FAIL
+
+  [Registering script with good MIME type text/x-ecmascript]
+    expected: FAIL
+
+  [Registering script with bad MIME type]
+    expected: FAIL
+
+  [Registering script with good MIME type text/x-javascript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/jscript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type application/javascript]
+    expected: FAIL
+
+  [Registering script with no MIME type]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/javascript1.0]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/javascript1.1]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/javascript1.2]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/javascript1.3]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/javascript1.4]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/javascript1.5]
+    expected: FAIL
+
+  [Registering script with good MIME type text/javascript1.2]
+    expected: FAIL
+
+  [Registering script with good MIME type text/javascript1.3]
+    expected: FAIL
+
+  [Registering script with good MIME type text/javascript1.0]
+    expected: FAIL
+
+  [Registering script with good MIME type text/javascript1.1]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/x-ecmascript]
+    expected: FAIL
+
+  [Registering script with good MIME type text/javascript1.4]
+    expected: FAIL
+
+  [Registering script with good MIME type text/javascript1.5]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type application/x-javascript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/livescript]
+    expected: FAIL
+
+  [Registering script with good MIME type text/jscript]
+    expected: FAIL
+
+  [Registering script with good MIME type text/livescript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/javascript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type text/ecmascript]
+    expected: FAIL
+
+  [Registering script that imports script with good MIME type application/x-ecmascript]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/registration-scope.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/registration-scope.https.html.ini
@@ -1,0 +1,16 @@
+[registration-scope.https.html]
+  [Scope including self-reference]
+    expected: FAIL
+
+  [Scope including consecutive slashes]
+    expected: FAIL
+
+  [Scope including parent-reference]
+    expected: FAIL
+
+  [Scope including non-escaped multibyte characters]
+    expected: FAIL
+
+  [Scope including URL-encoded multibyte characters]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/registration-script-url.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/registration-script-url.https.html.ini
@@ -1,0 +1,7 @@
+[registration-script-url.https.html]
+  [Script URL including parent-reference]
+    expected: FAIL
+
+  [Script URL including self-reference]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/registration-script.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/registration-script.https.html.ini
@@ -1,0 +1,4 @@
+[registration-script.https.html]
+  [Registering script including caught exception]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/registration-security-error.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/registration-security-error.https.html.ini
@@ -1,0 +1,19 @@
+[registration-security-error.https.html]
+  [Script URL including consecutive slashes]
+    expected: FAIL
+
+  [Registering same scope as the script directory without the last slash]
+    expected: FAIL
+
+  [Registering redirected script]
+    expected: FAIL
+
+  [Registration scope outside the script directory]
+    expected: FAIL
+
+  [Registering scope outside domain]
+    expected: FAIL
+
+  [Scope including parent-reference and not under the script directory]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/registration-service-worker-attributes.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/registration-service-worker-attributes.https.html.ini
@@ -1,0 +1,4 @@
+[registration-service-worker-attributes.https.html]
+  [installing/waiting/active after registration]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/registration-updateviacache.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/registration-updateviacache.https.html.ini
@@ -1,0 +1,73 @@
+[registration-updateviacache.https.html]
+  [register-with-updateViaCache-undefined]
+    expected: FAIL
+
+  [register-with-updateViaCache-all]
+    expected: FAIL
+
+  [register-with-updateViaCache-imports]
+    expected: FAIL
+
+  [register-with-updateViaCache-imports-then-imports]
+    expected: FAIL
+
+  [access-updateViaCache-after-unregister-none]
+    expected: FAIL
+
+  [register-with-updateViaCache-undefined-then-none]
+    expected: FAIL
+
+  [register-with-updateViaCache-none-then-undefined]
+    expected: FAIL
+
+  [register-with-updateViaCache-undefined-then-undefined]
+    expected: FAIL
+
+  [access-updateViaCache-after-unregister-imports]
+    expected: FAIL
+
+  [register-with-updateViaCache-all-then-imports]
+    expected: FAIL
+
+  [register-with-updateViaCache-all-then-none]
+    expected: FAIL
+
+  [register-with-updateViaCache-all-then-all]
+    expected: FAIL
+
+  [access-updateViaCache-after-unregister-all]
+    expected: FAIL
+
+  [register-with-updateViaCache-none-then-none]
+    expected: FAIL
+
+  [register-with-updateViaCache-none-then-all]
+    expected: FAIL
+
+  [register-with-updateViaCache-none]
+    expected: FAIL
+
+  [register-with-updateViaCache-undefined-then-imports]
+    expected: FAIL
+
+  [register-with-updateViaCache-imports-then-none]
+    expected: FAIL
+
+  [register-with-updateViaCache-none-then-imports]
+    expected: FAIL
+
+  [register-with-updateViaCache-imports-then-all]
+    expected: FAIL
+
+  [register-with-updateViaCache-undefined-then-all]
+    expected: FAIL
+
+  [access-updateViaCache-after-unregister-undefined]
+    expected: FAIL
+
+  [register-with-updateViaCache-imports-then-undefined]
+    expected: FAIL
+
+  [register-with-updateViaCache-all-then-undefined]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/request-end-to-end.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/request-end-to-end.https.html.ini
@@ -1,0 +1,4 @@
+[request-end-to-end.https.html]
+  [Test FetchEvent.request passed to onfetch]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/resource-timing-cross-origin.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/resource-timing-cross-origin.https.html.ini
@@ -1,0 +1,4 @@
+[resource-timing-cross-origin.https.html]
+  [Test that timing allow check fails when service worker changes origin from same to cross origin.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/resource-timing.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/resource-timing.https.html.ini
@@ -1,0 +1,7 @@
+[resource-timing.https.html]
+  [Controlled resource loads]
+    expected: FAIL
+
+  [Non-controlled resource loads]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/respond-with-body-accessed-response.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/respond-with-body-accessed-response.https.html.ini
@@ -1,0 +1,58 @@
+[respond-with-body-accessed-response.https.html]
+  [test: type=basic]
+    expected: FAIL
+
+  [test: type=default&clone=2]
+    expected: FAIL
+
+  [test: type=opaque&clone=2&passThroughCache=true]
+    expected: FAIL
+
+  [test: type=opaque&clone=1&passThroughCache=true]
+    expected: FAIL
+
+  [test: type=default&clone=1]
+    expected: FAIL
+
+  [test: type=default&clone=2&passThroughCache=true]
+    expected: FAIL
+
+  [test: type=default]
+    expected: FAIL
+
+  [test: type=opaque&passThroughCache=true]
+    expected: FAIL
+
+  [test: type=default&passThroughCache=true]
+    expected: FAIL
+
+  [test: type=basic&passThroughCache=true]
+    expected: FAIL
+
+  [test: type=opaque&clone=1]
+    expected: FAIL
+
+  [test: type=basic&clone=1&passThroughCache=true]
+    expected: FAIL
+
+  [test: type=basic&clone=2&passThroughCache=true]
+    expected: FAIL
+
+  [test: type=opaque&clone=2]
+    expected: FAIL
+
+  [test: type=default&clone=1&passThroughCache=true]
+    expected: FAIL
+
+  [initialize global state]
+    expected: FAIL
+
+  [test: type=basic&clone=1]
+    expected: FAIL
+
+  [test: type=basic&clone=2]
+    expected: FAIL
+
+  [test: type=opaque]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/sandboxed-iframe-fetch-event.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/sandboxed-iframe-fetch-event.https.html.ini
@@ -1,0 +1,88 @@
+[sandboxed-iframe-fetch-event.https.html]
+  [Fetch request from iframe sandboxed by CSP HTTP header with allow-scripts flag]
+    expected: FAIL
+
+  [Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the iframe sandboxed by CSP HTTP header with allow-scripts flag]
+    expected: FAIL
+
+  [Request for an iframe in the iframe sandboxed by an attribute with allow-scripts and allow-same-origin flag]
+    expected: FAIL
+
+  [Fetch request from a normal iframe]
+    expected: FAIL
+
+  [Request for an iframe in the normal iframe]
+    expected: FAIL
+
+  [Request for an iframe in the iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag]
+    expected: FAIL
+
+  [Prepare a normal iframe.]
+    expected: FAIL
+
+  [Fetch request from a worker in a normal iframe]
+    expected: FAIL
+
+  [Request for an sandboxed iframe with allow-scripts flag in the normal iframe]
+    expected: FAIL
+
+  [Fetch request from a worker in iframe sandboxed by an attribute with allow-scripts and allow-same-origin flag]
+    expected: FAIL
+
+  [Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag]
+    expected: FAIL
+
+  [Prepare an iframe sandboxed by <iframe sandbox="allow-scripts">.]
+    expected: FAIL
+
+  [Fetch request from iframe sandboxed by an attribute with allow-scripts flag]
+    expected: FAIL
+
+  [Request for an iframe in the iframe sandboxed by CSP HTTP header with allow-scripts flag]
+    expected: FAIL
+
+  [Request for an sandboxed iframe with allow-scripts flag in the iframe sandboxed by attribute with allow-scripts and allow-same-origin flag]
+    expected: FAIL
+
+  [Prepare an iframe sandboxed by CSP HTTP header with allow-scripts.]
+    expected: FAIL
+
+  [Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the iframe sandboxed by an attribute with allow-scripts flag]
+    expected: FAIL
+
+  [Fetch request from iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag]
+    expected: FAIL
+
+  [Request for an sandboxed iframe with allow-scripts flag in the iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag]
+    expected: FAIL
+
+  [Request for an sandboxed iframe with allow-scripts flag in the iframe sandboxed by an attribute with allow-scripts flag]
+    expected: FAIL
+
+  [Fetch request from a worker in iframe sandboxed by an attribute with allow-scripts flag]
+    expected: FAIL
+
+  [Request for an iframe in the iframe sandboxed by an attribute with allow-scripts flag]
+    expected: FAIL
+
+  [Fetch request from iframe sandboxed by an attribute with allow-scripts and allow-same-origin flag]
+    expected: FAIL
+
+  [Prepare an iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin.]
+    expected: FAIL
+
+  [Prepare an iframe sandboxed by <iframe sandbox="allow-scripts allow-same-origin">.]
+    expected: FAIL
+
+  [Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the iframe sandboxed by attribute with allow-scripts and allow-same-origin flag]
+    expected: FAIL
+
+  [Prepare a service worker.]
+    expected: FAIL
+
+  [Request for an sandboxed iframe with allow-scripts flag in the iframe sandboxed by CSP HTTP header with allow-scripts flag]
+    expected: FAIL
+
+  [Request for an sandboxed iframe with allow-scripts and allow-same-origin flag in the normal iframe]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/sandboxed-iframe-navigator-serviceworker.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/sandboxed-iframe-navigator-serviceworker.https.html.ini
@@ -1,0 +1,14 @@
+[sandboxed-iframe-navigator-serviceworker.https.html]
+  expected: TIMEOUT
+  [Switching iframe sandbox attribute while loading the iframe]
+    expected: NOTRUN
+
+  [Accessing navigator.serviceWorker in sandboxed iframe should throw.]
+    expected: NOTRUN
+
+  [Accessing navigator.serviceWorker in normal iframe should not throw.]
+    expected: TIMEOUT
+
+  [Accessing navigator.serviceWorker in sandboxed iframe with allow-same-origin flag should not throw.]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/service-workers/service-worker/service-worker-csp-connect.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/service-worker-csp-connect.https.html.ini
@@ -1,0 +1,4 @@
+[service-worker-csp-connect.https.html]
+  [CSP test for connect-src in ServiceWorkerGlobalScope]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/service-worker-csp-default.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/service-worker-csp-default.https.html.ini
@@ -1,0 +1,4 @@
+[service-worker-csp-default.https.html]
+  [CSP test for default-src in ServiceWorkerGlobalScope]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/service-worker-csp-script.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/service-worker-csp-script.https.html.ini
@@ -1,0 +1,4 @@
+[service-worker-csp-script.https.html]
+  [CSP test for script-src in ServiceWorkerGlobalScope]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/service-worker-header.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/service-worker-header.https.html.ini
@@ -1,0 +1,4 @@
+[service-worker-header.https.html]
+  [A request to fetch service worker main script should have Service-Worker header and imported scripts should not have one]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/serviceworker-message-event-historical.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/serviceworker-message-event-historical.https.html.ini
@@ -1,0 +1,4 @@
+[serviceworker-message-event-historical.https.html]
+  [Test MessageEvent supplants ServiceWorkerMessageEvent.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/serviceworkerobject-scripturl.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/serviceworkerobject-scripturl.https.html.ini
@@ -1,0 +1,13 @@
+[serviceworkerobject-scripturl.https.html]
+  [Verify the scriptURL property: relative]
+    expected: FAIL
+
+  [Verify the scriptURL property: with-fragment]
+    expected: FAIL
+
+  [Verify the scriptURL property: absolute]
+    expected: FAIL
+
+  [Verify the scriptURL property: with-query]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/shared-worker-controlled.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/shared-worker-controlled.https.html.ini
@@ -1,0 +1,10 @@
+[shared-worker-controlled.https.html]
+  [Verify subresource loads in SharedWorker are controlled by a Service Worker]
+    expected: FAIL
+
+  [Verify SharedWorker construction is controlled by a Service Worker]
+    expected: FAIL
+
+  [Verify importScripts from SharedWorker is controlled by a Service Worker]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/skip-waiting-installed.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/skip-waiting-installed.https.html.ini
@@ -1,0 +1,4 @@
+[skip-waiting-installed.https.html]
+  [Test skipWaiting when a installed worker is waiting]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/skip-waiting-using-registration.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/skip-waiting-using-registration.https.html.ini
@@ -1,0 +1,4 @@
+[skip-waiting-using-registration.https.html]
+  [Test skipWaiting while a client is using the registration]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/skip-waiting-without-client.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/skip-waiting-without-client.https.html.ini
@@ -1,0 +1,4 @@
+[skip-waiting-without-client.https.html]
+  [Test single skipWaiting() when no client attached]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/skip-waiting-without-using-registration.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/skip-waiting-without-using-registration.https.html.ini
@@ -1,0 +1,4 @@
+[skip-waiting-without-using-registration.https.html]
+  [Test skipWaiting while a client is not being controlled]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/skip-waiting.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/skip-waiting.https.html.ini
@@ -1,0 +1,4 @@
+[skip-waiting.https.html]
+  [Test skipWaiting with both active and waiting workers]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/state.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/state.https.html.ini
@@ -1,0 +1,4 @@
+[state.https.html]
+  [Service Worker state property and "statechange" event]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/svg-target-reftest.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/svg-target-reftest.https.html.ini
@@ -1,0 +1,2 @@
+[svg-target-reftest.https.html]
+  expected: TIMEOUT

--- a/tests/wpt/metadata/service-workers/service-worker/synced-state.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/synced-state.https.html.ini
@@ -1,0 +1,4 @@
+[synced-state.https.html]
+  [worker objects for the same entity have the same state]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/uncontrolled-page.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/uncontrolled-page.https.html.ini
@@ -1,0 +1,4 @@
+[uncontrolled-page.https.html]
+  [Fetch events should not go through uncontrolled page.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/unregister-controller.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/unregister-controller.https.html.ini
@@ -1,0 +1,10 @@
+[unregister-controller.https.html]
+  [Unregister prevents new controllee even if registration is still in use]
+    expected: FAIL
+
+  [Unregister does not affect existing controller]
+    expected: FAIL
+
+  [Unregister prevents control of subsequent navigations]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/unregister-then-register-new-script.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/unregister-then-register-new-script.https.html.ini
@@ -1,0 +1,10 @@
+[unregister-then-register-new-script.https.html]
+  [Registering a new script URL while an unregistered registration is in use]
+    expected: FAIL
+
+  [Registering a new script URL that fails to install does resurrect an unregistered registration]
+    expected: FAIL
+
+  [Registering a new script URL that 404s does resurrect an unregistered registration]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/unregister-then-register.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/unregister-then-register.https.html.ini
@@ -1,0 +1,16 @@
+[unregister-then-register.https.html]
+  [Unregister then register does not affect existing controllee]
+    expected: FAIL
+
+  [Unregister then register resolves to the original value if the registration is in use.]
+    expected: FAIL
+
+  [Unregister then register resolves to a new value]
+    expected: FAIL
+
+  [Unregister then register resurrects the registration]
+    expected: FAIL
+
+  [Reloading the last controlled iframe after unregistration should ensure the deletion of the registration]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/unregister.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/unregister.https.html.ini
@@ -1,0 +1,7 @@
+[unregister.https.html]
+  [Register then unregister]
+    expected: FAIL
+
+  [Unregister twice]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/update-after-navigation-fetch-event.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/update-after-navigation-fetch-event.https.html.ini
@@ -1,0 +1,10 @@
+[update-after-navigation-fetch-event.https.html]
+  [Update should be triggered after a navigation (network error).]
+    expected: FAIL
+
+  [Update should be triggered after a navigation (no fetch event worker).]
+    expected: FAIL
+
+  [Update should be triggered after a navigation (fetch event worker).]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/update-after-navigation-redirect.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/update-after-navigation-redirect.https.html.ini
@@ -1,0 +1,4 @@
+[update-after-navigation-redirect.https.html]
+  [service workers are updated on redirects during navigation]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/update-after-oneday.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/update-after-oneday.https.html.ini
@@ -1,0 +1,4 @@
+[update-after-oneday.https.html]
+  [Update should be triggered after a functional event when last update time is over 24 hours]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/update-bytecheck.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/update-bytecheck.https.html.ini
@@ -1,0 +1,25 @@
+[update-bytecheck.https.html]
+  [Test(cors: true, main: default, imported: default)]
+    expected: FAIL
+
+  [Test(cors: true, main: time, imported: default)]
+    expected: FAIL
+
+  [Test(cors: false, main: time, imported: time)]
+    expected: FAIL
+
+  [Test(cors: true, main: default, imported: time)]
+    expected: FAIL
+
+  [Test(cors: true, main: time, imported: time)]
+    expected: FAIL
+
+  [Test(cors: false, main: default, imported: time)]
+    expected: FAIL
+
+  [Test(cors: false, main: default, imported: default)]
+    expected: FAIL
+
+  [Test(cors: false, main: time, imported: default)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/update-missing-import-scripts.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/update-missing-import-scripts.https.html.ini
@@ -1,0 +1,7 @@
+[update-missing-import-scripts.https.html]
+  [Update service worker with new script that's missing importScripts()]
+    expected: FAIL
+
+  [Initialize global state]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/update-not-allowed.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/update-not-allowed.https.html.ini
@@ -1,0 +1,7 @@
+[update-not-allowed.https.html]
+  [ServiceWorkerRegistration.update() from installing service worker throws.]
+    expected: FAIL
+
+  [ServiceWorkerRegistration.update() from client throws while installing service worker.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/update-recovery.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/update-recovery.https.html.ini
@@ -1,0 +1,4 @@
+[update-recovery.https.html]
+  [Recover from a bad service worker by updating after a failed navigation.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/update-registration-with-type.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/update-registration-with-type.https.html.ini
@@ -1,0 +1,22 @@
+[update-registration-with-type.https.html]
+  [Update the registration with a different script type (module => classic).]
+    expected: FAIL
+
+  [Update the registration with a different script type (classic => module) and with a same main script.]
+    expected: FAIL
+
+  [Update the registration with a different script type (classic => module).]
+    expected: FAIL
+
+  [Update the registration with a different script type (classic => module) and with a same main script. Expect evaluation failed.]
+    expected: FAIL
+
+  [Update the registration with a different script type (module => classic) and with a same main script.]
+    expected: FAIL
+
+  [Update the registration with a different script type (module => classic) and with a same main script. Expect evaluation failed.]
+    expected: FAIL
+
+  [Does not update the registration with the same script type and the same main script.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/update-result.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/update-result.https.html.ini
@@ -1,0 +1,4 @@
+[update-result.https.html]
+  [ServiceWorkerRegistration.update() should resolve a registration object]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/update.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/update.https.html.ini
@@ -1,0 +1,4 @@
+[update.https.html]
+  [Update a registration.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/waiting.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/waiting.https.html.ini
@@ -1,0 +1,8 @@
+[waiting.https.html]
+  expected: ERROR
+  [The ServiceWorker objects returned from waiting attribute getter that represent the same service worker are the same objects]
+    expected: NOTRUN
+
+  [waiting is set after installation]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/websocket-in-service-worker.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/websocket-in-service-worker.https.html.ini
@@ -1,0 +1,4 @@
+[websocket-in-service-worker.https.html]
+  [Verify WebSockets can be created in a Service Worker]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/websocket.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/websocket.https.html.ini
@@ -1,0 +1,4 @@
+[websocket.https.html]
+  [Verify WebSocket handshake channel does not get intercepted]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/webvtt-cross-origin.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/webvtt-cross-origin.https.html.ini
@@ -1,0 +1,28 @@
+[webvtt-cross-origin.https.html]
+  [cross-origin text track with approved cors request should not load]
+    expected: FAIL
+
+  [same-origin text track that redirects to a cross-origin text track with rejected cors should not load]
+    expected: FAIL
+
+  [same-origin text track that redirects to a cross-origin text track with approved cors should not load]
+    expected: FAIL
+
+  [same-origin text track should load]
+    expected: FAIL
+
+  [same-origin text track that redirects cross-origin should not load]
+    expected: FAIL
+
+  [initialize global state]
+    expected: FAIL
+
+  [cross-origin text track with rejected cors request should not load]
+    expected: FAIL
+
+  [same-origin text track that redirects same-origin should load]
+    expected: FAIL
+
+  [cross-origin text track with no-cors request should not load]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/windowclient-navigate.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/windowclient-navigate.https.html.ini
@@ -1,0 +1,31 @@
+[windowclient-navigate.https.html]
+  [blank url]
+    expected: FAIL
+
+  [in scope but not controlled test on active worker]
+    expected: FAIL
+
+  [normal]
+    expected: FAIL
+
+  [invalid url (view-source://example.com)]
+    expected: FAIL
+
+  [in scope but not controlled test on installing worker]
+    expected: FAIL
+
+  [out of scope]
+    expected: FAIL
+
+  [invalid url (http://[example.com\])]
+    expected: FAIL
+
+  [invalid url (about:blank)]
+    expected: FAIL
+
+  [invalid url (file:///)]
+    expected: FAIL
+
+  [cross orgin url]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/worker-client-id.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/worker-client-id.https.html.ini
@@ -1,0 +1,4 @@
+[worker-client-id.https.html]
+  [Verify workers have a unique client id separate from their owning documents window]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/worker-in-sandboxed-iframe-by-csp-fetch-event.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/worker-in-sandboxed-iframe-by-csp-fetch-event.https.html.ini
@@ -1,0 +1,16 @@
+[worker-in-sandboxed-iframe-by-csp-fetch-event.https.html]
+  [Prepare an iframe sandboxed by CSP HTTP header with allow-scripts.]
+    expected: FAIL
+
+  [Fetch request from a worker in iframe sandboxed by CSP HTTP header allow-scripts flag]
+    expected: FAIL
+
+  [Fetch request from a worker in iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin flag]
+    expected: FAIL
+
+  [Prepare a service worker.]
+    expected: FAIL
+
+  [Prepare an iframe sandboxed by CSP HTTP header with allow-scripts and allow-same-origin.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/worker-interception-redirect.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/worker-interception-redirect.https.html.ini
@@ -1,0 +1,16 @@
+[worker-interception-redirect.https.html]
+  [request to sw1 scope gets network redirect to out-of-scope]
+    expected: FAIL
+
+  [request to sw1 scope gets service-worker redirect to out-of-scope]
+    expected: FAIL
+
+  [request to sw1 scope gets service-worker redirect to sw2 scope]
+    expected: FAIL
+
+  [request to sw1 scope gets network redirect to sw2 scope]
+    expected: FAIL
+
+  [initialize global state]
+    expected: FAIL
+

--- a/tests/wpt/metadata/service-workers/service-worker/worker-interception.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/worker-interception.https.html.ini
@@ -1,0 +1,16 @@
+[worker-interception.https.html]
+  [Verify worker script intercepted by no-cors cross-origin response fails]
+    expected: FAIL
+
+  [Verify worker script from uncontrolled document is intercepted by Service Worker]
+    expected: FAIL
+
+  [Verify worker loads from controlled document are intercepted by Service Worker]
+    expected: FAIL
+
+  [Verify worker script intercepted by same-origin response succeeds]
+    expected: FAIL
+
+  [Verify worker script intercepted by cors response fails]
+    expected: FAIL
+


### PR DESCRIPTION
Generated these metadata with following command

```sh
$ ./mach test-wpt --log-raw=update.log tests/wpt/web-platform-tests/service-workers
$ ./mach update-wpt update.log
```

Ref: https://github.com/servo/servo/pull/22218#discussion_r236739048

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] This PR will turn on `ServiceWorker` for upstream WPT tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22278)
<!-- Reviewable:end -->
