### PR TITLE
Add PerformanceResourceTiming: redirectStart

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -41,8 +41,8 @@ use net_traits::request::{CacheMode, CredentialsMode, Destination, Origin};
 use net_traits::request::{RedirectMode, Referrer, Request, RequestMode};
 use net_traits::request::{ResponseTainting, ServiceWorkersMode};
 use net_traits::response::{HttpsState, Response, ResponseBody, ResponseType};
-use net_traits::ResourceAttribute;
 use net_traits::{CookieSource, FetchMetadata, NetworkError, ReferrerPolicy};
+use net_traits::{RedirectStartValue, ResourceAttribute};
 use openssl::ssl::SslConnectorBuilder;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use std::collections::{HashMap, HashSet};
@@ -528,7 +528,6 @@ pub fn http_fetch(
         // Generally, we use a persistent connection, so we will also set other PerformanceResourceTiming
         //   attributes to this as well (domain_lookup_start, domain_lookup_end, connect_start, connect_end,
         //   secure_connection_start)
-        // TODO(#21256) maybe set redirect_start if this resource initiates the redirect
         // TODO(#21254) also set startTime equal to either fetch_start or redirect_start
         //   (https://w3c.github.io/resource-timing/#dfn-starttime)
         context
@@ -659,6 +658,15 @@ pub fn http_redirect_fetch(
     };
 
     // Step 1 of https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-fetchstart
+    // TODO: check origin and timing allow check
+    context
+        .timing
+        .lock()
+        .unwrap()
+        .set_attribute(ResourceAttribute::RedirectStart(
+            RedirectStartValue::FetchStart,
+        ));
+
     context
         .timing
         .lock()

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -449,16 +449,23 @@ pub struct ResourceFetchTiming {
     pub response_start: u64,
     pub fetch_start: u64,
     // pub response_end: u64,
-    // pub redirect_start: u64,
+    pub redirect_start: u64,
     // pub redirect_end: u64,
     // pub connect_start: u64,
     // pub connect_end: u64,
+}
+
+pub enum RedirectStartValue {
+    #[allow(dead_code)]
+    Zero,
+    FetchStart,
 }
 
 pub enum ResourceAttribute {
     RedirectCount(u16),
     RequestStart,
     ResponseStart,
+    RedirectStart(RedirectStartValue),
     FetchStart,
 }
 
@@ -478,6 +485,7 @@ impl ResourceFetchTiming {
             request_start: 0,
             response_start: 0,
             fetch_start: 0,
+            redirect_start: 0,
         }
     }
 
@@ -488,6 +496,14 @@ impl ResourceFetchTiming {
             ResourceAttribute::RedirectCount(count) => self.redirect_count = count,
             ResourceAttribute::RequestStart => self.request_start = precise_time_ns(),
             ResourceAttribute::ResponseStart => self.response_start = precise_time_ns(),
+            ResourceAttribute::RedirectStart(val) => match val {
+                RedirectStartValue::Zero => self.redirect_start = 0,
+                RedirectStartValue::FetchStart => {
+                    if self.redirect_start == 0 {
+                        self.redirect_start = self.fetch_start
+                    }
+                },
+            },
             ResourceAttribute::FetchStart => self.fetch_start = precise_time_ns(),
         }
     }

--- a/components/script/dom/performanceresourcetiming.rs
+++ b/components/script/dom/performanceresourcetiming.rs
@@ -116,7 +116,7 @@ impl PerformanceResourceTiming {
             initiator_type: initiator_type,
             next_hop: next_hop,
             worker_start: 0.,
-            redirect_start: 0.,
+            redirect_start: resource_timing.redirect_start as f64,
             redirect_end: 0.,
             fetch_start: resource_timing.fetch_start as f64,
             domain_lookup_start: 0.,
@@ -177,6 +177,11 @@ impl PerformanceResourceTimingMethods for PerformanceResourceTiming {
     fn RequestStart(&self) -> DOMHighResTimeStamp {
         // TODO
         Finite::wrap(self.request_start)
+    }
+
+    // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-redirectstart
+    fn RedirectStart(&self) -> DOMHighResTimeStamp {
+        Finite::wrap(self.redirect_start)
     }
 
     // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responsestart

--- a/components/script/dom/webidls/PerformanceResourceTiming.webidl
+++ b/components/script/dom/webidls/PerformanceResourceTiming.webidl
@@ -12,7 +12,7 @@ interface PerformanceResourceTiming : PerformanceEntry {
     readonly attribute DOMString           initiatorType;
     readonly attribute DOMString           nextHopProtocol;
     // readonly attribute DOMHighResTimeStamp workerStart;
-    // readonly attribute DOMHighResTimeStamp redirectStart;
+    readonly attribute DOMHighResTimeStamp redirectStart;
     // readonly attribute DOMHighResTimeStamp redirectEnd;
     readonly attribute DOMHighResTimeStamp fetchStart;
     // readonly attribute DOMHighResTimeStamp domainLookupStart;

--- a/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
+++ b/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
@@ -57,7 +57,7 @@
     expected: FAIL
 
   [PerformanceResourceTiming interface: resource must inherit property "redirectStart" with the proper type]
-    expected: FAIL
+    expected: PASS
 
   [PerformanceResourceTiming interface: attribute connectStart]
     expected: FAIL
@@ -81,7 +81,7 @@
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute redirectStart]
-    expected: FAIL
+    expected: PASS
 
   [PerformanceResourceTiming interface: resource must inherit property "connectEnd" with the proper type]
     expected: FAIL
@@ -188,5 +188,5 @@
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute redirectStart]
-    expected: FAIL
+    expected: PASS
 

--- a/tests/wpt/metadata/resource-timing/resource_TAO_origin.htm.ini
+++ b/tests/wpt/metadata/resource-timing/resource_TAO_origin.htm.ini
@@ -24,7 +24,7 @@
     expected: FAIL
 
   [redirectStart should be 0 in cross-origin request since no redirect.]
-    expected: FAIL
+    expected: PASS
 
   [redirectEnd should be 0 in cross-origin request since no redirect.]
     expected: FAIL

--- a/tests/wpt/metadata/resource-timing/resource_TAO_zero.htm.ini
+++ b/tests/wpt/metadata/resource-timing/resource_TAO_zero.htm.ini
@@ -18,7 +18,7 @@
     expected: FAIL
 
   [redirectStart should be 0 in cross-origin request.]
-    expected: FAIL
+    expected: PASS
 
   [domainLookupEnd should be 0 in cross-origin request.]
     expected: FAIL


### PR DESCRIPTION
1. Added `RedirectStart` to `ResourceAttribute` in `net_traits` crate
2. Match the enum in `set_attribute` to record the start time in `ResourceFetchTiming.redirect_start`.
3. In `http_loader.rs::http_fetch`, added the call the context timing on the `RedirectStart`

fix 21256

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21256 (github issue number if applicable).

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because _____

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22319)
<!-- Reviewable:end -->
