### PR TITLE
Add test infrastructure for WebVR reftests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4838,8 +4838,11 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "rust-webvr 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr-api 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
  "servo_config 0.0.1",
+ "servo_geometry 0.0.1",
+ "style_traits 0.0.1",
  "webvr_traits 0.0.1",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3310,8 +3310,8 @@ dependencies = [
 
 [[package]]
 name = "rust-webvr"
-version = "0.9.17"
-source = "git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag#51d5a63d41aade01f0c2c442cc0e1cdc2331ba9c"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3320,13 +3320,13 @@ dependencies = [
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ovr-mobile-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-webvr-api 0.9.3 (git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag)",
+ "rust-webvr-api 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rust-webvr-api"
-version = "0.9.3"
-source = "git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag#51d5a63d41aade01f0c2c442cc0e1cdc2331ba9c"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_injected_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4837,8 +4837,8 @@ dependencies = [
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "rust-webvr 0.9.17 (git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag)",
- "rust-webvr-api 0.9.3 (git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag)",
+ "rust-webvr 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr-api 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
  "servo_config 0.0.1",
  "servo_geometry 0.0.1",
@@ -4852,7 +4852,7 @@ version = "0.0.1"
 dependencies = [
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "rust-webvr-api 0.9.3 (git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag)",
+ "rust-webvr-api 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5330,8 +5330,8 @@ dependencies = [
 "checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "da06feaa07f69125ab9ddc769b11de29090122170b402547f64b86fe16ebc399"
-"checksum rust-webvr 0.9.17 (git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag)" = "<none>"
-"checksum rust-webvr-api 0.9.3 (git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag)" = "<none>"
+"checksum rust-webvr 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "971e5c60463f9abb9110210761d78a5b01a844e3ac24973ed0d86aa32db49709"
+"checksum rust-webvr-api 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d54f1423df09c01a1937133229d3617bf40cdbc473f0decd98b6013e6c2fef5"
 "checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusttype 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b8eb11f5b0a98c8eca2fb1483f42646d8c340e83e46ab416f8a063a0fd0eeb20"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "rust-webvr"
 version = "0.9.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag#51d5a63d41aade01f0c2c442cc0e1cdc2331ba9c"
 dependencies = [
  "bindgen 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3320,13 +3320,13 @@ dependencies = [
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ovr-mobile-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-webvr-api 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr-api 0.9.3 (git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag)",
 ]
 
 [[package]]
 name = "rust-webvr-api"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag#51d5a63d41aade01f0c2c442cc0e1cdc2331ba9c"
 dependencies = [
  "android_injected_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4837,8 +4837,8 @@ dependencies = [
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "rust-webvr 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-webvr-api 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr 0.9.17 (git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag)",
+ "rust-webvr-api 0.9.3 (git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag)",
  "script_traits 0.0.1",
  "servo_config 0.0.1",
  "servo_geometry 0.0.1",
@@ -4852,7 +4852,7 @@ version = "0.0.1"
 dependencies = [
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "rust-webvr-api 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr-api 0.9.3 (git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5330,8 +5330,8 @@ dependencies = [
 "checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "da06feaa07f69125ab9ddc769b11de29090122170b402547f64b86fe16ebc399"
-"checksum rust-webvr 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)" = "c44fadb2f8b67a3ee909c158e0bdd0c1c2f21cab7d37c8f30cd8955419ece9a7"
-"checksum rust-webvr-api 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "daf1b163d8522d2b25ec99de77785573dbd2db4825df515d241d3d5408b958d5"
+"checksum rust-webvr 0.9.17 (git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag)" = "<none>"
+"checksum rust-webvr-api 0.9.3 (git+https://github.com/asajeffrey/rust-webvr.git?branch=vrdisplay-presented-by-browser-flag)" = "<none>"
 "checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusttype 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b8eb11f5b0a98c8eca2fb1483f42646d8c340e83e46ab416f8a063a0fd0eeb20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ opt-level = 3
 # lto = false
 
 [patch.crates-io]
+rust-webvr = { git = "https://github.com/asajeffrey/rust-webvr.git", branch = "vrdisplay-presented-by-browser-flag" }
+rust-webvr-api = { git = "https://github.com/asajeffrey/rust-webvr.git", branch = "vrdisplay-presented-by-browser-flag" }
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,6 @@ opt-level = 3
 # lto = false
 
 [patch.crates-io]
-rust-webvr = { git = "https://github.com/asajeffrey/rust-webvr.git", branch = "vrdisplay-presented-by-browser-flag" }
-rust-webvr-api = { git = "https://github.com/asajeffrey/rust-webvr.git", branch = "vrdisplay-presented-by-browser-flag" }
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:
 #

--- a/components/script/dom/vrdisplay.rs
+++ b/components/script/dom/vrdisplay.rs
@@ -516,7 +516,7 @@ impl VRDisplay {
         // Enter fullscreen mode.
         // TODO: fullscreen mode isn't quite right because
         // a) it requires the element to be attached to the DOM tree, and
-        // b) it fullscreens the element together with it's CSS styling.
+        // b) it fullscreens the element together with its CSS styling.
         if let Some(old) = self.layer_ctx.get() {
             debug!("VR exiting full screen mode");
             let canvas = old.Canvas();
@@ -725,7 +725,7 @@ impl VRDisplay {
 
     fn using_dedicated_raf_thread(&self) -> bool {
         // We spin up a dedicated rAF thread when we're presenting, and
-        // when the display does it's own presentation rather than asking
+        // when the display does its own presentation rather than asking
         // the browser to do it.
         self.presenting.get() && !self.display.borrow().capabilities.presented_by_browser
     }

--- a/components/webvr/Cargo.toml
+++ b/components/webvr/Cargo.toml
@@ -21,8 +21,8 @@ euclid = "0.19"
 ipc-channel = "0.11"
 log = "0.4"
 msg = {path = "../msg"}
-rust-webvr-api = "0.9"
-rust-webvr = {version = "0.9", features = ["openvr", "vrexternal"]}
+rust-webvr-api = "0.10"
+rust-webvr = {version = "0.10", features = ["openvr", "vrexternal"]}
 style_traits = {path = "../style_traits"}
 script_traits = {path = "../script_traits"}
 servo_config = {path = "../config"}

--- a/components/webvr/Cargo.toml
+++ b/components/webvr/Cargo.toml
@@ -21,7 +21,10 @@ euclid = "0.19"
 ipc-channel = "0.11"
 log = "0.4"
 msg = {path = "../msg"}
+rust-webvr-api = "0.9"
 rust-webvr = {version = "0.9", features = ["openvr", "vrexternal"]}
+style_traits = {path = "../style_traits"}
 script_traits = {path = "../script_traits"}
 servo_config = {path = "../config"}
+servo_geometry = {path = "../geometry"}
 webvr_traits = {path = "../webvr_traits" }

--- a/components/webvr/lib.rs
+++ b/components/webvr/lib.rs
@@ -3,10 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![feature(stmt_expr_attributes)]
 
 #[macro_use]
 extern crate log;
 
+mod webvr_test;
 mod webvr_thread;
 pub use crate::webvr_thread::{WebVRCompositorHandler, WebVRThread};
 pub use rust_webvr::api::VRExternalShmemPtr;

--- a/components/webvr/webvr_test.rs
+++ b/components/webvr/webvr_test.rs
@@ -8,6 +8,7 @@
 
 use euclid::Angle;
 use euclid::Trig;
+use euclid::TypedScale;
 use euclid::TypedSize2D;
 use rust_webvr_api::VRDisplay;
 use rust_webvr_api::VRDisplayCapabilities;
@@ -23,6 +24,8 @@ use rust_webvr_api::VRGamepadPtr;
 use rust_webvr_api::VRLayer;
 use rust_webvr_api::VRService;
 use rust_webvr_api::VRViewport;
+use servo_config::opts;
+use servo_geometry::DeviceIndependentPixel;
 use std::cell::RefCell;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::Relaxed;
@@ -240,10 +243,15 @@ impl VRService for TestVRService {
 }
 
 impl TestVRService {
-    pub fn new(size: TypedSize2D<u32, DevicePixel>) -> TestVRService {
+    pub fn new() -> TestVRService {
+        // Rather annoyingly there's no easy way to get the window size
+        // from the constellation, so we guess based on the options.
+        let size = opts::get().initial_window_size;
+        let hidpi: TypedScale<u32, DeviceIndependentPixel, DevicePixel> =
+            TypedScale::new(opts::get().device_pixels_per_px.unwrap_or(1.0) as u32);
         TestVRService {
             display: None,
-            size: size,
+            size: size * hidpi,
         }
     }
 }

--- a/components/webvr/webvr_test.rs
+++ b/components/webvr/webvr_test.rs
@@ -1,0 +1,248 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This module implements a test WebVR display, which renders to the screen
+// in the same way as fullscreen does. It gets its render size from the current
+// size of the window.
+
+use euclid::Angle;
+use euclid::Trig;
+use euclid::TypedSize2D;
+use rust_webvr_api::VRDisplay;
+use rust_webvr_api::VRDisplayCapabilities;
+use rust_webvr_api::VRDisplayData;
+use rust_webvr_api::VRDisplayPtr;
+use rust_webvr_api::VREvent;
+use rust_webvr_api::VREyeParameters;
+use rust_webvr_api::VRFieldOfView;
+use rust_webvr_api::VRFrameData;
+use rust_webvr_api::VRFramebuffer;
+use rust_webvr_api::VRFramebufferAttributes;
+use rust_webvr_api::VRGamepadPtr;
+use rust_webvr_api::VRLayer;
+use rust_webvr_api::VRService;
+use rust_webvr_api::VRViewport;
+use std::cell::RefCell;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Arc;
+use style_traits::DevicePixel;
+
+pub type TestVRDisplayPtr = Arc<RefCell<TestVRDisplay>>;
+
+// This is very very unsafe, but the API requires it.
+#[allow(unsafe_code)]
+unsafe impl Sync for TestVRService {}
+#[allow(unsafe_code)]
+unsafe impl Send for TestVRService {}
+
+pub struct TestVRService {
+    display: Option<TestVRDisplayPtr>,
+    size: TypedSize2D<u32, DevicePixel>,
+}
+
+pub struct TestVRDisplay {
+    timestamp: AtomicUsize,
+    size: TypedSize2D<u32, DevicePixel>,
+}
+
+// Each Test device only has one display
+const DISPLAY_ID: u32 = 1;
+const DISPLAY_NAME: &str = "Test Display";
+
+// Fake a display with a distance between eyes of 5cm.
+const EYE_DISTANCE: f32 = 0.05;
+
+impl VRDisplay for TestVRDisplay {
+    fn id(&self) -> u32 {
+        DISPLAY_ID
+    }
+
+    fn data(&self) -> VRDisplayData {
+        let capabilities = VRDisplayCapabilities {
+            has_position: false,
+            has_orientation: false,
+            has_external_display: false,
+            can_present: true,
+            max_layers: 1,
+        };
+
+        let fov_right = self.fov_right().to_degrees();
+        let fov_up = self.fov_up().to_degrees();
+
+        let field_of_view = VRFieldOfView {
+            down_degrees: fov_up,
+            left_degrees: fov_right,
+            right_degrees: fov_right,
+            up_degrees: fov_up,
+        };
+
+        let left_eye_parameters = VREyeParameters {
+            offset: [-EYE_DISTANCE / 2.0, 0.0, 0.0],
+            render_width: self.size.width / 2,
+            render_height: self.size.height,
+            field_of_view: field_of_view,
+        };
+
+        let right_eye_parameters = VREyeParameters {
+            offset: [EYE_DISTANCE / 2.0, 0.0, 0.0],
+            ..left_eye_parameters.clone()
+        };
+
+        VRDisplayData {
+            display_id: DISPLAY_ID,
+            display_name: String::from(DISPLAY_NAME),
+            connected: true,
+            capabilities: capabilities,
+            stage_parameters: None,
+            left_eye_parameters: left_eye_parameters,
+            right_eye_parameters: right_eye_parameters,
+        }
+    }
+
+    fn immediate_frame_data(&self, near: f64, far: f64) -> VRFrameData {
+        let left_projection_matrix = self.perspective(near, far);
+        let right_projection_matrix = left_projection_matrix.clone();
+
+        VRFrameData {
+            timestamp: self.timestamp.fetch_add(1, Relaxed) as f64,
+            // TODO: adjust matrices for stereoscopic vision
+            left_projection_matrix: left_projection_matrix,
+            right_projection_matrix: right_projection_matrix,
+            ..VRFrameData::default()
+        }
+    }
+
+    fn synced_frame_data(&self, near: f64, far: f64) -> VRFrameData {
+        self.immediate_frame_data(near, far)
+    }
+
+    fn reset_pose(&mut self) {}
+
+    fn sync_poses(&mut self) {}
+
+    fn bind_framebuffer(&mut self, _eye_index: u32) {}
+
+    fn get_framebuffers(&self) -> Vec<VRFramebuffer> {
+        let left_viewport = VRViewport {
+            x: 0,
+            y: 0,
+            width: (self.size.width as i32) / 2,
+            height: self.size.height as i32,
+        };
+
+        let right_viewport = VRViewport {
+            x: self.size.width as i32 - left_viewport.width,
+            ..left_viewport
+        };
+
+        vec![
+            VRFramebuffer {
+                eye_index: 0,
+                attributes: VRFramebufferAttributes::default(),
+                viewport: left_viewport,
+            },
+            VRFramebuffer {
+                eye_index: 1,
+                attributes: VRFramebufferAttributes::default(),
+                viewport: right_viewport,
+            },
+        ]
+    }
+
+    fn render_layer(&mut self, layer: &VRLayer) {
+        if let Some((width, height)) = layer.texture_size {
+            self.size = TypedSize2D::new(width, height);
+        }
+    }
+
+    fn submit_frame(&mut self) {}
+
+    fn start_present(&mut self, _attributes: Option<VRFramebufferAttributes>) {}
+
+    fn stop_present(&mut self) {}
+}
+
+impl TestVRDisplay {
+    pub fn new(size: TypedSize2D<u32, DevicePixel>) -> TestVRDisplay {
+        TestVRDisplay {
+            timestamp: AtomicUsize::new(0),
+            size: size,
+        }
+    }
+
+    fn fov_up(&self) -> Angle<f64> {
+        Angle::radians(f64::fast_atan2(
+            2.0 * self.size.height as f64,
+            self.size.width as f64,
+        ))
+    }
+
+    fn fov_right(&self) -> Angle<f64> {
+        Angle::radians(f64::fast_atan2(
+            2.0 * self.size.width as f64,
+            self.size.height as f64,
+        ))
+    }
+
+    fn perspective(&self, near: f64, far: f64) -> [f32; 16] {
+        // https://github.com/toji/gl-matrix/blob/bd3307196563fbb331b40fc6ebecbbfcc2a4722c/src/mat4.js#L1271
+        let near = near as f32;
+        let far = far as f32;
+        let f = 1.0 / self.fov_up().radians.tan() as f32;
+        let nf = 1.0 / (near - far);
+        let aspect = ((self.size.width / 2) as f32) / (self.size.height as f32);
+
+        // Dear rustfmt, This is a 4x4 matrix, please leave it alone. Best, ajeffrey.
+        #[rustfmt::skip]
+        [
+            f / aspect, 0.0, 0.0,                   0.0,
+            0.0,        f,   0.0,                   0.0,
+            0.0,        0.0, (far + near) * nf,     -1.0,
+            0.0,        0.0, 2.0 * far * near * nf, 0.0,
+        ]
+    }
+}
+
+impl VRService for TestVRService {
+    fn initialize(&mut self) -> Result<(), String> {
+        if self.display.is_some() {
+            return Ok(());
+        }
+
+        self.display = Some(Arc::new(RefCell::new(TestVRDisplay::new(self.size))));
+
+        Ok(())
+    }
+
+    fn fetch_displays(&mut self) -> Result<Vec<VRDisplayPtr>, String> {
+        self.initialize()?;
+        self.display
+            .iter()
+            .map(|display| Ok(display.clone() as VRDisplayPtr))
+            .collect()
+    }
+
+    fn fetch_gamepads(&mut self) -> Result<Vec<VRGamepadPtr>, String> {
+        self.initialize()?;
+        Ok(vec![])
+    }
+
+    fn is_available(&self) -> bool {
+        true
+    }
+
+    fn poll_events(&self) -> Vec<VREvent> {
+        Vec::new()
+    }
+}
+
+impl TestVRService {
+    pub fn new(size: TypedSize2D<u32, DevicePixel>) -> TestVRService {
+        TestVRService {
+            display: None,
+            size: size,
+        }
+    }
+}

--- a/components/webvr/webvr_test.rs
+++ b/components/webvr/webvr_test.rs
@@ -65,6 +65,7 @@ impl VRDisplay for TestVRDisplay {
             has_orientation: false,
             has_external_display: false,
             can_present: true,
+            presented_by_browser: true,
             max_layers: 1,
         };
 

--- a/components/webvr/webvr_thread.rs
+++ b/components/webvr/webvr_thread.rs
@@ -7,18 +7,14 @@ use crate::VRExternalShmemPtr;
 use canvas_traits::webgl;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use euclid::Size2D;
-use euclid::TypedScale;
 use ipc_channel::ipc;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use msg::constellation_msg::PipelineId;
 use rust_webvr::VRServiceManager;
 use script_traits::ConstellationMsg;
-use servo_config::opts;
 use servo_config::prefs::PREFS;
-use servo_geometry::DeviceIndependentPixel;
 use std::collections::{HashMap, HashSet};
 use std::{thread, time};
-use style_traits::DevicePixel;
 use webvr_traits::webvr::*;
 use webvr_traits::{WebVRMsg, WebVRResult};
 
@@ -68,12 +64,7 @@ impl WebVRThread {
 
         // If the pref is set, install a test WebVR display
         if PREFS.get("dom.webvr.test").as_boolean().unwrap_or(false) {
-            // Rather annoyingly there's no easy way to get the window size
-            // from the constellation, so we guess based on the options.
-            let size = opts::get().initial_window_size;
-            let hidpi: TypedScale<u32, DeviceIndependentPixel, DevicePixel> =
-                TypedScale::new(opts::get().device_pixels_per_px.unwrap_or(1.0) as u32);
-            service.register(Box::new(TestVRService::new(size * hidpi)));
+            service.register(Box::new(TestVRService::new()));
         }
 
         WebVRThread {

--- a/components/webvr/webvr_thread.rs
+++ b/components/webvr/webvr_thread.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::VRExternalShmemPtr;
 use crate::webvr_test::TestVRService;
+use crate::VRExternalShmemPtr;
 use canvas_traits::webgl;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use euclid::Size2D;

--- a/components/webvr/webvr_thread.rs
+++ b/components/webvr/webvr_thread.rs
@@ -3,17 +3,22 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::VRExternalShmemPtr;
+use crate::webvr_test::TestVRService;
 use canvas_traits::webgl;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use euclid::Size2D;
+use euclid::TypedScale;
 use ipc_channel::ipc;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use msg::constellation_msg::PipelineId;
 use rust_webvr::VRServiceManager;
 use script_traits::ConstellationMsg;
+use servo_config::opts;
 use servo_config::prefs::PREFS;
+use servo_geometry::DeviceIndependentPixel;
 use std::collections::{HashMap, HashSet};
 use std::{thread, time};
+use style_traits::DevicePixel;
 use webvr_traits::webvr::*;
 use webvr_traits::{WebVRMsg, WebVRResult};
 
@@ -60,6 +65,17 @@ impl WebVRThread {
         if let Some(ptr) = webvr_shmem {
             service.register_vrexternal(ptr);
         }
+
+        // If the pref is set, install a test WebVR display
+        if PREFS.get("dom.webvr.test").as_boolean().unwrap_or(false) {
+            // Rather annoyingly there's no easy way to get the window size
+            // from the constellation, so we guess based on the options.
+            let size = opts::get().initial_window_size;
+            let hidpi: TypedScale<u32, DeviceIndependentPixel, DevicePixel> =
+                TypedScale::new(opts::get().device_pixels_per_px.unwrap_or(1.0) as u32);
+            service.register(Box::new(TestVRService::new(size * hidpi)));
+        }
+
         WebVRThread {
             receiver: receiver,
             sender: sender,

--- a/components/webvr_traits/Cargo.toml
+++ b/components/webvr_traits/Cargo.toml
@@ -13,5 +13,5 @@ path = "lib.rs"
 [dependencies]
 ipc-channel = "0.11"
 msg = {path = "../msg"}
-rust-webvr-api = {version = "0.9", features = ["serde-serialization"]}
+rust-webvr-api = {version = "0.10", features = ["serde-serialization"]}
 serde = "1.0"

--- a/resources/user-agent.css
+++ b/resources/user-agent.css
@@ -303,6 +303,9 @@ textarea { white-space: pre-wrap; }
   /* intentionally not !important */
   object-fit:contain;
 
+  /* A work-around for https://github.com/servo/servo/issues/19771 */
+  display: block !important;
+
   /* The internal-only -servo-top-layer attribute is used
      to implement https://fullscreen.spec.whatwg.org/#top-layer */
   -servo-top-layer: top;

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -7277,6 +7277,18 @@
      {}
     ]
    ],
+   "mozilla/webvr/reftests/webvr-baseline.html": [
+    [
+     "/_mozilla/mozilla/webvr/reftests/webvr-baseline.html",
+     [
+      [
+       "/_mozilla/mozilla/webvr/reftests/webvr-baseline-ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "mozilla/worklets/test_paint_worklet.html": [
     [
      "/_mozilla/mozilla/worklets/test_paint_worklet.html",
@@ -10645,6 +10657,11 @@
     ]
    ],
    "mozilla/webgl/tex_image_2d_simple_ref.html": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/webvr/reftests/webvr-baseline-ref.html": [
     [
      {}
     ]
@@ -20171,6 +20188,14 @@
   "mozilla/websocket_connection_fail.html": [
    "95c56636d53407fd9f18cb089bdd05bad5b1a4d9",
    "testharness"
+  ],
+  "mozilla/webvr/reftests/webvr-baseline-ref.html": [
+   "d3114d13b36738da12b88fbf15833a4542a65866",
+   "support"
+  ],
+  "mozilla/webvr/reftests/webvr-baseline.html": [
+   "5b046dbfa0697ec562e883dfb20723bf71015e46",
+   "reftest"
   ],
   "mozilla/window-postmessage-sameorigin.html": [
    "a3ec80929b784c6d5c766fe4cf9d99996cb8850b",

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -20194,7 +20194,7 @@
    "support"
   ],
   "mozilla/webvr/reftests/webvr-baseline.html": [
-   "5b046dbfa0697ec562e883dfb20723bf71015e46",
+   "80e29ab09deddad34e0793c885df87f370244bb9",
    "reftest"
   ],
   "mozilla/window-postmessage-sameorigin.html": [

--- a/tests/wpt/mozilla/meta/mozilla/webvr/reftests/__dir__.ini
+++ b/tests/wpt/mozilla/meta/mozilla/webvr/reftests/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: ["dom.webvr.enabled:true","dom.webvr.test:true"]

--- a/tests/wpt/mozilla/tests/mozilla/webvr/reftests/webvr-baseline-ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/webvr/reftests/webvr-baseline-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>WebVR baseline test reference</title>
+    <style>
+      div { position: fixed; top: 0; height: 100%; width: 50%; }
+      #left { left: 0px; background: #00FF00; }
+      #right { right: 0px; background: #0000FF; }
+    </style>
+  </head>
+  <body>
+    <div id="left"></div>
+    <div id="right"></div>
+  </body>
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/webvr/reftests/webvr-baseline.html
+++ b/tests/wpt/mozilla/tests/mozilla/webvr/reftests/webvr-baseline.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <head>
+    <link rel="match" href="webvr-baseline-ref.html"></link>
+    <meta charset="utf-8" />
+    <title>WebVR baseline test</title>
+  </head>
+  <body>
+    The canvas: <canvas id="canvas" width="640" height="480"></canvas>
+  </body>
+  <script>
+var canvas = document.getElementById("canvas");
+var gl = canvas.getContext("webgl");
+var display = null;
+gl.clearColor(1.0, 0.0, 0.0, 1.0);
+gl.clear(gl.COLOR_BUFFER_BIT);
+
+navigator.getVRDisplays()
+    .then(function (displays) { display = displays[0]; })
+    .then(function () { display.requestPresent([{ source: canvas }]); })
+    .then(function () { display.requestAnimationFrame(rAF); });
+
+function rAF() {
+  var frameData = new VRFrameData();
+  var leftEye = display.getEyeParameters("left");
+  var rightEye = display.getEyeParameters("right");
+
+  canvas.width = leftEye.renderWidth + rightEye.renderWidth;
+  canvas.height = Math.max(leftEye.renderHeight, rightEye.renderHeight);
+
+  display.getFrameData(frameData);
+
+  gl.enable(gl.SCISSOR_TEST);
+
+  gl.viewport(0, 0, leftEye.renderWidth, leftEye.renderHeight);
+  gl.scissor(0, 0, leftEye.renderWidth, leftEye.renderHeight);
+  gl.clearColor(0.0, 1.0, 0.0, 1.0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+
+  gl.viewport(leftEye.renderWidth, 0, rightEye.renderWidth, rightEye.renderHeight);
+  gl.scissor(leftEye.renderWidth, 0, rightEye.renderWidth, rightEye.renderHeight);
+  gl.clearColor(0.0, 0.0, 1.0, 1.0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+
+  gl.disable(gl.SCISSOR_TEST);
+
+  display.submitFrame();
+  display.requestAnimationFrame(done);
+}
+
+function done() {
+  document.documentElement.classList.remove("reftest-wait");
+}
+  </script>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Adds a `dom.webvr.test` pref, which puts WebVR content into fullscreen mode, so we can use our shiny new fullscreen reftesting apparatus for writing WebVR reftests.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22795 and fix #22804
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22840)
<!-- Reviewable:end -->
