### PR TITLE
Use consistent local branch name for WPT sync.

### DIFF
--- a/etc/ci/update-wpt-checkout
+++ b/etc/ci/update-wpt-checkout
@@ -11,7 +11,8 @@ set -o pipefail
 REMOTE_NAME=sync-fork
 LOG_FILE=test-wpt.log
 CURRENT_DATE=$(date +"%d-%m-%Y")
-BRANCH_NAME="wpt_update_${CURRENT_DATE}"
+BRANCH_NAME="wpt_update"
+REMOTE_BRANCH_NAME="wpt_update_${CURRENT_DATE}"
 
 export GIT_AUTHOR_NAME="WPT Sync Bot"
 export GIT_AUTHOR_EMAIL="josh+wptsync@joshmatthews.net"
@@ -94,7 +95,7 @@ function unsafe_open_pull_request() {
     AUTH="${WPT_SYNC_USER}:${WPT_SYNC_TOKEN}"
     UPSTREAM="https://${AUTH}@github.com/${WPT_SYNC_USER}/servo.git"
     git remote add "${REMOTE_NAME}" "${UPSTREAM}" || return 2
-    git push -f "${REMOTE_NAME}" "${BRANCH_NAME}" &>/dev/null || return 3
+    git push -f "${REMOTE_NAME}" "${BRANCH_NAME}:${REMOTE_BRANCH_NAME}" &>/dev/null || return 3
 
     # Prepare the pull request metadata.
     BODY="Automated downstream sync of changes from upstream as of "
@@ -103,7 +104,7 @@ function unsafe_open_pull_request() {
     cat <<EOF >prdata.json || return 4
 {
   "title": "Sync WPT with upstream (${CURRENT_DATE})",
-  "head": "${WPT_SYNC_USER}:${BRANCH_NAME}",
+  "head": "${WPT_SYNC_USER}:${REMOTE_BRANCH_NAME}",
   "base": "master",
   "body": "${BODY}",
   "maintainer_can_modify": true


### PR DESCRIPTION
This avoids the problem of the WPT sync running two commands on different dates and therefore not finding the previously created branch.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23052

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23112)
<!-- Reviewable:end -->
