### PR TITLE
Remove an unnecessary synchronous full reflow.

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2201,7 +2201,6 @@ impl Document {
                 window,
             );
 
-        window.reflow(ReflowGoal::Full, ReflowReason::DOMContentLoaded);
         update_with_current_time_ms(&self.dom_content_loaded_event_end);
 
         // html parsing has finished - set dom content loaded


### PR DESCRIPTION
We already reflow any nodes that are dirtied during any turn of the event loop. There is no reason to synchronously reflow the entire document, especially when we don't even modify it in this method.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22988
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22995)
<!-- Reviewable:end -->
