### PR TITLE
Enable upstream bluetooth tests

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -39,6 +39,8 @@ mac-rel-wpt4:
   - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
   - ./mach test-wpt --release --pref dom.servoparser.async_html_tokenizer.enabled --processes=8 --log-raw test-async-parsing.log --log-errorsummary async-parsing-errorsummary.log --always-succeed domparsing html/syntax html/dom/documents html/dom/dynamic-markup-insertion
   - ./mach filter-intermittents async-parsing-errorsummary.log --log-intermittents async-parsing-intermittents.log --log-filteredsummary filtered-async-parsing-errorsummary.log --tracker-api default --reporter-api default
+  - ./mach test-wpt --release --processes=8 --log-raw test-bluetooth.log --log-errorsummary bluetooth-errorsummary.log --always-succeed bluetooth
+  - ./mach filter-intermittents bluetooth-errorsummary.log --log-intermittents bluetooth-intermittents.log --log-filteredsummary filtered-bluetooth-errorsummary.log --tracker-api default --reporter-api default
 
 mac-rel-css1:
   - ./mach clean-nightlies --keep 3 --force
@@ -54,14 +56,6 @@ mac-rel-css2:
   - env PKG_CONFIG_PATH=/usr/local/opt/zlib/lib/pkgconfig ./mach build --release
   - ./mach test-wpt --release --processes 4 --total-chunks 6 --this-chunk 6 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
   - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
-
-mac-rel-bluetooth:
-  - ./mach clean-nightlies --keep 3 --force
-  - ./mach clean-cargo-cache --keep 3 --force
-  - env PKG_CONFIG_PATH=/usr/local/opt/zlib/lib/pkgconfig ./mach build --release
-  - ./mach test-wpt --release --processes=8 --log-raw test-bluetooth.log --log-errorsummary bluetooth-errorsummary.log --always-succeed bluetooth
-  - ./mach filter-intermittents bluetooth-errorsummary.log --log-intermittents bluetooth-intermittents.log --log-filteredsummary filtered-bluetooth-errorsummary.log --tracker-api default --reporter-api default
-  - bash ./etc/ci/lockfile_changed.sh
 
 mac-nightly:
   - ./mach clean-nightlies --keep 3 --force

--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -55,6 +55,14 @@ mac-rel-css2:
   - ./mach test-wpt --release --processes 4 --total-chunks 6 --this-chunk 6 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
   - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
 
+mac-rel-bluetooth:
+  - ./mach clean-nightlies --keep 3 --force
+  - ./mach clean-cargo-cache --keep 3 --force
+  - env PKG_CONFIG_PATH=/usr/local/opt/zlib/lib/pkgconfig ./mach build --release
+  - ./mach test-wpt --release --processes=8 --log-raw test-bluetooth.log --log-errorsummary bluetooth-errorsummary.log --always-succeed bluetooth
+  - ./mach filter-intermittents bluetooth-errorsummary.log --log-intermittents bluetooth-intermittents.log --log-filteredsummary filtered-bluetooth-errorsummary.log --tracker-api default --reporter-api default
+  - bash ./etc/ci/lockfile_changed.sh
+
 mac-nightly:
   - ./mach clean-nightlies --keep 3 --force
   - ./mach clean-cargo-cache --keep 3 --force

--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -39,7 +39,7 @@ mac-rel-wpt4:
   - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
   - ./mach test-wpt --release --pref dom.servoparser.async_html_tokenizer.enabled --processes=8 --log-raw test-async-parsing.log --log-errorsummary async-parsing-errorsummary.log --always-succeed domparsing html/syntax html/dom/documents html/dom/dynamic-markup-insertion
   - ./mach filter-intermittents async-parsing-errorsummary.log --log-intermittents async-parsing-intermittents.log --log-filteredsummary filtered-async-parsing-errorsummary.log --tracker-api default --reporter-api default
-  - ./mach test-wpt --release --processes=8 --log-raw test-bluetooth.log --log-errorsummary bluetooth-errorsummary.log --always-succeed bluetooth
+  - ./mach test-wpt --release --product=servodriver --headless --log-raw test-bluetooth.log --log-errorsummary bluetooth-errorsummary.log --always-succeed bluetooth
   - ./mach filter-intermittents bluetooth-errorsummary.log --log-intermittents bluetooth-intermittents.log --log-filteredsummary filtered-bluetooth-errorsummary.log --tracker-api default --reporter-api default
 
 mac-rel-css1:

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -9,6 +9,8 @@ skip: true
   skip: false
 [2dcontext]
   skip: false
+[bluetooth]
+  skip: false
 [cors]
   skip: false
 [css]

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -9,8 +9,6 @@ skip: true
   skip: false
 [2dcontext]
   skip: false
-[bluetooth]
-  skip: false
 [cors]
   skip: false
 [css]

--- a/tests/wpt/metadata/bluetooth/__dir__.ini
+++ b/tests/wpt/metadata/bluetooth/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: ["dom.bluetooth.enabled:true"]

--- a/tests/wpt/metadata/bluetooth/characteristic/characteristicProperties.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/characteristicProperties.https.html.ini
@@ -1,0 +1,4 @@
+[characteristicProperties.https.html]
+  [characteristicProperties]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/getDescriptor/gen-characteristic-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/getDescriptor/gen-characteristic-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[gen-characteristic-is-removed.https.html]
+  [gen-characteristic-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/getDescriptor/gen-descriptor-get-same-object.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/getDescriptor/gen-descriptor-get-same-object.https.html.ini
@@ -1,0 +1,4 @@
+[gen-descriptor-get-same-object.https.html]
+  [gen-descriptor-get-same-object]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/getDescriptor/gen-service-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/getDescriptor/gen-service-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[gen-service-is-removed.https.html]
+  [gen-service-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/getDescriptors/gen-characteristic-is-removed-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/getDescriptors/gen-characteristic-is-removed-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-characteristic-is-removed-with-uuid.https.html]
+  [gen-characteristic-is-removed-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/getDescriptors/gen-characteristic-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/getDescriptors/gen-characteristic-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[gen-characteristic-is-removed.https.html]
+  [gen-characteristic-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/getDescriptors/gen-descriptor-get-same-object.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/getDescriptors/gen-descriptor-get-same-object.https.html.ini
@@ -1,0 +1,4 @@
+[gen-descriptor-get-same-object.https.html]
+  [gen-descriptor-get-same-object]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/getDescriptors/gen-service-is-removed-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/getDescriptors/gen-service-is-removed-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-service-is-removed-with-uuid.https.html]
+  [gen-service-is-removed-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/getDescriptors/gen-service-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/getDescriptors/gen-service-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[gen-service-is-removed.https.html]
+  [gen-service-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/notifications/characteristic-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/notifications/characteristic-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[characteristic-is-removed.https.html]
+  [characteristic-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/notifications/service-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/notifications/service-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[service-is-removed.https.html]
+  [service-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/readValue/add-multiple-event-listeners.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/readValue/add-multiple-event-listeners.https.html.ini
@@ -1,0 +1,4 @@
+[add-multiple-event-listeners.https.html]
+  [add-multiple-event-listeners]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/readValue/characteristic-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/readValue/characteristic-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[characteristic-is-removed.https.html]
+  [characteristic-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/readValue/event-is-fired.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/readValue/event-is-fired.https.html.ini
@@ -1,0 +1,4 @@
+[event-is-fired.https.html]
+  [event-is-fired]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/readValue/gen-characteristic-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/readValue/gen-characteristic-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[gen-characteristic-is-removed.https.html]
+  [gen-characteristic-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/readValue/read-succeeds.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/readValue/read-succeeds.https.html.ini
@@ -1,0 +1,4 @@
+[read-succeeds.https.html]
+  [read-succeeds]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/readValue/read-updates-value.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/readValue/read-updates-value.https.html.ini
@@ -1,0 +1,4 @@
+[read-updates-value.https.html]
+  [read-updates-value]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/readValue/service-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/readValue/service-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[service-is-removed.https.html]
+  [service-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/service-same-from-2-characteristics.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/service-same-from-2-characteristics.https.html.ini
@@ -1,0 +1,4 @@
+[service-same-from-2-characteristics.https.html]
+  [service-same-from-2-characteristics]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/service-same-object.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/service-same-object.https.html.ini
@@ -1,0 +1,4 @@
+[service-same-object.https.html]
+  [service-same-object]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/startNotifications/gen-characteristic-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/startNotifications/gen-characteristic-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[gen-characteristic-is-removed.https.html]
+  [gen-characteristic-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/writeValue/characteristic-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/writeValue/characteristic-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[characteristic-is-removed.https.html]
+  [characteristic-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/writeValue/gen-characteristic-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/writeValue/gen-characteristic-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[gen-characteristic-is-removed.https.html]
+  [gen-characteristic-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/writeValue/service-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/writeValue/service-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[service-is-removed.https.html]
+  [service-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/characteristic/writeValue/write-succeeds.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/characteristic/writeValue/write-succeeds.https.html.ini
@@ -1,0 +1,4 @@
+[write-succeeds.https.html]
+  [write-succeeds]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/descriptor/readValue/gen-service-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/descriptor/readValue/gen-service-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[gen-service-is-removed.https.html]
+  [gen-service-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/descriptor/readValue/read-succeeds.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/descriptor/readValue/read-succeeds.https.html.ini
@@ -1,0 +1,4 @@
+[read-succeeds.https.html]
+  [read-succeeds]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/descriptor/writeValue/gen-service-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/descriptor/writeValue/gen-service-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[gen-service-is-removed.https.html]
+  [gen-service-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/device/gattserverdisconnected-event/disconnected.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/device/gattserverdisconnected-event/disconnected.https.html.ini
@@ -1,0 +1,4 @@
+[disconnected.https.html]
+  [disconnected]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/device/gattserverdisconnected-event/disconnected_gc.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/device/gattserverdisconnected-event/disconnected_gc.https.html.ini
@@ -1,0 +1,4 @@
+[disconnected_gc.https.html]
+  [disconnected_gc]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/device/gattserverdisconnected-event/one-event-per-disconnection.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/device/gattserverdisconnected-event/one-event-per-disconnection.https.html.ini
@@ -1,0 +1,4 @@
+[one-event-per-disconnection.https.html]
+  [one-event-per-disconnection]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/device/gattserverdisconnected-event/reconnect-during-disconnected-event.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/device/gattserverdisconnected-event/reconnect-during-disconnected-event.https.html.ini
@@ -1,0 +1,4 @@
+[reconnect-during-disconnected-event.https.html]
+  [reconnect-during-disconnected-event]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/idl/idl-BluetoothDevice.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/idl/idl-BluetoothDevice.https.html.ini
@@ -1,0 +1,4 @@
+[idl-BluetoothDevice.https.html]
+  [idl-BluetoothDevice]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/idl/idl-NavigatorBluetooth.html.ini
+++ b/tests/wpt/metadata/bluetooth/idl/idl-NavigatorBluetooth.html.ini
@@ -1,0 +1,4 @@
+[idl-NavigatorBluetooth.html]
+  [navigator.bluetooth not available in insecure contexts]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/idl/idlharness.tentative.https.window.js.ini
+++ b/tests/wpt/metadata/bluetooth/idl/idlharness.tentative.https.window.js.ini
@@ -1,0 +1,223 @@
+[idlharness.tentative.https.window.html]
+  [BluetoothRemoteGATTService interface: attribute oncharacteristicvaluechanged]
+    expected: FAIL
+
+  [Bluetooth interface: attribute onserviceadded]
+    expected: FAIL
+
+  [BluetoothRemoteGATTService interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Bluetooth interface: navigator.bluetooth must inherit property "oncharacteristicvaluechanged" with the proper type]
+    expected: FAIL
+
+  [BluetoothServiceDataMap interface object length]
+    expected: FAIL
+
+  [BluetoothDevice interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [BluetoothManufacturerDataMap interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: attribute manufacturerData]
+    expected: FAIL
+
+  [BluetoothRemoteGATTDescriptor interface: operation readValue()]
+    expected: FAIL
+
+  [BluetoothRemoteGATTCharacteristic interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "uuids" with the proper type]
+    expected: FAIL
+
+  [BluetoothPermissionResult interface: attribute devices]
+    expected: FAIL
+
+  [BluetoothRemoteGATTServer interface: operation getPrimaryServices(BluetoothServiceUUID)]
+    expected: FAIL
+
+  [BluetoothRemoteGATTCharacteristic interface: operation readValue()]
+    expected: FAIL
+
+  [BluetoothRemoteGATTServer interface: operation connect()]
+    expected: FAIL
+
+  [Bluetooth interface: attribute referringDevice]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: attribute uuids]
+    expected: FAIL
+
+  [BluetoothRemoteGATTService interface: operation getCharacteristics(BluetoothCharacteristicUUID)]
+    expected: FAIL
+
+  [BluetoothRemoteGATTService interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [BluetoothRemoteGATTCharacteristic interface: operation stopNotifications()]
+    expected: FAIL
+
+  [BluetoothManufacturerDataMap interface: existence and properties of interface object]
+    expected: FAIL
+
+  [BluetoothRemoteGATTDescriptor interface: operation writeValue(BufferSource)]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent must be primary interface of event]
+    expected: FAIL
+
+  [BluetoothServiceDataMap interface: existence and properties of interface object]
+    expected: FAIL
+
+  [BluetoothRemoteGATTService interface: operation getIncludedServices(BluetoothServiceUUID)]
+    expected: FAIL
+
+  [Bluetooth interface: navigator.bluetooth must inherit property "onserviceremoved" with the proper type]
+    expected: FAIL
+
+  [BluetoothServiceDataMap interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "manufacturerData" with the proper type]
+    expected: FAIL
+
+  [BluetoothManufacturerDataMap interface object length]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: attribute serviceData]
+    expected: FAIL
+
+  [Bluetooth interface: attribute onserviceremoved]
+    expected: FAIL
+
+  [BluetoothManufacturerDataMap interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [Bluetooth interface: operation requestDevice(RequestDeviceOptions)]
+    expected: FAIL
+
+  [BluetoothRemoteGATTCharacteristic interface: operation getDescriptor(BluetoothDescriptorUUID)]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "txPower" with the proper type]
+    expected: FAIL
+
+  [ValueEvent interface: attribute value]
+    expected: FAIL
+
+  [BluetoothManufacturerDataMap interface object name]
+    expected: FAIL
+
+  [BluetoothRemoteGATTCharacteristic interface: operation startNotifications()]
+    expected: FAIL
+
+  [BluetoothServiceDataMap interface object name]
+    expected: FAIL
+
+  [BluetoothDevice interface: attribute onservicechanged]
+    expected: FAIL
+
+  [Bluetooth interface: attribute onservicechanged]
+    expected: FAIL
+
+  [Bluetooth interface: navigator.bluetooth must inherit property "ongattserverdisconnected" with the proper type]
+    expected: FAIL
+
+  [BluetoothRemoteGATTCharacteristic interface: operation writeValue(BufferSource)]
+    expected: FAIL
+
+  [BluetoothRemoteGATTCharacteristic interface: existence and properties of interface object]
+    expected: FAIL
+
+  [BluetoothRemoteGATTServer interface: operation getPrimaryService(BluetoothServiceUUID)]
+    expected: FAIL
+
+  [BluetoothDevice interface: attribute oncharacteristicvaluechanged]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "name" with the proper type]
+    expected: FAIL
+
+  [BluetoothManufacturerDataMap interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [ValueEvent interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [Stringification of event]
+    expected: FAIL
+
+  [Bluetooth interface: attribute ongattserverdisconnected]
+    expected: FAIL
+
+  [ValueEvent interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [ValueEvent interface object length]
+    expected: FAIL
+
+  [BluetoothDevice interface: existence and properties of interface object]
+    expected: FAIL
+
+  [ValueEvent interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [ValueEvent interface: existence and properties of interface object]
+    expected: FAIL
+
+  [BluetoothRemoteGATTCharacteristic interface: operation getDescriptors(BluetoothDescriptorUUID)]
+    expected: FAIL
+
+  [Bluetooth interface: operation getAvailability()]
+    expected: FAIL
+
+  [BluetoothRemoteGATTService interface: operation getIncludedService(BluetoothServiceUUID)]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "rssi" with the proper type]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "appearance" with the proper type]
+    expected: FAIL
+
+  [BluetoothServiceDataMap interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [Bluetooth interface: navigator.bluetooth must inherit property "onserviceadded" with the proper type]
+    expected: FAIL
+
+  [BluetoothDevice interface: attribute onserviceremoved]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "device" with the proper type]
+    expected: FAIL
+
+  [ValueEvent interface object name]
+    expected: FAIL
+
+  [BluetoothRemoteGATTService interface: operation getCharacteristic(BluetoothCharacteristicUUID)]
+    expected: FAIL
+
+  [BluetoothDevice interface: attribute onserviceadded]
+    expected: FAIL
+
+  [Bluetooth interface: navigator.bluetooth must inherit property "referringDevice" with the proper type]
+    expected: FAIL
+
+  [Bluetooth interface: navigator.bluetooth must inherit property "onservicechanged" with the proper type]
+    expected: FAIL
+
+  [BluetoothServiceDataMap interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "serviceData" with the proper type]
+    expected: FAIL
+
+  [BluetoothDevice interface: operation watchAdvertisements()]
+    expected: FAIL
+
+  [Bluetooth interface: attribute oncharacteristicvaluechanged]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/acceptAllDevices/device-with-empty-name.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/acceptAllDevices/device-with-empty-name.https.html.ini
@@ -1,0 +1,4 @@
+[device-with-empty-name.https.html]
+  [device-with-empty-name]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/acceptAllDevices/device-with-name.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/acceptAllDevices/device-with-name.https.html.ini
@@ -1,0 +1,4 @@
+[device-with-name.https.html]
+  [device-with-name]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/acceptAllDevices/optional-services-missing.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/acceptAllDevices/optional-services-missing.https.html.ini
@@ -1,0 +1,4 @@
+[optional-services-missing.https.html]
+  [optional-services-missing]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/acceptAllDevices/optional-services-present.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/acceptAllDevices/optional-services-present.https.html.ini
@@ -1,0 +1,4 @@
+[optional-services-present.https.html]
+  [optional-services-present]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/blocklisted-service-in-filter.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/blocklisted-service-in-filter.https.html.ini
@@ -1,0 +1,4 @@
+[blocklisted-service-in-filter.https.html]
+  [blocklisted-service-in-filter]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/blocklisted-service-in-optionalServices.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/blocklisted-service-in-optionalServices.https.html.ini
@@ -1,0 +1,4 @@
+[blocklisted-service-in-optionalServices.https.html]
+  [blocklisted-service-in-optionalServices]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/device-name-longer-than-29-bytes.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/device-name-longer-than-29-bytes.https.html.ini
@@ -1,0 +1,4 @@
+[device-name-longer-than-29-bytes.https.html]
+  [device-name-longer-than-29-bytes]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/empty-filter.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/empty-filter.https.html.ini
@@ -1,0 +1,4 @@
+[empty-filter.https.html]
+  [empty-filter]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/empty-filters-member.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/empty-filters-member.https.html.ini
@@ -1,0 +1,4 @@
+[empty-filters-member.https.html]
+  [empty-filters-member]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/empty-namePrefix.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/empty-namePrefix.https.html.ini
@@ -1,0 +1,4 @@
+[empty-namePrefix.https.html]
+  [empty-namePrefix]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/empty-services-member.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/empty-services-member.https.html.ini
@@ -1,0 +1,4 @@
+[empty-services-member.https.html]
+  [empty-services-member]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/filters-xor-acceptAllDevices.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/filters-xor-acceptAllDevices.https.html.ini
@@ -1,0 +1,4 @@
+[filters-xor-acceptAllDevices.https.html]
+  [filters-xor-acceptAllDevices]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-name-unicode.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-name-unicode.https.html.ini
@@ -1,0 +1,4 @@
+[max-length-exceeded-name-unicode.https.html]
+  [max-length-exceeded-name-unicode]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-name.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-name.https.html.ini
@@ -1,0 +1,4 @@
+[max-length-exceeded-name.https.html]
+  [max-length-exceeded-name]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-namePrefix-unicode.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-namePrefix-unicode.https.html.ini
@@ -1,0 +1,4 @@
+[max-length-exceeded-namePrefix-unicode.https.html]
+  [max-length-exceeded-namePrefix-unicode]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-namePrefix.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-exceeded-namePrefix.https.html.ini
@@ -1,0 +1,4 @@
+[max-length-exceeded-namePrefix.https.html]
+  [max-length-exceeded-namePrefix]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-name-unicode.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-name-unicode.https.html.ini
@@ -1,0 +1,4 @@
+[max-length-name-unicode.https.html]
+  [max-length-name-unicode]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-name.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-name.https.html.ini
@@ -1,0 +1,4 @@
+[max-length-name.https.html]
+  [max-length-name]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-namePrefix-unicode.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-namePrefix-unicode.https.html.ini
@@ -1,0 +1,4 @@
+[max-length-namePrefix-unicode.https.html]
+  [max-length-namePrefix-unicode]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-namePrefix.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/max-length-namePrefix.https.html.ini
@@ -1,0 +1,4 @@
+[max-length-namePrefix.https.html]
+  [max-length-namePrefix]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/no-arguments.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/no-arguments.https.html.ini
@@ -1,0 +1,4 @@
+[no-arguments.https.html]
+  [no-arguments]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/unicode-valid-length-name-name.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/unicode-valid-length-name-name.https.html.ini
@@ -1,0 +1,4 @@
+[unicode-valid-length-name-name.https.html]
+  [unicode-valid-length-name-name]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/unicode-valid-length-name-namePrefix.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/unicode-valid-length-name-namePrefix.https.html.ini
@@ -1,0 +1,4 @@
+[unicode-valid-length-name-namePrefix.https.html]
+  [unicode-valid-length-name-namePrefix]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-optionalServices-member.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-optionalServices-member.https.html.ini
@@ -1,0 +1,4 @@
+[wrong-service-in-optionalServices-member.https.html]
+  [wrong-service-in-optionalServices-member]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-services-member.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/canonicalizeFilter/wrong-service-in-services-member.https.html.ini
@@ -1,0 +1,4 @@
+[wrong-service-in-services-member.https.html]
+  [wrong-service-in-services-member]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/cross-origin-iframe.sub.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/cross-origin-iframe.sub.https.html.ini
@@ -1,0 +1,4 @@
+[cross-origin-iframe.sub.https.html]
+  [cross-origin-iframe]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/discovery-succeeds.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/discovery-succeeds.https.html.ini
@@ -1,0 +1,4 @@
+[discovery-succeeds.https.html]
+  [discovery-succeeds]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/doesnt-consume-user-gesture.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/doesnt-consume-user-gesture.https.html.ini
@@ -1,0 +1,4 @@
+[doesnt-consume-user-gesture.https.html]
+  [doesnt-consume-user-gesture]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/filter-matches.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/filter-matches.https.html.ini
@@ -1,0 +1,4 @@
+[filter-matches.https.html]
+  [filter-matches]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/le-not-supported.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/le-not-supported.https.html.ini
@@ -1,0 +1,4 @@
+[le-not-supported.https.html]
+  [le-not-supported]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/name-empty-device-from-name-empty-filter.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/name-empty-device-from-name-empty-filter.https.html.ini
@@ -1,0 +1,4 @@
+[name-empty-device-from-name-empty-filter.https.html]
+  [name-empty-device-from-name-empty-filter]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/not-processing-user-gesture.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/not-processing-user-gesture.https.html.ini
@@ -1,0 +1,4 @@
+[not-processing-user-gesture.https.html]
+  [not-processing-user-gesture]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/radio-not-present.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/radio-not-present.https.html.ini
@@ -1,0 +1,4 @@
+[radio-not-present.https.html]
+  [radio-not-present]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/request-from-iframe.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/request-from-iframe.https.html.ini
@@ -1,0 +1,4 @@
+[request-from-iframe.https.html]
+  [request-from-iframe]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/request-from-sandboxed-iframe.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/request-from-sandboxed-iframe.https.html.ini
@@ -1,0 +1,4 @@
+[request-from-sandboxed-iframe.https.html]
+  [request-from-sandboxed-iframe]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/same-device.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/same-device.https.html.ini
@@ -1,0 +1,4 @@
+[same-device.https.html]
+  [same-device]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/requestDevice/single-filter-single-service.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/requestDevice/single-filter-single-service.https.html.ini
@@ -1,0 +1,4 @@
+[single-filter-single-service.https.html]
+  [single-filter-single-service]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/connect/connection-succeeds.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/connect/connection-succeeds.https.html.ini
@@ -1,0 +1,4 @@
+[connection-succeeds.https.html]
+  [connection-succeeds]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/connect/garbage-collection-ran-during-success.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/connect/garbage-collection-ran-during-success.https.html.ini
@@ -1,0 +1,4 @@
+[garbage-collection-ran-during-success.https.html]
+  [garbage-collection-ran-during-success]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/connect/get-same-gatt-server.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/connect/get-same-gatt-server.https.html.ini
@@ -1,0 +1,4 @@
+[get-same-gatt-server.https.html]
+  [get-same-gatt-server]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/device-same-object.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/device-same-object.https.html.ini
@@ -1,0 +1,4 @@
+[device-same-object.https.html]
+  [device-same-object]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/disconnect/connect-disconnect-twice.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/disconnect/connect-disconnect-twice.https.html.ini
@@ -1,0 +1,4 @@
+[connect-disconnect-twice.https.html]
+  [connect-disconnect-twice]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/disconnect/detach-gc.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/disconnect/detach-gc.https.html.ini
@@ -1,0 +1,4 @@
+[detach-gc.https.html]
+  [detach-gc]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/disconnect/disconnect-twice-in-a-row.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/disconnect/disconnect-twice-in-a-row.https.html.ini
@@ -1,0 +1,4 @@
+[disconnect-twice-in-a-row.https.html]
+  [disconnect-twice-in-a-row]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/disconnect/gc-detach.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/disconnect/gc-detach.https.html.ini
@@ -1,0 +1,4 @@
+[gc-detach.https.html]
+  [gc-detach]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-disconnect-called-before.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-disconnect-called-before.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnect-called-before.https.html]
+  [gen-disconnect-called-before]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-disconnect-called-during-error.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-disconnect-called-during-error.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnect-called-during-error.https.html]
+  [gen-disconnect-called-during-error]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-disconnect-called-during-success.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-disconnect-called-during-success.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnect-called-during-success.https.html]
+  [gen-disconnect-called-during-success]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-disconnect-invalidates-objects.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-disconnect-invalidates-objects.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnect-invalidates-objects.https.html]
+  [gen-disconnect-invalidates-objects]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-disconnected-device.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-disconnected-device.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnected-device.https.html]
+  [gen-disconnected-device]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-discovery-complete-no-permission-absent-service.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-discovery-complete-no-permission-absent-service.https.html.ini
@@ -1,0 +1,4 @@
+[gen-discovery-complete-no-permission-absent-service.https.html]
+  [gen-discovery-complete-no-permission-absent-service]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-discovery-complete-service-not-found.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-discovery-complete-service-not-found.https.html.ini
@@ -1,0 +1,4 @@
+[gen-discovery-complete-service-not-found.https.html]
+  [gen-discovery-complete-service-not-found]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-garbage-collection-ran-during-error.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-garbage-collection-ran-during-error.https.html.ini
@@ -1,0 +1,4 @@
+[gen-garbage-collection-ran-during-error.https.html]
+  [gen-garbage-collection-ran-during-error]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-garbage-collection-ran-during-success.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-garbage-collection-ran-during-success.https.html.ini
@@ -1,0 +1,4 @@
+[gen-garbage-collection-ran-during-success.https.html]
+  [gen-garbage-collection-ran-during-success]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-get-different-service-after-reconnection.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-get-different-service-after-reconnection.https.html.ini
@@ -1,0 +1,4 @@
+[gen-get-different-service-after-reconnection.https.html]
+  [gen-get-different-service-after-reconnection]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-get-same-object.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-get-same-object.https.html.ini
@@ -1,0 +1,4 @@
+[gen-get-same-object.https.html]
+  [gen-get-same-object]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-invalid-service-name.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-invalid-service-name.https.html.ini
@@ -1,0 +1,4 @@
+[gen-invalid-service-name.https.html]
+  [gen-invalid-service-name]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-no-permission-absent-service.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-no-permission-absent-service.https.html.ini
@@ -1,0 +1,4 @@
+[gen-no-permission-absent-service.https.html]
+  [gen-no-permission-absent-service]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-no-permission-for-any-service.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-no-permission-for-any-service.https.html.ini
@@ -1,0 +1,4 @@
+[gen-no-permission-for-any-service.https.html]
+  [gen-no-permission-for-any-service]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-no-permission-present-service.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-no-permission-present-service.https.html.ini
@@ -1,0 +1,4 @@
+[gen-no-permission-present-service.https.html]
+  [gen-no-permission-present-service]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-service-not-found.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/gen-service-not-found.https.html.ini
@@ -1,0 +1,4 @@
+[gen-service-not-found.https.html]
+  [gen-service-not-found]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/service-found.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/service-found.https.html.ini
@@ -1,0 +1,4 @@
+[service-found.https.html]
+  [service-found]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryService/two-iframes-from-same-origin.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryService/two-iframes-from-same-origin.https.html.ini
@@ -1,0 +1,4 @@
+[two-iframes-from-same-origin.https.html]
+  [two-iframes-from-same-origin]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/blocklisted-services-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/blocklisted-services-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[blocklisted-services-with-uuid.https.html]
+  [blocklisted-services-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/blocklisted-services.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/blocklisted-services.https.html.ini
@@ -1,0 +1,4 @@
+[blocklisted-services.https.html]
+  [blocklisted-services]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/correct-services.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/correct-services.https.html.ini
@@ -1,0 +1,4 @@
+[correct-services.https.html]
+  [correct-services]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-called-before-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-called-before-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnect-called-before-with-uuid.https.html]
+  [gen-disconnect-called-before-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-called-before.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-called-before.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnect-called-before.https.html]
+  [gen-disconnect-called-before]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-error-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-error-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnect-called-during-error-with-uuid.https.html]
+  [gen-disconnect-called-during-error-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-error.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-error.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnect-called-during-error.https.html]
+  [gen-disconnect-called-during-error]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-success-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-success-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnect-called-during-success-with-uuid.https.html]
+  [gen-disconnect-called-during-success-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-success.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-called-during-success.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnect-called-during-success.https.html]
+  [gen-disconnect-called-during-success]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-invalidates-objects-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-invalidates-objects-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnect-invalidates-objects-with-uuid.https.html]
+  [gen-disconnect-invalidates-objects-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-invalidates-objects.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnect-invalidates-objects.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnect-invalidates-objects.https.html]
+  [gen-disconnect-invalidates-objects]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnected-device-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnected-device-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnected-device-with-uuid.https.html]
+  [gen-disconnected-device-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnected-device.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-disconnected-device.https.html.ini
@@ -1,0 +1,4 @@
+[gen-disconnected-device.https.html]
+  [gen-disconnected-device]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-discovery-complete-no-permission-absent-service-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-discovery-complete-no-permission-absent-service-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-discovery-complete-no-permission-absent-service-with-uuid.https.html]
+  [gen-discovery-complete-no-permission-absent-service-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-discovery-complete-service-not-found-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-discovery-complete-service-not-found-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-discovery-complete-service-not-found-with-uuid.https.html]
+  [gen-discovery-complete-service-not-found-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-error-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-error-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-garbage-collection-ran-during-error-with-uuid.https.html]
+  [gen-garbage-collection-ran-during-error-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-error.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-error.https.html.ini
@@ -1,0 +1,4 @@
+[gen-garbage-collection-ran-during-error.https.html]
+  [gen-garbage-collection-ran-during-error]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-success-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-success-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-garbage-collection-ran-during-success-with-uuid.https.html]
+  [gen-garbage-collection-ran-during-success-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-success.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-garbage-collection-ran-during-success.https.html.ini
@@ -1,0 +1,4 @@
+[gen-garbage-collection-ran-during-success.https.html]
+  [gen-garbage-collection-ran-during-success]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-get-different-service-after-reconnection-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-get-different-service-after-reconnection-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-get-different-service-after-reconnection-with-uuid.https.html]
+  [gen-get-different-service-after-reconnection-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-get-different-service-after-reconnection.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-get-different-service-after-reconnection.https.html.ini
@@ -1,0 +1,4 @@
+[gen-get-different-service-after-reconnection.https.html]
+  [gen-get-different-service-after-reconnection]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-get-same-object-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-get-same-object-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-get-same-object-with-uuid.https.html]
+  [gen-get-same-object-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-get-same-object.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-get-same-object.https.html.ini
@@ -1,0 +1,4 @@
+[gen-get-same-object.https.html]
+  [gen-get-same-object]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-invalid-service-name.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-invalid-service-name.https.html.ini
@@ -1,0 +1,4 @@
+[gen-invalid-service-name.https.html]
+  [gen-invalid-service-name]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-no-permission-absent-service-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-no-permission-absent-service-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-no-permission-absent-service-with-uuid.https.html]
+  [gen-no-permission-absent-service-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-no-permission-for-any-service-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-no-permission-for-any-service-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-no-permission-for-any-service-with-uuid.https.html]
+  [gen-no-permission-for-any-service-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-no-permission-for-any-service.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-no-permission-for-any-service.https.html.ini
@@ -1,0 +1,4 @@
+[gen-no-permission-for-any-service.https.html]
+  [gen-no-permission-for-any-service]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-no-permission-present-service-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-no-permission-present-service-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-no-permission-present-service-with-uuid.https.html]
+  [gen-no-permission-present-service-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-service-not-found-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/gen-service-not-found-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-service-not-found-with-uuid.https.html]
+  [gen-service-not-found-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/services-found-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/services-found-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[services-found-with-uuid.https.html]
+  [services-found-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/services-found.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/services-found.https.html.ini
@@ -1,0 +1,4 @@
+[services-found.https.html]
+  [services-found]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/server/getPrimaryServices/services-not-found.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/server/getPrimaryServices/services-not-found.https.html.ini
@@ -1,0 +1,4 @@
+[services-not-found.https.html]
+  [services-not-found]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/device-same-from-2-services.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/device-same-from-2-services.https.html.ini
@@ -1,0 +1,4 @@
+[device-same-from-2-services.https.html]
+  [device-same-from-2-services]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/device-same-object.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/device-same-object.https.html.ini
@@ -1,0 +1,4 @@
+[device-same-object.https.html]
+  [device-same-object]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristic/characteristic-found.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristic/characteristic-found.https.html.ini
@@ -1,0 +1,4 @@
+[characteristic-found.https.html]
+  [characteristic-found]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristic/gen-blocklisted-characteristic.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristic/gen-blocklisted-characteristic.https.html.ini
@@ -1,0 +1,4 @@
+[gen-blocklisted-characteristic.https.html]
+  [gen-blocklisted-characteristic]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristic/gen-characteristic-not-found.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristic/gen-characteristic-not-found.https.html.ini
@@ -1,0 +1,4 @@
+[gen-characteristic-not-found.https.html]
+  [gen-characteristic-not-found]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristic/gen-garbage-collection-ran-during-error.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristic/gen-garbage-collection-ran-during-error.https.html.ini
@@ -1,0 +1,4 @@
+[gen-garbage-collection-ran-during-error.https.html]
+  [gen-garbage-collection-ran-during-error]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristic/gen-get-same-object.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristic/gen-get-same-object.https.html.ini
@@ -1,0 +1,4 @@
+[gen-get-same-object.https.html]
+  [gen-get-same-object]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristic/gen-invalid-characteristic-name.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristic/gen-invalid-characteristic-name.https.html.ini
@@ -1,0 +1,4 @@
+[gen-invalid-characteristic-name.https.html]
+  [gen-invalid-characteristic-name]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristic/gen-reconnect-during.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristic/gen-reconnect-during.https.html.ini
@@ -1,0 +1,4 @@
+[gen-reconnect-during.https.html]
+  [gen-reconnect-during]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristic/gen-service-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristic/gen-service-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[gen-service-is-removed.https.html]
+  [gen-service-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/blocklisted-characteristics.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/blocklisted-characteristics.https.html.ini
@@ -1,0 +1,4 @@
+[blocklisted-characteristics.https.html]
+  [blocklisted-characteristics]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/characteristics-found-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/characteristics-found-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[characteristics-found-with-uuid.https.html]
+  [characteristics-found-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/characteristics-found.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/characteristics-found.https.html.ini
@@ -1,0 +1,4 @@
+[characteristics-found.https.html]
+  [characteristics-found]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/characteristics-not-found.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/characteristics-not-found.https.html.ini
@@ -1,0 +1,4 @@
+[characteristics-not-found.https.html]
+  [characteristics-not-found]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-blocklisted-characteristic-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-blocklisted-characteristic-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-blocklisted-characteristic-with-uuid.https.html]
+  [gen-blocklisted-characteristic-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-characteristic-not-found-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-characteristic-not-found-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-characteristic-not-found-with-uuid.https.html]
+  [gen-characteristic-not-found-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-garbage-collection-ran-during-error-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-garbage-collection-ran-during-error-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-garbage-collection-ran-during-error-with-uuid.https.html]
+  [gen-garbage-collection-ran-during-error-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-garbage-collection-ran-during-error.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-garbage-collection-ran-during-error.https.html.ini
@@ -1,0 +1,4 @@
+[gen-garbage-collection-ran-during-error.https.html]
+  [gen-garbage-collection-ran-during-error]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-get-same-object-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-get-same-object-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-get-same-object-with-uuid.https.html]
+  [gen-get-same-object-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-get-same-object.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-get-same-object.https.html.ini
@@ -1,0 +1,4 @@
+[gen-get-same-object.https.html]
+  [gen-get-same-object]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-invalid-characteristic-name.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-invalid-characteristic-name.https.html.ini
@@ -1,0 +1,4 @@
+[gen-invalid-characteristic-name.https.html]
+  [gen-invalid-characteristic-name]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-reconnect-during-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-reconnect-during-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-reconnect-during-with-uuid.https.html]
+  [gen-reconnect-during-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-reconnect-during.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-reconnect-during.https.html.ini
@@ -1,0 +1,4 @@
+[gen-reconnect-during.https.html]
+  [gen-reconnect-during]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-service-is-removed-with-uuid.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-service-is-removed-with-uuid.https.html.ini
@@ -1,0 +1,4 @@
+[gen-service-is-removed-with-uuid.https.html]
+  [gen-service-is-removed-with-uuid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-service-is-removed.https.html.ini
+++ b/tests/wpt/metadata/bluetooth/service/getCharacteristics/gen-service-is-removed.https.html.ini
@@ -1,0 +1,4 @@
+[gen-service-is-removed.https.html]
+  [gen-service-is-removed]
+    expected: FAIL
+

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -33,6 +33,7 @@ def write_hosts_file(config):
 
 
 class ServoTestharnessExecutor(ProcessTestExecutor):
+    supports_testdriver = True
     convert_result = testharness_result_converter
 
     def __init__(self, browser, server_config, timeout_multiplier=1, debug_info=None,

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -33,7 +33,6 @@ def write_hosts_file(config):
 
 
 class ServoTestharnessExecutor(ProcessTestExecutor):
-    supports_testdriver = True
     convert_result = testharness_result_converter
 
     def __init__(self, browser, server_config, timeout_multiplier=1, debug_info=None,

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -177,6 +177,7 @@ def timeout_func(timeout):
 
 
 class ServoWebDriverTestharnessExecutor(TestharnessExecutor):
+    supports_testdriver = True
     def __init__(self, browser, server_config, timeout_multiplier=1,
                  close_after_done=True, capabilities=None, debug_info=None,
                  **kwargs):


### PR DESCRIPTION
I enabled bluetooth WPT tests

But I'm still worry that a lot of tests failed (more than 150).  I decreased them by  
```
prefs: ["dom.bluetooth.enabled:true"]
```
But it's still a lot of failed tests

Checks
---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #20437 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because the changes are tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22420)
<!-- Reviewable:end -->
