### PR TITLE
Move macOS WPT chunk 1 (only) from Buildbot to Taskcluster 

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -5,18 +5,6 @@ env:
   SCCACHE_IDLE_TIMEOUT: "1200"
   GST_DEBUG: '3'
 
-mac-rel-wpt1:
-  - ./mach clean-nightlies --keep 3 --force
-  - ./mach clean-cargo-cache --keep 3 --force
-  - env PKG_CONFIG_PATH=/usr/local/opt/zlib/lib/pkgconfig ./mach build --release
-  - ./mach run -r -o output.png
-  - ./mach test-wpt-failure
-  - ./mach test-wpt --release --processes 4 --total-chunks 6 --this-chunk 1 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
-  - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
-  - ./mach test-wpt --release --binary-arg=--multiprocess --processes 8 --log-raw test-wpt-mp.log --log-errorsummary wpt-mp-errorsummary.log eventsource
-  - ./mach test-wpt --release --product=servodriver --headless tests/wpt/mozilla/tests/mozilla/DOMParser.html tests/wpt/mozilla/tests/css/per_glyph_font_fallback_a.html tests/wpt/mozilla/tests/css/img_simple.html tests/wpt/mozilla/tests/mozilla/secure.https.html
-  - bash ./etc/ci/lockfile_changed.sh
-
 mac-rel-wpt2:
   - ./mach clean-nightlies --keep 3 --force
   - ./mach clean-cargo-cache --keep 3 --force
@@ -245,3 +233,4 @@ android: []
 android-x86: []
 linux-rel-wpt: []
 linux-rel-css: []
+mac-rel-wpt1: []

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -365,7 +365,7 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
                 PROCESSES=str(processes),
             )
         )
-        if this_chunk == 1:
+        if this_chunk == chunks[-1]:
             task.name += " + extra"
             task.extra["treeherder"]["symbol"] += "+"
             task.with_script("""

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -21,9 +21,6 @@ def main(task_for):
         magicleap_dev = linux_arm32_dev = linux_arm64_dev = \
             android_arm32_dev_from_macos = lambda: None
 
-        # FIXME: not enabled yet
-        macos_wpt = lambda: None
-
         # FIXME https://github.com/servo/servo/issues/22187
         # In-emulator testing is disabled for now. (Instead we only compile.)
         # This local variable shadows the module-level function of the same name.
@@ -82,8 +79,6 @@ def main(task_for):
 # but should still run when testing this Python code. (See `mock.py`.)
 def mocked_only():
     windows_release()
-    linux_wpt()
-    macos_wpt()
     android_x86_wpt()
     decisionlib.DockerWorkerTask("Indexed by task definition").find_or_create()
 
@@ -343,7 +338,7 @@ def macos_wpt():
     def macos_run_task(name):
         return macos_task(name).with_python2()
     wpt_chunks("macOS x64", macos_run_task, build_task, repo_dir="repo",
-               total_chunks=6, processes=4)
+               total_chunks=6, processes=4, chunks=[1])
 
 
 def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,

--- a/etc/taskcluster/macos/Brewfile
+++ b/etc/taskcluster/macos/Brewfile
@@ -9,7 +9,8 @@ brew "gst-libav"
 brew "gst-plugins-bad"
 brew "gst-plugins-good"
 brew "gst-rtsp-server"
-brew "htop"
 brew "llvm"
-brew "openssl@1.1"
 brew "yasm"
+
+# For sccache
+brew "openssl@1.1"

--- a/etc/taskcluster/macos/config/roster
+++ b/etc/taskcluster/macos/config/roster
@@ -1,2 +1,4 @@
 mac1:
     host: servo-tc-mac1.servo.org
+mac2:
+    host: servo-tc-mac2.servo.org

--- a/etc/taskcluster/macos/states/generic-worker.plist.jinja
+++ b/etc/taskcluster/macos/states/generic-worker.plist.jinja
@@ -7,7 +7,7 @@
     <key>StandardOutPath</key>   <string>stdout.log</string>
     <key>StandardErrorPath</key> <string>stderr.log</string>
     <key>WorkingDirectory</key>  <string>{{ home }}</string>
-    <key>UserName</key>          <string>{{ user }}</string>
+    <key>UserName</key>          <string>{{ username }}</string>
     <key>ProgramArguments</key>  <array>
         <string>{{ bin }}/generic-worker</string>
         <string>run</string>

--- a/etc/taskcluster/macos/states/generic-worker.sls
+++ b/etc/taskcluster/macos/states/generic-worker.sls
@@ -46,7 +46,7 @@ GMT:
         provisionerId: proj-servo
         workerType: macos
         workerGroup: servo-macos
-        workerId: mac1
+        workerId: {{ grains["id"] }}
         tasksDir: {{ home }}/tasks
         publicIP: {{ salt.network.ip_addrs()[0] }}
         signingKeyLocation: {{ home }}/key
@@ -85,7 +85,7 @@ GMT:
       bin: {{ bin }}
       etc: {{ etc }}
       home: {{ home }}
-      user: {{ user }}
+      username: {{ user }}
 
 net.generic.worker:
   service.running:

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -574,9 +574,6 @@ class MachCommands(CommandBase):
                     json.dump(intermittent, intermittents_file, indent=4)
                     print("\n", end='', file=intermittents_file)
 
-        if len(actual_failures) == 0:
-            return 0
-
         output = open(log_filteredsummary, "w") if log_filteredsummary else sys.stdout
         for failure in actual_failures:
             json.dump(failure, output, indent=4)
@@ -584,6 +581,9 @@ class MachCommands(CommandBase):
 
         if output is not sys.stdout:
             output.close()
+
+        if len(actual_failures) == 0:
+            return 0
         return 1
 
     @Command('test-android-startup',


### PR DESCRIPTION
This is only one chunk at a time so that we don’t need to double the number of worker nor the cycle time during the migration.

A release build takes ~40 minutes which seems worrying, but this also happens (sometimes) on Buildbot. For example: https://build.servo.org/builders/mac-rel-wpt1/builds/10401

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22459)
<!-- Reviewable:end -->
