### PR TITLE
Magicleap package fixes

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -238,9 +238,6 @@ class PackageCommands(CommandBase):
                 mabu,
                 "-o", target_dir,
                 "-t", build_type,
-                # Servo SEGVs if we don't set the debuggable flag in the mpk's taildata
-                # https://github.com/servo/servo/issues/22188
-                "--add-tail-data-args=--debuggable",
                 package
             ]
             try:

--- a/support/magicleap/Servo2D/Servo2D.mabu
+++ b/support/magicleap/Servo2D/Servo2D.mabu
@@ -21,6 +21,10 @@ SHLIBS = \
     log \
     z
 
+# https://github.com/servo/servo/issues/23267
+CXXFLAGS = \
+    -Wno-deprecated
+
 USES = \
     lumin_runtime \
     code/srcsGen

--- a/support/magicleap/Servo2D/Servo2D.package
+++ b/support/magicleap/Servo2D/Servo2D.package
@@ -5,3 +5,7 @@ DATAS = \
     fonts.xml : etc/fonts.xml
 
 REFS = Servo2D
+
+# Servo SEGVs if we don't set the debuggable flag in the mpk's taildata
+# https://github.com/servo/servo/issues/22188
+OPTIONS=package/debuggable/on


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

A couple of fixes for magicleap packaging...
* Move the setting of the debuggable flag into the `.package` file where it belongs,
* Allow compiling with v0.20.0 of the SDK.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it fixes the build

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23268)
<!-- Reviewable:end -->
