### PR TITLE
Make desktop webdriver WPT harness work

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4034,17 +4034,16 @@ where
 
     /// Send the current frame tree to compositor
     fn send_frame_tree(&mut self, top_level_browsing_context_id: TopLevelBrowsingContextId) {
-        self.active_browser_id = Some(top_level_browsing_context_id);
-        let browsing_context_id = BrowsingContextId::from(top_level_browsing_context_id);
-
         // Note that this function can panic, due to ipc-channel creation failure.
         // avoiding this panic would require a mechanism for dealing
         // with low-resource scenarios.
-        debug!(
-            "Sending frame tree for browsing context {}.",
-            browsing_context_id
-        );
+        let browsing_context_id = BrowsingContextId::from(top_level_browsing_context_id);
         if let Some(frame_tree) = self.browsing_context_to_sendable(browsing_context_id) {
+            debug!(
+                "Sending frame tree for browsing context {}.",
+                browsing_context_id
+            );
+            self.active_browser_id = Some(top_level_browsing_context_id);
             self.compositor_proxy
                 .send(ToCompositorMsg::SetFrameTree(frame_tree));
         }

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1159,6 +1159,8 @@ impl WebDriverHandler<ServoExtensionRoute> for Handler {
         _session: &Option<Session>,
         msg: WebDriverMessage<ServoExtensionRoute>,
     ) -> WebDriverResult<WebDriverResponse> {
+        info!("{:?}", msg.command);
+
         // Unless we are trying to create a new session, we need to ensure that a
         // session has previously been created
         match msg.command {

--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -14,6 +14,7 @@ mac-rel-wpt1:
   - ./mach test-wpt --release --processes 4 --total-chunks 6 --this-chunk 1 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
   - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
   - ./mach test-wpt --release --binary-arg=--multiprocess --processes 8 --log-raw test-wpt-mp.log --log-errorsummary wpt-mp-errorsummary.log eventsource
+  - ./mach test-wpt --release --product=servodriver --headless tests/wpt/mozilla/tests/mozilla/DOMParser.html tests/wpt/mozilla/tests/css/per_glyph_font_fallback_a.html tests/wpt/mozilla/tests/css/img_simple.html
   - bash ./etc/ci/lockfile_changed.sh
 
 mac-rel-wpt2:
@@ -141,6 +142,7 @@ linux-rel-wpt:
     - ./mach test-wpt --release --processes 24 --total-chunks 2 --this-chunk 1 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
     - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
     - ./mach test-wpt --release --binary-arg=--multiprocess --processes 24 --log-raw test-wpt-mp.log --log-errorsummary wpt-mp-errorsummary.log eventsource
+    - ./mach test-wpt --release --product=servodriver --headless tests/wpt/mozilla/tests/mozilla/DOMParser.html tests/wpt/mozilla/tests/css/per_glyph_font_fallback_a.html tests/wpt/mozilla/tests/css/img_simple.html
     - ./etc/ci/clean_build_artifacts.sh
 
 linux-rel-css:

--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -14,7 +14,7 @@ mac-rel-wpt1:
   - ./mach test-wpt --release --processes 4 --total-chunks 6 --this-chunk 1 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
   - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
   - ./mach test-wpt --release --binary-arg=--multiprocess --processes 8 --log-raw test-wpt-mp.log --log-errorsummary wpt-mp-errorsummary.log eventsource
-  - ./mach test-wpt --release --product=servodriver --headless tests/wpt/mozilla/tests/mozilla/DOMParser.html tests/wpt/mozilla/tests/css/per_glyph_font_fallback_a.html tests/wpt/mozilla/tests/css/img_simple.html
+  - ./mach test-wpt --release --product=servodriver --headless tests/wpt/mozilla/tests/mozilla/DOMParser.html tests/wpt/mozilla/tests/css/per_glyph_font_fallback_a.html tests/wpt/mozilla/tests/css/img_simple.html tests/wpt/mozilla/tests/mozilla/secure.https.html
   - bash ./etc/ci/lockfile_changed.sh
 
 mac-rel-wpt2:
@@ -142,7 +142,7 @@ linux-rel-wpt:
     - ./mach test-wpt --release --processes 24 --total-chunks 2 --this-chunk 1 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
     - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
     - ./mach test-wpt --release --binary-arg=--multiprocess --processes 24 --log-raw test-wpt-mp.log --log-errorsummary wpt-mp-errorsummary.log eventsource
-    - ./mach test-wpt --release --product=servodriver --headless tests/wpt/mozilla/tests/mozilla/DOMParser.html tests/wpt/mozilla/tests/css/per_glyph_font_fallback_a.html tests/wpt/mozilla/tests/css/img_simple.html
+    - ./mach test-wpt --release --product=servodriver --headless tests/wpt/mozilla/tests/mozilla/DOMParser.html tests/wpt/mozilla/tests/css/per_glyph_font_fallback_a.html tests/wpt/mozilla/tests/css/img_simple.html tests/wpt/mozilla/tests/mozilla/secure.https.html
     - ./etc/ci/clean_build_artifacts.sh
 
 linux-rel-css:

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -40,6 +40,7 @@ def browser_kwargs(test_type, run_info_data, config, **kwargs):
         "debug_info": kwargs["debug_info"],
         "server_config": config,
         "user_stylesheets": kwargs.get("user_stylesheets"),
+        "headless": kwargs.get("headless"),
     }
 
 
@@ -75,7 +76,7 @@ class ServoWebDriverBrowser(Browser):
     init_timeout = 300  # Large timeout for cases where we're booting an Android emulator
 
     def __init__(self, logger, binary, debug_info=None, webdriver_host="127.0.0.1",
-                 server_config=None, binary_args=None, user_stylesheets=None):
+                 server_config=None, binary_args=None, user_stylesheets=None, headless=None):
         Browser.__init__(self, logger)
         self.binary = binary
         self.binary_args = binary_args or []
@@ -87,6 +88,7 @@ class ServoWebDriverBrowser(Browser):
         self.server_ports = server_config.ports if server_config else {}
         self.command = None
         self.user_stylesheets = user_stylesheets if user_stylesheets else []
+        self.headless = headless if headless else False
 
     def start(self, **kwargs):
         self.webdriver_port = get_free_port(4444, exclude=self.used_ports)
@@ -111,6 +113,9 @@ class ServoWebDriverBrowser(Browser):
             ],
             self.debug_info
         )
+
+        if self.headless:
+            command += ["--headless"]
 
         for stylesheet in self.user_stylesheets:
             command += ["--user-stylesheet", stylesheet]

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -89,6 +89,7 @@ class ServoWebDriverBrowser(Browser):
         self.command = None
         self.user_stylesheets = user_stylesheets if user_stylesheets else []
         self.headless = headless if headless else False
+        self.ca_certificate_path = server_config.ssl_config["ca_cert_path"]
 
     def start(self, **kwargs):
         self.webdriver_port = get_free_port(4444, exclude=self.used_ports)
@@ -116,6 +117,9 @@ class ServoWebDriverBrowser(Browser):
 
         if self.headless:
             command += ["--headless"]
+
+        if self.ca_certificate_path:
+            command += ["--certificate-path", self.ca_certificate_path]
 
         for stylesheet in self.user_stylesheets:
             command += ["--user-stylesheet", stylesheet]


### PR DESCRIPTION
This change allows me to run `./mach test-wpt --product servodriver --no-pause-after-test tests/wpt/mozilla/tests/mozilla/DOMParser.html` successfully again.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22409
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22411)
<!-- Reviewable:end -->
