### PR TITLE
Bug 1548573 - Upgrade macOS workers to generic-worker 14.1.0

### DIFF
--- a/etc/taskcluster/macos/modules/pillar/taskcluster_secrets.py
+++ b/etc/taskcluster/macos/modules/pillar/taskcluster_secrets.py
@@ -10,7 +10,4 @@ import tc
 
 def ext_pillar(_minion_id, _pillar, *_args):
     tc.check()
-    data = {}
-    data.update(tc.secret("project/servo/tc-client/worker/macos/1"))
-    data.update(tc.livelog())
-    return data
+    return tc.secret("project/servo/tc-client/worker/macos/1")

--- a/etc/taskcluster/macos/states/generic-worker.sls
+++ b/etc/taskcluster/macos/states/generic-worker.sls
@@ -21,6 +21,13 @@ GMT:
     - mode: 755
     - makedirs: True
 
+{{ bin }}/taskcluster-proxy:
+  file.managed:
+    - source: https://github.com/taskcluster/taskcluster-proxy/releases/download/v5.1.0/taskcluster-proxy-darwin-amd64
+    - source_hash: sha256=3faf524b9c6b9611339510797bf1013d4274e9f03e7c4bd47e9ab5ec8813d3ae
+    - mode: 755
+    - makedirs: True
+
 {{ user }} group:
   group.present:
     - name: {{ user }}
@@ -52,6 +59,8 @@ GMT:
         ed25519SigningKeyLocation: {{ home }}/keypair
         clientId: {{ pillar["client_id"] }}
         accessToken: {{ pillar["access_token"] }}
+        taskclusterProxyExecutable: {{ bin }}/taskcluster-proxy
+        taskclusterProxyPort: 8080
         livelogExecutable: {{ bin }}/livelog
         wstAudience: taskcluster-net
         wstServerURL: https://websocktunnel.tasks.build

--- a/etc/taskcluster/macos/states/generic-worker.sls
+++ b/etc/taskcluster/macos/states/generic-worker.sls
@@ -9,8 +9,8 @@ GMT:
 {{ bin }}/generic-worker:
   file.managed:
     - name:
-    - source: https://github.com/taskcluster/generic-worker/releases/download/v11.0.1/generic-worker-darwin-amd64
-    - source_hash: sha256=059331865670d3722a710f0b6f4dae97d347811cc347d1810c6dfc1b413c4b48
+    - source: https://github.com/taskcluster/generic-worker/releases/download/v14.1.0/generic-worker-nativeEngine-darwin-amd64
+    - source_hash: sha256=be9496acc40553c925571f344f84ea79fb5370cd68f11a637b9922843d216cae
     - mode: 755
     - makedirs: True
 
@@ -49,36 +49,25 @@ GMT:
         workerId: {{ grains["id"] }}
         tasksDir: {{ home }}/tasks
         publicIP: {{ salt.network.ip_addrs()[0] }}
-        signingKeyLocation: {{ home }}/key
+        ed25519SigningKeyLocation: {{ home }}/keypair
         clientId: {{ pillar["client_id"] }}
         accessToken: {{ pillar["access_token"] }}
         livelogExecutable: {{ bin }}/livelog
-        livelogCertificate: {{ etc }}/livelog.crt
-        livelogKey: {{ etc }}/livelog.key
-        livelogSecret: {{ pillar["livelog_secret"] }}
+        wstAudience: taskcluster-net
+        wstServerURL: https://websocktunnel.tasks.build
+        rootURL: https://taskcluster.net
     - watch_in:
       - service: net.generic.worker
 
-{{ etc }}/livelog.crt:
-  file.managed:
-    - contents_pillar: livelog_cert
-    - group: {{ user }}
-    - mode: 640
-
-{{ etc }}/livelog.key:
-  file.managed:
-    - contents_pillar: livelog_key
-    - group: {{ user }}
-    - mode: 640
-
-{{ bin }}/generic-worker new-openpgp-keypair --file {{ home }}/key:
+{{ bin }}/generic-worker new-ed25519-keypair --file {{ home }}/keypair:
   cmd.run:
-    - creates: {{ home }}/key
+    - creates: {{ home }}/keypair
     - runas: {{ user }}
 
 /Library/LaunchAgents/net.generic.worker.plist:
   file.managed:
-    - mode: 644
+    - mode: 600
+    - user: root
     - template: jinja
     - source: salt://generic-worker.plist.jinja
     - context:

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -546,7 +546,7 @@ class PackageCommands(CommandBase):
         import boto3
 
         def get_taskcluster_secret(name):
-            url = os.environ["TASKCLUSTER_PROXY_URL"] "/secrets/v1/secret/project/servo/" + name
+            url = os.environ["TASKCLUSTER_PROXY_URL"] + "/secrets/v1/secret/project/servo/" + name
             return json.load(urllib.urlopen(url))["secret"]
 
         def get_s3_secret():

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -546,7 +546,7 @@ class PackageCommands(CommandBase):
         import boto3
 
         def get_taskcluster_secret(name):
-            url = "http://taskcluster/secrets/v1/secret/project/servo/" + name
+            url = os.environ["TASKCLUSTER_PROXY_URL"] "/secrets/v1/secret/project/servo/" + name
             return json.load(urllib.urlopen(url))["secret"]
 
         def get_s3_secret():


### PR DESCRIPTION
Also follow-up on #23304 to (hopefully) fix use of `taskcluster-proxy` in daily tasks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23319)
<!-- Reviewable:end -->
