### PR TITLE
Update cmake for MSVC builds.

### DIFF
--- a/python/servo/packages.py
+++ b/python/servo/packages.py
@@ -3,7 +3,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 WINDOWS_MSVC = {
-    "cmake": "3.7.2",
+    "cmake": "3.14.3",
     "llvm": "7.0.0",
     "moztools": "3.2",
     "ninja": "1.7.1",


### PR DESCRIPTION
This is required for making builds with clang-cl instead of MSVC's cl.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23254)
<!-- Reviewable:end -->
