### PR TITLE
Don't filter the bodies of cross-origin cached responses

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -478,7 +478,7 @@ fn wait_for_response(response: &mut Response, target: Target, done_chan: &mut Do
             }
         }
     } else {
-        let body = response.body.lock().unwrap();
+        let body = response.actual_response().body.lock().unwrap();
         if let ResponseBody::Done(ref vec) = *body {
             // in case there was no channel to wait for, the body was
             // obtained synchronously via scheme_fetch for data/file/about/etc


### PR DESCRIPTION
There are a few issues at play in #22330:
* loading https://servo.org followed by http://servo.org retrieves the second response from the cache (since http://servo.org is upgraded due to HSTS)
* since the request URL differs from the request origin, the response is filtered according to the rules of CORS
* since the response body is already present, there's no async response channel to wait on in `wait_for_response`
* a filtered response stores an empty response, while the real response sits inside the inner response

The effect of this combination was that the constellation's fetch listener would receive the response headers, followed immediately by a response EOF. That is no longer the case, since `wait_for_response` correctly transfers the underlying response body to the network listener.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22330

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22340)
<!-- Reviewable:end -->
