### PR TITLE
Make create_typed_array an unsafe function

### DIFF
--- a/components/script/dom/vrframedata.rs
+++ b/components/script/dom/vrframedata.rs
@@ -58,10 +58,12 @@ impl VRFrameData {
             VRFrameDataBinding::Wrap,
         );
         let cx = global.get_cx();
-        create_typed_array(cx, &matrix, &root.left_proj);
-        create_typed_array(cx, &matrix, &root.left_view);
-        create_typed_array(cx, &matrix, &root.right_proj);
-        create_typed_array(cx, &matrix, &root.right_view);
+        unsafe {
+            create_typed_array(cx, &matrix, &root.left_proj);
+            create_typed_array(cx, &matrix, &root.left_view);
+            create_typed_array(cx, &matrix, &root.right_proj);
+            create_typed_array(cx, &matrix, &root.right_view);
+        }
 
         root
     }
@@ -73,11 +75,9 @@ impl VRFrameData {
 
 /// FIXME(#22526) this should be in a better place
 #[allow(unsafe_code)]
-pub fn create_typed_array(cx: *mut JSContext, src: &[f32], dst: &Heap<*mut JSObject>) {
+pub unsafe fn create_typed_array(cx: *mut JSContext, src: &[f32], dst: &Heap<*mut JSObject>) {
     rooted!(in (cx) let mut array = ptr::null_mut::<JSObject>());
-    unsafe {
-        let _ = Float32Array::create(cx, CreateWith::Slice(src), array.handle_mut());
-    }
+    let _ = Float32Array::create(cx, CreateWith::Slice(src), array.handle_mut());
     (*dst).set(array.get());
 }
 

--- a/components/script/dom/xrview.rs
+++ b/components/script/dom/xrview.rs
@@ -34,6 +34,7 @@ impl XRView {
         }
     }
 
+    #[allow(unsafe_code)]
     pub fn new(
         global: &GlobalScope,
         session: &XRSession,
@@ -53,8 +54,10 @@ impl XRView {
         };
 
         let cx = global.get_cx();
-        create_typed_array(cx, proj, &ret.proj);
-        create_typed_array(cx, view, &ret.view);
+        unsafe {
+            create_typed_array(cx, proj, &ret.proj);
+            create_typed_array(cx, view, &ret.view);
+        }
         ret
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Make `create_typed_array` function in `components/script/dom/vrframedata.rs` an unsafe function as it accepts an unsafe pointer
Wrapped the function calls into an unsafe block in `components/script/dom/xrview.rs` and `components/script/dom/vrframedata.rs`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22600 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the reporter of the issue said it's fine if it compiles with no warning or errors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22640)
<!-- Reviewable:end -->
