### PR TITLE
Compare gstreamer version via `pkg-config --modversion` in bootstrap python script

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -46,7 +46,7 @@ def install_trusty_deps(force):
 
 
 def check_gstreamer_lib():
-    return subprocess.call(["pkg-config", "gstreamer-1.0 >= 1.12"],
+    return subprocess.call(["pkg-config", "--atleast-version=1.12", "gstreamer-1.0"],
                            stdout=PIPE, stderr=PIPE) == 0
 
 


### PR DESCRIPTION
Not sure why calling `["pkg-config", "gstreamer-1.0 >= 1.12"]` did not work for some people on Mojave. (Btw, I'm also on Mojave but checking version with `gstreamer-1.0 >= 1.12` works fine for me 🤔)

I'd like to send this PR and ask bors to try to see if this will also work for other platform.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23015 
- [x] These changes do not require tests because it tries to fix building issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23069)
<!-- Reviewable:end -->
