### PR TITLE
Do not unwrap empty unminified_js_dir in HTMLScriptElement.unminify_js.

### DIFF
--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -560,7 +560,7 @@ impl HTMLScriptElement {
         match window_from_node(self).unminified_js_dir() {
             Some(unminified_js_dir) => path = PathBuf::from(unminified_js_dir),
             None => {
-                warn!("Could not store script directory not found");
+                warn!("Unminified script directory not found");
                 return;
             },
         }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -556,7 +556,15 @@ impl HTMLScriptElement {
             },
         }
 
-        let path = PathBuf::from(window_from_node(self).unminified_js_dir().unwrap());
+        let path;
+        match window_from_node(self).unminified_js_dir() {
+            Some(unminified_js_dir) => path = PathBuf::from(unminified_js_dir),
+            None => {
+                warn!("Could not store script directory not found");
+                return;
+            },
+        }
+
         let path = if script.external {
             // External script.
             let path_parts = script.url.path_segments().unwrap();


### PR DESCRIPTION
Calling unwrap caused a panic when a directory could not be created.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23031

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23187)
<!-- Reviewable:end -->
