### PR TITLE
Remove `foreign` service-workers mode

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -505,21 +505,11 @@ pub fn http_fetch(
     // nothing to do, since actual_response is a function on response
 
     // Step 3
-    if request.service_workers_mode != ServiceWorkersMode::None {
-        // Substep 1
-        if request.service_workers_mode == ServiceWorkersMode::All {
-            // TODO (handle fetch unimplemented)
-        }
+    if request.service_workers_mode == ServiceWorkersMode::All {
+        // TODO: Substep 1
+        // Set response to the result of invoking handle fetch for request.
 
         // Substep 2
-        if response.is_none() && request.is_subresource_request() && match request.origin {
-            Origin::Origin(ref origin) => *origin == request.url().origin(),
-            _ => false,
-        } {
-            // TODO (handle foreign fetch unimplemented)
-        }
-
-        // Substep 3
         if let Some(ref res) = response {
             // Subsubstep 1
             // TODO: transmit body for request
@@ -567,7 +557,7 @@ pub fn http_fetch(
 
         // Substep 2
         if request.redirect_mode == RedirectMode::Follow {
-            request.service_workers_mode = ServiceWorkersMode::Foreign;
+            request.service_workers_mode = ServiceWorkersMode::None;
         }
 
         // Substep 3

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -102,7 +102,6 @@ pub enum CacheMode {
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub enum ServiceWorkersMode {
     All,
-    Foreign,
     None,
 }
 

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -152,7 +152,7 @@ pub fn Fetch(
 
     // Step 3
     if global.downcast::<ServiceWorkerGlobalScope>().is_some() {
-        request_init.service_workers_mode = ServiceWorkersMode::Foreign;
+        request_init.service_workers_mode = ServiceWorkersMode::None;
     }
 
     // Step 4


### PR DESCRIPTION
Bringing in the spec changes from whatwg/fetch#596

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because the corresponding tests should already be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22533)
<!-- Reviewable:end -->
