### PR TITLE
Taskcluster: start a decision task for all try-* branches

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -5,7 +5,9 @@ policy:
 tasks:
   - $if: 'tasks_for == "github-push"'
     then:
-      $if: 'event.ref in ["refs/heads/auto", "refs/heads/try", "refs/heads/try-taskcluster"]'
+      $if: >-
+        event.ref in ["refs/heads/auto", "refs/heads/try"] ||
+        event.ref[:15] == "refs/heads/try-"
       then:
 
         # NOTE: when updating this consider whether the daily hook needs similar changes:


### PR DESCRIPTION
This is an alternative fix for https://github.com/servo/saltfs/issues/903, and anticipates adding trychooser support to Taskcluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22426)
<!-- Reviewable:end -->
