### PR TITLE
  Truncate debug output for long data URLs #22485

### DIFF
--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -174,7 +174,7 @@ impl fmt::Debug for ServoUrl {
         if self.0.as_str().len() > 40 {
             let hasher = DefaultHasher::new();
             let truncated: String = self.0.as_str().chars().take(40).collect();
-            let result = format!("{}... ({:x})", truncated, hasher.finish().to_string());
+            let result = format!("{}... ({:x})", truncated, hasher.finish());
             return result.fmt(formatter);
         }
         self.0.fmt(formatter)

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -174,7 +174,7 @@ impl fmt::Debug for ServoUrl {
         if self.0.as_str().len() > 40 {
             let hasher = DefaultHasher::new();
             let truncated: String = self.0.as_str().chars().take(40).collect();
-            let result = format!("{}... ({})", truncated, hasher.finish().to_string());
+            let result = format!("{}... ({:x})", truncated, hasher.finish().to_string());
             return result.fmt(formatter);
         }
         self.0.fmt(formatter)

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -17,7 +17,9 @@ pub mod origin;
 
 pub use crate::origin::{ImmutableOrigin, MutableOrigin, OpaqueOrigin};
 
+use std::collections::hash_map::DefaultHasher;
 use std::fmt;
+use std::hash::Hasher;
 use std::net::IpAddr;
 use std::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};
 use std::path::Path;
@@ -169,6 +171,12 @@ impl fmt::Display for ServoUrl {
 
 impl fmt::Debug for ServoUrl {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        if self.0.as_str().len() > 40 {
+            let hasher = DefaultHasher::new();
+            let truncated: String = self.0.as_str().chars().take(40).collect();
+            let result = format!("{}... ({})", truncated, hasher.finish().to_string());
+            return result.fmt(formatter);
+        }
         self.0.fmt(formatter)
     }
 }


### PR DESCRIPTION
  I tried to solve the patch, here i did what you told but i am not getting the
  exact result after the build can you take a look

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #22485 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [x] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22740)
<!-- Reviewable:end -->
