### PR TITLE
Instructions for checking magicleap builds on linux

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -463,7 +463,9 @@ class MachCommands(CommandBase):
 
         if magicleap:
             if platform.system() not in ["Darwin"]:
-                raise Exception("Magic Leap builds are only supported on macOS.")
+                raise Exception("Magic Leap builds are only supported on macOS. "
+                                "If you only wish to test if your code builds, "
+                                "run ./mach build -p libmlservo.")
 
             ml_sdk = env.get("MAGICLEAP_SDK")
             if not ml_sdk:


### PR DESCRIPTION
Needed to test a build failure, but couldn't on linux. This should be a
decent stop gap for now.

r? @asajeffrey

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22281)
<!-- Reviewable:end -->
