### PR TITLE
Fix log filter. simpleservo::api doesn't exist anymore

### DIFF
--- a/ports/libsimpleservo/jniapi/src/lib.rs
+++ b/ports/libsimpleservo/jniapi/src/lib.rs
@@ -65,7 +65,7 @@ pub fn Java_org_mozilla_servoview_JNIServo_init(
         // should show up in adb logcat with a release build.
         let filters = [
             "servo",
-            "simpleservo::api",
+            "simpleservo",
             "simpleservo::jniapi",
             "simpleservo::gl_glue::egl",
             // Show JS errors by default.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22910)
<!-- Reviewable:end -->
