### PR TITLE
Add optional ANGLE support to glutin port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,6 +1493,16 @@ dependencies = [
 
 [[package]]
 name = "gl_generator"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "khronos_api 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gl_generator"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2233,6 +2243,11 @@ dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "khronos_api"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "khronos_api"
@@ -3809,6 +3824,7 @@ dependencies = [
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "libservo 0.0.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mozangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-src 0.1.0 (git+https://github.com/servo/osmesa-src)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-webvr 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5322,6 +5338,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xml-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "xml-rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -5488,6 +5509,7 @@ dependencies = [
 "checksum getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
 "checksum gif 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff3414b424657317e708489d2857d9575f4403698428b040b609b9d1c1a84a2c"
 "checksum gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0ffaf173cf76c73a73e080366bf556b4776ece104b06961766ff11449f38604"
+"checksum gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a795170cbd85b5a7baa58d6d7525cae6a03e486859860c220f7ebbbdd379d0a"
 "checksum gleam 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d7591624fbbc384a8195791facbd16a5b118d5d2240c508de518b7ccc771fe"
 "checksum glib 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e8fdc159c196a5dfa53a92929ac4c10c8a6637ffb43951f3fff89c2cd2365"
 "checksum glib-sys 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5bda542f3caee39a027638e9644ff89204101ad916fd7370b585ad2c5fc97e61"
@@ -5550,6 +5572,7 @@ dependencies = [
 "checksum jpeg-decoder 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "0dfe27a6c0dabd772d0f9b9f8701c4ca12c4d1eebcadf2be1f6f70396f6a1434"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum keyboard-types 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "53b536dc22c0dabb295e85dbd0c062023885b12b8db24e1d86833f4e50ea7959"
+"checksum khronos_api 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "037ab472c33f67b5fbd3e9163a2645319e5356fcd355efa6d4eb7fff4bbcb554"
 "checksum khronos_api 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62237e6d326bd5871cd21469323bf096de81f1618cd82cbaf5d87825335aeb49"
 "checksum lalrpop 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e2e80bee40b22bca46665b4ef1f3cd88ed0fb043c971407eac17a0712c02572"
 "checksum lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)" = "33b27d8490dbe1f9704b0088d61e8d46edc10d5673a8829836c6ded26a9912c7"
@@ -5784,6 +5807,7 @@ dependencies = [
 "checksum xcb 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
 "checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"
 "checksum xi-unicode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12ea8eda4b1eb72f02d148402e23832d56a33f55d8c1b2d5bcdde91d79d47cb1"
+"checksum xml-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3646aef67e75922d0e77af92599ed8499c0a60f043708821f5c3c940e88f67f3"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
 "checksum xml5ever 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "32cd7ebf0203c620906230ce22caa5df0b603c32b6fef72a275a48f6a2ae64b9"
 "checksum zip 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "77ce0ceee93c995954a31f77903925a6a8bb094709445238e344f2107910e29e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,16 +1493,6 @@ dependencies = [
 
 [[package]]
 name = "gl_generator"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "khronos_api 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gl_generator"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2246,11 +2236,6 @@ dependencies = [
 
 [[package]]
 name = "khronos_api"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "khronos_api"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -2805,10 +2790,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "mozangle"
-version = "0.1.7"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3603,7 +3589,7 @@ dependencies = [
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mitochondria 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "mozangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mozangle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mozjs 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "net_traits 0.0.1",
@@ -3824,7 +3810,7 @@ dependencies = [
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "libservo 0.0.1",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mozangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mozangle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-src 0.1.0 (git+https://github.com/servo/osmesa-src)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-webvr 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5338,11 +5324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xml-rs"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "xml-rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -5509,7 +5490,6 @@ dependencies = [
 "checksum getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
 "checksum gif 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff3414b424657317e708489d2857d9575f4403698428b040b609b9d1c1a84a2c"
 "checksum gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0ffaf173cf76c73a73e080366bf556b4776ece104b06961766ff11449f38604"
-"checksum gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a795170cbd85b5a7baa58d6d7525cae6a03e486859860c220f7ebbbdd379d0a"
 "checksum gleam 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d7591624fbbc384a8195791facbd16a5b118d5d2240c508de518b7ccc771fe"
 "checksum glib 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e8fdc159c196a5dfa53a92929ac4c10c8a6637ffb43951f3fff89c2cd2365"
 "checksum glib-sys 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5bda542f3caee39a027638e9644ff89204101ad916fd7370b585ad2c5fc97e61"
@@ -5572,7 +5552,6 @@ dependencies = [
 "checksum jpeg-decoder 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "0dfe27a6c0dabd772d0f9b9f8701c4ca12c4d1eebcadf2be1f6f70396f6a1434"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum keyboard-types 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "53b536dc22c0dabb295e85dbd0c062023885b12b8db24e1d86833f4e50ea7959"
-"checksum khronos_api 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "037ab472c33f67b5fbd3e9163a2645319e5356fcd355efa6d4eb7fff4bbcb554"
 "checksum khronos_api 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62237e6d326bd5871cd21469323bf096de81f1618cd82cbaf5d87825335aeb49"
 "checksum lalrpop 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e2e80bee40b22bca46665b4ef1f3cd88ed0fb043c971407eac17a0712c02572"
 "checksum lalrpop-util 0.16.3 (registry+https://github.com/rust-lang/crates.io-index)" = "33b27d8490dbe1f9704b0088d61e8d46edc10d5673a8829836c6ded26a9912c7"
@@ -5610,7 +5589,7 @@ dependencies = [
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum mitochondria 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9de3eca27871df31c33b807f834b94ef7d000956f57aa25c5aed9c5f0aae8f6f"
-"checksum mozangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "45a8a18a41cfab0fde25cc2f43ea89064d211a0fbb33225b8ff93ab20406e0e7"
+"checksum mozangle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c9ba1ce5212fd56a71cfbc463aedd4ece76090d98b96d5122f84dedffa0cc508"
 "checksum mozjs 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "622108d35f4fdd68b3aa39bfe9bedaee5fa9efd19711d046e1d56ff607c0a36f"
 "checksum mozjs_sys 0.61.12 (registry+https://github.com/rust-lang/crates.io-index)" = "370887111c83436555cde840bb2639c5a088c77f01b152957d99e1f279397f48"
 "checksum msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729"
@@ -5807,7 +5786,6 @@ dependencies = [
 "checksum xcb 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
 "checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"
 "checksum xi-unicode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12ea8eda4b1eb72f02d148402e23832d56a33f55d8c1b2d5bcdde91d79d47cb1"
-"checksum xml-rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3646aef67e75922d0e77af92599ed8499c0a60f043708821f5c3c940e88f67f3"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
 "checksum xml5ever 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "32cd7ebf0203c620906230ce22caa5df0b603c32b6fef72a275a48f6a2ae64b9"
 "checksum zip 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "77ce0ceee93c995954a31f77903925a6a8bb094709445238e344f2107910e29e"

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -76,6 +76,10 @@ pub struct Opts {
     pub load_webfonts_synchronously: bool,
 
     pub headless: bool,
+
+    /// Use ANGLE to create the GL context (Windows-only).
+    pub angle: bool,
+
     pub hard_fail: bool,
 
     /// True if we should bubble intrinsic widths sequentially (`-b`). If this is true, then
@@ -558,6 +562,7 @@ pub fn default_opts() -> Opts {
         gc_profile: false,
         load_webfonts_synchronously: false,
         headless: false,
+        angle: false,
         hard_fail: true,
         bubble_inline_sizes_separately: false,
         show_debug_fragment_borders: false,
@@ -666,6 +671,11 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         "",
     );
     opts.optflag("z", "headless", "Headless mode");
+    opts.optflag(
+        "",
+        "angle",
+        "Use ANGLE to create a GL context (Windows-only)",
+    );
     opts.optflag(
         "f",
         "hard-fail",
@@ -998,6 +1008,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         gc_profile: debug_options.gc_profile,
         load_webfonts_synchronously: debug_options.load_webfonts_synchronously,
         headless: opt_match.opt_present("z"),
+        angle: opt_match.opt_present("angle"),
         hard_fail: opt_match.opt_present("f") && !opt_match.opt_present("F"),
         bubble_inline_sizes_separately: bubble_inline_sizes_separately,
         profile_script_events: debug_options.profile_script_events,

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -115,4 +115,4 @@ webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
 webvr_traits = {path = "../webvr_traits"}
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]
-mozangle = "0.1"
+mozangle = "0.2"

--- a/ports/glutin/Cargo.toml
+++ b/ports/glutin/Cargo.toml
@@ -66,7 +66,7 @@ sig = "1.0"
 x11 = "2.0.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mozangle = { version = "0.1", features = ["egl"] }
+mozangle = { version = "0.2", features = ["egl"] }
 winapi = { version = "0.3", features = ["wingdi", "winuser"] }
 
 [target.'cfg(any(target_os = "macos", all(target_arch = "x86_64", target_os = "linux")))'.dependencies]

--- a/ports/glutin/Cargo.toml
+++ b/ports/glutin/Cargo.toml
@@ -66,6 +66,7 @@ sig = "1.0"
 x11 = "2.0.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
+mozangle = { version = "0.1", features = ["egl"] }
 winapi = { version = "0.3", features = ["wingdi", "winuser"] }
 
 [target.'cfg(any(target_os = "macos", all(target_arch = "x86_64", target_os = "linux")))'.dependencies]

--- a/ports/glutin/app.rs
+++ b/ports/glutin/app.rs
@@ -184,12 +184,13 @@ fn get_default_url() -> ServoUrl {
     cmdline_url.or(pref_url).or(blank_url).unwrap()
 }
 
-#[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
 pub fn gl_version() -> glutin::GlRequest {
-    glutin::GlRequest::Specific(glutin::Api::OpenGl, (3, 2))
-}
-
-#[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-pub fn gl_version() -> glutin::GlRequest {
-    glutin::GlRequest::Specific(glutin::Api::OpenGlEs, (3, 0))
+    if opts::get().angle {
+        glutin::GlRequest::Specific(glutin::Api::OpenGlEs, (3, 0))
+    } else {
+        glutin::GlRequest::GlThenGles {
+            opengl_version: (3, 2),
+            opengles_version: (3, 0),
+        }
+    }
 }

--- a/ports/glutin/headed_window.rs
+++ b/ports/glutin/headed_window.rs
@@ -14,7 +14,7 @@ use glutin::dpi::{LogicalPosition, LogicalSize, PhysicalSize};
 use glutin::os::macos::{ActivationPolicy, WindowBuilderExt};
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 use glutin::Icon;
-use glutin::{ContextBuilder, GlContext, GlWindow};
+use glutin::{Api, ContextBuilder, GlContext, GlWindow};
 use glutin::{ElementState, KeyboardInput, MouseButton, MouseScrollDelta, TouchPhase};
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 use image;
@@ -145,13 +145,14 @@ impl Window {
 
         glutin_window.show();
 
-        let gl = match gl::GlType::default() {
-            gl::GlType::Gl => unsafe {
+        let gl = match glutin_window.context().get_api() {
+            Api::OpenGl => unsafe {
                 gl::GlFns::load_with(|s| glutin_window.get_proc_address(s) as *const _)
             },
-            gl::GlType::Gles => unsafe {
+            Api::OpenGlEs => unsafe {
                 gl::GlesFns::load_with(|s| glutin_window.get_proc_address(s) as *const _)
             },
+            Api::WebGl => unreachable!("webgl is unsupported"),
         };
 
         gl.clear_color(0.6, 0.6, 0.6, 1.0);

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -629,16 +629,23 @@ class MachCommands(CommandBase):
                                 servo_exe_dir)
                 # Search for the generated nspr4.dll
                 build_path = path.join(servo_exe_dir, "build")
-                nspr4 = "nspr4.dll"
-                nspr4_path = None
-                for root, dirs, files in os.walk(build_path):
-                    if nspr4 in files:
-                        nspr4_path = path.join(root, nspr4)
-                        break
-                if nspr4_path is None:
-                    print("WARNING: could not find nspr4.dll")
-                else:
-                    shutil.copy(nspr4_path, servo_exe_dir)
+
+                def package_generated_shared_libraries(libs, build_path, servo_exe_dir):
+                    for root, dirs, files in os.walk(build_path):
+                        remaining_libs = list(libs)
+                        for lib in libs:
+                            if lib in files:
+                                shutil.copy(path.join(root, lib), servo_exe_dir)
+                                remaining_libs.remove(lib)
+                                continue
+                        libs = remaining_libs
+                        if not libs:
+                            return
+                    for lib in libs:
+                        print("WARNING: could not find " + lib)
+
+                package_generated_shared_libraries(["nspr4.dll", "libEGL.dll"], build_path, servo_exe_dir)
+
                 # copy needed gstreamer DLLs in to servo.exe dir
                 gst_x64 = "X86_64" if msvc_x64 == "64" else "X86"
                 gst_root = ""

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -971,3 +971,13 @@ testing/web-platform/mozilla/tests for Servo-only tests""" % reference_path)
         run_globals = {"__file__": run_file}
         execfile(run_file, run_globals)
         return run_globals["update_conformance"](version, dest_folder, None, patches_dir)
+
+    @Command('smoketest',
+             description='Load a simple page in Servo and ensure that it closes properly',
+             category='testing')
+    @CommandArgument('params', nargs='...',
+                     help="Command-line arguments to be passed through to Servo")
+    def smoketest(self, params):
+        params = params + ['tests/html/close-on-load.html']
+        return self.context.commands.dispatch(
+            'run', self.context, params=params)

--- a/tests/html/close-on-load.html
+++ b/tests/html/close-on-load.html
@@ -1,0 +1,5 @@
+<script>
+  window.onload = function() {
+    window.close();
+  }
+</script>


### PR DESCRIPTION
Supporting ANGLE in Servo has two important benefits:
* we can actually run Servo instances on our Windows CI machines, which gives us more confidence that we're not breaking it
* we can continue to use OpenGL on devices like the Hololens, rather than creating platform-specific graphical backends

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22856)
<!-- Reviewable:end -->
