### PR TITLE
Remove :-servo-case-sensitive-type-attr()

### DIFF
--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -817,9 +817,6 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
                     _ => true,
                 }
             },
-            NonTSPseudoClass::ServoCaseSensitiveTypeAttr(ref expected_value) => self
-                .get_attr_enum(&ns!(), &local_name!("type"))
-                .map_or(false, |attr| attr == expected_value),
             NonTSPseudoClass::ReadOnly => !self
                 .element
                 .get_state_for_layout()

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2889,10 +2889,6 @@ impl<'a> SelectorsElement for DomRoot<Element> {
                 },
             },
 
-            NonTSPseudoClass::ServoCaseSensitiveTypeAttr(ref expected_value) => self
-                .get_attribute(&ns!(), &local_name!("type"))
-                .map_or(false, |attr| attr.value().eq(expected_value)),
-
             // FIXME(heycam): This is wrong, since extended_filtering accepts
             // a string containing commas (separating each language tag in
             // a list) but the pseudo-class instead should be parsing and

--- a/resources/presentational-hints.css
+++ b/resources/presentational-hints.css
@@ -19,14 +19,10 @@ br[clear=all i], br[clear=both i] { clear: both; }
 
 
 ol[type="1"], li[type="1"] { list-style-type: decimal; }
-ol:-servo-case-sensitive-type-attr(a),
-li:-servo-case-sensitive-type-attr(a) { list-style-type: lower-alpha; }
-ol:-servo-case-sensitive-type-attr(A),
-li:-servo-case-sensitive-type-attr(A) { list-style-type: upper-alpha; }
-ol:-servo-case-sensitive-type-attr(i),
-li:-servo-case-sensitive-type-attr(i) { list-style-type: lower-roman; }
-ol:-servo-case-sensitive-type-attr(I),
-li:-servo-case-sensitive-type-attr(I) { list-style-type: upper-roman; }
+ol[type=a s], li[type=a s] { list-style-type: lower-alpha; }
+ol[type=A s], li[type=A s] { list-style-type: upper-alpha; }
+ol[type=i s], li[type=i s] { list-style-type: lower-roman; }
+ol[type=I s], li[type=I s] { list-style-type: upper-roman; }
 ul[type=none i], li[type=none i] { list-style-type: none; }
 ul[type=disc i], li[type=disc i] { list-style-type: disc; }
 ul[type=circle i], li[type=circle i] { list-style-type: circle; }


### PR DESCRIPTION
No longer needed now that the case-sensitive flag for attributes selectors is
supported.
Update user-agent CSS sheet to use the standard flag.

Mostly just a (manual) backout of 7149a6a29de6d1c351eedf1404369aa5f9efbd09.

(7149a6a29de6d1c351eedf1404369aa5f9efbd09 also implemented PartialEq for AttrValue which I've left for now:) https://github.com/servo/servo/blob/7149a6a29de6d1c351eedf1404369aa5f9efbd09/components/style/attr.rs#L382-L389

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23227
- [x] There are tests for these changes (wpt html/rendering/non-replaced-elements/lists)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23228)
<!-- Reviewable:end -->
