### PR TITLE
Comments

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -789,6 +789,7 @@ impl LayoutThread {
                 self.prepare_to_exit(response_chan);
                 return false;
             },
+            // Receiving the Exit message at this stage only happens when layout is undergoing a "force exit".
             Msg::ExitNow => {
                 debug!("layout: ExitNow received");
                 self.exit_now();


### PR DESCRIPTION
Regarding  clarify layout-thread exit workflow (Specifically:when will a Exit message be received )

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22475 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they add comments to the code and don't affect the code itself.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22634)
<!-- Reviewable:end -->
