### PR TITLE
Make XR/VR presenting code async

### DIFF
--- a/components/script/dom/vrdisplay.rs
+++ b/components/script/dom/vrdisplay.rs
@@ -15,7 +15,7 @@ use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::codegen::Bindings::XRSessionBinding::XRFrameRequestCallback;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
-use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::{DomRoot, MutDom, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
@@ -34,7 +34,7 @@ use crate::dom::xrframe::XRFrame;
 use crate::dom::xrsession::XRSession;
 use crate::script_runtime::CommonScriptMsg;
 use crate::script_runtime::ScriptThreadEventCategory::WebVREvent;
-use crate::task_source::TaskSourceName;
+use crate::task_source::{TaskSource, TaskSourceName};
 use canvas_traits::webgl::{webgl_channel, WebGLReceiver, WebVRCommand};
 use crossbeam_channel::{unbounded, Sender};
 use dom_struct::dom_struct;
@@ -347,35 +347,8 @@ impl VRDisplayMethods for VRDisplay {
             },
         };
 
-        // WebVR spec: Repeat calls while already presenting will update the VRLayers being displayed.
-        if self.presenting.get() {
-            *self.layer.borrow_mut() = layer_bounds;
-            self.layer_ctx.set(Some(&layer_ctx));
-            promise.resolve_native(&());
-            return promise;
-        }
-
-        // Request Present
-        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
-        self.webvr_thread()
-            .send(WebVRMsg::RequestPresent(
-                self.global().pipeline_id(),
-                self.display.borrow().display_id,
-                sender,
-            ))
-            .unwrap();
-        match receiver.recv().unwrap() {
-            Ok(()) => {
-                *self.layer.borrow_mut() = layer_bounds;
-                self.layer_ctx.set(Some(&layer_ctx));
-                self.init_present();
-                promise.resolve_native(&());
-            },
-            Err(e) => {
-                promise.reject_native(&e);
-            },
-        }
-
+        self.request_present(layer_bounds, Some(&layer_ctx),
+                             promise.clone(), |p| p.resolve_native(&()));
         promise
     }
 
@@ -462,6 +435,60 @@ impl VRDisplay {
         } else {
             self.stage_params.set(None);
         }
+    }
+
+    pub fn request_present<F>(&self, layer_bounds: WebVRLayer,
+                              ctx: Option<&WebGLRenderingContext>,
+                              promise: Rc<Promise>, resolve: F)
+        where F: FnOnce(Rc<Promise>) + Send + 'static {
+        // WebVR spec: Repeat calls while already presenting will update the VRLayers being displayed.
+        if self.presenting.get() {
+            *self.layer.borrow_mut() = layer_bounds;
+            self.layer_ctx.set(ctx);
+            resolve(promise);
+            return;
+        }
+
+        // Request Present
+        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        self.webvr_thread()
+            .send(WebVRMsg::RequestPresent(
+                self.global().pipeline_id(),
+                self.display.borrow().display_id,
+                sender,
+            ))
+            .unwrap();
+        let promise = TrustedPromise::new(promise);
+        let this = Trusted::new(self);
+        let ctx = ctx.map(|c| Trusted::new(c));
+        let global = self.global();
+        let window = global.as_window();
+        let (task_source, canceller) = window
+            .task_manager()
+            .dom_manipulation_task_source_with_canceller();
+        thread::spawn(move || {
+            let recv = receiver.recv().unwrap();
+            let _ = task_source.queue_with_canceller(
+                task!(vr_presenting: move || {
+                    let this = this.root();
+                    let promise = promise.root();
+                    let ctx = ctx.map(|c| c.root());
+                    match recv {
+                        Ok(()) => {
+                            *this.layer.borrow_mut() = layer_bounds;
+                            this.layer_ctx.set(ctx.as_ref().map(|c| &**c));
+                            this.init_present();
+                            resolve(promise);
+                        },
+                        Err(e) => {
+                            promise.reject_native(&e);
+                        },
+                    }
+                }),
+                &canceller,
+            );
+
+        });
     }
 
     pub fn handle_webvr_event(&self, event: &WebVRDisplayEvent) {

--- a/components/script/dom/vrdisplay.rs
+++ b/components/script/dom/vrdisplay.rs
@@ -688,12 +688,12 @@ impl VRDisplay {
 // XR stuff
 // XXXManishearth eventually we should share as much logic as possible
 impl VRDisplay {
-    pub fn xr_present(&self, session: &XRSession, ctx: &WebGLRenderingContext) {
+    pub fn xr_present(&self, session: &XRSession, ctx: Option<&WebGLRenderingContext>) {
         let layer_bounds = WebVRLayer::default();
         self.xr_session.set(Some(session));
         if self.presenting.get() {
             *self.layer.borrow_mut() = layer_bounds;
-            self.layer_ctx.set(Some(&ctx));
+            self.layer_ctx.set(ctx);
             return;
         }
 
@@ -709,7 +709,7 @@ impl VRDisplay {
 
         if let Ok(()) = receiver.recv().unwrap() {
             *self.layer.borrow_mut() = layer_bounds;
-            self.layer_ctx.set(Some(&ctx));
+            self.layer_ctx.set(ctx);
             self.init_present();
         }
     }

--- a/components/script/dom/xr.rs
+++ b/components/script/dom/xr.rs
@@ -95,10 +95,9 @@ impl XRMethods for XR {
         }
 
         let session = XRSession::new(&self.global(), &displays[0]);
+        // XXXManishearth we should actually xr_present() here instead of
+        // in XRSession::new, and resolve a promise based on it
         promise.resolve_native(&session);
-        // whether or not we should initiate presentation is unclear
-        // https://github.com/immersive-web/webxr/issues/453
-
         promise
     }
 }

--- a/components/script/dom/xr.rs
+++ b/components/script/dom/xr.rs
@@ -95,9 +95,7 @@ impl XRMethods for XR {
         }
 
         let session = XRSession::new(&self.global(), &displays[0]);
-        // XXXManishearth we should actually xr_present() here instead of
-        // in XRSession::new, and resolve a promise based on it
-        promise.resolve_native(&session);
+        session.xr_present(promise.clone());
         promise
     }
 }

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -14,6 +14,7 @@ use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::promise::Promise;
 use crate::dom::vrdisplay::VRDisplay;
 use crate::dom::xrlayer::XRLayer;
 use crate::dom::xrwebgllayer::XRWebGLLayer;
@@ -37,13 +38,15 @@ impl XRSession {
     }
 
     pub fn new(global: &GlobalScope, display: &VRDisplay) -> DomRoot<XRSession> {
-        let ret = reflect_dom_object(
+        reflect_dom_object(
             Box::new(XRSession::new_inherited(display)),
             global,
             XRSessionBinding::Wrap,
-        );
-        ret.display.xr_present(&ret, None);
-        ret
+        )
+    }
+
+    pub fn xr_present(&self, p: Rc<Promise>) {
+        self.display.xr_present(self, None, Some(p));
     }
 }
 
@@ -78,7 +81,7 @@ impl XRSessionMethods for XRSession {
         self.base_layer.set(layer);
         if let Some(layer) = layer {
             let layer = layer.downcast::<XRWebGLLayer>().unwrap();
-            self.display.xr_present(&self, Some(&layer.Context()));
+            self.display.xr_present(&self, Some(&layer.Context()), None);
         } else {
             // steps unknown
             // https://github.com/immersive-web/webxr/issues/453

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -37,11 +37,13 @@ impl XRSession {
     }
 
     pub fn new(global: &GlobalScope, display: &VRDisplay) -> DomRoot<XRSession> {
-        reflect_dom_object(
+        let ret = reflect_dom_object(
             Box::new(XRSession::new_inherited(display)),
             global,
             XRSessionBinding::Wrap,
-        )
+        );
+        ret.display.xr_present(&ret, None);
+        ret
     }
 }
 
@@ -76,7 +78,7 @@ impl XRSessionMethods for XRSession {
         self.base_layer.set(layer);
         if let Some(layer) = layer {
             let layer = layer.downcast::<XRWebGLLayer>().unwrap();
-            self.display.xr_present(&self, &layer.Context());
+            self.display.xr_present(&self, Some(&layer.Context()));
         } else {
             // steps unknown
             // https://github.com/immersive-web/webxr/issues/453


### PR DESCRIPTION
Previously we only pretended to be async, we returned promises that were already resolved because we synchronously blocked on the channel.

This:

 - Moves XR presentation to session creation (where it belongs, see https://github.com/immersive-web/webxr/issues/453)
 - Factors out common presentation code in a way that supports asynchronously resolving promises
 - Uses this for `VRDisplay::RequestPresent()` and `XR::RequestSession()`

r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22649)
<!-- Reviewable:end -->
