### PR TITLE
Fix missing textures on reloading three.js image content

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -964,6 +964,9 @@ impl HTMLImageElement {
                     CanRequestImages::No,
                 );
                 if let Ok(ImageOrMetadataAvailable::ImageAvailable(image, url)) = response {
+                    // Cancel any outstanding tasks that were queued before the src was
+                    // set on this element.
+                    self.generation.set(self.generation.get() + 1);
                     // Step 6.3
                     let metadata = ImageMetadata {
                         height: image.height,
@@ -971,7 +974,7 @@ impl HTMLImageElement {
                     };
                     // Step 6.3.2 abort requests
                     self.abort_request(State::CompletelyAvailable, ImageRequestPhase::Current);
-                    self.abort_request(State::CompletelyAvailable, ImageRequestPhase::Pending);
+                    self.abort_request(State::Unavailable, ImageRequestPhase::Pending);
                     let mut current_request = self.current_request.borrow_mut();
                     current_request.final_url = Some(url);
                     current_request.image = Some(image.clone());


### PR DESCRIPTION
The fundamental problem is that three.js sets the crossOrigin property of an image, which kicks off an image microtask, and then sets the src. When the image URL is in the image cache (such as when reloading a page), this causes the shortcut to be taken and the image data is made available immediately, but the queued image task is unaware of this and asks the image cache to feed the image data. The existing code then ended up in an unexpected state when trying to deal with this data, such that when three.js received the image load notification and performed the texImage2D operation on the image data, it would discover that the image element did not claim to have a URL, and it would treat this as a broken image. Ultimately, this caused the texture that three.js obtained to be completely black.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22152.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22336)
<!-- Reviewable:end -->
