### PR TITLE
HTMLMediaElement backoff protocol and other improvements to a/v playback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3507,7 +3507,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#35014baeb603b56b1b8b4de75919c58f7390cc30"
+source = "git+https://github.com/servo/media#c8cc491c850b18393586500233cc55e29800146c"
 dependencies = [
  "servo-media-audio 0.1.0 (git+https://github.com/servo/media)",
  "servo-media-gstreamer 0.1.0 (git+https://github.com/servo/media)",
@@ -3517,7 +3517,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#35014baeb603b56b1b8b4de75919c58f7390cc30"
+source = "git+https://github.com/servo/media#c8cc491c850b18393586500233cc55e29800146c"
 dependencies = [
  "boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-slice-cast 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3534,7 +3534,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#35014baeb603b56b1b8b4de75919c58f7390cc30"
+source = "git+https://github.com/servo/media#c8cc491c850b18393586500233cc55e29800146c"
 dependencies = [
  "byte-slice-cast 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glib 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#35014baeb603b56b1b8b4de75919c58f7390cc30"
+source = "git+https://github.com/servo/media#c8cc491c850b18393586500233cc55e29800146c"
 dependencies = [
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3640,7 +3640,7 @@ dependencies = [
 [[package]]
 name = "servo_media_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#35014baeb603b56b1b8b4de75919c58f7390cc30"
+source = "git+https://github.com/servo/media#c8cc491c850b18393586500233cc55e29800146c"
 dependencies = [
  "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -488,7 +488,7 @@ unsafe_no_jsmanaged_fields!(Mutex<MediaFrameRenderer>);
 unsafe_no_jsmanaged_fields!(RenderApiSender);
 unsafe_no_jsmanaged_fields!(ResourceFetchTiming);
 unsafe_no_jsmanaged_fields!(Timespec);
-unsafe_no_jsmanaged_fields!(Mutex<HTMLMediaElementFetchContext>);
+unsafe_no_jsmanaged_fields!(HTMLMediaElementFetchContext);
 
 unsafe impl<'a> JSTraceable for &'a str {
     #[inline]

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -38,7 +38,7 @@ use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::utils::WindowProxyHandler;
 use crate::dom::document::PendingRestyle;
 use crate::dom::htmlimageelement::SourceSet;
-use crate::dom::htmlmediaelement::MediaFrameRenderer;
+use crate::dom::htmlmediaelement::{HTMLMediaElementContext, MediaFrameRenderer};
 use crate::task::TaskBox;
 use app_units::Au;
 use canvas_traits::canvas::{
@@ -103,7 +103,6 @@ use servo_media::audio::panner_node::{DistanceModel, PanningModel};
 use servo_media::audio::param::ParamType;
 use servo_media::player::Player;
 use servo_media::Backend;
-use servo_media::Error as ServoMediaError;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use smallvec::SmallVec;
 use std::cell::{Cell, RefCell, UnsafeCell};
@@ -484,11 +483,12 @@ unsafe_no_jsmanaged_fields!(AudioBuffer);
 unsafe_no_jsmanaged_fields!(AudioContext<Backend>);
 unsafe_no_jsmanaged_fields!(NodeId);
 unsafe_no_jsmanaged_fields!(AnalysisEngine, DistanceModel, PanningModel, ParamType);
-unsafe_no_jsmanaged_fields!(dyn Player<Error = ServoMediaError>);
+unsafe_no_jsmanaged_fields!(dyn Player);
 unsafe_no_jsmanaged_fields!(Mutex<MediaFrameRenderer>);
 unsafe_no_jsmanaged_fields!(RenderApiSender);
 unsafe_no_jsmanaged_fields!(ResourceFetchTiming);
 unsafe_no_jsmanaged_fields!(Timespec);
+unsafe_no_jsmanaged_fields!(Mutex<HTMLMediaElementContext>);
 
 unsafe impl<'a> JSTraceable for &'a str {
     #[inline]

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -38,7 +38,7 @@ use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::utils::WindowProxyHandler;
 use crate::dom::document::PendingRestyle;
 use crate::dom::htmlimageelement::SourceSet;
-use crate::dom::htmlmediaelement::{HTMLMediaElementContext, MediaFrameRenderer};
+use crate::dom::htmlmediaelement::{HTMLMediaElementFetchContext, MediaFrameRenderer};
 use crate::task::TaskBox;
 use app_units::Au;
 use canvas_traits::canvas::{
@@ -488,7 +488,7 @@ unsafe_no_jsmanaged_fields!(Mutex<MediaFrameRenderer>);
 unsafe_no_jsmanaged_fields!(RenderApiSender);
 unsafe_no_jsmanaged_fields!(ResourceFetchTiming);
 unsafe_no_jsmanaged_fields!(Timespec);
-unsafe_no_jsmanaged_fields!(Mutex<HTMLMediaElementContext>);
+unsafe_no_jsmanaged_fields!(Mutex<HTMLMediaElementFetchContext>);
 
 unsafe impl<'a> JSTraceable for &'a str {
     #[inline]

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1938,7 +1938,6 @@ impl HTMLMediaElementFetchContext {
         url: ServoUrl,
         offset: u64,
     ) -> (HTMLMediaElementFetchContext, ipc::IpcReceiver<()>) {
-        elem.generation_id.set(elem.generation_id.get() + 1);
         let mut fetch_canceller = FetchCanceller::new();
         let cancel_receiver = fetch_canceller.initialize();
         (


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

This PR implements a backoff protocol to keep us from dropping frames whenever it's possible. It also add some other improvements like:
- Clean up the implementation a little bit by adding all fetch request related state to `HTMLMediaElementFetchContext`.
- Make sure that we ignore responses from old requests.
- Set the stream to seekable iff there's support for range requests. This will likely change when we add the media cache.
- Implements part of [step 8 of the seek spec](https://html.spec.whatwg.org/multipage/media.html#dom-media-seek) where we bail out if the stream is not seekable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22522)
<!-- Reviewable:end -->
