### PR TITLE
Add a sampling profiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,7 @@ dependencies = [
  "mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,6 @@ dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -16,7 +16,6 @@ doctest = false
 backtrace = "0.3"
 bitflags = "1.0"
 ipc-channel = "0.11"
-lazy_static = "1"
 libc = "0.2"
 log = "0.4"
 msg = {path = "../msg"}

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -21,6 +21,7 @@ libc = "0.2"
 log = "0.4"
 msg = {path = "../msg"}
 serde = "1.0.60"
+serde_json = "1.0"
 crossbeam-channel = "0.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/components/background_hang_monitor/lib.rs
+++ b/components/background_hang_monitor/lib.rs
@@ -7,6 +7,8 @@
 #[macro_use]
 extern crate crossbeam_channel;
 #[macro_use]
+extern crate lazy_static;
+#[macro_use]
 extern crate log;
 
 pub mod background_hang_monitor;

--- a/components/background_hang_monitor/lib.rs
+++ b/components/background_hang_monitor/lib.rs
@@ -7,8 +7,6 @@
 #[macro_use]
 extern crate crossbeam_channel;
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate log;
 
 pub mod background_hang_monitor;

--- a/components/background_hang_monitor/tests/hang_monitor_tests.rs
+++ b/components/background_hang_monitor/tests/hang_monitor_tests.rs
@@ -6,18 +6,63 @@ use background_hang_monitor::HangMonitorRegister;
 use ipc_channel::ipc;
 use msg::constellation_msg::ScriptHangAnnotation;
 use msg::constellation_msg::TEST_PIPELINE_ID;
-use msg::constellation_msg::{HangAlert, HangAnnotation};
+use msg::constellation_msg::{HangAlert, HangAnnotation, HangMonitorAlert};
 use msg::constellation_msg::{MonitoredComponentId, MonitoredComponentType};
 use std::thread;
 use std::time::Duration;
 
 #[test]
+#[cfg(target_os = "macos")]
+fn test_sampler() {
+    use msg::constellation_msg::SamplerControlMsg;
+    use serde_json::Value;
+
+    let (background_hang_monitor_ipc_sender, background_hang_monitor_receiver) =
+        ipc::channel().expect("ipc channel failure");
+    let (sampler_sender, sampler_receiver) = ipc::channel().expect("ipc channel failure");
+
+    let background_hang_monitor_register =
+        HangMonitorRegister::init(background_hang_monitor_ipc_sender.clone(), sampler_receiver);
+    let _background_hang_monitor = background_hang_monitor_register.register_component(
+        MonitoredComponentId(TEST_PIPELINE_ID, MonitoredComponentType::Script),
+        Duration::from_millis(10),
+        Duration::from_millis(1000),
+    );
+
+    const RATE: u64 = 10;
+    sampler_sender
+        .send(SamplerControlMsg::Enable(Duration::from_millis(RATE)))
+        .unwrap();
+
+    thread::sleep(Duration::from_millis(30));
+
+    sampler_sender.send(SamplerControlMsg::Disable).unwrap();
+
+    loop {
+        match background_hang_monitor_receiver.recv().unwrap() {
+            HangMonitorAlert::Hang(_) => continue,
+            HangMonitorAlert::Profile(ref bytes) => {
+                let json: Value = serde_json::from_slice(bytes).unwrap();
+                let rate = json["rate"].as_u64().unwrap();
+                assert_eq!(rate, RATE);
+                let data = json["data"].as_array().unwrap();
+                assert!(data.len() > 1);
+                assert_eq!(data[0]["name"].as_str().unwrap(), "test_sampler");
+                assert!(data[0]["frames"].as_array().unwrap().len() > 0);
+                break;
+            },
+        }
+    }
+}
+
+#[test]
 fn test_hang_monitoring() {
     let (background_hang_monitor_ipc_sender, background_hang_monitor_receiver) =
         ipc::channel().expect("ipc channel failure");
+    let (_sampler_sender, sampler_receiver) = ipc::channel().expect("ipc channel failure");
 
     let background_hang_monitor_register =
-        HangMonitorRegister::init(background_hang_monitor_ipc_sender.clone());
+        HangMonitorRegister::init(background_hang_monitor_ipc_sender.clone(), sampler_receiver);
     let background_hang_monitor = background_hang_monitor_register.register_component(
         MonitoredComponentId(TEST_PIPELINE_ID, MonitoredComponentType::Script),
         Duration::from_millis(10),
@@ -33,11 +78,11 @@ fn test_hang_monitoring() {
 
     // Check for a transient hang alert.
     match background_hang_monitor_receiver.recv().unwrap() {
-        HangAlert::Transient(component_id, _annotation) => {
+        HangMonitorAlert::Hang(HangAlert::Transient(component_id, _annotation)) => {
             let expected = MonitoredComponentId(TEST_PIPELINE_ID, MonitoredComponentType::Script);
             assert_eq!(expected, component_id);
         },
-        HangAlert::Permanent(..) => unreachable!(),
+        _ => unreachable!(),
     }
 
     // Sleep until the "permanent" timeout has been reached.
@@ -45,11 +90,11 @@ fn test_hang_monitoring() {
 
     // Check for a permanent hang alert.
     match background_hang_monitor_receiver.recv().unwrap() {
-        HangAlert::Permanent(component_id, _annotation, _profile) => {
+        HangMonitorAlert::Hang(HangAlert::Permanent(component_id, _annotation, _profile)) => {
             let expected = MonitoredComponentId(TEST_PIPELINE_ID, MonitoredComponentType::Script);
             assert_eq!(expected, component_id);
         },
-        HangAlert::Transient(..) => unreachable!(),
+        _ => unreachable!(),
     }
 
     // Now the component is not hanging anymore.
@@ -61,11 +106,11 @@ fn test_hang_monitoring() {
 
     // Check for a transient hang alert.
     match background_hang_monitor_receiver.recv().unwrap() {
-        HangAlert::Transient(component_id, _annotation) => {
+        HangMonitorAlert::Hang(HangAlert::Transient(component_id, _annotation)) => {
             let expected = MonitoredComponentId(TEST_PIPELINE_ID, MonitoredComponentType::Script);
             assert_eq!(expected, component_id);
         },
-        HangAlert::Permanent(..) => unreachable!(),
+        _ => unreachable!(),
     }
 
     // Now the component is waiting for a new task.
@@ -85,11 +130,11 @@ fn test_hang_monitoring() {
 
     // We're getting new hang alerts for the latest task.
     match background_hang_monitor_receiver.recv().unwrap() {
-        HangAlert::Transient(component_id, _annotation) => {
+        HangMonitorAlert::Hang(HangAlert::Transient(component_id, _annotation)) => {
             let expected = MonitoredComponentId(TEST_PIPELINE_ID, MonitoredComponentType::Script);
             assert_eq!(expected, component_id);
         },
-        HangAlert::Permanent(..) => unreachable!(),
+        _ => unreachable!(),
     }
 
     // No new alert yet
@@ -110,9 +155,10 @@ fn test_hang_monitoring() {
 fn test_hang_monitoring_unregister() {
     let (background_hang_monitor_ipc_sender, background_hang_monitor_receiver) =
         ipc::channel().expect("ipc channel failure");
+    let (_sampler_sender, sampler_receiver) = ipc::channel().expect("ipc channel failure");
 
     let background_hang_monitor_register =
-        HangMonitorRegister::init(background_hang_monitor_ipc_sender.clone());
+        HangMonitorRegister::init(background_hang_monitor_ipc_sender.clone(), sampler_receiver);
     let background_hang_monitor = background_hang_monitor_register.register_component(
         MonitoredComponentId(TEST_PIPELINE_ID, MonitoredComponentType::Script),
         Duration::from_millis(10),

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -16,6 +16,7 @@ use servo_url::ServoUrl;
 use std::fmt::{Debug, Error, Formatter};
 #[cfg(feature = "gl")]
 use std::rc::Rc;
+use std::time::Duration;
 use style_traits::DevicePixel;
 use webrender_api::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePoint, ScrollLocation};
 use webvr::VRServiceManager;
@@ -91,6 +92,8 @@ pub enum WindowEvent {
     ToggleWebRenderDebug(WebRenderDebugOption),
     /// Capture current WebRender
     CaptureWebRender,
+    /// Toggle sampling profiler with the given sampling rate
+    ToggleSamplingProfiler(Duration),
 }
 
 impl Debug for WindowEvent {
@@ -118,6 +121,7 @@ impl Debug for WindowEvent {
             WindowEvent::SelectBrowser(..) => write!(f, "SelectBrowser"),
             WindowEvent::ToggleWebRenderDebug(..) => write!(f, "ToggleWebRenderDebug"),
             WindowEvent::CaptureWebRender => write!(f, "CaptureWebRender"),
+            WindowEvent::ToggleSamplingProfiler(..) => write!(f, "ToggleSamplingProfiler"),
         }
     }
 }

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -18,7 +18,7 @@ use ipc_channel::Error;
 use layout_traits::LayoutThreadFactory;
 use metrics::PaintTimeMetrics;
 use msg::constellation_msg::TopLevelBrowsingContextId;
-use msg::constellation_msg::{BackgroundHangMonitorRegister, HangAlert};
+use msg::constellation_msg::{BackgroundHangMonitorRegister, HangMonitorAlert};
 use msg::constellation_msg::{BrowsingContextId, HistoryStateId, PipelineId, PipelineNamespaceId};
 use net::image_cache::ImageCacheImpl;
 use net_traits::image_cache::ImageCache;
@@ -122,7 +122,7 @@ pub struct InitialPipelineState {
     pub background_monitor_register: Option<Box<BackgroundHangMonitorRegister>>,
 
     /// A channel for the background hang monitor to send messages to the constellation.
-    pub background_hang_monitor_to_constellation_chan: IpcSender<HangAlert>,
+    pub background_hang_monitor_to_constellation_chan: IpcSender<HangMonitorAlert>,
 
     /// A channel for the layout thread to send messages to the constellation.
     pub layout_to_constellation_chan: IpcSender<LayoutMsg>,
@@ -467,7 +467,7 @@ pub struct UnprivilegedPipelineContent {
     parent_pipeline_id: Option<PipelineId>,
     opener: Option<BrowsingContextId>,
     script_to_constellation_chan: ScriptToConstellationChan,
-    background_hang_monitor_to_constellation_chan: IpcSender<HangAlert>,
+    background_hang_monitor_to_constellation_chan: IpcSender<HangMonitorAlert>,
     layout_to_constellation_chan: IpcSender<LayoutMsg>,
     scheduler_chan: IpcSender<TimerSchedulerMsg>,
     devtools_chan: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
@@ -669,7 +669,7 @@ impl UnprivilegedPipelineContent {
         }
     }
 
-    pub fn background_hang_monitor_to_constellation_chan(&self) -> &IpcSender<HangAlert> {
+    pub fn background_hang_monitor_to_constellation_chan(&self) -> &IpcSender<HangMonitorAlert> {
         &self.background_hang_monitor_to_constellation_chan
     }
 

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::event_loop::EventLoop;
+use background_hang_monitor::HangMonitorRegister;
 use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::WebGLPipeline;
 use compositing::compositor_thread::Msg as CompositorMsg;
@@ -18,7 +19,7 @@ use ipc_channel::Error;
 use layout_traits::LayoutThreadFactory;
 use metrics::PaintTimeMetrics;
 use msg::constellation_msg::TopLevelBrowsingContextId;
-use msg::constellation_msg::{BackgroundHangMonitorRegister, HangMonitorAlert};
+use msg::constellation_msg::{BackgroundHangMonitorRegister, HangMonitorAlert, SamplerControlMsg};
 use msg::constellation_msg::{BrowsingContextId, HistoryStateId, PipelineId, PipelineNamespaceId};
 use net::image_cache::ImageCacheImpl;
 use net_traits::image_cache::ImageCache;
@@ -188,10 +189,15 @@ pub struct InitialPipelineState {
     pub webvr_chan: Option<IpcSender<WebVRMsg>>,
 }
 
+pub struct NewPipeline {
+    pub pipeline: Pipeline,
+    pub sampler_control_chan: Option<IpcSender<SamplerControlMsg>>,
+}
+
 impl Pipeline {
     /// Starts a layout thread, and possibly a script thread, in
     /// a new process if requested.
-    pub fn spawn<Message, LTF, STF>(state: InitialPipelineState) -> Result<Pipeline, Error>
+    pub fn spawn<Message, LTF, STF>(state: InitialPipelineState) -> Result<NewPipeline, Error>
     where
         LTF: LayoutThreadFactory<Message = Message>,
         STF: ScriptThreadFactory<Message = Message>,
@@ -210,7 +216,7 @@ impl Pipeline {
 
         let url = state.load_data.url.clone();
 
-        let script_chan = match state.event_loop {
+        let (script_chan, sampler_chan) = match state.event_loop {
             Some(script_chan) => {
                 let new_layout_info = NewLayoutInfo {
                     parent_info: state.parent_pipeline_id,
@@ -229,7 +235,7 @@ impl Pipeline {
                 {
                     warn!("Sending to script during pipeline creation failed ({})", e);
                 }
-                script_chan
+                (script_chan, None)
             },
             None => {
                 let (script_chan, script_port) = ipc::channel().expect("Pipeline script chan");
@@ -262,7 +268,7 @@ impl Pipeline {
                 let (script_content_process_shutdown_chan, script_content_process_shutdown_port) =
                     ipc::channel().expect("Pipeline script content process shutdown chan");
 
-                let unprivileged_pipeline_content = UnprivilegedPipelineContent {
+                let mut unprivileged_pipeline_content = UnprivilegedPipelineContent {
                     id: state.id,
                     browsing_context_id: state.browsing_context_id,
                     top_level_browsing_context_id: state.top_level_browsing_context_id,
@@ -272,6 +278,7 @@ impl Pipeline {
                     background_hang_monitor_to_constellation_chan: state
                         .background_hang_monitor_to_constellation_chan
                         .clone(),
+                    sampling_profiler_port: None,
                     scheduler_chan: state.scheduler_chan,
                     devtools_chan: script_to_devtools_chan,
                     bluetooth_thread: state.bluetooth_thread,
@@ -302,21 +309,25 @@ impl Pipeline {
                 // Spawn the child process.
                 //
                 // Yes, that's all there is to it!
-                if opts::multiprocess() {
+                let sampler_chan = if opts::multiprocess() {
+                    let (sampler_chan, sampler_port) = ipc::channel().expect("Sampler chan");
+                    unprivileged_pipeline_content.sampling_profiler_port = Some(sampler_port);
                     let _ = unprivileged_pipeline_content.spawn_multiprocess()?;
+                    Some(sampler_chan)
                 } else {
                     // Should not be None in single-process mode.
                     let register = state
                         .background_monitor_register
                         .expect("Couldn't start content, no background monitor has been initiated");
                     unprivileged_pipeline_content.start_all::<Message, LTF, STF>(false, register);
-                }
+                    None
+                };
 
-                EventLoop::new(script_chan)
+                (EventLoop::new(script_chan), sampler_chan)
             },
         };
 
-        Ok(Pipeline::new(
+        let pipeline = Pipeline::new(
             state.id,
             state.browsing_context_id,
             state.top_level_browsing_context_id,
@@ -327,7 +338,11 @@ impl Pipeline {
             url,
             state.prev_visibility,
             state.load_data,
-        ))
+        );
+        Ok(NewPipeline {
+            pipeline,
+            sampler_control_chan: sampler_chan,
+        })
     }
 
     /// Creates a new `Pipeline`, after the script and layout threads have been
@@ -468,6 +483,7 @@ pub struct UnprivilegedPipelineContent {
     opener: Option<BrowsingContextId>,
     script_to_constellation_chan: ScriptToConstellationChan,
     background_hang_monitor_to_constellation_chan: IpcSender<HangMonitorAlert>,
+    sampling_profiler_port: Option<IpcReceiver<SamplerControlMsg>>,
     layout_to_constellation_chan: IpcSender<LayoutMsg>,
     scheduler_chan: IpcSender<TimerSchedulerMsg>,
     devtools_chan: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
@@ -669,8 +685,13 @@ impl UnprivilegedPipelineContent {
         }
     }
 
-    pub fn background_hang_monitor_to_constellation_chan(&self) -> &IpcSender<HangMonitorAlert> {
-        &self.background_hang_monitor_to_constellation_chan
+    pub fn register_with_background_hang_monitor(&mut self) -> Box<BackgroundHangMonitorRegister> {
+        HangMonitorRegister::init(
+            self.background_hang_monitor_to_constellation_chan.clone(),
+            self.sampling_profiler_port
+                .take()
+                .expect("no sampling profiler?"),
+        )
     }
 
     pub fn script_to_constellation_chan(&self) -> &ScriptToConstellationChan {

--- a/components/embedder_traits/lib.rs
+++ b/components/embedder_traits/lib.rs
@@ -160,6 +160,8 @@ pub enum EmbedderMsg {
     HideIME,
     /// Servo has shut down
     Shutdown,
+    /// Report a complete sampled profile
+    ReportProfile(Vec<u8>),
 }
 
 impl Debug for EmbedderMsg {
@@ -189,6 +191,7 @@ impl Debug for EmbedderMsg {
             EmbedderMsg::Shutdown => write!(f, "Shutdown"),
             EmbedderMsg::AllowOpeningBrowser(..) => write!(f, "AllowOpeningBrowser"),
             EmbedderMsg::BrowserCreated(..) => write!(f, "BrowserCreated"),
+            EmbedderMsg::ReportProfile(..) => write!(f, "ReportProfile"),
         }
     }
 }

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -352,6 +352,24 @@ pub enum HangAnnotation {
 
 /// Hang-alerts are sent by the monitor to the constellation.
 #[derive(Deserialize, Serialize)]
+pub enum HangMonitorAlert {
+    /// A component hang has been detected.
+    Hang(HangAlert),
+    /// Report a completed sampled profile.
+    Profile(Vec<u8>),
+}
+
+impl fmt::Debug for HangMonitorAlert {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            HangMonitorAlert::Hang(..) => write!(fmt, "Hang"),
+            HangMonitorAlert::Profile(..) => write!(fmt, "Profile"),
+        }
+    }
+}
+
+/// Hang-alerts are sent by the monitor to the constellation.
+#[derive(Deserialize, Serialize)]
 pub enum HangAlert {
     /// Report a transient hang.
     Transient(MonitoredComponentId, HangAnnotation),

--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -490,3 +490,10 @@ pub trait BackgroundHangMonitor {
     /// Unregister the component from monitor.
     fn unregister(&self);
 }
+
+/// Messages to control the sampling profiler.
+#[derive(Deserialize, Serialize)]
+pub enum SamplerControlMsg {
+    Enable(Duration),
+    Disable,
+}

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -51,6 +51,7 @@ use servo_url::ServoUrl;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
+use std::time::Duration;
 use style_traits::CSSPixel;
 use style_traits::SpeculativePainter;
 use webrender_api::{
@@ -777,6 +778,10 @@ pub enum ConstellationMsg {
     ForwardEvent(PipelineId, CompositorEvent),
     /// Requesting a change to the onscreen cursor.
     SetCursor(Cursor),
+    /// Enable the sampling profiler.
+    EnableProfiler(Duration),
+    /// Disable the sampling profiler.
+    DisableProfiler,
 }
 
 impl fmt::Debug for ConstellationMsg {
@@ -804,6 +809,8 @@ impl fmt::Debug for ConstellationMsg {
             SelectBrowser(..) => "SelectBrowser",
             ForwardEvent(..) => "ForwardEvent",
             SetCursor(..) => "SetCursor",
+            EnableProfiler(..) => "EnableProfiler",
+            DisableProfiler => "DisableProfiler",
         };
         write!(formatter, "ConstellationMsg::{}", variant)
     }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -406,6 +406,10 @@ where
                 }
             },
 
+            WindowEvent::ToggleSamplingProfiler(rate) => {
+                HangMonitorRegister::toggle(rate);
+            },
+
             WindowEvent::ToggleWebRenderDebug(option) => {
                 self.compositor.toggle_webrender_debug(option);
             },

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -60,7 +60,6 @@ fn webdriver(port: u16, constellation: Sender<ConstellationMsg>) {
 #[cfg(not(feature = "webdriver"))]
 fn webdriver(_port: u16, _constellation: Sender<ConstellationMsg>) {}
 
-use background_hang_monitor::HangMonitorRegister;
 use bluetooth::BluetoothThreadFactory;
 use bluetooth_traits::BluetoothRequest;
 use canvas::gl_context::GLContextFactory;
@@ -133,6 +132,7 @@ pub struct Servo<Window: WindowMethods + 'static> {
     constellation_chan: Sender<ConstellationMsg>,
     embedder_receiver: EmbedderReceiver,
     embedder_events: Vec<(Option<BrowserId>, EmbedderMsg)>,
+    profiler_enabled: bool,
 }
 
 #[derive(Clone)]
@@ -318,6 +318,7 @@ where
             constellation_chan: constellation_chan,
             embedder_receiver: embedder_receiver,
             embedder_events: Vec::new(),
+            profiler_enabled: false,
         }
     }
 
@@ -407,7 +408,15 @@ where
             },
 
             WindowEvent::ToggleSamplingProfiler(rate) => {
-                HangMonitorRegister::toggle(rate);
+                self.profiler_enabled = !self.profiler_enabled;
+                let msg = if self.profiler_enabled {
+                    ConstellationMsg::EnableProfiler(rate)
+                } else {
+                    ConstellationMsg::DisableProfiler
+                };
+                if let Err(e) = self.constellation_chan.send(msg) {
+                    warn!("Sending profiler toggle to constellation failed ({:?}).", e);
+                }
             },
 
             WindowEvent::ToggleWebRenderDebug(option) => {
@@ -714,7 +723,7 @@ pub fn run_content_process(token: String) {
         .send(unprivileged_content_sender)
         .unwrap();
 
-    let unprivileged_content = unprivileged_content_receiver.recv().unwrap();
+    let mut unprivileged_content = unprivileged_content_receiver.recv().unwrap();
     opts::set_options(unprivileged_content.opts());
     PREFS.extend(unprivileged_content.prefs());
     set_logger(unprivileged_content.script_to_constellation_chan().clone());
@@ -724,11 +733,8 @@ pub fn run_content_process(token: String) {
         create_sandbox();
     }
 
-    let background_hang_monitor_register = HangMonitorRegister::init(
-        unprivileged_content
-            .background_hang_monitor_to_constellation_chan()
-            .clone(),
-    );
+    let background_hang_monitor_register =
+        unprivileged_content.register_with_background_hang_monitor();
 
     // send the required channels to the service worker manager
     let sw_senders = unprivileged_content.swmanager_senders();

--- a/etc/profilicate.py
+++ b/etc/profilicate.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+
+# Copyright 2018 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# Script to take raw sample output from Servo sampling profiler and
+# output a [processed profile]. Based largely on [this script] and
+# [this documentation].
+#
+# [processed profile]: https://github.com/firefox-devtools/profiler/blob/master/docs-developer/processed-profile-format.md
+# [this script]: https://github.com/firefox-devtools/profiler/blob/master/src/profile-logic/import/linux-perf.js
+# [this documentation]: https://github.com/firefox-devtools/profiler/blob/master/src/types/profile.js
+
+from collections import defaultdict
+import json
+import sys
+
+
+class StringTable:
+    def __init__(self):
+        self.table = {}
+        self.idx = 0
+
+    def get(self, s):
+        assert s
+        if s not in self.table:
+            self.table[s] = self.idx
+            self.idx += 1
+        return self.table[s]
+
+    def length(self):
+        return len(self.table.keys())
+
+    def contents(self):
+        return sorted(self.table.keys(), key=self.table.__getitem__)
+
+
+with open(sys.argv[1]) as f:
+    profile = json.load(f)
+    rate = profile["rate"]
+    samples = profile["data"]
+    startTime = profile["start"]
+
+frames = {}
+stacks = {}
+
+thread_data = defaultdict(list)
+thread_order = {}
+for sample in samples:
+    if sample['name']:
+        name = sample['name']
+    else:
+        name = "%s %d %d" % (sample['type'], sample['namespace'], sample['index'])
+    thread_data[name].append((sample['time'], sample['frames']))
+    if name not in thread_order:
+        thread_order[name] = (sample['namespace'], sample['index'])
+
+tid = 0
+threads = []
+for (name, raw_samples) in sorted(thread_data.iteritems(), key=lambda x: thread_order[x[0]]):
+    string_table = StringTable()
+    tid += 1
+
+    stackMap = {}
+    stacks = []
+    frameMap = {}
+    frames = []
+
+    samples = []
+
+    for sample in raw_samples:
+        prefix = None
+        for frame in sample[1]:
+            if not frame['name']:
+                continue
+            if not frame['name'] in frameMap:
+                frameMap[frame['name']] = len(frames)
+                frame_index = string_table.get(frame['name'])
+                frames.append([frame_index])
+            frame = frameMap[frame['name']]
+
+            stack_key = "%d,%d" % (frame, prefix) if prefix else str(frame)
+            if stack_key not in stackMap:
+                stackMap[stack_key] = len(stacks)
+                stacks.append([frame, prefix])
+            stack = stackMap[stack_key]
+            prefix = stack
+        samples.append([stack, sample[0]])
+
+    threads.append({
+        'tid': tid,
+        'name': name,
+        'markers': {
+            'schema': {
+                'name': 0,
+                'time': 1,
+                'data': 2,
+            },
+            'data': [],
+        },
+        'samples': {
+            'schema': {
+                'stack': 0,
+                'time': 1,
+                'responsiveness': 2,
+                'rss': 2,
+                'uss': 4,
+                'frameNumber': 5,
+            },
+            'data': samples,
+        },
+        'frameTable': {
+            'schema': {
+                'location': 0,
+                'implementation': 1,
+                'optimizations': 2,
+                'line': 3,
+                'category': 4,
+            },
+            'data': frames,
+        },
+        'stackTable': {
+            'schema': {
+                'frame': 0,
+                'prefix': 1,
+            },
+            'data': stacks,
+        },
+        'stringTable': string_table.contents(),
+    })
+
+
+output = {
+    'meta': {
+        'interval': rate,
+        'processType': 0,
+        'product': 'Servo',
+        'stackwalk': 1,
+        'startTime': startTime,
+        'version': 4,
+        'presymbolicated': True,
+    },
+    'libs': [],
+    'threads': threads,
+}
+
+print(json.dumps(output))

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -519,7 +519,8 @@ impl ServoGlue {
                 EmbedderMsg::SetFullscreenState(..) |
                 EmbedderMsg::ShowIME(..) |
                 EmbedderMsg::HideIME |
-                EmbedderMsg::Panic(..) => {},
+                EmbedderMsg::Panic(..) |
+                EmbedderMsg::ReportProfile(..) => {},
             }
         }
         Ok(())


### PR DESCRIPTION
This uses the code already built for the background hang monitor and adds the ability to repeatedly sample all monitored threads. This sampling allows us to generate profiles that we can translate into the format used by https://perf-html.io/, allowing us to benefit from modern Gecko performance tooling.

You can run Servo with `PROFILE_OUTPUT=foo.json` and `SAMPLING_RATE=50` (for example), otherwise these values will default to `samples.json` and 10ms, respectively. To activate the profiler, press cmd+p, and to stop profiling, press cmd+p again. This will the captured samples to be symbolicated, which will take a very long time, and eventually there will be a new JSON profile in the output location.

To create a profile for use by Gecko's tools, run `python etc/profilicate.py path/to/profile.json >gecko_profile.json`, and load `gecko_profile.json` in the https://perf-html.io/ to see something like [this](https://profiler.firefox.com/public/8137e2b11fbb92afb80090bc534fd83015c87ee6/calltree/?globalTrackOrder=0-1&thread=1&v=3);

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13103
- [x] These changes do not require tests because way too many pieces to automate

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23080)
<!-- Reviewable:end -->
