### PR TITLE
Do not store state when syncing WPT.

### DIFF
--- a/tests/wpt/update.py
+++ b/tests/wpt/update.py
@@ -31,6 +31,7 @@ def set_defaults(kwargs):
         kwargs["product"] = "servo"
     if kwargs["config"] is None:
         kwargs["config"] = wpt_path('config.ini')
+    kwargs["store_state"] = False
     updatecommandline.check_args(kwargs)
 
 

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/update/state.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/update/state.py
@@ -3,9 +3,7 @@ import cPickle as pickle
 
 here = os.path.abspath(os.path.split(__file__)[0])
 
-class State(object):
-    filename = os.path.join(here, ".wpt-update.lock")
-
+class BaseState(object):
     def __new__(cls, logger):
         rv = cls.load(logger)
         if rv is not None:
@@ -17,11 +15,6 @@ class State(object):
 
     def __init__(self, logger):
         """Object containing state variables created when running Steps.
-
-        On write the state is serialized to disk, such that it can be restored in
-        the event that the program is interrupted before all steps are complete.
-        Note that this only works well if the values are immutable; mutating an
-        existing value will not cause the data to be serialized.
 
         Variables are set and get as attributes e.g. state_obj.spam = "eggs".
 
@@ -40,23 +33,6 @@ class State(object):
         del rv["_logger"]
         return rv
 
-    @classmethod
-    def load(cls, logger):
-        """Load saved state from a file"""
-        try:
-            if not os.path.isfile(cls.filename):
-                return None
-            with open(cls.filename) as f:
-                try:
-                    rv = pickle.load(f)
-                    logger.debug("Loading data %r" % (rv._data,))
-                    rv._logger = logger
-                    rv._index = 0
-                    return rv
-                except EOFError:
-                    logger.warning("Found empty state file")
-        except IOError:
-            logger.debug("IOError loading stored state")
 
     def push(self, init_values):
         """Push a new clean state dictionary
@@ -66,22 +42,12 @@ class State(object):
 
         return StateContext(self, init_values)
 
-    def save(self):
-        """Write the state to disk"""
-        with open(self.filename, "w") as f:
-            pickle.dump(self, f, 2)
-
     def is_empty(self):
         return len(self._data) == 1 and self._data[0] == {}
 
     def clear(self):
         """Remove all state and delete the stored copy."""
-        try:
-            os.unlink(self.filename)
-        except OSError:
-            pass
         self._data = [{}]
-
 
     def __setattr__(self, key, value):
         if key.startswith("_"):
@@ -108,6 +74,62 @@ class State(object):
 
     def keys(self):
         return self._data[self._index].keys()
+
+
+    @classmethod
+    def load(self):
+        raise NotImplementedError
+
+    def save(self):
+        raise NotImplementedError
+
+
+class SavedState(BaseState):
+    """On write the state is serialized to disk, such that it can be restored in
+       the event that the program is interrupted before all steps are complete.
+       Note that this only works well if the values are immutable; mutating an
+       existing value will not cause the data to be serialized."""
+    filename = os.path.join(here, ".wpt-update.lock")
+
+    @classmethod
+    def load(cls, logger):
+        """Load saved state from a file"""
+        try:
+            if not os.path.isfile(cls.filename):
+                return None
+            with open(cls.filename) as f:
+                try:
+                    rv = pickle.load(f)
+                    logger.debug("Loading data %r" % (rv._data,))
+                    rv._logger = logger
+                    rv._index = 0
+                    return rv
+                except EOFError:
+                    logger.warning("Found empty state file")
+        except IOError:
+            logger.debug("IOError loading stored state")
+
+    def save(self):
+        """Write the state to disk"""
+        with open(self.filename, "w") as f:
+            pickle.dump(self, f)
+
+    def clear(self):
+        super(SavedState, self).clear()
+        try:
+            os.unlink(self.filename)
+        except OSError:
+            pass
+
+
+class UnsavedState(BaseState):
+    @classmethod
+    def load(cls, logger):
+        return None
+
+    def save(self):
+        return
+
 
 class StateContext(object):
     def __init__(self, state, init_values):

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/update/update.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/update/update.py
@@ -6,7 +6,7 @@ from sync import SyncFromUpstreamRunner
 from tree import GitTree, HgTree, NoVCSTree
 
 from base import Step, StepRunner, exit_clean, exit_unclean
-from state import State
+from state import SavedState, UnsavedState
 
 def setup_paths(sync_path):
     sys.path.insert(0, os.path.abspath(sync_path))
@@ -149,7 +149,10 @@ class WPTUpdate(object):
                 # If the sync path doesn't exist we defer this until it does
                 setup_paths(kwargs["sync_path"])
 
-        self.state = State(logger)
+        if kwargs["store_state"]:
+            self.state = SavedState(logger)
+        else:
+            self.state = UnsavedState(logger)
         self.kwargs = kwargs
         self.logger = logger
 


### PR DESCRIPTION
This eliminates unnecessary state saving during the syncing process which was broken by recent changes upstream. This also incorporates the changes from https://hg.mozilla.org/mozilla-central/rev/bc1c54e5dcea which were never synced, causing the command line argument to be useless until the divergence is resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22968)
<!-- Reviewable:end -->
