### PR TITLE
Buildbot: disable jobs that have moved to Taskcluster

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -39,15 +39,6 @@ mac-rel-wpt4:
   - ./mach test-wpt --release --pref dom.servoparser.async_html_tokenizer.enabled --processes=8 --log-raw test-async-parsing.log --log-errorsummary async-parsing-errorsummary.log --always-succeed domparsing html/syntax html/dom/documents html/dom/dynamic-markup-insertion
   - ./mach filter-intermittents async-parsing-errorsummary.log --log-intermittents async-parsing-intermittents.log --log-filteredsummary filtered-async-parsing-errorsummary.log --tracker-api default --reporter-api default
 
-mac-dev-unit:
-  - ./mach clean-nightlies --keep 3 --force
-  - ./mach clean-cargo-cache --keep 3 --force
-  - env PKG_CONFIG_PATH=/usr/local/opt/zlib/lib/pkgconfig ./mach build --dev
-  - env PKG_CONFIG_PATH=/usr/local/opt/zlib/lib/pkgconfig ./mach test-unit
-  - python ./etc/memory_reports_over_time.py --test
-  - ./mach package --dev
-  - bash ./etc/ci/lockfile_changed.sh
-
 mac-rel-css1:
   - ./mach clean-nightlies --keep 3 --force
   - ./mach clean-cargo-cache --keep 3 --force
@@ -104,28 +95,6 @@ mac-rel-intermittent:
   - env PKG_CONFIG_PATH=/usr/local/opt/zlib/lib/pkgconfig ./mach build --release
   - ./etc/ci/check_intermittents.sh --log-raw intermittents.log
 
-linux-dev:
-  env:
-    CCACHE: sccache
-    RUSTC_WRAPPER: sccache
-    CC: gcc-5
-    CXX: g++-5
-  commands:
-    - ./mach clean-nightlies --keep 3 --force
-    - ./mach clean-cargo-cache --keep 3 --force
-    - ./etc/ci/clean_build_artifacts.sh
-    - ./mach test-tidy --no-progress --all
-    - ./mach test-tidy --no-progress --self-test
-    - ./mach build --dev -p servo
-    - ./mach test-unit
-    - python ./etc/memory_reports_over_time.py --test
-    - ./mach package --dev
-    - ./mach build --libsimpleservo
-    - ./mach build --dev --no-default-features --features default-except-unstable -p servo
-    - bash ./etc/ci/lockfile_changed.sh
-    - bash ./etc/ci/check_no_panic.sh
-    - ./etc/ci/clean_build_artifacts.sh
-
 linux-rel-wpt:
   env:
     CCACHE: sccache
@@ -176,21 +145,6 @@ linux-nightly:
   - rm -rf ./python/_virtualenv
   - ./etc/ci/clean_build_artifacts.sh
 
-android:
- env:
-   HOST_CC: gcc-5
-   HOST_CXX: g++-5
- commands:
-  - ./mach clean-nightlies --keep 3 --force
-  - ./mach clean-cargo-cache --keep 3 --force
-  - ./etc/ci/clean_build_artifacts.sh
-  - ./mach bootstrap-android --accept-all-licences --build
-  - env --unset ANDROID_NDK --unset ANDROID_SDK ./mach build --android --dev
-  - env --unset ANDROID_NDK --unset ANDROID_SDK ./mach package --android --dev
-  - bash ./etc/ci/lockfile_changed.sh
-  - python ./etc/ci/check_dynamic_symbols.py
-  - ./etc/ci/clean_build_artifacts.sh
-
 android-mac:
  commands:
   - ./mach clean-nightlies --keep 3 --force
@@ -198,19 +152,6 @@ android-mac:
   - ./mach bootstrap-android --accept-all-licences --build
   - ./mach build --android --dev
   - ./mach package --android --dev
-  - bash ./etc/ci/lockfile_changed.sh
-  - ./etc/ci/clean_build_artifacts.sh
-
-android-x86:
- env:
-   HOST_CC: gcc-5
-   HOST_CXX: g++-5
- commands:
-  - ./mach clean-nightlies --keep 3 --force
-  - ./mach clean-cargo-cache --keep 3 --force
-  - ./etc/ci/clean_build_artifacts.sh
-  - ./mach bootstrap-android --accept-all-licences --build --emulator-x86
-  - env --unset ANDROID_NDK --unset ANDROID_SDK ./mach build --target i686-linux-android --release
   - bash ./etc/ci/lockfile_changed.sh
   - ./etc/ci/clean_build_artifacts.sh
 
@@ -318,16 +259,6 @@ arm64:
   - bash ./etc/ci/lockfile_changed.sh
   - ./etc/ci/clean_build_artifacts.sh
 
-windows-msvc-dev:
-  env:
-    CARGO_HOME: C:\buildbot\.cargo
-  commands:
-  - mach.bat clean-cargo-cache --keep 3 --force
-  - mach.bat clean-nightlies --keep 3 --force
-  - mach.bat build --dev
-  - mach.bat test-unit
-  - mach.bat package --dev
-
 windows-msvc-nightly:
   env:
     CARGO_HOME: C:\buildbot\.cargo
@@ -337,3 +268,10 @@ windows-msvc-nightly:
   - mach.bat build --release
   - mach.bat package --release
   - mach.bat upload-nightly windows-msvc
+
+# Moved to Taskcluster
+linux-dev: []
+mac-dev-unit: []
+windows-msvc-dev: []
+android: []
+android-x86: []

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -30,7 +30,6 @@ def main(task_for, mock=False):
     elif task_for == "daily":
         daily_tasks_setup()
         with_rust_nightly()
-        android_arm32()
 
     else:  # pragma: no cover
         raise ValueError("Unrecognized $TASK_FOR value: %r", task_for)

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -77,6 +77,8 @@ def linux_tidy_unit():
             ./mach build --dev
             ./mach test-unit
             ./mach package --dev
+            ./mach build --dev --libsimpleservo
+            ./mach build --dev --no-default-features --features default-except-unstable
             ./mach test-tidy --no-progress --self-test
             ./etc/memory_reports_over_time.py --test
             ./etc/taskcluster/mock.py

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -16,6 +16,7 @@ def main(task_for, mock=False):
             linux_tidy_unit()
             android_arm32_dev()
             android_arm32_release()
+            android_x86_release()
             windows_unit()
             macos_unit()
 
@@ -25,7 +26,7 @@ def main(task_for, mock=False):
                 windows_release()
                 linux_wpt()
                 linux_build_task("Indexed by task definition").find_or_create()
-                android_x86()
+                android_x86_wpt()
 
     # https://tools.taskcluster.net/hooks/project-servo/daily
     elif task_for == "daily":
@@ -145,8 +146,8 @@ def android_arm32_release():
     )
 
 
-def android_x86():
-    build_task = (
+def android_x86_release():
+    return (
         android_build_task("Release build")
         .with_treeherder("Android x86")
         .with_script("./mach build --target i686-linux-android --release")
@@ -156,6 +157,10 @@ def android_x86():
         )
         .find_or_create("build.android_x86_release." + CONFIG.git_sha)
     )
+
+
+def android_x86_wpt():
+    build_task = android_x86_release()
     return (
         DockerWorkerTask("WPT")
         .with_treeherder("Android x86")

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -14,7 +14,8 @@ def main(task_for, mock=False):
             CONFIG.treeherder_repo_name = "servo-" + CONFIG.git_ref.split("/")[-1]
 
             linux_tidy_unit()
-            android_arm32()
+            android_arm32_dev()
+            android_arm32_release()
             windows_unit()
             macos_unit()
 
@@ -118,7 +119,20 @@ def with_rust_nightly():
     )
 
 
-def android_arm32():
+def android_arm32_dev():
+    return (
+        android_build_task("Dev build")
+        .with_treeherder("Android ARMv7")
+        .with_script("""
+            ./mach build --android --dev
+            ./etc/ci/lockfile_changed.sh
+            python ./etc/ci/check_dynamic_symbols.py
+        """)
+        .create()
+    )
+
+
+def android_arm32_release():
     return (
         android_build_task("Release build")
         .with_treeherder("Android ARMv7")

--- a/etc/taskcluster/packet.net/tc.py
+++ b/etc/taskcluster/packet.net/tc.py
@@ -26,9 +26,13 @@ def livelog():
     files = win2016["secrets"]["files"]
     assert all(f["encoding"] == "base64" for f in files)
     files = {f.get("description"): f["content"] for f in files}
+    cert = files["SSL certificate for livelog"]
+    key = files["SSL key for livelog"]
     return {
-        "livelog_cert": base64.b64decode(files["SSL certificate for livelog"]),
-        "livelog_key": base64.b64decode(files["SSL key for livelog"]),
+        "livelog_cert_base64": cert,
+        "livelog_key_base64": key,
+        "livelog_cert": base64.b64decode(cert),
+        "livelog_key": base64.b64decode(key),
         "livelog_secret": win2016["secrets"]["generic-worker"]["config"]["livelogSecret"],
     }
 

--- a/etc/taskcluster/packet.net/terraform_with_vars.py
+++ b/etc/taskcluster/packet.net/terraform_with_vars.py
@@ -29,7 +29,8 @@ def main(*args):
     env = dict(os.environ)
     env["PACKET_AUTH_TOKEN"] = terraform_vars["packet_api_key"]
     env.update({"TF_VAR_" + k: v for k, v in terraform_vars.items()})
-    sys.exit(subprocess.call(["terraform"] + list(args), env=env))
+    cwd = os.path.abspath(os.path.dirname(__file__))
+    sys.exit(subprocess.call(["terraform"] + list(args), env=env, cwd=cwd))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For now the Buildbot jobs are made no-ops. A separate PR to https://github.com/servo/saltfs will disable them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22419)
<!-- Reviewable:end -->
