### PR TITLE
Refactoring RequestInit to use a Builder Pattern

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -130,7 +130,7 @@ use msg::constellation_msg::{
 };
 use msg::constellation_msg::{PipelineNamespace, PipelineNamespaceId, TraversalDirection};
 use net_traits::pub_domains::reg_host;
-use net_traits::request::RequestInit;
+use net_traits::request::RequestBuilder;
 use net_traits::storage_thread::{StorageThreadMsg, StorageType};
 use net_traits::{self, FetchResponseMsg, IpcSend, ResourceThreads};
 use profile_traits::mem;
@@ -1934,11 +1934,11 @@ where
     fn handle_navigate_request(
         &self,
         id: PipelineId,
-        req_init: RequestInit,
+        request_builder: RequestBuilder,
         cancel_chan: IpcReceiver<()>,
     ) {
         let listener = NetworkListener::new(
-            req_init,
+            request_builder,
             id,
             self.public_resource_threads.clone(),
             self.network_listener_sender.clone(),

--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -13,7 +13,7 @@ use crate::platform::font_list::SANS_SERIF_FONT_FAMILY;
 use crate::platform::font_template::FontTemplateData;
 use app_units::Au;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
-use net_traits::request::{Destination, RequestInit};
+use net_traits::request::{Destination, RequestBuilder};
 use net_traits::{fetch_async, CoreResourceThread, FetchResponseMsg};
 use servo_atoms::Atom;
 use servo_url::ServoUrl;
@@ -238,13 +238,7 @@ impl FontCache {
                     None => return,
                 };
 
-                let request = RequestInit {
-                    url: url.clone(),
-                    destination: Destination::Font,
-                    // TODO: Add a proper origin - Can't import GlobalScope from gfx
-                    // We can leave origin to be set by default
-                    ..RequestInit::default()
-                };
+                let request = RequestBuilder::new(url.clone()).destination(Destination::Font);
 
                 let channel_to_self = self.channel_to_self.clone();
                 let bytes = Mutex::new(Vec::new());

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -18,7 +18,7 @@ extern crate serde;
 extern crate url;
 
 use crate::filemanager_thread::FileManagerThreadMsg;
-use crate::request::{Request, RequestInit};
+use crate::request::{Request, RequestBuilder};
 use crate::response::{HttpsState, Response, ResponseInit};
 use crate::storage_thread::StorageThreadMsg;
 use cookie::Cookie;
@@ -377,10 +377,10 @@ pub enum FetchChannels {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum CoreResourceMsg {
-    Fetch(RequestInit, FetchChannels),
+    Fetch(RequestBuilder, FetchChannels),
     /// Initiate a fetch in response to processing a redirection
     FetchRedirect(
-        RequestInit,
+        RequestBuilder,
         ResponseInit,
         IpcSender<FetchResponseMsg>,
         /* cancel_chan */ Option<IpcReceiver<()>>,
@@ -415,7 +415,7 @@ pub enum CoreResourceMsg {
 }
 
 /// Instruct the resource thread to make a new request.
-pub fn fetch_async<F>(request: RequestInit, core_resource_thread: &CoreResourceThread, f: F)
+pub fn fetch_async<F>(request: RequestBuilder, core_resource_thread: &CoreResourceThread, f: F)
 where
     F: Fn(FetchResponseMsg) + Send + 'static,
 {
@@ -595,7 +595,7 @@ pub enum CookieSource {
 
 /// Convenience function for synchronously loading a whole resource.
 pub fn load_whole_resource(
-    request: RequestInit,
+    request: RequestBuilder,
     core_resource_thread: &CoreResourceThread,
 ) -> Result<(Metadata, Vec<u8>), NetworkError> {
     let (action_sender, action_receiver) = ipc::channel().unwrap();

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -10,7 +10,7 @@ use crate::dom::bindings::root::Dom;
 use crate::dom::document::Document;
 use crate::fetch::FetchCanceller;
 use ipc_channel::ipc::IpcSender;
-use net_traits::request::RequestInit;
+use net_traits::request::RequestBuilder;
 use net_traits::{CoreResourceMsg, FetchChannels, FetchResponseMsg};
 use net_traits::{IpcSend, ResourceThreads};
 use servo_url::ServoUrl;
@@ -131,7 +131,7 @@ impl DocumentLoader {
     pub fn fetch_async(
         &mut self,
         load: LoadType,
-        request: RequestInit,
+        request: RequestBuilder,
         fetch_target: IpcSender<FetchResponseMsg>,
     ) {
         self.add_blocking_load(load);
@@ -141,7 +141,7 @@ impl DocumentLoader {
     /// Initiate a new fetch that does not block the document load event.
     pub fn fetch_async_background(
         &mut self,
-        request: RequestInit,
+        request: RequestBuilder,
         fetch_target: IpcSender<FetchResponseMsg>,
     ) {
         let mut canceller = FetchCanceller::new();

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -81,7 +81,7 @@ use msg::constellation_msg::{
 use net_traits::filemanager_thread::RelativePos;
 use net_traits::image::base::{Image, ImageMetadata};
 use net_traits::image_cache::{ImageCache, PendingImageId};
-use net_traits::request::{Request, RequestInit};
+use net_traits::request::{Request, RequestBuilder};
 use net_traits::response::HttpsState;
 use net_traits::response::{Response, ResponseBody};
 use net_traits::storage_thread::StorageType;
@@ -446,7 +446,7 @@ unsafe_no_jsmanaged_fields!(PendingRestyle);
 unsafe_no_jsmanaged_fields!(Stylesheet);
 unsafe_no_jsmanaged_fields!(HttpsState);
 unsafe_no_jsmanaged_fields!(Request);
-unsafe_no_jsmanaged_fields!(RequestInit);
+unsafe_no_jsmanaged_fields!(RequestBuilder);
 unsafe_no_jsmanaged_fields!(StyleSharedRwLock);
 unsafe_no_jsmanaged_fields!(USVString);
 unsafe_no_jsmanaged_fields!(ReferrerPolicy);

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -36,7 +36,7 @@ use js::jsapi::{JSAutoCompartment, JSContext};
 use js::jsval::UndefinedValue;
 use js::rust::HandleValue;
 use msg::constellation_msg::{PipelineId, TopLevelBrowsingContextId};
-use net_traits::request::{CredentialsMode, Destination, RequestInit};
+use net_traits::request::{CredentialsMode, Destination, RequestBuilder};
 use net_traits::{load_whole_resource, IpcSend};
 use script_traits::{TimerEvent, TimerSource, WorkerGlobalScopeInit, WorkerScriptLoadOrigin};
 use servo_rand::random;
@@ -305,17 +305,14 @@ impl DedicatedWorkerGlobalScope {
                     pipeline_id,
                 } = worker_load_origin;
 
-                let request = RequestInit {
-                    url: worker_url.clone(),
-                    destination: Destination::Worker,
-                    credentials_mode: CredentialsMode::Include,
-                    use_url_credentials: true,
-                    pipeline_id: pipeline_id,
-                    referrer_url: referrer_url,
-                    referrer_policy: referrer_policy,
-                    origin,
-                    ..RequestInit::default()
-                };
+                let request = RequestBuilder::new(worker_url.clone())
+                    .destination(Destination::Worker)
+                    .credentials_mode(CredentialsMode::Include)
+                    .use_url_credentials(true)
+                    .pipeline_id(pipeline_id)
+                    .referrer_url(referrer_url)
+                    .referrer_policy(referrer_policy)
+                    .origin(origin);
 
                 let (metadata, bytes) =
                     match load_whole_resource(request, &init.resource_threads.sender()) {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -123,7 +123,7 @@ use metrics::{
 use mime::{self, Mime};
 use msg::constellation_msg::BrowsingContextId;
 use net_traits::pub_domains::is_pub_domain;
-use net_traits::request::RequestInit;
+use net_traits::request::RequestBuilder;
 use net_traits::response::HttpsState;
 use net_traits::CookieSource::NonHTTP;
 use net_traits::CoreResourceMsg::{GetCookiesForUrl, SetCookiesForUrl};
@@ -1712,7 +1712,7 @@ impl Document {
     pub fn fetch_async(
         &self,
         load: LoadType,
-        request: RequestInit,
+        request: RequestBuilder,
         fetch_target: IpcSender<FetchResponseMsg>,
     ) {
         let mut loader = self.loader.borrow_mut();

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -55,7 +55,7 @@ use net_traits::image::base::{Image, ImageMetadata};
 use net_traits::image_cache::UsePlaceholder;
 use net_traits::image_cache::{CanRequestImages, ImageCache, ImageOrMetadataAvailable};
 use net_traits::image_cache::{ImageResponder, ImageResponse, ImageState, PendingImageId};
-use net_traits::request::RequestInit;
+use net_traits::request::RequestBuilder;
 use net_traits::{FetchMetadata, FetchResponseListener, FetchResponseMsg, NetworkError};
 use net_traits::{ResourceFetchTiming, ResourceTimingType};
 use num_traits::ToPrimitive;
@@ -324,12 +324,9 @@ impl HTMLImageElement {
             }),
         );
 
-        let request = RequestInit {
-            url: img_url.clone(),
-            origin: document.origin().immutable().clone(),
-            pipeline_id: Some(document.global().pipeline_id()),
-            ..RequestInit::default()
-        };
+        let request = RequestBuilder::new(img_url.clone())
+            .origin(document.origin().immutable().clone())
+            .pipeline_id(Some(document.global().pipeline_id()));
 
         // This is a background load because the load blocker already fulfills the
         // purpose of delaying the document's load event.

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -64,7 +64,7 @@ use ipc_channel::router::ROUTER;
 use mime::{self, Mime};
 use net_traits::image::base::Image;
 use net_traits::image_cache::ImageResponse;
-use net_traits::request::{CredentialsMode, Destination, RequestInit};
+use net_traits::request::{CredentialsMode, Destination, RequestBuilder};
 use net_traits::{CoreResourceMsg, FetchChannels, FetchMetadata, FetchResponseListener, Metadata};
 use net_traits::{NetworkError, ResourceFetchTiming, ResourceTimingType};
 use script_layout_interface::HTMLMediaData;
@@ -710,18 +710,16 @@ impl HTMLMediaElement {
             Some(url) => url.clone(),
             None => self.blob_url.borrow().as_ref().unwrap().clone(),
         };
-        let request = RequestInit {
-            url: url.clone(),
-            headers,
-            destination,
-            credentials_mode: CredentialsMode::Include,
-            use_url_credentials: true,
-            origin: document.origin().immutable().clone(),
-            pipeline_id: Some(self.global().pipeline_id()),
-            referrer_url: Some(document.url()),
-            referrer_policy: document.get_referrer_policy(),
-            ..RequestInit::default()
-        };
+
+        let request = RequestBuilder::new(url.clone())
+            .headers(headers)
+            .destination(destination)
+            .credentials_mode(CredentialsMode::Include)
+            .use_url_credentials(true)
+            .origin(document.origin().immutable().clone())
+            .pipeline_id(Some(self.global().pipeline_id()))
+            .referrer_url(Some(document.url()))
+            .referrer_policy(document.get_referrer_policy());
 
         let mut current_fetch_context = self.current_fetch_context.borrow_mut();
         if let Some(ref mut current_fetch_context) = *current_fetch_context {

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -32,7 +32,9 @@ use html5ever::{LocalName, Prefix};
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use js::jsval::UndefinedValue;
-use net_traits::request::{CorsSettings, CredentialsMode, Destination, RequestInit, RequestMode};
+use net_traits::request::{
+    CorsSettings, CredentialsMode, Destination, RequestBuilder, RequestMode,
+};
 use net_traits::{FetchMetadata, FetchResponseListener, Metadata, NetworkError};
 use net_traits::{ResourceFetchTiming, ResourceTimingType};
 use servo_atoms::Atom;
@@ -290,28 +292,25 @@ fn fetch_a_classic_script(
     let doc = document_from_node(script);
 
     // Step 1, 2.
-    let request = RequestInit {
-        url: url.clone(),
-        destination: Destination::Script,
+    let request = RequestBuilder::new(url.clone())
+        .destination(Destination::Script)
         // https://html.spec.whatwg.org/multipage/#create-a-potential-cors-request
         // Step 1
-        mode: match cors_setting {
+        .mode(match cors_setting {
             Some(_) => RequestMode::CorsMode,
             None => RequestMode::NoCors,
-        },
+        })
         // https://html.spec.whatwg.org/multipage/#create-a-potential-cors-request
         // Step 3-4
-        credentials_mode: match cors_setting {
+        .credentials_mode(match cors_setting {
             Some(CorsSettings::Anonymous) => CredentialsMode::CredentialsSameOrigin,
             _ => CredentialsMode::Include,
-        },
-        origin: doc.origin().immutable().clone(),
-        pipeline_id: Some(script.global().pipeline_id()),
-        referrer_url: Some(doc.url()),
-        referrer_policy: doc.get_referrer_policy(),
-        integrity_metadata: integrity_metadata,
-        ..RequestInit::default()
-    };
+        })
+        .origin(doc.origin().immutable().clone())
+        .pipeline_id(Some(script.global().pipeline_id()))
+        .referrer_url(Some(doc.url()))
+        .referrer_policy(doc.get_referrer_policy())
+        .integrity_metadata(integrity_metadata);
 
     // TODO: Step 3, Add custom steps to perform fetch
 

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -29,7 +29,7 @@ use ipc_channel::router::ROUTER;
 use net_traits::image_cache::UsePlaceholder;
 use net_traits::image_cache::{CanRequestImages, ImageCache, ImageOrMetadataAvailable};
 use net_traits::image_cache::{ImageResponse, ImageState, PendingImageId};
-use net_traits::request::{CredentialsMode, Destination, RequestInit};
+use net_traits::request::{CredentialsMode, Destination, RequestBuilder};
 use net_traits::{
     CoreResourceMsg, FetchChannels, FetchMetadata, FetchResponseListener, FetchResponseMsg,
 };
@@ -162,15 +162,12 @@ impl HTMLVideoElement {
     ) {
         // Continuation of step 4.
         let document = document_from_node(self);
-        let request = RequestInit {
-            url: poster_url.clone(),
-            destination: Destination::Image,
-            credentials_mode: CredentialsMode::Include,
-            use_url_credentials: true,
-            origin: document.origin().immutable().clone(),
-            pipeline_id: Some(document.global().pipeline_id()),
-            ..RequestInit::default()
-        };
+        let request = RequestBuilder::new(poster_url.clone())
+            .destination(Destination::Image)
+            .credentials_mode(CredentialsMode::Include)
+            .use_url_credentials(true)
+            .origin(document.origin().immutable().clone())
+            .pipeline_id(Some(document.global().pipeline_id()));
 
         // Step 5.
         // This delay must be independent from the ones created by HTMLMediaElement during

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -30,7 +30,7 @@ use ipc_channel::router::ROUTER;
 use js::jsapi::{JSAutoCompartment, JSContext, JS_AddInterruptCallback};
 use js::jsval::UndefinedValue;
 use msg::constellation_msg::PipelineId;
-use net_traits::request::{CredentialsMode, Destination, RequestInit};
+use net_traits::request::{CredentialsMode, Destination, RequestBuilder};
 use net_traits::{load_whole_resource, CustomResponseMediator, IpcSend};
 use script_traits::{
     ScopeThings, ServiceWorkerMsg, TimerEvent, WorkerGlobalScopeInit, WorkerScriptLoadOrigin,
@@ -281,17 +281,14 @@ impl ServiceWorkerGlobalScope {
                     pipeline_id,
                 } = worker_load_origin;
 
-                let request = RequestInit {
-                    url: script_url.clone(),
-                    destination: Destination::ServiceWorker,
-                    credentials_mode: CredentialsMode::Include,
-                    use_url_credentials: true,
-                    pipeline_id: pipeline_id,
-                    referrer_url: referrer_url,
-                    referrer_policy: referrer_policy,
-                    origin,
-                    ..RequestInit::default()
-                };
+                let request = RequestBuilder::new(script_url.clone())
+                    .destination(Destination::ServiceWorker)
+                    .credentials_mode(CredentialsMode::Include)
+                    .use_url_credentials(true)
+                    .pipeline_id(pipeline_id)
+                    .referrer_url(referrer_url)
+                    .referrer_policy(referrer_policy)
+                    .origin(origin);
 
                 let (url, source) =
                     match load_whole_resource(request, &init.resource_threads.sender()) {

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -31,7 +31,7 @@ use js::jsapi::{JSAutoCompartment, JSObject};
 use js::jsval::UndefinedValue;
 use js::rust::CustomAutoRooterGuard;
 use js::typedarray::{ArrayBuffer, ArrayBufferView, CreateWith};
-use net_traits::request::{RequestInit, RequestMode};
+use net_traits::request::{RequestBuilder, RequestMode};
 use net_traits::MessageData;
 use net_traits::{CoreResourceMsg, FetchChannels};
 use net_traits::{WebSocketDomAction, WebSocketNetworkEvent};
@@ -201,12 +201,10 @@ impl WebSocket {
         let address = Trusted::new(&*ws);
 
         // Step 8.
-        let request = RequestInit {
-            url: url_record,
-            origin: global.origin().immutable().clone(),
-            mode: RequestMode::WebSocket { protocols },
-            ..RequestInit::default()
-        };
+        let request = RequestBuilder::new(url_record)
+            .origin(global.origin().immutable().clone())
+            .mode(RequestMode::WebSocket { protocols });
+
         let channels = FetchChannels::WebSocket {
             event_sender: resource_event_sender,
             action_receiver: resource_action_receiver,

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -48,7 +48,7 @@ use js::jsapi::JS_GC;
 use msg::constellation_msg::PipelineId;
 use net_traits::load_whole_resource;
 use net_traits::request::Destination;
-use net_traits::request::RequestInit;
+use net_traits::request::RequestBuilder;
 use net_traits::request::RequestMode;
 use net_traits::IpcSend;
 use servo_url::ImmutableOrigin;
@@ -620,14 +620,12 @@ impl WorkletThread {
         // TODO: Fetch the script asynchronously?
         // TODO: Caching.
         let resource_fetcher = self.global_init.resource_threads.sender();
-        let request = RequestInit {
-            url: script_url,
-            destination: Destination::Script,
-            mode: RequestMode::CorsMode,
-            credentials_mode: credentials.into(),
-            origin,
-            ..RequestInit::default()
-        };
+        let request = RequestBuilder::new(script_url)
+            .destination(Destination::Script)
+            .mode(RequestMode::CorsMode)
+            .credentials_mode(credentials.into())
+            .origin(origin);
+
         let script = load_whole_resource(request, &resource_fetcher)
             .ok()
             .and_then(|(_, bytes)| String::from_utf8(bytes).ok());

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -24,7 +24,7 @@ use crate::task_source::TaskSourceName;
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use js::jsapi::JSAutoCompartment;
-use net_traits::request::RequestInit as NetTraitsRequestInit;
+use net_traits::request::RequestBuilder;
 use net_traits::request::{Request as NetTraitsRequest, ServiceWorkersMode};
 use net_traits::CoreResourceMsg::Fetch as NetTraitsFetch;
 use net_traits::{FetchChannels, FetchResponseListener, NetworkError};
@@ -98,16 +98,18 @@ fn from_referrer_to_referrer_url(request: &NetTraitsRequest) -> Option<ServoUrl>
     request.referrer.to_url().map(|url| url.clone())
 }
 
-fn request_init_from_request(request: NetTraitsRequest) -> NetTraitsRequestInit {
-    NetTraitsRequestInit {
+fn request_init_from_request(request: NetTraitsRequest) -> RequestBuilder {
+    RequestBuilder {
         method: request.method.clone(),
         url: request.url(),
         headers: request.headers.clone(),
         unsafe_request: request.unsafe_request,
         body: request.body.clone(),
+        service_workers_mode: ServiceWorkersMode::All,
         destination: request.destination,
         synchronous: request.synchronous,
         mode: request.mode.clone(),
+        cache_mode: request.cache_mode,
         use_cors_preflight: request.use_cors_preflight,
         credentials_mode: request.credentials_mode,
         use_url_credentials: request.use_url_credentials,
@@ -120,8 +122,8 @@ fn request_init_from_request(request: NetTraitsRequest) -> NetTraitsRequestInit 
         referrer_policy: request.referrer_policy,
         pipeline_id: request.pipeline_id,
         redirect_mode: request.redirect_mode,
-        cache_mode: request.cache_mode,
-        ..NetTraitsRequestInit::default()
+        integrity_metadata: "".to_owned(),
+        url_list: vec![],
     }
 }
 

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -18,7 +18,7 @@ use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingLi
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use net_traits::image_cache::{ImageCache, PendingImageId};
-use net_traits::request::{Destination, RequestInit as FetchRequestInit};
+use net_traits::request::{Destination, RequestBuilder as FetchRequestInit};
 use net_traits::{FetchMetadata, FetchResponseListener, FetchResponseMsg, NetworkError};
 use net_traits::{ResourceFetchTiming, ResourceTimingType};
 use servo_url::ServoUrl;
@@ -110,13 +110,10 @@ pub fn fetch_image_for_layout(
         }),
     );
 
-    let request = FetchRequestInit {
-        url: url,
-        origin: document.origin().immutable().clone(),
-        destination: Destination::Image,
-        pipeline_id: Some(document.global().pipeline_id()),
-        ..FetchRequestInit::default()
-    };
+    let request = FetchRequestInit::new(url)
+        .origin(document.origin().immutable().clone())
+        .destination(Destination::Image)
+        .pipeline_id(Some(document.global().pipeline_id()));
 
     // Layout image loads do not delay the document load event.
     document

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -110,7 +110,7 @@ use msg::constellation_msg::{BrowsingContextId, HistoryStateId, PipelineId};
 use msg::constellation_msg::{HangAnnotation, MonitoredComponentId, MonitoredComponentType};
 use msg::constellation_msg::{PipelineNamespace, TopLevelBrowsingContextId};
 use net_traits::image_cache::{ImageCache, PendingImageResponse};
-use net_traits::request::{CredentialsMode, Destination, RedirectMode, RequestInit};
+use net_traits::request::{CredentialsMode, Destination, RedirectMode, RequestBuilder};
 use net_traits::storage_thread::StorageType;
 use net_traits::{FetchMetadata, FetchResponseListener, FetchResponseMsg};
 use net_traits::{
@@ -3327,21 +3327,18 @@ impl ScriptThread {
     /// argument until a notification is received that the fetch is complete.
     fn pre_page_load(&self, mut incomplete: InProgressLoad, load_data: LoadData) {
         let id = incomplete.pipeline_id.clone();
-        let req_init = RequestInit {
-            url: load_data.url.clone(),
-            method: load_data.method,
-            destination: Destination::Document,
-            credentials_mode: CredentialsMode::Include,
-            use_url_credentials: true,
-            pipeline_id: Some(id),
-            referrer_url: load_data.referrer_url,
-            referrer_policy: load_data.referrer_policy,
-            headers: load_data.headers,
-            body: load_data.data,
-            redirect_mode: RedirectMode::Manual,
-            origin: incomplete.origin.immutable().clone(),
-            ..RequestInit::default()
-        };
+        let req_init = RequestBuilder::new(load_data.url.clone())
+            .method(load_data.method)
+            .destination(Destination::Document)
+            .credentials_mode(CredentialsMode::Include)
+            .use_url_credentials(true)
+            .pipeline_id(Some(id))
+            .referrer_url(load_data.referrer_url)
+            .referrer_policy(load_data.referrer_policy)
+            .headers(load_data.headers)
+            .body(load_data.data)
+            .redirect_mode(RedirectMode::Manual)
+            .origin(incomplete.origin.immutable().clone());
 
         let context = ParserContext::new(id, load_data.url);
         self.incomplete_parser_contexts

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -20,7 +20,7 @@ use gfx_traits::Epoch;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use msg::constellation_msg::{BrowsingContextId, PipelineId, TopLevelBrowsingContextId};
 use msg::constellation_msg::{HistoryStateId, TraversalDirection};
-use net_traits::request::RequestInit;
+use net_traits::request::RequestBuilder;
 use net_traits::storage_thread::StorageType;
 use net_traits::CoreResourceMsg;
 use servo_url::ImmutableOrigin;
@@ -107,7 +107,7 @@ pub enum ScriptMsg {
     ForwardToEmbedder(EmbedderMsg),
     /// Requests are sent to constellation and fetches are checked manually
     /// for cross-origin loads
-    InitiateNavigateRequest(RequestInit, /* cancellation_chan */ IpcReceiver<()>),
+    InitiateNavigateRequest(RequestBuilder, /* cancellation_chan */ IpcReceiver<()>),
     /// Broadcast a storage event to every same-origin pipeline.
     /// The strings are key, old value and new value.
     BroadcastStorageEvent(


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

If RequestInit::new accepts all of the mandatory arguments and then the builder pattern is used for customizable options, the resulting code might be easier to match against specification text like 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22427
- [x] These changes do not require tests because it is a code refactoring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22521)
<!-- Reviewable:end -->
