### PR TITLE
Use a test VRDisplay that renders to a GL window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "webrender 0.58.0 (git+https://github.com/servo/webrender)",
  "webrender_api 0.58.0 (git+https://github.com/servo/webrender)",
  "webvr 0.0.1",
+ "webvr_traits 0.0.1",
 ]
 
 [[package]]
@@ -3327,22 +3328,26 @@ dependencies = [
 
 [[package]]
 name = "rust-webvr"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gvr-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ovr-mobile-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-webvr-api 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr-api 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rust-webvr-api"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_injected_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3666,6 +3671,7 @@ dependencies = [
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-src 0.1.0 (git+https://github.com/servo/osmesa-src)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sig 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinyfiledialogs 3.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4867,7 +4873,7 @@ dependencies = [
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "rust-webvr 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
  "servo_config 0.0.1",
  "webvr_traits 0.0.1",
@@ -4879,7 +4885,7 @@ version = "0.0.1"
 dependencies = [
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "rust-webvr-api 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr-api 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5358,8 +5364,8 @@ dependencies = [
 "checksum regex-syntax 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fbc557aac2b708fe84121caf261346cc2eed71978024337e42eb46b8a252ac6e"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "da06feaa07f69125ab9ddc769b11de29090122170b402547f64b86fe16ebc399"
-"checksum rust-webvr 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4251e156fc27e2ce17a747e3270ee6940c754145cead0cf5da29792328baf473"
-"checksum rust-webvr-api 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f8ae20fc34d4b4f59d00be7fa2c06802ad90a0a33195a6f5f73832c6acc5b8fa"
+"checksum rust-webvr 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ab7402cf0d85fa4323297ac9d2b329b6d5f730a8cb40c90a8708e6b58d643c60"
+"checksum rust-webvr-api 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1b2af5c6c86fb79e70b5a34daa3d488411225707c73dc5467c7da7c83d557daf"
 "checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusttype 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b8eb11f5b0a98c8eca2fb1483f42646d8c340e83e46ab416f8a063a0fd0eeb20"

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -39,6 +39,7 @@ style_traits = {path = "../style_traits"}
 time = "0.1.17"
 webrender = {git = "https://github.com/servo/webrender", features = ["capture"]}
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
+webvr_traits = {path = "../webvr_traits"}
 webvr = {path = "../webvr"}
 
 [build-dependencies]

--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -18,6 +18,7 @@ use script_traits::{AnimationState, ConstellationMsg, EventResult};
 use std::fmt::{Debug, Error, Formatter};
 use style_traits::viewport::ViewportConstraints;
 use webrender_api::{self, DeviceIntPoint, DeviceIntSize};
+use webvr_traits::WebVRMainThreadHeartbeat;
 
 /// Sends messages to the compositor.
 pub struct CompositorProxy {
@@ -153,4 +154,5 @@ pub struct InitialCompositorState {
     pub webrender: webrender::Renderer,
     pub webrender_document: webrender_api::DocumentId,
     pub webrender_api: webrender_api::RenderApi,
+    pub webvr_heartbeats: Vec<Box<WebVRMainThreadHeartbeat>>,
 }

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -19,6 +19,7 @@ use std::rc::Rc;
 use style_traits::DevicePixel;
 use webrender_api::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePoint, ScrollLocation};
 use webvr::VRServiceManager;
+use webvr_traits::WebVRMainThreadHeartbeat;
 
 #[derive(Clone)]
 pub enum MouseWindowEvent {
@@ -147,7 +148,12 @@ pub trait WindowMethods {
     /// run the event loop at the vsync interval.
     fn set_animation_state(&self, _state: AnimationState);
     /// Register services with a VRServiceManager.
-    fn register_vr_services(&self, _: &mut VRServiceManager) {}
+    fn register_vr_services(
+        &self,
+        _: &mut VRServiceManager,
+        _: &mut Vec<Box<WebVRMainThreadHeartbeat>>,
+    ) {
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -257,10 +257,11 @@ where
         // can't defer it after `create_constellation` has started.
         script::init();
 
+        let mut webvr_heartbeats = Vec::new();
         let webvr_services = if PREFS.is_webvr_enabled() {
             let mut services = VRServiceManager::new();
             services.register_defaults();
-            window.register_vr_services(&mut services);
+            window.register_vr_services(&mut services, &mut webvr_heartbeats);
             Some(services)
         } else {
             None
@@ -307,6 +308,7 @@ where
                 webrender,
                 webrender_document,
                 webrender_api,
+                webvr_heartbeats,
             },
         );
 

--- a/components/webvr/Cargo.toml
+++ b/components/webvr/Cargo.toml
@@ -22,7 +22,7 @@ gleam = "0.6"
 ipc-channel = "0.11"
 log = "0.4"
 msg = {path = "../msg"}
-rust-webvr = {version = "0.10", features = ["openvr", "vrexternal"]}
+rust-webvr = {version = "0.10.2", features = ["openvr", "vrexternal"]}
 script_traits = {path = "../script_traits"}
 servo_config = {path = "../config"}
 webvr_traits = {path = "../webvr_traits" }

--- a/components/webvr/lib.rs
+++ b/components/webvr/lib.rs
@@ -10,4 +10,5 @@ extern crate log;
 mod webvr_thread;
 pub use crate::webvr_thread::{WebVRCompositorHandler, WebVRThread};
 pub use rust_webvr::api::VRExternalShmemPtr;
+pub use rust_webvr::VRMainThreadHeartbeat;
 pub use rust_webvr::VRServiceManager;

--- a/components/webvr_traits/lib.rs
+++ b/components/webvr_traits/lib.rs
@@ -27,5 +27,6 @@ pub use rust_webvr_api::VRGamepadEvent as WebVRGamepadEvent;
 pub use rust_webvr_api::VRGamepadHand as WebVRGamepadHand;
 pub use rust_webvr_api::VRGamepadState as WebVRGamepadState;
 pub use rust_webvr_api::VRLayer as WebVRLayer;
+pub use rust_webvr_api::VRMainThreadHeartbeat as WebVRMainThreadHeartbeat;
 pub use rust_webvr_api::VRPose as WebVRPose;
 pub use rust_webvr_api::VRStageParameters as WebVRStageParameters;

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -18,7 +18,7 @@ use servo::script_traits::{MouseButton, TouchEventType, TouchId};
 use servo::servo_config::opts;
 use servo::servo_config::prefs::{PrefValue, PREFS};
 use servo::servo_url::ServoUrl;
-use servo::webvr::{VRExternalShmemPtr, VRServiceManager};
+use servo::webvr::{VRExternalShmemPtr, VRMainThreadHeartbeat, VRServiceManager};
 use servo::{self, gl, webrender_api, BrowserId, Servo};
 use std::cell::{Cell, RefCell};
 use std::mem;
@@ -536,7 +536,11 @@ impl WindowMethods for ServoCallbacks {
         }
     }
 
-    fn register_vr_services(&self, services: &mut VRServiceManager) {
+    fn register_vr_services(
+        &self,
+        services: &mut VRServiceManager,
+        _: &mut Vec<Box<VRMainThreadHeartbeat>>,
+    ) {
         if let Some(ptr) = self.vr_pointer {
             services.register_vrexternal(VRExternalShmemPtr::new(ptr));
         }

--- a/ports/servo/Cargo.toml
+++ b/ports/servo/Cargo.toml
@@ -51,6 +51,7 @@ lazy_static = "1"
 libservo = {path = "../../components/servo"}
 libc = "0.2"
 log = "0.4"
+rust-webvr = { version = "0.10.2", features = ["glwindow"] }
 tinyfiledialogs = "3.0"
 winit = {version = "0.18", features = ["icon_loading"]}
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Add a `dom.webvr.test` pref that registers a new VR display, which registers to a GL window.

The matching webvr PR is https://github.com/servo/rust-webvr/pull/66.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22795
- [X] These changes do not require tests because we need a followup PR to support reftests which use the VR display

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22953)
<!-- Reviewable:end -->
