### PR TITLE
Add default paths for WPT tests

### DIFF
--- a/tests/wpt/run.py
+++ b/tests/wpt/run.py
@@ -23,8 +23,7 @@ paths = {"include_manifest": wpt_path("include.ini"),
          "config": wpt_path("config.ini"),
          "ca-cert-path": wpt_path("web-platform-tests/tools/certs/cacert.pem"),
          "host-key-path": wpt_path("web-platform-tests/tools/certs/web-platform.test.key"),
-         "host-cert-path": wpt_path("web-platform-tests/tools/certs/web-platform.test.pem"),
-        }
+         "host-cert-path": wpt_path("web-platform-tests/tools/certs/web-platform.test.pem")}
 # Imports
 sys.path.append(wpt_path("web-platform-tests", "tools"))
 import localpaths  # noqa: flake8

--- a/tests/wpt/run.py
+++ b/tests/wpt/run.py
@@ -20,7 +20,11 @@ def servo_path(*args):
     return os.path.join(servo_root, *args)
 
 paths = {"include_manifest": wpt_path("include.ini"),
-         "config": wpt_path("config.ini")}
+         "config": wpt_path("config.ini"),
+         "ca-cert-path": wpt_path("web-platform-tests/tools/certs/cacert.pem"),
+         "host-key-path": wpt_path("web-platform-tests/tools/certs/web-platform.test.key"),
+         "host-cert-path": wpt_path("web-platform-tests/tools/certs/web-platform.test.pem"),
+        }
 # Imports
 sys.path.append(wpt_path("web-platform-tests", "tools"))
 import localpaths  # noqa: flake8
@@ -73,6 +77,18 @@ def set_defaults(kwargs):
 
     if kwargs["processes"] is None:
         kwargs["processes"] = multiprocessing.cpu_count()
+
+    if kwargs["ca_cert_path"] is None:
+        kwargs["ca_cert_path"] = paths["ca-cert-path"]
+
+    if kwargs["host_key_path"] is None:
+        kwargs["host_key_path"] = paths["host-key-path"]
+
+    if kwargs["host_cert_path"] is None:
+        kwargs["host_cert_path"] = paths["host-cert-path"]
+
+    if kwargs["ssl_type"] is None:
+        kwargs["ssl_type"] = "pregenerated"
 
     kwargs["user_stylesheets"].append(servo_path("resources", "ahem.css"))
 


### PR DESCRIPTION
Set the following default configs for WPT tests.
```--ca-cert-path=tests\wpt\web-platform-tests\tools\certs\cacert.pem
--host-key-path=tests\wpt\web-platform-tests\tools\certs\web-platform.test.key
--host-cert-path=tests\wpt\web-platform-tests\tools\certs\web-platform.test.pem
--ssl-type=pregenerated
```
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23133

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23174)
<!-- Reviewable:end -->
