### PR TITLE
Make serializeToString serialize document nodes correctly

### DIFF
--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -167,7 +167,7 @@ fn rev_children_iter(n: &Node) -> impl Iterator<Item = DomRoot<Node>> {
 impl SerializationIterator {
     fn new(node: &Node, skip_first: bool) -> SerializationIterator {
         let mut ret = SerializationIterator { stack: vec![] };
-        if skip_first || node.is::<DocumentFragment>() {
+        if skip_first || node.is::<DocumentFragment>() || node.is::<Document>() {
             for c in rev_children_iter(node) {
                 ret.push_node(&*c);
             }

--- a/tests/wpt/metadata/domparsing/XMLSerializer-serializeToString.html.ini
+++ b/tests/wpt/metadata/domparsing/XMLSerializer-serializeToString.html.ini
@@ -1,5 +1,8 @@
 [XMLSerializer-serializeToString.html]
   type: testharness
+  [check XMLSerializer.serializeToString method could parsing document to string]
+    expected: FAIL
+
   [Check if the default namespace is correctly reset.]
     expected: FAIL
 

--- a/tests/wpt/web-platform-tests/domparsing/XMLSerializer-serializeToString.html
+++ b/tests/wpt/web-platform-tests/domparsing/XMLSerializer-serializeToString.html
@@ -32,6 +32,11 @@ test(function() {
 }, 'check XMLSerializer.serializeToString method could parsing xmldoc to string');
 
 test(function() {
+  var root = parse('<html><head></head><body><div></div><span></span></body></html>');
+  assert_equals(serialize(root.ownerDocument), '<html><head/><body><div/><span/></body></html>');
+}, 'check XMLSerializer.serializeToString method could parsing document to string');
+
+test(function() {
   var root = createXmlDoc().documentElement;
   var element = root.ownerDocument.createElementNS('urn:foo', 'another');
   var child1 = root.firstChild;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is the fix for ScriptThread panic when `new XMLSerializer().serializeToString(document);` is called.

r?@jdm

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23130

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23153)
<!-- Reviewable:end -->
