### PR TITLE
Force python 2.7 on TravisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+python: 2.7
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
From TravisCI:
```
 This job is running using the default Python version, which will be updated to 3.6 on April 16th, 2019. You can explicitly stay on the previous version by specifying python: 2.7 in your .travis.yml. 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23184)
<!-- Reviewable:end -->
