### PR TITLE
Update XR code to use rigid transforms and new pose/transform stuff from the spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ version = "0.35.0"
 source = "git+https://github.com/servo/rust-azure#5c648f2bd5d2d600c28d56f07c29c4e2a08173b6"
 dependencies = [
  "cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-freetype-sys 4.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-skia 0.30000020.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -415,7 +415,7 @@ dependencies = [
  "canvas_traits 0.0.1",
  "compositing 0.0.1",
  "cssparser 0.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "half 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -435,7 +435,7 @@ name = "canvas_traits"
 version = "0.0.1"
 dependencies = [
  "cssparser 0.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -612,7 +612,7 @@ version = "0.0.1"
 dependencies = [
  "crossbeam-channel 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "embedder_traits 0.0.1",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
  "gleam 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -653,7 +653,7 @@ dependencies = [
  "debugger 0.0.1",
  "devtools_traits 0.0.1",
  "embedder_traits 0.0.1",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gaol 0.2.0 (git+https://github.com/servo/gaol)",
  "gfx 0.0.1",
  "gfx_traits 0.0.1",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.19.5"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "euclid_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1378,7 +1378,7 @@ dependencies = [
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 13.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwrote 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fontsan 0.4.0 (git+https://github.com/servo/fontsan)",
  "freetype 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2188,7 +2188,7 @@ dependencies = [
  "canvas_traits 0.0.1",
  "crossbeam-channel 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "embedder_traits 0.0.1",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.0.1",
@@ -2234,7 +2234,7 @@ dependencies = [
  "atomic_refcell 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "embedder_traits 0.0.1",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.0.1",
@@ -2371,7 +2371,7 @@ dependencies = [
  "devtools_traits 0.0.1",
  "embedder_traits 0.0.1",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gaol 0.2.0 (git+https://github.com/servo/gaol)",
  "gfx 0.0.1",
  "gleam 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2481,7 +2481,7 @@ dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashglobe 0.1.0",
  "hyper 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper_serde 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2967,7 +2967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3135,7 +3135,7 @@ dependencies = [
 name = "pixels"
 version = "0.0.1"
 dependencies = [
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "malloc_size_of 0.0.1",
  "malloc_size_of_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3152,7 +3152,7 @@ version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "binary-space-partition 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3372,7 +3372,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.46.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3474,7 +3474,7 @@ dependencies = [
  "embedder_traits 0.0.1",
  "encoding_rs 0.8.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "enum-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "headers-core 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3553,7 +3553,7 @@ dependencies = [
  "canvas_traits 0.0.1",
  "crossbeam-channel 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
  "html5ever 0.22.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3590,7 +3590,7 @@ dependencies = [
 name = "script_tests"
 version = "0.0.1"
 dependencies = [
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "keyboard-types 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "script 0.0.1",
  "servo_url 0.0.1",
@@ -3606,7 +3606,7 @@ dependencies = [
  "crossbeam-channel 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "devtools_traits 0.0.1",
  "embedder_traits 0.0.1",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
  "http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3706,7 +3706,7 @@ dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3779,7 +3779,7 @@ source = "git+https://github.com/servo/media#a5a8490087d786a4dbebed43e9705874c43
 dependencies = [
  "boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-slice-cast 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3874,7 +3874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "expat-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3919,7 +3919,7 @@ dependencies = [
  "dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "embedder_traits 0.0.1",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3949,7 +3949,7 @@ name = "servo_geometry"
 version = "0.0.1"
 dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "malloc_size_of 0.0.1",
  "malloc_size_of_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "style_traits 0.0.1",
@@ -4203,7 +4203,7 @@ dependencies = [
  "cssparser 0.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible 0.0.1",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashglobe 0.1.0",
@@ -4266,7 +4266,7 @@ dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.22.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4289,7 +4289,7 @@ dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cssparser 0.25.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "malloc_size_of 0.0.1",
  "malloc_size_of_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "selectors 0.21.0",
@@ -4866,7 +4866,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4938,7 +4938,7 @@ dependencies = [
  "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "malloc_size_of_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4962,7 +4962,7 @@ version = "0.0.1"
 dependencies = [
  "canvas_traits 0.0.1",
  "crossbeam-channel 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5073,7 +5073,7 @@ version = "0.0.1"
 source = "git+https://github.com/servo/webrender#e53aae02728e155e555b8baa9d180d90dac3b86f"
 dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5287,7 +5287,7 @@ dependencies = [
 "checksum enum-iterator-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "293ee6af5f9349c2594a7c867b7c89347fb939415508e6367a19bd246ffc08d8"
 "checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
-"checksum euclid 0.19.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d1a7698bdda3d7444a79d33bdc96e8b518d44ea3ff101d8492a6ca1207b886ea"
+"checksum euclid 0.19.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8acd6a7f2740b7b936008acd58b1def492854254dc4af9d2b850ca01f4960e"
 "checksum euclid_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdcb84c18ea5037a1c5a23039b4ff29403abce2e0d6b1daa11cf0bde2b30be15"
 "checksum expat-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa"
 "checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -50,7 +50,7 @@ domobject_derive = {path = "../domobject_derive"}
 embedder_traits = {path = "../embedder_traits"}
 encoding_rs = "0.8"
 enum-iterator = "0.2.0"
-euclid = "0.19"
+euclid = "0.19.7"
 fnv = "1.0"
 gleam = "0.6"
 headers-core = "0.0.1"

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -57,7 +57,8 @@ use devtools_traits::{CSSError, TimelineMarkerType, WorkerId};
 use encoding_rs::{Decoder, Encoding};
 use euclid::Length as EuclidLength;
 use euclid::{
-    Point2D, Rect, Rotation3D, Transform2D, Transform3D, TypedScale, TypedSize2D, Vector2D,
+    Point2D, Rect, RigidTransform3D, Rotation3D, Transform2D, Transform3D, TypedScale, TypedSize2D,
+    Vector2D,
 };
 use html5ever::buffer_queue::BufferQueue;
 use html5ever::{LocalName, Namespace, Prefix, QualName};
@@ -494,7 +495,8 @@ unsafe_no_jsmanaged_fields!(ResourceFetchTiming);
 unsafe_no_jsmanaged_fields!(Timespec);
 unsafe_no_jsmanaged_fields!(HTMLMediaElementFetchContext);
 unsafe_no_jsmanaged_fields!(Rotation3D<f64>, Transform2D<f32>, Transform3D<f64>);
-unsafe_no_jsmanaged_fields!(Point2D<f32>, Vector2D<f32>, Rect<Au>, Rect<f32>);
+unsafe_no_jsmanaged_fields!(Point2D<f32>, Vector2D<f32>, Rect<Au>);
+unsafe_no_jsmanaged_fields!(Rect<f32>, RigidTransform3D<f64>);
 
 unsafe impl<'a> JSTraceable for &'a str {
     #[inline]

--- a/components/script/dom/dompointreadonly.rs
+++ b/components/script/dom/dompointreadonly.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::dom::bindings::codegen::Bindings::DOMPointBinding::DOMPointInit;
 use crate::dom::bindings::codegen::Bindings::DOMPointReadOnlyBinding::{
     DOMPointReadOnlyMethods, Wrap,
 };
@@ -50,10 +49,6 @@ impl DOMPointReadOnly {
         w: f64,
     ) -> Fallible<DomRoot<DOMPointReadOnly>> {
         Ok(DOMPointReadOnly::new(global, x, y, z, w))
-    }
-
-    pub fn new_from_init(global: &GlobalScope, p: &DOMPointInit) -> DomRoot<DOMPointReadOnly> {
-        DOMPointReadOnly::new(global, p.x, p.y, p.z, p.w)
     }
 }
 

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -537,6 +537,7 @@ pub mod xmlserializer;
 pub mod xr;
 pub mod xrframe;
 pub mod xrlayer;
+pub mod xrpose;
 pub mod xrreferencespace;
 pub mod xrrenderstate;
 pub mod xrrigidtransform;

--- a/components/script/dom/webidls/XRPose.webidl
+++ b/components/script/dom/webidls/XRPose.webidl
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://immersive-web.github.io/webxr/#xrpose-interface
+
+[SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]
+interface XRPose {
+  // readonly attribute XRRigidTransform transform;
+  // readonly attribute boolean emulatedPosition;
+};

--- a/components/script/dom/webidls/XRPose.webidl
+++ b/components/script/dom/webidls/XRPose.webidl
@@ -6,6 +6,6 @@
 
 [SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]
 interface XRPose {
-  // readonly attribute XRRigidTransform transform;
+  readonly attribute XRRigidTransform transform;
   // readonly attribute boolean emulatedPosition;
 };

--- a/components/script/dom/webidls/XRRigidTransform.webidl
+++ b/components/script/dom/webidls/XRRigidTransform.webidl
@@ -9,6 +9,6 @@
 interface XRRigidTransform {
   readonly attribute DOMPointReadOnly position;
   readonly attribute DOMPointReadOnly orientation;
-  // readonly attribute Float32Array matrix;
+  readonly attribute Float32Array matrix;
   readonly attribute XRRigidTransform inverse;
 };

--- a/components/script/dom/webidls/XRRigidTransform.webidl
+++ b/components/script/dom/webidls/XRRigidTransform.webidl
@@ -10,5 +10,5 @@ interface XRRigidTransform {
   readonly attribute DOMPointReadOnly position;
   readonly attribute DOMPointReadOnly orientation;
   // readonly attribute Float32Array matrix;
-  XRRigidTransform inverse();
+  readonly attribute XRRigidTransform inverse;
 };

--- a/components/script/dom/webidls/XRView.webidl
+++ b/components/script/dom/webidls/XRView.webidl
@@ -14,5 +14,5 @@ interface XRView {
   readonly attribute XREye eye;
   readonly attribute Float32Array projectionMatrix;
   readonly attribute Float32Array viewMatrix;
-  // readonly attribute XRRigidTransform transform;
+  readonly attribute XRRigidTransform transform;
 };

--- a/components/script/dom/webidls/XRView.webidl
+++ b/components/script/dom/webidls/XRView.webidl
@@ -13,6 +13,5 @@ enum XREye {
 interface XRView {
   readonly attribute XREye eye;
   readonly attribute Float32Array projectionMatrix;
-  readonly attribute Float32Array viewMatrix;
   readonly attribute XRRigidTransform transform;
 };

--- a/components/script/dom/webidls/XRViewerPose.webidl
+++ b/components/script/dom/webidls/XRViewerPose.webidl
@@ -5,8 +5,7 @@
 // https://immersive-web.github.io/webxr/#xrviewerpose-interface
 
 [SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]
-interface XRViewerPose {
-  // readonly attribute XRRigidTransform transform;
+interface XRViewerPose : XRPose {
   // readonly attribute FrozenArray<XRView> views;
   // workaround until we have FrozenArray
   // see https://github.com/servo/servo/issues/10427#issuecomment-449593626

--- a/components/script/dom/xrframe.rs
+++ b/components/script/dom/xrframe.rs
@@ -4,13 +4,11 @@
 
 use crate::dom::bindings::codegen::Bindings::XRFrameBinding;
 use crate::dom::bindings::codegen::Bindings::XRFrameBinding::XRFrameMethods;
-use crate::dom::bindings::codegen::Bindings::XRViewBinding::XREye;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrreferencespace::XRReferenceSpace;
 use crate::dom::xrsession::XRSession;
-use crate::dom::xrview::XRView;
 use crate::dom::xrviewerpose::XRViewerPose;
 use dom_struct::dom_struct;
 use webvr_traits::WebVRFrameData;
@@ -54,20 +52,11 @@ impl XRFrameMethods for XRFrame {
     /// https://immersive-web.github.io/webxr/#dom-xrframe-getviewerpose
     fn GetViewerPose(&self, reference: &XRReferenceSpace) -> Option<DomRoot<XRViewerPose>> {
         let pose = reference.get_viewer_pose(&self.data);
-        let left = XRView::new(
+        Some(XRViewerPose::new(
             &self.global(),
             &self.session,
-            XREye::Left,
-            &pose,
+            pose,
             &self.data,
-        );
-        let right = XRView::new(
-            &self.global(),
-            &self.session,
-            XREye::Right,
-            &pose,
-            &self.data,
-        );
-        Some(XRViewerPose::new(&self.global(), &left, &right))
+        ))
     }
 }

--- a/components/script/dom/xrpose.rs
+++ b/components/script/dom/xrpose.rs
@@ -27,7 +27,7 @@ impl XRPose {
 
     #[allow(unused)]
     pub fn new(global: &GlobalScope, transform: RigidTransform3D<f64>) -> DomRoot<XRPose> {
-        let transform = XRRigidTransform::new(&global.as_window(), transform);
+        let transform = XRRigidTransform::new(global, transform);
         reflect_dom_object(
             Box::new(XRPose::new_inherited(&transform)),
             global,

--- a/components/script/dom/xrpose.rs
+++ b/components/script/dom/xrpose.rs
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::bindings::reflector::Reflector;
+use dom_struct::dom_struct;
+
+#[dom_struct]
+pub struct XRPose {
+    reflector_: Reflector,
+}
+
+impl XRPose {
+    pub fn new_inherited() -> XRPose {
+        XRPose {
+            reflector_: Reflector::new(),
+        }
+    }
+}

--- a/components/script/dom/xrpose.rs
+++ b/components/script/dom/xrpose.rs
@@ -6,7 +6,7 @@ use crate::dom::bindings::codegen::Bindings::XRPoseBinding;
 use crate::dom::bindings::codegen::Bindings::XRPoseBinding::XRPoseMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::window::Window;
+use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use dom_struct::dom_struct;
 use euclid::RigidTransform3D;
@@ -26,8 +26,8 @@ impl XRPose {
     }
 
     #[allow(unused)]
-    pub fn new(global: &Window, transform: RigidTransform3D<f64>) -> DomRoot<XRPose> {
-        let transform = XRRigidTransform::new(global, transform);
+    pub fn new(global: &GlobalScope, transform: RigidTransform3D<f64>) -> DomRoot<XRPose> {
+        let transform = XRRigidTransform::new(&global.as_window(), transform);
         reflect_dom_object(
             Box::new(XRPose::new_inherited(&transform)),
             global,

--- a/components/script/dom/xrpose.rs
+++ b/components/script/dom/xrpose.rs
@@ -2,18 +2,43 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::dom::bindings::reflector::Reflector;
+use crate::dom::bindings::codegen::Bindings::XRPoseBinding;
+use crate::dom::bindings::codegen::Bindings::XRPoseBinding::XRPoseMethods;
+use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
+use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::window::Window;
+use crate::dom::xrrigidtransform::XRRigidTransform;
 use dom_struct::dom_struct;
+use euclid::RigidTransform3D;
 
 #[dom_struct]
 pub struct XRPose {
     reflector_: Reflector,
+    transform: Dom<XRRigidTransform>,
 }
 
 impl XRPose {
-    pub fn new_inherited() -> XRPose {
+    pub fn new_inherited(transform: &XRRigidTransform) -> XRPose {
         XRPose {
             reflector_: Reflector::new(),
+            transform: Dom::from_ref(transform),
         }
+    }
+
+    #[allow(unused)]
+    pub fn new(global: &Window, transform: RigidTransform3D<f64>) -> DomRoot<XRPose> {
+        let transform = XRRigidTransform::new(global, transform);
+        reflect_dom_object(
+            Box::new(XRPose::new_inherited(&transform)),
+            global,
+            XRPoseBinding::Wrap,
+        )
+    }
+}
+
+impl XRPoseMethods for XRPose {
+    /// https://immersive-web.github.io/webxr/#dom-xrpose-transform
+    fn Transform(&self) -> DomRoot<XRRigidTransform> {
+        DomRoot::from_ref(&self.transform)
     }
 }

--- a/components/script/dom/xrreferencespace.rs
+++ b/components/script/dom/xrreferencespace.rs
@@ -7,7 +7,6 @@ use crate::dom::bindings::codegen::Bindings::XRReferenceSpaceBinding::XRReferenc
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::{DomRoot, MutDom};
-use crate::dom::dompointreadonly::DOMPointReadOnly;
 use crate::dom::window::Window;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::XRSession;
@@ -29,21 +28,6 @@ impl XRReferenceSpace {
             xrspace: XRSpace::new_inherited(session),
             transform: MutDom::new(transform),
         }
-    }
-
-    #[allow(unused)]
-    pub fn new(
-        global: &Window,
-        session: &XRSession,
-        position: &DOMPointReadOnly,
-        orientation: &DOMPointReadOnly,
-    ) -> DomRoot<XRReferenceSpace> {
-        let transform = XRRigidTransform::new(global, position, orientation);
-        reflect_dom_object(
-            Box::new(XRReferenceSpace::new_inherited(session, &transform)),
-            global,
-            XRReferenceSpaceBinding::Wrap,
-        )
     }
 
     #[allow(unused)]

--- a/components/script/dom/xrreferencespace.rs
+++ b/components/script/dom/xrreferencespace.rs
@@ -13,7 +13,7 @@ use crate::dom::xrsession::XRSession;
 use crate::dom::xrspace::XRSpace;
 use crate::dom::xrstationaryreferencespace::XRStationaryReferenceSpace;
 use dom_struct::dom_struct;
-use euclid::Transform3D;
+use euclid::RigidTransform3D;
 use webvr_traits::WebVRFrameData;
 
 #[dom_struct]
@@ -55,30 +55,25 @@ impl XRReferenceSpaceMethods for XRReferenceSpace {
 
 impl XRReferenceSpace {
     /// Gets viewer pose represented by this space
-    pub fn get_viewer_pose(&self, base_pose: &WebVRFrameData) -> Transform3D<f64> {
+    pub fn get_viewer_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
         let pose = self.get_pose(base_pose);
 
         // This may change, see https://github.com/immersive-web/webxr/issues/567
-        let offset = self.transform.get().matrix();
-        // XXXManishearth we can directly compute the inverse from the transform parameters
-        // (and perhaps cache it)
-        // XXXManishearth we can also optimize for the unset/identity offset case
-        let inverse = offset
-            .inverse()
-            .expect("rigid transforms are always invertible");
+        let offset = self.transform.get().transform();
+        let inverse = offset.inverse();
         inverse.pre_mul(&pose)
     }
 
     /// Gets pose represented by this space
     ///
     /// Does not apply originOffset, use get_viewer_pose instead if you need it
-    pub fn get_pose(&self, base_pose: &WebVRFrameData) -> Transform3D<f64> {
+    pub fn get_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
         if let Some(stationary) = self.downcast::<XRStationaryReferenceSpace>() {
             stationary.get_pose(base_pose)
         } else {
             // non-subclassed XRReferenceSpaces exist, obtained via the "identity"
             // type. The pose does not depend on the base pose.
-            Transform3D::identity()
+            RigidTransform3D::identity()
         }
     }
 }

--- a/components/script/dom/xrreferencespace.rs
+++ b/components/script/dom/xrreferencespace.rs
@@ -7,7 +7,7 @@ use crate::dom::bindings::codegen::Bindings::XRReferenceSpaceBinding::XRReferenc
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::{DomRoot, MutDom};
-use crate::dom::window::Window;
+use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::XRSession;
 use crate::dom::xrspace::XRSpace;
@@ -31,7 +31,7 @@ impl XRReferenceSpace {
     }
 
     #[allow(unused)]
-    pub fn identity(global: &Window, session: &XRSession) -> DomRoot<XRReferenceSpace> {
+    pub fn identity(global: &GlobalScope, session: &XRSession) -> DomRoot<XRReferenceSpace> {
         let transform = XRRigidTransform::identity(global);
         reflect_dom_object(
             Box::new(XRReferenceSpace::new_inherited(session, &transform)),

--- a/components/script/dom/xrrigidtransform.rs
+++ b/components/script/dom/xrrigidtransform.rs
@@ -13,7 +13,7 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::dompointreadonly::DOMPointReadOnly;
 use crate::dom::window::Window;
 use dom_struct::dom_struct;
-use euclid::{RigidTransform3D, Rotation3D, Transform3D, Vector3D};
+use euclid::{RigidTransform3D, Rotation3D, Vector3D};
 
 #[dom_struct]
 pub struct XRRigidTransform {
@@ -34,7 +34,6 @@ impl XRRigidTransform {
         }
     }
 
-    #[allow(unused)]
     pub fn new(global: &Window, transform: RigidTransform3D<f64>) -> DomRoot<XRRigidTransform> {
         reflect_dom_object(
             Box::new(XRRigidTransform::new_inherited(transform)),
@@ -43,7 +42,6 @@ impl XRRigidTransform {
         )
     }
 
-    #[allow(unused)]
     pub fn identity(window: &Window) -> DomRoot<XRRigidTransform> {
         let transform = RigidTransform3D::identity();
         XRRigidTransform::new(window, transform)
@@ -97,9 +95,8 @@ impl XRRigidTransformMethods for XRRigidTransform {
 }
 
 impl XRRigidTransform {
-    pub fn matrix(&self) -> Transform3D<f64> {
-        // Spec says the orientation applies first,
-        // so post-multiply (?)
-        self.transform.to_transform()
+    /// https://immersive-web.github.io/webxr/#dom-xrpose-transform
+    pub fn transform(&self) -> RigidTransform3D<f64> {
+        self.transform
     }
 }

--- a/components/script/dom/xrrigidtransform.rs
+++ b/components/script/dom/xrrigidtransform.rs
@@ -5,6 +5,7 @@
 use crate::dom::bindings::codegen::Bindings::DOMPointBinding::DOMPointInit;
 use crate::dom::bindings::codegen::Bindings::XRRigidTransformBinding;
 use crate::dom::bindings::codegen::Bindings::XRRigidTransformBinding::XRRigidTransformMethods;
+use crate::dom::bindings::error::Error;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
@@ -54,7 +55,13 @@ impl XRRigidTransform {
         position: &DOMPointInit,
         orientation: &DOMPointInit,
     ) -> Fallible<DomRoot<Self>> {
-        let global = window.global();
+        if position.w != 1.0 {
+            return Err(Error::Type(format!(
+                "XRRigidTransform must be constructed with a position that has a w value of of 1.0, not {}",
+                position.w
+            )));
+        }
+
         let translate = Vector3D::new(position.x as f64, position.y as f64, position.z as f64);
         let rotate = Rotation3D::unit_quaternion(
             orientation.x as f64,

--- a/components/script/dom/xrrigidtransform.rs
+++ b/components/script/dom/xrrigidtransform.rs
@@ -95,9 +95,8 @@ impl XRRigidTransformMethods for XRRigidTransform {
     }
     // https://immersive-web.github.io/webxr/#dom-xrrigidtransform-inverse
     fn Inverse(&self) -> DomRoot<XRRigidTransform> {
-        self.inverse.or_init(|| {
-            XRRigidTransform::new(&self.global(), self.transform.inverse())
-        })
+        self.inverse
+            .or_init(|| XRRigidTransform::new(&self.global(), self.transform.inverse()))
     }
 }
 

--- a/components/script/dom/xrrigidtransform.rs
+++ b/components/script/dom/xrrigidtransform.rs
@@ -23,6 +23,7 @@ pub struct XRRigidTransform {
     orientation: MutNullableDom<DOMPointReadOnly>,
     #[ignore_malloc_size_of = "defined in euclid"]
     transform: RigidTransform3D<f64>,
+    inverse: MutNullableDom<XRRigidTransform>,
 }
 
 impl XRRigidTransform {
@@ -32,6 +33,7 @@ impl XRRigidTransform {
             position: MutNullableDom::default(),
             orientation: MutNullableDom::default(),
             transform,
+            inverse: MutNullableDom::default(),
         }
     }
 
@@ -93,7 +95,9 @@ impl XRRigidTransformMethods for XRRigidTransform {
     }
     // https://immersive-web.github.io/webxr/#dom-xrrigidtransform-inverse
     fn Inverse(&self) -> DomRoot<XRRigidTransform> {
-        XRRigidTransform::new(&self.global(), self.transform.inverse())
+        self.inverse.or_init(|| {
+            XRRigidTransform::new(&self.global(), self.transform.inverse())
+        })
     }
 }
 

--- a/components/script/dom/xrrigidtransform.rs
+++ b/components/script/dom/xrrigidtransform.rs
@@ -11,6 +11,7 @@ use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::dompointreadonly::DOMPointReadOnly;
+use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
 use dom_struct::dom_struct;
 use euclid::{RigidTransform3D, Rotation3D, Vector3D};
@@ -34,7 +35,10 @@ impl XRRigidTransform {
         }
     }
 
-    pub fn new(global: &Window, transform: RigidTransform3D<f64>) -> DomRoot<XRRigidTransform> {
+    pub fn new(
+        global: &GlobalScope,
+        transform: RigidTransform3D<f64>,
+    ) -> DomRoot<XRRigidTransform> {
         reflect_dom_object(
             Box::new(XRRigidTransform::new_inherited(transform)),
             global,
@@ -42,7 +46,7 @@ impl XRRigidTransform {
         )
     }
 
-    pub fn identity(window: &Window) -> DomRoot<XRRigidTransform> {
+    pub fn identity(window: &GlobalScope) -> DomRoot<XRRigidTransform> {
         let transform = RigidTransform3D::identity();
         XRRigidTransform::new(window, transform)
     }
@@ -68,7 +72,7 @@ impl XRRigidTransform {
             orientation.w as f64,
         );
         let transform = RigidTransform3D::new(rotate, translate);
-        Ok(XRRigidTransform::new(window, transform))
+        Ok(XRRigidTransform::new(&window.global(), transform))
     }
 }
 
@@ -89,8 +93,7 @@ impl XRRigidTransformMethods for XRRigidTransform {
     }
     // https://immersive-web.github.io/webxr/#dom-xrrigidtransform-inverse
     fn Inverse(&self) -> DomRoot<XRRigidTransform> {
-        let global = self.global();
-        XRRigidTransform::new(global.as_window(), self.transform.inverse())
+        XRRigidTransform::new(&self.global(), self.transform.inverse())
     }
 }
 

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -115,15 +115,12 @@ impl XRSessionMethods for XRSession {
 
         match options.type_ {
             XRReferenceSpaceType::Identity => {
-                p.resolve_native(&XRReferenceSpace::identity(
-                    &self.global().as_window(),
-                    self,
-                ));
+                p.resolve_native(&XRReferenceSpace::identity(&self.global(), self));
             },
             XRReferenceSpaceType::Stationary => {
                 if let Some(subtype) = options.subtype {
                     p.resolve_native(&XRStationaryReferenceSpace::new(
-                        &self.global().as_window(),
+                        &self.global(),
                         self,
                         subtype,
                     ));

--- a/components/script/dom/xrspace.rs
+++ b/components/script/dom/xrspace.rs
@@ -11,7 +11,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrreferencespace::XRReferenceSpace;
 use crate::dom::xrsession::XRSession;
 use dom_struct::dom_struct;
-use euclid::Transform3D;
+use euclid::RigidTransform3D;
 use webvr_traits::WebVRFrameData;
 
 #[dom_struct]
@@ -41,7 +41,7 @@ impl XRSpace {
 impl XRSpace {
     /// Gets viewer pose represented by this space
     #[allow(unused)]
-    pub fn get_viewer_pose(&self, base_pose: &WebVRFrameData) -> Transform3D<f64> {
+    pub fn get_viewer_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
         if let Some(reference) = self.downcast::<XRReferenceSpace>() {
             reference.get_viewer_pose(base_pose)
         } else {
@@ -53,7 +53,7 @@ impl XRSpace {
     ///
     /// Does not apply originOffset, use get_viewer_pose instead if you need it
     #[allow(unused)]
-    pub fn get_pose(&self, base_pose: &WebVRFrameData) -> Transform3D<f64> {
+    pub fn get_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
         if let Some(reference) = self.downcast::<XRReferenceSpace>() {
             reference.get_pose(base_pose)
         } else {

--- a/components/script/dom/xrstationaryreferencespace.rs
+++ b/components/script/dom/xrstationaryreferencespace.rs
@@ -11,7 +11,7 @@ use crate::dom::xrreferencespace::XRReferenceSpace;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::XRSession;
 use dom_struct::dom_struct;
-use euclid::{Rotation3D, RigidTransform3D, Vector3D};
+use euclid::{RigidTransform3D, Rotation3D, Vector3D};
 use webvr_traits::WebVRFrameData;
 
 #[dom_struct]

--- a/components/script/dom/xrstationaryreferencespace.rs
+++ b/components/script/dom/xrstationaryreferencespace.rs
@@ -11,7 +11,7 @@ use crate::dom::xrreferencespace::XRReferenceSpace;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::XRSession;
 use dom_struct::dom_struct;
-use euclid::{Rotation3D, Transform3D};
+use euclid::{Rotation3D, RigidTransform3D, Vector3D};
 use webvr_traits::WebVRFrameData;
 
 #[dom_struct]
@@ -53,11 +53,10 @@ impl XRStationaryReferenceSpace {
     /// Gets pose represented by this space
     ///
     /// Does not apply originOffset, use get_viewer_pose instead
-    pub fn get_pose(&self, base_pose: &WebVRFrameData) -> Transform3D<f64> {
+    pub fn get_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
         // XXXManishearth add floor-level transform for floor-level and disable position in position-disabled
         let pos = base_pose.pose.position.unwrap_or([0., 0., 0.]);
-        let translation =
-            Transform3D::create_translation(pos[0] as f64, pos[1] as f64, pos[2] as f64);
+        let translation = Vector3D::new(pos[0] as f64, pos[1] as f64, pos[2] as f64);
         let orient = base_pose.pose.orientation.unwrap_or([0., 0., 0., 0.]);
         let rotation = Rotation3D::quaternion(
             orient[0] as f64,
@@ -65,6 +64,6 @@ impl XRStationaryReferenceSpace {
             orient[2] as f64,
             orient[3] as f64,
         );
-        translation.pre_mul(&rotation.to_transform())
+        RigidTransform3D::new(rotation, translation)
     }
 }

--- a/components/script/dom/xrstationaryreferencespace.rs
+++ b/components/script/dom/xrstationaryreferencespace.rs
@@ -6,7 +6,7 @@ use crate::dom::bindings::codegen::Bindings::XRStationaryReferenceSpaceBinding;
 use crate::dom::bindings::codegen::Bindings::XRStationaryReferenceSpaceBinding::XRStationaryReferenceSpaceSubtype;
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::window::Window;
+use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrreferencespace::XRReferenceSpace;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::XRSession;
@@ -34,16 +34,16 @@ impl XRStationaryReferenceSpace {
     }
 
     pub fn new(
-        window: &Window,
+        global: &GlobalScope,
         session: &XRSession,
         ty: XRStationaryReferenceSpaceSubtype,
     ) -> DomRoot<XRStationaryReferenceSpace> {
-        let transform = XRRigidTransform::identity(window);
+        let transform = XRRigidTransform::identity(global);
         reflect_dom_object(
             Box::new(XRStationaryReferenceSpace::new_inherited(
                 session, ty, &transform,
             )),
-            window,
+            global,
             XRStationaryReferenceSpaceBinding::Wrap,
         )
     }

--- a/components/script/dom/xrview.rs
+++ b/components/script/dom/xrview.rs
@@ -65,7 +65,11 @@ impl XRView {
         };
 
         let offset = Vector3D::new(offset[0] as f64, offset[1] as f64, offset[2] as f64);
-        let view = pose.post_mul(&offset.into()).to_transform().cast().to_column_major_array();
+        let view = pose
+            .post_mul(&offset.into())
+            .to_transform()
+            .cast()
+            .to_column_major_array();
 
         let cx = global.get_cx();
         unsafe {

--- a/components/script/dom/xrview.rs
+++ b/components/script/dom/xrview.rs
@@ -10,7 +10,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::vrframedata::create_typed_array;
 use crate::dom::xrsession::XRSession;
 use dom_struct::dom_struct;
-use euclid::Transform3D;
+use euclid::{RigidTransform3D, Vector3D};
 use js::jsapi::{Heap, JSContext, JSObject};
 use std::ptr::NonNull;
 use webvr_traits::WebVRFrameData;
@@ -40,7 +40,7 @@ impl XRView {
         global: &GlobalScope,
         session: &XRSession,
         eye: XREye,
-        pose: &Transform3D<f64>,
+        pose: &RigidTransform3D<f64>,
         data: &WebVRFrameData,
     ) -> DomRoot<XRView> {
         let ret = reflect_dom_object(
@@ -64,9 +64,8 @@ impl XRView {
             )
         };
 
-        let offset =
-            Transform3D::create_translation(offset[0] as f64, offset[1] as f64, offset[2] as f64);
-        let view = pose.post_mul(&offset).cast().to_column_major_array();
+        let offset = Vector3D::new(offset[0] as f64, offset[1] as f64, offset[2] as f64);
+        let view = pose.post_mul(&offset.into()).to_transform().cast().to_column_major_array();
 
         let cx = global.get_cx();
         unsafe {

--- a/components/script/dom/xrview.rs
+++ b/components/script/dom/xrview.rs
@@ -63,7 +63,6 @@ impl XRView {
 
         let offset = Vector3D::new(offset[0] as f64, offset[1] as f64, offset[2] as f64);
         let transform = pose.post_mul(&offset.into());
-        let view = transform.to_transform().cast().to_column_major_array();
         let transform = XRRigidTransform::new(global, transform);
 
         let ret = reflect_dom_object(
@@ -75,7 +74,6 @@ impl XRView {
         let cx = global.get_cx();
         unsafe {
             create_typed_array(cx, proj, &ret.proj);
-            create_typed_array(cx, &view, &ret.view);
         }
         ret
     }
@@ -95,12 +93,6 @@ impl XRViewMethods for XRView {
     /// https://immersive-web.github.io/webxr/#dom-xrview-projectionmatrix
     unsafe fn ProjectionMatrix(&self, _cx: *mut JSContext) -> NonNull<JSObject> {
         NonNull::new(self.proj.get()).unwrap()
-    }
-
-    #[allow(unsafe_code)]
-    /// https://immersive-web.github.io/webxr/#dom-xrview-projectionmatrix
-    unsafe fn ViewMatrix(&self, _cx: *mut JSContext) -> NonNull<JSObject> {
-        NonNull::new(self.view.get()).unwrap()
     }
 
     /// https://immersive-web.github.io/webxr/#dom-xrview-transform

--- a/components/script/dom/xrviewerpose.rs
+++ b/components/script/dom/xrviewerpose.rs
@@ -42,7 +42,7 @@ impl XRViewerPose {
     ) -> DomRoot<XRViewerPose> {
         let left = XRView::new(global, session, XREye::Left, &pose, &data);
         let right = XRView::new(global, session, XREye::Right, &pose, &data);
-        let transform = XRRigidTransform::new(&global.as_window(), pose);
+        let transform = XRRigidTransform::new(global, pose);
         let pose = reflect_dom_object(
             Box::new(XRViewerPose::new_inherited(&transform)),
             global,

--- a/components/script/dom/xrviewerpose.rs
+++ b/components/script/dom/xrviewerpose.rs
@@ -2,35 +2,49 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::dom::bindings::codegen::Bindings::XRViewBinding::XREye;
 use crate::dom::bindings::codegen::Bindings::XRViewerPoseBinding;
 use crate::dom::bindings::codegen::Bindings::XRViewerPoseBinding::XRViewerPoseMethods;
-use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
+use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::xrpose::XRPose;
+use crate::dom::xrrigidtransform::XRRigidTransform;
+use crate::dom::xrsession::XRSession;
 use crate::dom::xrview::XRView;
 use dom_struct::dom_struct;
+use euclid::RigidTransform3D;
 use js::conversions::ToJSValConvertible;
 use js::jsapi::{Heap, JSContext};
 use js::jsval::{JSVal, UndefinedValue};
+use webvr_traits::WebVRFrameData;
 
 #[dom_struct]
 pub struct XRViewerPose {
-    reflector_: Reflector,
+    pose: XRPose,
     views: Heap<JSVal>,
 }
 
 impl XRViewerPose {
-    fn new_inherited() -> XRViewerPose {
+    fn new_inherited(transform: &XRRigidTransform) -> XRViewerPose {
         XRViewerPose {
-            reflector_: Reflector::new(),
+            pose: XRPose::new_inherited(transform),
             views: Heap::default(),
         }
     }
 
     #[allow(unsafe_code)]
-    pub fn new(global: &GlobalScope, left: &XRView, right: &XRView) -> DomRoot<XRViewerPose> {
+    pub fn new(
+        global: &GlobalScope,
+        session: &XRSession,
+        pose: RigidTransform3D<f64>,
+        data: &WebVRFrameData,
+    ) -> DomRoot<XRViewerPose> {
+        let left = XRView::new(global, session, XREye::Left, &pose, &data);
+        let right = XRView::new(global, session, XREye::Right, &pose, &data);
+        let transform = XRRigidTransform::new(&global.as_window(), pose);
         let pose = reflect_dom_object(
-            Box::new(XRViewerPose::new_inherited()),
+            Box::new(XRViewerPose::new_inherited(&transform)),
             global,
             XRViewerPoseBinding::Wrap,
         );
@@ -38,7 +52,7 @@ impl XRViewerPose {
         unsafe {
             let cx = global.get_cx();
             rooted!(in(cx) let mut jsval = UndefinedValue());
-            let vec = vec![DomRoot::from_ref(left), DomRoot::from_ref(right)];
+            let vec = vec![left, right];
             vec.to_jsval(cx, jsval.handle_mut());
             pose.views.set(jsval.get());
         }


### PR DESCRIPTION
This updates our XR code to use euclid's new [RigidTransform3D type](https://github.com/servo/euclid/pull/328), which is more efficent and convenient to work with.

It additionally brings us up to speed with the spec:

 - `XRViewerPose` was made a subclass of `XRPose` (https://github.com/immersive-web/webxr/pull/496)
 - `XRView.viewMatrix` was removed in favor of `XRRigidTransform.inverse.matrix` (https://github.com/immersive-web/webxr/pull/531)
 - `XRRigidTransform.inverse` is an attribute (https://github.com/immersive-web/webxr/pull/560)
 - `XRRigidTransform` now validates positions in its constructor (https://github.com/immersive-web/webxr/pull/568)


Furthermore, it adds support for `XRRigidTransform.matrix`.


While fixing this I also noticed that our view matrix code was incorrect, we calculated view matrices as `pose.to_column_major_array()`, whereas it *should* be `pose.inverse().to_row_major_array()` (since Euclid uses row vectors, whenever the spec says it wants a column major array we should use `.to_row_major_array()` since all web specs implicitly use column vectors). For 3DOF devices poses are mostly rotations anyway, so the effective transpose behaved _like_ an inversion, but was incorrect.


This PR gets rid of `view.viewMatrix` anyway, however I felt like I should mention this discrepancy, since otherwise the replacement of `view.viewMatrix` with `view.transform.inverse.matrix` doesn't make sense


r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23159)
<!-- Reviewable:end -->
