### PR TITLE
Expose TextTrack.activeCues

### DIFF
--- a/components/script/dom/texttrack.rs
+++ b/components/script/dom/texttrack.rs
@@ -110,6 +110,13 @@ impl TextTrackMethods for TextTrack {
         }
     }
 
+    // https://html.spec.whatwg.org/multipage/#dom-texttrack-activecues
+    fn GetActiveCues(&self) -> Option<DomRoot<TextTrackCueList>> {
+        // XXX implement active cues logic
+        //      https://github.com/servo/servo/issues/22314
+        None
+    }
+
     // https://html.spec.whatwg.org/multipage/#dom-texttrack-addcue
     fn AddCue(&self, cue: &TextTrackCue) -> ErrorResult {
         // FIXME(#22314, dlrobertson) add Step 1 & 2

--- a/components/script/dom/webidls/TextTrack.webidl
+++ b/components/script/dom/webidls/TextTrack.webidl
@@ -19,7 +19,7 @@ interface TextTrack : EventTarget {
   attribute TextTrackMode mode;
 
   readonly attribute TextTrackCueList? cues;
-  // readonly attribute TextTrackCueList? activeCues;
+  readonly attribute TextTrackCueList? activeCues;
 
   [Throws]
   void addCue(TextTrackCue cue);

--- a/tests/wpt/metadata/html/dom/interfaces.https.html.ini
+++ b/tests/wpt/metadata/html/dom/interfaces.https.html.ini
@@ -9563,13 +9563,7 @@
   [TextTrack interface: attribute inBandMetadataTrackDispatchType]
     expected: FAIL
 
-  [TextTrack interface: attribute activeCues]
-    expected: FAIL
-
   [TextTrack interface: document.createElement("track").track must inherit property "inBandMetadataTrackDispatchType" with the proper type]
-    expected: FAIL
-
-  [TextTrack interface: document.createElement("track").track must inherit property "activeCues" with the proper type]
     expected: FAIL
 
   [TimeRanges must be primary interface of document.createElement("video").buffered]


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22675

This only exposes the `activeCues` property to make sure that `/html/semantics/embedded-content/media-elements/track/track-element/track-active-cues.html` timeouts consistently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22676)
<!-- Reviewable:end -->
