### PR TITLE
Pass not none value in setfullscreen

### DIFF
--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -78,6 +78,8 @@ pub enum WindowEvent {
     Navigation(TopLevelBrowsingContextId, TraversalDirection),
     /// Sent when the user quits the application
     Quit,
+    /// Sent when the user exits from fullscreen mode
+    ExitFullScreen(TopLevelBrowsingContextId),
     /// Sent when a key input state changes
     Keyboard(KeyboardEvent),
     /// Sent when Ctr+R/Apple+R is called to reload the current page.
@@ -125,6 +127,7 @@ impl Debug for WindowEvent {
             WindowEvent::ToggleWebRenderDebug(..) => write!(f, "ToggleWebRenderDebug"),
             WindowEvent::CaptureWebRender => write!(f, "CaptureWebRender"),
             WindowEvent::ToggleSamplingProfiler(..) => write!(f, "ToggleSamplingProfiler"),
+            WindowEvent::ExitFullScreen(..) => write!(f, "ExitFullScreen"),
         }
     }
 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3211,7 +3211,7 @@ impl Document {
 
         let window = self.window();
         // Step 8
-        let event = EmbedderMsg::SetFullscreenState(true);
+        let event = EmbedderMsg::SetFullscreenState(false);
         self.send_to_embedder(event);
 
         // Step 9

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -262,6 +262,8 @@ pub enum ConstellationControlMsg {
     Resize(PipelineId, WindowSizeData, WindowSizeType),
     /// Notifies script that window has been resized but to not take immediate action.
     ResizeInactive(PipelineId, WindowSizeData),
+    /// Window switched from fullscreen mode.
+    ExitFullScreen(PipelineId),
     /// Notifies the script that the document associated with this pipeline should 'unload'.
     UnloadDocument(PipelineId),
     /// Notifies the script that a pipeline should be closed.
@@ -388,6 +390,7 @@ impl fmt::Debug for ConstellationControlMsg {
             Reload(..) => "Reload",
             WebVREvents(..) => "WebVREvents",
             PaintMetric(..) => "PaintMetric",
+            ExitFullScreen(..) => "ExitFullScreen",
         };
         write!(formatter, "ConstellationControlMsg::{}", variant)
     }
@@ -782,6 +785,8 @@ pub enum ConstellationMsg {
     EnableProfiler(Duration, Duration),
     /// Disable the sampling profiler.
     DisableProfiler,
+    /// Request to exit from fullscreen mode
+    ExitFullScreen(TopLevelBrowsingContextId),
 }
 
 impl fmt::Debug for ConstellationMsg {
@@ -811,6 +816,7 @@ impl fmt::Debug for ConstellationMsg {
             SetCursor(..) => "SetCursor",
             EnableProfiler(..) => "EnableProfiler",
             DisableProfiler => "DisableProfiler",
+            ExitFullScreen(..) => "ExitFullScreen",
         };
         write!(formatter, "ConstellationMsg::{}", variant)
     }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -401,6 +401,13 @@ where
                 self.compositor.maybe_start_shutting_down();
             },
 
+            WindowEvent::ExitFullScreen(top_level_browsing_context_id) => {
+                let msg = ConstellationMsg::ExitFullScreen(top_level_browsing_context_id);
+                if let Err(e) = self.constellation_chan.send(msg) {
+                    warn!("Sending exit fullscreen to constellation failed ({:?}).", e);
+                }
+            },
+
             WindowEvent::Reload(top_level_browsing_context_id) => {
                 let msg = ConstellationMsg::Reload(top_level_browsing_context_id);
                 if let Err(e) = self.constellation_chan.send(msg) {

--- a/ports/servo/browser.rs
+++ b/ports/servo/browser.rs
@@ -159,7 +159,15 @@ impl Browser {
                 }
             })
             .shortcut(Modifiers::empty(), Key::Escape, || {
-                self.event_queue.push(WindowEvent::Quit);
+                let state = self.window.get_fullscreen();
+                if state {
+                    if let Some(id) = self.browser_id {
+                        let event = WindowEvent::ExitFullScreen(id);
+                        self.event_queue.push(event);
+                    }
+                } else {
+                    self.event_queue.push(WindowEvent::Quit);
+                }
             })
             .otherwise(|| self.platform_handle_key(key_event));
     }

--- a/ports/servo/glutin_app/window.rs
+++ b/ports/servo/glutin_app/window.rs
@@ -329,12 +329,16 @@ impl Window {
         match self.kind {
             WindowKind::Window(ref window, ..) => {
                 if self.fullscreen.get() != state {
-                    window.set_fullscreen(None);
+                    window.set_fullscreen(Some(window.get_primary_monitor()));
                 }
             },
             WindowKind::Headless(..) => {},
         }
         self.fullscreen.set(state);
+    }
+
+    pub fn get_fullscreen(&self) -> bool {
+        return self.fullscreen.get();
     }
 
     fn is_animating(&self) -> bool {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
# Diagnose

Entering fullscreen mode is passing `None` value to `Window` when `set_fullscreen` function is called which prevents 
Servo actually entering fullscreen mode. 
In addition, the function `exit_fullscreen` in `document.rs` is passing True value to 
`SetFullscreenState` which doesn't allow to exit from fullscreen mode.

# Solution

1. Instead of passing `None` value when `FullScreenState` is true, `window.get_primary_monitor()` is called in order to pass a monitor id.
This fix make Servo actually enter fullscreen mode.
2. Changed `SetFullscreenState` to false when `exit_fullscreen` function is called.
3. In addition, added new implementation to support exiting from fullscreen mode by pressing `Escape` button.

# Testing Plan

After my change in [windows.rs and document.rs](https://github.com/kamal-umudlu/servo/commit/af6b5981541bd407fba8a0e9f4ea1713f7c6e25c),
the Servo app can enter/exit fullscreen mode. 
In addition, the [`ESC button support`](https://github.com/kamal-umudlu/servo/commit/14ebd5bbb055d436a01756fd8fc0a5595e41332e)
allows to exit from fullscreenmode.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22853 

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23128)
<!-- Reviewable:end -->
