### PR TITLE
Replace panic with warn in DocumentLoader.finish_load.

### DIFF
--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -167,8 +167,12 @@ impl DocumentLoader {
             .blocking_loads
             .iter()
             .position(|unfinished| *unfinished == *load);
-        self.blocking_loads
-            .remove(idx.unwrap_or_else(|| panic!("unknown completed load {:?}", load)));
+        match idx {
+            Some(i) => {
+                self.blocking_loads.remove(i);
+            },
+            None => warn!("unknown completed load {:?}", load),
+        }
     }
 
     pub fn is_blocked(&self) -> bool {


### PR DESCRIPTION
Fix panic on broken script URL with an onerror handler that rewrites the document.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23144

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23183)
<!-- Reviewable:end -->
