### PR TITLE
Remove compound microtasks

### DIFF
--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -90,13 +90,13 @@ impl MutationObserver {
     }
 
     /// <https://dom.spec.whatwg.org/#queue-a-mutation-observer-compound-microtask>
-    pub fn queue_mutation_observer_compound_microtask() {
+    pub fn queue_mutation_observer_microtask() {
         // Step 1
-        if ScriptThread::is_mutation_observer_compound_microtask_queued() {
+        if ScriptThread::is_mutation_observer_microtask_queued() {
             return;
         }
         // Step 2
-        ScriptThread::set_mutation_observer_compound_microtask_queued(true);
+        ScriptThread::set_mutation_observer_microtask_queued(true);
         // Step 3
         ScriptThread::enqueue_microtask(Microtask::NotifyMutationObservers);
     }
@@ -104,7 +104,7 @@ impl MutationObserver {
     /// <https://dom.spec.whatwg.org/#notify-mutation-observers>
     pub fn notify_mutation_observers() {
         // Step 1
-        ScriptThread::set_mutation_observer_compound_microtask_queued(false);
+        ScriptThread::set_mutation_observer_microtask_queued(false);
         // Step 2
         let notify_list = ScriptThread::get_mutation_observers();
         // TODO: steps 3-4 (slots)
@@ -239,7 +239,7 @@ impl MutationObserver {
         }
 
         // Step 5
-        MutationObserver::queue_mutation_observer_compound_microtask();
+        MutationObserver::queue_mutation_observer_microtask();
     }
 }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -615,7 +615,7 @@ pub struct ScriptThread {
     microtask_queue: Rc<MicrotaskQueue>,
 
     /// Microtask Queue for adding support for mutation observer microtasks
-    mutation_observer_compound_microtask_queued: Cell<bool>,
+    mutation_observer_microtask_queued: Cell<bool>,
 
     /// The unit of related similar-origin browsing contexts' list of MutationObserver objects
     mutation_observers: DomRefCell<Vec<Dom<MutationObserver>>>,
@@ -767,21 +767,17 @@ impl ScriptThread {
         })
     }
 
-    pub fn set_mutation_observer_compound_microtask_queued(value: bool) {
+    pub fn set_mutation_observer_microtask_queued(value: bool) {
         SCRIPT_THREAD_ROOT.with(|root| {
             let script_thread = unsafe { &*root.get().unwrap() };
-            script_thread
-                .mutation_observer_compound_microtask_queued
-                .set(value);
+            script_thread.mutation_observer_microtask_queued.set(value);
         })
     }
 
-    pub fn is_mutation_observer_compound_microtask_queued() -> bool {
+    pub fn is_mutation_observer_microtask_queued() -> bool {
         SCRIPT_THREAD_ROOT.with(|root| {
             let script_thread = unsafe { &*root.get().unwrap() };
-            return script_thread
-                .mutation_observer_compound_microtask_queued
-                .get();
+            return script_thread.mutation_observer_microtask_queued.get();
         })
     }
 
@@ -1145,7 +1141,7 @@ impl ScriptThread {
 
             microtask_queue: Default::default(),
 
-            mutation_observer_compound_microtask_queued: Default::default(),
+            mutation_observer_microtask_queued: Default::default(),
 
             mutation_observers: Default::default(),
 


### PR DESCRIPTION
We handled compound microtasks as microtasks so, basically, we only need
to remove the naming of `compound`.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23140 
- [x] These changes do not require tests because the updated spec is more about editorial.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23143)
<!-- Reviewable:end -->
