### PR TITLE
Implement DocumentFragment XML serialization.

### DIFF
--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::characterdata::CharacterData;
 use crate::dom::document::Document;
+use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documenttype::DocumentType;
 use crate::dom::element::Element;
 use crate::dom::htmlscriptelement::HTMLScriptElement;
@@ -166,7 +167,7 @@ fn rev_children_iter(n: &Node) -> impl Iterator<Item = DomRoot<Node>> {
 impl SerializationIterator {
     fn new(node: &Node, skip_first: bool) -> SerializationIterator {
         let mut ret = SerializationIterator { stack: vec![] };
-        if skip_first {
+        if skip_first || node.is::<DocumentFragment>() {
             for c in rev_children_iter(node) {
                 ret.push_node(&*c);
             }

--- a/tests/wpt/web-platform-tests/domparsing/XMLSerializer-serializeToString.html
+++ b/tests/wpt/web-platform-tests/domparsing/XMLSerializer-serializeToString.html
@@ -204,6 +204,14 @@ test(function() {
   assert_equals(serialize(root2), '<root xmlns:xl="http://www.w3.org/1999/xlink" xl:type="v"/>');
 }, 'Check if no special handling for XLink namespace unlike HTML serializer.');
 
+test(function() {
+  var root = new DocumentFragment;
+  root.append(document.createElement('div'));
+  root.append(document.createElement('span'));
+  assert_equals(serialize(root), '<div xmlns="http://www.w3.org/1999/xhtml"></div><span xmlns="http://www.w3.org/1999/xhtml"></span>');
+}, 'Check if document fragment serializes.');
+
+
 </script>
  </body>
 </html>


### PR DESCRIPTION
When serializing a DocumentFragment node, we should follow [this guy](https://w3c.github.io/DOM-Parsing/#dfn-xml-serializing-a-documentfragment-node) and serialize the node's immediate children. This commit makes that change.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] These changes fix #23134 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___ well, they probably do, but I don't know how to do that and could use some help.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23192)
<!-- Reviewable:end -->
