### PR TITLE
Use webvr future_frame_data to avoid blocking the WebGL thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,7 @@ dependencies = [
  "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_config 0.0.1",
  "webrender_api 0.58.0 (git+https://github.com/servo/webrender)",
+ "webvr_traits 0.0.1",
 ]
 
 [[package]]
@@ -3336,15 +3337,16 @@ dependencies = [
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ovr-mobile-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-webvr-api 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr-api 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rust-webvr-api"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_injected_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4875,7 +4877,7 @@ version = "0.0.1"
 dependencies = [
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "rust-webvr-api 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr-api 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5355,7 +5357,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "da06feaa07f69125ab9ddc769b11de29090122170b402547f64b86fe16ebc399"
 "checksum rust-webvr 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4251e156fc27e2ce17a747e3270ee6940c754145cead0cf5da29792328baf473"
-"checksum rust-webvr-api 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d54f1423df09c01a1937133229d3617bf40cdbc473f0decd98b6013e6c2fef5"
+"checksum rust-webvr-api 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95d96901d94bc4e43998cc77f804f6944acb993b61c8470fc3c9600650608148"
 "checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusttype 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b8eb11f5b0a98c8eca2fb1483f42646d8c340e83e46ab416f8a063a0fd0eeb20"

--- a/components/canvas_traits/Cargo.toml
+++ b/components/canvas_traits/Cargo.toml
@@ -27,3 +27,4 @@ serde = "1.0"
 serde_bytes = "0.10"
 servo_config = {path = "../config"}
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
+webvr_traits = {path = "../webvr_traits"}

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -7,12 +7,12 @@ use gleam::gl;
 use ipc_channel::ipc::{IpcBytesReceiver, IpcBytesSender, IpcSharedMemory};
 use offscreen_gl_context::{GLContextAttributes, GLLimits};
 use pixels::PixelFormat;
-use serde_bytes::ByteBuf;
 use std::borrow::Cow;
 use std::fmt;
 use std::num::NonZeroU32;
 use std::ops::Deref;
 use webrender_api::{DocumentId, ImageKey, PipelineId};
+use webvr_traits::WebVRFutureFrameData;
 
 /// Helper function that creates a WebGL channel (WebGLSender, WebGLReceiver) to be used in WebGLCommands.
 pub use crate::webgl_channel::webgl_channel;
@@ -506,7 +506,12 @@ pub enum WebVRCommand {
     /// Start presenting to a VR device.
     Create(WebVRDeviceId),
     /// Synchronize the pose information to be used in the frame.
-    SyncPoses(WebVRDeviceId, f64, f64, WebGLSender<Result<ByteBuf, ()>>),
+    SyncPoses(
+        WebVRDeviceId,
+        f64,
+        f64,
+        WebGLSender<Result<WebVRFutureFrameData, ()>>,
+    ),
     /// Submit the frame to a VR device using the specified texture coordinates.
     SubmitFrame(WebVRDeviceId, [f32; 4], [f32; 4]),
     /// Stop presenting to a VR device

--- a/components/webvr/webvr_thread.rs
+++ b/components/webvr/webvr_thread.rs
@@ -382,11 +382,8 @@ impl webgl::WebVRRenderHandler for WebVRCompositorHandler {
             },
             webgl::WebVRCommand::SyncPoses(compositor_id, near, far, sender) => {
                 if let Some(compositor) = self.compositors.get(&compositor_id) {
-                    let pose = unsafe {
-                        (*compositor.0).sync_poses();
-                        (*compositor.0).synced_frame_data(near, far).to_bytes()
-                    };
-                    let _ = sender.send(Ok(pose.into()));
+                    let pose = unsafe { (*compositor.0).future_frame_data(near, far) };
+                    let _ = sender.send(Ok(pose));
                 } else {
                     let _ = sender.send(Err(()));
                 }

--- a/components/webvr_traits/Cargo.toml
+++ b/components/webvr_traits/Cargo.toml
@@ -13,5 +13,5 @@ path = "lib.rs"
 [dependencies]
 ipc-channel = "0.11"
 msg = {path = "../msg"}
-rust-webvr-api = {version = "0.10", features = ["serde-serialization"]}
+rust-webvr-api = {version = "0.10.2", features = ["ipc"]}
 serde = "1.0"

--- a/components/webvr_traits/lib.rs
+++ b/components/webvr_traits/lib.rs
@@ -20,6 +20,7 @@ pub use rust_webvr_api::VREye as WebVREye;
 pub use rust_webvr_api::VREyeParameters as WebVREyeParameters;
 pub use rust_webvr_api::VRFieldOfView as WebVRFieldOfView;
 pub use rust_webvr_api::VRFrameData as WebVRFrameData;
+pub use rust_webvr_api::VRFutureFrameData as WebVRFutureFrameData;
 pub use rust_webvr_api::VRGamepadButton as WebVRGamepadButton;
 pub use rust_webvr_api::VRGamepadData as WebVRGamepadData;
 pub use rust_webvr_api::VRGamepadEvent as WebVRGamepadEvent;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR fixes a potential deadlock caused by the WebGL thread being blocked on a VR device. Rather than blocking on the VR device, it forwards a future to the script thread, and then then script thread blocks.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it's fixing a potential deadlock

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22938)
<!-- Reviewable:end -->
