### PR TITLE
Remove 'on' prefix from event handler macros

### DIFF
--- a/components/script/dom/permissionstatus.rs
+++ b/components/script/dom/permissionstatus.rs
@@ -56,7 +56,7 @@ impl PermissionStatusMethods for PermissionStatus {
     }
 
     // https://w3c.github.io/permissions/#dom-permissionstatus-onchange
-    event_handler!(onchange, GetOnchange, SetOnchange);
+    event_handler!(change, GetOnchange, SetOnchange);
 }
 
 impl Display for PermissionName {

--- a/components/script/dom/texttrack.rs
+++ b/components/script/dom/texttrack.rs
@@ -148,5 +148,5 @@ impl TextTrackMethods for TextTrack {
     }
 
     // https://html.spec.whatwg.org/multipage/#handler-texttrack-oncuechange
-    event_handler!(oncuechange, GetOncuechange, SetOncuechange);
+    event_handler!(cuechange, GetOncuechange, SetOncuechange);
 }

--- a/components/script/dom/texttrackcue.rs
+++ b/components/script/dom/texttrackcue.rs
@@ -104,8 +104,8 @@ impl TextTrackCueMethods for TextTrackCue {
     }
 
     // https://html.spec.whatwg.org/multipage/#handler-texttrackcue-onenter
-    event_handler!(onenter, GetOnenter, SetOnenter);
+    event_handler!(enter, GetOnenter, SetOnenter);
 
     // https://html.spec.whatwg.org/multipage/#handler-texttrackcue-onexit
-    event_handler!(onexit, GetOnexit, SetOnexit);
+    event_handler!(exit, GetOnexit, SetOnexit);
 }

--- a/components/script/dom/texttracklist.rs
+++ b/components/script/dom/texttracklist.rs
@@ -130,11 +130,11 @@ impl TextTrackListMethods for TextTrackList {
     }
 
     // https://html.spec.whatwg.org/multipage/#handler-texttracklist-onchange
-    event_handler!(onchange, GetOnchange, SetOnchange);
+    event_handler!(change, GetOnchange, SetOnchange);
 
     // https://html.spec.whatwg.org/multipage/#handler-texttracklist-onaddtrack
-    event_handler!(onaddtrack, GetOnaddtrack, SetOnaddtrack);
+    event_handler!(addtrack, GetOnaddtrack, SetOnaddtrack);
 
     // https://html.spec.whatwg.org/multipage/#handler-texttracklist-onremovetrack
-    event_handler!(onremovetrack, GetOnremovetrack, SetOnremovetrack);
+    event_handler!(removetrack, GetOnremovetrack, SetOnremovetrack);
 }

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/interfaces/TextTrack/oncuechange.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/interfaces/TextTrack/oncuechange.html.ini
@@ -1,4 +1,0 @@
-[oncuechange.html]
-  [TextTrack.oncuechange]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/interfaces/TextTrackList/onaddtrack.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/interfaces/TextTrackList/onaddtrack.html.ini
@@ -1,4 +1,0 @@
-[onaddtrack.html]
-  [TextTrackList.onaddtrack]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/embedded-content/media-elements/interfaces/TextTrackList/onremovetrack.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/media-elements/interfaces/TextTrackList/onremovetrack.html.ini
@@ -1,4 +1,0 @@
-[onremovetrack.html]
-  [TextTrackList.onremovetrack]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Remove 'on' prefix from event handler macros

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22516 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23016)
<!-- Reviewable:end -->
