### PR TITLE
#23065 removed unnecessary headless checking

### DIFF
--- a/components/bluetooth/lib.rs
+++ b/components/bluetooth/lib.rs
@@ -20,7 +20,6 @@ use device::bluetooth::{BluetoothAdapter, BluetoothDevice, BluetoothGATTCharacte
 use device::bluetooth::{BluetoothGATTDescriptor, BluetoothGATTService};
 use embedder_traits::{EmbedderMsg, EmbedderProxy};
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
-use servo_config::opts;
 use servo_config::pref;
 use servo_rand::{self, Rng};
 use std::borrow::ToOwned;
@@ -381,7 +380,7 @@ impl BluetoothManager {
         devices: Vec<BluetoothDevice>,
         adapter: &BluetoothAdapter,
     ) -> Option<String> {
-        if is_mock_adapter(adapter) || opts::get().headless {
+        if is_mock_adapter(adapter) {
             for device in &devices {
                 if let Ok(address) = device.get_address() {
                     return Some(address);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23065 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes (it's wpt tests, isn't it?)
- [ ] These changes do not require tests because _____

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23079)
<!-- Reviewable:end -->
