### PR TITLE
Revert "Move linux WPT from Buildbot to Taskcluster"

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -84,6 +84,40 @@ mac-rel-intermittent:
   - env PKG_CONFIG_PATH=/usr/local/opt/zlib/lib/pkgconfig ./mach build --release
   - ./etc/ci/check_intermittents.sh --log-raw intermittents.log
 
+linux-rel-wpt:
+  env:
+    CCACHE: sccache
+    RUSTC_WRAPPER: sccache
+    CC: gcc-5
+    CXX: g++-5
+  commands:
+    - ./mach clean-nightlies --keep 3 --force
+    - ./mach clean-cargo-cache --keep 3 --force
+    - ./etc/ci/clean_build_artifacts.sh
+    - ./mach build --release --with-debug-assertions -p servo
+    - ./mach test-wpt-failure
+    - ./mach test-wpt --release --processes 24 --total-chunks 2 --this-chunk 1 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
+    - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
+    - ./mach test-wpt --release --binary-arg=--multiprocess --processes 24 --log-raw test-wpt-mp.log --log-errorsummary wpt-mp-errorsummary.log eventsource
+    - ./mach test-wpt --release --product=servodriver --headless tests/wpt/mozilla/tests/mozilla/DOMParser.html tests/wpt/mozilla/tests/css/per_glyph_font_fallback_a.html tests/wpt/mozilla/tests/css/img_simple.html tests/wpt/mozilla/tests/mozilla/secure.https.html
+    - ./etc/ci/clean_build_artifacts.sh
+
+linux-rel-css:
+  env:
+    CCACHE: sccache
+    RUSTC_WRAPPER: sccache
+    CC: gcc-5
+    CXX: g++-5
+  commands:
+    - ./mach clean-nightlies --keep 3 --force
+    - ./mach clean-cargo-cache --keep 3 --force
+    - ./etc/ci/clean_build_artifacts.sh
+    - ./mach build --release --with-debug-assertions -p servo
+    - ./mach test-wpt --release --processes 24 --total-chunks 2 --this-chunk 2 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
+    - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
+    - bash ./etc/ci/lockfile_changed.sh
+    - ./etc/ci/clean_build_artifacts.sh
+
 linux-nightly:
  env:
   CC: gcc-5
@@ -229,6 +263,4 @@ mac-dev-unit: []
 windows-msvc-dev: []
 android: []
 android-x86: []
-linux-rel-wpt: []
-linux-rel-css: []
 mac-rel-wpt1: []

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -84,6 +84,7 @@ def main(task_for):
 def mocked_only():
     windows_release()
     android_x86_wpt()
+    linux_wpt()
     decisionlib.DockerWorkerTask("Indexed by task definition").find_or_create()
 
 

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -26,6 +26,9 @@ def main(task_for):
         # This local variable shadows the module-level function of the same name.
         android_x86_wpt = android_x86_release
 
+        # Implemented but disabled for now:
+        linux_wpt = lambda: None  # Shadows the existing top-level function
+
         all_tests = [
             linux_tidy_unit_docs,
             windows_unit,


### PR DESCRIPTION
This reverts commit e60e534d23209c944b48596d437a9a9c09f20542.

We haven't been able to merge anything for several days, and my investigations have not shown me a solution yet. Let's revert this change; I can continue experimenting in try builds without holding up the rest of our CI queue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22527)
<!-- Reviewable:end -->
