### PR TITLE
Add support for MediaTrackConstraints

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -747,7 +747,15 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
             for memberType in type.unroll().flatMemberTypes
             if memberType.isDictionary()
         ]
-        if dictionaries:
+        if defaultValue and not isinstance(defaultValue, IDLNullValue):
+            tag = defaultValue.type.tag()
+            if tag is IDLType.Tags.bool:
+                default = "%s::Boolean(%s)" % (
+                    union_native_type(type),
+                    "true" if defaultValue.value else "false")
+            else:
+                raise("We don't currently support default values that aren't null or boolean")
+        elif dictionaries:
             if defaultValue:
                 assert isinstance(defaultValue, IDLNullValue)
                 dictionary, = dictionaries

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2379,6 +2379,7 @@ def UnionTypes(descriptors, dictionaries, callbacks, typedefs, config):
         'crate::dom::bindings::conversions::root_from_handlevalue',
         'std::ptr::NonNull',
         'crate::dom::bindings::mozmap::MozMap',
+        'crate::dom::bindings::num::Finite',
         'crate::dom::bindings::root::DomRoot',
         'crate::dom::bindings::str::ByteString',
         'crate::dom::bindings::str::DOMString',

--- a/components/script/dom/mediadevices.rs
+++ b/components/script/dom/mediadevices.rs
@@ -4,6 +4,8 @@
 
 use crate::dom::bindings::codegen::Bindings::MediaDevicesBinding::MediaStreamConstraints;
 use crate::dom::bindings::codegen::Bindings::MediaDevicesBinding::{self, MediaDevicesMethods};
+use crate::dom::bindings::codegen::UnionTypes::BooleanOrMediaTrackConstraints;
+use crate::dom::bindings::codegen::UnionTypes::ClampedUnsignedLongOrConstrainULongRange as ConstrainULong;
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
@@ -12,6 +14,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::mediastream::MediaStream;
 use crate::dom::promise::Promise;
 use dom_struct::dom_struct;
+use servo_media::streams::capture::{Constrain, ConstrainRange, MediaTrackConstraintSet};
 use servo_media::ServoMedia;
 use std::rc::Rc;
 
@@ -42,18 +45,52 @@ impl MediaDevicesMethods for MediaDevices {
         let p = Promise::new(&self.global());
         let media = ServoMedia::get().unwrap();
         let mut tracks = vec![];
-        if constraints.audio {
-            if let Some(audio) = media.create_audioinput_stream(Default::default()) {
+        if let Some(constraints) = convert_constraints(&constraints.audio) {
+            if let Some(audio) = media.create_audioinput_stream(constraints) {
                 tracks.push(audio)
             }
         }
-        if constraints.video {
-            if let Some(video) = media.create_videoinput_stream(Default::default()) {
+        if let Some(constraints) = convert_constraints(&constraints.video) {
+            if let Some(video) = media.create_videoinput_stream(constraints) {
                 tracks.push(video)
             }
         }
         let stream = MediaStream::new(&self.global(), tracks);
         p.resolve_native(&stream);
         p
+    }
+}
+
+fn convert_constraints(js: &BooleanOrMediaTrackConstraints) -> Option<MediaTrackConstraintSet> {
+    match js {
+        BooleanOrMediaTrackConstraints::Boolean(false) => None,
+        BooleanOrMediaTrackConstraints::Boolean(true) => Some(Default::default()),
+        BooleanOrMediaTrackConstraints::MediaTrackConstraints(ref c) => {
+            Some(MediaTrackConstraintSet {
+                height: convert_culong(&c.parent.height),
+                width: convert_culong(&c.parent.width),
+                ..Default::default()
+            })
+        },
+    }
+}
+
+fn convert_culong(js: &ConstrainULong) -> Option<Constrain<u32>> {
+    match js {
+        ConstrainULong::ClampedUnsignedLong(val) => Some(Constrain::Value(*val)),
+        ConstrainULong::ConstrainULongRange(ref range) => {
+            if range.parent.min.is_some() || range.parent.max.is_some() {
+                Some(Constrain::Range(ConstrainRange {
+                    min: range.parent.min,
+                    max: range.parent.max,
+                    ideal: range.ideal,
+                }))
+            } else if let Some(exact) = range.exact {
+                Some(Constrain::Value(exact))
+            } else {
+                // the unspecified case is treated as all three being none
+                None
+            }
+        },
     }
 }

--- a/components/script/dom/webidls/MediaDevices.webidl
+++ b/components/script/dom/webidls/MediaDevices.webidl
@@ -29,15 +29,15 @@ dictionary MediaStreamConstraints {
         // (boolean or MediaTrackConstraints) audio = false;
 };
 
-// dictionary DoubleRange {
-//              double max;
-//              double min;
-// };
+dictionary DoubleRange {
+             double max;
+             double min;
+};
 
-// dictionary ConstrainDoubleRange : DoubleRange {
-//              double exact;
-//              double ideal;
-// };
+dictionary ConstrainDoubleRange : DoubleRange {
+             double exact;
+             double ideal;
+};
 
 dictionary ULongRange {
              [Clamp] unsigned long max;
@@ -64,19 +64,19 @@ dictionary MediaTrackConstraints : MediaTrackConstraintSet {
 };
 
 typedef ([Clamp] unsigned long or ConstrainULongRange) ConstrainULong;
-// typedef (double or ConstrainDoubleRange) ConstrainDouble;
+typedef (double or ConstrainDoubleRange) ConstrainDouble;
 // typedef (boolean or ConstrainBooleanParameters) ConstrainBoolean;
 // typedef (DOMString or sequence<DOMString> or ConstrainDOMStringParameters) ConstrainDOMString;
 
 dictionary MediaTrackConstraintSet {
              ConstrainULong width;
              ConstrainULong height;
-             // ConstrainDouble aspectRatio;
-             // ConstrainDouble frameRate;
+             ConstrainDouble aspectRatio;
+             ConstrainDouble frameRate;
              // ConstrainDOMString facingMode;
              // ConstrainDOMString resizeMode;
              // ConstrainDouble volume;
-             // ConstrainULong sampleRate;
+             ConstrainULong sampleRate;
              // ConstrainULong sampleSize;
              // ConstrainBoolean echoCancellation;
              // ConstrainBoolean autoGainControl;

--- a/components/script/dom/webidls/MediaDevices.webidl
+++ b/components/script/dom/webidls/MediaDevices.webidl
@@ -23,10 +23,10 @@ partial interface MediaDevices {
 
 
 dictionary MediaStreamConstraints {
-    //         (boolean or MediaTrackConstraints) video = false;
-    //         (boolean or MediaTrackConstraints) audio = false;
-                boolean video = false;
-                boolean audio = false;
+        (boolean or MediaTrackConstraints) video;
+        // (boolean or MediaTrackConstraints) video = false;
+        (boolean or MediaTrackConstraints) audio;
+        // (boolean or MediaTrackConstraints) audio = false;
 };
 
 // dictionary DoubleRange {
@@ -39,15 +39,15 @@ dictionary MediaStreamConstraints {
 //              double ideal;
 // };
 
-// dictionary ULongRange {
-//              [Clamp] unsigned long max;
-//              [Clamp] unsigned long min;
-// };
+dictionary ULongRange {
+             [Clamp] unsigned long max;
+             [Clamp] unsigned long min;
+};
 
-// dictionary ConstrainULongRange : ULongRange {
-//              [Clamp] unsigned long exact;
-//              [Clamp] unsigned long ideal;
-// };
+dictionary ConstrainULongRange : ULongRange {
+             [Clamp] unsigned long exact;
+             [Clamp] unsigned long ideal;
+};
 
 // dictionary ConstrainBooleanParameters {
 //              boolean exact;
@@ -59,30 +59,30 @@ dictionary MediaStreamConstraints {
 //              (DOMString or sequence<DOMString>) ideal;
 // };
 
-// dictionary MediaTrackConstraints : MediaTrackConstraintSet {
-//              sequence<MediaTrackConstraintSet> advanced;
-// };
+dictionary MediaTrackConstraints : MediaTrackConstraintSet {
+             sequence<MediaTrackConstraintSet> advanced;
+};
 
-// typedef ([Clamp] unsigned long or ConstrainULongRange) ConstrainULong;
+typedef ([Clamp] unsigned long or ConstrainULongRange) ConstrainULong;
 // typedef (double or ConstrainDoubleRange) ConstrainDouble;
 // typedef (boolean or ConstrainBooleanParameters) ConstrainBoolean;
 // typedef (DOMString or sequence<DOMString> or ConstrainDOMStringParameters) ConstrainDOMString;
 
-// dictionary MediaTrackConstraintSet {
-//              ConstrainULong width;
-//              ConstrainULong height;
-//              ConstrainDouble aspectRatio;
-//              ConstrainDouble frameRate;
-//              ConstrainDOMString facingMode;
-//              ConstrainDOMString resizeMode;
-//              ConstrainDouble volume;
-//              ConstrainULong sampleRate;
-//              ConstrainULong sampleSize;
-//              ConstrainBoolean echoCancellation;
-//              ConstrainBoolean autoGainControl;
-//              ConstrainBoolean noiseSuppression;
-//              ConstrainDouble latency;
-//              ConstrainULong channelCount;
-//              ConstrainDOMString deviceId;
-//              ConstrainDOMString groupId;
-// };
+dictionary MediaTrackConstraintSet {
+             ConstrainULong width;
+             ConstrainULong height;
+             // ConstrainDouble aspectRatio;
+             // ConstrainDouble frameRate;
+             // ConstrainDOMString facingMode;
+             // ConstrainDOMString resizeMode;
+             // ConstrainDouble volume;
+             // ConstrainULong sampleRate;
+             // ConstrainULong sampleSize;
+             // ConstrainBoolean echoCancellation;
+             // ConstrainBoolean autoGainControl;
+             // ConstrainBoolean noiseSuppression;
+             // ConstrainDouble latency;
+             // ConstrainULong channelCount;
+             // ConstrainDOMString deviceId;
+             // ConstrainDOMString groupId;
+};

--- a/components/script/dom/webidls/MediaDevices.webidl
+++ b/components/script/dom/webidls/MediaDevices.webidl
@@ -23,10 +23,8 @@ partial interface MediaDevices {
 
 
 dictionary MediaStreamConstraints {
-        (boolean or MediaTrackConstraints) video;
-        // (boolean or MediaTrackConstraints) video = false;
-        (boolean or MediaTrackConstraints) audio;
-        // (boolean or MediaTrackConstraints) audio = false;
+        (boolean or MediaTrackConstraints) video = false;
+        (boolean or MediaTrackConstraints) audio = false;
 };
 
 dictionary DoubleRange {


### PR DESCRIPTION
This uses the WebIDL attributes-on-types support landed in https://github.com/servo/servo/pull/22958 to fill out the MediaTrackConstraints dictionary for constraints that servo-media supports.

r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22874)
<!-- Reviewable:end -->
