### PR TITLE
Remove extra backslash from Gstreamer info added to the PATH on Windows

### DIFF
--- a/support/windows/Servo.wxs.mako
+++ b/support/windows/Servo.wxs.mako
@@ -46,7 +46,7 @@
                           Advertise="yes"/>
               </File>
 	      ${include_dependencies()}
-              <Environment Id="PATH" Name="PATH" Value="[GSTINSTALLDIR]\1.0\x86\bin;[GSTINSTALLDIR64]\1.0\x86_64\bin" Permanent="yes" Part="last" Action="set" System="yes" />
+              <Environment Id="PATH" Name="PATH" Value="[GSTINSTALLDIR]1.0\x86\bin;[GSTINSTALLDIR64]1.0\x86_64\bin" Permanent="yes" Part="last" Action="set" System="yes" />
             </Component>
 
             ${include_directory(resources_path, "resources")}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22322)
<!-- Reviewable:end -->
