### PR TITLE
ISSUE-23088: updated deprecated links in HACKING_QUICKSTART

### DIFF
--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -60,7 +60,7 @@ This guide only covers the most important options. Be sure to look at all the av
 
 Even if you have never seen any Rust code, it's not too hard to read Servo's code. But there are some basics things one must know:
 
-- [Match](https://doc.rust-lang.org/book/first-edition/match.html) and [Patterns](https://doc.rust-lang.org/book/first-edition/patterns.html)
+- [Match](https://doc.rust-lang.org/stable/rust-by-example/flow_control/match.html) and [Patterns](https://doc.rust-lang.org/book/ch18-00-patterns.html)
 - [Options](https://rustbyexample.com/std/option.html)
 - [Expression](https://rustbyexample.com/expression.html)
 - [Traits](https://rustbyexample.com/trait.html)


### PR DESCRIPTION
Replaced two links in `HACKING_QUICKSTART.md`: "match" now points to the rust-by-example match page and "patterns" points to the rust book 2.0 overview of structural pattern matching.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23088 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they represent docs changes only

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23092)
<!-- Reviewable:end -->
