### PR TITLE
Update ServiceWorkerContainer Webidl

### DIFF
--- a/components/script/dom/webidls/ServiceWorkerContainer.webidl
+++ b/components/script/dom/webidls/ServiceWorkerContainer.webidl
@@ -2,25 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-// https://w3c.github.io/ServiceWorker/#service-worker-container
+// https://w3c.github.io/ServiceWorker/#serviceworkercontainer-interface
 [Pref="dom.serviceworker.enabled", Exposed=(Window,Worker)]
 interface ServiceWorkerContainer : EventTarget {
-  [Unforgeable] readonly attribute ServiceWorker? controller;
-  //[SameObject] readonly attribute Promise<ServiceWorkerRegistration> ready;
+  readonly attribute ServiceWorker? controller;
+  //readonly attribute Promise<ServiceWorkerRegistration> ready;
 
   [NewObject] Promise<ServiceWorkerRegistration> register(USVString scriptURL, optional RegistrationOptions options);
 
-  //[NewObject] /*Promise<any>*/ any getRegistration(optional USVString clientURL = "");
-  //[NewObject] /* Promise */<sequence<ServiceWorkerRegistration>> getRegistrations();
+  //[NewObject] Promise<any> getRegistration(optional USVString clientURL = "");
+  //[NewObject] Promise<FrozenArray<ServiceWorkerRegistration>> getRegistrations();
 
+  //void startMessages();
 
   // events
   //attribute EventHandler oncontrollerchange;
   //attribute EventHandler onerror;
   //attribute EventHandler onmessage; // event.source of message events is ServiceWorker object
+  //attribute EventHandler onmessageerror;
 };
 
 dictionary RegistrationOptions {
   USVString scope;
   //WorkerType type = "classic";
+  ServiceWorkerUpdateViaCache updateViaCache = "imports";
 };


### PR DESCRIPTION
Looks like the spec has changed a lot. Maybe it's better to update the implementation for these methods in a separate PR.

Let's just update webidl in this PR?

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix part of  #19302 
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22538)
<!-- Reviewable:end -->
