### PR TITLE
Implement deprecated setPosition and setOrientation methods for AudioListener #22898

### DIFF
--- a/components/script/dom/audiolistener.rs
+++ b/components/script/dom/audiolistener.rs
@@ -6,9 +6,13 @@ use crate::dom::audioparam::AudioParam;
 use crate::dom::baseaudiocontext::BaseAudioContext;
 use crate::dom::bindings::codegen::Bindings::AudioListenerBinding::{self, AudioListenerMethods};
 use crate::dom::bindings::codegen::Bindings::AudioParamBinding::AutomationRate;
+use crate::dom::bindings::error::Fallible;
+use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::window::Window;
+
+use crate::dom::bindings::codegen::Bindings::AudioParamBinding::AudioParamMethods;
 use dom_struct::dom_struct;
 use servo_media::audio::param::{ParamDir, ParamType};
 use std::f32;
@@ -121,6 +125,7 @@ impl AudioListener {
             f32::MIN, // min value
             f32::MAX, // max value
         );
+
         AudioListener {
             reflector_: Reflector::new(),
             position_x: Dom::from_ref(&position_x),
@@ -180,5 +185,37 @@ impl AudioListenerMethods for AudioListener {
     // https://webaudio.github.io/web-audio-api/#dom-audiolistener-upz
     fn UpZ(&self) -> DomRoot<AudioParam> {
         DomRoot::from_ref(&self.up_z)
+    }
+
+    // https://webaudio.github.io/web-audio-api/#dom-audiolistener-setorientation
+    fn SetOrientation(
+        &self,
+        x: Finite<f32>,
+        y: Finite<f32>,
+        z: Finite<f32>,
+        xUp: Finite<f32>,
+        yUp: Finite<f32>,
+        zUp: Finite<f32>,
+    ) -> Fallible<DomRoot<AudioListener>> {
+        self.forward_x.SetValue(x);
+        self.forward_y.SetValue(y);
+        self.forward_z.SetValue(z);
+        self.up_x.SetValue(xUp);
+        self.up_y.SetValue(yUp);
+        self.up_z.SetValue(zUp);
+        Ok(DomRoot::from_ref(self))
+    }
+
+    // https://webaudio.github.io/web-audio-api/#dom-audiolistener-setposition
+    fn SetPosition(
+        &self,
+        x: Finite<f32>,
+        y: Finite<f32>,
+        z: Finite<f32>,
+    ) -> Fallible<DomRoot<AudioListener>> {
+        self.position_x.SetValue(x);
+        self.position_y.SetValue(y);
+        self.position_z.SetValue(z);
+        Ok(DomRoot::from_ref(self))
     }
 }

--- a/components/script/dom/webidls/AudioListener.webidl
+++ b/components/script/dom/webidls/AudioListener.webidl
@@ -17,6 +17,6 @@ interface AudioListener {
   readonly attribute AudioParam upX;
   readonly attribute AudioParam upY;
   readonly attribute AudioParam upZ;
-  // void setPosition (float x, float y, float z);
-  // void setOrientation (float x, float y, float z, float xUp, float yUp, float zUp);
+  [Throws] AudioListener setPosition (float x, float y, float z);
+  [Throws] AudioListener setOrientation (float x, float y, float z, float xUp, float yUp, float zUp);
 };

--- a/tests/wpt/metadata/webaudio/idlharness.https.window.js.ini
+++ b/tests/wpt/metadata/webaudio/idlharness.https.window.js.ini
@@ -5,9 +5,6 @@
   [StereoPannerNode interface: attribute pan]
     expected: FAIL
 
-  [AudioListener interface: calling setPosition(float, float, float) on context.listener with too few arguments must throw TypeError]
-    expected: FAIL
-
   [AudioNode interface: new MediaElementAudioSourceNode(context, {mediaElement: new Audio}) must inherit property "disconnect(AudioParam)" with the proper type]
     expected: FAIL
 
@@ -353,9 +350,6 @@
   [AudioNode interface: new IIRFilterNode(context, {feedforward: [1\], feedback: [1\]}) must inherit property "disconnect(AudioNode)" with the proper type]
     expected: FAIL
 
-  [AudioListener interface: calling setOrientation(float, float, float, float, float, float) on context.listener with too few arguments must throw TypeError]
-    expected: FAIL
-
   [ScriptProcessorNode interface: existence and properties of interface prototype object's "constructor" property]
     expected: FAIL
 
@@ -420,9 +414,6 @@
     expected: FAIL
 
   [AudioNode interface: new MediaElementAudioSourceNode(context, {mediaElement: new Audio}) must inherit property "disconnect()" with the proper type]
-    expected: FAIL
-
-  [AudioListener interface: operation setOrientation(float, float, float, float, float, float)]
     expected: FAIL
 
   [AudioNode interface: new StereoPannerNode(context) must inherit property "disconnect(AudioNode, unsigned long, unsigned long)" with the proper type]
@@ -717,9 +708,6 @@
     expected: FAIL
 
   [OfflineAudioContext interface: new OfflineAudioContext(1, 1, sample_rate) must inherit property "suspend(double)" with the proper type]
-    expected: FAIL
-
-  [AudioListener interface: operation setPosition(float, float, float)]
     expected: FAIL
 
   [AudioNode interface: new ConvolverNode(context) must inherit property "channelCount" with the proper type]
@@ -1310,9 +1298,6 @@
   [AudioNode interface: new IIRFilterNode(context, {feedforward: [1\], feedback: [1\]}) must inherit property "disconnect(AudioParam, unsigned long)" with the proper type]
     expected: FAIL
 
-  [AudioListener interface: context.listener must inherit property "setOrientation(float, float, float, float, float, float)" with the proper type]
-    expected: FAIL
-
   [WaveShaperNode interface object name]
     expected: FAIL
 
@@ -1539,9 +1524,6 @@
     expected: FAIL
 
   [AudioNode interface: new ConvolverNode(context) must inherit property "context" with the proper type]
-    expected: FAIL
-
-  [AudioListener interface: context.listener must inherit property "setPosition(float, float, float)" with the proper type]
     expected: FAIL
 
   [ConvolverNode interface: new ConvolverNode(context) must inherit property "normalize" with the proper type]

--- a/tests/wpt/metadata/webaudio/the-audio-api/the-pannernode-interface/panner-equalpower.html.ini
+++ b/tests/wpt/metadata/webaudio/the-audio-api/the-pannernode-interface/panner-equalpower.html.ini
@@ -1,8 +1,10 @@
 [panner-equalpower.html]
-  expected: ERROR
   [X Number of impulses found is not equal to 100. Got 0.]
     expected: FAIL
 
   [< [test\] 1 out of 4 assertions were failed.]
+    expected: FAIL
+
+  [# AUDIT TASK RUNNER FINISHED: 1 out of 3 tasks were failed.]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I have uncommented the two methods SetPosition and SetOrientation in AudioListener.webidl and have included the two methods in the AudioListener.rs file. I have some errors while handling the NotSupported error for the methods. Can you please review the code and help me out with the errors?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23279)
<!-- Reviewable:end -->
