### PR TITLE
Improve implementation of media resource fetch algorithm

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1614,12 +1614,16 @@ impl FetchResponseListener for HTMLMediaElementContext {
 
     // https://html.spec.whatwg.org/multipage/#media-data-processing-steps-list
     fn process_response_eof(&mut self, status: Result<ResourceFetchTiming, NetworkError>) {
+        let elem = self.elem.root();
         if self.ignore_response {
-            // An error was received previously, skip processing the payload.
+            // An error was received previously, skip processing the payload
+            // and notify the media backend that we are done pushing data. 
+            if let Err(e) = elem.player.end_of_stream() {
+                warn!("Could not signal EOS to player {:?}", e);
+            }
             return;
         }
 
-        let elem = self.elem.root();
         if status.is_ok() {
             if elem.ready_state.get() == ReadyState::HaveNothing {
                 // Make sure that we don't skip the HaveMetadata and HaveCurrentData

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/load-events-networkState.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/load-events-networkState.html.ini
@@ -1,4 +1,0 @@
-[load-events-networkState.html]
-  [NETWORK_NO_SOURCE]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-insert-into-iframe.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-insert-into-iframe.html.ini
@@ -1,4 +1,0 @@
-[resource-selection-invoke-insert-into-iframe.html]
-  [NOT invoking resource selection by inserting into other document with src set]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-pause-networkState.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-pause-networkState.html.ini
@@ -1,4 +1,0 @@
-[resource-selection-invoke-pause-networkState.html]
-  [NOT invoking resource selection with pause() when networkState is not NETWORK_EMPTY]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-remove-from-document-networkState.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-remove-from-document-networkState.html.ini
@@ -1,4 +1,0 @@
-[resource-selection-invoke-remove-from-document-networkState.html]
-  [NOT invoking resource selection with implicit pause() when networkState is not NETWORK_EMPTY]
-    expected: FAIL
-


### PR DESCRIPTION
I have been observing inconsistent behaviors with my local tests depending of the media asset being played. I figured that we had these issues:

- We were setting the player EOS as soon as we got the first [process_response_eof](https://github.com/servo/servo/blob/1046ae58a155d3f1ab4d011242a03a81a712f3c4/components/script/dom/htmlmediaelement.rs#L1596). This is fine only if there is a single request. But that's not the case for multiple range requests or for seeks. Setting the player EOS makes the player appsrc reject any new buffers, and that breaks playback. Figuring out when is the right time to set the player EOS won't be a straight forward task, so my suggested fix for now is to simply not set it for now. It is a cleanup step that it would be nice to have but it is not mandatory.

- We were setting the input size more than once for multiple range requests and with the incorrect value. The fix uses the `content-length` or the `content-range` headers for single and range requests respectively.

- We were moving to the HaveEnoughData state if a fetch request succeded but no data was fetched from the network.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22433)
<!-- Reviewable:end -->
