### PR TITLE
Implement AudioParam.setValueCurveAtTime #22897 

### DIFF
--- a/components/script/dom/audioparam.rs
+++ b/components/script/dom/audioparam.rs
@@ -231,6 +231,40 @@ impl AudioParamMethods for AudioParam {
         Ok(DomRoot::from_ref(self))
     }
 
+    // https://webaudio.github.io/web-audio-api/#dom-audioparam-setvaluecurveattime
+    fn SetValueCurveAtTime(
+        &self,
+        values: Vec<Finite<f32>>,
+        start_time: Finite<f64>,
+        end_time: Finite<f64>,
+    ) -> Fallible<DomRoot<AudioParam>> {
+        if *start_time < 0. {
+            return Err(Error::Range(format!(
+                "start time {} should not be negative",
+                *start_time
+            )));
+        }
+        if values.len() < 2. as usize {
+            return Err(Error::InvalidState);
+        }
+
+        if *end_time < 0. {
+            return Err(Error::Range(format!(
+                "end time {} should not be negative",
+                *end_time
+            )));
+        }
+        self.message_node(AudioNodeMessage::SetParam(
+            self.param,
+            UserAutomationEvent::SetValueCurveAtTime(
+                values.into_iter().map(|v| *v).collect(),
+                *start_time,
+                *end_time,
+            ),
+        ));
+        Ok(DomRoot::from_ref(self))
+    }
+
     // https://webaudio.github.io/web-audio-api/#dom-audioparam-cancelscheduledvalues
     fn CancelScheduledValues(&self, cancel_time: Finite<f64>) -> Fallible<DomRoot<AudioParam>> {
         if *cancel_time < 0. {

--- a/components/script/dom/webidls/AudioParam.webidl
+++ b/components/script/dom/webidls/AudioParam.webidl
@@ -24,9 +24,9 @@ interface AudioParam {
     [Throws] AudioParam setTargetAtTime(float target,
                                double startTime,
                                float timeConstant);
-//    AudioParam setValueCurveAtTime(sequence<float> values,
-//                                   double startTime,
-//                                   double duration);
+    [Throws] AudioParam setValueCurveAtTime(sequence<float> values,
+                                   double startTime,
+                                   double duration);
     [Throws] AudioParam cancelScheduledValues(double cancelTime);
     [Throws] AudioParam cancelAndHoldAtTime(double cancelTime);
 };

--- a/tests/wpt/metadata/webaudio/idlharness.https.window.js.ini
+++ b/tests/wpt/metadata/webaudio/idlharness.https.window.js.ini
@@ -752,9 +752,6 @@
   [AudioNode interface: new MediaElementAudioSourceNode(context, {mediaElement: new Audio}) must inherit property "channelInterpretation" with the proper type]
     expected: FAIL
 
-  [AudioParam interface: operation setValueCurveAtTime([object Object\], double, double)]
-    expected: FAIL
-
   [BaseAudioContext interface: operation createIIRFilter([object Object\], [object Object\])]
     expected: FAIL
 
@@ -1253,9 +1250,6 @@
   [IIRFilterNode interface: existence and properties of interface object]
     expected: FAIL
 
-  [AudioParam interface: calling setValueCurveAtTime([object Object\], double, double) on new AudioBufferSourceNode(context).playbackRate with too few arguments must throw TypeError]
-    expected: FAIL
-
   [OfflineAudioContext interface: operation startRendering()]
     expected: FAIL
 
@@ -1470,9 +1464,6 @@
     expected: FAIL
 
   [AudioNode interface: calling disconnect(AudioParam) on worklet_node with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [AudioParam interface: new AudioBufferSourceNode(context).playbackRate must inherit property "setValueCurveAtTime([object Object\], double, double)" with the proper type]
     expected: FAIL
 
   [AudioNode interface: context.createScriptProcessor() must inherit property "disconnect(AudioNode, unsigned long, unsigned long)" with the proper type]

--- a/tests/wpt/metadata/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.html.ini
+++ b/tests/wpt/metadata/webaudio/the-audio-api/the-audioparam-interface/audioparam-exceptional-values.html.ini
@@ -17,3 +17,21 @@
   [# AUDIT TASK RUNNER FINISHED: 1 out of 6 tasks were failed.]
     expected: FAIL
 
+  [X gain.gain.setValueCurveAtTime([0,0,0\],-1,1) did not throw an exception.]
+    expected: FAIL
+
+  [X gain.gain.setValueCurveAtTime(curve, 1, -1) did not throw an exception.]
+    expected: FAIL
+
+  [X gain.gain.setValueCurveAtTime([0,0,0\],1,-1) did not throw an exception.]
+    expected: FAIL
+
+  [X gain.gain.setValueCurveAtTime(curve, 1, 0) did not throw an exception.]
+    expected: FAIL
+
+  [< [special cases 1\] 6 out of 9 assertions were failed.]
+    expected: FAIL
+
+  [< [special cases 1\] 1 out of 9 assertions were failed.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webaudio/the-audio-api/the-audioparam-interface/audioparam-method-chaining.html.ini
+++ b/tests/wpt/metadata/webaudio/the-audio-api/the-audioparam-interface/audioparam-method-chaining.html.ini
@@ -1,2 +1,28 @@
 [audioparam-method-chaining.html]
-  expected: ERROR
+  [< [invalid-operation\] 4 out of 4 assertions were failed.]
+    expected: FAIL
+
+  [X The gain value of the second gain node is not equal to 0.5. Got 0.]
+    expected: FAIL
+
+  [# AUDIT TASK RUNNER FINISHED: 2 out of 3 tasks were failed.]
+    expected: FAIL
+
+  [< [verification\] 1 out of 1 assertions were failed.]
+    expected: FAIL
+
+  [X Calling setValueAtTime() with a negative end time did not throw an exception.]
+    expected: FAIL
+
+  [X Calling exponentialRampToValueAtTime() with a zero target value did not throw an exception.]
+    expected: FAIL
+
+  [X The gain value of the first gain node is not equal to 1. Got 2.]
+    expected: FAIL
+
+  [X The rendered envelope does not equal [0,0.000125,0.00025,0.000375,0.0005,0.000625,0.00075,0.000875,0.001,0.001125,0.00125,0.001375,0.0015,0.001625,0.00175,0.001875...\] with an element-wise tolerance of {"absoluteThreshold":0.0000040532,"relativeThreshold":0}.\n\tIndex\tActual\t\t\tExpected\t\tAbsError\t\tRelError\t\tTest threshold\n\t[1\]\t0.0000000000000000e+0\t1.2500000000000000e-4\t1.2500000000000000e-4\t1.0000000000000000e+0\t4.0531999999999996e-6\n\t[2\]\t0.0000000000000000e+0\t2.5000000000000001e-4\t2.5000000000000001e-4\t1.0000000000000000e+0\t4.0531999999999996e-6\n\t[3\]\t0.0000000000000000e+0\t3.7500000000000001e-4\t3.7500000000000001e-4\t1.0000000000000000e+0\t4.0531999999999996e-6\n\t[4\]\t0.0000000000000000e+0\t5.0000000000000001e-4\t5.0000000000000001e-4\t1.0000000000000000e+0\t4.0531999999999996e-6\n\t[5\]\t0.0000000000000000e+0\t6.2500000000000001e-4\t6.2500000000000001e-4\t1.0000000000000000e+0\t4.0531999999999996e-6\n\t...and 31994 more errors.\n\tMax AbsError of 1.0000000000000000e+0 at index of 8000.\n\t[8000\]\t0.0000000000000000e+0\t1.0000000000000000e+0\t1.0000000000000000e+0\t1.0000000000000000e+0\t4.0531999999999996e-6\n\tMax RelError of 1.0000000000000000e+0 at index of 1.\n]
+    expected: FAIL
+
+  [# AUDIT TASK RUNNER FINISHED: 1 out of 3 tasks were failed.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webaudio/the-audio-api/the-audioparam-interface/audioparam-setValueCurve-exceptions.html.ini
+++ b/tests/wpt/metadata/webaudio/the-audio-api/the-audioparam-interface/audioparam-setValueCurve-exceptions.html.ini
@@ -33,3 +33,18 @@
   [X exponentialRampToValueAtTime(1, 0.018750000000000003) did not throw an exception.]
     expected: FAIL
 
+  [X setValueCurveAtTime(curve, 0.043750000000000004, 0.01) did not throw an exception.]
+    expected: FAIL
+
+  [< [setValueCurve\] 4 out of 6 assertions were failed.]
+    expected: FAIL
+
+  [X setValueCurveAtTime(curve, 0.018750000000000003, 0.01) did not throw an exception.]
+    expected: FAIL
+
+  [X setValueCurveAtTime(curve, 0.00625, 0.01) did not throw an exception.]
+    expected: FAIL
+
+  [X setValueCurveAtTime(curve, 0.03125, 0.01) did not throw an exception.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webaudio/the-audio-api/the-audioparam-interface/audioparam-setValueCurveAtTime.html.ini
+++ b/tests/wpt/metadata/webaudio/the-audio-api/the-audioparam-interface/audioparam-setValueCurveAtTime.html.ini
@@ -1,2 +1,124 @@
 [audioparam-setValueCurveAtTime.html]
-  expected: ERROR
+  [X Max error for test 12 at offset 15876 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 1323. Got 1325.]
+    expected: FAIL
+
+  [X Max error for test 15 at offset 19845 is not less than or equal to 0.0000037194. Got 0.464914441108627.]
+    expected: FAIL
+
+  [X Max error for test 19 at offset 25137 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Max error for test 17 at offset 22491 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 7938. Got 7940.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 6615. Got 6617.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 11907. Got 11909.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 9261. Got 9263.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 3969. Got 3971.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 23814. Got 23816.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 22491. Got 22493.]
+    expected: FAIL
+
+  [X Max error for test 14 at offset 18522 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 17199. Got 17201.]
+    expected: FAIL
+
+  [X Number of discontinuites at incorrect locations is not equal to 0. Got 19.]
+    expected: FAIL
+
+  [X Max error for test 11 at offset 14553 is not less than or equal to 0.0000037194. Got 0.464914441108627.]
+    expected: FAIL
+
+  [X Max error for test 4 at offset 5292 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Max error for test 13 at offset 17199 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Max error for test 2 at offset 2646 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Max error for test 18 at offset 23814 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [< [test\] 39 out of 41 assertions were failed.]
+    expected: FAIL
+
+  [X Max error for test 6 at offset 7938 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 21168. Got 21170.]
+    expected: FAIL
+
+  [X Max error for test 10 at offset 13230 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 5292. Got 5294.]
+    expected: FAIL
+
+  [X Max error for test 3 at offset 3969 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 19845. Got 19847.]
+    expected: FAIL
+
+  [X Max error for test 7 at offset 9261 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 2646. Got 2648.]
+    expected: FAIL
+
+  [X Max error for test 1 at offset 1323 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 18522. Got 18524.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 10584. Got 10586.]
+    expected: FAIL
+
+  [# AUDIT TASK RUNNER FINISHED: 1 out of 1 tasks were failed.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 25137. Got 25139.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 14553. Got 14555.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 15876. Got 15878.]
+    expected: FAIL
+
+  [X Max error for test 8 at offset 10584 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Max error for test 16 at offset 21168 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Max error for test 5 at offset 6615 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Max error for test 9 at offset 11907 is not less than or equal to 0.0000037194. Got 0.4649144411087036.]
+    expected: FAIL
+
+  [X Discontinuity at index is not equal to 13230. Got 13232.]
+    expected: FAIL
+


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Updated audioparam.rs to send the new UserAutomationEvent SetValueCurveAtTime to the audio engine and updated test results.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22897 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23259)
<!-- Reviewable:end -->
