### PR TITLE
Update SetCursor behavior

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -191,6 +191,9 @@ pub struct IOCompositor<Window: WindowMethods> {
 
     /// The coordinates of the native window, its view and the screen.
     embedder_coordinates: EmbedderCoordinates,
+
+    /// Current mouse cursor.
+    cursor: Cursor,
 }
 
 #[derive(Clone, Copy)]
@@ -291,6 +294,7 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             webrender_api: state.webrender_api,
             webvr_heartbeats: state.webvr_heartbeats,
             pending_paint_metrics: HashMap::new(),
+            cursor: Cursor::None,
         }
     }
 
@@ -709,9 +713,12 @@ impl<Window: WindowMethods> IOCompositor<Window> {
             }
 
             if let Some(cursor) = Cursor::from_u8(item.tag.1 as _) {
-                let msg = ConstellationMsg::SetCursor(cursor);
-                if let Err(e) = self.constellation_chan.send(msg) {
-                    warn!("Sending event to constellation failed ({:?}).", e);
+                if cursor != self.cursor {
+                    self.cursor = cursor;
+                    let msg = ConstellationMsg::SetCursor(cursor);
+                    if let Err(e) = self.constellation_chan.send(msg) {
+                        warn!("Sending event to constellation failed ({:?}).", e);
+                    }
                 }
             }
         }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1469,7 +1469,6 @@ where
             FromLayoutMsg::PendingPaintMetric(pipeline_id, epoch) => {
                 self.handle_pending_paint_metric(pipeline_id, epoch);
             },
-            FromLayoutMsg::SetCursor(cursor) => self.handle_set_cursor_msg(cursor),
             FromLayoutMsg::ViewportConstrained(pipeline_id, constraints) => {
                 self.handle_viewport_constrained_msg(pipeline_id, constraints);
             },

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -14,7 +14,7 @@ use crate::WorkerGlobalScopeInit;
 use crate::WorkerScriptLoadOrigin;
 use canvas_traits::canvas::{CanvasId, CanvasMsg};
 use devtools_traits::{ScriptToDevtoolsControlMsg, WorkerId};
-use embedder_traits::{Cursor, EmbedderMsg};
+use embedder_traits::EmbedderMsg;
 use euclid::{Size2D, TypedSize2D};
 use gfx_traits::Epoch;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
@@ -58,8 +58,6 @@ pub enum LayoutMsg {
     /// Requests that the constellation inform the compositor that it needs to record
     /// the time when the frame with the given ID (epoch) is painted.
     PendingPaintMetric(PipelineId, Epoch),
-    /// Requests that the constellation inform the compositor of the a cursor change.
-    SetCursor(Cursor),
     /// Notifies the constellation that the viewport has been constrained in some manner
     ViewportConstrained(PipelineId, ViewportConstraints),
 }
@@ -71,7 +69,6 @@ impl fmt::Debug for LayoutMsg {
             ChangeRunningAnimationsState(..) => "ChangeRunningAnimationsState",
             IFrameSizes(..) => "IFrameSizes",
             PendingPaintMetric(..) => "PendingPaintMetric",
-            SetCursor(..) => "SetCursor",
             ViewportConstrained(..) => "ViewportConstrained",
         };
         write!(formatter, "LayoutMsg::{}", variant)


### PR DESCRIPTION
We were initially sending a SetCursor message on every mouse move because of a winit bug, which is now fixed.

Also, we had a layout SetCursor message that was never used.

Fix #18599

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23262)
<!-- Reviewable:end -->
