### PR TITLE
Add PerformanceResourceTiming: ResponseEnd

### DIFF
--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -449,7 +449,7 @@ pub struct ResourceFetchTiming {
     pub request_start: u64,
     pub response_start: u64,
     pub fetch_start: u64,
-    // pub response_end: u64,
+    pub response_end: u64,
     pub redirect_start: u64,
     // pub redirect_end: u64,
     // pub connect_start: u64,
@@ -469,6 +469,7 @@ pub enum ResourceAttribute {
     RedirectStart(RedirectStartValue),
     FetchStart,
     ConnectEnd(u64),
+    ResponseEnd,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
@@ -489,6 +490,7 @@ impl ResourceFetchTiming {
             fetch_start: 0,
             redirect_start: 0,
             connect_end: 0,
+            response_end: 0,
         }
     }
 
@@ -509,6 +511,7 @@ impl ResourceFetchTiming {
             },
             ResourceAttribute::FetchStart => self.fetch_start = precise_time_ns(),
             ResourceAttribute::ConnectEnd(val) => self.connect_end = val,
+            ResourceAttribute::ResponseEnd => self.response_end = precise_time_ns(),
         }
     }
 }

--- a/components/script/dom/performanceresourcetiming.rs
+++ b/components/script/dom/performanceresourcetiming.rs
@@ -66,7 +66,6 @@ pub struct PerformanceResourceTiming {
 // TODO(#21260): domain_lookup_end
 // TODO(#21261): connect_start
 // TODO(#21262): connect_end
-// TODO(#21263): response_end
 impl PerformanceResourceTiming {
     pub fn new_inherited(
         url: ServoUrl,
@@ -126,7 +125,7 @@ impl PerformanceResourceTiming {
             secure_connection_start: 0.,
             request_start: resource_timing.request_start as f64,
             response_start: resource_timing.response_start as f64,
-            response_end: 0.,
+            response_end: resource_timing.response_end as f64,
         }
     }
 
@@ -175,7 +174,6 @@ impl PerformanceResourceTimingMethods for PerformanceResourceTiming {
 
     // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-requeststart
     fn RequestStart(&self) -> DOMHighResTimeStamp {
-        // TODO
         Finite::wrap(self.request_start)
     }
 
@@ -186,7 +184,6 @@ impl PerformanceResourceTimingMethods for PerformanceResourceTiming {
 
     // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responsestart
     fn ResponseStart(&self) -> DOMHighResTimeStamp {
-        // TODO
         Finite::wrap(self.response_start)
     }
 
@@ -198,5 +195,10 @@ impl PerformanceResourceTimingMethods for PerformanceResourceTiming {
     // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-connectend
     fn ConnectEnd(&self) -> DOMHighResTimeStamp {
         Finite::wrap(self.connect_end)
+    }
+
+    // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responseend
+    fn ResponseEnd(&self) -> DOMHighResTimeStamp {
+        Finite::wrap(self.response_end)
     }
 }

--- a/components/script/dom/webidls/PerformanceResourceTiming.webidl
+++ b/components/script/dom/webidls/PerformanceResourceTiming.webidl
@@ -22,7 +22,7 @@ interface PerformanceResourceTiming : PerformanceEntry {
     // readonly attribute DOMHighResTimeStamp secureConnectionStart;
     readonly attribute DOMHighResTimeStamp requestStart;
     readonly attribute DOMHighResTimeStamp responseStart;
-    // readonly attribute DOMHighResTimeStamp responseEnd;
+    readonly attribute DOMHighResTimeStamp responseEnd;
     /// readonly attribute unsigned long long  transferSize;
     /// readonly attribute unsigned long long  encodedBodySize;
     /// readonly attribute unsigned long long  decodedBodySize;

--- a/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
+++ b/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
@@ -35,9 +35,6 @@
   [PerformanceResourceTiming interface: resource must inherit property "workerStart" with the proper type]
     expected: FAIL
 
-  [PerformanceResourceTiming interface: attribute responseEnd]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: attribute secureConnectionStart]
     expected: FAIL
 
@@ -57,9 +54,6 @@
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute connectStart]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: resource must inherit property "responseEnd" with the proper type]
     expected: FAIL
 
   [PerformanceResourceTiming interface: resource must inherit property "redirectEnd" with the proper type]
@@ -152,9 +146,6 @@
     expected: FAIL
 
   [PerformanceResourceTiming must be primary interface of resource]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: attribute responseEnd]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute secureConnectionStart]

--- a/tests/wpt/metadata/resource-timing/resource_reuse.sub.html.ini
+++ b/tests/wpt/metadata/resource-timing/resource_reuse.sub.html.ini
@@ -8,9 +8,6 @@
   [Entry name should end with file name]
     expected: FAIL
 
-  [responseEnd should not be before startTime]
-    expected: FAIL
-
   [requestStart should be non-zero on the same-origin request]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
1. Added `ResponseEnd` to `ResourceAttribute` enum in `net_traits` and added it to the `set_attribute` function on `ResourceFetchTiming`
2. Added `response_end` field to `performanceresourcetiming.rs`
3. In `http_loader.rs`, set ResponseEnd after response body read is complete, or before return due to network error.

I could use a little guidance on testing. After building and running `wpt` tests, I noticed that some tests now "Pass" when they were expected to "Fail". As per the wiki instructions, I've removed those expectations from the `metadata`. 

I noticed that there are a handful of other "failing" test expectations associated with `responseEnd`, but those still do not pass. I looked through some similar PRs (`connectEnd`, `redirectStart`, etc) and saw that they also still have a few failing test expectations here and there. Does that mean this is OK for now? How can I better understand which tests we expect to resolve for a given issue? Thanks!

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #21263 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23178)
<!-- Reviewable:end -->
