### PR TITLE
Cancel animations that affect nodes that do not participate in layout.

### DIFF
--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -9,7 +9,7 @@ use crate::display_list::items::OpaqueNode;
 use crate::flow::{Flow, GetBaseFlow};
 use crate::opaque_node::OpaqueNodeMethods;
 use crossbeam_channel::Receiver;
-use fxhash::FxHashMap;
+use fxhash::{FxHashMap, FxHashSet};
 use ipc_channel::ipc::IpcSender;
 use msg::constellation_msg::PipelineId;
 use script_traits::UntrustedNodeAddress;
@@ -28,6 +28,7 @@ pub fn update_animation_state<E>(
     script_chan: &IpcSender<ConstellationControlMsg>,
     running_animations: &mut FxHashMap<OpaqueNode, Vec<Animation>>,
     expired_animations: &mut FxHashMap<OpaqueNode, Vec<Animation>>,
+    mut keys_to_remove: FxHashSet<OpaqueNode>,
     mut newly_transitioning_nodes: Option<&mut Vec<UntrustedNodeAddress>>,
     new_animations_receiver: &Receiver<Animation>,
     pipeline_id: PipelineId,
@@ -74,7 +75,6 @@ pub fn update_animation_state<E>(
     // TODO: Do not expunge Keyframes animations, since we need that state if
     // the animation gets re-triggered. Probably worth splitting in two
     // different maps, or at least using a linked list?
-    let mut keys_to_remove = vec![];
     for (key, running_animations) in running_animations.iter_mut() {
         let mut animations_still_running = vec![];
         for mut running_animation in running_animations.drain(..) {
@@ -116,7 +116,7 @@ pub fn update_animation_state<E>(
         }
 
         if animations_still_running.is_empty() {
-            keys_to_remove.push(*key);
+            keys_to_remove.insert(*key);
         } else {
             *running_animations = animations_still_running
         }
@@ -160,17 +160,33 @@ pub fn update_animation_state<E>(
 }
 
 /// Recalculates style for a set of animations. This does *not* run with the DOM
-/// lock held.
+/// lock held. Returns a set of nodes associated with animations that are no longer
+/// valid.
 pub fn recalc_style_for_animations<E>(
     context: &LayoutContext,
     flow: &mut dyn Flow,
     animations: &FxHashMap<OpaqueNode, Vec<Animation>>,
+) -> FxHashSet<OpaqueNode>
+where
+    E: TElement,
+{
+    let mut invalid_nodes = animations.keys().cloned().collect();
+    do_recalc_style_for_animations::<E>(context, flow, animations, &mut invalid_nodes);
+    invalid_nodes
+}
+
+fn do_recalc_style_for_animations<E>(
+    context: &LayoutContext,
+    flow: &mut dyn Flow,
+    animations: &FxHashMap<OpaqueNode, Vec<Animation>>,
+    invalid_nodes: &mut FxHashSet<OpaqueNode>,
 ) where
     E: TElement,
 {
     let mut damage = RestyleDamage::empty();
     flow.mutate_fragments(&mut |fragment| {
         if let Some(ref animations) = animations.get(&fragment.node) {
+            invalid_nodes.remove(&fragment.node);
             for animation in animations.iter() {
                 let old_style = fragment.style.clone();
                 update_style_for_animation::<E>(
@@ -189,6 +205,6 @@ pub fn recalc_style_for_animations<E>(
     let base = flow.mut_base();
     base.restyle_damage.insert(damage);
     for kid in base.children.iter_mut() {
-        recalc_style_for_animations::<E>(context, kid, animations)
+        do_recalc_style_for_animations::<E>(context, kid, animations, invalid_nodes)
     }
 }

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -310,6 +310,7 @@ pub enum LayoutHangAnnotation {
     UpdateScrollStateFromScript,
     RegisterPaint,
     SetNavigationStart,
+    GetRunningAnimations,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]

--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -173,3 +173,8 @@ partial interface Window {
    readonly attribute TestRunner testRunner;
    //readonly attribute EventSender eventSender;
 };
+
+partial interface Window {
+   [Pref="css.animations.testing.enabled"]
+   readonly attribute unsigned long runningAnimationCount;
+};

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -74,7 +74,7 @@ use devtools_traits::{ScriptToDevtoolsControlMsg, TimelineMarker, TimelineMarker
 use dom_struct::dom_struct;
 use embedder_traits::EmbedderMsg;
 use euclid::{Point2D, Rect, Size2D, TypedPoint2D, TypedScale, TypedSize2D, Vector2D};
-use ipc_channel::ipc::IpcSender;
+use ipc_channel::ipc::{channel, IpcSender};
 use ipc_channel::router::ROUTER;
 use js::jsapi::JSAutoCompartment;
 use js::jsapi::JSContext;
@@ -1142,6 +1142,12 @@ impl WindowMethods for Window {
 
     fn TestRunner(&self) -> DomRoot<TestRunner> {
         self.test_runner.or_init(|| TestRunner::new(self.upcast()))
+    }
+
+    fn RunningAnimationCount(&self) -> u32 {
+        let (sender, receiver) = channel().unwrap();
+        let _ = self.layout_chan.send(Msg::GetRunningAnimations(sender));
+        receiver.recv().unwrap_or(0) as u32
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-name

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -98,6 +98,9 @@ pub enum Msg {
 
     /// Send to layout the precise time when the navigation started.
     SetNavigationStart(u64),
+
+    /// Request the current number of animations that are running.
+    GetRunningAnimations(IpcSender<usize>),
 }
 
 #[derive(Debug, PartialEq)]

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13458,6 +13458,12 @@
      {}
     ]
    ], 
+   "mozilla/animation-removed-node.html": [
+    [
+     "/_mozilla/mozilla/animation-removed-node.html", 
+     {}
+    ]
+   ], 
    "mozilla/binding_keyword.html": [
     [
      "/_mozilla/mozilla/binding_keyword.html", 
@@ -26611,6 +26617,10 @@
   ], 
   "mozilla/adopted_node_is_same_origin_domain.html": [
    "81de5b389c922067c61effe03208ea740ba8e067", 
+   "testharness"
+  ], 
+  "mozilla/animation-removed-node.html": [
+   "6ba0318ea1e07b42ef444f838753adbefe9633d6", 
    "testharness"
   ], 
   "mozilla/binding_keyword.html": [

--- a/tests/wpt/mozilla/meta/mozilla/animation-removed-node.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/animation-removed-node.html.ini
@@ -1,0 +1,2 @@
+[animation-removed-node.html]
+  prefs: [css.animations.testing.enabled:true]

--- a/tests/wpt/mozilla/tests/mozilla/animation-removed-node.html
+++ b/tests/wpt/mozilla/tests/mozilla/animation-removed-node.html
@@ -1,0 +1,28 @@
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+@keyframes boo {
+  0%   { opacity: 0; }
+  100% { opacity: 1; }
+}
+div.test { animation: boo 1s infinite; }
+</style>
+<div class="test" id="first">hi there!</div>
+<div class="test" id="second">hi again!</div>
+<script>
+  async_test(function(t) {
+    window.onload = t.step_func(function() {
+      // Verify that there are the expected animations active.
+      assert_equals(window.runningAnimationCount, 2);
+      // Cause the animating nodes to become uninvolved with layout.
+      document.getElementById('first').remove();
+      document.getElementById('second').style.display = 'none';
+      // Ensure that we wait until the next layout is complete.
+      requestAnimationFrame(t.step_func(function() {
+        // Verify that the previous animations are no longer considered active.
+        assert_equals(window.runningAnimationCount, 0);
+        t.done();
+      }));
+    });
+  }, "Animations are no longer active when a node can't be animated.");
+</script>


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22378
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22389)
<!-- Reviewable:end -->
