### PR TITLE
Implement performance interface extension

### DIFF
--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -56,11 +56,12 @@ const INVALID_ENTRY_NAMES: &'static [&'static str] = &[
 #[derive(JSTraceable, MallocSizeOf)]
 pub struct PerformanceEntryList {
     entries: DOMPerformanceEntryList,
+    maxSize:i32,
 }
 
 impl PerformanceEntryList {
     pub fn new(entries: DOMPerformanceEntryList) -> Self {
-        PerformanceEntryList { entries }
+        PerformanceEntryList { entries,250 } // minimum default size mentioned in the specs was 250
     }
 
     pub fn get_entries_by_name_and_type(
@@ -405,4 +406,24 @@ impl PerformanceMethods for Performance {
             .borrow_mut()
             .clear_entries_by_name_and_type(measure_name, Some(DOMString::from("measure")));
     }
+    //https://w3c.github.io/resource-timing/#sec-extensions-performance-interface
+    //clears the PerformanceEntryList 
+     fn clearResourceTimings(&mut self){
+         self.entries.entries =  Vec<DomRoot<PerformanceEntry>>;
+         
+}
+    //sets the maximum size of the buffer
+    fn setResourceTimingBufferSize(&mut self,maxSize:i32)-> bool{
+        self.entries.maxSize = maxSize;
+}
+    //event for buffer overflow
+    fn onresourcetimingbufferfull(&self){
+        if self.entries.entries.len()>self.entries.maxSize{
+            return True;
+        }
+        else{
+            return False;
+        }
+            
+} 
 }


### PR DESCRIPTION
Implemented the following : 
 a) Added the maxSize Field to the PerformanceEntryList structure.
 b) Implemented the clearResourceTimings, setResourceTimingBufferSize, onresourcetimingbufferfull fuctions for the Performance Structure according to the Interface Specification given at : https://w3c.github.io/resource-timing/#sec-extensions-performance-interface

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] These changes fix #22307 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22421)
<!-- Reviewable:end -->
