### PR TITLE
create uuid before sending PromoteMemory message

### DIFF
--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -126,20 +126,8 @@ impl FileManager {
         )
     }
 
-    pub fn promote_memory(
-        &self,
-        blob_buf: BlobBuf,
-        set_valid: bool,
-        sender: IpcSender<Result<Uuid, BlobURLStoreError>>,
-        origin: FileOrigin,
-    ) {
-        let store = self.store.clone();
-        thread::Builder::new()
-            .name("transfer memory".to_owned())
-            .spawn(move || {
-                store.promote_memory(blob_buf, set_valid, sender, origin);
-            })
-            .expect("Thread spawning failed");
+    pub fn promote_memory(&self, id: Uuid, blob_buf: BlobBuf, set_valid: bool, origin: FileOrigin) {
+        self.store.promote_memory(id, blob_buf, set_valid, origin);
     }
 
     /// Message handler
@@ -168,8 +156,8 @@ impl FileManager {
             FileManagerThreadMsg::ReadFile(sender, id, check_url_validity, origin) => {
                 self.read_file(sender, id, check_url_validity, origin);
             },
-            FileManagerThreadMsg::PromoteMemory(blob_buf, set_valid, sender, origin) => {
-                self.promote_memory(blob_buf, set_valid, sender, origin);
+            FileManagerThreadMsg::PromoteMemory(id, blob_buf, set_valid, origin) => {
+                self.promote_memory(id, blob_buf, set_valid, origin);
             },
             FileManagerThreadMsg::AddSlicedURLEntry(id, rel_pos, sender, origin) => {
                 self.store.add_sliced_url_entry(id, rel_pos, sender, origin);
@@ -667,17 +655,10 @@ impl FileManagerStore {
         Ok(())
     }
 
-    fn promote_memory(
-        &self,
-        blob_buf: BlobBuf,
-        set_valid: bool,
-        sender: IpcSender<Result<Uuid, BlobURLStoreError>>,
-        origin: FileOrigin,
-    ) {
+    fn promote_memory(&self, id: Uuid, blob_buf: BlobBuf, set_valid: bool, origin: FileOrigin) {
         match Url::parse(&origin) {
             // parse to check sanity
             Ok(_) => {
-                let id = Uuid::new_v4();
                 self.insert(
                     id,
                     FileStoreEntry {
@@ -687,12 +668,8 @@ impl FileManagerStore {
                         is_valid_url: AtomicBool::new(set_valid),
                     },
                 );
-
-                let _ = sender.send(Ok(id));
             },
-            Err(_) => {
-                let _ = sender.send(Err(BlobURLStoreError::InvalidOrigin));
-            },
+            Err(_) => {},
         }
     }
 

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -47,6 +47,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
+use uuid::Uuid;
 
 // TODO write a struct that impls Handler for storing test values
 
@@ -125,7 +126,6 @@ fn test_fetch_aboutblank() {
 
 #[test]
 fn test_fetch_blob() {
-    use ipc_channel::ipc;
     use net_traits::blob_url_store::BlobBuf;
 
     struct FetchResponseCollector {
@@ -160,11 +160,10 @@ fn test_fetch_blob() {
 
     let origin = ServoUrl::parse("http://www.example.org/").unwrap();
 
-    let (sender, receiver) = ipc::channel().unwrap();
+    let id = Uuid::new_v4();
     context
         .filemanager
-        .promote_memory(blob_buf, true, sender, "http://www.example.org".into());
-    let id = receiver.recv().unwrap().unwrap();
+        .promote_memory(id.clone(), blob_buf, true, "http://www.example.org".into());
     let url = ServoUrl::parse(&format!("blob:{}{}", origin.as_str(), id.to_simple())).unwrap();
 
     let mut request = Request::new(url, Some(Origin::Origin(origin.origin())), None);

--- a/components/net_traits/filemanager_thread.rs
+++ b/components/net_traits/filemanager_thread.rs
@@ -137,14 +137,8 @@ pub enum FileManagerThreadMsg {
         FileOrigin,
     ),
 
-    /// Add an entry as promoted memory-based blob and send back the associated FileID
-    /// as part of a valid/invalid Blob URL depending on the boolean flag
-    PromoteMemory(
-        BlobBuf,
-        bool,
-        IpcSender<Result<Uuid, BlobURLStoreError>>,
-        FileOrigin,
-    ),
+    /// Add an entry as promoted memory-based blob
+    PromoteMemory(Uuid, BlobBuf, bool, FileOrigin),
 
     /// Add a sliced entry pointing to the parent FileID, and send back the associated FileID
     /// as part of a valid Blob URL

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -238,23 +238,17 @@ impl Blob {
             bytes: bytes.to_vec(),
         };
 
-        let (tx, rx) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
-        let msg = FileManagerThreadMsg::PromoteMemory(blob_buf, set_valid, tx, origin.clone());
+        let id = Uuid::new_v4();
+        let msg = FileManagerThreadMsg::PromoteMemory(id, blob_buf, set_valid, origin.clone());
         self.send_to_file_manager(msg);
 
-        match rx.recv().unwrap() {
-            Ok(id) => {
-                *self.blob_impl.borrow_mut() = BlobImpl::File(FileBlob {
-                    id: id.clone(),
-                    name: None,
-                    cache: DomRefCell::new(Some(bytes.to_vec())),
-                    size: bytes.len() as u64,
-                });
-                id
-            },
-            // Dummy id
-            Err(_) => Uuid::new_v4(),
-        }
+        *self.blob_impl.borrow_mut() = BlobImpl::File(FileBlob {
+            id: id.clone(),
+            name: None,
+            cache: DomRefCell::new(Some(bytes.to_vec())),
+            size: bytes.len() as u64,
+        });
+        id
     }
 
     /// Get a FileID representing sliced parent-blob content


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
When `Blob::promote` is promoting a `BlobImpl::Memory`, create uuid and send it with the `FileManagerThreadMsg::PromoteMemory` message rather than blocking until one is received.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23032  (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23045)
<!-- Reviewable:end -->
