### PR TITLE
Add a note to indicate PKG_CONFIG_PATH required

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ export OPENSSL_LIB_DIR="$(brew --prefix openssl)/lib"
 ./mach build ...
 ```
 
+##### Note: Please make sure the required `PKG_CONFIG_PATH` environment variable is set the same as the one provided from `brew info libffi` ([Check this comment for more details](https://github.com/servo/servo/issues/23015#issuecomment-475050175)).
+
 If you've already partially compiled servo but forgot to do this step, run `./mach clean`, set the shell variables, and recompile.
 
 #### On Debian-based Linuxes


### PR DESCRIPTION
I just got the error messages like #23015 again and then I think the root cause should be about 
`PKG_CONFIG_PATH`. After following https://github.com/servo/servo/issues/23015#issuecomment-475050175 said, I can build Servo successfully.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this just updates README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23175)
<!-- Reviewable:end -->
