### PR TITLE
Fix frame-pointer stackwalking

### DIFF
--- a/components/background_hang_monitor/sampler_mac.rs
+++ b/components/background_hang_monitor/sampler_mac.rs
@@ -96,7 +96,9 @@ unsafe fn frame_pointer_stack_walk(regs: Registers) -> NativeStack {
     // --dev,
     // or --with-frame-pointer.
 
-    let stackaddr = libc::pthread_get_stackaddr_np(libc::pthread_self());
+    let pthread_t = libc::pthread_self();
+    let stackaddr = libc::pthread_get_stackaddr_np(pthread_t);
+    let stacksize = libc::pthread_get_stacksize_np(pthread_t);
     let mut native_stack = NativeStack::new();
     let pc = regs.instruction_ptr as *mut std::ffi::c_void;
     let stack = regs.stack_ptr as *mut std::ffi::c_void;
@@ -104,12 +106,21 @@ unsafe fn frame_pointer_stack_walk(regs: Registers) -> NativeStack {
     let mut current = regs.frame_ptr as *mut *mut std::ffi::c_void;
     while !current.is_null() {
         if (current as usize) < stackaddr as usize {
+            // Reached the end of the stack.
+            break;
+        }
+        if current as usize >= stackaddr.add(stacksize * 8) as usize {
+            // Reached the beginning of the stack.
+            // Assumining 64 bit mac(see the stacksize * 8).
             break;
         }
         let next = *current as *mut *mut std::ffi::c_void;
         let pc = current.add(1);
         let stack = current.add(2);
         if let Err(()) = native_stack.process_register(*pc, *stack) {
+            break;
+        }
+        if (next <= current) || (next as usize & 3 != 0) {
             break;
         }
         current = next;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This seems to fix the problem, it's a check that is also done at https://dxr.mozilla.org/mozilla-central/rev/c2593a3058afdfeaac5c990e18794ee8257afe99/mozglue/misc/StackWalk.cpp#904

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #22604 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22637)
<!-- Reviewable:end -->
