### PR TITLE
Fix daydream support

### DIFF
--- a/support/android/apk/servoapp/src/googlevr/AndroidManifest.xml
+++ b/support/android/apk/servoapp/src/googlevr/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- BEGIN_INCLUDE(manifest) -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto"
+        package="org.mozilla.servo">
+    <application android:label="Servo">
+        <activity android:name=".MainActivity"
+                  android:label="Servo">
+            <meta-data android:name="android.app.lib_name" android:value="servo" />
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.google.intent.category.LAUNCHER"/>
+                <category android:name="com.google.intent.category.DAYDREAM"/>
+                <category android:name="com.google.intent.category.CARDBOARD"/>
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>
+<!-- END_INCLUDE(manifest) -->

--- a/support/android/apk/servoapp/src/main/res/values/styles.xml
+++ b/support/android/apk/servoapp/src/main/res/values/styles.xml
@@ -2,6 +2,7 @@
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="android:Theme.Holo.Light.DarkActionBar">
+        <item name="android:windowNoTitle">true</item>
         <!-- Customize your theme here. -->
     </style>
 


### PR DESCRIPTION
Added a googlevr-flavor AndroidManifest.xml for servoapp (this gets
merged with the main one). Daydream works now.


I haven't added an oculus one since as far as I can tell we don't
support pure servo on oculus yet.

r? @jdm @paulrouget

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22317)
<!-- Reviewable:end -->
