### PR TITLE
Add connectEnd attribute to PerformanceResourceTiming interface

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -349,6 +349,7 @@ fn obtain_response(
     iters: u32,
     request_id: Option<&str>,
     is_xhr: bool,
+    context: &FetchContext,
 ) -> Box<
     dyn Future<
         Item = (HyperResponse<Decoder>, Option<ChromeToDevtoolsControlMsg>),
@@ -400,8 +401,12 @@ fn obtain_response(
     };
     *request.headers_mut() = headers.clone();
 
-    //TODO(#21262) connect_end
     let connect_end = precise_time_ms();
+    context
+        .timing
+        .lock()
+        .unwrap()
+        .set_attribute(ResourceAttribute::ConnectEnd(connect_end));
 
     let request_id = request_id.map(|v| v.to_owned());
     let pipeline_id = pipeline_id.clone();
@@ -1190,6 +1195,7 @@ fn http_network_fetch(
         request.redirect_count + 1,
         request_id.as_ref().map(Deref::deref),
         is_xhr,
+        context,
     );
 
     let pipeline_id = request.pipeline_id;

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -452,7 +452,7 @@ pub struct ResourceFetchTiming {
     pub redirect_start: u64,
     // pub redirect_end: u64,
     // pub connect_start: u64,
-    // pub connect_end: u64,
+    pub connect_end: u64,
 }
 
 pub enum RedirectStartValue {
@@ -467,6 +467,7 @@ pub enum ResourceAttribute {
     ResponseStart,
     RedirectStart(RedirectStartValue),
     FetchStart,
+    ConnectEnd(u64),
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
@@ -486,6 +487,7 @@ impl ResourceFetchTiming {
             response_start: 0,
             fetch_start: 0,
             redirect_start: 0,
+            connect_end: 0,
         }
     }
 
@@ -505,6 +507,7 @@ impl ResourceFetchTiming {
                 },
             },
             ResourceAttribute::FetchStart => self.fetch_start = precise_time_ns(),
+            ResourceAttribute::ConnectEnd(val) => self.connect_end = val,
         }
     }
 }

--- a/components/script/dom/performanceresourcetiming.rs
+++ b/components/script/dom/performanceresourcetiming.rs
@@ -122,7 +122,7 @@ impl PerformanceResourceTiming {
             domain_lookup_start: 0.,
             domain_lookup_end: 0.,
             connect_start: 0.,
-            connect_end: 0.,
+            connect_end: resource_timing.connect_end as f64,
             secure_connection_start: 0.,
             request_start: resource_timing.request_start as f64,
             response_start: resource_timing.response_start as f64,
@@ -193,5 +193,10 @@ impl PerformanceResourceTimingMethods for PerformanceResourceTiming {
     // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-fetchstart
     fn FetchStart(&self) -> DOMHighResTimeStamp {
         Finite::wrap(self.fetch_start)
+    }
+
+    // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-connectend
+    fn ConnectEnd(&self) -> DOMHighResTimeStamp {
+        Finite::wrap(self.connect_end)
     }
 }

--- a/components/script/dom/webidls/PerformanceResourceTiming.webidl
+++ b/components/script/dom/webidls/PerformanceResourceTiming.webidl
@@ -18,7 +18,7 @@ interface PerformanceResourceTiming : PerformanceEntry {
     // readonly attribute DOMHighResTimeStamp domainLookupStart;
     // readonly attribute DOMHighResTimeStamp domainLookupEnd;
     // readonly attribute DOMHighResTimeStamp connectStart;
-    // readonly attribute DOMHighResTimeStamp connectEnd;
+    readonly attribute DOMHighResTimeStamp connectEnd;
     // readonly attribute DOMHighResTimeStamp secureConnectionStart;
     readonly attribute DOMHighResTimeStamp requestStart;
     readonly attribute DOMHighResTimeStamp responseStart;

--- a/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
+++ b/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
@@ -62,9 +62,6 @@
   [PerformanceResourceTiming interface: resource must inherit property "responseEnd" with the proper type]
     expected: FAIL
 
-  [PerformanceResourceTiming interface: attribute connectEnd]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: resource must inherit property "redirectEnd" with the proper type]
     expected: FAIL
 
@@ -75,9 +72,6 @@
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute domainLookupEnd]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: resource must inherit property "connectEnd" with the proper type]
     expected: FAIL
 
   [PerformanceResourceTiming interface: default toJSON operation on resource]
@@ -173,9 +167,6 @@
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute connectStart]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: attribute connectEnd]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute redirectEnd]

--- a/tests/wpt/metadata/resource-timing/resource_TAO_zero.htm.ini
+++ b/tests/wpt/metadata/resource-timing/resource_TAO_zero.htm.ini
@@ -8,9 +8,6 @@
   [secureConnectionStart should be 0 in cross-origin request.]
     expected: FAIL
 
-  [connectEnd should be 0 in cross-origin request.]
-    expected: FAIL
-
   [domainLookupStart should be 0 in cross-origin request.]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [x] These changes fix #21262

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23145)
<!-- Reviewable:end -->
