### PR TITLE
Enable webvr by default

### DIFF
--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -19,7 +19,7 @@
   "dom.webgl.dom_to_texture.enabled": false,
   "dom.webgl2.enabled": false,
   "dom.webrtc.enabled": false,
-  "dom.webvr.enabled": false,
+  "dom.webvr.enabled": true,
   "dom.webvr.event_polling_interval": 500,
   "gfx.subpixel-text-antialiasing.enabled": true,
   "js.asmjs.enabled": true,


### PR DESCRIPTION
We don't have to, and I'm not sure what the policy is when it comes to enabling such features.

But I often forget to toggle that pref.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22822)
<!-- Reviewable:end -->
