### PR TITLE
Implement HTMLMediaElement.crossorigin

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -161,7 +161,7 @@ pub struct HTMLMediaElement {
     src_object: MutNullableDom<Blob>,
     /// <https://html.spec.whatwg.org/multipage/#dom-media-currentsrc>
     current_src: DomRefCell<String>,
-    /// <https://html.spec.whatwg.org/multipage/media.html#attr-media-crossorigin>
+    /// <https://html.spec.whatwg.org/multipage/#attr-media-crossorigin>
     cross_origin: DomRefCell<String>,
     /// Incremented whenever tasks associated with this element are cancelled.
     generation_id: Cell<u32>,
@@ -1446,11 +1446,11 @@ impl HTMLMediaElementMethods for HTMLMediaElement {
         USVString(self.current_src.borrow().clone())
     }
 
-    // https://html.spec.whatwg.org/multipage/media.html#attr-media-crossorigin
+    // https://html.spec.whatwg.org/multipage/#attr-media-crossorigin
     fn CrossOrigin(&self) -> DOMString {
         DOMString::from_string(self.cross_origin.borrow().clone())
     }
-    // https://html.spec.whatwg.org/multipage/media.html#attr-media-crossorigin
+    // https://html.spec.whatwg.org/multipage/#attr-media-crossorigin
     make_setter!(SetCrossOrigin, "crossorigin");
 
     // https://html.spec.whatwg.org/multipage/#dom-media-load

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -53,6 +53,8 @@ use ipc_channel::router::ROUTER;
 use mime::{self, Mime};
 use net_traits::image::base::Image;
 use net_traits::image_cache::ImageResponse;
+use net_traits::request::CorsSettings;
+use net_traits::request::RequestMode;
 use net_traits::request::{CredentialsMode, Destination, RequestInit};
 use net_traits::{CoreResourceMsg, FetchChannels, FetchMetadata, FetchResponseListener, Metadata};
 use net_traits::{NetworkError, ResourceFetchTiming, ResourceTimingType};
@@ -71,8 +73,6 @@ use std::sync::{Arc, Mutex};
 use time::{self, Duration, Timespec};
 use webrender_api::{ImageData, ImageDescriptor, ImageFormat, ImageKey, RenderApi};
 use webrender_api::{RenderApiSender, Transaction};
-use net_traits::request::RequestMode;
-use net_traits::request::CorsSettings;
 
 pub struct MediaFrameRenderer {
     api: RenderApi,
@@ -293,7 +293,7 @@ impl HTMLMediaElement {
         return match self.CrossOrigin().as_ref() {
             "anonymous" => Some(CorsSettings::Anonymous),
             "use-credentials" => Some(CorsSettings::UseCredentials),
-            _ => None
+            _ => None,
         };
     }
 
@@ -676,11 +676,11 @@ impl HTMLMediaElement {
             destination,
             mode: match cors_settings {
                 Some(_) => RequestMode::CorsMode,
-                None => RequestMode::NoCors
+                None => RequestMode::NoCors,
             },
             credentials_mode: match cors_settings {
                 Some(CorsSettings::Anonymous) => CredentialsMode::CredentialsSameOrigin,
-                _ => CredentialsMode::Include
+                _ => CredentialsMode::Include,
             },
             use_url_credentials: true,
             origin: document.origin().immutable().clone(),

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1415,6 +1415,16 @@ impl HTMLMediaElementMethods for HTMLMediaElement {
         self.media_element_load_algorithm();
     }
 
+    // https://html.spec.whatwg.org/multipage/media.html#attr-media-crossorigin
+    fn GetCrossOrigin(&self) {
+        self.cross_origin.get();
+    }
+
+    // https://html.spec.whatwg.org/multipage/media.html#attr-media-crossorigin
+    fn SetCrossOrigin(&self, value: Option<DOMString>) {
+        self.cross_origin.set(value);
+    }
+
     // https://html.spec.whatwg.org/multipage/#attr-media-preload
     // Missing value default is user-agent defined.
     make_enumerated_getter!(Preload, "preload", "", "none" | "metadata" | "auto");

--- a/components/script/dom/webidls/HTMLMediaElement.webidl
+++ b/components/script/dom/webidls/HTMLMediaElement.webidl
@@ -16,7 +16,7 @@ interface HTMLMediaElement : HTMLElement {
   [CEReactions] attribute USVString src;
   attribute MediaProvider? srcObject;
   readonly attribute USVString currentSrc;
-  // [CEReactions] attribute DOMString crossOrigin;
+  [CEReactions] attribute DOMString crossOrigin;
   const unsigned short NETWORK_EMPTY = 0;
   const unsigned short NETWORK_IDLE = 1;
   const unsigned short NETWORK_LOADING = 2;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
1. uncommented HTMLMediaElement webidl
2. added getter and setter to HTMLMedieElementMethods trait implementation
3. added logic to modify RequestInit values based on value of CorsSettings property.  added cross origin property to html media elment struct.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22287  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because "the test expectations seem to already cover the new property, and there was no impact on the test results"

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22824)
<!-- Reviewable:end -->
