### PR TITLE
Support for ExternalVR implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3310,20 +3310,22 @@ dependencies = [
 
 [[package]]
 name = "rust-webvr"
-version = "0.9.12"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "bindgen 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gvr-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ovr-mobile-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-webvr-api 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr-api 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rust-webvr-api"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_injected_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4833,7 +4835,7 @@ dependencies = [
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "rust-webvr 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
  "servo_config 0.0.1",
  "webvr_traits 0.0.1",
@@ -4845,7 +4847,7 @@ version = "0.0.1"
 dependencies = [
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "rust-webvr-api 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr-api 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5323,8 +5325,8 @@ dependencies = [
 "checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "da06feaa07f69125ab9ddc769b11de29090122170b402547f64b86fe16ebc399"
-"checksum rust-webvr 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9355af34c9a072f567d8f3a7e51ef170935b5bf22d8d0450f0e8c41da6df46a2"
-"checksum rust-webvr-api 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "712e22ba3c03a7075b40842ae91029a0ab96a81f95e97c0cf623800ec0cbac07"
+"checksum rust-webvr 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)" = "c44fadb2f8b67a3ee909c158e0bdd0c1c2f21cab7d37c8f30cd8955419ece9a7"
+"checksum rust-webvr-api 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "daf1b163d8522d2b25ec99de77785573dbd2db4825df515d241d3d5408b958d5"
 "checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusttype 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b8eb11f5b0a98c8eca2fb1483f42646d8c340e83e46ab416f8a063a0fd0eeb20"

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -14,6 +14,7 @@ use script_traits::{MouseButton, TouchEventType, TouchId};
 use servo_geometry::DeviceIndependentPixel;
 use servo_url::ServoUrl;
 use std::fmt::{Debug, Error, Formatter};
+use std::os::raw::c_void;
 #[cfg(feature = "gl")]
 use std::rc::Rc;
 use style_traits::DevicePixel;
@@ -145,6 +146,11 @@ pub trait WindowMethods {
     /// will want to avoid blocking on UI events, and just
     /// run the event loop at the vsync interval.
     fn set_animation_state(&self, _state: AnimationState);
+    /// Provide a c_void pointer to a VRExternal shared memory.
+    /// See: https://github.com/servo/rust-webvr/tree/master/rust-webvr/src/api/vrexternal
+    fn get_vrexternal_pointer(&self) -> Option<*mut c_void> {
+        None
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/components/webvr/Cargo.toml
+++ b/components/webvr/Cargo.toml
@@ -21,7 +21,7 @@ euclid = "0.19"
 ipc-channel = "0.11"
 log = "0.4"
 msg = {path = "../msg"}
-rust-webvr = {version = "0.9", features = ["openvr"]}
+rust-webvr = {version = "0.9", features = ["openvr", "vrexternal"]}
 script_traits = {path = "../script_traits"}
 servo_config = {path = "../config"}
 webvr_traits = {path = "../webvr_traits" }

--- a/components/webvr/lib.rs
+++ b/components/webvr/lib.rs
@@ -9,3 +9,4 @@ extern crate log;
 
 mod webvr_thread;
 pub use crate::webvr_thread::{WebVRCompositorHandler, WebVRThread};
+pub use rust_webvr::api::VRExternalShmemPtr;

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -21,6 +21,7 @@ use servo::servo_url::ServoUrl;
 use servo::{self, gl, webrender_api, BrowserId, Servo};
 use std::cell::{Cell, RefCell};
 use std::mem;
+use std::os::raw::c_void;
 use std::path::PathBuf;
 use std::rc::Rc;
 
@@ -39,6 +40,7 @@ pub struct InitOptions {
     pub width: u32,
     pub height: u32,
     pub density: f32,
+    pub vr_pointer: Option<*mut c_void>,
     pub enable_subpixel_text_antialiasing: bool,
 }
 
@@ -152,6 +154,7 @@ pub fn init(
         width: Cell::new(init_opts.width),
         height: Cell::new(init_opts.height),
         density: init_opts.density,
+        vr_pointer: init_opts.vr_pointer,
         waker,
     });
 
@@ -495,6 +498,7 @@ struct ServoCallbacks {
     width: Cell<u32>,
     height: Cell<u32>,
     density: f32,
+    vr_pointer: Option<*mut c_void>,
 }
 
 impl WindowMethods for ServoCallbacks {
@@ -535,6 +539,10 @@ impl WindowMethods for ServoCallbacks {
             screen_avail: size,
             hidpi_factor: TypedScale::new(self.density),
         }
+    }
+
+    fn get_vrexternal_pointer(&self) -> Option<*mut c_void> {
+        self.vr_pointer.clone()
     }
 }
 

--- a/ports/libsimpleservo/capi/src/lib.rs
+++ b/ports/libsimpleservo/capi/src/lib.rs
@@ -10,7 +10,7 @@ use simpleservo::{
 };
 use std::ffi::{CStr, CString};
 use std::mem;
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_void};
 
 fn call<F>(f: F)
 where
@@ -51,6 +51,7 @@ pub struct CInitOptions {
     pub width: u32,
     pub height: u32,
     pub density: f32,
+    pub vr_pointer: *mut c_void,
     pub enable_subpixel_text_antialiasing: bool,
 }
 
@@ -83,6 +84,11 @@ fn init(
         width: opts.width,
         height: opts.height,
         density: opts.density,
+        vr_pointer: if opts.vr_pointer.is_null() {
+            None
+        } else {
+            Some(opts.vr_pointer)
+        },
         enable_subpixel_text_antialiasing: opts.enable_subpixel_text_antialiasing,
     };
 

--- a/ports/libsimpleservo/jniapi/src/lib.rs
+++ b/ports/libsimpleservo/jniapi/src/lib.rs
@@ -66,7 +66,9 @@ pub fn Java_org_mozilla_servoview_JNIServo_init(
         // debug!() will only show in a debug build. Use info!() if logs
         // should show up in adb logcat with a release build.
         let filters = [
-            "simpleservo",
+            "servo",
+            "simpleservo::api",
+            "simpleservo::jniapi",
             "simpleservo::gl_glue::egl",
             // Show JS errors by default.
             "script::dom::bindings::error",
@@ -686,6 +688,9 @@ fn get_options(env: &JNIEnv, opts: JObject) -> Result<(InitOptions, bool, Option
         get_non_null_field(env, opts, "enableSubpixelTextAntialiasing", "Z")?
             .z()
             .map_err(|_| "enableSubpixelTextAntialiasing not a boolean")?;
+    let vr_pointer = get_non_null_field(env, opts, "VRExternalContext", "J")?
+        .j()
+        .map_err(|_| "VRExternalContext is not a long")? as *mut c_void;
     let opts = InitOptions {
         args,
         url,
@@ -693,6 +698,11 @@ fn get_options(env: &JNIEnv, opts: JObject) -> Result<(InitOptions, bool, Option
         height,
         density,
         enable_subpixel_text_antialiasing,
+        vr_pointer: if vr_pointer.is_null() {
+            None
+        } else {
+            Some(vr_pointer)
+        },
     };
     Ok((opts, log, log_str))
 }

--- a/support/android/apk/servoview/src/main/java/org/mozilla/servoview/JNIServo.java
+++ b/support/android/apk/servoview/src/main/java/org/mozilla/servoview/JNIServo.java
@@ -73,6 +73,7 @@ public class JNIServo {
       public int height = 0;
       public float density = 1;
       public boolean enableSubpixelTextAntialiasing = true;
+      public long VRExternalContext = 0;
       public String logStr;
       public boolean enableLogs = false;
     }

--- a/support/android/apk/servoview/src/main/java/org/mozilla/servoview/ServoSurface.java
+++ b/support/android/apk/servoview/src/main/java/org/mozilla/servoview/ServoSurface.java
@@ -36,6 +36,7 @@ public class ServoSurface {
     private Surface mASurface;
     private int mWidth;
     private int mHeight;
+    private long mVRExternalContext;
     private Servo mServo;
     private Client mClient = null;
     private String mServoArgs;
@@ -67,6 +68,10 @@ public class ServoSurface {
 
     public void setActivity(Activity activity) {
         mActivity = activity;
+    }
+
+    public void setVRExternalContext(long context) {
+        mVRExternalContext = context;
     }
 
     public void runLoop() {
@@ -265,6 +270,7 @@ public class ServoSurface {
               options.logStr = mServoLog;
               options.enableLogs = true;
               options.enableSubpixelTextAntialiasing = false;
+              options.VRExternalContext = mVRExternalContext;
 
               mServo = new Servo(options, this, mSurface, mClient, mActivity);
             });


### PR DESCRIPTION
This PR adds the hook necessary for the ExternalVR rust-webvr driver.
Waiting on rust-webvr 0.9.3 to be published before landing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22773)
<!-- Reviewable:end -->
