### PR TITLE
Keep track of cursor location to update shape while scrolling

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -194,6 +194,9 @@ pub struct IOCompositor<Window: WindowMethods + ?Sized> {
 
     /// Current mouse cursor.
     cursor: Cursor,
+
+    /// Current cursor position.
+    cursor_pos: DevicePoint,
 }
 
 #[derive(Clone, Copy)]
@@ -295,6 +298,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             webvr_heartbeats: state.webvr_heartbeats,
             pending_paint_metrics: HashMap::new(),
             cursor: Cursor::None,
+            cursor_pos: DevicePoint::new(0.0, 0.0),
         }
     }
 
@@ -434,6 +438,8 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
 
             (Msg::NewScrollFrameReady(recomposite_needed), ShutdownState::NotShuttingDown) => {
                 self.waiting_for_results_of_scroll = false;
+                self.dispatch_mouse_window_move_event_class(self.cursor_pos);
+
                 if recomposite_needed {
                     self.composition_request = CompositionRequest::CompositeNow(
                         CompositingReason::NewWebRenderScrollFrame,
@@ -690,6 +696,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             return;
         }
 
+        self.cursor_pos = cursor;
         self.dispatch_mouse_window_move_event_class(cursor);
     }
 
@@ -1304,6 +1311,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
 
         self.process_animations();
         self.waiting_for_results_of_scroll = false;
+        self.dispatch_mouse_window_move_event_class(self.cursor_pos);
 
         Ok(rv)
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR adds a field `cursor_pos: DevicePoint` to `IOCompositor` to keep track of where the cursor is during compositing. This allows us to update the cursor shape during scrolling.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #12604 

<!-- Either: -->
- [X] These changes do not require tests because they aren't testable, as discussed in the comments on #12604 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23313)
<!-- Reviewable:end -->
