### PR TITLE
Implement srcObject logic for Blob media providers

### DIFF
--- a/components/script/dom/webidls/HTMLMediaElement.webidl
+++ b/components/script/dom/webidls/HTMLMediaElement.webidl
@@ -5,7 +5,7 @@
 // https://html.spec.whatwg.org/multipage/#htmlmediaelement
 
 enum CanPlayTypeResult { "" /* empty string */, "maybe", "probably" };
-typedef /* (MediaStream or MediaSource or */ Blob /* ) */ MediaProvider;
+typedef (MediaStream /*or MediaSource */ or Blob) MediaProvider;
 
 [Abstract]
 interface HTMLMediaElement : HTMLElement {

--- a/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/src_object_blob.html
+++ b/tests/wpt/web-platform-tests/html/semantics/embedded-content/media-elements/src_object_blob.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>HTMLMediaElement.srcObject blob</title>
+<script src='/common/media.js'></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<video></video>
+<script>
+  async_test(function(t) {
+    t.step(function() {
+      fetch(getVideoURI('/media/movie_5'))
+        .then(function(response) {
+          return response.blob();
+        })
+        .then(function(blob) {
+          let video = document.querySelector("video");
+          video.srcObject = blob;
+          video.addEventListener('ended', function() {
+            t.done();
+          });
+          video.play().catch(function(error) {
+            assert(false, error);
+          });
+        })
+        .catch(function(error) {
+          assert(false, error);
+        });
+    });
+  });
+</script>
+


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23103)
<!-- Reviewable:end -->
