### PR TITLE
Add test for contentDocument behaviour during parsing

### DIFF
--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-iframe-element/content_document_changes_only_after_load_matures.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-iframe-element/content_document_changes_only_after_load_matures.html
@@ -8,13 +8,20 @@
 async_test(function(t) {
     var iframe = document.createElement("iframe");
     document.body.appendChild(iframe);
-    iframe.onload = t.step_func(function() {
-        assert_true(iframe.contentDocument.location.toString().includes("support/blank.htm"));
-        t.done();
+    var checkedDuringParse = false;
+    iframe.onload = t.step_func_done(function() {
+        testContentDocument();
+        assert_true(checkedDuringParse);
+    });
+
+    let url = "support/iframe-that-checks-contentDocument.html";
+    window.testContentDocument = t.step_func(function() {
+        assert_true(iframe.contentDocument.location.toString().includes(url));
+        checkedDuringParse = true;
     });
 
     assert_equals(iframe.contentDocument.location.toString(), "about:blank");
-    iframe.src = "support/blank.htm?pipe=trickle(d2)";
+    iframe.src = url + "?pipe=trickle(d2)";
     // The location of the contentDocument should not change until the new document has matured.
     assert_equals(iframe.contentDocument.location.toString(), "about:blank");
 }, "contentDocument should only change after a load matures.");

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-iframe-element/support/iframe-that-checks-contentDocument.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-iframe-element/support/iframe-that-checks-contentDocument.html
@@ -1,0 +1,3 @@
+<script>
+  parent.testContentDocument();
+</script>


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22503
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22841)
<!-- Reviewable:end -->
