### PR TITLE
Disable referrer-policy tests for frequent intermittent failures.

### DIFF
--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -489,7 +489,7 @@ def check_manifest_dirs(config_file, print_text=True):
     p = parser.parse(lines)
     paths = rec_parse(wpt_path("web-platform-tests"), p)
     for idx, path in enumerate(paths):
-        if path.endswith("_mozilla") or path.endswith("_webgl"):
+        if '_mozilla' in path or '_webgl' in path:
             continue
         if not os.path.isdir(path):
             yield(config_file, idx + 1, "Path in manifest was not found: {}".format(path))

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -1,6 +1,10 @@
 skip: true
 [_mozilla]
   skip: false
+  [mozilla]
+    skip: false
+    [referrer-policy]
+      skip: true
 [_webgl]
   skip: false
 [2dcontext]
@@ -102,7 +106,7 @@ skip: true
 [quirks]
   skip: false
 [referrer-policy]
-  skip: false
+  skip: true
 [resource-timing]
   skip: false
 [subresource-integrity]


### PR DESCRIPTION
This is hitting us really hard on the taskcluster WPT runs, so I'm going to disable them until we can investigate it properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22453)
<!-- Reviewable:end -->
