### PR TITLE
Py2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
     - sudo: false
       before_install:
         - curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain none -y
+        - pip install virtualenv
         - source ~/.profile
       script:
          - ./mach test-tidy --no-progress --all
@@ -20,6 +21,7 @@ matrix:
         - sudo add-apt-repository 'deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.9 main' -y
         - sudo apt-get update -q
         - sudo apt-get install clang-3.9 llvm-3.9 llvm-3.9-runtime libunwind8-dev -y
+        - pip install virtualenv
         - curl -L http://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-1.14-x86_64-linux-gnu.20190213.tar.gz | tar xz
         - sed -i "s;prefix=/opt/gst;prefix=$PWD/gst;g" $PWD/gst/lib/pkgconfig/*.pc
         - export PKG_CONFIG_PATH=$PWD/gst/lib/pkgconfig

--- a/etc/taskcluster/docker/base.dockerfile
+++ b/etc/taskcluster/docker/base.dockerfile
@@ -16,8 +16,10 @@ RUN \
         #
         # Running mach
         python \
-        virtualenv \
+        python-pip \
         #
         # Installing rustup and sccache (build dockerfile) or fetching build artifacts (run tasks)
-        curl
+        curl && \
+    # Running mach
+    pip install virtualenv
 

--- a/mach.bat
+++ b/mach.bat
@@ -1,5 +1,11 @@
 @echo off
 
+setlocal
+
+if EXIST "%VCINSTALLDIR%" (
+  GOTO mach
+)
+
 pushd .
 
 IF EXIST "%ProgramFiles(x86)%" (
@@ -8,37 +14,52 @@ IF EXIST "%ProgramFiles(x86)%" (
   set "ProgramFiles32=%ProgramFiles%"
 )
 
-set VC14VARS=%VS140COMNTOOLS%..\..\VC\vcvarsall.bat
-IF EXIST "%VC14VARS%" (
-  set "VS_VCVARS=%VC14VARS%"
-) ELSE (
+for %%v in (2019 2017) do (
   for %%e in (Enterprise Professional Community BuildTools) do (
-    IF EXIST "%ProgramFiles32%\Microsoft Visual Studio\2017\%%e\VC\Auxiliary\Build\vcvarsall.bat" (
-      set "VS_VCVARS=%ProgramFiles32%\Microsoft Visual Studio\2017\%%e\VC\Auxiliary\Build\vcvarsall.bat"
+    IF EXIST "%ProgramFiles32%\Microsoft Visual Studio\%%v\%%e\VC\Auxiliary\Build\vcvarsall.bat" (
+      set "VS_VCVARS=%ProgramFiles32%\Microsoft Visual Studio\%%v\%%e\VC\Auxiliary\Build\vcvarsall.bat"
+      GOTO vcvars
     )
   )
 )
 
+set VC14VARS=%VS140COMNTOOLS%..\..\VC\vcvarsall.bat
+IF EXIST "%VC14VARS%" (
+  set "VS_VCVARS=%VC14VARS%"
+)
+
+:vcvars
 IF EXIST "%VS_VCVARS%" (
   IF NOT DEFINED Platform (
     IF EXIST "%ProgramFiles(x86)%" (
       call "%VS_VCVARS%" x64
     ) ELSE (
       ECHO 32-bit Windows is currently unsupported.
-      EXIT /B 1
+      GOTO bad_exit
     )
   )
 ) ELSE (
-  ECHO Visual Studio 2015 or 2017 is not installed.
-  ECHO Download and install Visual Studio 2015 or 2017 from https://www.visualstudio.com/
-  EXIT /B 1
+  ECHO Visual Studio 2015, 2017, or 2019 is not installed.
+  ECHO Download and install Visual Studio from https://www.visualstudio.com/
+  GOTO bad_exit
 )
 
 popd
 
+:mach
 where /Q py.exe
 IF %ERRORLEVEL% NEQ 0 (
   python mach %*
 ) ELSE (
   py -2 mach %*
 )
+
+GOTO exit
+
+:bad_exit
+endlocal
+EXIT /B 1
+
+:exit
+endlocal
+exit /B

--- a/mach.bat
+++ b/mach.bat
@@ -36,4 +36,9 @@ IF EXIST "%VS_VCVARS%" (
 
 popd
 
-python mach %*
+where /Q py.exe
+IF %ERRORLEVEL% NEQ 0 (
+  python mach %*
+) ELSE (
+  py -2 mach %*
+)

--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -78,14 +78,7 @@ CATEGORIES = {
 # Possible names of executables
 # NOTE: Windows Python doesn't provide versioned executables, so we must use
 # the plain names. On MSYS, we still use Windows Python.
-if sys.platform in ['msys', 'win32']:
-    PYTHON_NAMES = ["python"]
-    VIRTUALENV_NAMES = ["virtualenv"]
-    PIP_NAMES = ["pip"]
-else:
-    PYTHON_NAMES = ["python-2.7", "python2.7", "python2", "python"]
-    VIRTUALENV_NAMES = ["virtualenv-2.7", "virtualenv2.7", "virtualenv2", "virtualenv"]
-    PIP_NAMES = ["pip-2.7", "pip2.7", "pip2", "pip"]
+PYTHON_NAMES = ["python-2.7", "python2.7", "python2", "python"]
 
 
 def _get_exec_path(names, is_valid_path=lambda _path: True):
@@ -154,7 +147,7 @@ def wptserve_path(is_firefox, topdir, *paths):
 def _activate_virtualenv(topdir, is_firefox):
     virtualenv_path = os.path.join(topdir, "python", "_virtualenv")
     check_exec_path = lambda path: path.startswith(virtualenv_path)
-    python = _get_exec_path(PYTHON_NAMES)   # If there was no python, mach wouldn't have run at all!
+    python = sys.executable   # If there was no python, mach wouldn't have run at all!
     if not python:
         sys.exit('Failed to find python executable for starting virtualenv.')
 
@@ -162,11 +155,13 @@ def _activate_virtualenv(topdir, is_firefox):
     activate_path = os.path.join(virtualenv_path, script_dir, "activate_this.py")
     need_pip_upgrade = False
     if not (os.path.exists(virtualenv_path) and os.path.exists(activate_path)):
-        virtualenv = _get_exec_path(VIRTUALENV_NAMES)
-        if not virtualenv:
+        import imp
+        try:
+            imp.find_module('virtualenv')
+        except ImportError:
             sys.exit("Python virtualenv is not installed. Please install it prior to running mach.")
 
-        _process_exec([virtualenv, "-p", python, "--system-site-packages", virtualenv_path])
+        _process_exec([python, "-m", "virtualenv", "-p", python, "--system-site-packages", virtualenv_path])
 
         # We want to upgrade pip when virtualenv created for the first time
         need_pip_upgrade = True


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
da3102338c: Rework mach.bat to support VS2019 and user-supplied environments.
4551f6031f: Default mach.bat to using py -2.
03e47081fe: Don't assume the user's environment in mach_bootstrap.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23083 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it changes the python bootstrap slightly and the changes are obvious.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

The virtualenv changes shouldn't disrupt anything as it just uses the existing python (being used) to call itself `-m virtualenv`, and only if it exists. imp is still apparently the preferred builtin way to find this in Python 2.x without actually importing it. Importing it would cause an unused import warning in tidy. It still picks up the new things in _virtualenv, just no longer has a special case for Win32/MSYS because it's no longer needed.

The .bat change is the simplest I could think of that allows fallback in both cases and is no worse than before. `where /Q` is documented by Microsoft to return 0 if a successful match is found, and print nothing in either case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23098)
<!-- Reviewable:end -->
