### PR TITLE
Refactor promise compartment

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -54,7 +54,7 @@ pub fn consume_body<T: BodyOperations + DomObject>(object: &T, body_type: BodyTy
     let in_compartment_proof = AlreadyInCompartment::assert(&object.global());
     let promise = Promise::new_in_current_compartment(
         &object.global(),
-        &InCompartment::Already(&in_compartment_proof),
+        InCompartment::Already(&in_compartment_proof),
     );
 
     // Step 1

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::codegen::Bindings::FormDataBinding::FormDataMethods;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::DomObject;
@@ -49,9 +50,12 @@ pub enum FetchedData {
 
 // https://fetch.spec.whatwg.org/#concept-body-consume-body
 #[allow(unrooted_must_root)]
-#[allow(unsafe_code)]
 pub fn consume_body<T: BodyOperations + DomObject>(object: &T, body_type: BodyType) -> Rc<Promise> {
-    let promise = unsafe { Promise::new_in_current_compartment(&object.global()) };
+    let in_compartment_proof = AlreadyInCompartment::assert(&object.global());
+    let promise = Promise::new_in_current_compartment(
+        &object.global(),
+        &InCompartment::Already(&in_compartment_proof),
+    );
 
     // Step 1
     if object.get_body_used() || object.is_locked() {

--- a/components/script/compartments.rs
+++ b/components/script/compartments.rs
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::globalscope::GlobalScope;
+use js::jsapi::{GetCurrentRealmOrNull, JSAutoCompartment};
+
+pub struct AlreadyInCompartment(());
+
+impl AlreadyInCompartment {
+    #![allow(unsafe_code)]
+    pub fn assert(global: &GlobalScope) -> AlreadyInCompartment {
+        unsafe {
+            assert!(!GetCurrentRealmOrNull(global.get_cx()).is_null());
+        }
+        AlreadyInCompartment(())
+    }
+}
+
+pub enum InCompartment<'a> {
+    Already(&'a AlreadyInCompartment),
+    Entered(&'a JSAutoCompartment),
+}
+
+impl<'a> InCompartment<'a> {
+    pub fn in_compartment(token: &AlreadyInCompartment) -> InCompartment {
+        InCompartment::Already(token)
+    }
+
+    pub fn entered(token: &JSAutoCompartment) -> InCompartment {
+        InCompartment::Entered(token)
+    }
+}

--- a/components/script/compartments.rs
+++ b/components/script/compartments.rs
@@ -17,6 +17,7 @@ impl AlreadyInCompartment {
     }
 }
 
+#[derive(Clone, Copy)]
 pub enum InCompartment<'a> {
     Already(&'a AlreadyInCompartment),
     Entered(&'a JSAutoCompartment),

--- a/components/script/dom/audiocontext.rs
+++ b/components/script/dom/audiocontext.rs
@@ -113,7 +113,7 @@ impl AudioContextMethods for AudioContext {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let promise = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
 
         // Step 2.
@@ -178,7 +178,7 @@ impl AudioContextMethods for AudioContext {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let promise = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
 
         // Step 2.

--- a/components/script/dom/audiocontext.rs
+++ b/components/script/dom/audiocontext.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::baseaudiocontext::{BaseAudioContext, BaseAudioContextOptions};
 use crate::dom::bindings::codegen::Bindings::AudioContextBinding;
 use crate::dom::bindings::codegen::Bindings::AudioContextBinding::{
@@ -107,10 +108,13 @@ impl AudioContextMethods for AudioContext {
     }
 
     // https://webaudio.github.io/web-audio-api/#dom-audiocontext-suspend
-    #[allow(unsafe_code)]
     fn Suspend(&self) -> Rc<Promise> {
         // Step 1.
-        let promise = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let promise = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
 
         // Step 2.
         if self.context.control_thread_state() == ProcessingState::Closed {
@@ -169,10 +173,13 @@ impl AudioContextMethods for AudioContext {
     }
 
     // https://webaudio.github.io/web-audio-api/#dom-audiocontext-close
-    #[allow(unsafe_code)]
     fn Close(&self) -> Rc<Promise> {
         // Step 1.
-        let promise = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let promise = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
 
         // Step 2.
         if self.context.control_thread_state() == ProcessingState::Closed {

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -277,7 +277,7 @@ impl BaseAudioContextMethods for BaseAudioContext {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let promise = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
 
         // Step 2.
@@ -418,7 +418,7 @@ impl BaseAudioContextMethods for BaseAudioContext {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let promise = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         let global = self.global();
         let window = global.as_window();

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::analysernode::AnalyserNode;
 use crate::dom::audiobuffer::AudioBuffer;
 use crate::dom::audiobuffersourcenode::AudioBufferSourceNode;
@@ -271,10 +272,13 @@ impl BaseAudioContextMethods for BaseAudioContext {
     }
 
     /// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-resume
-    #[allow(unsafe_code)]
     fn Resume(&self) -> Rc<Promise> {
         // Step 1.
-        let promise = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let promise = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
 
         // Step 2.
         if self.audio_context_impl.state() == ProcessingState::Closed {
@@ -404,7 +408,6 @@ impl BaseAudioContextMethods for BaseAudioContext {
     }
 
     // https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-decodeaudiodata
-    #[allow(unsafe_code)]
     fn DecodeAudioData(
         &self,
         audio_data: CustomAutoRooterGuard<ArrayBuffer>,
@@ -412,7 +415,11 @@ impl BaseAudioContextMethods for BaseAudioContext {
         decode_error_callback: Option<Rc<DecodeErrorCallback>>,
     ) -> Rc<Promise> {
         // Step 1.
-        let promise = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let promise = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         let global = self.global();
         let window = global.as_window();
 

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -295,7 +295,7 @@ where
     let in_compartment_proof = AlreadyInCompartment::assert(&attribute.global());
     let p = Promise::new_in_current_compartment(
         &attribute.global(),
-        &InCompartment::Already(&in_compartment_proof),
+        InCompartment::Already(&in_compartment_proof),
     );
 
     let result_uuid = if let Some(u) = uuid {
@@ -539,7 +539,7 @@ impl BluetoothMethods for Bluetooth {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         // Step 1.
         if (option.filters.is_some() && option.acceptAllDevices) ||
@@ -561,7 +561,7 @@ impl BluetoothMethods for Bluetooth {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         // Step 1. We did not override the method
         // Step 2 - 3. in handle_response

--- a/components/script/dom/bluetoothdevice.rs
+++ b/components/script/dom/bluetoothdevice.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothDeviceBinding;
 use crate::dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
@@ -277,9 +278,12 @@ impl BluetoothDeviceMethods for BluetoothDevice {
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-watchadvertisements
-    #[allow(unsafe_code)]
     fn WatchAdvertisements(&self) -> Rc<Promise> {
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         let sender = response_async(&p, self);
         // TODO: Step 1.
         // Note: Steps 2 - 3 are implemented in components/bluetooth/lib.rs in watch_advertisements function

--- a/components/script/dom/bluetoothdevice.rs
+++ b/components/script/dom/bluetoothdevice.rs
@@ -282,7 +282,7 @@ impl BluetoothDeviceMethods for BluetoothDevice {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         let sender = response_async(&p, self);
         // TODO: Step 1.

--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothCharacteristicPropertiesBinding::BluetoothCharacteristicPropertiesMethods;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTCharacteristicBinding;
@@ -134,9 +135,12 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-readvalue
-    #[allow(unsafe_code)]
     fn ReadValue(&self) -> Rc<Promise> {
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
 
         // Step 1.
         if uuid_is_blocklisted(self.uuid.as_ref(), Blocklist::Reads) {
@@ -168,9 +172,12 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-writevalue
-    #[allow(unsafe_code)]
     fn WriteValue(&self, value: ArrayBufferViewOrArrayBuffer) -> Rc<Promise> {
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
 
         // Step 1.
         if uuid_is_blocklisted(self.uuid.as_ref(), Blocklist::Writes) {
@@ -220,9 +227,12 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-startnotifications
-    #[allow(unsafe_code)]
     fn StartNotifications(&self) -> Rc<Promise> {
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
 
         // Step 1.
         if uuid_is_blocklisted(self.uuid.as_ref(), Blocklist::Reads) {
@@ -258,9 +268,12 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-stopnotifications
-    #[allow(unsafe_code)]
     fn StopNotifications(&self) -> Rc<Promise> {
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         let sender = response_async(&p, self);
 
         // TODO: Step 3 - 4: Implement `active notification context set` for BluetoothRemoteGATTCharacteristic,

--- a/components/script/dom/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetoothremotegattcharacteristic.rs
@@ -139,7 +139,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
 
         // Step 1.
@@ -176,7 +176,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
 
         // Step 1.
@@ -231,7 +231,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
 
         // Step 1.
@@ -272,7 +272,7 @@ impl BluetoothRemoteGATTCharacteristicMethods for BluetoothRemoteGATTCharacteris
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         let sender = response_async(&p, self);
 

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -98,7 +98,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
 
         // Step 1.
@@ -134,7 +134,7 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
 
         // Step 1.

--- a/components/script/dom/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetoothremotegattdescriptor.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTCharacteristicBinding::BluetoothRemoteGATTCharacteristicMethods;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTDescriptorBinding;
@@ -93,9 +94,12 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-readvalue
-    #[allow(unsafe_code)]
     fn ReadValue(&self) -> Rc<Promise> {
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
 
         // Step 1.
         if uuid_is_blocklisted(self.uuid.as_ref(), Blocklist::Reads) {
@@ -126,9 +130,12 @@ impl BluetoothRemoteGATTDescriptorMethods for BluetoothRemoteGATTDescriptor {
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattdescriptor-writevalue
-    #[allow(unsafe_code)]
     fn WriteValue(&self, value: ArrayBufferViewOrArrayBuffer) -> Rc<Promise> {
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
 
         // Step 1.
         if uuid_is_blocklisted(self.uuid.as_ref(), Blocklist::Writes) {

--- a/components/script/dom/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetoothremotegattserver.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
@@ -72,7 +73,11 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
     #[allow(unsafe_code)]
     fn Connect(&self) -> Rc<Promise> {
         // Step 1.
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         let sender = response_async(&p, self);
 
         // TODO: Step 3: Check if the UA is currently using the Bluetooth system.

--- a/components/script/dom/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetoothremotegattserver.rs
@@ -76,7 +76,7 @@ impl BluetoothRemoteGATTServerMethods for BluetoothRemoteGATTServer {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         let sender = response_async(&p, self);
 

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -409,7 +409,7 @@ impl CustomElementRegistryMethods for CustomElementRegistry {
             let in_compartment_proof = AlreadyInCompartment::assert(&global_scope);
             let promise = Promise::new_in_current_compartment(
                 &global_scope,
-                &InCompartment::Already(&in_compartment_proof),
+                InCompartment::Already(&in_compartment_proof),
             );
             promise.reject_native(&DOMException::new(&global_scope, DOMErrorName::SyntaxError));
             return promise;
@@ -420,7 +420,7 @@ impl CustomElementRegistryMethods for CustomElementRegistry {
             let in_compartment_proof = AlreadyInCompartment::assert(&global_scope);
             let promise = Promise::new_in_current_compartment(
                 &global_scope,
-                &InCompartment::Already(&in_compartment_proof),
+                InCompartment::Already(&in_compartment_proof),
             );
             promise.resolve_native(&UndefinedValue());
             return promise;
@@ -434,7 +434,7 @@ impl CustomElementRegistryMethods for CustomElementRegistry {
             let in_compartment_proof = AlreadyInCompartment::assert(&global_scope);
             let promise = Promise::new_in_current_compartment(
                 &global_scope,
-                &InCompartment::Already(&in_compartment_proof),
+                InCompartment::Already(&in_compartment_proof),
             );
             map.insert(name, promise.clone());
             promise

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::callback::{CallbackContainer, ExceptionHandling};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::CustomElementRegistryBinding;
@@ -399,21 +400,28 @@ impl CustomElementRegistryMethods for CustomElementRegistry {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-whendefined>
-    #[allow(unsafe_code)]
     fn WhenDefined(&self, name: DOMString) -> Rc<Promise> {
         let global_scope = self.window.upcast::<GlobalScope>();
         let name = LocalName::from(&*name);
 
         // Step 1
         if !is_valid_custom_element_name(&name) {
-            let promise = unsafe { Promise::new_in_current_compartment(global_scope) };
-            promise.reject_native(&DOMException::new(global_scope, DOMErrorName::SyntaxError));
+            let in_compartment_proof = AlreadyInCompartment::assert(&global_scope);
+            let promise = Promise::new_in_current_compartment(
+                &global_scope,
+                &InCompartment::Already(&in_compartment_proof),
+            );
+            promise.reject_native(&DOMException::new(&global_scope, DOMErrorName::SyntaxError));
             return promise;
         }
 
         // Step 2
         if self.definitions.borrow().contains_key(&name) {
-            let promise = unsafe { Promise::new_in_current_compartment(global_scope) };
+            let in_compartment_proof = AlreadyInCompartment::assert(&global_scope);
+            let promise = Promise::new_in_current_compartment(
+                &global_scope,
+                &InCompartment::Already(&in_compartment_proof),
+            );
             promise.resolve_native(&UndefinedValue());
             return promise;
         }
@@ -423,7 +431,11 @@ impl CustomElementRegistryMethods for CustomElementRegistry {
 
         // Steps 4, 5
         let promise = map.get(&name).cloned().unwrap_or_else(|| {
-            let promise = unsafe { Promise::new_in_current_compartment(global_scope) };
+            let in_compartment_proof = AlreadyInCompartment::assert(&global_scope);
+            let promise = Promise::new_in_current_compartment(
+                &global_scope,
+                &InCompartment::Already(&in_compartment_proof),
+            );
             map.insert(name, promise.clone());
             promise
         });

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3135,7 +3135,7 @@ impl Document {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let promise = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         let mut error = false;
 
@@ -3206,7 +3206,7 @@ impl Document {
         let in_compartment_proof = AlreadyInCompartment::assert(&global);
         let promise = Promise::new_in_current_compartment(
             &global,
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         // Step 2
         if self.fullscreen_element.get().is_none() {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::document_loader::{DocumentLoader, LoadType};
 use crate::dom::activation::{synthetic_click_activation, ActivationSource};
 use crate::dom::attr::Attr;
@@ -3129,10 +3130,13 @@ impl Document {
     }
 
     // https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen
-    #[allow(unsafe_code)]
     pub fn enter_fullscreen(&self, pending: &Element) -> Rc<Promise> {
         // Step 1
-        let promise = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let promise = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         let mut error = false;
 
         // Step 4
@@ -3196,11 +3200,14 @@ impl Document {
     }
 
     // https://fullscreen.spec.whatwg.org/#exit-fullscreen
-    #[allow(unsafe_code)]
     pub fn exit_fullscreen(&self) -> Rc<Promise> {
         let global = self.global();
         // Step 1
-        let promise = unsafe { Promise::new_in_current_compartment(&global) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&global);
+        let promise = Promise::new_in_current_compartment(
+            &global,
+            &InCompartment::Already(&in_compartment_proof),
+        );
         // Step 2
         if self.fullscreen_element.get().is_none() {
             promise.reject_error(Error::Type(String::from("fullscreen is null")));

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::document_loader::{LoadBlocker, LoadType};
 use crate::dom::attr::Attr;
 use crate::dom::audiotrack::AudioTrack;
@@ -1683,9 +1684,12 @@ impl HTMLMediaElementMethods for HTMLMediaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-media-play
-    #[allow(unsafe_code)]
     fn Play(&self) -> Rc<Promise> {
-        let promise = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let promise = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         // Step 1.
         // FIXME(nox): Reject promise if not allowed to play.
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1688,7 +1688,7 @@ impl HTMLMediaElementMethods for HTMLMediaElement {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let promise = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         // Step 1.
         // FIXME(nox): Reject promise if not allowed to play.

--- a/components/script/dom/mediadevices.rs
+++ b/components/script/dom/mediadevices.rs
@@ -48,7 +48,7 @@ impl MediaDevicesMethods for MediaDevices {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         let media = ServoMedia::get().unwrap();
         let mut tracks = vec![];

--- a/components/script/dom/navigationpreloadmanager.rs
+++ b/components/script/dom/navigationpreloadmanager.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::codegen::Bindings::NavigationPreloadManagerBinding::NavigationPreloadState;
 use crate::dom::bindings::codegen::Bindings::NavigationPreloadManagerBinding::{
     NavigationPreloadManagerMethods, Wrap,
@@ -43,9 +44,12 @@ impl NavigationPreloadManager {
 
 impl NavigationPreloadManagerMethods for NavigationPreloadManager {
     // https://w3c.github.io/ServiceWorker/#navigation-preload-manager-enable
-    #[allow(unsafe_code)]
     fn Enable(&self) -> Rc<Promise> {
-        let promise = unsafe { Promise::new_in_current_compartment(&*self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&*self.global());
+        let promise = Promise::new_in_current_compartment(
+            &*self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
 
         // 2.
         if self.serviceworker_registration.active().is_none() {
@@ -66,9 +70,12 @@ impl NavigationPreloadManagerMethods for NavigationPreloadManager {
     }
 
     // https://w3c.github.io/ServiceWorker/#navigation-preload-manager-disable
-    #[allow(unsafe_code)]
     fn Disable(&self) -> Rc<Promise> {
-        let promise = unsafe { Promise::new_in_current_compartment(&*self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&*self.global());
+        let promise = Promise::new_in_current_compartment(
+            &*self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
 
         // 2.
         if self.serviceworker_registration.active().is_none() {
@@ -89,9 +96,12 @@ impl NavigationPreloadManagerMethods for NavigationPreloadManager {
     }
 
     // https://w3c.github.io/ServiceWorker/#navigation-preload-manager-setheadervalue
-    #[allow(unsafe_code)]
     fn SetHeaderValue(&self, value: ByteString) -> Rc<Promise> {
-        let promise = unsafe { Promise::new_in_current_compartment(&*self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&*self.global());
+        let promise = Promise::new_in_current_compartment(
+            &*self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
 
         // 2.
         if self.serviceworker_registration.active().is_none() {
@@ -112,9 +122,12 @@ impl NavigationPreloadManagerMethods for NavigationPreloadManager {
     }
 
     // https://w3c.github.io/ServiceWorker/#navigation-preload-manager-getstate
-    #[allow(unsafe_code)]
     fn GetState(&self) -> Rc<Promise> {
-        let promise = unsafe { Promise::new_in_current_compartment(&*self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&*self.global());
+        let promise = Promise::new_in_current_compartment(
+            &*self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         // 2.
         let mut state = NavigationPreloadState::empty();
 

--- a/components/script/dom/navigationpreloadmanager.rs
+++ b/components/script/dom/navigationpreloadmanager.rs
@@ -48,7 +48,7 @@ impl NavigationPreloadManagerMethods for NavigationPreloadManager {
         let in_compartment_proof = AlreadyInCompartment::assert(&*self.global());
         let promise = Promise::new_in_current_compartment(
             &*self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
 
         // 2.
@@ -74,7 +74,7 @@ impl NavigationPreloadManagerMethods for NavigationPreloadManager {
         let in_compartment_proof = AlreadyInCompartment::assert(&*self.global());
         let promise = Promise::new_in_current_compartment(
             &*self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
 
         // 2.
@@ -100,7 +100,7 @@ impl NavigationPreloadManagerMethods for NavigationPreloadManager {
         let in_compartment_proof = AlreadyInCompartment::assert(&*self.global());
         let promise = Promise::new_in_current_compartment(
             &*self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
 
         // 2.
@@ -126,7 +126,7 @@ impl NavigationPreloadManagerMethods for NavigationPreloadManager {
         let in_compartment_proof = AlreadyInCompartment::assert(&*self.global());
         let promise = Promise::new_in_current_compartment(
             &*self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         // 2.
         let mut state = NavigationPreloadState::empty();

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -155,7 +155,7 @@ impl NavigatorMethods for Navigator {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let promise = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         let displays = self.Xr().get_displays();
         match displays {

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding;
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorMethods;
 use crate::dom::bindings::error::Error;
@@ -150,9 +151,12 @@ impl NavigatorMethods for Navigator {
     }
 
     // https://w3c.github.io/webvr/spec/1.1/#navigator-getvrdisplays-attribute
-    #[allow(unsafe_code)]
     fn GetVRDisplays(&self) -> Rc<Promise> {
-        let promise = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let promise = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         let displays = self.Xr().get_displays();
         match displays {
             Ok(displays) => promise.resolve_native(&displays),

--- a/components/script/dom/offlineaudiocontext.rs
+++ b/components/script/dom/offlineaudiocontext.rs
@@ -118,7 +118,7 @@ impl OfflineAudioContextMethods for OfflineAudioContext {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let promise = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         if self.rendering_started.get() {
             promise.reject_error(Error::InvalidState);

--- a/components/script/dom/offlineaudiocontext.rs
+++ b/components/script/dom/offlineaudiocontext.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::audiobuffer::{AudioBuffer, MAX_SAMPLE_RATE, MIN_SAMPLE_RATE};
 use crate::dom::audionode::MAX_CHANNEL_COUNT;
 use crate::dom::baseaudiocontext::{BaseAudioContext, BaseAudioContextOptions};
@@ -113,9 +114,12 @@ impl OfflineAudioContextMethods for OfflineAudioContext {
     }
 
     // https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-startrendering
-    #[allow(unsafe_code)]
     fn StartRendering(&self) -> Rc<Promise> {
-        let promise = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let promise = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         if self.rendering_started.get() {
             promise.reject_error(Error::InvalidState);
             return promise;

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -102,7 +102,7 @@ impl Permissions {
                 let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
                 Promise::new_in_current_compartment(
                     &self.global(),
-                    &InCompartment::Already(&in_compartment_proof),
+                    InCompartment::Already(&in_compartment_proof),
                 )
             },
         };

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -11,7 +11,7 @@
 //! native Promise values that refer to the same JS value yet are distinct native objects
 //! (ie. address equality for the native objects is meaningless).
 
-use crate::compartments::{AlreadyInCompartment, InCompartment};
+use crate::compartments::InCompartment;
 use crate::dom::bindings::conversions::root_from_object;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{DomObject, MutDomObject, Reflector};
@@ -81,8 +81,10 @@ impl Drop for Promise {
 
 impl Promise {
     pub fn new(global: &GlobalScope) -> Rc<Promise> {
-        let comp = AlreadyInCompartment::assert(&global);
-        Promise::new_in_current_compartment(global, InCompartment::Already(&comp))
+        let compartment =
+            JSAutoCompartment::new(global.get_cx(), global.reflector().get_jsobject().get());
+        let comp = InCompartment::Entered(&compartment);
+        Promise::new_in_current_compartment(global, comp)
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -11,7 +11,7 @@
 //! native Promise values that refer to the same JS value yet are distinct native objects
 //! (ie. address equality for the native objects is meaningless).
 
-use crate::compartments::InCompartment;
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::conversions::root_from_object;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{DomObject, MutDomObject, Reflector};
@@ -80,12 +80,13 @@ impl Drop for Promise {
 }
 
 impl Promise {
-    pub fn new(global: &GlobalScope, comp: &InCompartment) -> Rc<Promise> {
-        Promise::new_in_current_compartment(global, comp)
+    pub fn new(global: &GlobalScope) -> Rc<Promise> {
+        let comp = AlreadyInCompartment::assert(&global);
+        Promise::new_in_current_compartment(global, InCompartment::Already(&comp))
     }
 
     #[allow(unsafe_code)]
-    pub fn new_in_current_compartment(global: &GlobalScope, _comp: &InCompartment) -> Rc<Promise> {
+    pub fn new_in_current_compartment(global: &GlobalScope, _comp: InCompartment) -> Rc<Promise> {
         let cx = global.get_cx();
         rooted!(in(cx) let mut obj = ptr::null_mut::<JSObject>());
         unsafe {

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -11,6 +11,7 @@
 //! native Promise values that refer to the same JS value yet are distinct native objects
 //! (ie. address equality for the native objects is meaningless).
 
+use crate::compartments::InCompartment;
 use crate::dom::bindings::conversions::root_from_object;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{DomObject, MutDomObject, Reflector};
@@ -79,17 +80,18 @@ impl Drop for Promise {
 }
 
 impl Promise {
-    #[allow(unsafe_code)]
-    pub fn new(global: &GlobalScope, _comp: &JSAutoCompartment) -> Rc<Promise> {
-        unsafe { Promise::new_in_current_compartment(global) }
+    pub fn new(global: &GlobalScope, comp: &InCompartment) -> Rc<Promise> {
+        Promise::new_in_current_compartment(global, comp)
     }
 
     #[allow(unsafe_code)]
-    pub unsafe fn new_in_current_compartment(global: &GlobalScope) -> Rc<Promise> {
+    pub fn new_in_current_compartment(global: &GlobalScope, _comp: &InCompartment) -> Rc<Promise> {
         let cx = global.get_cx();
         rooted!(in(cx) let mut obj = ptr::null_mut::<JSObject>());
-        Promise::create_js_promise(cx, HandleObject::null(), obj.handle_mut());
-        Promise::new_with_js_promise(obj.handle(), cx)
+        unsafe {
+            Promise::create_js_promise(cx, HandleObject::null(), obj.handle_mut());
+            Promise::new_with_js_promise(obj.handle(), cx)
+        }
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::RTCIceCandidateBinding::RTCIceCandidateInit;
 use crate::dom::bindings::codegen::Bindings::RTCPeerConnectionBinding;
@@ -427,9 +428,12 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
     );
 
     /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-addicecandidate
-    #[allow(unsafe_code)]
     fn AddIceCandidate(&self, candidate: &RTCIceCandidateInit) -> Rc<Promise> {
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         if candidate.sdpMid.is_none() && candidate.sdpMLineIndex.is_none() {
             p.reject_error(Error::Type(format!(
                 "one of sdpMid and sdpMLineIndex must be set"
@@ -463,9 +467,12 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
     }
 
     /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-createoffer
-    #[allow(unsafe_code)]
     fn CreateOffer(&self, _options: &RTCOfferOptions) -> Rc<Promise> {
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         if self.closed.get() {
             p.reject_error(Error::InvalidState);
             return p;
@@ -476,9 +483,12 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
     }
 
     /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-createoffer
-    #[allow(unsafe_code)]
     fn CreateAnswer(&self, _options: &RTCAnswerOptions) -> Rc<Promise> {
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         if self.closed.get() {
             p.reject_error(Error::InvalidState);
             return p;
@@ -499,10 +509,13 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
     }
 
     /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-setlocaldescription
-    #[allow(unsafe_code)]
     fn SetLocalDescription(&self, desc: &RTCSessionDescriptionInit) -> Rc<Promise> {
         // XXXManishearth validate the current state
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         let this = Trusted::new(self);
         let desc: SessionDescription = desc.into();
         let trusted_promise = TrustedPromise::new(p.clone());
@@ -533,10 +546,13 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
     }
 
     /// https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-setremotedescription
-    #[allow(unsafe_code)]
     fn SetRemoteDescription(&self, desc: &RTCSessionDescriptionInit) -> Rc<Promise> {
         // XXXManishearth validate the current state
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         let this = Trusted::new(self);
         let desc: SessionDescription = desc.into();
         let trusted_promise = TrustedPromise::new(p.clone());

--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -432,7 +432,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         if candidate.sdpMid.is_none() && candidate.sdpMLineIndex.is_none() {
             p.reject_error(Error::Type(format!(
@@ -471,7 +471,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         if self.closed.get() {
             p.reject_error(Error::InvalidState);
@@ -487,7 +487,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         if self.closed.get() {
             p.reject_error(Error::InvalidState);
@@ -514,7 +514,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         let this = Trusted::new(self);
         let desc: SessionDescription = desc.into();
@@ -551,7 +551,7 @@ impl RTCPeerConnectionMethods for RTCPeerConnection {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         let this = Trusted::new(self);
         let desc: SessionDescription = desc.into();

--- a/components/script/dom/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworkercontainer.rs
@@ -60,7 +60,7 @@ impl ServiceWorkerContainerMethods for ServiceWorkerContainer {
         let in_compartment_proof = AlreadyInCompartment::assert(&*self.global());
         let promise = Promise::new_in_current_compartment(
             &*self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         let USVString(ref script_url) = script_url;
         let api_base_url = self.global().api_base_url();

--- a/components/script/dom/serviceworkercontainer.rs
+++ b/components/script/dom/serviceworkercontainer.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::codegen::Bindings::ServiceWorkerContainerBinding::RegistrationOptions;
 use crate::dom::bindings::codegen::Bindings::ServiceWorkerContainerBinding::{
     ServiceWorkerContainerMethods, Wrap,
@@ -54,10 +55,13 @@ impl ServiceWorkerContainerMethods for ServiceWorkerContainer {
     #[allow(unrooted_must_root)] // Job is unrooted
     /// https://w3c.github.io/ServiceWorker/#service-worker-container-register-method and - A
     /// https://w3c.github.io/ServiceWorker/#start-register-algorithm - B
-    #[allow(unsafe_code)]
     fn Register(&self, script_url: USVString, options: &RegistrationOptions) -> Rc<Promise> {
         // A: Step 1
-        let promise = unsafe { Promise::new_in_current_compartment(&*self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&*self.global());
+        let promise = Promise::new_in_current_compartment(
+            &*self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         let USVString(ref script_url) = script_url;
         let api_base_url = self.global().api_base_url();
         // A: Step 3-5

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -1024,7 +1024,7 @@ impl TestBindingMethods for TestBinding {
         let in_compartment_proof = AlreadyInCompartment::assert(&global);
         let p = Promise::new_in_current_compartment(
             &global,
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         p.append_native_handler(&handler);
         return p;
@@ -1052,7 +1052,7 @@ impl TestBindingMethods for TestBinding {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         )
     }
 

--- a/components/script/dom/vrdisplay.rs
+++ b/components/script/dom/vrdisplay.rs
@@ -346,7 +346,7 @@ impl VRDisplayMethods for VRDisplay {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let promise = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         // TODO: WebVR spec: this method must be called in response to a user gesture
 
@@ -414,7 +414,7 @@ impl VRDisplayMethods for VRDisplay {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let promise = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
 
         // WebVR spec: If the VRDisplay is not presenting the promise MUST be rejected.

--- a/components/script/dom/vrdisplay.rs
+++ b/components/script/dom/vrdisplay.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorMethods;
@@ -341,9 +342,12 @@ impl VRDisplayMethods for VRDisplay {
     }
 
     // https://w3c.github.io/webvr/#dom-vrdisplay-requestpresent
-    #[allow(unsafe_code)]
     fn RequestPresent(&self, layers: Vec<VRLayer>) -> Rc<Promise> {
-        let promise = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let promise = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         // TODO: WebVR spec: this method must be called in response to a user gesture
 
         // WebVR spec: If canPresent is false the promise MUST be rejected
@@ -406,9 +410,12 @@ impl VRDisplayMethods for VRDisplay {
     }
 
     // https://w3c.github.io/webvr/#dom-vrdisplay-exitpresent
-    #[allow(unsafe_code)]
     fn ExitPresent(&self) -> Rc<Promise> {
-        let promise = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let promise = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
 
         // WebVR spec: If the VRDisplay is not presenting the promise MUST be rejected.
         if !self.presenting.get() {

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -117,7 +117,7 @@ impl WorkletMethods for Worklet {
         let in_compartment_proof = AlreadyInCompartment::assert(&global);
         let promise = Promise::new_in_current_compartment(
             &global,
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
 
         // Step 3.

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -10,6 +10,7 @@
 //! thread pool implementation, which only performs GC or code loading on
 //! a backup thread, not on the primary worklet thread.
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::codegen::Bindings::RequestBinding::RequestCredentials;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowBinding::WindowMethods;
 use crate::dom::bindings::codegen::Bindings::WorkletBinding::WorkletMethods;
@@ -110,10 +111,14 @@ impl Worklet {
 
 impl WorkletMethods for Worklet {
     /// <https://drafts.css-houdini.org/worklets/#dom-worklet-addmodule>
-    #[allow(unsafe_code)]
     fn AddModule(&self, module_url: USVString, options: &WorkletOptions) -> Rc<Promise> {
         // Step 1.
-        let promise = unsafe { Promise::new_in_current_compartment(self.window.upcast()) };
+        let global = self.window.upcast();
+        let in_compartment_proof = AlreadyInCompartment::assert(&global);
+        let promise = Promise::new_in_current_compartment(
+            &global,
+            &InCompartment::Already(&in_compartment_proof),
+        );
 
         // Step 3.
         let module_url_record = match self.window.Document().base_url().join(&module_url.0) {

--- a/components/script/dom/xr.rs
+++ b/components/script/dom/xr.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::VRDisplayBinding::VRDisplayMethods;
 use crate::dom::bindings::codegen::Bindings::XRBinding;
@@ -83,10 +84,13 @@ impl Drop for XR {
 
 impl XRMethods for XR {
     /// https://immersive-web.github.io/webxr/#dom-xr-supportssessionmode
-    #[allow(unsafe_code)]
     fn SupportsSessionMode(&self, mode: XRSessionMode) -> Rc<Promise> {
         // XXXManishearth this should select an XR device first
-        let promise = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let promise = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         if mode == XRSessionMode::Immersive_vr {
             promise.resolve_native(&());
         } else {
@@ -98,9 +102,12 @@ impl XRMethods for XR {
     }
 
     /// https://immersive-web.github.io/webxr/#dom-xr-requestsession
-    #[allow(unsafe_code)]
     fn RequestSession(&self, options: &XRSessionCreationOptions) -> Rc<Promise> {
-        let promise = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let promise = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         if options.mode != XRSessionMode::Immersive_vr {
             promise.reject_error(Error::NotSupported);
             return promise;

--- a/components/script/dom/xr.rs
+++ b/components/script/dom/xr.rs
@@ -89,7 +89,7 @@ impl XRMethods for XR {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let promise = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         if mode == XRSessionMode::Immersive_vr {
             promise.resolve_native(&());
@@ -106,7 +106,7 @@ impl XRMethods for XR {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let promise = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         if options.mode != XRSessionMode::Immersive_vr {
             promise.reject_error(Error::NotSupported);

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::codegen::Bindings::VRDisplayBinding::VRDisplayMethods;
 use crate::dom::bindings::codegen::Bindings::XRBinding::XRSessionMode;
 use crate::dom::bindings::codegen::Bindings::XRRenderStateBinding::XRRenderStateInit;
@@ -89,9 +90,12 @@ impl XRSessionMethods for XRSession {
     }
 
     /// https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe
-    #[allow(unsafe_code)]
     fn UpdateRenderState(&self, init: &XRRenderStateInit) -> Rc<Promise> {
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
         self.display.queue_renderstate(init, p.clone());
         p
     }
@@ -112,9 +116,12 @@ impl XRSessionMethods for XRSession {
     }
 
     /// https://immersive-web.github.io/webxr/#dom-xrsession-requestreferencespace
-    #[allow(unsafe_code)]
     fn RequestReferenceSpace(&self, options: &XRReferenceSpaceOptions) -> Rc<Promise> {
-        let p = unsafe { Promise::new_in_current_compartment(&self.global()) };
+        let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
+        let p = Promise::new_in_current_compartment(
+            &self.global(),
+            &InCompartment::Already(&in_compartment_proof),
+        );
 
         // https://immersive-web.github.io/webxr/#create-a-reference-space
 

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -94,7 +94,7 @@ impl XRSessionMethods for XRSession {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
         self.display.queue_renderstate(init, p.clone());
         p
@@ -120,7 +120,7 @@ impl XRSessionMethods for XRSession {
         let in_compartment_proof = AlreadyInCompartment::assert(&self.global());
         let p = Promise::new_in_current_compartment(
             &self.global(),
-            &InCompartment::Already(&in_compartment_proof),
+            InCompartment::Already(&in_compartment_proof),
         );
 
         // https://immersive-web.github.io/webxr/#create-a-reference-space

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -139,7 +139,7 @@ pub fn Fetch(
 
     // Step 1
     let aic = AlreadyInCompartment::assert(global);
-    let promise = Promise::new_in_current_compartment(global, &InCompartment::Already(&aic));
+    let promise = Promise::new_in_current_compartment(global, InCompartment::Already(&aic));
     let response = Response::new(global);
 
     // Step 2

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::codegen::Bindings::RequestBinding::RequestInfo;
 use crate::dom::bindings::codegen::Bindings::RequestBinding::RequestInit;
 use crate::dom::bindings::codegen::Bindings::ResponseBinding::ResponseBinding::ResponseMethods;
@@ -129,7 +130,6 @@ fn request_init_from_request(request: NetTraitsRequest) -> RequestBuilder {
 
 // https://fetch.spec.whatwg.org/#fetch-method
 #[allow(unrooted_must_root)]
-#[allow(unsafe_code)]
 pub fn Fetch(
     global: &GlobalScope,
     input: RequestInfo,
@@ -138,7 +138,8 @@ pub fn Fetch(
     let core_resource_thread = global.core_resource_thread();
 
     // Step 1
-    let promise = unsafe { Promise::new_in_current_compartment(global) };
+    let aic = AlreadyInCompartment::assert(global);
+    let promise = Promise::new_in_current_compartment(global, &InCompartment::Already(&aic));
     let response = Response::new(global);
 
     // Step 2

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -57,6 +57,7 @@ mod devtools;
 pub mod document_loader;
 #[macro_use]
 mod dom;
+mod compartments;
 pub mod fetch;
 mod image_listener;
 mod layout_image;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR adds a mechanism to verify that certain code is executed inside a ```JSAutoCompartment```, and applies this to the ```Promise::new_in_current_compartment``` constructor.

r? @jdm 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23167 

<!-- Either: -->
- [x] These changes do not require tests because they do not change existing functionality.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23253)
<!-- Reviewable:end -->
