### PR TITLE
Assert fail #18439

### DIFF
--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -14,7 +14,6 @@ use net_traits::request::RequestInit;
 use net_traits::{CoreResourceMsg, FetchChannels, FetchResponseMsg};
 use net_traits::{IpcSend, ResourceThreads};
 use servo_url::ServoUrl;
-use std::thread;
 
 #[derive(Clone, Debug, JSTraceable, MallocSizeOf, PartialEq)]
 pub enum LoadType {
@@ -77,8 +76,8 @@ impl LoadBlocker {
 
 impl Drop for LoadBlocker {
     fn drop(&mut self) {
-        if let Some(script_thread) = self.load.take() {
-            self.doc.finish_load(script_thread);
+        if let Some(load) = self.load.take() {
+            self.doc.finish_load(load);
         }
     }
 }

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -77,8 +77,8 @@ impl LoadBlocker {
 
 impl Drop for LoadBlocker {
     fn drop(&mut self) {
-        if !thread::panicking() {
-            debug_assert!(self.load.is_none());
+        if let Some(script_thread) = self.load.take() {
+            self.doc.finish_load(script_thread);
         }
     }
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -809,13 +809,13 @@ impl ScriptThread {
 
     pub fn mark_document_with_no_blocked_loads(doc: &Document) {
         SCRIPT_THREAD_ROOT.with(|root| {
-            unsafe {
             if let Some(script_thread) = root.get() {
-                (*script_thread)
+                let script_thread = unsafe { &*script_thread };
+                script_thread
                     .docs_with_no_blocking_loads
                     .borrow_mut()
                     .insert(Dom::from_ref(doc));
-            }}
+            }
         })
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -809,11 +809,13 @@ impl ScriptThread {
 
     pub fn mark_document_with_no_blocked_loads(doc: &Document) {
         SCRIPT_THREAD_ROOT.with(|root| {
-            let script_thread = unsafe { &*root.get().unwrap() };
-            script_thread
-                .docs_with_no_blocking_loads
-                .borrow_mut()
-                .insert(Dom::from_ref(doc));
+            unsafe {
+            if let Some(script_thread) = root.get() {
+                (*script_thread)
+                    .docs_with_no_blocking_loads
+                    .borrow_mut()
+                    .insert(Dom::from_ref(doc));
+            }}
         })
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR addresses #18439 by removing an assert statement that forces a panic whenever `LoadBlocker` is dropped during a GC sweep and receives a `None` `SCRIPT_THREAD_ROOT` value from `mark_document_with_no_blocked_loads()`. Instead of panicking on the assert, we remove it and let the None value pass silently.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #18439 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23021)
<!-- Reviewable:end -->
