### PR TITLE
Upgrade brotli dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,12 +339,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "alloc-no-stdlib 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "alloc-stdlib 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "brotli-decompressor 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "brotli-decompressor 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "alloc-no-stdlib 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4967,7 +4967,7 @@ dependencies = [
 "checksum blurz 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6dae8337ff67fe8ead29a28a0115605753e6a5205d4b6017e9f42f198c3c50a"
 "checksum boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cbec60c560f322d8e3cd403f91d8908cfd965fff53ba97154bd1b9d90149d98e"
 "checksum brotli 3.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "43b92d759a5f8532e5b0bc06dc31593af01447db9e141c3b67bdb132e58c2844"
-"checksum brotli-decompressor 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "87c3078b67cd0fad2263321042a60f620186cce666bedba14c6bf09ace508ce9"
+"checksum brotli-decompressor 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3f34b04c706eaa3f9e5f47f35a1aa3fdb4d3a2854632dacf87b77995827b19ac"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byte-slice-cast 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "28346c117b50270785fbc123bd6e4ecad20d0c6d5f43d081dc80a3abcc62be64"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"


### PR DESCRIPTION
This incorporates [a fix](https://github.com/dropbox/rust-brotli-decompressor/issues/6) for streaming decoding that drops content when a WouldBlock error is encountered.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22749 and fix #22717 and fix (maybe) #22712.
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22776)
<!-- Reviewable:end -->
