### PR TITLE
Implement performance interface extension for PerformanceResourceTiming 

### DIFF
--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -74,6 +74,7 @@ rejectionhandled
 removetrack
 reset
 resize
+resourcetimingbufferfull
 right
 rtl
 sans-serif

--- a/components/script/dom/webidls/Performance.webidl
+++ b/components/script/dom/webidls/Performance.webidl
@@ -34,8 +34,15 @@ partial interface Performance {
   [Throws]
   void measure(DOMString measureName, optional DOMString startMark, optional DOMString endMark);
   void clearMeasures(optional DOMString measureName);
-};
 
+
+};
+//https://w3c.github.io/resource-timing/#sec-extensions-performance-interface
+partial interface Performance {
+  void clearResourceTimings ();
+  void setResourceTimingBufferSize (unsigned long maxSize);
+              attribute EventHandler onresourcetimingbufferfull;
+};
 // FIXME(avada): this should be deprecated, but is currently included for web compat
 // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/NavigationTiming/Overview.html#performance-timing-attribute
 [Exposed=(Window)]

--- a/tests/wpt/metadata/resource-timing/buffer-full-add-after-full-event.html.ini
+++ b/tests/wpt/metadata/resource-timing/buffer-full-add-after-full-event.html.ini
@@ -1,5 +1,5 @@
 [buffer-full-add-after-full-event.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Test that entry was added to the buffer after a buffer full event]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/resource-timing/buffer-full-add-entries-during-callback-that-drop.html.ini
+++ b/tests/wpt/metadata/resource-timing/buffer-full-add-entries-during-callback-that-drop.html.ini
@@ -1,5 +1,5 @@
 [buffer-full-add-entries-during-callback-that-drop.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Test that entries synchronously added to the buffer during the callback are dropped]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/resource-timing/buffer-full-add-entries-during-callback.html.ini
+++ b/tests/wpt/metadata/resource-timing/buffer-full-add-entries-during-callback.html.ini
@@ -1,5 +1,5 @@
 [buffer-full-add-entries-during-callback.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Test that entries synchronously added to the buffer during the callback don't get dropped if the buffer is increased]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/resource-timing/buffer-full-add-then-clear.html.ini
+++ b/tests/wpt/metadata/resource-timing/buffer-full-add-then-clear.html.ini
@@ -1,5 +1,4 @@
 [buffer-full-add-then-clear.html]
-  expected: ERROR
   [Test that if the buffer is cleared after entries were added to the secondary buffer, those entries make it into the primary one]
     expected: FAIL
 

--- a/tests/wpt/metadata/resource-timing/buffer-full-decrease-buffer-during-callback.html.ini
+++ b/tests/wpt/metadata/resource-timing/buffer-full-decrease-buffer-during-callback.html.ini
@@ -1,5 +1,5 @@
 [buffer-full-decrease-buffer-during-callback.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Test that decreasing the buffer limit during the callback does not drop entries]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/resource-timing/buffer-full-increase-buffer-during-callback.html.ini
+++ b/tests/wpt/metadata/resource-timing/buffer-full-increase-buffer-during-callback.html.ini
@@ -1,5 +1,5 @@
 [buffer-full-increase-buffer-during-callback.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Test that increasing the buffer during the callback is enough for entries not to be dropped]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/resource-timing/buffer-full-inspect-buffer-during-callback.html.ini
+++ b/tests/wpt/metadata/resource-timing/buffer-full-inspect-buffer-during-callback.html.ini
@@ -1,5 +1,5 @@
 [buffer-full-inspect-buffer-during-callback.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Test that entries in the secondary buffer are not exposed during the callback and before they are copied to the primary buffer]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/resource-timing/buffer-full-set-to-current-buffer.html.ini
+++ b/tests/wpt/metadata/resource-timing/buffer-full-set-to-current-buffer.html.ini
@@ -1,5 +1,5 @@
 [buffer-full-set-to-current-buffer.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Test that entries added and event firing happened in the right sequence]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/resource-timing/buffer-full-store-and-clear-during-callback.html.ini
+++ b/tests/wpt/metadata/resource-timing/buffer-full-store-and-clear-during-callback.html.ini
@@ -1,5 +1,5 @@
 [buffer-full-store-and-clear-during-callback.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Test that entries overflowing the buffer trigger the buffer full event, can be stored, and find themselves in the primary buffer after it's cleared.]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/resource-timing/buffer-full-then-increased.html.ini
+++ b/tests/wpt/metadata/resource-timing/buffer-full-then-increased.html.ini
@@ -1,5 +1,4 @@
 [buffer-full-then-increased.html]
-  expected: ERROR
   [Test that overflowing the buffer and immediately increasing its limit does not trigger the resourcetimingbufferfull event]
     expected: FAIL
 

--- a/tests/wpt/metadata/resource-timing/buffer-full-when-populate-entries.html.ini
+++ b/tests/wpt/metadata/resource-timing/buffer-full-when-populate-entries.html.ini
@@ -1,5 +1,5 @@
 [buffer-full-when-populate-entries.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Test that a buffer full event does not bubble and that resourcetimingbufferfull is called only once per overflow]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/resource-timing/clear_resource_timing_functionality.html.ini
+++ b/tests/wpt/metadata/resource-timing/clear_resource_timing_functionality.html.ini
@@ -1,5 +1,4 @@
 [clear_resource_timing_functionality.html]
-  expected: ERROR
   [4 resource timing entries should be stored in this page.]
     expected: FAIL
 

--- a/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
+++ b/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
@@ -38,13 +38,7 @@
   [PerformanceResourceTiming interface: attribute responseEnd]
     expected: FAIL
 
-  [Performance interface: operation setResourceTimingBufferSize(unsigned long)]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: attribute secureConnectionStart]
-    expected: FAIL
-
-  [Performance interface: calling setResourceTimingBufferSize(unsigned long) on performance with too few arguments must throw TypeError]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute fetchStart]
@@ -71,19 +65,7 @@
   [PerformanceResourceTiming interface: attribute connectStart]
     expected: FAIL
 
-  [Performance interface: operation clearResourceTimings()]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: resource must inherit property "responseEnd" with the proper type]
-    expected: FAIL
-
-  [Performance interface: performance must inherit property "onresourcetimingbufferfull" with the proper type]
-    expected: FAIL
-
-  [Performance interface: performance must inherit property "setResourceTimingBufferSize(unsigned long)" with the proper type]
-    expected: FAIL
-
-  [Performance interface: attribute onresourcetimingbufferfull]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute connectEnd]
@@ -96,9 +78,6 @@
     expected: FAIL
 
   [PerformanceResourceTiming interface: resource must inherit property "domainLookupEnd" with the proper type]
-    expected: FAIL
-
-  [Performance interface: performance must inherit property "clearResourceTimings()" with the proper type]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute domainLookupEnd]
@@ -193,13 +172,7 @@
   [PerformanceResourceTiming interface: attribute responseEnd]
     expected: FAIL
 
-  [Performance interface: operation setResourceTimingBufferSize(unsigned long)]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: attribute secureConnectionStart]
-    expected: FAIL
-
-  [Performance interface: calling setResourceTimingBufferSize(unsigned long) on performance with too few arguments must throw TypeError]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute fetchStart]
@@ -214,25 +187,10 @@
   [PerformanceResourceTiming interface: attribute connectStart]
     expected: FAIL
 
-  [Performance interface: operation clearResourceTimings()]
-    expected: FAIL
-
-  [Performance interface: performance must inherit property "onresourcetimingbufferfull" with the proper type]
-    expected: FAIL
-
-  [Performance interface: performance must inherit property "setResourceTimingBufferSize(unsigned long)" with the proper type]
-    expected: FAIL
-
-  [Performance interface: attribute onresourcetimingbufferfull]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: attribute connectEnd]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute redirectEnd]
-    expected: FAIL
-
-  [Performance interface: performance must inherit property "clearResourceTimings()" with the proper type]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute domainLookupEnd]

--- a/tests/wpt/metadata/resource-timing/resource_memory_cached.sub.html.ini
+++ b/tests/wpt/metadata/resource-timing/resource_memory_cached.sub.html.ini
@@ -1,5 +1,4 @@
 [resource_memory_cached.sub.html]
-  expected: ERROR
   [http://web-platform.test:8000/resource-timing/resources/blue.png?id=cached is expected to be in the Resource Timing buffer]
     expected: FAIL
 

--- a/tests/wpt/metadata/resource-timing/resource_subframe_self_navigation.html.ini
+++ b/tests/wpt/metadata/resource-timing/resource_subframe_self_navigation.html.ini
@@ -1,13 +1,14 @@
 [resource_subframe_self_navigation.html]
+  expected: TIMEOUT
   [Subsequent <iframe> navigations don't appear in the resource-timing buffer.]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Subsequent <frame> navigations don't appear in the resource-timing buffer.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Subsequent <embed> navigations don't appear in the resource-timing buffer.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Subsequent <object> navigations don't appear in the resource-timing buffer.]
-    expected: FAIL
+    expected: NOTRUN
 

--- a/tests/wpt/metadata/resource-timing/resource_timing.worker.js.ini
+++ b/tests/wpt/metadata/resource-timing/resource_timing.worker.js.ini
@@ -1,7 +1,8 @@
 [resource_timing.worker.html]
+  expected: TIMEOUT
   [Performance Resouce Entries in workers]
     expected: FAIL
 
   [Performance Resource Entries in workers]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/resource-timing/resource_timing_buffer_full_eventually.html.ini
+++ b/tests/wpt/metadata/resource-timing/resource_timing_buffer_full_eventually.html.ini
@@ -1,5 +1,0 @@
-[resource_timing_buffer_full_eventually.html]
-  expected: TIMEOUT
-  [Finite resource timing entries buffer size]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata/workers/worker-performance.worker.js.ini
+++ b/tests/wpt/metadata/workers/worker-performance.worker.js.ini
@@ -12,12 +12,6 @@
   [Resource timing seems to work in workers]
     expected: FAIL
 
-  [performance.clearResourceTimings in workers]
-    expected: FAIL
-
-  [performance.setResourceTimingBufferSize in workers]
-    expected: FAIL
-
   [performance.timing is not available in workers]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

(There is a previous closed pull for this #22431)
Implemented the following :
a) Added the maxSize Field to the PerformanceEntryList structure.
b) Implemented the clearResourceTimings, setResourceTimingBufferSize, onresourcetimingbufferfull fuctions for the Performance Structure according to the Interface Specification given at : https://w3c.github.io/resource-timing/#sec-extensions-performance-interface

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22307 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22599)
<!-- Reviewable:end -->
