### PR TITLE
implement historical srcElement attribute for Event interface

### DIFF
--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -259,6 +259,11 @@ impl EventMethods for Event {
         self.target.get()
     }
 
+    // https://dom.spec.whatwg.org/#dom-event-srcelement
+    fn GetSrcElement(&self) -> Option<DomRoot<EventTarget>> {
+        self.target.get()
+    }
+
     // https://dom.spec.whatwg.org/#dom-event-currenttarget
     fn GetCurrentTarget(&self) -> Option<DomRoot<EventTarget>> {
         self.current_target.get()

--- a/components/script/dom/webidls/Event.webidl
+++ b/components/script/dom/webidls/Event.webidl
@@ -11,6 +11,7 @@ interface Event {
   [Pure]
   readonly attribute DOMString type;
   readonly attribute EventTarget? target;
+  readonly attribute EventTarget? srcElement;
   readonly attribute EventTarget? currentTarget;
 
   const unsigned short NONE = 0;

--- a/tests/wpt/metadata/dom/events/Event-defaultPrevented-after-dispatch.html.ini
+++ b/tests/wpt/metadata/dom/events/Event-defaultPrevented-after-dispatch.html.ini
@@ -1,7 +1,4 @@
 [Event-defaultPrevented-after-dispatch.html]
-  [Default prevention via preventDefault]
-    expected: FAIL
-
   [Default prevention via returnValue]
     expected: FAIL
 

--- a/tests/wpt/metadata/dom/events/Event-dispatch-detached-click.html.ini
+++ b/tests/wpt/metadata/dom/events/Event-dispatch-detached-click.html.ini
@@ -1,4 +1,0 @@
-[Event-dispatch-detached-click.html]
-  [Click event can be dispatched to an element that is not in the document.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/dom/events/Event-dispatch-other-document.html.ini
+++ b/tests/wpt/metadata/dom/events/Event-dispatch-other-document.html.ini
@@ -1,4 +1,0 @@
-[Event-dispatch-other-document.html]
-  [Custom event on an element in another document]
-    expected: FAIL
-

--- a/tests/wpt/metadata/dom/events/EventListener-handleEvent.html.ini
+++ b/tests/wpt/metadata/dom/events/EventListener-handleEvent.html.ini
@@ -5,6 +5,3 @@
   [throws if `handleEvent` is not callable]
     expected: FAIL
 
-  [calls `handleEvent` method of `EventListener`]
-    expected: FAIL
-

--- a/tests/wpt/metadata/dom/interfaces.html.ini
+++ b/tests/wpt/metadata/dom/interfaces.html.ini
@@ -866,9 +866,6 @@
   [DOM IDL tests]
     expected: FAIL
 
-  [Event interface: attribute srcElement]
-    expected: FAIL
-
   [Event interface: operation composedPath()]
     expected: FAIL
 
@@ -878,9 +875,6 @@
   [Event interface: attribute composed]
     expected: FAIL
 
-  [Event interface: document.createEvent("Event") must inherit property "srcElement" with the proper type]
-    expected: FAIL
-
   [Event interface: document.createEvent("Event") must inherit property "composedPath()" with the proper type]
     expected: FAIL
 
@@ -888,9 +882,6 @@
     expected: FAIL
 
   [Event interface: document.createEvent("Event") must inherit property "composed" with the proper type]
-    expected: FAIL
-
-  [Event interface: new Event("foo") must inherit property "srcElement" with the proper type]
     expected: FAIL
 
   [Event interface: new Event("foo") must inherit property "composedPath()" with the proper type]
@@ -903,9 +894,6 @@
     expected: FAIL
 
   [CustomEvent interface: operation initCustomEvent(DOMString, boolean, boolean, any)]
-    expected: FAIL
-
-  [Event interface: new CustomEvent("foo") must inherit property "srcElement" with the proper type]
     expected: FAIL
 
   [Event interface: new CustomEvent("foo") must inherit property "composedPath()" with the proper type]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Implementation of `srcElement` attribute for Event interface. Reference: https://dom.spec.whatwg.org/#dom-event-srcelement

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22880 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22918)
<!-- Reviewable:end -->
