### PR TITLE
Update ServiceWorker webidl

### DIFF
--- a/components/script/dom/webidls/ServiceWorker.webidl
+++ b/components/script/dom/webidls/ServiceWorker.webidl
@@ -2,17 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-// http://w3c.github.io/ServiceWorker/#service-worker-obj
-[Pref="dom.serviceworker.enabled", Exposed=(Window,Worker)]
+// https://w3c.github.io/ServiceWorker/#serviceworker-interface
+[Pref="dom.serviceworker.enabled", SecureContext, Exposed=(Window,Worker)]
 interface ServiceWorker : EventTarget {
   readonly attribute USVString scriptURL;
   readonly attribute ServiceWorkerState state;
-  [Throws] void postMessage(any message/*, optional sequence<Transferable> transfer*/);
+  [Throws] void postMessage(any message/*, optional sequence<object> transfer = []*/);
 
   // event
   attribute EventHandler onstatechange;
 };
 
+// FIXME: use `includes` instead of `implements` after #22539 is fixed.
 ServiceWorker implements AbstractWorker;
 
 enum ServiceWorkerState {


### PR DESCRIPTION
About the `void postMessage`, I found the spec doesn't have `[Throws]`; however, as the implementation for `postMessage` in spec, we should have `[Throws]` for it because it will throw errors. Then, I realized that `[Throws]` is not part of standard webidl. Btw, there's a issue discussing about if `[Throws]` should be standardized or not at heycam/webidl#603.

Also, per the spec, `ServiceWorker` will `includes` `AbstractWorker` instead of `implements` so I filed #22539 for it. We can update it after the issue is fixed.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix part of #19302 
- [x] These changes do not require tests because it just updates the webidl and the changes should have no impact to current implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22540)
<!-- Reviewable:end -->
