### PR TITLE
Add various state tracking to RTCPeerConnection, add .close()

### DIFF
--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -37,6 +37,7 @@ gattserverdisconnected
 hashchange
 hidden
 icecandidate
+iceconnectionstatechange
 icegatheringstatechange
 image
 input

--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -37,6 +37,7 @@ gattserverdisconnected
 hashchange
 hidden
 icecandidate
+icegatheringstatechange
 image
 input
 invalid

--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -97,6 +97,7 @@ seeked
 seeking
 select
 serif
+signalingstatechange
 srclang
 statechange
 storage

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -586,6 +586,31 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
     fn SignalingState(&self) -> RTCSignalingState {
         self.signaling_state.get()
     }
+
+    /// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-close
+    fn Close(&self) {
+        // Step 1
+        if self.closed.get() {
+            return;
+        }
+        // Step 2
+        self.closed.set(true);
+
+        // Step 4
+        self.signaling_state.set(RTCSignalingState::Closed);
+
+        // Step 5 handled by backend
+        self.controller.borrow_mut().as_ref().unwrap().quit();
+
+        // Step 6-10
+        // (no current support for data channels, transports, etc)
+
+        // Step 11
+        self.ice_connection_state.set(RTCIceConnectionState::Closed);
+
+        // Step 11
+        // (no current support for connection state)
+    }
 }
 
 impl From<SessionDescription> for RTCSessionDescriptionInit {

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -8,7 +8,7 @@ use crate::dom::bindings::codegen::Bindings::RTCPeerConnectionBinding;
 use crate::dom::bindings::codegen::Bindings::RTCPeerConnectionBinding::RTCPeerConnectionMethods;
 use crate::dom::bindings::codegen::Bindings::RTCPeerConnectionBinding::{
     RTCAnswerOptions, RTCBundlePolicy, RTCConfiguration, RTCIceConnectionState,
-    RTCIceGatheringState, RTCOfferOptions,
+    RTCIceGatheringState, RTCOfferOptions, RTCSignalingState,
 };
 use crate::dom::bindings::codegen::Bindings::RTCSessionDescriptionBinding::{
     RTCSdpType, RTCSessionDescriptionInit,
@@ -38,7 +38,7 @@ use dom_struct::dom_struct;
 use servo_media::streams::MediaStream as BackendMediaStream;
 use servo_media::webrtc::{
     BundlePolicy, GatheringState, IceCandidate, IceConnectionState, SdpType, SessionDescription,
-    WebRtcController, WebRtcSignaller,
+    SignalingState, WebRtcController, WebRtcSignaller,
 };
 use servo_media::ServoMedia;
 use servo_media_auto::Backend;
@@ -63,6 +63,7 @@ pub struct RTCPeerConnection {
     remote_description: MutNullableDom<RTCSessionDescription>,
     gathering_state: Cell<RTCIceGatheringState>,
     ice_connection_state: Cell<RTCIceConnectionState>,
+    signaling_state: Cell<RTCSignalingState>,
 }
 
 struct RTCSignaller {
@@ -116,6 +117,17 @@ impl WebRtcSignaller for RTCSignaller {
         );
     }
 
+    fn update_signaling_state(&self, state: SignalingState) {
+        let this = self.trusted.clone();
+        let _ = self.task_source.queue_with_canceller(
+            task!(update_signaling_state: move || {
+                let this = this.root();
+                this.update_signaling_state(state);
+            }),
+            &self.canceller,
+        );
+    }
+
     fn on_add_stream(&self, _: Box<BackendMediaStream>) {}
 
     fn close(&self) {
@@ -136,6 +148,7 @@ impl RTCPeerConnection {
             remote_description: Default::default(),
             gathering_state: Cell::new(RTCIceGatheringState::New),
             ice_connection_state: Cell::new(RTCIceConnectionState::New),
+            signaling_state: Cell::new(RTCSignalingState::Stable),
         }
     }
 
@@ -294,6 +307,28 @@ impl RTCPeerConnection {
         event.upcast::<Event>().fire(self.upcast());
     }
 
+    fn update_signaling_state(&self, state: SignalingState) {
+        if self.closed.get() {
+            return;
+        }
+
+        let state: RTCSignalingState = state.into();
+
+        if state == self.signaling_state.get() {
+            return;
+        }
+
+        self.signaling_state.set(state);
+
+        let event = Event::new(
+            &self.global(),
+            atom!("signalingstatechange"),
+            EventBubbles::DoesNotBubble,
+            EventCancelable::NotCancelable,
+        );
+        event.upcast::<Event>().fire(self.upcast());
+    }
+
     fn create_offer(&self) {
         let generation = self.offer_answer_generation.get();
         let (task_source, canceller) = self
@@ -384,6 +419,13 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
         negotiationneeded,
         GetOnnegotiationneeded,
         SetOnnegotiationneeded
+    );
+
+    /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-signalingstatechange
+    event_handler!(
+        signalingstatechange,
+        GetOnsignalingstatechange,
+        SetOnsignalingstatechange
     );
 
     /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addicecandidate
@@ -539,6 +581,11 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
     fn IceConnectionState(&self) -> RTCIceConnectionState {
         self.ice_connection_state.get()
     }
+
+    /// https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-signalingstate
+    fn SignalingState(&self) -> RTCSignalingState {
+        self.signaling_state.get()
+    }
 }
 
 impl From<SessionDescription> for RTCSessionDescriptionInit {
@@ -591,6 +638,19 @@ impl From<IceConnectionState> for RTCIceConnectionState {
             IceConnectionState::Disconnected => RTCIceConnectionState::Disconnected,
             IceConnectionState::Failed => RTCIceConnectionState::Failed,
             IceConnectionState::Closed => RTCIceConnectionState::Closed,
+        }
+    }
+}
+
+impl From<SignalingState> for RTCSignalingState {
+    fn from(state: SignalingState) -> Self {
+        match state {
+            SignalingState::Stable => RTCSignalingState::Stable,
+            SignalingState::HaveLocalOffer => RTCSignalingState::Have_local_offer,
+            SignalingState::HaveRemoteOffer => RTCSignalingState::Have_remote_offer,
+            SignalingState::HaveLocalPranswer => RTCSignalingState::Have_local_pranswer,
+            SignalingState::HaveRemotePranswer => RTCSignalingState::Have_remote_pranswer,
+            SignalingState::Closed => RTCSignalingState::Closed,
         }
     }
 }

--- a/components/script/dom/webidls/RTCPeerConnection.webidl
+++ b/components/script/dom/webidls/RTCPeerConnection.webidl
@@ -19,7 +19,7 @@ interface RTCPeerConnection : EventTarget {
     // readonly attribute RTCSessionDescription? pendingRemoteDescription;
     Promise<void>                      addIceCandidate(optional RTCIceCandidateInit candidate);
     // readonly attribute RTCSignalingState      signalingState;
-    // readonly attribute RTCIceGatheringState   iceGatheringState;
+    readonly attribute RTCIceGatheringState   iceGatheringState;
     // readonly attribute RTCIceConnectionState  iceConnectionState;
     // readonly attribute RTCPeerConnectionState connectionState;
     // readonly attribute boolean?               canTrickleIceCandidates;
@@ -32,7 +32,7 @@ interface RTCPeerConnection : EventTarget {
     //          attribute EventHandler           onicecandidateerror;
     //          attribute EventHandler           onsignalingstatechange;
     //          attribute EventHandler           oniceconnectionstatechange;
-    //          attribute EventHandler           onicegatheringstatechange;
+             attribute EventHandler           onicegatheringstatechange;
     //          attribute EventHandler           onconnectionstatechange;
 
     // removed from spec, but still shipped by browsers
@@ -88,4 +88,10 @@ dictionary RTCOfferOptions : RTCOfferAnswerOptions {
 };
 
 dictionary RTCAnswerOptions : RTCOfferAnswerOptions {
+};
+
+enum RTCIceGatheringState {
+    "new",
+    "gathering",
+    "complete"
 };

--- a/components/script/dom/webidls/RTCPeerConnection.webidl
+++ b/components/script/dom/webidls/RTCPeerConnection.webidl
@@ -18,7 +18,7 @@ interface RTCPeerConnection : EventTarget {
     // readonly attribute RTCSessionDescription? currentRemoteDescription;
     // readonly attribute RTCSessionDescription? pendingRemoteDescription;
     Promise<void>                      addIceCandidate(optional RTCIceCandidateInit candidate);
-    // readonly attribute RTCSignalingState      signalingState;
+    readonly attribute RTCSignalingState      signalingState;
     readonly attribute RTCIceGatheringState   iceGatheringState;
     readonly attribute RTCIceConnectionState  iceConnectionState;
     // readonly attribute RTCPeerConnectionState connectionState;
@@ -30,7 +30,7 @@ interface RTCPeerConnection : EventTarget {
              attribute EventHandler           onnegotiationneeded;
              attribute EventHandler           onicecandidate;
     //          attribute EventHandler           onicecandidateerror;
-    //          attribute EventHandler           onsignalingstatechange;
+             attribute EventHandler           onsignalingstatechange;
              attribute EventHandler           oniceconnectionstatechange;
              attribute EventHandler           onicegatheringstatechange;
     //          attribute EventHandler           onconnectionstatechange;
@@ -103,5 +103,14 @@ enum RTCIceConnectionState {
     "completed",
     "disconnected",
     "failed",
+    "closed"
+};
+
+enum RTCSignalingState {
+    "stable",
+    "have-local-offer",
+    "have-remote-offer",
+    "have-local-pranswer",
+    "have-remote-pranswer",
     "closed"
 };

--- a/components/script/dom/webidls/RTCPeerConnection.webidl
+++ b/components/script/dom/webidls/RTCPeerConnection.webidl
@@ -20,7 +20,7 @@ interface RTCPeerConnection : EventTarget {
     Promise<void>                      addIceCandidate(optional RTCIceCandidateInit candidate);
     // readonly attribute RTCSignalingState      signalingState;
     readonly attribute RTCIceGatheringState   iceGatheringState;
-    // readonly attribute RTCIceConnectionState  iceConnectionState;
+    readonly attribute RTCIceConnectionState  iceConnectionState;
     // readonly attribute RTCPeerConnectionState connectionState;
     // readonly attribute boolean?               canTrickleIceCandidates;
     // static sequence<RTCIceServer>      getDefaultIceServers();
@@ -31,7 +31,7 @@ interface RTCPeerConnection : EventTarget {
              attribute EventHandler           onicecandidate;
     //          attribute EventHandler           onicecandidateerror;
     //          attribute EventHandler           onsignalingstatechange;
-    //          attribute EventHandler           oniceconnectionstatechange;
+             attribute EventHandler           oniceconnectionstatechange;
              attribute EventHandler           onicegatheringstatechange;
     //          attribute EventHandler           onconnectionstatechange;
 
@@ -94,4 +94,14 @@ enum RTCIceGatheringState {
     "new",
     "gathering",
     "complete"
+};
+
+enum RTCIceConnectionState {
+    "new",
+    "checking",
+    "connected",
+    "completed",
+    "disconnected",
+    "failed",
+    "closed"
 };

--- a/components/script/dom/webidls/RTCPeerConnection.webidl
+++ b/components/script/dom/webidls/RTCPeerConnection.webidl
@@ -26,7 +26,7 @@ interface RTCPeerConnection : EventTarget {
     // static sequence<RTCIceServer>      getDefaultIceServers();
     // RTCConfiguration                   getConfiguration();
     // void                               setConfiguration(RTCConfiguration configuration);
-    // void                               close();
+    void                               close();
              attribute EventHandler           onnegotiationneeded;
              attribute EventHandler           onicecandidate;
     //          attribute EventHandler           onicecandidateerror;


### PR DESCRIPTION
This adds support for `signalingState`, `iceGatheringState`, and `iceConnectionState` on RTCPeerConnection, as well as `RTCPeerConnection::close()`

This doesn't yet support `connectionState`.

r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22974)
<!-- Reviewable:end -->
