### PR TITLE
Remove unnecessary explicit reflows

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1229,7 +1229,8 @@ impl LayoutThread {
                             rw_data.element_inner_text_response = String::new();
                         },
                     },
-                    ReflowGoal::Full | ReflowGoal::TickAnimations => {},
+                    ReflowGoal::Full | ReflowGoal::TickAnimations | ReflowGoal::AnimationFrame => {
+                    },
                 }
                 return;
             },
@@ -1570,7 +1571,7 @@ impl LayoutThread {
                         process_element_inner_text_query(node, &rw_data.indexable_text);
                 },
             },
-            ReflowGoal::Full | ReflowGoal::TickAnimations => {},
+            ReflowGoal::Full | ReflowGoal::TickAnimations | ReflowGoal::AnimationFrame => {},
         }
     }
 

--- a/components/script/dom/activation.rs
+++ b/components/script/dom/activation.rs
@@ -9,9 +9,8 @@ use crate::dom::element::Element;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::mouseevent::MouseEvent;
-use crate::dom::node::window_from_node;
+use crate::dom::node::{document_from_node, window_from_node};
 use crate::dom::window::ReflowReason;
-use script_layout_interface::message::ReflowGoal;
 
 /// Trait for elements with defined activation behavior
 pub trait Activatable {
@@ -36,15 +35,15 @@ pub trait Activatable {
     fn enter_formal_activation_state(&self) {
         self.as_element().set_active_state(true);
 
-        let win = window_from_node(self.as_element());
-        win.reflow(ReflowGoal::Full, ReflowReason::ElementStateChanged);
+        let doc = document_from_node(self.as_element());
+        doc.mark_reflow_reason(ReflowReason::ElementStateChanged);
     }
 
     fn exit_formal_activation_state(&self) {
         self.as_element().set_active_state(false);
 
-        let win = window_from_node(self.as_element());
-        win.reflow(ReflowGoal::Full, ReflowReason::ElementStateChanged);
+        let doc = document_from_node(self.as_element());
+        doc.mark_reflow_reason(ReflowReason::ElementStateChanged);
     }
 }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -95,7 +95,6 @@ use js::jsval::JSVal;
 use msg::constellation_msg::InputMethodType;
 use net_traits::request::CorsSettings;
 use ref_filter_map::ref_filter_map;
-use script_layout_interface::message::ReflowGoal;
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
 use selectors::matching::{ElementSelectorFlags, MatchingContext};
 use selectors::sink::Push;
@@ -3407,9 +3406,7 @@ impl TaskOnce for ElementPerformFullscreenEnter {
         // Step 7.5
         element.set_fullscreen_state(true);
         document.set_fullscreen_element(Some(&element));
-        document
-            .window()
-            .reflow(ReflowGoal::Full, ReflowReason::ElementStateChanged);
+        document.mark_reflow_reason(ReflowReason::ElementStateChanged);
 
         // Step 7.6
         document
@@ -3447,9 +3444,7 @@ impl TaskOnce for ElementPerformFullscreenExit {
         // Step 9.6
         element.set_fullscreen_state(false);
 
-        document
-            .window()
-            .reflow(ReflowGoal::Full, ReflowReason::ElementStateChanged);
+        document.mark_reflow_reason(ReflowReason::ElementStateChanged);
 
         document.set_fullscreen_element(None);
 

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -31,7 +31,6 @@ use html5ever::{LocalName, Prefix};
 use ipc_channel::ipc;
 use msg::constellation_msg::{BrowsingContextId, PipelineId, TopLevelBrowsingContextId};
 use profile_traits::ipc as ProfiledIpc;
-use script_layout_interface::message::ReflowGoal;
 use script_traits::IFrameSandboxState::{IFrameSandboxed, IFrameUnsandboxed};
 use script_traits::{
     IFrameLoadInfo, IFrameLoadInfoWithData, JsEvalResult, LoadData, UpdatePipelineIdReason,
@@ -336,9 +335,9 @@ impl HTMLIFrameElement {
             LoadBlocker::terminate(&mut blocker);
         }
 
+        let doc = document_from_node(self);
+        doc.mark_reflow_reason(ReflowReason::FramedContentChanged);
         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
-        let window = window_from_node(self);
-        window.reflow(ReflowGoal::Full, ReflowReason::FramedContentChanged);
     }
 
     fn new_inherited(
@@ -412,15 +411,14 @@ impl HTMLIFrameElement {
         // TODO Step 3 - set child document  `mut iframe load` flag
 
         // Step 4
+        let doc = document_from_node(self);
+        doc.mark_reflow_reason(ReflowReason::IFrameLoadEvent);
         self.upcast::<EventTarget>().fire_event(atom!("load"));
 
         let mut blocker = self.load_blocker.borrow_mut();
         LoadBlocker::terminate(&mut blocker);
 
         // TODO Step 5 - unset child document `mut iframe load` flag
-
-        let window = window_from_node(self);
-        window.reflow(ReflowGoal::Full, ReflowReason::IFrameLoadEvent);
     }
 }
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -37,7 +37,7 @@ use crate::dom::performanceresourcetiming::InitiatorType;
 use crate::dom::progressevent::ProgressEvent;
 use crate::dom::values::UNSIGNED_LONG_MAX;
 use crate::dom::virtualmethods::VirtualMethods;
-use crate::dom::window::Window;
+use crate::dom::window::{ReflowReason, Window};
 use crate::image_listener::{add_cache_listener_for_element, ImageCacheListener};
 use crate::microtask::{Microtask, MicrotaskRunnable};
 use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingListener};
@@ -412,7 +412,7 @@ impl HTMLImageElement {
 
         // Trigger reflow
         let window = window_from_node(self);
-        window.add_pending_reflow();
+        window.add_pending_reflow(ReflowReason::ImageLoaded);
     }
 
     fn process_image_response_for_environment_change(

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1377,26 +1377,16 @@ impl ScriptThread {
 
         // https://html.spec.whatwg.org/multipage/#event-loop-processing-model step 7.12
 
-        // Issue batched reflows on any pages that require it (e.g. if images loaded)
-        // TODO(gw): In the future we could probably batch other types of reflows
-        // into this loop too, but for now it's only images.
-        debug!("Issuing batched reflows.");
+        debug!("Reflowing all known documents.");
         for (_, document) in self.documents.borrow().iter() {
             // Step 13
             if !document.is_fully_active() {
                 continue;
             }
             let window = document.window();
-            let pending_reflows = window.get_pending_reflow_count();
-            if pending_reflows > 0 {
-                window.reflow(ReflowGoal::Full, ReflowReason::ImageLoaded);
-            } else {
-                // Reflow currently happens when explicitly invoked by code that
-                // knows the document could have been modified. This should really
-                // be driven by the compositor on an as-needed basis instead, to
-                // minimize unnecessary work.
-                window.reflow(ReflowGoal::Full, ReflowReason::MissingExplicitReflow);
-            }
+            // TODO: This should really be driven by the compositor on an as-needed basis
+            // instead of running on every turn of the event loop, to minimize unnecessary work.
+            window.reflow(ReflowGoal::Full);
         }
 
         true
@@ -1976,7 +1966,7 @@ impl ScriptThread {
         let document = self.documents.borrow().find_document(id);
         if let Some(document) = document {
             if document.window().set_page_clip_rect_with_new_viewport(rect) {
-                self.rebuild_and_force_reflow(&document, ReflowReason::Viewport);
+                document.dirty_all_nodes(ReflowReason::Viewport);
             }
             return;
         }
@@ -2625,7 +2615,7 @@ impl ScriptThread {
     fn handle_web_font_loaded(&self, pipeline_id: PipelineId) {
         let document = self.documents.borrow().find_document(pipeline_id);
         if let Some(document) = document {
-            self.rebuild_and_force_reflow(&document, ReflowReason::WebFontLoaded);
+            document.dirty_all_nodes(ReflowReason::WebFontLoaded);
         }
     }
 
@@ -2633,7 +2623,7 @@ impl ScriptThread {
     fn handle_worklet_loaded(&self, pipeline_id: PipelineId) {
         let document = self.documents.borrow().find_document(pipeline_id);
         if let Some(document) = document {
-            self.rebuild_and_force_reflow(&document, ReflowReason::WorkletLoaded);
+            document.dirty_all_nodes(ReflowReason::WorkletLoaded);
         }
     }
 
@@ -3029,13 +3019,6 @@ impl ScriptThread {
             ))
             .unwrap();
         }
-    }
-
-    /// Reflows non-incrementally, rebuilding the entire layout tree in the process.
-    fn rebuild_and_force_reflow(&self, document: &Document, reason: ReflowReason) {
-        let window = window_from_node(&*document);
-        document.dirty_all_nodes();
-        window.reflow(ReflowGoal::Full, reason);
     }
 
     /// This is the main entry point for receiving and dispatching DOM events.

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -133,6 +133,7 @@ pub enum QueryMsg {
 #[derive(Debug, PartialEq)]
 pub enum ReflowGoal {
     Full,
+    AnimationFrame,
     TickAnimations,
     LayoutQuery(QueryMsg, u64),
 }
@@ -143,6 +144,7 @@ impl ReflowGoal {
     pub fn needs_display_list(&self) -> bool {
         match *self {
             ReflowGoal::Full | ReflowGoal::TickAnimations => true,
+            ReflowGoal::AnimationFrame => false,
             ReflowGoal::LayoutQuery(ref querymsg, _) => match *querymsg {
                 QueryMsg::NodesFromPointQuery(..) |
                 QueryMsg::TextIndexQuery(..) |
@@ -164,6 +166,7 @@ impl ReflowGoal {
     pub fn needs_display(&self) -> bool {
         match *self {
             ReflowGoal::Full | ReflowGoal::TickAnimations => true,
+            ReflowGoal::AnimationFrame => false,
             ReflowGoal::LayoutQuery(ref querymsg, _) => match *querymsg {
                 QueryMsg::NodesFromPointQuery(..) |
                 QueryMsg::TextIndexQuery(..) |


### PR DESCRIPTION
These should be unnecessary since the introduction of the catch-all reflow in #9421. Any explicit reflow that is not performing a layout query is unnecessary, and we should be postponing reflow for as long as possible. This should allow pages to perform better when processing mouse events, for example, and allow profiles to better reflect the actual work being done by a page.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #5329
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23118)
<!-- Reviewable:end -->
