### PR TITLE
Report all messages processed by the webgl thread.

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -117,6 +117,7 @@ impl<VR: WebVRRenderHandler + 'static> WebGLThread<VR> {
     /// Handles a generic WebGLMsg message
     #[inline]
     fn handle_msg(&mut self, msg: WebGLMsg, webgl_chan: &WebGLChan) -> bool {
+        trace!("processing {:?}", msg);
         match msg {
             WebGLMsg::CreateContext(version, size, attributes, result_sender) => {
                 let result = self.create_webgl_context(version, size, attributes);
@@ -1104,7 +1105,7 @@ impl WebGLImpl {
                     alpha_treatment,
                     y_axis_treatment,
                     pixel_format,
-                    Cow::Borrowed(data),
+                    Cow::Borrowed(&*data),
                 );
 
                 ctx.gl()
@@ -1144,7 +1145,7 @@ impl WebGLImpl {
                     alpha_treatment,
                     y_axis_treatment,
                     pixel_format,
-                    Cow::Borrowed(data),
+                    Cow::Borrowed(&*data),
                 );
 
                 ctx.gl()

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -708,7 +708,7 @@ impl WebGLRenderingContext {
             alpha_treatment,
             y_axis_treatment,
             pixel_format: pixels.pixel_format,
-            data: pixels.data,
+            data: pixels.data.into(),
         });
 
         if let Some(fb) = self.bound_framebuffer.get() {
@@ -783,7 +783,7 @@ impl WebGLRenderingContext {
             alpha_treatment,
             y_axis_treatment,
             pixel_format: pixels.pixel_format,
-            data: pixels.data,
+            data: pixels.data.into(),
         });
     }
 


### PR DESCRIPTION
This might be useful for figuring out what a WebGL-based page is doing when it's not behaving correctly.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are debug-logging changes only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22798)
<!-- Reviewable:end -->
