### PR TITLE
Invert worker type selection logic for taskcluster.

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -75,6 +75,7 @@ def main(task_for):
     elif task_for == "github-pull-request":
         CONFIG.treeherder_repository_name = "servo-prs"
         CONFIG.index_read_only = True
+        CONFIG.docker_image_build_worker_type = None
 
         # We want the merge commit that GitHub creates for the PR.
         # The event does contain a `pull_request.merge_commit_sha` key, but it is wrong:
@@ -625,7 +626,7 @@ def macos_build_task(name):
 
 CONFIG.task_name_template = "Servo: %s"
 CONFIG.index_prefix = "project.servo.servo"
-CONFIG.docker_image_buil_worker_type = "servo-docker-worker"
+CONFIG.docker_image_build_worker_type = "servo-docker-worker"
 CONFIG.docker_images_expire_in = build_dependencies_artifacts_expire_in
 CONFIG.repacked_msi_files_expire_in = build_dependencies_artifacts_expire_in
 

--- a/etc/taskcluster/decisionlib.py
+++ b/etc/taskcluster/decisionlib.py
@@ -41,7 +41,7 @@ class Config:
         self.index_read_only = False
         self.scopes_for_all_subtasks = []
         self.routes_for_all_subtasks = []
-        self.docker_image_buil_worker_type = None
+        self.docker_image_build_worker_type = None
         self.docker_images_expire_in = "1 month"
         self.repacked_msi_files_expire_in = "1 month"
         self.treeherder_repository_name = None
@@ -723,7 +723,7 @@ class DockerWorkerTask(UnixTaskMixin, Task):
 
         image_build_task = (
             DockerWorkerTask("Docker image: " + image_name)
-            .with_worker_type(CONFIG.docker_image_buil_worker_type or self.worker_type)
+            .with_worker_type(CONFIG.docker_image_build_worker_type or self.worker_type)
             .with_max_run_time_minutes(30)
             .with_index_and_artifacts_expire_in(CONFIG.docker_images_expire_in)
             .with_features("dind")


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23105
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23106)
<!-- Reviewable:end -->
