### PR TITLE
Enable evaluating javascript in the firefox devtools console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -24,3 +24,4 @@ msg = {path = "../msg"}
 serde = "1.0"
 serde_json = "1.0"
 time = "0.1"
+uuid = {version = "0.7", features = ["v4"]}


### PR DESCRIPTION
This enables one to use the Firefox Devtools console to evaluate things in servo.

Steps:
start servo: ./mach run tests/html/about-mozilla.html -d --devtools 6000
start firefox and go to Tools -> Web Developer -> Connect...
Set the port to connect to as 6000
Try evaluating things in the console.

<img width="901" alt="Screenshot 2019-05-01 at 13 02 37" src="https://user-images.githubusercontent.com/26968615/57015054-0aa0ce80-6c13-11e9-8031-9299f2da5dba.png">


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors 
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23296)
<!-- Reviewable:end -->
