### PR TITLE
Add a reftest that entering fullscreen mode takes over the window

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3164,8 +3164,20 @@ impl Document {
         if !pending.fullscreen_element_ready_check() {
             error = true;
         }
-        // TODO fullscreen is supported
-        // TODO This algorithm is allowed to request fullscreen.
+
+        if PREFS
+            .get("dom.fullscreen.test")
+            .as_boolean()
+            .unwrap_or(false)
+        {
+            // For reftests we just take over the current window,
+            // and don't try to really enter fullscreen.
+            info!("Tests don't really enter fullscreen.");
+        } else {
+            // TODO fullscreen is supported
+            // TODO This algorithm is allowed to request fullscreen.
+            warn!("Fullscreen not supported yet");
+        }
 
         // Step 5 Parallel start
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -6965,6 +6965,30 @@
      {}
     ]
    ],
+   "mozilla/fullscreen/reftests/fullscreen-baseline.html": [
+    [
+     "/_mozilla/mozilla/fullscreen/reftests/fullscreen-baseline.html",
+     [
+      [
+       "/_mozilla/mozilla/fullscreen/reftests/fullscreen-baseline-ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
+   "mozilla/fullscreen/reftests/fullscreen-hides-others.html": [
+    [
+     "/_mozilla/mozilla/fullscreen/reftests/fullscreen-hides-others.html",
+     [
+      [
+       "/_mozilla/mozilla/fullscreen/reftests/fullscreen-baseline-ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "mozilla/iframe/resize_after_load.html": [
     [
      "/_mozilla/mozilla/iframe/resize_after_load.html",
@@ -10331,6 +10355,11 @@
     ]
    ],
    "mozilla/form_submit_about_frame.html": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/fullscreen/reftests/fullscreen-baseline-ref.html": [
     [
      {}
     ]
@@ -19344,6 +19373,18 @@
   "mozilla/fullscreen-remove-single.html": [
    "1e3246f791df31532c32a816a14e4e3959582146",
    "testharness"
+  ],
+  "mozilla/fullscreen/reftests/fullscreen-baseline-ref.html": [
+   "7272fa8b6e84979d5fad66bfe8c906d6e714cdb4",
+   "support"
+  ],
+  "mozilla/fullscreen/reftests/fullscreen-baseline.html": [
+   "80503a9befe86e8cbd109eaf870f41c92a1952b2",
+   "reftest"
+  ],
+  "mozilla/fullscreen/reftests/fullscreen-hides-others.html": [
+   "83a9abd907fc899dcfb60bab24691feb25878f7c",
+   "reftest"
   ],
   "mozilla/getBoundingClientRect.html": [
    "a8e92d836330126f6ccc4a13354368e223d260da",

--- a/tests/wpt/mozilla/meta/mozilla/fullscreen/reftests/__dir__.ini
+++ b/tests/wpt/mozilla/meta/mozilla/fullscreen/reftests/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: ["dom.fullscreen.test:true"]

--- a/tests/wpt/mozilla/meta/mozilla/fullscreen/reftests/fullscreen-hides-others.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/fullscreen/reftests/fullscreen-hides-others.html.ini
@@ -1,0 +1,3 @@
+[fullscreen-hides-others.html]
+  type: reftest
+  expected: FAIL

--- a/tests/wpt/mozilla/tests/mozilla/fullscreen/reftests/fullscreen-baseline-ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/fullscreen/reftests/fullscreen-baseline-ref.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<head>
+  <meta charset=utf-8>
+  <title>Baseline fullscreen reference</title>
+  <style>
+    div {
+      position: fixed; top: 0; left: 0;
+      height: 100%; width: 100%;
+      background: green;
+    }
+  </style>
+</head>
+<body>
+  <div>0</div>
+</body>

--- a/tests/wpt/mozilla/tests/mozilla/fullscreen/reftests/fullscreen-baseline.html
+++ b/tests/wpt/mozilla/tests/mozilla/fullscreen/reftests/fullscreen-baseline.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<head>
+  <meta charset=utf-8>
+  <title>Baseline fullscreen</title>
+  <link rel=match href=fullscreen-baseline-ref.html>
+  <style>
+    div { background: red; }
+    #it { background: green; }
+  </style>
+</head>
+<body>
+  <div>-1</div>
+  <div id="it">0</div>
+  <div>1</div>
+</body>
+<script>
+  document.getElementById("it").requestFullscreen();
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/fullscreen/reftests/fullscreen-hides-others.html
+++ b/tests/wpt/mozilla/tests/mozilla/fullscreen/reftests/fullscreen-hides-others.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<head>
+  <meta charset=utf-8>
+  <title>Elements which try to get in front of fullscreen</title>
+  <link rel=match href=fullscreen-baseline-ref.html>
+  <style>
+    div { background: red; }
+    #it { background: green; }
+
+    /* Fixed elements should not show up in front of fullscreen elements */
+    .fixed { position: fixed; top: 0; left: 0; background: blue; }
+
+    /* Elements with a large z-index (even the maximum u32)
+       should not show up in front of fullscreen elements */
+    .zindex { z-index: 4294967295; background: yellow; }
+  </style>
+</head>
+<body>
+  <div>-4</div>
+  <div class="fixed zindex">-3</div>
+  <div class="fixed">-2</div>
+  <div class="zindex">-1</div>
+  <div id="it">0</div>
+  <div>1</div>
+  <div class="fixed zindex">2</div>
+  <div class="fixed">3</div>
+  <div class="zindex">4</div>
+</body>
+<script>
+  document.getElementById("it").requestFullscreen();
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Add a baseline reftest for fullscreen that ensures that going fullscreen actually uses the whole window. This uses a pref that requests that fullscreen mode takes over the window rather than the whole screen. The pref doesn't do anything right now, but is a bit of future-proofing for when we do have proper fullscreen.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22804.
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22809)
<!-- Reviewable:end -->
