### PR TITLE
Add css-align tests with failure expectations.

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -15,6 +15,8 @@ skip: true
     skip: false
   [CSS2]
     skip: false
+  [css-align]
+    skip: false
   [css-animations]
     skip: false
   [css-backgrounds]

--- a/tests/wpt/metadata/css/css-align/baseline-of-scrollable-1a.html.ini
+++ b/tests/wpt/metadata/css/css-align/baseline-of-scrollable-1a.html.ini
@@ -1,0 +1,2 @@
+[baseline-of-scrollable-1a.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-align/baseline-of-scrollable-1b.html.ini
+++ b/tests/wpt/metadata/css/css-align/baseline-of-scrollable-1b.html.ini
@@ -1,0 +1,2 @@
+[baseline-of-scrollable-1b.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-align/baseline-rules/synthesized-baseline-flexbox-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/baseline-rules/synthesized-baseline-flexbox-001.html.ini
@@ -1,0 +1,13 @@
+[synthesized-baseline-flexbox-001.html]
+  [.wrapper 5]
+    expected: FAIL
+
+  [.wrapper 4]
+    expected: FAIL
+
+  [.wrapper 7]
+    expected: FAIL
+
+  [.wrapper 6]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/baseline-rules/synthesized-baseline-grid-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/baseline-rules/synthesized-baseline-grid-001.html.ini
@@ -1,0 +1,19 @@
+[synthesized-baseline-grid-001.html]
+  [.wrapper 5]
+    expected: FAIL
+
+  [.wrapper 4]
+    expected: FAIL
+
+  [.wrapper 7]
+    expected: FAIL
+
+  [.wrapper 6]
+    expected: FAIL
+
+  [.wrapper 1]
+    expected: FAIL
+
+  [.wrapper 2]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/parse-align-content-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/parse-align-content-001.html.ini
@@ -1,0 +1,37 @@
+[parse-align-content-001.html]
+  [Checking align-content: safe end]
+    expected: FAIL
+
+  [Checking align-content: first baseline]
+    expected: FAIL
+
+  [Checking align-content: safe flex-end]
+    expected: FAIL
+
+  [Checking align-content: baseline]
+    expected: FAIL
+
+  [Checking align-content: last baseline]
+    expected: FAIL
+
+  [Checking align-content: start]
+    expected: FAIL
+
+  [Checking align-content: unsafe flex-start]
+    expected: FAIL
+
+  [Checking align-content: unsafe end]
+    expected: FAIL
+
+  [Checking align-content: end]
+    expected: FAIL
+
+  [Checking align-content: space-evenly]
+    expected: FAIL
+
+  [Checking align-content: safe center]
+    expected: FAIL
+
+  [Checking align-content: normal]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/parse-align-content-002.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/parse-align-content-002.html.ini
@@ -1,0 +1,22 @@
+[parse-align-content-002.html]
+  [Test grid items align-content: 'initial']
+    expected: FAIL
+
+  [Test absolute positioned grid items align-content: 'initial']
+    expected: FAIL
+
+  [Test align-content: 'initial']
+    expected: FAIL
+
+  [Test absolute positioned flex items align-content: 'initial']
+    expected: FAIL
+
+  [Test flex items align-content: 'initial']
+    expected: FAIL
+
+  [Test 'initial' value when nothing is specified]
+    expected: FAIL
+
+  [Test absolute positioned elements align-content: 'initial']
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/parse-align-content-003.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/parse-align-content-003.html.ini
@@ -1,0 +1,37 @@
+[parse-align-content-003.html]
+  [Checking align-content: safe end]
+    expected: FAIL
+
+  [Checking align-content: first baseline]
+    expected: FAIL
+
+  [Checking align-content: safe flex-end]
+    expected: FAIL
+
+  [Checking align-content: baseline]
+    expected: FAIL
+
+  [Checking align-content: last baseline]
+    expected: FAIL
+
+  [Checking align-content: start]
+    expected: FAIL
+
+  [Checking align-content: unsafe flex-start]
+    expected: FAIL
+
+  [Checking align-content: unsafe end]
+    expected: FAIL
+
+  [Checking align-content: end]
+    expected: FAIL
+
+  [Checking align-content: space-evenly]
+    expected: FAIL
+
+  [Checking align-content: safe center]
+    expected: FAIL
+
+  [Checking align-content: normal]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/parse-align-content-005.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/parse-align-content-005.html.ini
@@ -1,0 +1,10 @@
+[parse-align-content-005.html]
+  [Test the value 'inherit' overrides current value ('end')]
+    expected: FAIL
+
+  [Test the value 'inherit' overrides current value ('unsafe center')]
+    expected: FAIL
+
+  [Test the value 'inherit' overrides current value ('safe start')]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/parse-justify-content-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/parse-justify-content-001.html.ini
@@ -1,0 +1,34 @@
+[parse-justify-content-001.html]
+  [Checking justify-content: start]
+    expected: FAIL
+
+  [Checking justify-content: safe center]
+    expected: FAIL
+
+  [Checking justify-content: end]
+    expected: FAIL
+
+  [Checking justify-content: left]
+    expected: FAIL
+
+  [Checking justify-content: unsafe flex-start]
+    expected: FAIL
+
+  [Checking justify-content: right]
+    expected: FAIL
+
+  [Checking justify-content: safe end]
+    expected: FAIL
+
+  [Checking justify-content: space-evenly]
+    expected: FAIL
+
+  [Checking justify-content: safe flex-end]
+    expected: FAIL
+
+  [Checking justify-content: normal]
+    expected: FAIL
+
+  [Checking justify-content: unsafe end]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/parse-justify-content-002.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/parse-justify-content-002.html.ini
@@ -1,0 +1,22 @@
+[parse-justify-content-002.html]
+  [Test flex items justify-content: 'initial']
+    expected: FAIL
+
+  [Test grid items justify-content: 'initial']
+    expected: FAIL
+
+  [Test justify-content: 'initial']
+    expected: FAIL
+
+  [Test absolute positioned flex items justify-content: 'initial']
+    expected: FAIL
+
+  [Test absolute positioned grid items justify-content: 'initial']
+    expected: FAIL
+
+  [Test absolute positioned elements justify-content: 'initial']
+    expected: FAIL
+
+  [Test 'initial' value when nothing is specified]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/parse-justify-content-003.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/parse-justify-content-003.html.ini
@@ -1,0 +1,34 @@
+[parse-justify-content-003.html]
+  [Checking justify-content: start]
+    expected: FAIL
+
+  [Checking justify-content: safe center]
+    expected: FAIL
+
+  [Checking justify-content: end]
+    expected: FAIL
+
+  [Checking justify-content: left]
+    expected: FAIL
+
+  [Checking justify-content: unsafe flex-start]
+    expected: FAIL
+
+  [Checking justify-content: right]
+    expected: FAIL
+
+  [Checking justify-content: safe end]
+    expected: FAIL
+
+  [Checking justify-content: space-evenly]
+    expected: FAIL
+
+  [Checking justify-content: safe flex-end]
+    expected: FAIL
+
+  [Checking justify-content: normal]
+    expected: FAIL
+
+  [Checking justify-content: unsafe end]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/parse-justify-content-005.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/parse-justify-content-005.html.ini
@@ -1,0 +1,10 @@
+[parse-justify-content-005.html]
+  [Test the value 'inherit' overrides current value ('end')]
+    expected: FAIL
+
+  [Test the value 'inherit' overrides current value ('safe left')]
+    expected: FAIL
+
+  [Test the value 'inherit' overrides current value ('unsafe center')]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/place-content-shorthand-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/place-content-shorthand-001.html.ini
@@ -1,0 +1,46 @@
+[place-content-shorthand-001.html]
+  [Checking place-content: unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-content: space-between]
+    expected: FAIL
+
+  [Checking place-content: flex-end]
+    expected: FAIL
+
+  [Checking place-content: flex-start]
+    expected: FAIL
+
+  [Checking place-content: unsafe end]
+    expected: FAIL
+
+  [Checking place-content: end]
+    expected: FAIL
+
+  [Checking place-content: safe end]
+    expected: FAIL
+
+  [Checking place-content: start]
+    expected: FAIL
+
+  [Checking place-content: center]
+    expected: FAIL
+
+  [Checking place-content: normal]
+    expected: FAIL
+
+  [Checking place-content: space-evenly]
+    expected: FAIL
+
+  [Checking place-content: safe flex-end]
+    expected: FAIL
+
+  [Checking place-content: safe center]
+    expected: FAIL
+
+  [Checking place-content: space-around]
+    expected: FAIL
+
+  [Checking place-content: stretch]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/place-content-shorthand-002.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/place-content-shorthand-002.html.ini
@@ -1,0 +1,649 @@
+[place-content-shorthand-002.html]
+  [Checking place-content: space-around flex-start]
+    expected: FAIL
+
+  [Checking place-content: flex-end end]
+    expected: FAIL
+
+  [Checking place-content: safe flex-end stretch]
+    expected: FAIL
+
+  [Checking place-content: space-between stretch]
+    expected: FAIL
+
+  [Checking place-content: start normal]
+    expected: FAIL
+
+  [Checking place-content: last baseline left]
+    expected: FAIL
+
+  [Checking place-content: safe end stretch]
+    expected: FAIL
+
+  [Checking place-content: unsafe end space-around]
+    expected: FAIL
+
+  [Checking place-content: baseline space-around]
+    expected: FAIL
+
+  [Checking place-content: center normal]
+    expected: FAIL
+
+  [Checking place-content: center center]
+    expected: FAIL
+
+  [Checking place-content: flex-end flex-start]
+    expected: FAIL
+
+  [Checking place-content: flex-start space-around]
+    expected: FAIL
+
+  [Checking place-content: first baseline right]
+    expected: FAIL
+
+  [Checking place-content: safe flex-end right]
+    expected: FAIL
+
+  [Checking place-content: baseline stretch]
+    expected: FAIL
+
+  [Checking place-content: safe center right]
+    expected: FAIL
+
+  [Checking place-content: flex-start start]
+    expected: FAIL
+
+  [Checking place-content: safe center normal]
+    expected: FAIL
+
+  [Checking place-content: baseline right]
+    expected: FAIL
+
+  [Checking place-content: start space-between]
+    expected: FAIL
+
+  [Checking place-content: baseline space-between]
+    expected: FAIL
+
+  [Checking place-content: unsafe end stretch]
+    expected: FAIL
+
+  [Checking place-content: last baseline space-between]
+    expected: FAIL
+
+  [Checking place-content: baseline start]
+    expected: FAIL
+
+  [Checking place-content: stretch stretch]
+    expected: FAIL
+
+  [Checking place-content: unsafe flex-start flex-start]
+    expected: FAIL
+
+  [Checking place-content: space-around space-evenly]
+    expected: FAIL
+
+  [Checking place-content: unsafe end space-between]
+    expected: FAIL
+
+  [Checking place-content: start start]
+    expected: FAIL
+
+  [Checking place-content: flex-start normal]
+    expected: FAIL
+
+  [Checking place-content: start flex-end]
+    expected: FAIL
+
+  [Checking place-content: unsafe end start]
+    expected: FAIL
+
+  [Checking place-content: unsafe end right]
+    expected: FAIL
+
+  [Checking place-content: space-between normal]
+    expected: FAIL
+
+  [Checking place-content: space-around space-around]
+    expected: FAIL
+
+  [Checking place-content: unsafe flex-start left]
+    expected: FAIL
+
+  [Checking place-content: space-around flex-end]
+    expected: FAIL
+
+  [Checking place-content: space-evenly space-around]
+    expected: FAIL
+
+  [Checking place-content: start left]
+    expected: FAIL
+
+  [Checking place-content: stretch normal]
+    expected: FAIL
+
+  [Checking place-content: unsafe flex-start space-between]
+    expected: FAIL
+
+  [Checking place-content: stretch space-around]
+    expected: FAIL
+
+  [Checking place-content: space-around right]
+    expected: FAIL
+
+  [Checking place-content: safe center space-around]
+    expected: FAIL
+
+  [Checking place-content: center space-evenly]
+    expected: FAIL
+
+  [Checking place-content: center space-around]
+    expected: FAIL
+
+  [Checking place-content: space-around space-between]
+    expected: FAIL
+
+  [Checking place-content: flex-end start]
+    expected: FAIL
+
+  [Checking place-content: end flex-start]
+    expected: FAIL
+
+  [Checking place-content: stretch center]
+    expected: FAIL
+
+  [Checking place-content: flex-end normal]
+    expected: FAIL
+
+  [Checking place-content: safe flex-end flex-start]
+    expected: FAIL
+
+  [Checking place-content: last baseline flex-end]
+    expected: FAIL
+
+  [Checking place-content: baseline left]
+    expected: FAIL
+
+  [Checking place-content: first baseline flex-end]
+    expected: FAIL
+
+  [Checking place-content: flex-start flex-start]
+    expected: FAIL
+
+  [Checking place-content: space-between flex-end]
+    expected: FAIL
+
+  [Checking place-content: space-between end]
+    expected: FAIL
+
+  [Checking place-content: unsafe flex-start start]
+    expected: FAIL
+
+  [Checking place-content: safe center space-evenly]
+    expected: FAIL
+
+  [Checking place-content: unsafe flex-start center]
+    expected: FAIL
+
+  [Checking place-content: safe end normal]
+    expected: FAIL
+
+  [Checking place-content: end space-between]
+    expected: FAIL
+
+  [Checking place-content: unsafe flex-start space-around]
+    expected: FAIL
+
+  [Checking place-content: normal stretch]
+    expected: FAIL
+
+  [Checking place-content: space-between space-evenly]
+    expected: FAIL
+
+  [Checking place-content: normal flex-end]
+    expected: FAIL
+
+  [Checking place-content: safe end center]
+    expected: FAIL
+
+  [Checking place-content: space-evenly end]
+    expected: FAIL
+
+  [Checking place-content: flex-end stretch]
+    expected: FAIL
+
+  [Checking place-content: start flex-start]
+    expected: FAIL
+
+  [Checking place-content: stretch end]
+    expected: FAIL
+
+  [Checking place-content: unsafe end center]
+    expected: FAIL
+
+  [Checking place-content: normal space-between]
+    expected: FAIL
+
+  [Checking place-content: space-evenly right]
+    expected: FAIL
+
+  [Checking place-content: flex-end space-between]
+    expected: FAIL
+
+  [Checking place-content: normal start]
+    expected: FAIL
+
+  [Checking place-content: flex-end space-around]
+    expected: FAIL
+
+  [Checking place-content: center stretch]
+    expected: FAIL
+
+  [Checking place-content: end start]
+    expected: FAIL
+
+  [Checking place-content: last baseline space-around]
+    expected: FAIL
+
+  [Checking place-content: stretch right]
+    expected: FAIL
+
+  [Checking place-content: unsafe end space-evenly]
+    expected: FAIL
+
+  [Checking place-content: normal right]
+    expected: FAIL
+
+  [Checking place-content: safe end start]
+    expected: FAIL
+
+  [Checking place-content: safe flex-end start]
+    expected: FAIL
+
+  [Checking place-content: safe center stretch]
+    expected: FAIL
+
+  [Checking place-content: unsafe flex-start end]
+    expected: FAIL
+
+  [Checking place-content: unsafe end left]
+    expected: FAIL
+
+  [Checking place-content: safe center flex-start]
+    expected: FAIL
+
+  [Checking place-content: center space-between]
+    expected: FAIL
+
+  [Checking place-content: safe end space-evenly]
+    expected: FAIL
+
+  [Checking place-content: first baseline end]
+    expected: FAIL
+
+  [Checking place-content: last baseline stretch]
+    expected: FAIL
+
+  [Checking place-content: normal space-evenly]
+    expected: FAIL
+
+  [Checking place-content: safe end end]
+    expected: FAIL
+
+  [Checking place-content: center end]
+    expected: FAIL
+
+  [Checking place-content: safe end flex-start]
+    expected: FAIL
+
+  [Checking place-content: end normal]
+    expected: FAIL
+
+  [Checking place-content: start stretch]
+    expected: FAIL
+
+  [Checking place-content: center start]
+    expected: FAIL
+
+  [Checking place-content: safe end flex-end]
+    expected: FAIL
+
+  [Checking place-content: normal normal]
+    expected: FAIL
+
+  [Checking place-content: start right]
+    expected: FAIL
+
+  [Checking place-content: safe flex-end left]
+    expected: FAIL
+
+  [Checking place-content: space-around normal]
+    expected: FAIL
+
+  [Checking place-content: flex-start space-between]
+    expected: FAIL
+
+  [Checking place-content: start space-around]
+    expected: FAIL
+
+  [Checking place-content: safe flex-end space-between]
+    expected: FAIL
+
+  [Checking place-content: normal center]
+    expected: FAIL
+
+  [Checking place-content: safe center left]
+    expected: FAIL
+
+  [Checking place-content: flex-end space-evenly]
+    expected: FAIL
+
+  [Checking place-content: end left]
+    expected: FAIL
+
+  [Checking place-content: space-evenly space-between]
+    expected: FAIL
+
+  [Checking place-content: unsafe end flex-end]
+    expected: FAIL
+
+  [Checking place-content: baseline flex-end]
+    expected: FAIL
+
+  [Checking place-content: safe flex-end space-evenly]
+    expected: FAIL
+
+  [Checking place-content: space-between space-between]
+    expected: FAIL
+
+  [Checking place-content: safe end right]
+    expected: FAIL
+
+  [Checking place-content: stretch space-evenly]
+    expected: FAIL
+
+  [Checking place-content: normal flex-start]
+    expected: FAIL
+
+  [Checking place-content: baseline center]
+    expected: FAIL
+
+  [Checking place-content: space-evenly space-evenly]
+    expected: FAIL
+
+  [Checking place-content: first baseline stretch]
+    expected: FAIL
+
+  [Checking place-content: flex-start right]
+    expected: FAIL
+
+  [Checking place-content: stretch flex-start]
+    expected: FAIL
+
+  [Checking place-content: last baseline space-evenly]
+    expected: FAIL
+
+  [Checking place-content: safe flex-end space-around]
+    expected: FAIL
+
+  [Checking place-content: unsafe flex-start space-evenly]
+    expected: FAIL
+
+  [Checking place-content: last baseline end]
+    expected: FAIL
+
+  [Checking place-content: end center]
+    expected: FAIL
+
+  [Checking place-content: first baseline left]
+    expected: FAIL
+
+  [Checking place-content: safe center end]
+    expected: FAIL
+
+  [Checking place-content: stretch start]
+    expected: FAIL
+
+  [Checking place-content: space-around end]
+    expected: FAIL
+
+  [Checking place-content: space-around center]
+    expected: FAIL
+
+  [Checking place-content: safe end space-between]
+    expected: FAIL
+
+  [Checking place-content: flex-end center]
+    expected: FAIL
+
+  [Checking place-content: unsafe flex-start right]
+    expected: FAIL
+
+  [Checking place-content: unsafe flex-start flex-end]
+    expected: FAIL
+
+  [Checking place-content: safe end left]
+    expected: FAIL
+
+  [Checking place-content: flex-end flex-end]
+    expected: FAIL
+
+  [Checking place-content: baseline end]
+    expected: FAIL
+
+  [Checking place-content: unsafe flex-start normal]
+    expected: FAIL
+
+  [Checking place-content: unsafe end end]
+    expected: FAIL
+
+  [Checking place-content: last baseline normal]
+    expected: FAIL
+
+  [Checking place-content: last baseline center]
+    expected: FAIL
+
+  [Checking place-content: flex-start center]
+    expected: FAIL
+
+  [Checking place-content: first baseline flex-start]
+    expected: FAIL
+
+  [Checking place-content: space-around start]
+    expected: FAIL
+
+  [Checking place-content: end stretch]
+    expected: FAIL
+
+  [Checking place-content: end right]
+    expected: FAIL
+
+  [Checking place-content: end end]
+    expected: FAIL
+
+  [Checking place-content: space-evenly flex-end]
+    expected: FAIL
+
+  [Checking place-content: space-evenly stretch]
+    expected: FAIL
+
+  [Checking place-content: start space-evenly]
+    expected: FAIL
+
+  [Checking place-content: space-around stretch]
+    expected: FAIL
+
+  [Checking place-content: space-between right]
+    expected: FAIL
+
+  [Checking place-content: unsafe flex-start stretch]
+    expected: FAIL
+
+  [Checking place-content: baseline space-evenly]
+    expected: FAIL
+
+  [Checking place-content: stretch flex-end]
+    expected: FAIL
+
+  [Checking place-content: end space-evenly]
+    expected: FAIL
+
+  [Checking place-content: flex-start space-evenly]
+    expected: FAIL
+
+  [Checking place-content: space-evenly start]
+    expected: FAIL
+
+  [Checking place-content: space-evenly normal]
+    expected: FAIL
+
+  [Checking place-content: flex-end left]
+    expected: FAIL
+
+  [Checking place-content: space-evenly flex-start]
+    expected: FAIL
+
+  [Checking place-content: baseline normal]
+    expected: FAIL
+
+  [Checking place-content: first baseline start]
+    expected: FAIL
+
+  [Checking place-content: normal space-around]
+    expected: FAIL
+
+  [Checking place-content: unsafe end normal]
+    expected: FAIL
+
+  [Checking place-content: start end]
+    expected: FAIL
+
+  [Checking place-content: safe flex-end center]
+    expected: FAIL
+
+  [Checking place-content: center right]
+    expected: FAIL
+
+  [Checking place-content: space-between start]
+    expected: FAIL
+
+  [Checking place-content: space-evenly left]
+    expected: FAIL
+
+  [Checking place-content: start center]
+    expected: FAIL
+
+  [Checking place-content: first baseline center]
+    expected: FAIL
+
+  [Checking place-content: safe center space-between]
+    expected: FAIL
+
+  [Checking place-content: flex-start stretch]
+    expected: FAIL
+
+  [Checking place-content: safe flex-end end]
+    expected: FAIL
+
+  [Checking place-content: last baseline flex-start]
+    expected: FAIL
+
+  [Checking place-content: center flex-end]
+    expected: FAIL
+
+  [Checking place-content: first baseline normal]
+    expected: FAIL
+
+  [Checking place-content: safe flex-end normal]
+    expected: FAIL
+
+  [Checking place-content: end flex-end]
+    expected: FAIL
+
+  [Checking place-content: space-evenly center]
+    expected: FAIL
+
+  [Checking place-content: baseline flex-start]
+    expected: FAIL
+
+  [Checking place-content: safe end space-around]
+    expected: FAIL
+
+  [Checking place-content: flex-start left]
+    expected: FAIL
+
+  [Checking place-content: flex-start end]
+    expected: FAIL
+
+  [Checking place-content: stretch left]
+    expected: FAIL
+
+  [Checking place-content: center left]
+    expected: FAIL
+
+  [Checking place-content: space-between left]
+    expected: FAIL
+
+  [Checking place-content: safe center start]
+    expected: FAIL
+
+  [Checking place-content: safe center flex-end]
+    expected: FAIL
+
+  [Checking place-content: stretch space-between]
+    expected: FAIL
+
+  [Checking place-content: space-between center]
+    expected: FAIL
+
+  [Checking place-content: space-between flex-start]
+    expected: FAIL
+
+  [Checking place-content: safe flex-end flex-end]
+    expected: FAIL
+
+  [Checking place-content: last baseline start]
+    expected: FAIL
+
+  [Checking place-content: last baseline right]
+    expected: FAIL
+
+  [Checking place-content: normal end]
+    expected: FAIL
+
+  [Checking place-content: flex-start flex-end]
+    expected: FAIL
+
+  [Checking place-content: end space-around]
+    expected: FAIL
+
+  [Checking place-content: first baseline space-around]
+    expected: FAIL
+
+  [Checking place-content: flex-end right]
+    expected: FAIL
+
+  [Checking place-content: first baseline space-between]
+    expected: FAIL
+
+  [Checking place-content: safe center center]
+    expected: FAIL
+
+  [Checking place-content: normal left]
+    expected: FAIL
+
+  [Checking place-content: space-around left]
+    expected: FAIL
+
+  [Checking place-content: space-between space-around]
+    expected: FAIL
+
+  [Checking place-content: unsafe end flex-start]
+    expected: FAIL
+
+  [Checking place-content: first baseline space-evenly]
+    expected: FAIL
+
+  [Checking place-content: center flex-start]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/place-content-shorthand-003.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/place-content-shorthand-003.html.ini
@@ -1,0 +1,7 @@
+[place-content-shorthand-003.html]
+  [Check place-content: initial - align-content expanded value]
+    expected: FAIL
+
+  [Check place-content: initial - justify-content expanded value]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/place-content-shorthand-004.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/place-content-shorthand-004.html.ini
@@ -1,0 +1,22 @@
+[place-content-shorthand-004.html]
+  [Verify fallback values are invalid]
+    expected: FAIL
+
+  [Verify numeric values are invalid]
+    expected: FAIL
+
+  [Verify 'auto' values are invalid]
+    expected: FAIL
+
+  [Verify self-position values are invalid]
+    expected: FAIL
+
+  [Verify <baseline-position> values are invalid for the justify-content property]
+    expected: FAIL
+
+  [Verify empty declaration is invalid]
+    expected: FAIL
+
+  [Verify 'left' and 'right' values are invalid for block/cross axis alignment]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/place-content-shorthand-005.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/place-content-shorthand-005.html.ini
@@ -1,0 +1,7 @@
+[place-content-shorthand-005.html]
+  [Check place-content: inherit - align-content resolved value]
+    expected: FAIL
+
+  [Check place-content: inherit - justify-content resolved value]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/place-content-shorthand-006.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/place-content-shorthand-006.html.ini
@@ -1,0 +1,67 @@
+[place-content-shorthand-006.html]
+  [Checking place-content: center center]
+    expected: FAIL
+
+  [Checking place-content: first baseline right]
+    expected: FAIL
+
+  [Checking place-content: stretch stretch]
+    expected: FAIL
+
+  [Checking place-content: start start]
+    expected: FAIL
+
+  [Checking place-content: space-around space-around]
+    expected: FAIL
+
+  [Checking place-content: first baseline flex-end]
+    expected: FAIL
+
+  [Checking place-content: flex-start flex-start]
+    expected: FAIL
+
+  [Checking place-content: first baseline end]
+    expected: FAIL
+
+  [Checking place-content: normal normal]
+    expected: FAIL
+
+  [Checking place-content: space-between space-between]
+    expected: FAIL
+
+  [Checking place-content: space-evenly space-evenly]
+    expected: FAIL
+
+  [Checking place-content: first baseline stretch]
+    expected: FAIL
+
+  [Checking place-content: first baseline left]
+    expected: FAIL
+
+  [Checking place-content: flex-end flex-end]
+    expected: FAIL
+
+  [Checking place-content: first baseline flex-start]
+    expected: FAIL
+
+  [Checking place-content: end end]
+    expected: FAIL
+
+  [Checking place-content: first baseline start]
+    expected: FAIL
+
+  [Checking place-content: first baseline center]
+    expected: FAIL
+
+  [Checking place-content: first baseline normal]
+    expected: FAIL
+
+  [Checking place-content: first baseline space-around]
+    expected: FAIL
+
+  [Checking place-content: first baseline space-between]
+    expected: FAIL
+
+  [Checking place-content: first baseline space-evenly]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/content-distribution/place-content-shorthand-007.html.ini
+++ b/tests/wpt/metadata/css/css-align/content-distribution/place-content-shorthand-007.html.ini
@@ -1,0 +1,2 @@
+[place-content-shorthand-007.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-align/default-alignment/justify-items-legacy-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/justify-items-legacy-001.html.ini
@@ -1,0 +1,4 @@
+[justify-items-legacy-001.html]
+  [legacy value for justify-items]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/parse-align-items-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/parse-align-items-001.html.ini
@@ -1,0 +1,37 @@
+[parse-align-items-001.html]
+  [Checking align-items: normal]
+    expected: FAIL
+
+  [Checking align-items: safe flex-end]
+    expected: FAIL
+
+  [Checking align-items: unsafe end]
+    expected: FAIL
+
+  [Checking align-items: safe end]
+    expected: FAIL
+
+  [Checking align-items: end]
+    expected: FAIL
+
+  [Checking align-items: start]
+    expected: FAIL
+
+  [Checking align-items: self-start]
+    expected: FAIL
+
+  [Checking align-items: last baseline]
+    expected: FAIL
+
+  [Checking align-items: self-end]
+    expected: FAIL
+
+  [Checking align-items: safe center]
+    expected: FAIL
+
+  [Checking align-items: first baseline]
+    expected: FAIL
+
+  [Checking align-items: unsafe flex-start]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/parse-align-items-002.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/parse-align-items-002.html.ini
@@ -1,0 +1,22 @@
+[parse-align-items-002.html]
+  [Test flex items align-items: 'initial']
+    expected: FAIL
+
+  [Test absolute positioned flex items align-items: 'initial']
+    expected: FAIL
+
+  [Test grid items align-items: 'initial']
+    expected: FAIL
+
+  [Test absolute positioned grid items align-items: 'initial']
+    expected: FAIL
+
+  [Test absolute positioned elements align-items: 'initial']
+    expected: FAIL
+
+  [Test align-items: 'initial']
+    expected: FAIL
+
+  [Test 'initial' value when nothing is specified]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/parse-align-items-003.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/parse-align-items-003.html.ini
@@ -1,0 +1,37 @@
+[parse-align-items-003.html]
+  [Checking align-items: normal]
+    expected: FAIL
+
+  [Checking align-items: safe flex-end]
+    expected: FAIL
+
+  [Checking align-items: unsafe end]
+    expected: FAIL
+
+  [Checking align-items: safe end]
+    expected: FAIL
+
+  [Checking align-items: end]
+    expected: FAIL
+
+  [Checking align-items: start]
+    expected: FAIL
+
+  [Checking align-items: self-start]
+    expected: FAIL
+
+  [Checking align-items: last baseline]
+    expected: FAIL
+
+  [Checking align-items: self-end]
+    expected: FAIL
+
+  [Checking align-items: safe center]
+    expected: FAIL
+
+  [Checking align-items: first baseline]
+    expected: FAIL
+
+  [Checking align-items: unsafe flex-start]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/parse-align-items-005.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/parse-align-items-005.html.ini
@@ -1,0 +1,10 @@
+[parse-align-items-005.html]
+  [Test the value 'inherit' overrides current value ('end')]
+    expected: FAIL
+
+  [Test the value 'inherit' overrides current value ('unsafe center')]
+    expected: FAIL
+
+  [Test the value 'inherit' overrides current value ('safe start')]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/parse-justify-items-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/parse-justify-items-001.html.ini
@@ -1,0 +1,67 @@
+[parse-justify-items-001.html]
+  [Checking justify-items: right]
+    expected: FAIL
+
+  [Checking justify-items: flex-end]
+    expected: FAIL
+
+  [Checking justify-items: legacy center]
+    expected: FAIL
+
+  [Checking justify-items: start]
+    expected: FAIL
+
+  [Checking justify-items: self-end]
+    expected: FAIL
+
+  [Checking justify-items: normal]
+    expected: FAIL
+
+  [Checking justify-items: stretch]
+    expected: FAIL
+
+  [Checking justify-items: first baseline]
+    expected: FAIL
+
+  [Checking justify-items: safe flex-end]
+    expected: FAIL
+
+  [Checking justify-items: safe center]
+    expected: FAIL
+
+  [Checking justify-items: center]
+    expected: FAIL
+
+  [Checking justify-items: flex-start]
+    expected: FAIL
+
+  [Checking justify-items: left]
+    expected: FAIL
+
+  [Checking justify-items: self-start]
+    expected: FAIL
+
+  [Checking justify-items: last baseline]
+    expected: FAIL
+
+  [Checking justify-items: legacy left]
+    expected: FAIL
+
+  [Checking justify-items: unsafe end]
+    expected: FAIL
+
+  [Checking justify-items: unsafe flex-start]
+    expected: FAIL
+
+  [Checking justify-items: baseline]
+    expected: FAIL
+
+  [Checking justify-items: legacy right]
+    expected: FAIL
+
+  [Checking justify-items: end]
+    expected: FAIL
+
+  [Checking justify-items: safe end]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/parse-justify-items-002.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/parse-justify-items-002.html.ini
@@ -1,0 +1,22 @@
+[parse-justify-items-002.html]
+  [Test absolute positioned grid items justify-items: 'initial']
+    expected: FAIL
+
+  [Test absolute positioned elements justify-items: 'initial']
+    expected: FAIL
+
+  [Test flex items justify-items: 'initial']
+    expected: FAIL
+
+  [Test absolute positioned flex items justify-items: 'initial']
+    expected: FAIL
+
+  [Test justify-items: 'initial']
+    expected: FAIL
+
+  [Test grid items justify-items: 'initial']
+    expected: FAIL
+
+  [Test 'initial' value when nothing is specified]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/parse-justify-items-003.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/parse-justify-items-003.html.ini
@@ -1,0 +1,67 @@
+[parse-justify-items-003.html]
+  [Checking justify-items: right]
+    expected: FAIL
+
+  [Checking justify-items: flex-end]
+    expected: FAIL
+
+  [Checking justify-items: legacy center]
+    expected: FAIL
+
+  [Checking justify-items: start]
+    expected: FAIL
+
+  [Checking justify-items: self-end]
+    expected: FAIL
+
+  [Checking justify-items: normal]
+    expected: FAIL
+
+  [Checking justify-items: stretch]
+    expected: FAIL
+
+  [Checking justify-items: first baseline]
+    expected: FAIL
+
+  [Checking justify-items: safe flex-end]
+    expected: FAIL
+
+  [Checking justify-items: safe center]
+    expected: FAIL
+
+  [Checking justify-items: center]
+    expected: FAIL
+
+  [Checking justify-items: flex-start]
+    expected: FAIL
+
+  [Checking justify-items: left]
+    expected: FAIL
+
+  [Checking justify-items: self-start]
+    expected: FAIL
+
+  [Checking justify-items: last baseline]
+    expected: FAIL
+
+  [Checking justify-items: legacy left]
+    expected: FAIL
+
+  [Checking justify-items: unsafe end]
+    expected: FAIL
+
+  [Checking justify-items: unsafe flex-start]
+    expected: FAIL
+
+  [Checking justify-items: baseline]
+    expected: FAIL
+
+  [Checking justify-items: legacy right]
+    expected: FAIL
+
+  [Checking justify-items: end]
+    expected: FAIL
+
+  [Checking justify-items: safe end]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/parse-justify-items-004.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/parse-justify-items-004.html.ini
@@ -1,0 +1,97 @@
+[parse-justify-items-004.html]
+  [Checking invalid combination - justify-items: unsafe safe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: legacy stretch]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: legacy end]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: baseline normal]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: first baseline center]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: baseline first]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: baseline safe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: last baseline center]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: unsafe safe left]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: auto safe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: legacy left right]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: unsafe stretch]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: space-around]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: normal stretch]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: safe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: unsafe left safe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: left safe unsafe safe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: legacy right unsafe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: center start]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: auto left]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: baseline center]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: legacy auto]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: unsafe unsafe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: stretch unsafe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: safe stretch]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: baseline last]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: stretch right]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: legacy start]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: normal unsafe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: start safe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: auto]
+    expected: FAIL
+
+  [Checking invalid combination - justify-items: unsafe baseline]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/parse-justify-items-005.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/parse-justify-items-005.html.ini
@@ -1,0 +1,10 @@
+[parse-justify-items-005.html]
+  [Test the value 'inherit' overrides current value ('end')]
+    expected: FAIL
+
+  [Test the value 'inherit' overrides current value ('safe left')]
+    expected: FAIL
+
+  [Test the value 'inherit' overrides current value ('unsafe center')]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/parse-justify-items-006.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/parse-justify-items-006.html.ini
@@ -1,0 +1,10 @@
+[parse-justify-items-006.html]
+  [Test the value justify-items: legacy left]
+    expected: FAIL
+
+  [Test the value justify-items: legacy center]
+    expected: FAIL
+
+  [Test the value justify-items: legacy right]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/place-items-shorthand-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/place-items-shorthand-001.html.ini
@@ -1,0 +1,52 @@
+[place-items-shorthand-001.html]
+  [Checking place-items: end]
+    expected: FAIL
+
+  [Checking place-items: center]
+    expected: FAIL
+
+  [Checking place-items: flex-start]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: stretch]
+    expected: FAIL
+
+  [Checking place-items: first baseline]
+    expected: FAIL
+
+  [Checking place-items: unsafe end]
+    expected: FAIL
+
+  [Checking place-items: flex-end]
+    expected: FAIL
+
+  [Checking place-items: self-end]
+    expected: FAIL
+
+  [Checking place-items: safe center]
+    expected: FAIL
+
+  [Checking place-items: safe end]
+    expected: FAIL
+
+  [Checking place-items: self-start]
+    expected: FAIL
+
+  [Checking place-items: normal]
+    expected: FAIL
+
+  [Checking place-items: last baseline]
+    expected: FAIL
+
+  [Checking place-items: start]
+    expected: FAIL
+
+  [Checking place-items: baseline]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/place-items-shorthand-002.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/place-items-shorthand-002.html.ini
@@ -1,0 +1,1123 @@
+[place-items-shorthand-002.html]
+  [Checking place-items: end right]
+    expected: FAIL
+
+  [Checking place-items: safe center safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: normal unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: start end]
+    expected: FAIL
+
+  [Checking place-items: end normal]
+    expected: FAIL
+
+  [Checking place-items: normal self-start]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end legacy left]
+    expected: FAIL
+
+  [Checking place-items: end self-end]
+    expected: FAIL
+
+  [Checking place-items: normal last baseline]
+    expected: FAIL
+
+  [Checking place-items: safe end safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: baseline self-end]
+    expected: FAIL
+
+  [Checking place-items: flex-start flex-start]
+    expected: FAIL
+
+  [Checking place-items: unsafe end legacy right]
+    expected: FAIL
+
+  [Checking place-items: safe end unsafe end]
+    expected: FAIL
+
+  [Checking place-items: self-start start]
+    expected: FAIL
+
+  [Checking place-items: self-start safe center]
+    expected: FAIL
+
+  [Checking place-items: self-start first baseline]
+    expected: FAIL
+
+  [Checking place-items: baseline flex-start]
+    expected: FAIL
+
+  [Checking place-items: safe end flex-end]
+    expected: FAIL
+
+  [Checking place-items: unsafe end safe end]
+    expected: FAIL
+
+  [Checking place-items: safe center left]
+    expected: FAIL
+
+  [Checking place-items: first baseline last baseline]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end baseline]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end stretch]
+    expected: FAIL
+
+  [Checking place-items: start right]
+    expected: FAIL
+
+  [Checking place-items: flex-end center]
+    expected: FAIL
+
+  [Checking place-items: unsafe end self-end]
+    expected: FAIL
+
+  [Checking place-items: self-start last baseline]
+    expected: FAIL
+
+  [Checking place-items: safe center flex-end]
+    expected: FAIL
+
+  [Checking place-items: unsafe end flex-end]
+    expected: FAIL
+
+  [Checking place-items: unsafe end safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: start first baseline]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start unsafe end]
+    expected: FAIL
+
+  [Checking place-items: stretch baseline]
+    expected: FAIL
+
+  [Checking place-items: center safe center]
+    expected: FAIL
+
+  [Checking place-items: start left]
+    expected: FAIL
+
+  [Checking place-items: center center]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start legacy center]
+    expected: FAIL
+
+  [Checking place-items: unsafe end unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: start unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: self-end stretch]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end safe center]
+    expected: FAIL
+
+  [Checking place-items: normal baseline]
+    expected: FAIL
+
+  [Checking place-items: safe end legacy center]
+    expected: FAIL
+
+  [Checking place-items: stretch legacy center]
+    expected: FAIL
+
+  [Checking place-items: unsafe end self-start]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end normal]
+    expected: FAIL
+
+  [Checking place-items: unsafe end unsafe end]
+    expected: FAIL
+
+  [Checking place-items: baseline normal]
+    expected: FAIL
+
+  [Checking place-items: first baseline baseline]
+    expected: FAIL
+
+  [Checking place-items: flex-end first baseline]
+    expected: FAIL
+
+  [Checking place-items: safe center center]
+    expected: FAIL
+
+  [Checking place-items: first baseline safe center]
+    expected: FAIL
+
+  [Checking place-items: unsafe end center]
+    expected: FAIL
+
+  [Checking place-items: baseline center]
+    expected: FAIL
+
+  [Checking place-items: stretch first baseline]
+    expected: FAIL
+
+  [Checking place-items: center self-end]
+    expected: FAIL
+
+  [Checking place-items: self-end flex-end]
+    expected: FAIL
+
+  [Checking place-items: self-end self-end]
+    expected: FAIL
+
+  [Checking place-items: last baseline legacy center]
+    expected: FAIL
+
+  [Checking place-items: last baseline safe center]
+    expected: FAIL
+
+  [Checking place-items: safe end safe center]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start safe center]
+    expected: FAIL
+
+  [Checking place-items: unsafe end left]
+    expected: FAIL
+
+  [Checking place-items: first baseline safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: safe end self-start]
+    expected: FAIL
+
+  [Checking place-items: baseline legacy right]
+    expected: FAIL
+
+  [Checking place-items: self-end last baseline]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end legacy center]
+    expected: FAIL
+
+  [Checking place-items: self-end unsafe end]
+    expected: FAIL
+
+  [Checking place-items: first baseline legacy left]
+    expected: FAIL
+
+  [Checking place-items: stretch flex-start]
+    expected: FAIL
+
+  [Checking place-items: safe center safe end]
+    expected: FAIL
+
+  [Checking place-items: first baseline unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: self-start legacy right]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end self-start]
+    expected: FAIL
+
+  [Checking place-items: stretch legacy left]
+    expected: FAIL
+
+  [Checking place-items: normal flex-start]
+    expected: FAIL
+
+  [Checking place-items: first baseline legacy right]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start self-start]
+    expected: FAIL
+
+  [Checking place-items: safe center legacy right]
+    expected: FAIL
+
+  [Checking place-items: flex-end last baseline]
+    expected: FAIL
+
+  [Checking place-items: first baseline center]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: self-start safe end]
+    expected: FAIL
+
+  [Checking place-items: flex-start start]
+    expected: FAIL
+
+  [Checking place-items: flex-end unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: baseline right]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end end]
+    expected: FAIL
+
+  [Checking place-items: self-start self-end]
+    expected: FAIL
+
+  [Checking place-items: self-end baseline]
+    expected: FAIL
+
+  [Checking place-items: self-start flex-end]
+    expected: FAIL
+
+  [Checking place-items: flex-start legacy center]
+    expected: FAIL
+
+  [Checking place-items: last baseline self-end]
+    expected: FAIL
+
+  [Checking place-items: last baseline last baseline]
+    expected: FAIL
+
+  [Checking place-items: stretch self-start]
+    expected: FAIL
+
+  [Checking place-items: start safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: unsafe end flex-start]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start baseline]
+    expected: FAIL
+
+  [Checking place-items: end left]
+    expected: FAIL
+
+  [Checking place-items: stretch safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: self-end normal]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: unsafe end baseline]
+    expected: FAIL
+
+  [Checking place-items: safe end normal]
+    expected: FAIL
+
+  [Checking place-items: normal right]
+    expected: FAIL
+
+  [Checking place-items: safe center unsafe end]
+    expected: FAIL
+
+  [Checking place-items: center legacy left]
+    expected: FAIL
+
+  [Checking place-items: first baseline right]
+    expected: FAIL
+
+  [Checking place-items: center legacy center]
+    expected: FAIL
+
+  [Checking place-items: start self-end]
+    expected: FAIL
+
+  [Checking place-items: start unsafe end]
+    expected: FAIL
+
+  [Checking place-items: unsafe end right]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start flex-end]
+    expected: FAIL
+
+  [Checking place-items: end stretch]
+    expected: FAIL
+
+  [Checking place-items: safe center legacy left]
+    expected: FAIL
+
+  [Checking place-items: last baseline stretch]
+    expected: FAIL
+
+  [Checking place-items: start legacy center]
+    expected: FAIL
+
+  [Checking place-items: first baseline unsafe end]
+    expected: FAIL
+
+  [Checking place-items: flex-end normal]
+    expected: FAIL
+
+  [Checking place-items: safe center self-start]
+    expected: FAIL
+
+  [Checking place-items: self-end safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: last baseline flex-end]
+    expected: FAIL
+
+  [Checking place-items: center end]
+    expected: FAIL
+
+  [Checking place-items: first baseline flex-end]
+    expected: FAIL
+
+  [Checking place-items: unsafe end first baseline]
+    expected: FAIL
+
+  [Checking place-items: flex-end safe center]
+    expected: FAIL
+
+  [Checking place-items: last baseline safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: self-start legacy center]
+    expected: FAIL
+
+  [Checking place-items: last baseline unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: flex-start normal]
+    expected: FAIL
+
+  [Checking place-items: self-start left]
+    expected: FAIL
+
+  [Checking place-items: self-end start]
+    expected: FAIL
+
+  [Checking place-items: baseline left]
+    expected: FAIL
+
+  [Checking place-items: end end]
+    expected: FAIL
+
+  [Checking place-items: flex-start center]
+    expected: FAIL
+
+  [Checking place-items: safe center first baseline]
+    expected: FAIL
+
+  [Checking place-items: self-end unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: baseline self-start]
+    expected: FAIL
+
+  [Checking place-items: flex-end stretch]
+    expected: FAIL
+
+  [Checking place-items: baseline first baseline]
+    expected: FAIL
+
+  [Checking place-items: flex-end legacy left]
+    expected: FAIL
+
+  [Checking place-items: center unsafe end]
+    expected: FAIL
+
+  [Checking place-items: baseline flex-end]
+    expected: FAIL
+
+  [Checking place-items: end safe center]
+    expected: FAIL
+
+  [Checking place-items: start safe center]
+    expected: FAIL
+
+  [Checking place-items: baseline unsafe end]
+    expected: FAIL
+
+  [Checking place-items: normal unsafe end]
+    expected: FAIL
+
+  [Checking place-items: normal safe center]
+    expected: FAIL
+
+  [Checking place-items: normal start]
+    expected: FAIL
+
+  [Checking place-items: stretch last baseline]
+    expected: FAIL
+
+  [Checking place-items: flex-start safe end]
+    expected: FAIL
+
+  [Checking place-items: flex-end self-end]
+    expected: FAIL
+
+  [Checking place-items: start safe end]
+    expected: FAIL
+
+  [Checking place-items: flex-end legacy center]
+    expected: FAIL
+
+  [Checking place-items: center unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: end legacy right]
+    expected: FAIL
+
+  [Checking place-items: stretch flex-end]
+    expected: FAIL
+
+  [Checking place-items: normal left]
+    expected: FAIL
+
+  [Checking place-items: last baseline first baseline]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end flex-end]
+    expected: FAIL
+
+  [Checking place-items: flex-start self-end]
+    expected: FAIL
+
+  [Checking place-items: first baseline safe end]
+    expected: FAIL
+
+  [Checking place-items: first baseline left]
+    expected: FAIL
+
+  [Checking place-items: safe center end]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start self-end]
+    expected: FAIL
+
+  [Checking place-items: center baseline]
+    expected: FAIL
+
+  [Checking place-items: self-start unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: stretch unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: baseline baseline]
+    expected: FAIL
+
+  [Checking place-items: unsafe end start]
+    expected: FAIL
+
+  [Checking place-items: self-start baseline]
+    expected: FAIL
+
+  [Checking place-items: stretch safe center]
+    expected: FAIL
+
+  [Checking place-items: safe center safe center]
+    expected: FAIL
+
+  [Checking place-items: flex-end right]
+    expected: FAIL
+
+  [Checking place-items: last baseline start]
+    expected: FAIL
+
+  [Checking place-items: baseline start]
+    expected: FAIL
+
+  [Checking place-items: start start]
+    expected: FAIL
+
+  [Checking place-items: safe center flex-start]
+    expected: FAIL
+
+  [Checking place-items: last baseline legacy left]
+    expected: FAIL
+
+  [Checking place-items: last baseline self-start]
+    expected: FAIL
+
+  [Checking place-items: first baseline start]
+    expected: FAIL
+
+  [Checking place-items: unsafe end last baseline]
+    expected: FAIL
+
+  [Checking place-items: center last baseline]
+    expected: FAIL
+
+  [Checking place-items: safe end flex-start]
+    expected: FAIL
+
+  [Checking place-items: end start]
+    expected: FAIL
+
+  [Checking place-items: last baseline center]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start flex-start]
+    expected: FAIL
+
+  [Checking place-items: end first baseline]
+    expected: FAIL
+
+  [Checking place-items: start normal]
+    expected: FAIL
+
+  [Checking place-items: baseline last baseline]
+    expected: FAIL
+
+  [Checking place-items: safe end self-end]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end center]
+    expected: FAIL
+
+  [Checking place-items: start flex-end]
+    expected: FAIL
+
+  [Checking place-items: stretch normal]
+    expected: FAIL
+
+  [Checking place-items: flex-start legacy right]
+    expected: FAIL
+
+  [Checking place-items: safe center normal]
+    expected: FAIL
+
+  [Checking place-items: normal legacy left]
+    expected: FAIL
+
+  [Checking place-items: start legacy right]
+    expected: FAIL
+
+  [Checking place-items: safe center self-end]
+    expected: FAIL
+
+  [Checking place-items: self-end safe center]
+    expected: FAIL
+
+  [Checking place-items: stretch stretch]
+    expected: FAIL
+
+  [Checking place-items: end safe end]
+    expected: FAIL
+
+  [Checking place-items: safe end safe end]
+    expected: FAIL
+
+  [Checking place-items: flex-start safe center]
+    expected: FAIL
+
+  [Checking place-items: self-end legacy right]
+    expected: FAIL
+
+  [Checking place-items: last baseline unsafe end]
+    expected: FAIL
+
+  [Checking place-items: first baseline self-end]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start legacy left]
+    expected: FAIL
+
+  [Checking place-items: safe center legacy center]
+    expected: FAIL
+
+  [Checking place-items: first baseline flex-start]
+    expected: FAIL
+
+  [Checking place-items: normal self-end]
+    expected: FAIL
+
+  [Checking place-items: end flex-start]
+    expected: FAIL
+
+  [Checking place-items: center legacy right]
+    expected: FAIL
+
+  [Checking place-items: center flex-start]
+    expected: FAIL
+
+  [Checking place-items: end unsafe end]
+    expected: FAIL
+
+  [Checking place-items: baseline safe center]
+    expected: FAIL
+
+  [Checking place-items: stretch right]
+    expected: FAIL
+
+  [Checking place-items: safe end start]
+    expected: FAIL
+
+  [Checking place-items: flex-end end]
+    expected: FAIL
+
+  [Checking place-items: self-start normal]
+    expected: FAIL
+
+  [Checking place-items: end baseline]
+    expected: FAIL
+
+  [Checking place-items: center left]
+    expected: FAIL
+
+  [Checking place-items: start stretch]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start center]
+    expected: FAIL
+
+  [Checking place-items: flex-end safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: unsafe end stretch]
+    expected: FAIL
+
+  [Checking place-items: normal normal]
+    expected: FAIL
+
+  [Checking place-items: normal stretch]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start normal]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end last baseline]
+    expected: FAIL
+
+  [Checking place-items: self-end end]
+    expected: FAIL
+
+  [Checking place-items: self-start safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: safe end unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: first baseline self-start]
+    expected: FAIL
+
+  [Checking place-items: baseline legacy center]
+    expected: FAIL
+
+  [Checking place-items: last baseline legacy right]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start right]
+    expected: FAIL
+
+  [Checking place-items: safe end legacy left]
+    expected: FAIL
+
+  [Checking place-items: baseline legacy left]
+    expected: FAIL
+
+  [Checking place-items: start last baseline]
+    expected: FAIL
+
+  [Checking place-items: unsafe end end]
+    expected: FAIL
+
+  [Checking place-items: normal flex-end]
+    expected: FAIL
+
+  [Checking place-items: baseline end]
+    expected: FAIL
+
+  [Checking place-items: self-start stretch]
+    expected: FAIL
+
+  [Checking place-items: safe end stretch]
+    expected: FAIL
+
+  [Checking place-items: flex-start unsafe end]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start safe end]
+    expected: FAIL
+
+  [Checking place-items: flex-end flex-start]
+    expected: FAIL
+
+  [Checking place-items: flex-start self-start]
+    expected: FAIL
+
+  [Checking place-items: center stretch]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start start]
+    expected: FAIL
+
+  [Checking place-items: flex-start first baseline]
+    expected: FAIL
+
+  [Checking place-items: safe end left]
+    expected: FAIL
+
+  [Checking place-items: center safe end]
+    expected: FAIL
+
+  [Checking place-items: flex-end left]
+    expected: FAIL
+
+  [Checking place-items: unsafe end legacy left]
+    expected: FAIL
+
+  [Checking place-items: last baseline flex-start]
+    expected: FAIL
+
+  [Checking place-items: self-end first baseline]
+    expected: FAIL
+
+  [Checking place-items: center flex-end]
+    expected: FAIL
+
+  [Checking place-items: end safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: self-start end]
+    expected: FAIL
+
+  [Checking place-items: flex-end safe end]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end safe end]
+    expected: FAIL
+
+  [Checking place-items: safe end baseline]
+    expected: FAIL
+
+  [Checking place-items: stretch safe end]
+    expected: FAIL
+
+  [Checking place-items: flex-end legacy right]
+    expected: FAIL
+
+  [Checking place-items: safe end right]
+    expected: FAIL
+
+  [Checking place-items: end center]
+    expected: FAIL
+
+  [Checking place-items: safe end last baseline]
+    expected: FAIL
+
+  [Checking place-items: stretch center]
+    expected: FAIL
+
+  [Checking place-items: stretch legacy right]
+    expected: FAIL
+
+  [Checking place-items: flex-end flex-end]
+    expected: FAIL
+
+  [Checking place-items: first baseline legacy center]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start end]
+    expected: FAIL
+
+  [Checking place-items: self-end left]
+    expected: FAIL
+
+  [Checking place-items: safe center unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: center start]
+    expected: FAIL
+
+  [Checking place-items: safe center start]
+    expected: FAIL
+
+  [Checking place-items: last baseline right]
+    expected: FAIL
+
+  [Checking place-items: safe center right]
+    expected: FAIL
+
+  [Checking place-items: safe end legacy right]
+    expected: FAIL
+
+  [Checking place-items: self-end center]
+    expected: FAIL
+
+  [Checking place-items: center normal]
+    expected: FAIL
+
+  [Checking place-items: self-start legacy left]
+    expected: FAIL
+
+  [Checking place-items: normal first baseline]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start legacy right]
+    expected: FAIL
+
+  [Checking place-items: self-start self-start]
+    expected: FAIL
+
+  [Checking place-items: baseline stretch]
+    expected: FAIL
+
+  [Checking place-items: stretch start]
+    expected: FAIL
+
+  [Checking place-items: self-start unsafe end]
+    expected: FAIL
+
+  [Checking place-items: flex-start baseline]
+    expected: FAIL
+
+  [Checking place-items: normal legacy center]
+    expected: FAIL
+
+  [Checking place-items: safe center last baseline]
+    expected: FAIL
+
+  [Checking place-items: stretch self-end]
+    expected: FAIL
+
+  [Checking place-items: flex-start legacy left]
+    expected: FAIL
+
+  [Checking place-items: stretch end]
+    expected: FAIL
+
+  [Checking place-items: flex-start flex-end]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end flex-start]
+    expected: FAIL
+
+  [Checking place-items: start self-start]
+    expected: FAIL
+
+  [Checking place-items: center right]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end start]
+    expected: FAIL
+
+  [Checking place-items: end last baseline]
+    expected: FAIL
+
+  [Checking place-items: end legacy center]
+    expected: FAIL
+
+  [Checking place-items: normal center]
+    expected: FAIL
+
+  [Checking place-items: safe end center]
+    expected: FAIL
+
+  [Checking place-items: end legacy left]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start left]
+    expected: FAIL
+
+  [Checking place-items: center first baseline]
+    expected: FAIL
+
+  [Checking place-items: safe end first baseline]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end first baseline]
+    expected: FAIL
+
+  [Checking place-items: end unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: flex-start right]
+    expected: FAIL
+
+  [Checking place-items: normal safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: start flex-start]
+    expected: FAIL
+
+  [Checking place-items: safe center baseline]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start first baseline]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end left]
+    expected: FAIL
+
+  [Checking place-items: flex-start stretch]
+    expected: FAIL
+
+  [Checking place-items: center self-start]
+    expected: FAIL
+
+  [Checking place-items: normal safe end]
+    expected: FAIL
+
+  [Checking place-items: last baseline end]
+    expected: FAIL
+
+  [Checking place-items: self-start center]
+    expected: FAIL
+
+  [Checking place-items: self-end right]
+    expected: FAIL
+
+  [Checking place-items: baseline unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end self-end]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end unsafe end]
+    expected: FAIL
+
+  [Checking place-items: first baseline first baseline]
+    expected: FAIL
+
+  [Checking place-items: last baseline safe end]
+    expected: FAIL
+
+  [Checking place-items: safe end end]
+    expected: FAIL
+
+  [Checking place-items: start center]
+    expected: FAIL
+
+  [Checking place-items: normal end]
+    expected: FAIL
+
+  [Checking place-items: flex-start last baseline]
+    expected: FAIL
+
+  [Checking place-items: stretch left]
+    expected: FAIL
+
+  [Checking place-items: first baseline end]
+    expected: FAIL
+
+  [Checking place-items: flex-end baseline]
+    expected: FAIL
+
+  [Checking place-items: flex-end self-start]
+    expected: FAIL
+
+  [Checking place-items: self-end legacy left]
+    expected: FAIL
+
+  [Checking place-items: first baseline stretch]
+    expected: FAIL
+
+  [Checking place-items: unsafe end normal]
+    expected: FAIL
+
+  [Checking place-items: baseline safe end]
+    expected: FAIL
+
+  [Checking place-items: start baseline]
+    expected: FAIL
+
+  [Checking place-items: flex-end start]
+    expected: FAIL
+
+  [Checking place-items: flex-end unsafe end]
+    expected: FAIL
+
+  [Checking place-items: baseline safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: start legacy left]
+    expected: FAIL
+
+  [Checking place-items: flex-start safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: flex-start unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-items: self-end flex-start]
+    expected: FAIL
+
+  [Checking place-items: self-start right]
+    expected: FAIL
+
+  [Checking place-items: end flex-end]
+    expected: FAIL
+
+  [Checking place-items: last baseline left]
+    expected: FAIL
+
+  [Checking place-items: self-end self-start]
+    expected: FAIL
+
+  [Checking place-items: flex-start end]
+    expected: FAIL
+
+  [Checking place-items: self-end safe end]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end right]
+    expected: FAIL
+
+  [Checking place-items: end self-start]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start last baseline]
+    expected: FAIL
+
+  [Checking place-items: self-start flex-start]
+    expected: FAIL
+
+  [Checking place-items: safe flex-end legacy right]
+    expected: FAIL
+
+  [Checking place-items: center safe flex-end]
+    expected: FAIL
+
+  [Checking place-items: flex-start left]
+    expected: FAIL
+
+  [Checking place-items: unsafe end safe center]
+    expected: FAIL
+
+  [Checking place-items: first baseline normal]
+    expected: FAIL
+
+  [Checking place-items: stretch unsafe end]
+    expected: FAIL
+
+  [Checking place-items: safe center stretch]
+    expected: FAIL
+
+  [Checking place-items: unsafe end legacy center]
+    expected: FAIL
+
+  [Checking place-items: last baseline normal]
+    expected: FAIL
+
+  [Checking place-items: last baseline baseline]
+    expected: FAIL
+
+  [Checking place-items: normal legacy right]
+    expected: FAIL
+
+  [Checking place-items: unsafe flex-start stretch]
+    expected: FAIL
+
+  [Checking place-items: self-end legacy center]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/place-items-shorthand-003.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/place-items-shorthand-003.html.ini
@@ -1,0 +1,7 @@
+[place-items-shorthand-003.html]
+  [Check place-items: initial - align-items expanded value]
+    expected: FAIL
+
+  [Check place-items: initial - justify-items expanded value]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/place-items-shorthand-004.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/place-items-shorthand-004.html.ini
@@ -1,0 +1,13 @@
+[place-items-shorthand-004.html]
+  [Verify empty declaration is invalid]
+    expected: FAIL
+
+  [Verify fallback values are invalid]
+    expected: FAIL
+
+  [Verify numeric values are invalid]
+    expected: FAIL
+
+  [Verify 'left' and 'right' values are invalid for block/cross axis alignment]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/place-items-shorthand-005.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/place-items-shorthand-005.html.ini
@@ -1,0 +1,7 @@
+[place-items-shorthand-005.html]
+  [Check place-items: inherit - align-items resolved value]
+    expected: FAIL
+
+  [Check place-items: inherit - justify-items resolved value]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/place-items-shorthand-006.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/place-items-shorthand-006.html.ini
@@ -1,0 +1,109 @@
+[place-items-shorthand-006.html]
+  [Checking place-items: first baseline start]
+    expected: FAIL
+
+  [Checking place-items: last baseline last baseline]
+    expected: FAIL
+
+  [Checking place-items: flex-start flex-start]
+    expected: FAIL
+
+  [Checking place-items: end first baseline]
+    expected: FAIL
+
+  [Checking place-items: self-start first baseline]
+    expected: FAIL
+
+  [Checking place-items: normal first baseline]
+    expected: FAIL
+
+  [Checking place-items: self-start self-start]
+    expected: FAIL
+
+  [Checking place-items: first baseline right]
+    expected: FAIL
+
+  [Checking place-items: flex-start first baseline]
+    expected: FAIL
+
+  [Checking place-items: stretch stretch]
+    expected: FAIL
+
+  [Checking place-items: first baseline last baseline]
+    expected: FAIL
+
+  [Checking place-items: first baseline self-end]
+    expected: FAIL
+
+  [Checking place-items: baseline baseline]
+    expected: FAIL
+
+  [Checking place-items: start first baseline]
+    expected: FAIL
+
+  [Checking place-items: first baseline flex-start]
+    expected: FAIL
+
+  [Checking place-items: first baseline flex-end]
+    expected: FAIL
+
+  [Checking place-items: center first baseline]
+    expected: FAIL
+
+  [Checking place-items: end end]
+    expected: FAIL
+
+  [Checking place-items: first baseline baseline]
+    expected: FAIL
+
+  [Checking place-items: first baseline first baseline]
+    expected: FAIL
+
+  [Checking place-items: flex-end flex-end]
+    expected: FAIL
+
+  [Checking place-items: first baseline self-start]
+    expected: FAIL
+
+  [Checking place-items: stretch first baseline]
+    expected: FAIL
+
+  [Checking place-items: first baseline end]
+    expected: FAIL
+
+  [Checking place-items: first baseline stretch]
+    expected: FAIL
+
+  [Checking place-items: self-end self-end]
+    expected: FAIL
+
+  [Checking place-items: last baseline first baseline]
+    expected: FAIL
+
+  [Checking place-items: center center]
+    expected: FAIL
+
+  [Checking place-items: flex-end first baseline]
+    expected: FAIL
+
+  [Checking place-items: first baseline left]
+    expected: FAIL
+
+  [Checking place-items: first baseline normal]
+    expected: FAIL
+
+  [Checking place-items: baseline first baseline]
+    expected: FAIL
+
+  [Checking place-items: first baseline center]
+    expected: FAIL
+
+  [Checking place-items: self-end first baseline]
+    expected: FAIL
+
+  [Checking place-items: normal normal]
+    expected: FAIL
+
+  [Checking place-items: start start]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/default-alignment/shorthand-serialization-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/default-alignment/shorthand-serialization-001.html.ini
@@ -1,0 +1,52 @@
+[shorthand-serialization-001.html]
+  [test shorthand serialization {"justifySelf":"unsafe start","shorthand":["auto start","auto unsafe start"\]}]
+    expected: FAIL
+
+  [test shorthand serialization {"justifySelf":"last baseline start","shorthand":""}]
+    expected: FAIL
+
+  [test shorthand serialization {"justifyContent":"safe start","shorthand":"normal safe start"}]
+    expected: FAIL
+
+  [test shorthand serialization {"justifyItems":"left legacy","shorthand":"normal legacy left"}]
+    expected: FAIL
+
+  [test shorthand serialization {"alignContent":"baseline safe right","shorthand":""}]
+    expected: FAIL
+
+  [test shorthand serialization {"justifyItems":"safe start","shorthand":"normal safe start"}]
+    expected: FAIL
+
+  [test shorthand serialization {"alignItems":"stretch","justifyItems":"end","shorthand":"stretch end"}]
+    expected: FAIL
+
+  [test shorthand serialization {"alignItems":"baseline","shorthand":"baseline legacy"}]
+    expected: FAIL
+
+  [test shorthand serialization {"justifyItems":"unsafe start","shorthand":["normal unsafe start"\]}]
+    expected: FAIL
+
+  [test shorthand serialization {"alignSelf":"self-end safe","shorthand":""}]
+    expected: FAIL
+
+  [test shorthand serialization {"justifyContent":"unsafe start","shorthand":["normal unsafe start"\]}]
+    expected: FAIL
+
+  [test shorthand serialization {"justifyItems":"stretch","shorthand":"normal stretch"}]
+    expected: FAIL
+
+  [test shorthand serialization {"alignContent":"center","shorthand":"center normal"}]
+    expected: FAIL
+
+  [test shorthand serialization {"alignContent":"start","justifyContent":"end","shorthand":"start end"}]
+    expected: FAIL
+
+  [test shorthand serialization {"justifyContent":"space-evenly start","shorthand":""}]
+    expected: FAIL
+
+  [test shorthand serialization {"alignItems":"center","shorthand":"center legacy"}]
+    expected: FAIL
+
+  [test shorthand serialization {"alignSelf":"baseline","justifySelf":"last baseline","shorthand":"baseline last baseline"}]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/distribution-values/space-evenly-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/distribution-values/space-evenly-001.html.ini
@@ -1,0 +1,2 @@
+[space-evenly-001.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-align/gaps/column-gap-animation-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/column-gap-animation-001.html.ini
@@ -1,0 +1,4 @@
+[column-gap-animation-001.html]
+  [column-gap is interpolable]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/column-gap-animation-002.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/column-gap-animation-002.html.ini
@@ -1,0 +1,4 @@
+[column-gap-animation-002.html]
+  [column-gap: normal is not interpolable]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/column-gap-animation-003.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/column-gap-animation-003.html.ini
@@ -1,0 +1,4 @@
+[column-gap-animation-003.html]
+  [Default column-gap is not interpolable]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/column-gap-parsing-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/column-gap-parsing-001.html.ini
@@ -1,0 +1,52 @@
+[column-gap-parsing-001.html]
+  [column-gap with multiple values is invalid]
+    expected: FAIL
+
+  [Resolution column-gap is invalid]
+    expected: FAIL
+
+  [column-gap accepts calc() mixing fixed and percentage values]
+    expected: FAIL
+
+  [column-gap is inheritable]
+    expected: FAIL
+
+  [Initial inherited column-gap is 'normal']
+    expected: FAIL
+
+  [column-gap accepts calc()]
+    expected: FAIL
+
+  ['none' column-gap is invalid]
+    expected: FAIL
+
+  [column-gap accepts em]
+    expected: FAIL
+
+  [Negative column-gap is invalid]
+    expected: FAIL
+
+  [Initial column-gap is 'normal' 2]
+    expected: FAIL
+
+  [Time column-gap is invalid]
+    expected: FAIL
+
+  [Default column-gap is 'normal']
+    expected: FAIL
+
+  [Initial column-gap is 'normal']
+    expected: FAIL
+
+  [Angle column-gap is invalid]
+    expected: FAIL
+
+  ['max-content' column-gap is invalid]
+    expected: FAIL
+
+  [column-gap accepts percentage]
+    expected: FAIL
+
+  [column-gap accepts pixels]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/gap-animation-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/gap-animation-001.html.ini
@@ -1,0 +1,4 @@
+[gap-animation-001.html]
+  [gap is interpolable]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/gap-animation-002.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/gap-animation-002.html.ini
@@ -1,0 +1,4 @@
+[gap-animation-002.html]
+  [gap: normal is not interpolable]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/gap-animation-003.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/gap-animation-003.html.ini
@@ -1,0 +1,4 @@
+[gap-animation-003.html]
+  [Default gap is not interpolable]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/gap-animation-004.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/gap-animation-004.html.ini
@@ -1,0 +1,4 @@
+[gap-animation-004.html]
+  [gap is interpolable]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/gap-normal-computed-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/gap-normal-computed-001.html.ini
@@ -1,0 +1,19 @@
+[gap-normal-computed-001.html]
+  [row-gap:normal computes to normal on grid]
+    expected: FAIL
+
+  [colum-gap:normal (main axis) computes to normal on flexbox]
+    expected: FAIL
+
+  [colum-gap:normal computes to normal on multicol elements]
+    expected: FAIL
+
+  [row-gap:normal computes to normal on multicol elements]
+    expected: FAIL
+
+  [row-gap:normal (cross axis) computes to normal on flexbox]
+    expected: FAIL
+
+  [colum-gap:normal computes to normal on grid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/gap-normal-used-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/gap-normal-used-001.html.ini
@@ -1,0 +1,2 @@
+[gap-normal-used-001.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-align/gaps/gap-parsing-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/gap-parsing-001.html.ini
@@ -1,0 +1,73 @@
+[gap-parsing-001.html]
+  [gap accepts percentage]
+    expected: FAIL
+
+  [gap accepts em 2]
+    expected: FAIL
+
+  [gap with slash is invalid]
+    expected: FAIL
+
+  [gap is inheritable]
+    expected: FAIL
+
+  [gap with three values is invalid]
+    expected: FAIL
+
+  [Initial inherited gap is 'normal']
+    expected: FAIL
+
+  [Angle gap is invalid]
+    expected: FAIL
+
+  [Default gap is 'normal']
+    expected: FAIL
+
+  [gap accepts percentage 2]
+    expected: FAIL
+
+  [Initial gap is 'normal']
+    expected: FAIL
+
+  [gap accepts em]
+    expected: FAIL
+
+  [gap accepts pixels 2]
+    expected: FAIL
+
+  [gap accepts pixels]
+    expected: FAIL
+
+  [gap accepts calc() mixing fixed and percentage values]
+    expected: FAIL
+
+  [Resolution gap is invalid]
+    expected: FAIL
+
+  [gap accepts calc()]
+    expected: FAIL
+
+  [Initial gap is 'normal' 2]
+    expected: FAIL
+
+  [gap accepts calc() 2]
+    expected: FAIL
+
+  [Negative gap is invalid]
+    expected: FAIL
+
+  ['max-content' gap is invalid]
+    expected: FAIL
+
+  [Time gap is invalid]
+    expected: FAIL
+
+  ['none' gap is invalid]
+    expected: FAIL
+
+  [gap with one wrong value is invalid]
+    expected: FAIL
+
+  [gap accepts pixels combined with percentage]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/grid-column-gap-parsing-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/grid-column-gap-parsing-001.html.ini
@@ -1,0 +1,52 @@
+[grid-column-gap-parsing-001.html]
+  ['none' grid-column-gap is invalid]
+    expected: FAIL
+
+  [Angle grid-column-gap is invalid]
+    expected: FAIL
+
+  [Resolution grid-column-gap is invalid]
+    expected: FAIL
+
+  [grid-column-gap is inheritable]
+    expected: FAIL
+
+  [Negative grid-column-gap is invalid]
+    expected: FAIL
+
+  [grid-column-gap accepts pixels]
+    expected: FAIL
+
+  [grid-column-gap accepts em]
+    expected: FAIL
+
+  [Initial grid-column-gap is 'normal' 2]
+    expected: FAIL
+
+  ['max-content' grid-column-gap is invalid]
+    expected: FAIL
+
+  [grid-column-gap with multiple values is invalid]
+    expected: FAIL
+
+  [Initial grid-column-gap is 'normal']
+    expected: FAIL
+
+  [Initial inherited grid-column-gap is 'normal']
+    expected: FAIL
+
+  [grid-column-gap accepts percentage]
+    expected: FAIL
+
+  [Default grid-column-gap is 'normal']
+    expected: FAIL
+
+  [Time grid-column-gap is invalid]
+    expected: FAIL
+
+  [grid-column-gap accepts calc() mixing fixed and percentage values]
+    expected: FAIL
+
+  [grid-column-gap accepts calc()]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/grid-gap-parsing-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/grid-gap-parsing-001.html.ini
@@ -1,0 +1,73 @@
+[grid-gap-parsing-001.html]
+  [grid-gap accepts em 2]
+    expected: FAIL
+
+  [grid-gap accepts em]
+    expected: FAIL
+
+  [grid-gap accepts pixels 2]
+    expected: FAIL
+
+  [Initial grid-gap is 'normal' 2]
+    expected: FAIL
+
+  [grid-gap with slash is invalid]
+    expected: FAIL
+
+  [grid-gap accepts pixels]
+    expected: FAIL
+
+  [grid-gap accepts calc() 2]
+    expected: FAIL
+
+  [Default grid-gap is 'normal']
+    expected: FAIL
+
+  [grid-gap accepts pixels combined with percentage]
+    expected: FAIL
+
+  [grid-gap accepts percentage]
+    expected: FAIL
+
+  [Initial inherited grid-gap is 'normal']
+    expected: FAIL
+
+  [grid-gap accepts percentage 2]
+    expected: FAIL
+
+  [Resolution grid-gap is invalid]
+    expected: FAIL
+
+  [grid-gap with three values is invalid]
+    expected: FAIL
+
+  [Negative grid-gap is invalid]
+    expected: FAIL
+
+  [Angle grid-gap is invalid]
+    expected: FAIL
+
+  [grid-gap accepts calc()]
+    expected: FAIL
+
+  [Time grid-gap is invalid]
+    expected: FAIL
+
+  [grid-gap accepts calc() mixing fixed and percentage values]
+    expected: FAIL
+
+  [grid-gap with one wrong value is invalid]
+    expected: FAIL
+
+  ['max-content' grid-gap is invalid]
+    expected: FAIL
+
+  [Initial grid-gap is 'normal']
+    expected: FAIL
+
+  [grid-gap is inheritable]
+    expected: FAIL
+
+  ['none' grid-gap is invalid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/grid-row-gap-parsing-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/grid-row-gap-parsing-001.html.ini
@@ -1,0 +1,52 @@
+[grid-row-gap-parsing-001.html]
+  [Negative grid-row-gap is invalid]
+    expected: FAIL
+
+  ['max-content' grid-row-gap is invalid]
+    expected: FAIL
+
+  [Time grid-row-gap is invalid]
+    expected: FAIL
+
+  [grid-row-gap accepts calc() mixing fixed and percentage values]
+    expected: FAIL
+
+  [Resolution grid-row-gap is invalid]
+    expected: FAIL
+
+  [grid-row-gap accepts percentage]
+    expected: FAIL
+
+  [Initial inherited grid-row-gap is 'normal']
+    expected: FAIL
+
+  ['none' grid-row-gap is invalid]
+    expected: FAIL
+
+  [Default grid-row-gap is 'normal']
+    expected: FAIL
+
+  [grid-row-gap is inheritable]
+    expected: FAIL
+
+  [grid-row-gap accepts pixels]
+    expected: FAIL
+
+  [grid-row-gap with multiple values is invalid]
+    expected: FAIL
+
+  [grid-row-gap accepts calc()]
+    expected: FAIL
+
+  [Angle grid-row-gap is invalid]
+    expected: FAIL
+
+  [grid-row-gap accepts em]
+    expected: FAIL
+
+  [Initial grid-row-gap is 'normal']
+    expected: FAIL
+
+  [Initial grid-row-gap is 'normal' 2]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/row-gap-animation-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/row-gap-animation-001.html.ini
@@ -1,0 +1,4 @@
+[row-gap-animation-001.html]
+  [row-gap is interpolable]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/row-gap-animation-002.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/row-gap-animation-002.html.ini
@@ -1,0 +1,4 @@
+[row-gap-animation-002.html]
+  [row-gap: normal is not interpolable]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/row-gap-animation-003.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/row-gap-animation-003.html.ini
@@ -1,0 +1,4 @@
+[row-gap-animation-003.html]
+  [Default row-gap is not interpolable]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/gaps/row-gap-parsing-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/gaps/row-gap-parsing-001.html.ini
@@ -1,0 +1,52 @@
+[row-gap-parsing-001.html]
+  [row-gap accepts percentage]
+    expected: FAIL
+
+  [row-gap with multiple values is invalid]
+    expected: FAIL
+
+  [row-gap accepts calc()]
+    expected: FAIL
+
+  [Default row-gap is 'normal']
+    expected: FAIL
+
+  [Resolution row-gap is invalid]
+    expected: FAIL
+
+  ['max-content' row-gap is invalid]
+    expected: FAIL
+
+  [row-gap accepts calc() mixing fixed and percentage values]
+    expected: FAIL
+
+  [Negative row-gap is invalid]
+    expected: FAIL
+
+  [row-gap accepts pixels]
+    expected: FAIL
+
+  [Initial inherited row-gap is 'normal']
+    expected: FAIL
+
+  ['none' row-gap is invalid]
+    expected: FAIL
+
+  [row-gap accepts em]
+    expected: FAIL
+
+  [Initial row-gap is 'normal']
+    expected: FAIL
+
+  [row-gap is inheritable]
+    expected: FAIL
+
+  [Angle row-gap is invalid]
+    expected: FAIL
+
+  [Initial row-gap is 'normal' 2]
+    expected: FAIL
+
+  [Time row-gap is invalid]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/inheritance.html.ini
+++ b/tests/wpt/metadata/css/css-align/inheritance.html.ini
@@ -1,0 +1,25 @@
+[inheritance.html]
+  [Property align-self does not inherit]
+    expected: FAIL
+
+  [Property align-items has initial value normal]
+    expected: FAIL
+
+  [Property align-content has initial value normal]
+    expected: FAIL
+
+  [Property align-items does not inherit]
+    expected: FAIL
+
+  [Property align-self has initial value auto]
+    expected: FAIL
+
+  [Property justify-content has initial value normal]
+    expected: FAIL
+
+  [Property justify-content does not inherit]
+    expected: FAIL
+
+  [Property align-content does not inherit]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/parse-align-self-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/parse-align-self-001.html.ini
@@ -1,0 +1,40 @@
+[parse-align-self-001.html]
+  [Checking align-self: auto]
+    expected: FAIL
+
+  [Checking align-self: normal]
+    expected: FAIL
+
+  [Checking align-self: safe flex-end]
+    expected: FAIL
+
+  [Checking align-self: end]
+    expected: FAIL
+
+  [Checking align-self: safe end]
+    expected: FAIL
+
+  [Checking align-self: unsafe end]
+    expected: FAIL
+
+  [Checking align-self: self-end]
+    expected: FAIL
+
+  [Checking align-self: first baseline]
+    expected: FAIL
+
+  [Checking align-self: safe center]
+    expected: FAIL
+
+  [Checking align-self: unsafe flex-start]
+    expected: FAIL
+
+  [Checking align-self: self-start]
+    expected: FAIL
+
+  [Checking align-self: start]
+    expected: FAIL
+
+  [Checking align-self: last baseline]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/parse-align-self-002.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/parse-align-self-002.html.ini
@@ -1,0 +1,22 @@
+[parse-align-self-002.html]
+  [Test grid items align-self: 'initial']
+    expected: FAIL
+
+  [Test align-self: 'initial']
+    expected: FAIL
+
+  [Test absolute positioned grid items align-self: 'initial']
+    expected: FAIL
+
+  [Test absolute positioned elements align-self: 'initial']
+    expected: FAIL
+
+  [Test flex items align-self: 'initial']
+    expected: FAIL
+
+  [Test 'initial' value when nothing is specified]
+    expected: FAIL
+
+  [Test absolute positioned flex items align-self: 'initial']
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/parse-align-self-003.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/parse-align-self-003.html.ini
@@ -1,0 +1,40 @@
+[parse-align-self-003.html]
+  [Checking align-self: auto]
+    expected: FAIL
+
+  [Checking align-self: normal]
+    expected: FAIL
+
+  [Checking align-self: safe flex-end]
+    expected: FAIL
+
+  [Checking align-self: end]
+    expected: FAIL
+
+  [Checking align-self: safe end]
+    expected: FAIL
+
+  [Checking align-self: unsafe end]
+    expected: FAIL
+
+  [Checking align-self: self-end]
+    expected: FAIL
+
+  [Checking align-self: first baseline]
+    expected: FAIL
+
+  [Checking align-self: safe center]
+    expected: FAIL
+
+  [Checking align-self: unsafe flex-start]
+    expected: FAIL
+
+  [Checking align-self: self-start]
+    expected: FAIL
+
+  [Checking align-self: start]
+    expected: FAIL
+
+  [Checking align-self: last baseline]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/parse-align-self-005.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/parse-align-self-005.html.ini
@@ -1,0 +1,10 @@
+[parse-align-self-005.html]
+  [Test the value 'inherit' overrides current value ('end')]
+    expected: FAIL
+
+  [Test the value 'inherit' overrides current value ('unsafe center')]
+    expected: FAIL
+
+  [Test the value 'inherit' overrides current value ('safe start')]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/parse-justify-self-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/parse-justify-self-001.html.ini
@@ -1,0 +1,61 @@
+[parse-justify-self-001.html]
+  [Checking justify-self: unsafe flex-start]
+    expected: FAIL
+
+  [Checking justify-self: unsafe end]
+    expected: FAIL
+
+  [Checking justify-self: first baseline]
+    expected: FAIL
+
+  [Checking justify-self: self-start]
+    expected: FAIL
+
+  [Checking justify-self: baseline]
+    expected: FAIL
+
+  [Checking justify-self: safe center]
+    expected: FAIL
+
+  [Checking justify-self: self-end]
+    expected: FAIL
+
+  [Checking justify-self: end]
+    expected: FAIL
+
+  [Checking justify-self: flex-end]
+    expected: FAIL
+
+  [Checking justify-self: safe flex-end]
+    expected: FAIL
+
+  [Checking justify-self: safe end]
+    expected: FAIL
+
+  [Checking justify-self: center]
+    expected: FAIL
+
+  [Checking justify-self: right]
+    expected: FAIL
+
+  [Checking justify-self: flex-start]
+    expected: FAIL
+
+  [Checking justify-self: auto]
+    expected: FAIL
+
+  [Checking justify-self: left]
+    expected: FAIL
+
+  [Checking justify-self: last baseline]
+    expected: FAIL
+
+  [Checking justify-self: start]
+    expected: FAIL
+
+  [Checking justify-self: normal]
+    expected: FAIL
+
+  [Checking justify-self: stretch]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/parse-justify-self-002.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/parse-justify-self-002.html.ini
@@ -1,0 +1,22 @@
+[parse-justify-self-002.html]
+  [Test absolute positioned elements justify-self: 'initial']
+    expected: FAIL
+
+  [Test flex items justify-self: 'initial']
+    expected: FAIL
+
+  [Test grid items justify-self: 'initial']
+    expected: FAIL
+
+  [Test justify-self: 'initial']
+    expected: FAIL
+
+  [Test absolute positioned flex items justify-self: 'initial']
+    expected: FAIL
+
+  [Test absolute positioned grid items justify-self: 'initial']
+    expected: FAIL
+
+  [Test 'initial' value when nothing is specified]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/parse-justify-self-003.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/parse-justify-self-003.html.ini
@@ -1,0 +1,61 @@
+[parse-justify-self-003.html]
+  [Checking justify-self: unsafe flex-start]
+    expected: FAIL
+
+  [Checking justify-self: unsafe end]
+    expected: FAIL
+
+  [Checking justify-self: first baseline]
+    expected: FAIL
+
+  [Checking justify-self: self-start]
+    expected: FAIL
+
+  [Checking justify-self: baseline]
+    expected: FAIL
+
+  [Checking justify-self: safe center]
+    expected: FAIL
+
+  [Checking justify-self: self-end]
+    expected: FAIL
+
+  [Checking justify-self: end]
+    expected: FAIL
+
+  [Checking justify-self: flex-end]
+    expected: FAIL
+
+  [Checking justify-self: safe flex-end]
+    expected: FAIL
+
+  [Checking justify-self: safe end]
+    expected: FAIL
+
+  [Checking justify-self: center]
+    expected: FAIL
+
+  [Checking justify-self: right]
+    expected: FAIL
+
+  [Checking justify-self: flex-start]
+    expected: FAIL
+
+  [Checking justify-self: auto]
+    expected: FAIL
+
+  [Checking justify-self: left]
+    expected: FAIL
+
+  [Checking justify-self: last baseline]
+    expected: FAIL
+
+  [Checking justify-self: start]
+    expected: FAIL
+
+  [Checking justify-self: normal]
+    expected: FAIL
+
+  [Checking justify-self: stretch]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/parse-justify-self-004.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/parse-justify-self-004.html.ini
@@ -1,0 +1,79 @@
+[parse-justify-self-004.html]
+  [Checking invalid combination - justify-self: baseline safe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: auto safe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: normal unsafe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: first baseline center]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: start safe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: last baseline center]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: unsafe stretch]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: space-around]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: auto left]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: safe stretch]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: center start]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: baseline last]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: normal stretch]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: legacy]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: unsafe left safe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: unsafe safe left]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: safe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: stretch right]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: unsafe unsafe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: stretch unsafe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: left safe unsafe safe]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: unsafe baseline]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: baseline center]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: baseline first]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: baseline normal]
+    expected: FAIL
+
+  [Checking invalid combination - justify-self: unsafe safe]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/parse-justify-self-005.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/parse-justify-self-005.html.ini
@@ -1,0 +1,10 @@
+[parse-justify-self-005.html]
+  [Test the value 'inherit' overrides current value ('end')]
+    expected: FAIL
+
+  [Test the value 'inherit' overrides current value ('safe left')]
+    expected: FAIL
+
+  [Test the value 'inherit' overrides current value ('unsafe center')]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/place-self-shorthand-001.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/place-self-shorthand-001.html.ini
@@ -1,0 +1,55 @@
+[place-self-shorthand-001.html]
+  [Checking place-self: self-start]
+    expected: FAIL
+
+  [Checking place-self: self-end]
+    expected: FAIL
+
+  [Checking place-self: first baseline]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: end]
+    expected: FAIL
+
+  [Checking place-self: auto]
+    expected: FAIL
+
+  [Checking place-self: safe end]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: unsafe end]
+    expected: FAIL
+
+  [Checking place-self: flex-end]
+    expected: FAIL
+
+  [Checking place-self: safe center]
+    expected: FAIL
+
+  [Checking place-self: last baseline]
+    expected: FAIL
+
+  [Checking place-self: center]
+    expected: FAIL
+
+  [Checking place-self: baseline]
+    expected: FAIL
+
+  [Checking place-self: flex-start]
+    expected: FAIL
+
+  [Checking place-self: start]
+    expected: FAIL
+
+  [Checking place-self: normal]
+    expected: FAIL
+
+  [Checking place-self: stretch]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/place-self-shorthand-002.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/place-self-shorthand-002.html.ini
@@ -1,0 +1,1081 @@
+[place-self-shorthand-002.html]
+  [Checking place-self: stretch last baseline]
+    expected: FAIL
+
+  [Checking place-self: start center]
+    expected: FAIL
+
+  [Checking place-self: flex-end safe center]
+    expected: FAIL
+
+  [Checking place-self: auto first baseline]
+    expected: FAIL
+
+  [Checking place-self: self-end self-start]
+    expected: FAIL
+
+  [Checking place-self: unsafe end flex-end]
+    expected: FAIL
+
+  [Checking place-self: stretch safe end]
+    expected: FAIL
+
+  [Checking place-self: baseline unsafe end]
+    expected: FAIL
+
+  [Checking place-self: self-start stretch]
+    expected: FAIL
+
+  [Checking place-self: flex-start end]
+    expected: FAIL
+
+  [Checking place-self: flex-end stretch]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start self-end]
+    expected: FAIL
+
+  [Checking place-self: end unsafe end]
+    expected: FAIL
+
+  [Checking place-self: first baseline center]
+    expected: FAIL
+
+  [Checking place-self: baseline auto]
+    expected: FAIL
+
+  [Checking place-self: center end]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end flex-start]
+    expected: FAIL
+
+  [Checking place-self: self-end stretch]
+    expected: FAIL
+
+  [Checking place-self: safe end flex-start]
+    expected: FAIL
+
+  [Checking place-self: start stretch]
+    expected: FAIL
+
+  [Checking place-self: baseline start]
+    expected: FAIL
+
+  [Checking place-self: safe center stretch]
+    expected: FAIL
+
+  [Checking place-self: safe end right]
+    expected: FAIL
+
+  [Checking place-self: safe center right]
+    expected: FAIL
+
+  [Checking place-self: normal flex-start]
+    expected: FAIL
+
+  [Checking place-self: self-start last baseline]
+    expected: FAIL
+
+  [Checking place-self: stretch self-start]
+    expected: FAIL
+
+  [Checking place-self: first baseline flex-end]
+    expected: FAIL
+
+  [Checking place-self: safe center left]
+    expected: FAIL
+
+  [Checking place-self: start left]
+    expected: FAIL
+
+  [Checking place-self: start end]
+    expected: FAIL
+
+  [Checking place-self: safe center safe end]
+    expected: FAIL
+
+  [Checking place-self: stretch self-end]
+    expected: FAIL
+
+  [Checking place-self: safe center safe center]
+    expected: FAIL
+
+  [Checking place-self: baseline right]
+    expected: FAIL
+
+  [Checking place-self: safe end safe end]
+    expected: FAIL
+
+  [Checking place-self: last baseline safe center]
+    expected: FAIL
+
+  [Checking place-self: normal end]
+    expected: FAIL
+
+  [Checking place-self: first baseline end]
+    expected: FAIL
+
+  [Checking place-self: last baseline stretch]
+    expected: FAIL
+
+  [Checking place-self: center first baseline]
+    expected: FAIL
+
+  [Checking place-self: auto unsafe end]
+    expected: FAIL
+
+  [Checking place-self: normal flex-end]
+    expected: FAIL
+
+  [Checking place-self: normal left]
+    expected: FAIL
+
+  [Checking place-self: flex-end end]
+    expected: FAIL
+
+  [Checking place-self: stretch unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: last baseline start]
+    expected: FAIL
+
+  [Checking place-self: center flex-end]
+    expected: FAIL
+
+  [Checking place-self: center last baseline]
+    expected: FAIL
+
+  [Checking place-self: self-end safe end]
+    expected: FAIL
+
+  [Checking place-self: first baseline self-end]
+    expected: FAIL
+
+  [Checking place-self: unsafe end center]
+    expected: FAIL
+
+  [Checking place-self: baseline safe center]
+    expected: FAIL
+
+  [Checking place-self: auto auto]
+    expected: FAIL
+
+  [Checking place-self: unsafe end end]
+    expected: FAIL
+
+  [Checking place-self: flex-end auto]
+    expected: FAIL
+
+  [Checking place-self: unsafe end unsafe end]
+    expected: FAIL
+
+  [Checking place-self: self-end safe center]
+    expected: FAIL
+
+  [Checking place-self: normal safe end]
+    expected: FAIL
+
+  [Checking place-self: center safe center]
+    expected: FAIL
+
+  [Checking place-self: self-start unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end stretch]
+    expected: FAIL
+
+  [Checking place-self: flex-end self-end]
+    expected: FAIL
+
+  [Checking place-self: start unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: self-end self-end]
+    expected: FAIL
+
+  [Checking place-self: stretch left]
+    expected: FAIL
+
+  [Checking place-self: unsafe end flex-start]
+    expected: FAIL
+
+  [Checking place-self: self-start normal]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end last baseline]
+    expected: FAIL
+
+  [Checking place-self: self-start first baseline]
+    expected: FAIL
+
+  [Checking place-self: safe end flex-end]
+    expected: FAIL
+
+  [Checking place-self: auto end]
+    expected: FAIL
+
+  [Checking place-self: safe end self-end]
+    expected: FAIL
+
+  [Checking place-self: first baseline last baseline]
+    expected: FAIL
+
+  [Checking place-self: flex-end flex-start]
+    expected: FAIL
+
+  [Checking place-self: safe end safe center]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start baseline]
+    expected: FAIL
+
+  [Checking place-self: flex-start start]
+    expected: FAIL
+
+  [Checking place-self: self-end auto]
+    expected: FAIL
+
+  [Checking place-self: first baseline stretch]
+    expected: FAIL
+
+  [Checking place-self: first baseline safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: self-start safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end auto]
+    expected: FAIL
+
+  [Checking place-self: last baseline unsafe end]
+    expected: FAIL
+
+  [Checking place-self: flex-start baseline]
+    expected: FAIL
+
+  [Checking place-self: stretch flex-start]
+    expected: FAIL
+
+  [Checking place-self: self-start start]
+    expected: FAIL
+
+  [Checking place-self: stretch start]
+    expected: FAIL
+
+  [Checking place-self: flex-start safe end]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end right]
+    expected: FAIL
+
+  [Checking place-self: flex-end safe end]
+    expected: FAIL
+
+  [Checking place-self: start last baseline]
+    expected: FAIL
+
+  [Checking place-self: unsafe end last baseline]
+    expected: FAIL
+
+  [Checking place-self: start baseline]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start safe center]
+    expected: FAIL
+
+  [Checking place-self: safe end first baseline]
+    expected: FAIL
+
+  [Checking place-self: end safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: flex-start left]
+    expected: FAIL
+
+  [Checking place-self: last baseline self-start]
+    expected: FAIL
+
+  [Checking place-self: self-start safe center]
+    expected: FAIL
+
+  [Checking place-self: auto baseline]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start left]
+    expected: FAIL
+
+  [Checking place-self: baseline baseline]
+    expected: FAIL
+
+  [Checking place-self: center start]
+    expected: FAIL
+
+  [Checking place-self: safe end baseline]
+    expected: FAIL
+
+  [Checking place-self: flex-end right]
+    expected: FAIL
+
+  [Checking place-self: auto self-start]
+    expected: FAIL
+
+  [Checking place-self: safe end end]
+    expected: FAIL
+
+  [Checking place-self: normal safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: normal auto]
+    expected: FAIL
+
+  [Checking place-self: start safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: flex-start self-start]
+    expected: FAIL
+
+  [Checking place-self: baseline self-start]
+    expected: FAIL
+
+  [Checking place-self: end baseline]
+    expected: FAIL
+
+  [Checking place-self: first baseline unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: center self-start]
+    expected: FAIL
+
+  [Checking place-self: first baseline flex-start]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end flex-end]
+    expected: FAIL
+
+  [Checking place-self: safe end center]
+    expected: FAIL
+
+  [Checking place-self: stretch first baseline]
+    expected: FAIL
+
+  [Checking place-self: auto safe end]
+    expected: FAIL
+
+  [Checking place-self: start first baseline]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end first baseline]
+    expected: FAIL
+
+  [Checking place-self: start flex-start]
+    expected: FAIL
+
+  [Checking place-self: auto right]
+    expected: FAIL
+
+  [Checking place-self: safe end last baseline]
+    expected: FAIL
+
+  [Checking place-self: normal start]
+    expected: FAIL
+
+  [Checking place-self: self-end last baseline]
+    expected: FAIL
+
+  [Checking place-self: unsafe end unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start center]
+    expected: FAIL
+
+  [Checking place-self: auto normal]
+    expected: FAIL
+
+  [Checking place-self: safe center self-end]
+    expected: FAIL
+
+  [Checking place-self: end safe end]
+    expected: FAIL
+
+  [Checking place-self: auto stretch]
+    expected: FAIL
+
+  [Checking place-self: normal self-start]
+    expected: FAIL
+
+  [Checking place-self: self-start baseline]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: flex-end last baseline]
+    expected: FAIL
+
+  [Checking place-self: auto start]
+    expected: FAIL
+
+  [Checking place-self: flex-end first baseline]
+    expected: FAIL
+
+  [Checking place-self: center stretch]
+    expected: FAIL
+
+  [Checking place-self: unsafe end safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: last baseline right]
+    expected: FAIL
+
+  [Checking place-self: flex-start stretch]
+    expected: FAIL
+
+  [Checking place-self: unsafe end start]
+    expected: FAIL
+
+  [Checking place-self: safe center end]
+    expected: FAIL
+
+  [Checking place-self: stretch stretch]
+    expected: FAIL
+
+  [Checking place-self: flex-start last baseline]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end normal]
+    expected: FAIL
+
+  [Checking place-self: center auto]
+    expected: FAIL
+
+  [Checking place-self: end self-start]
+    expected: FAIL
+
+  [Checking place-self: normal unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: start self-end]
+    expected: FAIL
+
+  [Checking place-self: normal center]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start first baseline]
+    expected: FAIL
+
+  [Checking place-self: auto self-end]
+    expected: FAIL
+
+  [Checking place-self: flex-end center]
+    expected: FAIL
+
+  [Checking place-self: unsafe end baseline]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start auto]
+    expected: FAIL
+
+  [Checking place-self: first baseline safe center]
+    expected: FAIL
+
+  [Checking place-self: stretch auto]
+    expected: FAIL
+
+  [Checking place-self: safe center safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: self-end flex-start]
+    expected: FAIL
+
+  [Checking place-self: center unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: self-start end]
+    expected: FAIL
+
+  [Checking place-self: flex-end normal]
+    expected: FAIL
+
+  [Checking place-self: end self-end]
+    expected: FAIL
+
+  [Checking place-self: safe center auto]
+    expected: FAIL
+
+  [Checking place-self: safe end self-start]
+    expected: FAIL
+
+  [Checking place-self: safe center unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: end first baseline]
+    expected: FAIL
+
+  [Checking place-self: stretch normal]
+    expected: FAIL
+
+  [Checking place-self: self-end first baseline]
+    expected: FAIL
+
+  [Checking place-self: safe end safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end safe center]
+    expected: FAIL
+
+  [Checking place-self: flex-start safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: start normal]
+    expected: FAIL
+
+  [Checking place-self: safe center baseline]
+    expected: FAIL
+
+  [Checking place-self: baseline flex-end]
+    expected: FAIL
+
+  [Checking place-self: safe center self-start]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end left]
+    expected: FAIL
+
+  [Checking place-self: flex-start unsafe end]
+    expected: FAIL
+
+  [Checking place-self: end start]
+    expected: FAIL
+
+  [Checking place-self: flex-end baseline]
+    expected: FAIL
+
+  [Checking place-self: safe end start]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start end]
+    expected: FAIL
+
+  [Checking place-self: self-start right]
+    expected: FAIL
+
+  [Checking place-self: safe center first baseline]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end self-start]
+    expected: FAIL
+
+  [Checking place-self: end center]
+    expected: FAIL
+
+  [Checking place-self: baseline first baseline]
+    expected: FAIL
+
+  [Checking place-self: safe end unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: first baseline baseline]
+    expected: FAIL
+
+  [Checking place-self: last baseline auto]
+    expected: FAIL
+
+  [Checking place-self: flex-end flex-end]
+    expected: FAIL
+
+  [Checking place-self: first baseline self-start]
+    expected: FAIL
+
+  [Checking place-self: safe center flex-start]
+    expected: FAIL
+
+  [Checking place-self: self-start self-end]
+    expected: FAIL
+
+  [Checking place-self: last baseline self-end]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end self-end]
+    expected: FAIL
+
+  [Checking place-self: first baseline auto]
+    expected: FAIL
+
+  [Checking place-self: start auto]
+    expected: FAIL
+
+  [Checking place-self: center unsafe end]
+    expected: FAIL
+
+  [Checking place-self: self-end right]
+    expected: FAIL
+
+  [Checking place-self: center safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: stretch unsafe end]
+    expected: FAIL
+
+  [Checking place-self: last baseline flex-start]
+    expected: FAIL
+
+  [Checking place-self: normal right]
+    expected: FAIL
+
+  [Checking place-self: auto center]
+    expected: FAIL
+
+  [Checking place-self: last baseline baseline]
+    expected: FAIL
+
+  [Checking place-self: first baseline first baseline]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: end safe center]
+    expected: FAIL
+
+  [Checking place-self: flex-end safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: self-start center]
+    expected: FAIL
+
+  [Checking place-self: baseline last baseline]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start self-start]
+    expected: FAIL
+
+  [Checking place-self: end normal]
+    expected: FAIL
+
+  [Checking place-self: self-start unsafe end]
+    expected: FAIL
+
+  [Checking place-self: auto unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: flex-start right]
+    expected: FAIL
+
+  [Checking place-self: baseline left]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start normal]
+    expected: FAIL
+
+  [Checking place-self: safe center flex-end]
+    expected: FAIL
+
+  [Checking place-self: unsafe end self-end]
+    expected: FAIL
+
+  [Checking place-self: last baseline safe end]
+    expected: FAIL
+
+  [Checking place-self: flex-start flex-start]
+    expected: FAIL
+
+  [Checking place-self: self-start flex-start]
+    expected: FAIL
+
+  [Checking place-self: end left]
+    expected: FAIL
+
+  [Checking place-self: end last baseline]
+    expected: FAIL
+
+  [Checking place-self: baseline flex-start]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start right]
+    expected: FAIL
+
+  [Checking place-self: stretch center]
+    expected: FAIL
+
+  [Checking place-self: unsafe end right]
+    expected: FAIL
+
+  [Checking place-self: flex-start unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: first baseline start]
+    expected: FAIL
+
+  [Checking place-self: flex-end unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: last baseline last baseline]
+    expected: FAIL
+
+  [Checking place-self: normal safe center]
+    expected: FAIL
+
+  [Checking place-self: last baseline left]
+    expected: FAIL
+
+  [Checking place-self: auto left]
+    expected: FAIL
+
+  [Checking place-self: start unsafe end]
+    expected: FAIL
+
+  [Checking place-self: start self-start]
+    expected: FAIL
+
+  [Checking place-self: unsafe end stretch]
+    expected: FAIL
+
+  [Checking place-self: auto last baseline]
+    expected: FAIL
+
+  [Checking place-self: self-end unsafe end]
+    expected: FAIL
+
+  [Checking place-self: end flex-start]
+    expected: FAIL
+
+  [Checking place-self: last baseline end]
+    expected: FAIL
+
+  [Checking place-self: self-end baseline]
+    expected: FAIL
+
+  [Checking place-self: baseline safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: stretch flex-end]
+    expected: FAIL
+
+  [Checking place-self: flex-end left]
+    expected: FAIL
+
+  [Checking place-self: self-start auto]
+    expected: FAIL
+
+  [Checking place-self: end auto]
+    expected: FAIL
+
+  [Checking place-self: flex-start normal]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start safe end]
+    expected: FAIL
+
+  [Checking place-self: stretch baseline]
+    expected: FAIL
+
+  [Checking place-self: self-start self-start]
+    expected: FAIL
+
+  [Checking place-self: safe center last baseline]
+    expected: FAIL
+
+  [Checking place-self: start safe center]
+    expected: FAIL
+
+  [Checking place-self: flex-start self-end]
+    expected: FAIL
+
+  [Checking place-self: baseline self-end]
+    expected: FAIL
+
+  [Checking place-self: normal baseline]
+    expected: FAIL
+
+  [Checking place-self: safe center unsafe end]
+    expected: FAIL
+
+  [Checking place-self: end end]
+    expected: FAIL
+
+  [Checking place-self: self-end flex-end]
+    expected: FAIL
+
+  [Checking place-self: last baseline safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start stretch]
+    expected: FAIL
+
+  [Checking place-self: auto safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: self-start safe end]
+    expected: FAIL
+
+  [Checking place-self: safe end unsafe end]
+    expected: FAIL
+
+  [Checking place-self: baseline unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: safe center normal]
+    expected: FAIL
+
+  [Checking place-self: unsafe end normal]
+    expected: FAIL
+
+  [Checking place-self: safe end stretch]
+    expected: FAIL
+
+  [Checking place-self: unsafe end first baseline]
+    expected: FAIL
+
+  [Checking place-self: auto safe center]
+    expected: FAIL
+
+  [Checking place-self: self-end center]
+    expected: FAIL
+
+  [Checking place-self: end flex-end]
+    expected: FAIL
+
+  [Checking place-self: first baseline unsafe end]
+    expected: FAIL
+
+  [Checking place-self: stretch end]
+    expected: FAIL
+
+  [Checking place-self: self-end unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: safe center start]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end center]
+    expected: FAIL
+
+  [Checking place-self: last baseline first baseline]
+    expected: FAIL
+
+  [Checking place-self: normal last baseline]
+    expected: FAIL
+
+  [Checking place-self: unsafe end auto]
+    expected: FAIL
+
+  [Checking place-self: flex-start flex-end]
+    expected: FAIL
+
+  [Checking place-self: safe end auto]
+    expected: FAIL
+
+  [Checking place-self: first baseline safe end]
+    expected: FAIL
+
+  [Checking place-self: self-end normal]
+    expected: FAIL
+
+  [Checking place-self: first baseline right]
+    expected: FAIL
+
+  [Checking place-self: end right]
+    expected: FAIL
+
+  [Checking place-self: normal stretch]
+    expected: FAIL
+
+  [Checking place-self: end unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: auto flex-start]
+    expected: FAIL
+
+  [Checking place-self: unsafe end safe end]
+    expected: FAIL
+
+  [Checking place-self: safe end left]
+    expected: FAIL
+
+  [Checking place-self: center center]
+    expected: FAIL
+
+  [Checking place-self: self-start left]
+    expected: FAIL
+
+  [Checking place-self: safe end normal]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end baseline]
+    expected: FAIL
+
+  [Checking place-self: flex-start center]
+    expected: FAIL
+
+  [Checking place-self: flex-start auto]
+    expected: FAIL
+
+  [Checking place-self: last baseline center]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start flex-start]
+    expected: FAIL
+
+  [Checking place-self: flex-start safe center]
+    expected: FAIL
+
+  [Checking place-self: center right]
+    expected: FAIL
+
+  [Checking place-self: center baseline]
+    expected: FAIL
+
+  [Checking place-self: start right]
+    expected: FAIL
+
+  [Checking place-self: baseline safe end]
+    expected: FAIL
+
+  [Checking place-self: center left]
+    expected: FAIL
+
+  [Checking place-self: start safe end]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end end]
+    expected: FAIL
+
+  [Checking place-self: flex-end unsafe end]
+    expected: FAIL
+
+  [Checking place-self: last baseline normal]
+    expected: FAIL
+
+  [Checking place-self: first baseline normal]
+    expected: FAIL
+
+  [Checking place-self: end stretch]
+    expected: FAIL
+
+  [Checking place-self: normal self-end]
+    expected: FAIL
+
+  [Checking place-self: flex-end start]
+    expected: FAIL
+
+  [Checking place-self: stretch right]
+    expected: FAIL
+
+  [Checking place-self: normal normal]
+    expected: FAIL
+
+  [Checking place-self: unsafe end self-start]
+    expected: FAIL
+
+  [Checking place-self: unsafe end left]
+    expected: FAIL
+
+  [Checking place-self: center self-end]
+    expected: FAIL
+
+  [Checking place-self: baseline center]
+    expected: FAIL
+
+  [Checking place-self: center normal]
+    expected: FAIL
+
+  [Checking place-self: start flex-end]
+    expected: FAIL
+
+  [Checking place-self: self-end end]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end start]
+    expected: FAIL
+
+  [Checking place-self: flex-start first baseline]
+    expected: FAIL
+
+  [Checking place-self: flex-end self-start]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end unsafe end]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: safe flex-end safe end]
+    expected: FAIL
+
+  [Checking place-self: baseline normal]
+    expected: FAIL
+
+  [Checking place-self: normal unsafe end]
+    expected: FAIL
+
+  [Checking place-self: stretch safe center]
+    expected: FAIL
+
+  [Checking place-self: auto flex-end]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start unsafe end]
+    expected: FAIL
+
+  [Checking place-self: first baseline left]
+    expected: FAIL
+
+  [Checking place-self: self-end safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: self-start flex-end]
+    expected: FAIL
+
+  [Checking place-self: safe center center]
+    expected: FAIL
+
+  [Checking place-self: last baseline flex-end]
+    expected: FAIL
+
+  [Checking place-self: normal first baseline]
+    expected: FAIL
+
+  [Checking place-self: baseline end]
+    expected: FAIL
+
+  [Checking place-self: self-end start]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start flex-end]
+    expected: FAIL
+
+  [Checking place-self: last baseline unsafe flex-start]
+    expected: FAIL
+
+  [Checking place-self: stretch safe flex-end]
+    expected: FAIL
+
+  [Checking place-self: baseline stretch]
+    expected: FAIL
+
+  [Checking place-self: center flex-start]
+    expected: FAIL
+
+  [Checking place-self: start start]
+    expected: FAIL
+
+  [Checking place-self: center safe end]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start start]
+    expected: FAIL
+
+  [Checking place-self: self-end left]
+    expected: FAIL
+
+  [Checking place-self: unsafe end safe center]
+    expected: FAIL
+
+  [Checking place-self: unsafe flex-start last baseline]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/place-self-shorthand-003.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/place-self-shorthand-003.html.ini
@@ -1,0 +1,7 @@
+[place-self-shorthand-003.html]
+  [Check place-self: initial - align-self expanded value]
+    expected: FAIL
+
+  [Check place-self: initial - justify-self expanded value]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/place-self-shorthand-004.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/place-self-shorthand-004.html.ini
@@ -1,0 +1,13 @@
+[place-self-shorthand-004.html]
+  [Verify empty declaration is invalid]
+    expected: FAIL
+
+  [Verify fallback values are invalid]
+    expected: FAIL
+
+  [Verify numeric values are invalid]
+    expected: FAIL
+
+  [Verify 'left' and 'right' values are invalid for block/cross axis alignment]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/place-self-shorthand-005.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/place-self-shorthand-005.html.ini
@@ -1,0 +1,7 @@
+[place-self-shorthand-005.html]
+  [Check place-self: inherit - align-self resolved value]
+    expected: FAIL
+
+  [Check place-self: inherit - justify-self resolved value]
+    expected: FAIL
+

--- a/tests/wpt/metadata/css/css-align/self-alignment/place-self-shorthand-006.html.ini
+++ b/tests/wpt/metadata/css/css-align/self-alignment/place-self-shorthand-006.html.ini
@@ -1,0 +1,118 @@
+[place-self-shorthand-006.html]
+  [Checking place-self: first baseline stretch]
+    expected: FAIL
+
+  [Checking place-self: self-start self-start]
+    expected: FAIL
+
+  [Checking place-self: auto first baseline]
+    expected: FAIL
+
+  [Checking place-self: end first baseline]
+    expected: FAIL
+
+  [Checking place-self: first baseline self-end]
+    expected: FAIL
+
+  [Checking place-self: first baseline center]
+    expected: FAIL
+
+  [Checking place-self: baseline baseline]
+    expected: FAIL
+
+  [Checking place-self: first baseline right]
+    expected: FAIL
+
+  [Checking place-self: last baseline first baseline]
+    expected: FAIL
+
+  [Checking place-self: flex-end flex-end]
+    expected: FAIL
+
+  [Checking place-self: first baseline self-start]
+    expected: FAIL
+
+  [Checking place-self: first baseline end]
+    expected: FAIL
+
+  [Checking place-self: center center]
+    expected: FAIL
+
+  [Checking place-self: first baseline flex-end]
+    expected: FAIL
+
+  [Checking place-self: stretch first baseline]
+    expected: FAIL
+
+  [Checking place-self: start first baseline]
+    expected: FAIL
+
+  [Checking place-self: first baseline auto]
+    expected: FAIL
+
+  [Checking place-self: first baseline first baseline]
+    expected: FAIL
+
+  [Checking place-self: first baseline normal]
+    expected: FAIL
+
+  [Checking place-self: normal normal]
+    expected: FAIL
+
+  [Checking place-self: baseline first baseline]
+    expected: FAIL
+
+  [Checking place-self: self-end first baseline]
+    expected: FAIL
+
+  [Checking place-self: center first baseline]
+    expected: FAIL
+
+  [Checking place-self: first baseline baseline]
+    expected: FAIL
+
+  [Checking place-self: flex-start flex-start]
+    expected: FAIL
+
+  [Checking place-self: flex-start first baseline]
+    expected: FAIL
+
+  [Checking place-self: flex-end first baseline]
+    expected: FAIL
+
+  [Checking place-self: first baseline start]
+    expected: FAIL
+
+  [Checking place-self: last baseline last baseline]
+    expected: FAIL
+
+  [Checking place-self: auto auto]
+    expected: FAIL
+
+  [Checking place-self: first baseline left]
+    expected: FAIL
+
+  [Checking place-self: stretch stretch]
+    expected: FAIL
+
+  [Checking place-self: normal first baseline]
+    expected: FAIL
+
+  [Checking place-self: self-end self-end]
+    expected: FAIL
+
+  [Checking place-self: self-start first baseline]
+    expected: FAIL
+
+  [Checking place-self: start start]
+    expected: FAIL
+
+  [Checking place-self: first baseline flex-start]
+    expected: FAIL
+
+  [Checking place-self: first baseline last baseline]
+    expected: FAIL
+
+  [Checking place-self: end end]
+    expected: FAIL
+


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Enabled `css-align` wpt tests.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #20576

<!-- Either: -->
- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23186)
<!-- Reviewable:end -->
