### PR TITLE
Refactor follow_hyperlink and its callers

### DIFF
--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -599,7 +599,7 @@ pub fn follow_hyperlink(
     hyperlink_suffix: Option<String>,
     referrer_policy: Option<ReferrerPolicy>,
 ) {
-    // Step 1: If subject cannot navigate, then return.
+    // Step 1.
     if subject.cannot_navigate() {
         return;
     }

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::activation::Activatable;
-use crate::dom::bindings::codegen::Bindings::DOMTokenListBinding::DOMTokenListMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLAreaElementBinding;
 use crate::dom::bindings::codegen::Bindings::HTMLAreaElementBinding::HTMLAreaElementMethods;
 use crate::dom::bindings::inheritance::Castable;
@@ -21,7 +20,6 @@ use crate::dom::virtualmethods::VirtualMethods;
 use dom_struct::dom_struct;
 use euclid::Point2D;
 use html5ever::{LocalName, Prefix};
-use net_traits::ReferrerPolicy;
 use std::default::Default;
 use std::f32;
 use std::str;
@@ -332,10 +330,6 @@ impl Activatable for HTMLAreaElement {
     }
 
     fn activation_behavior(&self, _event: &Event, _target: &EventTarget) {
-        let referrer_policy = match self.RelList().Contains("noreferrer".into()) {
-            true => Some(ReferrerPolicy::NoReferrer),
-            false => None,
-        };
-        follow_hyperlink(self.as_element(), None, referrer_policy);
+        follow_hyperlink(self.as_element(), None);
     }
 }

--- a/components/script/dom/htmlareaelement.rs
+++ b/components/script/dom/htmlareaelement.rs
@@ -16,7 +16,7 @@ use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlanchorelement::follow_hyperlink;
 use crate::dom::htmlelement::HTMLElement;
-use crate::dom::node::{document_from_node, Node};
+use crate::dom::node::Node;
 use crate::dom::virtualmethods::VirtualMethods;
 use dom_struct::dom_struct;
 use euclid::Point2D;
@@ -332,18 +332,10 @@ impl Activatable for HTMLAreaElement {
     }
 
     fn activation_behavior(&self, _event: &Event, _target: &EventTarget) {
-        // Step 1
-        let doc = document_from_node(self);
-        if !doc.is_fully_active() {
-            return;
-        }
-        // Step 2
-        // TODO : We should be choosing a browsing context and navigating to it.
-        // Step 3
         let referrer_policy = match self.RelList().Contains("noreferrer".into()) {
             true => Some(ReferrerPolicy::NoReferrer),
             false => None,
         };
-        follow_hyperlink(self.upcast::<Element>(), None, referrer_policy);
+        follow_hyperlink(self.as_element(), None, referrer_policy);
     }
 }


### PR DESCRIPTION
Now they follow the new spec stated at:
https://html.spec.whatwg.org/multipage/links.html#following-hyperlinks-2

It seems like choosing a browsing context is already done in the
follow_hyperlink method, so I have removed the TODO in
activation_behavior for HTMLAreaElement.

The tests in `tests/wpt/web-platform-tests/html/semantics/links/following-hyperlinks/`
pass in release builds, but still don't pass in dev build,
since the timeout in
`tests/wpt/web-platform-tests/html/semantics/links/following-hyperlinks/activation-behavior.window.js`
seems to be too short for dev builds.

Navigating to error page on failed URL parsing is still not implemented.

There seem to be potential code duplication in activation_behavior
methods for both htmlanchorelement.rs and htmlareaelement.rs, in:

    let referrer_policy = match self.RelList().Contains("noreferrer".into()) {
        true => Some(ReferrerPolicy::NoReferrer),
        false => None,
    };

I didn't pull them out to a separate function since I don't know
where I would put that new function.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22761 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22771)
<!-- Reviewable:end -->
