### PR TITLE
Rust's code of conduct link was changed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ For specific git instructions, see [GitHub workflow 101](https://github.com/serv
 
 ## Conduct
 
-In all Servo-related forums, we follow the [Rust Code of Conduct](https://www.rust-lang.org/conduct.html). For escalation or moderation issues, please contact Jack (jmoffitt@mozilla.com) and Lars (larsberg@mozilla.com) instead of the Rust moderation team.
+In all Servo-related forums, we follow the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct). For escalation or moderation issues, please contact Jack (jmoffitt@mozilla.com) and Lars (larsberg@mozilla.com) instead of the Rust moderation team.
 
 
 ## Communication


### PR DESCRIPTION
The older code of conduct link from Rust now is a 404 page.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22437)
<!-- Reviewable:end -->
