### PR TITLE
Set the target when packaging for magicleap

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -212,6 +212,11 @@ class PackageCommands(CommandBase):
             android = self.handle_android_target(target)
         else:
             target = self.config["android"]["target"]
+        if target and magicleap:
+            print("Please specify either --target or --magicleap.")
+            sys.exit(1)
+        if magicleap:
+            target = "aarch64-linux-android"
         env = self.build_env(target=target)
         binary_path = self.get_binary_path(release, dev, android=android, magicleap=magicleap)
         dir_to_root = self.get_top_dir()


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

If we don't set the target during packaging, we get errors checking for gstreamer.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it fixes packaging errors.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23117)
<!-- Reviewable:end -->
