### PR TITLE
Avoid sending idle message more than once after a reflow is complete

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1556,7 +1556,8 @@ impl Window {
             let is_ready_state_complete = document.ReadyState() == DocumentReadyState::Complete;
             let pending_images = self.pending_layout_images.borrow().is_empty();
 
-            if !has_sent_idle_message && is_ready_state_complete && !reftest_wait && pending_images {
+            if !has_sent_idle_message && is_ready_state_complete && !reftest_wait && pending_images
+            {
                 let event = ScriptMsg::SetDocumentState(DocumentState::Idle);
                 self.send_to_constellation(event);
                 self.has_sent_idle_message.set(true);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
A boolean variable is introduced to prevent sending SetDocumentState idle message multiple times after a reflow is complete.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22410 (GitHub issue number if applicable)

<!-- Either: -->
- [x] These changes do not require tests because automated test is not possible.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22451)
<!-- Reviewable:end -->
