### PR TITLE
Initialize iframe viewport immediately

### DIFF
--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -11,12 +11,10 @@ pub use crate::compositor::IOCompositor;
 pub use crate::compositor::RenderNotifier;
 pub use crate::compositor::ShutdownState;
 pub use crate::compositor_thread::CompositorProxy;
-use euclid::TypedSize2D;
 use ipc_channel::ipc::IpcSender;
 use msg::constellation_msg::PipelineId;
 use msg::constellation_msg::TopLevelBrowsingContextId;
 use script_traits::{ConstellationControlMsg, LayoutControlMsg};
-use style_traits::CSSPixel;
 
 mod compositor;
 pub mod compositor_thread;
@@ -27,7 +25,6 @@ pub mod windowing;
 
 pub struct SendableFrameTree {
     pub pipeline: CompositionPipeline,
-    pub size: Option<TypedSize2D<f32, CSSPixel>>,
     pub children: Vec<SendableFrameTree>,
 }
 

--- a/components/constellation/browsingcontext.rs
+++ b/components/constellation/browsingcontext.rs
@@ -41,7 +41,7 @@ pub struct BrowsingContext {
     pub top_level_id: TopLevelBrowsingContextId,
 
     /// The size of the frame.
-    pub size: Option<TypedSize2D<f32, CSSPixel>>,
+    pub size: TypedSize2D<f32, CSSPixel>,
 
     /// Whether this browsing context is in private browsing mode.
     pub is_private: bool,
@@ -70,6 +70,7 @@ impl BrowsingContext {
         top_level_id: TopLevelBrowsingContextId,
         pipeline_id: PipelineId,
         parent_pipeline_id: Option<PipelineId>,
+        size: TypedSize2D<f32, CSSPixel>,
         is_private: bool,
         is_visible: bool,
     ) -> BrowsingContext {
@@ -78,7 +79,7 @@ impl BrowsingContext {
         BrowsingContext {
             id: id,
             top_level_id: top_level_id,
-            size: None,
+            size: size,
             is_private: is_private,
             is_visible: is_visible,
             pipeline_id: pipeline_id,

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -152,7 +152,7 @@ pub struct InitialPipelineState {
     pub mem_profiler_chan: profile_mem::ProfilerChan,
 
     /// Information about the initial window size.
-    pub window_size: Option<TypedSize2D<f32, CSSPixel>>,
+    pub window_size: TypedSize2D<f32, CSSPixel>,
 
     /// Information about the device pixel ratio.
     pub device_pixel_ratio: TypedScale<f32, CSSPixel, DevicePixel>,
@@ -200,11 +200,10 @@ impl Pipeline {
         let (layout_content_process_shutdown_chan, layout_content_process_shutdown_port) =
             ipc::channel().expect("Pipeline layout content shutdown chan");
 
-        let device_pixel_ratio = state.device_pixel_ratio;
-        let window_size = state.window_size.map(|size| WindowSizeData {
-            initial_viewport: size,
-            device_pixel_ratio: device_pixel_ratio,
-        });
+        let window_size = WindowSizeData {
+            initial_viewport: state.window_size,
+            device_pixel_ratio: state.device_pixel_ratio,
+        };
 
         let url = state.load_data.url.clone();
 
@@ -475,7 +474,7 @@ pub struct UnprivilegedPipelineContent {
     resource_threads: ResourceThreads,
     time_profiler_chan: time::ProfilerChan,
     mem_profiler_chan: profile_mem::ProfilerChan,
-    window_size: Option<WindowSizeData>,
+    window_size: WindowSizeData,
     script_chan: IpcSender<ConstellationControlMsg>,
     load_data: LoadData,
     script_port: IpcReceiver<ConstellationControlMsg>,

--- a/components/gfx/platform/macos/font.rs
+++ b/components/gfx/platform/macos/font.rs
@@ -239,15 +239,14 @@ impl FontHandleMethods for FontHandle {
 
         let result = unsafe {
             self.ctfont
-                .get_glyphs_for_characters(&characters[0], &mut glyphs[0], count)
+                .get_glyphs_for_characters(characters.as_ptr(), glyphs.as_mut_ptr(), count)
         };
 
-        if !result {
+        if !result || glyphs[0] == 0 {
             // No glyph for this character
             return None;
         }
 
-        assert_ne!(glyphs[0], 0); // FIXME: error handling
         return Some(glyphs[0] as GlyphId);
     }
 

--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -4,12 +4,15 @@
 
 //! Base classes to work with IDL callbacks.
 
+use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowBinding::WindowMethods;
 use crate::dom::bindings::error::{report_pending_exception, Error, Fallible};
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::settings_stack::{AutoEntryScript, AutoIncumbentScript};
 use crate::dom::bindings::utils::AsCCharPtrPtr;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::window::Window;
 use js::jsapi::Heap;
 use js::jsapi::JSAutoCompartment;
 use js::jsapi::{AddRawValueRoot, IsCallable, JSContext, JSObject};
@@ -242,6 +245,9 @@ impl CallSetup {
     #[allow(unrooted_must_root)]
     pub fn new<T: CallbackContainer>(callback: &T, handling: ExceptionHandling) -> CallSetup {
         let global = unsafe { GlobalScope::from_object(callback.callback()) };
+        if let Some(window) = global.downcast::<Window>() {
+            window.Document().ensure_safe_to_run_script_or_layout();
+        }
         let cx = global.get_cx();
 
         let aes = AutoEntryScript::new(&global);

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -49,6 +49,7 @@ use crate::dom::bindings::utils::WindowProxyHandler;
 use crate::dom::document::PendingRestyle;
 use crate::dom::htmlimageelement::SourceSet;
 use crate::dom::htmlmediaelement::MediaFrameRenderer;
+use crate::task::TaskBox;
 use crossbeam_channel::{Receiver, Sender};
 use cssparser::RGBA;
 use devtools_traits::{CSSError, TimelineMarkerType, WorkerId};
@@ -138,6 +139,8 @@ pub unsafe trait JSTraceable {
     /// Trace `self`.
     unsafe fn trace(&self, trc: *mut JSTracer);
 }
+
+unsafe_no_jsmanaged_fields!(Box<dyn TaskBox>);
 
 unsafe_no_jsmanaged_fields!(CSSError);
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -410,6 +410,8 @@ pub struct Document {
     responsive_images: DomRefCell<Vec<Dom<HTMLImageElement>>>,
     /// Number of redirects for the document load
     redirect_count: Cell<u16>,
+    ///
+    script_and_layout_blockers: Cell<u32>,
 }
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -2695,7 +2697,25 @@ impl Document {
             fired_unload: Cell::new(false),
             responsive_images: Default::default(),
             redirect_count: Cell::new(0),
+            script_and_layout_blockers: Cell::new(0),
         }
+    }
+
+    pub fn add_script_and_layout_blocker(&self) {
+        self.script_and_layout_blockers.set(
+            self.script_and_layout_blockers.get() + 1
+        );
+    }
+
+    pub fn remove_script_and_layout_blocker(&self) {
+        assert!(self.script_and_layout_blockers.get() > 0);
+        self.script_and_layout_blockers.set(
+            self.script_and_layout_blockers.get() - 1
+        );
+    }
+
+    pub fn ensure_safe_to_run_script_or_layout(&self) {
+        assert_eq!(self.script_and_layout_blockers.get(), 0);
     }
 
     // https://dom.spec.whatwg.org/#dom-document-document

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2806,17 +2806,11 @@ impl Document {
     ///
     /// FIXME(emilio): This really needs to be somehow more in sync with layout.
     /// Feels like a hack.
-    ///
-    /// Also, shouldn't return an option, I'm quite sure.
-    pub fn device(&self) -> Option<Device> {
-        let window_size = self.window().window_size()?;
+    pub fn device(&self) -> Device {
+        let window_size = self.window().window_size();
         let viewport_size = window_size.initial_viewport;
         let device_pixel_ratio = window_size.device_pixel_ratio;
-        Some(Device::new(
-            MediaType::screen(),
-            viewport_size,
-            device_pixel_ratio,
-        ))
+        Device::new(MediaType::screen(), viewport_size, device_pixel_ratio)
     }
 
     /// Remove a stylesheet owned by `owner` from the list of document sheets.
@@ -4183,7 +4177,7 @@ impl DocumentMethods for Document {
         let y = *y as f32;
         let point = &Point2D::new(x, y);
         let window = window_from_node(self);
-        let viewport = window.window_size()?.initial_viewport;
+        let viewport = window.window_size().initial_viewport;
 
         if self.browsing_context().is_none() {
             return None;
@@ -4218,10 +4212,7 @@ impl DocumentMethods for Document {
         let y = *y as f32;
         let point = &Point2D::new(x, y);
         let window = window_from_node(self);
-        let viewport = match window.window_size() {
-            Some(size) => size.initial_viewport,
-            None => return vec![],
-        };
+        let viewport = window.window_size().initial_viewport;
 
         if self.browsing_context().is_none() {
             return vec![];

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -26,6 +26,7 @@ use crate::dom::windowproxy::WindowProxy;
 use crate::script_thread::ScriptThread;
 use crate::task_source::TaskSource;
 use dom_struct::dom_struct;
+use euclid::TypedSize2D;
 use html5ever::{LocalName, Prefix};
 use ipc_channel::ipc;
 use msg::constellation_msg::{BrowsingContextId, PipelineId, TopLevelBrowsingContextId};
@@ -34,6 +35,7 @@ use script_layout_interface::message::ReflowGoal;
 use script_traits::IFrameSandboxState::{IFrameSandboxed, IFrameUnsandboxed};
 use script_traits::{
     IFrameLoadInfo, IFrameLoadInfoWithData, JsEvalResult, LoadData, UpdatePipelineIdReason,
+    WindowSizeData,
 };
 use script_traits::{NewLayoutInfo, ScriptMsg};
 use servo_config::prefs::PREFS;
@@ -192,7 +194,16 @@ impl HTMLIFrameElement {
                     load_data: load_data.unwrap(),
                     pipeline_port: pipeline_receiver,
                     content_process_shutdown_chan: None,
-                    window_size: None,
+                    window_size: Some(WindowSizeData {
+                        initial_viewport: {
+                            let rect = self.upcast::<Node>().bounding_content_box_or_zero();
+                            TypedSize2D::new(
+                                rect.size.width.to_f32_px(),
+                                rect.size.height.to_f32_px(),
+                            )
+                        },
+                        device_pixel_ratio: window.device_pixel_ratio(),
+                    }),
                     layout_threads: PREFS.get("layout.threads").as_u64().expect("count") as usize,
                 };
 

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -194,7 +194,7 @@ impl HTMLIFrameElement {
                     load_data: load_data.unwrap(),
                     pipeline_port: pipeline_receiver,
                     content_process_shutdown_chan: None,
-                    window_size: Some(WindowSizeData {
+                    window_size: WindowSizeData {
                         initial_viewport: {
                             let rect = self.upcast::<Node>().bounding_content_box_or_zero();
                             TypedSize2D::new(
@@ -203,7 +203,7 @@ impl HTMLIFrameElement {
                             )
                         },
                         device_pixel_ratio: window.device_pixel_ratio(),
-                    }),
+                    },
                     layout_threads: PREFS.get("layout.threads").as_u64().expect("count") as usize,
                 };
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -777,7 +777,10 @@ impl VirtualMethods for HTMLScriptElement {
         }
 
         if tree_in_doc && !self.parser_inserted.get() {
-            self.prepare();
+            let script = Trusted::new(self);
+            document_from_node(self).add_delayed_task(task!(ScriptDelayedInitialize: move || {
+                    script.root().prepare();
+                }));
         }
     }
 

--- a/components/script/dom/mediaquerylist.rs
+++ b/components/script/dom/mediaquerylist.rs
@@ -69,10 +69,8 @@ impl MediaQueryList {
     }
 
     pub fn evaluate(&self) -> bool {
-        self.document.device().map_or(false, |device| {
-            self.media_query_list
-                .evaluate(&device, self.document.quirks_mode())
-        })
+        self.media_query_list
+            .evaluate(&self.document.device(), self.document.quirks_mode())
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1361,6 +1361,7 @@ impl Window {
     /// Returns true if layout actually happened, false otherwise.
     #[allow(unsafe_code)]
     pub fn force_reflow(&self, reflow_goal: ReflowGoal, reason: ReflowReason) -> bool {
+        self.Document().ensure_safe_to_run_script_or_layout();
         // Check if we need to unsuppress reflow. Note that this needs to be
         // *before* any early bailouts, or reflow might never be unsuppresed!
         match reason {
@@ -1497,6 +1498,7 @@ impl Window {
     /// may happen in the only case a query reflow may bail out, that is, if the
     /// viewport size is not present). See #11223 for an example of that.
     pub fn reflow(&self, reflow_goal: ReflowGoal, reason: ReflowReason) -> bool {
+        self.Document().ensure_safe_to_run_script_or_layout();
         let for_display = reflow_goal == ReflowGoal::Full;
 
         let mut issued_reflow = false;

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -289,7 +289,7 @@ impl WindowProxy {
                 load_data: load_data,
                 pipeline_port: pipeline_receiver,
                 content_process_shutdown_chan: None,
-                window_size: None,
+                window_size: window.window_size(),
                 layout_threads: PREFS.get("layout.threads").as_u64().expect("count") as usize,
             };
             let constellation_msg = ScriptMsg::ScriptNewAuxiliary(load_info, pipeline_sender);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -182,7 +182,7 @@ struct InProgressLoad {
     /// The opener, if this is an auxiliary.
     opener: Option<BrowsingContextId>,
     /// The current window size associated with this pipeline.
-    window_size: Option<WindowSizeData>,
+    window_size: WindowSizeData,
     /// Channel to the layout thread associated with this pipeline.
     layout_chan: Sender<message::Msg>,
     /// The activity level of the document (inactive, active or fully active).
@@ -210,7 +210,7 @@ impl InProgressLoad {
         parent_info: Option<PipelineId>,
         opener: Option<BrowsingContextId>,
         layout_chan: Sender<message::Msg>,
-        window_size: Option<WindowSizeData>,
+        window_size: WindowSizeData,
         url: ServoUrl,
         origin: MutableOrigin,
     ) -> InProgressLoad {
@@ -1852,7 +1852,7 @@ impl ScriptThread {
         }
         let mut loads = self.incomplete_loads.borrow_mut();
         if let Some(ref mut load) = loads.iter_mut().find(|load| load.pipeline_id == id) {
-            load.window_size = Some(size);
+            load.window_size = size;
             return;
         }
         warn!("resize sent to nonexistent pipeline");

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -190,7 +190,7 @@ pub struct NewLayoutInfo {
     /// Network request data which will be initiated by the script thread.
     pub load_data: LoadData,
     /// Information about the initial window size.
-    pub window_size: Option<WindowSizeData>,
+    pub window_size: WindowSizeData,
     /// A port on which layout can receive messages from the pipeline.
     pub pipeline_port: IpcReceiver<LayoutControlMsg>,
     /// A shutdown channel so that layout can tell the content process to shut down when it's done.
@@ -566,7 +566,7 @@ pub struct InitialScriptState {
     /// A channel to the developer tools, if applicable.
     pub devtools_chan: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
     /// Information about the initial window size.
-    pub window_size: Option<WindowSizeData>,
+    pub window_size: WindowSizeData,
     /// The ID of the pipeline namespace for this script thread.
     pub pipeline_namespace_id: PipelineNamespaceId,
     /// A ping will be sent on this channel once the script thread shuts down.

--- a/tests/wpt/metadata/css/cssom-view/matchMedia.xht.ini
+++ b/tests/wpt/metadata/css/cssom-view/matchMedia.xht.ini
@@ -4,16 +4,7 @@
   [window.matchMedia exists]
     expected: FAIL
 
-  [MediaQueryList.matches for "(max-width: 199px), all and (min-width: 200px)"]
-    expected: FAIL
-
   [MediaQueryList.matches for "(min-aspect-ratio: 1/1)"]
-    expected: FAIL
-
-  [MediaQueryList.matches for "(width: 200px)"]
-    expected: FAIL
-
-  [MediaQueryList.matches for "(min-width: 150px)"]
     expected: FAIL
 
   [Resize iframe from 200x100 to 200x50, then to 100x50]

--- a/tests/wpt/metadata/css/cssom/getComputedStyle-detached-subtree.html.ini
+++ b/tests/wpt/metadata/css/cssom/getComputedStyle-detached-subtree.html.ini
@@ -1,2 +1,8 @@
 [getComputedStyle-detached-subtree.html]
   expected: ERROR
+  [getComputedStyle returns no style for element in non-rendered iframe (display: none) from iframe's window]
+    expected: FAIL
+
+  [getComputedStyle returns no style for element in non-rendered iframe (display: none)]
+    expected: FAIL
+


### PR DESCRIPTION
This is probably a significant cause of unstable test results, and it finally bothered me enough to fix it. The solution isn't great for performance (a sync layout query every time a iframe is added to a document), but performance needs to follow correctness.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #14364 and fix #15689 and fix #15688.
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22395)
<!-- Reviewable:end -->
