### PR TITLE
Disable forked referrer-policy tests.

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -4,7 +4,7 @@ skip: true
   [mozilla]
     skip: false
     [referrer-policy]
-      skip: false
+      skip: true
 [_webgl]
   skip: false
 [2dcontext]


### PR DESCRIPTION
They keep timing out since they're missing the changes from https://github.com/web-platform-tests/wpt/pull/14634.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22661)
<!-- Reviewable:end -->
