### PR TITLE
One Treeherder page for all try-related branches

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -12,7 +12,9 @@ from decisionlib import CONFIG, SHARED
 def main(task_for):
     assert CONFIG.git_ref.startswith("refs/heads/")
     branch = CONFIG.git_ref[len("refs/heads/"):]
-    CONFIG.treeherder_repository_name = "servo-" + branch
+    CONFIG.treeherder_repository_name = "servo-" + (
+        branch if not branch.startswith("try-") else "try"
+    )
 
     if task_for == "github-push":
         # FIXME https://github.com/servo/servo/issues/22325 implement these:


### PR DESCRIPTION
This will be effective at https://treeherder.allizom.org/#/jobs?repo=servo-try once https://github.com/mozilla/treeherder/pull/4371 lands, and at https://treeherder.mozilla.org/#/jobs?repo=servo-try after it is deployed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22450)
<!-- Reviewable:end -->
