### PR TITLE
Fixed bug in textinput::adjust_vertical concerning selection_origin

### DIFF
--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -318,6 +318,10 @@ fn test_textinput_adjust_vertical() {
     textinput.adjust_vertical(2, Selection::NotSelected);
     assert_eq!(textinput.edit_point().line, 2);
     assert_eq!(textinput.edit_point().index, 1);
+
+    textinput.adjust_vertical(-1, Selection::Selected);
+    assert_eq!(textinput.edit_point().line, 1);
+    assert_eq!(textinput.edit_point().index, 1);
 }
 
 #[test]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The `adjust_vertical` function of the `TextInput` module was forgetting to update the `selection_origin`.

I discovered the bug and figured out how it fix it using formal verification. More precisely, I manually translated the Rust code in a [F*](https://www.fstar-lang.org/) program that was functionally equivalent. Then I used the `assert_ok_selection` as a post-condition on the following functions :

* `select_all`
* `clear_selection`
* `adjust_selection_for_horizontal_change`
* `clear_selection_to_limit`
* `adjust_vertical`
* `perform_horizontal_adjustment`
* `adjust_horizontal`
* `adjust_horizontal_to_line_end`

I managed to prove automatically (using the Z3 backend of F*) that the post-condition held for all the functions except for `adjust_vertical`. I used the error messages from F* to infer the missing code so that the postcondition could hold and manually translated it to this PR diff.

I also added a simple unit test that would fail without this patch, and observed that the assertion failures noted in https://github.com/servo/servo/issues/22457 disappeared with this patch.

This verification work also allows me to say that the code of all the functions is now functionally correct in the sense that they all yield a valid selection in the sense of `asssert_ok_selection`, in all cases.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22457 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22458)
<!-- Reviewable:end -->
