### PR TITLE
Implement Ended media attribute

### DIFF
--- a/components/script/dom/webidls/HTMLMediaElement.webidl
+++ b/components/script/dom/webidls/HTMLMediaElement.webidl
@@ -46,7 +46,7 @@ interface HTMLMediaElement : HTMLElement {
   [Throws] attribute double playbackRate;
   readonly attribute TimeRanges played;
   // readonly attribute TimeRanges seekable;
-  // readonly attribute boolean ended;
+  readonly attribute boolean ended;
   [CEReactions] attribute boolean autoplay;
   // [CEReactions] attribute boolean loop;
   Promise<void> play();

--- a/tests/wpt/metadata/html/dom/interfaces.https.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.https.html.ini
@@ -1052,9 +1052,6 @@
   [HTMLMediaElement interface: document.createElement("video") must inherit property "seekable" with the proper type]
     expected: FAIL
 
-  [HTMLMediaElement interface: document.createElement("video") must inherit property "ended" with the proper type]
-    expected: FAIL
-
   [HTMLMediaElement interface: document.createElement("video") must inherit property "loop" with the proper type]
     expected: FAIL
 
@@ -1122,9 +1119,6 @@
     expected: FAIL
 
   [HTMLMediaElement interface: document.createElement("audio") must inherit property "seekable" with the proper type]
-    expected: FAIL
-
-  [HTMLMediaElement interface: document.createElement("audio") must inherit property "ended" with the proper type]
     expected: FAIL
 
   [HTMLMediaElement interface: document.createElement("audio") must inherit property "loop" with the proper type]
@@ -1257,9 +1251,6 @@
     expected: FAIL
 
   [HTMLMediaElement interface: new Audio() must inherit property "seekable" with the proper type]
-    expected: FAIL
-
-  [HTMLMediaElement interface: new Audio() must inherit property "ended" with the proper type]
     expected: FAIL
 
   [HTMLMediaElement interface: new Audio() must inherit property "autoplay" with the proper type]
@@ -1410,9 +1401,6 @@
     expected: FAIL
 
   [HTMLMediaElement interface: attribute seekable]
-    expected: FAIL
-
-  [HTMLMediaElement interface: attribute ended]
     expected: FAIL
 
   [HTMLMediaElement interface: attribute loop]

--- a/tests/wpt/metadata/html/dom/interfaces.https.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.https.html.ini
@@ -6780,9 +6780,6 @@
   [HTMLMediaElement interface: document.createElement("video") must inherit property "seekable" with the proper type]
     expected: FAIL
 
-  [HTMLMediaElement interface: document.createElement("video") must inherit property "ended" with the proper type]
-    expected: FAIL
-
   [HTMLMediaElement interface: document.createElement("video") must inherit property "loop" with the proper type]
     expected: FAIL
 
@@ -6814,9 +6811,6 @@
     expected: FAIL
 
   [HTMLMediaElement interface: document.createElement("audio") must inherit property "seekable" with the proper type]
-    expected: FAIL
-
-  [HTMLMediaElement interface: document.createElement("audio") must inherit property "ended" with the proper type]
     expected: FAIL
 
   [HTMLMediaElement interface: document.createElement("audio") must inherit property "loop" with the proper type]
@@ -6852,9 +6846,6 @@
   [HTMLMediaElement interface: new Audio() must inherit property "seekable" with the proper type]
     expected: FAIL
 
-  [HTMLMediaElement interface: new Audio() must inherit property "ended" with the proper type]
-    expected: FAIL
-
   [HTMLMediaElement interface: new Audio() must inherit property "loop" with the proper type]
     expected: FAIL
 
@@ -6883,9 +6874,6 @@
     expected: FAIL
 
   [HTMLMediaElement interface: attribute seekable]
-    expected: FAIL
-
-  [HTMLMediaElement interface: attribute ended]
     expected: FAIL
 
   [HTMLMediaElement interface: attribute loop]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR should implement:
* New method `HTMLMediaElement::earliest_possible_position()` for the [earliest possible position](https://html.spec.whatwg.org/multipage/media.html#earliest-possible-position)
* `Ended` attribute following https://html.spec.whatwg.org/multipage/media.html#ended-playback
* Queue steps for when the playback position reaches the end

This PR contains placeholders for the following issues (I can rebase changes after the corresponding PRs get merged)
- #22321 (Define the Loop attribute)
- #22293 (To identify playback direction. Either forwards or backwards)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `__` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [x] These changes fix #22294.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22348)
<!-- Reviewable:end -->
