### PR TITLE
Stop catching Android click events

### DIFF
--- a/support/android/apk/servoview/src/main/java/org/mozilla/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/mozilla/servoview/ServoView.java
@@ -292,7 +292,6 @@ public class ServoView extends GLSurfaceView
     }
 
     public boolean onSingleTapUp(MotionEvent e) {
-        mServo.click((int) e.getX(), (int) e.getY());
         return false;
     }
 


### PR DESCRIPTION
Servo already can simulate clicks from multiple tap events

fixes https://github.com/servo/servo/issues/22702

r? @paulrouget

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22708)
<!-- Reviewable:end -->
