### PR TITLE
Make create-wpt mach command use new manifest update implementation

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -928,12 +928,13 @@ testing/web-platform/mozilla/tests for Servo-only tests""" % reference_path)
 
         if not kwargs["no_run"]:
             p = create_parser_wpt()
-            args = ["--manifest-update"]
+            args = []
             if kwargs["release"]:
                 args.append("--release")
             args.append(test_path)
             wpt_kwargs = vars(p.parse_args(args))
             self.context.commands.dispatch("test-wpt", self.context, **wpt_kwargs)
+            self.context.commands.dispatch("update-manifest", self.context)
 
         if editor:
             proc.wait()


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22525

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22549)
<!-- Reviewable:end -->
