### PR TITLE
Fixed inconsistency in import of gl::Gl

### DIFF
--- a/components/canvas/webgl_mode/inprocess.rs
+++ b/components/canvas/webgl_mode/inprocess.rs
@@ -11,7 +11,6 @@ use canvas_traits::webgl::{WebGLSender, WebVRCommand, WebVRRenderHandler};
 use euclid::Size2D;
 use fnv::FnvHashMap;
 use gleam::gl;
-use gleam::gl::Gl;
 use servo_config::prefs::PREFS;
 use std::rc::Rc;
 
@@ -113,7 +112,12 @@ impl WebGLExternalImageApi for WebGLExternalImages {
 struct WebVRRenderWrapper(Box<dyn WebVRRenderHandler>);
 
 impl WebVRRenderHandler for WebVRRenderWrapper {
-    fn handle(&mut self, gl: &dyn Gl, command: WebVRCommand, texture: Option<(u32, Size2D<i32>)>) {
+    fn handle(
+        &mut self,
+        gl: &dyn gl::Gl,
+        command: WebVRCommand,
+        texture: Option<(u32, Size2D<i32>)>,
+    ) {
         self.0.handle(gl, command, texture);
     }
 }


### PR DESCRIPTION
All other uses of `Gl` in this file use the qualified path `gl::Gl`.

<!-- Please describe your changes on the following line: -->

Fixed a small inconsistency with qualified import.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it is a minor syntactic change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22945)
<!-- Reviewable:end -->
