### PR TITLE
Expose public getter to stylesheet's owner

### DIFF
--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -6,12 +6,15 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::CSSRuleListBinding;
 use crate::dom::bindings::codegen::Bindings::CSSRuleListBinding::CSSRuleListMethods;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::csskeyframerule::CSSKeyframeRule;
 use crate::dom::cssrule::CSSRule;
 use crate::dom::cssstylesheet::CSSStyleSheet;
+use crate::dom::htmlelement::HTMLElement;
 use crate::dom::window::Window;
+use crate::stylesheet_loader::StylesheetLoader;
 use dom_struct::dom_struct;
 use servo_arc::Arc;
 use style::shared_lock::Locked;
@@ -101,6 +104,12 @@ impl CSSRuleList {
         let index = idx as usize;
 
         let parent_stylesheet = self.parent_stylesheet.style_stylesheet();
+        let owner = self
+            .parent_stylesheet
+            .get_owner()
+            .downcast::<HTMLElement>()
+            .unwrap();
+        let loader = StylesheetLoader::for_element(owner);
         let new_rule = css_rules.with_raw_offset_arc(|arc| {
             arc.insert_rule(
                 &parent_stylesheet.shared_lock,
@@ -108,7 +117,7 @@ impl CSSRuleList {
                 &parent_stylesheet.contents,
                 index,
                 nested,
-                None,
+                Some(&loader),
             )
         })?;
 

--- a/components/script/dom/cssstylesheet.rs
+++ b/components/script/dom/cssstylesheet.rs
@@ -75,6 +75,10 @@ impl CSSStyleSheet {
         self.style_stylesheet.disabled()
     }
 
+    pub fn get_owner(&self) -> &Element {
+        &*self.owner
+    }
+
     pub fn set_disabled(&self, disabled: bool) {
         if self.style_stylesheet.set_disabled(disabled) {
             self.global()

--- a/tests/wpt/metadata/css/cssom/insertRule-namespace-no-index.html.ini
+++ b/tests/wpt/metadata/css/cssom/insertRule-namespace-no-index.html.ini
@@ -1,3 +1,0 @@
-[insertRule-namespace-no-index.html]
-  expected: CRASH
-

--- a/tests/wpt/web-platform-tests/css/cssom/insertRule-from-script-ref.html
+++ b/tests/wpt/web-platform-tests/css/cssom/insertRule-from-script-ref.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8">
+  <title>insertrule @import test reference</title>
+  <link rel="stylesheet" href="support/black.css">
+</head>

--- a/tests/wpt/web-platform-tests/css/cssom/insertRule-from-script.html
+++ b/tests/wpt/web-platform-tests/css/cssom/insertRule-from-script.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8">
+  <title>insertrule @import test</title>
+  <link rel="help" href="https://drafts.csswg.org/cssom/">
+  <link rel="help" href="http://www.w3.org/TR/cssom-1/#the-cssrule-interface">
+  <link rel="match" href="insertRule-from-script-ref.html">
+  <style></style>
+</head>
+<body>
+  <script>document.styleSheets[0].insertRule("@import url(\"support/black.css\");");</script>
+</body>

--- a/tests/wpt/web-platform-tests/css/cssom/support/black.css
+++ b/tests/wpt/web-platform-tests/css/cssom/support/black.css
@@ -1,0 +1,4 @@
+html {
+background-color: black;
+color: white;
+}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

- [x] expose a public getter on CSSStyleSheet to return the stylesheet's owner
- [x] in CSSRuleList::insert_rule, use the new getter to pass a non-None value as an argument to arc.insert_rule
- [x] add a test for this that verifies that the new stylesheet is actually loaded
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23028 
 
<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23073)
<!-- Reviewable:end -->
