### PR TITLE
Add optional annotations for initEvent method of Event interface

### DIFF
--- a/components/script/dom/webidls/Event.webidl
+++ b/components/script/dom/webidls/Event.webidl
@@ -35,7 +35,7 @@ interface Event {
   [Constant]
   readonly attribute DOMTimeStamp timeStamp;
 
-  void initEvent(DOMString type, boolean bubbles, boolean cancelable);
+  void initEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false);
 };
 
 dictionary EventInit {

--- a/tests/wpt/metadata/dom/events/Event-initEvent.html.ini
+++ b/tests/wpt/metadata/dom/events/Event-initEvent.html.ini
@@ -3,9 +3,6 @@
   [Calling initEvent must unset the stop propagation flag.]
     expected: FAIL
 
-  [Tests initEvent's default parameter values.]
-    expected: FAIL
-
   [Properties of initEvent(type, true, true)]
     expected: FAIL
 

--- a/tests/wpt/metadata/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/dom/interfaces.html.ini
@@ -878,9 +878,6 @@
   [Event interface: attribute composed]
     expected: FAIL
 
-  [Event interface: operation initEvent(DOMString, boolean, boolean)]
-    expected: FAIL
-
   [Event interface: document.createEvent("Event") must inherit property "srcElement" with the proper type]
     expected: FAIL
 


### PR DESCRIPTION
Added `optional` and default values to parameters `bubbles` and `cancelable` of `initEvent` of `Event`.

I tried to update test results, but there seem to be no differences at all.

I checked similar code where `optional` is used, and there seems to be no special handling in Rust. If that is not the case with this issue, please let me know and I'll commit more follow-ups.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22883

<!-- Either: -->
- [x] There are tests for these changes OR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22917)
<!-- Reviewable:end -->
