### PR TITLE
Changed return value of GetActiveCues

### DIFF
--- a/components/script/dom/texttrack.rs
+++ b/components/script/dom/texttrack.rs
@@ -114,7 +114,7 @@ impl TextTrackMethods for TextTrack {
     fn GetActiveCues(&self) -> Option<DomRoot<TextTrackCueList>> {
         // XXX implement active cues logic
         //      https://github.com/servo/servo/issues/22314
-        None
+        Some(TextTrackCueList::new(&self.global().as_window(), &[]))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-texttrack-addcue


### PR DESCRIPTION
Return an empty TextTrackCueList rather than Some inside the GetActiveCues.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [X] These changes fix #22706 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22730)
<!-- Reviewable:end -->
