### PR TITLE
Stop building debugmozjs for magicleap

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -211,6 +211,11 @@ class MachCommands(CommandBase):
             print("Please specify either --target or --android.")
             sys.exit(1)
 
+        # https://github.com/servo/servo/issues/22069
+        if debug_mozjs and magicleap:
+            print("Please specify either --debug-mozjs or --magicleap.")
+            sys.exit(1)
+
         if android:
             target = self.config["android"]["target"]
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Block trying to build `--debug-mozjs` and `--magicleap` because that leads to horrid link errors.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because we don't test our CI as much as we probably should

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22745)
<!-- Reviewable:end -->
