### PR TITLE
Serialize the children of void html elements as empty strings

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1097,7 +1097,6 @@ impl Element {
             local_name!("input") |
             local_name!("keygen") |
             local_name!("link") |
-            local_name!("menuitem") |
             local_name!("meta") |
             local_name!("param") |
             local_name!("source") |

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -210,6 +210,12 @@ impl<'a> Serialize for &'a Node {
     ) -> io::Result<()> {
         let node = *self;
 
+        if let TraversalScope::ChildrenOnly(_) = traversal_scope {
+            if node.downcast::<Element>().map_or(false, |e| e.is_void()) {
+                return Ok(());
+            }
+        }
+
         let iter = SerializationIterator::new(node, traversal_scope != IncludeNode);
 
         for cmd in iter {

--- a/tests/wpt/metadata/html/syntax/serializing-html-fragments/serializing.html.ini
+++ b/tests/wpt/metadata/html/syntax/serializing-html-fragments/serializing.html.ini
@@ -6,63 +6,6 @@
   [outerHTML Attribute in non-standard namespace]
     expected: FAIL
 
-  [innerHTML Void context node area]
-    expected: FAIL
-
-  [innerHTML Void context node base]
-    expected: FAIL
-
-  [innerHTML Void context node basefont]
-    expected: FAIL
-
-  [innerHTML Void context node bgsound]
-    expected: FAIL
-
-  [innerHTML Void context node br]
-    expected: FAIL
-
-  [innerHTML Void context node col]
-    expected: FAIL
-
-  [innerHTML Void context node embed]
-    expected: FAIL
-
-  [innerHTML Void context node frame]
-    expected: FAIL
-
-  [innerHTML Void context node hr]
-    expected: FAIL
-
-  [innerHTML Void context node img]
-    expected: FAIL
-
-  [innerHTML Void context node input]
-    expected: FAIL
-
-  [innerHTML Void context node keygen]
-    expected: FAIL
-
-  [innerHTML Void context node link]
-    expected: FAIL
-
-  [innerHTML Void context node menuitem]
-    expected: FAIL
-
-  [innerHTML Void context node meta]
-    expected: FAIL
-
-  [innerHTML Void context node param]
-    expected: FAIL
-
-  [innerHTML Void context node source]
-    expected: FAIL
-
-  [innerHTML Void context node track]
-    expected: FAIL
-
-  [innerHTML Void context node wbr]
-    expected: FAIL
-
   [innerHTML void as first child with following siblings area]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22502  (GitHub issue number if applicable)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22542)
<!-- Reviewable:end -->
