### PR TITLE
implement stylesheet.ownerNode

### DIFF
--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -14,7 +14,9 @@ use crate::dom::cssrule::CSSRule;
 use crate::dom::cssstylesheet::CSSStyleSheet;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::window::Window;
+use crate::style::stylesheets::StylesheetLoader as StyleStylesheetLoader;
 use crate::stylesheet_loader::StylesheetLoader;
+
 use dom_struct::dom_struct;
 use servo_arc::Arc;
 use style::shared_lock::Locked;
@@ -104,12 +106,12 @@ impl CSSRuleList {
         let index = idx as usize;
 
         let parent_stylesheet = self.parent_stylesheet.style_stylesheet();
-        let owner = self
-            .parent_stylesheet
-            .get_owner()
-            .downcast::<HTMLElement>()
-            .unwrap();
-        let loader = StylesheetLoader::for_element(owner);
+
+        let owner = self.parent_stylesheet.get_owner();
+        let loader = owner
+            .as_ref()
+            .map(|owner| StylesheetLoader::for_element(owner.downcast::<HTMLElement>().unwrap()));
+
         let new_rule = css_rules.with_raw_offset_arc(|arc| {
             arc.insert_rule(
                 &parent_stylesheet.shared_lock,
@@ -117,7 +119,7 @@ impl CSSRuleList {
                 &parent_stylesheet.contents,
                 index,
                 nested,
-                Some(&loader),
+                loader.as_ref().map(|l| l as &StyleStylesheetLoader),
             )
         })?;
 

--- a/components/script/dom/cssstylesheet.rs
+++ b/components/script/dom/cssstylesheet.rs
@@ -7,7 +7,7 @@ use crate::dom::bindings::codegen::Bindings::CSSStyleSheetBinding::CSSStyleSheet
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowBinding::WindowMethods;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
-use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
+use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::cssrulelist::{CSSRuleList, RulesSource};
 use crate::dom::element::Element;
@@ -22,7 +22,7 @@ use style::stylesheets::Stylesheet as StyleStyleSheet;
 #[dom_struct]
 pub struct CSSStyleSheet {
     stylesheet: StyleSheet,
-    owner: Dom<Element>,
+    owner: MutNullableDom<Element>,
     rulelist: MutNullableDom<CSSRuleList>,
     #[ignore_malloc_size_of = "Arc"]
     style_stylesheet: Arc<StyleStyleSheet>,
@@ -39,7 +39,7 @@ impl CSSStyleSheet {
     ) -> CSSStyleSheet {
         CSSStyleSheet {
             stylesheet: StyleSheet::new_inherited(type_, href, title),
-            owner: Dom::from_ref(owner),
+            owner: MutNullableDom::new(Some(owner)),
             rulelist: MutNullableDom::new(None),
             style_stylesheet: stylesheet,
             origin_clean: Cell::new(true),
@@ -75,8 +75,8 @@ impl CSSStyleSheet {
         self.style_stylesheet.disabled()
     }
 
-    pub fn get_owner(&self) -> &Element {
-        &*self.owner
+    pub fn get_owner(&self) -> Option<DomRoot<Element>> {
+        self.owner.get()
     }
 
     pub fn set_disabled(&self, disabled: bool) {
@@ -86,6 +86,10 @@ impl CSSStyleSheet {
                 .Document()
                 .invalidate_stylesheets();
         }
+    }
+
+    pub fn set_owner(&self, value: Option<&Element>) {
+        self.owner.set(value);
     }
 
     pub fn shared_lock(&self) -> &SharedRwLock {

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -85,6 +85,12 @@ impl HTMLLinkElement {
         }
     }
 
+    fn stylesheet_owner_cleanup(&self) {
+        if let Some(cssom_stylesheet) = self.cssom_stylesheet.get() {
+            cssom_stylesheet.set_owner(None);
+        }
+    }
+
     #[allow(unrooted_must_root)]
     pub fn new(
         local_name: LocalName,
@@ -113,6 +119,7 @@ impl HTMLLinkElement {
             doc.remove_stylesheet(self.upcast(), s)
         }
         *self.stylesheet.borrow_mut() = Some(s.clone());
+        self.stylesheet_owner_cleanup();
         self.cssom_stylesheet.set(None);
         doc.add_stylesheet(self.upcast(), s);
     }
@@ -250,8 +257,8 @@ impl VirtualMethods for HTMLLinkElement {
         if let Some(ref s) = self.super_type() {
             s.unbind_from_tree(context);
         }
-
         if let Some(s) = self.stylesheet.borrow_mut().take() {
+            self.stylesheet_owner_cleanup();
             document_from_node(self).remove_stylesheet(self.upcast(), &s);
         }
     }

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -62,6 +62,12 @@ impl HTMLStyleElement {
         }
     }
 
+    fn stylesheet_owner_cleanup(&self) {
+        if let Some(cssom_stylesheet) = self.cssom_stylesheet.get() {
+            cssom_stylesheet.set_owner(None);
+        }
+    }
+
     #[allow(unrooted_must_root)]
     pub fn new(
         local_name: LocalName,
@@ -143,6 +149,7 @@ impl HTMLStyleElement {
             doc.remove_stylesheet(self.upcast(), s)
         }
         *self.stylesheet.borrow_mut() = Some(s.clone());
+        self.stylesheet_owner_cleanup();
         self.cssom_stylesheet.set(None);
         doc.add_stylesheet(self.upcast(), s);
     }
@@ -216,6 +223,7 @@ impl VirtualMethods for HTMLStyleElement {
 
         if context.tree_in_doc {
             if let Some(s) = self.stylesheet.borrow_mut().take() {
+                self.stylesheet_owner_cleanup();
                 document_from_node(self).remove_stylesheet(self.upcast(), &s)
             }
         }

--- a/components/script/dom/stylesheet.rs
+++ b/components/script/dom/stylesheet.rs
@@ -5,8 +5,10 @@
 use crate::dom::bindings::codegen::Bindings::StyleSheetBinding::StyleSheetMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::Reflector;
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::cssstylesheet::CSSStyleSheet;
+use crate::dom::element::Element;
 use dom_struct::dom_struct;
 
 #[dom_struct]
@@ -42,6 +44,11 @@ impl StyleSheetMethods for StyleSheet {
     // https://drafts.csswg.org/cssom/#dom-stylesheet-href
     fn GetHref(&self) -> Option<DOMString> {
         self.href.clone()
+    }
+
+    // https://drafts.csswg.org/cssom/#dom-stylesheet-ownernode
+    fn GetOwnerNode(&self) -> Option<DomRoot<Element>> {
+        self.downcast::<CSSStyleSheet>().unwrap().get_owner()
     }
 
     // https://drafts.csswg.org/cssom/#dom-stylesheet-title

--- a/components/script/dom/webidls/StyleSheet.webidl
+++ b/components/script/dom/webidls/StyleSheet.webidl
@@ -7,8 +7,8 @@
 interface StyleSheet {
   readonly attribute DOMString type_;
   readonly attribute DOMString? href;
+  readonly attribute Element? ownerNode;
 
-  // readonly attribute (Element or ProcessingInstruction)? ownerNode;
   // readonly attribute StyleSheet? parentStyleSheet;
   readonly attribute DOMString? title;
 

--- a/tests/wpt/metadata/css/cssom/MediaList2.xhtml.ini
+++ b/tests/wpt/metadata/css/cssom/MediaList2.xhtml.ini
@@ -1,4 +1,12 @@
-[MediaList2.xhtml]
-  [MediaList]
+[MediaList2.xhtml]	
+  [MediaList.mediaText]	
+    expected: FAIL	
+
+  [MediaList.length]	
     expected: FAIL
 
+  [MediaList getter]	
+    expected: FAIL
+    	
+  [MediaList.item]	
+    expected: FAIL	

--- a/tests/wpt/metadata/css/cssom/interfaces.html.ini
+++ b/tests/wpt/metadata/css/cssom/interfaces.html.ini
@@ -78,9 +78,6 @@
   [StyleSheet interface: attribute type]
     expected: FAIL
 
-  [StyleSheet interface: attribute ownerNode]
-    expected: FAIL
-
   [StyleSheet interface: attribute parentStyleSheet]
     expected: FAIL
 
@@ -678,9 +675,6 @@
   [StyleSheet interface: sheet must inherit property "type" with the proper type]
     expected: FAIL
 
-  [StyleSheet interface: sheet must inherit property "ownerNode" with the proper type]
-    expected: FAIL
-
   [StyleSheet interface: sheet must inherit property "parentStyleSheet" with the proper type]
     expected: FAIL
 
@@ -991,9 +985,6 @@
     expected: FAIL
 
   [StyleSheet interface: sheet must inherit property "type" with the proper type]
-    expected: FAIL
-
-  [StyleSheet interface: sheet must inherit property "ownerNode" with the proper type]
     expected: FAIL
 
   [StyleSheet interface: sheet must inherit property "parentStyleSheet" with the proper type]

--- a/tests/wpt/metadata/css/cssom/ttwf-cssom-doc-ext-load-count.html.ini
+++ b/tests/wpt/metadata/css/cssom/ttwf-cssom-doc-ext-load-count.html.ini
@@ -1,5 +1,4 @@
-[ttwf-cssom-doc-ext-load-count.html]
-  type: testharness
-  [stylesheet.css should be unloaded and styleSheets.length === 0]
+[ttwf-cssom-doc-ext-load-count.html]	
+  type: testharness	
+  [stylesheet-1.css should be loaded and styleSheets.length === 1]	
     expected: FAIL
-

--- a/tests/wpt/web-platform-tests/css/cssom/nullable-owner.html
+++ b/tests/wpt/web-platform-tests/css/cssom/nullable-owner.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8">
+  <title>ownerNode null test</title>
+  <link rel="help" href="https://drafts.csswg.org/cssom/#dom-stylesheet-ownernode">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <style></style>
+</head>
+<body>
+  <script>
+    test(function() {
+      let sheet = document.querySelector("style").sheet;
+      assert_true(sheet.ownerNode instanceof HTMLStyleElement, "ownerNode should be an instance of HTMLStyleElement");
+      sheet.ownerNode.remove();
+      assert_equals(sheet.ownerNode, null, "ownerNode should be null after removing the styleSheet");
+    }, "ownerNode should be cleared out before removing the styleSheet");
+  </script>
+</body>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
 
Implemented GetOwnerNode for StyleSheetMethods by using get_owner method

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23082 
- [x] There are tests for these changes that will be a new test for nullable owner.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23096)
<!-- Reviewable:end -->
