### PR TITLE
Bug 1546777 - Upgrade generic-worker to 14.1.0 in Windows AMI

### DIFF
--- a/etc/taskcluster/windows/first-boot.ps1
+++ b/etc/taskcluster/windows/first-boot.ps1
@@ -36,16 +36,11 @@ New-NetFirewallRule -DisplayName "Allow livelog GET requests" `
 # Install generic-worker and dependencies
 md C:\generic-worker
 $client.DownloadFile("https://github.com/taskcluster/generic-worker/releases/download" +
-    "/v13.0.2/generic-worker-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
+    "/v14.1.0/generic-worker-nativeEngine-windows-amd64.exe", "C:\generic-worker\generic-worker.exe")
 $client.DownloadFile("https://github.com/taskcluster/livelog/releases/download" +
     "/v1.1.0/livelog-windows-amd64.exe", "C:\generic-worker\livelog.exe")
 Expand-ZIPFile -File "C:\nssm-2.24.zip" -Destination "C:\" `
     -Url "https://www.nssm.cc/release/nssm-2.24.zip"
-Start-Process C:\generic-worker\generic-worker.exe -ArgumentList `
-    "new-openpgp-keypair --file C:\generic-worker\generic-worker-gpg-signing-key.key" `
-    -Wait -NoNewWindow -PassThru `
-    -RedirectStandardOutput C:\generic-worker\generate-gpg-signing-key.log `
-    -RedirectStandardError C:\generic-worker\generate-gpg-signing-key.err
 Start-Process C:\generic-worker\generic-worker.exe -ArgumentList `
     "new-ed25519-keypair --file C:\generic-worker\generic-worker-ed25519-signing-key.key" `
     -Wait -NoNewWindow -PassThru `


### PR DESCRIPTION
I’ve also tweaked the configuration at https://tools.taskcluster.net/aws-provisioner/servo-win2016-staging/edit according to the release notes https://github.com/taskcluster/generic-worker/releases/tag/v14.1.0

https://tools.taskcluster.net/groups/L2T4S2-2RL6aV3L1WzqhKA shows a push to the `try-taskcluster` branch configured to run the `windows_unit` job.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23312)
<!-- Reviewable:end -->
