### PR TITLE
Fix replacement logic when navigating nested browsing contexts

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2640,12 +2640,16 @@ where
             },
         };
 
-        let (old_pipeline_id, parent_pipeline_id) =
+        let (old_pipeline_id, parent_pipeline_id, top_level_id) =
             match self.browsing_contexts.get_mut(&browsing_context_id) {
                 Some(browsing_context) => {
                     let old_pipeline_id = browsing_context.pipeline_id;
                     browsing_context.update_current_entry(new_pipeline_id);
-                    (old_pipeline_id, browsing_context.parent_pipeline_id)
+                    (
+                        old_pipeline_id,
+                        browsing_context.parent_pipeline_id,
+                        browsing_context.top_level_id,
+                    )
                 },
                 None => {
                     return warn!(
@@ -2662,6 +2666,7 @@ where
             let msg = ConstellationControlMsg::UpdatePipelineId(
                 parent_pipeline_id,
                 browsing_context_id,
+                top_level_id,
                 new_pipeline_id,
                 UpdatePipelineIdReason::Traversal,
             );
@@ -3581,6 +3586,7 @@ where
                     let msg = ConstellationControlMsg::UpdatePipelineId(
                         parent_pipeline_id,
                         change.browsing_context_id,
+                        change.top_level_browsing_context_id,
                         pipeline_id,
                         UpdatePipelineIdReason::Navigation,
                     );

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -922,6 +922,14 @@ where
     }
 
     fn add_pending_change(&mut self, change: SessionHistoryChange) {
+        debug!(
+            "adding pending session history change with {}",
+            if change.replace.is_some() {
+                "replacement"
+            } else {
+                "no replacement"
+            },
+        );
         self.handle_load_start_msg(
             change.top_level_browsing_context_id,
             change.browsing_context_id,
@@ -1915,13 +1923,29 @@ where
             top_level_browsing_context_id,
             new_pipeline_id,
             is_private,
-            replace,
+            mut replace,
         } = load_info.info;
 
         // If no url is specified, reload.
         let old_pipeline = load_info
             .old_pipeline_id
             .and_then(|id| self.pipelines.get(&id));
+
+        // Replacement enabled also takes into account whether the document is "completely loaded",
+        // see https://html.spec.whatwg.org/multipage/#the-iframe-element:completely-loaded
+        debug!("checking old pipeline? {:?}", load_info.old_pipeline_id);
+        if let Some(old_pipeline) = old_pipeline {
+            replace |= !old_pipeline.completely_loaded;
+            debug!(
+                "old pipeline is {}completely loaded",
+                if old_pipeline.completely_loaded {
+                    ""
+                } else {
+                    "not "
+                }
+            );
+        }
+
         let load_data = load_info.load_data.unwrap_or_else(|| {
             let url = match old_pipeline {
                 Some(old_pipeline) => old_pipeline.url.clone(),
@@ -1964,6 +1988,7 @@ where
                 );
             },
         };
+
         let replace = if replace {
             Some(NeedsToReload::No(browsing_context.pipeline_id))
         } else {
@@ -2214,7 +2239,12 @@ where
         load_data: LoadData,
         replace: bool,
     ) -> Option<PipelineId> {
-        debug!("Loading {} in pipeline {}.", load_data.url, source_id);
+        debug!(
+            "Loading {} in pipeline {}, {}replacing.",
+            load_data.url,
+            source_id,
+            if replace { "" } else { "not " }
+        );
         // If this load targets an iframe, its framing element may exist
         // in a separate script thread than the framed document that initiated
         // the new load. The framing element must be notified about the
@@ -2374,6 +2404,11 @@ where
         }
         if webdriver_reset {
             self.webdriver.load_channel = None;
+        }
+
+        if let Some(pipeline) = self.pipelines.get_mut(&pipeline_id) {
+            debug!("marking pipeline {:?} as loaded", pipeline_id);
+            pipeline.completely_loaded = true;
         }
 
         // Notify the embedder that the TopLevelBrowsingContext current document

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -89,6 +89,9 @@ pub struct Pipeline {
 
     /// The history states owned by this pipeline.
     pub history_states: HashSet<HistoryStateId>,
+
+    /// Has this pipeline received a notification that it is completely loaded?
+    pub completely_loaded: bool,
 }
 
 /// Initial setup data needed to construct a pipeline.
@@ -355,6 +358,7 @@ impl Pipeline {
             load_data: load_data,
             history_state_id: None,
             history_states: HashSet::new(),
+            completely_loaded: false,
         };
 
         pipeline.notify_visibility(is_visible);

--- a/components/constellation/session_history.rs
+++ b/components/constellation/session_history.rs
@@ -37,6 +37,7 @@ impl JointSessionHistory {
     }
 
     pub fn push_diff(&mut self, diff: SessionHistoryDiff) -> Vec<SessionHistoryDiff> {
+        debug!("pushing a past entry; removing future");
         self.past.push(diff);
         mem::replace(&mut self.future, vec![])
     }
@@ -85,6 +86,7 @@ impl JointSessionHistory {
     }
 
     pub fn remove_entries_for_browsing_context(&mut self, context_id: BrowsingContextId) {
+        debug!("removing entries for context {}", context_id);
         self.past.retain(|diff| match diff {
             SessionHistoryDiff::BrowsingContextDiff {
                 browsing_context_id,

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -278,9 +278,7 @@ impl HTMLIFrameElement {
         // see https://html.spec.whatwg.org/multipage/#the-iframe-element:about:blank-3
         let is_about_blank =
             pipeline_id.is_some() && pipeline_id == self.about_blank_pipeline_id.get();
-        // Replacement enabled also takes into account whether the document is "completely loaded",
-        // see https://html.spec.whatwg.org/multipage/#the-iframe-element:completely-loaded
-        let replace = is_about_blank || !document.is_completely_loaded();
+        let replace = is_about_blank;
         self.navigate_or_reload_child_browsing_context(
             Some(load_data),
             NavigationType::Regular,

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -303,6 +303,7 @@ pub enum ConstellationControlMsg {
     UpdatePipelineId(
         PipelineId,
         BrowsingContextId,
+        TopLevelBrowsingContextId,
         PipelineId,
         UpdatePipelineIdReason,
     ),

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -10459,6 +10459,11 @@
      {}
     ]
    ],
+   "mozilla/resources/first.html": [
+    [
+     {}
+    ]
+   ],
    "mozilla/resources/http-cache.js": [
     [
      {}
@@ -10495,6 +10500,11 @@
     ]
    ],
    "mozilla/resources/range_small.txt": [
+    [
+     {}
+    ]
+   ],
+   "mozilla/resources/second.html": [
     [
      {}
     ]
@@ -12656,6 +12666,12 @@
    "mozilla/globals/entry.worker.js": [
     [
      "/_mozilla/mozilla/globals/entry.worker.html",
+     {}
+    ]
+   ],
+   "mozilla/history.html": [
+    [
+     "/_mozilla/mozilla/history.html",
      {}
     ]
    ],
@@ -19424,6 +19440,10 @@
    "9baa0cdcd5abad00b321e8b9351a1bc162783ed5",
    "support"
   ],
+  "mozilla/history.html": [
+   "130307f1e9c8bc4c5ee6fff4d5fef8fda89a1564",
+   "testharness"
+  ],
   "mozilla/hit-test-background.html": [
    "5212954e4ee6ecb684212e7373e24a2268434b1c",
    "testharness"
@@ -19796,6 +19816,10 @@
    "5f0242874cfa47b84af35325ad651690cd9fb790",
    "support"
   ],
+  "mozilla/resources/first.html": [
+   "b4359ad2855339999cfeda0c2681a51da6fdd940",
+   "support"
+  ],
   "mozilla/resources/http-cache.js": [
    "34aaacf536f31e4d9ae003cb0891ede965201f08",
    "support"
@@ -19826,6 +19850,10 @@
   ],
   "mozilla/resources/range_small.txt": [
    "b0883f382e1a80609b7b2c7904e701fbe6760b14",
+   "support"
+  ],
+  "mozilla/resources/second.html": [
+   "c4fbe534ed193e1d192c0338997a8d9da8eb6406",
    "support"
   ],
   "mozilla/resources/ssl.https.html": [

--- a/tests/wpt/mozilla/tests/mozilla/history.html
+++ b/tests/wpt/mozilla/tests/mozilla/history.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Traversing history causes iframe contentWindow to update</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe src="resources/first.html"></iframe>
+<script>
+  var iframe = document.querySelector('iframe');
+  var t = async_test();
+  onload = t.step_func(function() {
+    iframe.onload = t.step_func(function() {
+      assert_true(iframe.contentWindow.location.href.endsWith('second.html'));
+      iframe.contentWindow.history.back();
+      t.step_timeout(function() {
+        assert_true(iframe.contentWindow.location.href.endsWith('first.html'));
+        iframe.contentWindow.history.forward();
+        t.step_timeout(function() {
+          assert_true(iframe.contentWindow.location.href.endsWith('second.html'));
+          t.done();
+        }, 1000);
+      }, 1000);
+    });
+    iframe.src = "resources/second.html";
+  });
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/resources/first.html
+++ b/tests/wpt/mozilla/tests/mozilla/resources/first.html
@@ -1,0 +1,1 @@
+<body>hello world</body>

--- a/tests/wpt/mozilla/tests/mozilla/resources/second.html
+++ b/tests/wpt/mozilla/tests/mozilla/resources/second.html
@@ -1,0 +1,1 @@
+<body>goodbye world</body>


### PR DESCRIPTION
These changes also fix a bug where traversing the session history in a nested browsing context did not update the iframe's contentWindow appropriately.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #22996
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/22999)
<!-- Reviewable:end -->
