### PR TITLE
Update webdriver crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4750,10 +4750,10 @@ dependencies = [
 
 [[package]]
 name = "webdriver"
-version = "0.38.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4793,7 +4793,7 @@ dependencies = [
  "servo_url 0.0.1",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "webdriver 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webdriver 0.38.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5468,7 +5468,7 @@ dependencies = [
 "checksum wayland-protocols 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d3f6cebb98963f028d397e9bad2acf9d3b2f6b76fae65aea191edd9e7c0df88c"
 "checksum wayland-scanner 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f1927ee62e4e149c010dc9eca8ca47e238416cd6f45f688eb9f8a8e9c3794c30"
 "checksum wayland-sys 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ca41ed78a12256f81df6f53fcbe4503213ba442e02cdad3c9c888a64a668eaf4"
-"checksum webdriver 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57600e820ab8ac3fcfed782edfb5ac1b530f5980d9c17030d13fd367e9734681"
+"checksum webdriver 0.38.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c6022ea74cc9f0085c01ff24965d935cd40f9592d7a56f13909c65f08ea98149"
 "checksum webrender 0.58.0 (git+https://github.com/servo/webrender)" = "<none>"
 "checksum webrender_api 0.58.0 (git+https://github.com/servo/webrender)" = "<none>"
 "checksum webrender_build 0.0.1 (git+https://github.com/servo/webrender)" = "<none>"


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I was playing around with the WebDriver tests and I managed to get some of them pass (several tests in `new_session/default_values.py`) by updating the `webdriver` crate to the latest version. It looks like the fix of this bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1507428 made the tests pass.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23058)
<!-- Reviewable:end -->
