### PR TITLE
Update Player instantiator API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3857,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#38a1f2320f508b59639e04f6459851dd733329d4"
+source = "git+https://github.com/servo/media#01cd9be1b8e92e036b4ddff0294893f7e53ef373"
 dependencies = [
  "servo-media-audio 0.1.0 (git+https://github.com/servo/media)",
  "servo-media-player 0.1.0 (git+https://github.com/servo/media)",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#38a1f2320f508b59639e04f6459851dd733329d4"
+source = "git+https://github.com/servo/media#01cd9be1b8e92e036b4ddff0294893f7e53ef373"
 dependencies = [
  "boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-slice-cast 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3884,7 +3884,7 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#38a1f2320f508b59639e04f6459851dd733329d4"
+source = "git+https://github.com/servo/media#01cd9be1b8e92e036b4ddff0294893f7e53ef373"
 dependencies = [
  "boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3898,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#38a1f2320f508b59639e04f6459851dd733329d4"
+source = "git+https://github.com/servo/media#01cd9be1b8e92e036b4ddff0294893f7e53ef373"
 dependencies = [
  "boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-slice-cast 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3932,7 +3932,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#38a1f2320f508b59639e04f6459851dd733329d4"
+source = "git+https://github.com/servo/media#01cd9be1b8e92e036b4ddff0294893f7e53ef373"
 dependencies = [
  "gstreamer 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-video 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#38a1f2320f508b59639e04f6459851dd733329d4"
+source = "git+https://github.com/servo/media#01cd9be1b8e92e036b4ddff0294893f7e53ef373"
 dependencies = [
  "glib 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#38a1f2320f508b59639e04f6459851dd733329d4"
+source = "git+https://github.com/servo/media#01cd9be1b8e92e036b4ddff0294893f7e53ef373"
 dependencies = [
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3966,7 +3966,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#38a1f2320f508b59639e04f6459851dd733329d4"
+source = "git+https://github.com/servo/media#01cd9be1b8e92e036b4ddff0294893f7e53ef373"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#38a1f2320f508b59639e04f6459851dd733329d4"
+source = "git+https://github.com/servo/media#01cd9be1b8e92e036b4ddff0294893f7e53ef373"
 dependencies = [
  "boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4074,7 +4074,7 @@ dependencies = [
 [[package]]
 name = "servo_media_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#38a1f2320f508b59639e04f6459851dd733329d4"
+source = "git+https://github.com/servo/media#01cd9be1b8e92e036b4ddff0294893f7e53ef373"
 dependencies = [
  "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -70,6 +70,7 @@ use net_traits::{CoreResourceMsg, FetchChannels, FetchMetadata, FetchResponseLis
 use net_traits::{NetworkError, ResourceFetchTiming, ResourceTimingType};
 use script_layout_interface::HTMLMediaData;
 use servo_config::pref;
+use servo_media::player::context::{GlContext, NativeDisplay, PlayerGLContext};
 use servo_media::player::frame::{Frame, FrameRenderer};
 use servo_media::player::{PlaybackState, Player, PlayerError, PlayerEvent, StreamType};
 use servo_media::ServoMedia;
@@ -157,6 +158,16 @@ impl FrameRenderer for MediaFrameRenderer {
             },
         }
         self.api.update_resources(txn.resource_updates);
+    }
+}
+
+struct PlayerContextDummy();
+impl PlayerGLContext for PlayerContextDummy {
+    fn get_gl_context(&self) -> GlContext {
+        return GlContext::Unknown;
+    }
+    fn get_native_display(&self) -> NativeDisplay {
+        return NativeDisplay::Unknown;
     }
 }
 
@@ -1201,7 +1212,9 @@ impl HTMLMediaElement {
             _ => StreamType::Seekable,
         };
 
-        let player = ServoMedia::get().unwrap().create_player(stream_type);
+        let player = ServoMedia::get()
+            .unwrap()
+            .create_player(stream_type, Box::new(PlayerContextDummy()));
 
         let (action_sender, action_receiver) = ipc::channel().unwrap();
         player.register_event_handler(action_sender);

--- a/tests/wpt/metadata/webaudio/the-audio-api/the-audiobuffersourcenode-interface/buffer-resampling.html.ini
+++ b/tests/wpt/metadata/webaudio/the-audio-api/the-audiobuffersourcenode-interface/buffer-resampling.html.ini
@@ -11,3 +11,9 @@
   [X SNR (-0.5698 dB) is not greater than or equal to 37.17. Got -0.5697716379745515.]
     expected: FAIL
 
+  [X Interpolated sine wave does not equal [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0...\] with an element-wise tolerance of {"absoluteThreshold":0.090348,"relativeThreshold":0}.\n\tIndex\tActual\t\t\tExpected\t\tAbsError\t\tRelError\t\tTest threshold\n\t[1\]\t3.3873793482780457e-1\t0.0000000000000000e+0\t3.3873793482780457e-1\tInfinity\t9.0347999999999998e-2\n\t[2\]\t6.3742399215698242e-1\t0.0000000000000000e+0\t6.3742399215698242e-1\tInfinity\t9.0347999999999998e-2\n\t[3\]\t8.6074203252792358e-1\t0.0000000000000000e+0\t8.6074203252792358e-1\tInfinity\t9.0347999999999998e-2\n\t[4\]\t9.8228722810745239e-1\t0.0000000000000000e+0\t9.8228722810745239e-1\tInfinity\t9.0347999999999998e-2\n\t[5\]\t9.8768836259841919e-1\t0.0000000000000000e+0\t9.8768836259841919e-1\tInfinity\t9.0347999999999998e-2\n\t...and 81 more errors.\n\tMax AbsError of 1.0000000000000000e+0 at index of 200.\n\t[200\]\t-1.0000000000000000e+0\t0.0000000000000000e+0\t1.0000000000000000e+0\tInfinity\t9.0347999999999998e-2\n\tMax RelError of Infinity at index of 1.\n]
+    expected: FAIL
+
+  [X SNR (-Infinity dB) is not greater than or equal to 37.17. Got -Infinity.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webaudio/the-audio-api/the-audioparam-interface/audioparam-method-chaining.html.ini
+++ b/tests/wpt/metadata/webaudio/the-audio-api/the-audioparam-interface/audioparam-method-chaining.html.ini
@@ -26,3 +26,9 @@
   [# AUDIT TASK RUNNER FINISHED: 1 out of 3 tasks were failed.]
     expected: FAIL
 
+  [< [invalid-operation\] 1 out of 4 assertions were failed.]
+    expected: FAIL
+
+  [X The gain value of the second gain node is not equal to 0.5. Got 1.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webaudio/the-audio-api/the-oscillatornode-interface/detune-limiting.html.ini
+++ b/tests/wpt/metadata/webaudio/the-audio-api/the-oscillatornode-interface/detune-limiting.html.ini
@@ -17,3 +17,9 @@
   [X Osc(freq: 44100.00390625) output: Expected 0 for all values but found 5511 unexpected values: \n\tIndex\tActual\n\t[1\]\t5.565462970480439e-7\n\t[2\]\t0.0000011130925940960879\n\t[3\]\t0.0000016696390048309695\n\t[4\]\t0.0000022261851881921757\n\t...and 5507 more errors.]
     expected: FAIL
 
+  [# AUDIT TASK RUNNER FINISHED: 1 out of 2 tasks were failed.]
+    expected: FAIL
+
+  [X osc[0:4\] should have contain at least one value different from 0.]
+    expected: FAIL
+


### PR DESCRIPTION
Now servo/media player requires a new parameter for its creator, which is a trait object that provides the GL parameters needed for setup the generation of frames as GL textures.

This patch provides a dummy GL context trait object where the code path will go to the default of raw frames.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because there are no functional changes, only comply with the new API.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23294)
<!-- Reviewable:end -->
