### PR TITLE
Some tweaks in libsimpleservo C API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3936,6 +3936,7 @@ source = "git+https://github.com/pcwalton/signpost.git#7ed712507f343c38646b9d1fe
 name = "simpleservo"
 version = "0.0.1"
 dependencies = [
+ "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "libservo 0.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3949,6 +3949,7 @@ dependencies = [
 name = "simpleservo_capi"
 version = "0.0.1"
 dependencies = [
+ "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "simpleservo 0.0.1",
 ]

--- a/ports/libsimpleservo/api/Cargo.toml
+++ b/ports/libsimpleservo/api/Cargo.toml
@@ -14,6 +14,9 @@ serde_json = "1.0"
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 libc = "0.2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.6"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = "0.3.2"
 

--- a/ports/libsimpleservo/api/src/gl_glue.rs
+++ b/ports/libsimpleservo/api/src/gl_glue.rs
@@ -2,9 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::rc::Rc;
-
-pub type ServoGl = Rc<dyn servo::gl::Gl>;
+pub type ServoGl = std::rc::Rc<dyn servo::gl::Gl>;
 
 #[cfg(any(target_os = "android", target_os = "windows"))]
 #[allow(non_camel_case_types)]
@@ -56,7 +54,7 @@ pub mod egl {
     }
 
     #[cfg(target_os = "windows")]
-    pub fn init() -> Result<Rc<Gl>, &'static str> {
+    pub fn init() -> Result<crate::gl_glue::ServoGl, &'static str> {
         info!("Loading EGL...");
 
         let dll = b"libEGL.dll\0" as &[u8];
@@ -77,10 +75,38 @@ pub mod egl {
     }
 }
 
-#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 pub mod gl {
     pub fn init() -> Result<crate::gl_glue::ServoGl, &'static str> {
-        // FIXME: Add an OpenGL version
-        unimplemented!()
+        unimplemented!();
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub mod gl {
+    use core_foundation::base::TCFType;
+    use core_foundation::bundle::{
+        CFBundleGetBundleWithIdentifier, CFBundleGetFunctionPointerForName,
+    };
+    use core_foundation::string::CFString;
+    use servo::gl::GlFns;
+    use std::os::raw::c_void;
+    use std::str;
+
+    pub fn init() -> Result<crate::gl_glue::ServoGl, &'static str> {
+        info!("Loading OpenGL...");
+        let gl = unsafe {
+            GlFns::load_with(|addr| {
+                let symbol_name: CFString = str::FromStr::from_str(addr).unwrap();
+                let framework_name: CFString = str::FromStr::from_str("com.apple.opengl").unwrap();
+                let framework =
+                    CFBundleGetBundleWithIdentifier(framework_name.as_concrete_TypeRef());
+                let symbol =
+                    CFBundleGetFunctionPointerForName(framework, symbol_name.as_concrete_TypeRef());
+                symbol as *const c_void
+            })
+        };
+        info!("OpenGL loaded");
+        Ok(gl)
     }
 }

--- a/ports/libsimpleservo/capi/Cargo.toml
+++ b/ports/libsimpleservo/capi/Cargo.toml
@@ -15,6 +15,7 @@ bench = false
 [dependencies]
 simpleservo = { path = "../api" }
 log = "0.4"
+env_logger = "0.6"
 
 [features]
 default = ["unstable", "default-except-unstable"]

--- a/ports/libsimpleservo/capi/src/lib.rs
+++ b/ports/libsimpleservo/capi/src/lib.rs
@@ -5,6 +5,7 @@
 #[macro_use]
 extern crate log;
 
+use env_logger;
 use simpleservo::{self, gl_glue, EventLoopWaker, HostTrait, InitOptions, ServoGlue, SERVO};
 use std::ffi::{CStr, CString};
 use std::mem;
@@ -68,6 +69,8 @@ fn init(
     wakeup: extern "C" fn(),
     callbacks: CHostCallbacks,
 ) {
+    crate::env_logger::init();
+
     let args = unsafe { CStr::from_ptr(opts.args) };
     let args = args.to_str().map(|s| s.to_string()).ok();
 


### PR DESCRIPTION
- Adding logs.
- Adding OpenGL support for OSX.
- Fixing file reading issue.

With this, I can load Servo into a C app (with the C version of libui + https://github.com/andlabs/libui/pull/405).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22832)
<!-- Reviewable:end -->
