### PR TITLE
Tidy up UI of magicleap app

### DIFF
--- a/ports/libmlservo/src/lib.rs
+++ b/ports/libmlservo/src/lib.rs
@@ -376,8 +376,6 @@ impl WindowMethods for WindowInstance {
 
     fn prepare_for_composite(&self) -> bool {
         MakeCurrent(self.disp, self.surf, self.surf, self.ctxt);
-        self.gl
-            .viewport(0, 0, self.width as i32, self.height as i32);
         true
     }
 

--- a/support/magicleap/Servo2D/code/inc/Servo2D.h
+++ b/support/magicleap/Servo2D/code/inc/Servo2D.h
@@ -131,5 +131,6 @@ private:
   lumin::LineNode* laser_ = nullptr; // The laser pointer
   glm::vec3 controller_position_; // The last recorded position of the controller (in world coords)
   glm::quat controller_orientation_; // The last recorded orientation of the controller (in world coords)
+  bool controller_trigger_down_ = false; // Is the controller trigger currently down?
   ServoInstance* servo_ = nullptr; // the servo instance we're embedding
 };

--- a/support/magicleap/Servo2D/code/src/Servo2D.cpp
+++ b/support/magicleap/Servo2D/code/src/Servo2D.cpp
@@ -23,11 +23,17 @@ const float HIDPI = 1.0;
 
 // The prism dimensions (in m).
 const float PRISM_W = 2.0;
-const float PRISM_H = 2.0;
+const float PRISM_H = 0.75;
 const float PRISM_D = 2.0;
 
 // The length of the laser pointer (in m).
 const float LASER_LENGTH = 10.0;
+
+// The width of the keyboard
+const float KEYBOARD_W = 0.666;
+
+// The home page
+const char* HOME_PAGE = "https://servo.org/ml-home";
 
 // A function which calls the ML logger, suitable for passing into Servo
 typedef void (*MLLogger)(MLLogLevel lvl, char* msg);
@@ -136,7 +142,7 @@ int Servo2D::init() {
   EGLDisplay dpy = eglGetDisplay(EGL_DEFAULT_DISPLAY);
 
   // Hook into servo
-  servo_ = init_servo(ctx, surf, dpy, this, logger, history, "https://servo.org/", VIEWPORT_H, VIEWPORT_W, HIDPI);
+  servo_ = init_servo(ctx, surf, dpy, this, logger, history, HOME_PAGE, VIEWPORT_W, VIEWPORT_H, HIDPI);
   if (!servo_) {
     ML_LOG(Error, "Servo2D Failed to init servo instance");
     abort();
@@ -171,6 +177,10 @@ int Servo2D::init() {
     abort();
     return 1;
   }
+  lumin::ui::KeyboardProperties keyboard_properties;
+  keyboard_properties.keyboardZPosition = lumin::ui::KeyboardProperties::KeyboardZPosition::kVolumeCursorPlane;
+  keyboard_properties.width = KEYBOARD_W;
+  url_bar_->setKeyboardProperties(keyboard_properties);
   url_bar_->onFocusLostSub(std::bind(&Servo2D::urlBarEventListener, this));
 
   // Add the laser pointer
@@ -290,13 +300,10 @@ glm::vec2 Servo2D::redrawLaser() {
   glm::vec3 endpoint = position + direction * LASER_LENGTH;
 
   // The laser color
-  glm::vec4 color = glm::vec4(0.0, 0.0, 0.0, 0.0);
+  glm::vec4 color = glm::vec4(1.0, 0.0, 0.0, 1.0);
 
-  // Check to see if the cursor is over the content
-  glm::vec2 cursor = viewportPosition(lumin::ui::Cursor::GetPosition(prism_));
-
-  // Is the laser active and does the laser intersect z=0?
-  if (pointInsideViewport(cursor) && ((position.z < 0) ^ (endpoint.z < 0))) {
+  // Does the laser intersect z=0?
+  if ((position.z > 0) && (endpoint.z < 0)) {
     // How far along the laser did it intersect?
     float ratio = 1.0 / (1.0 - (endpoint.z / position.z));
     // The intersection point
@@ -306,8 +313,6 @@ glm::vec2 Servo2D::redrawLaser() {
     if (pointInsideViewport(result)) {
       color = glm::vec4(0.0, 1.0, 0.0, 1.0);
       endpoint = intersection;
-    } else {
-      color = glm::vec4(1.0, 0.0, 0.0, 1.0);
     }
   }
 
@@ -325,20 +330,20 @@ bool Servo2D::gestureEventListener(lumin::GestureInputEventData* event) {
     return false;
   }
 
-  // Only respond when the cursor is enabled
-  if (!lumin::ui::Cursor::IsEnabled(prism_)) {
+  // Only respond to trigger down if the laser is currently in the viewport
+  glm::vec2 pos = redrawLaser();
+  if ((typ == lumin::input::GestureType::TriggerDown) && !pointInsideViewport(pos)) {
     return false;
   }
 
-  // Only respond when the cursor is inside the viewport
-  glm::vec2 cursor = viewportPosition(lumin::ui::Cursor::GetPosition(prism_));
-  if (!pointInsideViewport(cursor)) {
+  // Only respond to trigger up if the trigger down happened inside the viewport
+  if ((typ == lumin::input::GestureType::TriggerUp) && !controller_trigger_down_) {
     return false;
   }
 
   // Inform Servo of the trigger
-  glm::vec2 pos = redrawLaser();
-  trigger_servo(servo_, pos.x, pos.y, typ == lumin::input::GestureType::TriggerDown);
+  controller_trigger_down_ = (typ == lumin::input::GestureType::TriggerDown);
+  trigger_servo(servo_, pos.x, pos.y, controller_trigger_down_);
   return true;
 }
 

--- a/support/magicleap/Servo2D/scenes/Servo2D.design
+++ b/support/magicleap/Servo2D/scenes/Servo2D.design
@@ -36,7 +36,7 @@
       <property id="scale"/>
       <property id="size">
         <property id="x" value="0.5"/>
-        <property id="y" value="0.44"/>
+        <property id="y" value="0.5"/>
       </property>
       <property id="texCoords">
         <property id="x">
@@ -140,7 +140,7 @@
       <property id="rotation"/>
       <property id="scale"/>
       <property id="scrollBarVisibilityMode" value="Off"/>
-      <property id="text" value="https://servo.org/"/>
+      <property id="text" value=""/>
       <property id="textPadding">
         <property id="top" value="0.003"/>
         <property id="right" value="0.003"/>
@@ -167,5 +167,33 @@
     <property id="position"/>
     <property id="rotation"/>
     <property id="scale"/>
+  </node>
+  <node name="bevel" nodeTypeId="lumin.quad">
+    <property id="color" value="0.4 0.302 0.702 1"/>
+    <property id="name" value="bevel"/>
+    <property id="position">
+      <property id="x" value="-0.26"/>
+      <property id="y" value="-0.17"/>
+      <property id="z" value="-0.01"/>
+    </property>
+    <property id="rotation"/>
+    <property id="scale"/>
+    <property id="size">
+      <property id="x" value="0.52"/>
+      <property id="y" value="0.52"/>
+    </property>
+    <property id="texCoords">
+      <property id="x">
+        <property id="y" value="1.0"/>
+      </property>
+      <property id="y">
+        <property id="x" value="1.0"/>
+        <property id="y" value="1.0"/>
+      </property>
+      <property id="z">
+        <property id="x" value="1.0"/>
+      </property>
+      <property id="w"/>
+    </property>
   </node>
 </design:rootNode>

--- a/support/magicleap/Servo2D/scenes/Servo2D.scene.xml
+++ b/support/magicleap/Servo2D/scenes/Servo2D.scene.xml
@@ -1,5 +1,8 @@
 <ObjectModel name="Servo2D" version="1">
     <TransformNode/>
+    <UiPanel gravityWellEnabled="false" gravityWellRoundness="0.000000" gravityWellSize="0.000000, 0.000000" gravityWellSnap="ClosestEdge" name="contentPanel" pos="0.000000, 0.060000, 0.000000" shape="[size:[0.5,0.44], roundness: 0, offset[0,0,0]]">
+        <QuadNode castShadow="false" name="content" pos="-0.250000, -0.220000, -0.000000" receiveShadow="false" shader="UnlitColorTex2d" size="0.500000, 0.500000"/>
+    </UiPanel>
     <UiLinearLayout alignment="Top, Center" gravityWellEnabled="false" gravityWellRoundness="0.000000" gravityWellSize="0.000000, 0.000000" gravityWellSnap="ClosestEdge" itemAlignment="Center, Left" itemPadding="0.000000, 0.010000, 0.000000, 0.010000" name="uiLinearLayout1" orientation="Horizontal" pos="0.000000, -0.200000, 0.000000" size="0.500000, 0.050000">
         <Content>
             <UiButton gravityWellEnabled="false" gravityWellRoundness="0.000000" gravityWellSize="0.000000, 0.000000" gravityWellSnap="ClosestEdge" name="backButton" pos="0.000000, -0.600000, 0.000000" size="0.100000, 0.100000" text="Back" textSize="0.050000"/>
@@ -8,11 +11,9 @@
             <UiButton gravityWellEnabled="false" gravityWellRoundness="0.000000" gravityWellSize="0.000000, 0.000000" gravityWellSnap="ClosestEdge" name="fwdButton" size="0.100000, 0.100000" text="Fwd" textSize="0.050000"/>
         </Content>
         <Content>
-            <UiTextEdit alignment="Center, Left" gravityWellEnabled="false" gravityWellRoundness="0.000000" gravityWellSize="0.000000, 0.000000" gravityWellSnap="ClosestEdge" name="urlBar" scrollSpeed="0.500000" size="0.600000, 0.050000" text="https://servo.org/" textSize="0.050000"/>
+            <UiTextEdit alignment="Center, Left" gravityWellEnabled="false" gravityWellRoundness="0.000000" gravityWellSize="0.000000, 0.000000" gravityWellSnap="ClosestEdge" name="urlBar" scrollSpeed="0.500000" size="0.600000, 0.050000" textSize="0.050000"/>
         </Content>
     </UiLinearLayout>
     <LineNode castShadow="false" color="0.000000, 0.000000, 0.000000, 0.000000" name="laser" opaque="false" points="0.000000, 0.000000, 0.000000, 1.000000, 1.000000, 1.000000" receiveShadow="false" shader="Line"/>
-    <UiPanel gravityWellEnabled="false" gravityWellRoundness="0.000000" gravityWellSize="0.000000, 0.000000" gravityWellSnap="ClosestEdge" name="contentPanel" pos="0.000000, 0.060000, 0.000000" shape="[size:[0.5,0.44], roundness: 0, offset[0,0,0]]">
-        <QuadNode castShadow="false" name="content" pos="-0.250000, -0.220000, -0.000000" receiveShadow="false" shader="UnlitColorTex2d" size="0.500000, 0.440000"/>
-    </UiPanel>
+    <QuadNode castShadow="false" color="0.157206, 0.092197, 0.481788, 1.000000" name="bevel" pos="-0.260000, -0.170000, -0.010000" receiveShadow="false" shader="UnlitColorTex2d" size="0.520000, 0.520000"/>
 </ObjectModel>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Various UI changes:
* The GL viewport doesn't need to be set by libmlservo.
* Send trigger-up to servo if trigger-down happened in the viewport.
* Make the prism shorter so the app name is closer.
* Adjust the keyboard position.
* Use a custom home page.
* Draw the laser even if the cursor isn't in the viewport.
* Add a purple bevel.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because its changes to the chrome UI

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22316)
<!-- Reviewable:end -->
