### PR TITLE
Fixup the issue related with an incorrect distro version string handling

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -345,7 +345,10 @@ def get_linux_distribution():
     distro, version, _ = platform.linux_distribution()
 
     if distro == 'LinuxMint':
-        major, minor = version.split('.')
+        if '.' in version:
+            major, _ = version.split('.', 1)
+        else:
+            major = version
 
         if major == '19':
             base_version = '18.04'


### PR DESCRIPTION
The original fixes for #21732 had a mistake.
The fix don't work on the LinuxMint with version 19:
```
  File "./mach", line 96, in <module>
    main(sys.argv)
  File "./mach", line 24, in main
    sys.exit(mach_bootstrap.bootstrap_command_only(topdir))
  File "/home/user/workspace/skv/servo/python/mach_bootstrap.py", line 239, in bootstrap_command_only
    bootstrap(context, force)
  File "/home/user/workspace/skv/servo/python/servo/bootstrap.py", line 380, in bootstrap
    distro, version = get_linux_distribution()
  File "/home/user/workspace/skv/servo/python/servo/bootstrap.py", line 349, in get_linux_distribution
    major, minor = version.split('.')
ValueError: need more than 1 value to unpack
```
I've fixed that

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #21732 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because _____

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22390)
<!-- Reviewable:end -->
