### PR TITLE
Add XRFrame.getPose()

### DIFF
--- a/components/script/dom/webidls/XRFrame.webidl
+++ b/components/script/dom/webidls/XRFrame.webidl
@@ -9,5 +9,6 @@ interface XRFrame {
   readonly attribute XRSession session;
 
   [Throws] XRViewerPose? getViewerPose(XRReferenceSpace referenceSpace);
+  [Throws] XRPose? getPose(XRSpace space, XRSpace relativeTo);
   // XRInputPose? getInputPose(XRInputSource inputSource, optional XRReferenceSpace referenceSpace);
 };

--- a/components/script/dom/webidls/XRFrame.webidl
+++ b/components/script/dom/webidls/XRFrame.webidl
@@ -8,6 +8,6 @@
 interface XRFrame {
   readonly attribute XRSession session;
 
-  XRViewerPose? getViewerPose(XRReferenceSpace referenceSpace);
+  [Throws] XRViewerPose? getViewerPose(XRReferenceSpace referenceSpace);
   // XRInputPose? getInputPose(XRInputSource inputSource, optional XRReferenceSpace referenceSpace);
 };

--- a/components/script/dom/webidls/XRSession.webidl
+++ b/components/script/dom/webidls/XRSession.webidl
@@ -20,6 +20,7 @@ interface XRSession : EventTarget {
   readonly attribute XREnvironmentBlendMode environmentBlendMode;
 
   readonly attribute XRRenderState renderState;
+  readonly attribute XRSpace viewerSpace;
 
   // // Methods
   Promise<XRReferenceSpace> requestReferenceSpace(XRReferenceSpaceOptions options);

--- a/components/script/dom/xrframe.rs
+++ b/components/script/dom/xrframe.rs
@@ -4,6 +4,8 @@
 
 use crate::dom::bindings::codegen::Bindings::XRFrameBinding;
 use crate::dom::bindings::codegen::Bindings::XRFrameBinding::XRFrameMethods;
+use crate::dom::bindings::error::Error;
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
@@ -50,13 +52,19 @@ impl XRFrameMethods for XRFrame {
     }
 
     /// https://immersive-web.github.io/webxr/#dom-xrframe-getviewerpose
-    fn GetViewerPose(&self, reference: &XRReferenceSpace) -> Option<DomRoot<XRViewerPose>> {
+    fn GetViewerPose(
+        &self,
+        reference: &XRReferenceSpace,
+    ) -> Result<Option<DomRoot<XRViewerPose>>, Error> {
+        if self.session != reference.upcast::<XRSpace>().session() {
+            return Err(Error::InvalidState);
+        }
         let pose = reference.get_viewer_pose(&self.data);
-        Some(XRViewerPose::new(
+        Ok(Some(XRViewerPose::new(
             &self.global(),
             &self.session,
             pose,
             &self.data,
-        ))
+        )))
     }
 }

--- a/components/script/dom/xrframe.rs
+++ b/components/script/dom/xrframe.rs
@@ -9,8 +9,10 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::xrpose::XRPose;
 use crate::dom::xrreferencespace::XRReferenceSpace;
 use crate::dom::xrsession::XRSession;
+use crate::dom::xrspace::XRSpace;
 use crate::dom::xrviewerpose::XRViewerPose;
 use dom_struct::dom_struct;
 use webvr_traits::WebVRFrameData;
@@ -66,5 +68,20 @@ impl XRFrameMethods for XRFrame {
             pose,
             &self.data,
         )))
+    }
+
+    /// https://immersive-web.github.io/webxr/#dom-xrframe-getpose
+    fn GetPose(
+        &self,
+        space: &XRSpace,
+        relative_to: &XRSpace,
+    ) -> Result<Option<DomRoot<XRPose>>, Error> {
+        if self.session != space.session() || self.session != relative_to.session() {
+            return Err(Error::InvalidState);
+        }
+        let space = space.get_pose(&self.data);
+        let relative_to = relative_to.get_pose(&self.data);
+        let pose = relative_to.inverse().pre_mul(&space);
+        Ok(Some(XRPose::new(&self.global(), pose)))
     }
 }

--- a/components/script/dom/xrreferencespace.rs
+++ b/components/script/dom/xrreferencespace.rs
@@ -55,6 +55,9 @@ impl XRReferenceSpaceMethods for XRReferenceSpace {
 
 impl XRReferenceSpace {
     /// Gets pose of the viewer with respect to this space
+    ///
+    /// This is equivalent to `get_pose(self).inverse() * get_pose(viewerSpace)`, however
+    /// we specialize it to be efficient
     pub fn get_viewer_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
         let pose = self.get_unoffset_viewer_pose(base_pose);
 
@@ -72,7 +75,8 @@ impl XRReferenceSpace {
             stationary.get_unoffset_viewer_pose(base_pose)
         } else {
             // non-subclassed XRReferenceSpaces exist, obtained via the "identity"
-            // type. The pose does not depend on the base pose.
+            // type. These poses are equivalent to the viewer pose and follow the headset
+            // around, so the viewer is always at an identity transform with respect to them
             RigidTransform3D::identity()
         }
     }
@@ -82,7 +86,25 @@ impl XRReferenceSpace {
     /// The reference origin used is common between all
     /// get_pose calls for spaces from the same device, so this can be used to compare
     /// with other spaces
-    pub fn get_pose(&self, _: &WebVRFrameData) -> RigidTransform3D<f64> {
-        unimplemented!()
+    pub fn get_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
+        let pose = self.get_unoffset_pose(base_pose);
+
+        // This may change, see https://github.com/immersive-web/webxr/issues/567
+        let offset = self.transform.get().transform();
+        offset.post_mul(&pose)
+    }
+
+    /// Gets pose represented by this space
+    ///
+    /// Does not apply originOffset, use get_viewer_pose instead if you need it
+    pub fn get_unoffset_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
+        if let Some(stationary) = self.downcast::<XRStationaryReferenceSpace>() {
+            stationary.get_unoffset_pose(base_pose)
+        } else {
+            // non-subclassed XRReferenceSpaces exist, obtained via the "identity"
+            // type. These are equivalent to the viewer pose and follow the headset
+            // around
+            XRSpace::viewer_pose_from_frame_data(base_pose)
+        }
     }
 }

--- a/components/script/dom/xrreferencespace.rs
+++ b/components/script/dom/xrreferencespace.rs
@@ -54,9 +54,9 @@ impl XRReferenceSpaceMethods for XRReferenceSpace {
 }
 
 impl XRReferenceSpace {
-    /// Gets viewer pose represented by this space
+    /// Gets pose of the viewer with respect to this space
     pub fn get_viewer_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
-        let pose = self.get_pose(base_pose);
+        let pose = self.get_unoffset_viewer_pose(base_pose);
 
         // This may change, see https://github.com/immersive-web/webxr/issues/567
         let offset = self.transform.get().transform();
@@ -64,16 +64,25 @@ impl XRReferenceSpace {
         inverse.pre_mul(&pose)
     }
 
-    /// Gets pose represented by this space
+    /// Gets pose of the viewer with respect to this space
     ///
     /// Does not apply originOffset, use get_viewer_pose instead if you need it
-    pub fn get_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
+    pub fn get_unoffset_viewer_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
         if let Some(stationary) = self.downcast::<XRStationaryReferenceSpace>() {
-            stationary.get_pose(base_pose)
+            stationary.get_unoffset_viewer_pose(base_pose)
         } else {
             // non-subclassed XRReferenceSpaces exist, obtained via the "identity"
             // type. The pose does not depend on the base pose.
             RigidTransform3D::identity()
         }
+    }
+
+    /// Gets pose represented by this space
+    ///
+    /// The reference origin used is common between all
+    /// get_pose calls for spaces from the same device, so this can be used to compare
+    /// with other spaces
+    pub fn get_pose(&self, _: &WebVRFrameData) -> RigidTransform3D<f64> {
+        unimplemented!()
     }
 }

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -21,6 +21,7 @@ use crate::dom::vrdisplay::VRDisplay;
 use crate::dom::xrlayer::XRLayer;
 use crate::dom::xrreferencespace::XRReferenceSpace;
 use crate::dom::xrrenderstate::XRRenderState;
+use crate::dom::xrspace::XRSpace;
 use crate::dom::xrstationaryreferencespace::XRStationaryReferenceSpace;
 use dom_struct::dom_struct;
 use std::rc::Rc;
@@ -80,6 +81,11 @@ impl XRSessionMethods for XRSession {
             *self.display.DepthFar(),
             self.base_layer.get().as_ref().map(|l| &**l),
         )
+    }
+
+    // https://immersive-web.github.io/webxr/#dom-xrsession-viewerspace
+    fn ViewerSpace(&self) -> DomRoot<XRSpace> {
+        XRSpace::new_viewerspace(&self.global(), &self)
     }
 
     /// https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe

--- a/components/script/dom/xrspace.rs
+++ b/components/script/dom/xrspace.rs
@@ -39,7 +39,7 @@ impl XRSpace {
 }
 
 impl XRSpace {
-    /// Gets viewer pose represented by this space
+    /// Gets pose of the viewer with respect to this space
     #[allow(unused)]
     pub fn get_viewer_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
         if let Some(reference) = self.downcast::<XRReferenceSpace>() {
@@ -51,7 +51,9 @@ impl XRSpace {
 
     /// Gets pose represented by this space
     ///
-    /// Does not apply originOffset, use get_viewer_pose instead if you need it
+    /// The reference origin used is common between all
+    /// get_pose calls for spaces from the same device, so this can be used to compare
+    /// with other spaces
     #[allow(unused)]
     pub fn get_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
         if let Some(reference) = self.downcast::<XRReferenceSpace>() {

--- a/components/script/dom/xrspace.rs
+++ b/components/script/dom/xrspace.rs
@@ -44,7 +44,6 @@ impl XRSpace {
     /// The reference origin used is common between all
     /// get_pose calls for spaces from the same device, so this can be used to compare
     /// with other spaces
-    #[allow(unused)]
     pub fn get_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
         if let Some(reference) = self.downcast::<XRReferenceSpace>() {
             reference.get_pose(base_pose)
@@ -64,5 +63,9 @@ impl XRSpace {
             orient[3] as f64,
         );
         RigidTransform3D::new(rotation, translation)
+    }
+
+    pub fn session(&self) -> &XRSession {
+        &self.session
     }
 }

--- a/components/script/dom/xrspace.rs
+++ b/components/script/dom/xrspace.rs
@@ -11,7 +11,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrreferencespace::XRReferenceSpace;
 use crate::dom::xrsession::XRSession;
 use dom_struct::dom_struct;
-use euclid::RigidTransform3D;
+use euclid::{RigidTransform3D, Rotation3D, Vector3D};
 use webvr_traits::WebVRFrameData;
 
 #[dom_struct]
@@ -39,16 +39,6 @@ impl XRSpace {
 }
 
 impl XRSpace {
-    /// Gets pose of the viewer with respect to this space
-    #[allow(unused)]
-    pub fn get_viewer_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
-        if let Some(reference) = self.downcast::<XRReferenceSpace>() {
-            reference.get_viewer_pose(base_pose)
-        } else {
-            unreachable!()
-        }
-    }
-
     /// Gets pose represented by this space
     ///
     /// The reference origin used is common between all
@@ -61,5 +51,18 @@ impl XRSpace {
         } else {
             unreachable!()
         }
+    }
+
+    pub fn viewer_pose_from_frame_data(data: &WebVRFrameData) -> RigidTransform3D<f64> {
+        let pos = data.pose.position.unwrap_or([0., 0., 0.]);
+        let translation = Vector3D::new(pos[0] as f64, pos[1] as f64, pos[2] as f64);
+        let orient = data.pose.orientation.unwrap_or([0., 0., 0., 0.]);
+        let rotation = Rotation3D::quaternion(
+            orient[0] as f64,
+            orient[1] as f64,
+            orient[2] as f64,
+            orient[3] as f64,
+        );
+        RigidTransform3D::new(rotation, translation)
     }
 }

--- a/components/script/dom/xrstationaryreferencespace.rs
+++ b/components/script/dom/xrstationaryreferencespace.rs
@@ -50,10 +50,10 @@ impl XRStationaryReferenceSpace {
 }
 
 impl XRStationaryReferenceSpace {
-    /// Gets pose represented by this space
+    /// Gets pose of the viewer with respect to this space
     ///
-    /// Does not apply originOffset, use get_viewer_pose instead
-    pub fn get_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
+    /// Does not apply originOffset, use get_viewer_pose on XRReferenceSpace instead
+    pub fn get_unoffset_viewer_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
         // XXXManishearth add floor-level transform for floor-level and disable position in position-disabled
         let pos = base_pose.pose.position.unwrap_or([0., 0., 0.]);
         let translation = Vector3D::new(pos[0] as f64, pos[1] as f64, pos[2] as f64);

--- a/components/script/dom/xrstationaryreferencespace.rs
+++ b/components/script/dom/xrstationaryreferencespace.rs
@@ -10,8 +10,9 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrreferencespace::XRReferenceSpace;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::XRSession;
+use crate::dom::xrspace::XRSpace;
 use dom_struct::dom_struct;
-use euclid::{RigidTransform3D, Rotation3D, Vector3D};
+use euclid::RigidTransform3D;
 use webvr_traits::WebVRFrameData;
 
 #[dom_struct]
@@ -55,15 +56,17 @@ impl XRStationaryReferenceSpace {
     /// Does not apply originOffset, use get_viewer_pose on XRReferenceSpace instead
     pub fn get_unoffset_viewer_pose(&self, base_pose: &WebVRFrameData) -> RigidTransform3D<f64> {
         // XXXManishearth add floor-level transform for floor-level and disable position in position-disabled
-        let pos = base_pose.pose.position.unwrap_or([0., 0., 0.]);
-        let translation = Vector3D::new(pos[0] as f64, pos[1] as f64, pos[2] as f64);
-        let orient = base_pose.pose.orientation.unwrap_or([0., 0., 0., 0.]);
-        let rotation = Rotation3D::quaternion(
-            orient[0] as f64,
-            orient[1] as f64,
-            orient[2] as f64,
-            orient[3] as f64,
-        );
-        RigidTransform3D::new(rotation, translation)
+        XRSpace::viewer_pose_from_frame_data(base_pose)
+    }
+
+    /// Gets pose represented by this space
+    ///
+    /// Does not apply originOffset, use get_pose on XRReferenceSpace instead
+    pub fn get_unoffset_pose(&self, _: &WebVRFrameData) -> RigidTransform3D<f64> {
+        // XXXManishearth add floor-level transform for floor-level and disable position in position-disabled
+
+        // The eye-level pose is basically whatever the headset pose was at t=0, which
+        // for most devices is (0, 0, 0)
+        RigidTransform3D::identity()
     }
 }


### PR DESCRIPTION
I think I've figured out the model of poses, waiting on Nell for confirmation.

Basically, `getViewerPose(p)` is equivalent to `getPose(source=viewerSpace, relative_to=p)`

The eye-level space, for example, is stationary and stuck to the origin. The position-disabled and identity spaces somewhat counterintuitively follow you around (and appear to be stationary from `getViewerPose()` but not `getPose()`.

The incorrect mental model kinda "works" when looking at only `getViewerPose()`, but we need to figure it out for `getPose()`.


Todo (may add to this PR, but probably not)

 - implement `XRSession.viewerSpace`
 - implement position-disabled
 - implement floor-level (hard to test without a 6dof device)

r? @asajeffrey

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23164)
<!-- Reviewable:end -->
