### PR TITLE
Implement connectStart in PerformanceResourceTiming

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -381,6 +381,12 @@ fn obtain_response(
     // TODO(#21261) connect_start: set if a persistent connection is *not* used and the last non-redirected
     // fetch passes the timing allow check
     let connect_start = precise_time_ms();
+    context
+        .timing
+        .lock()
+        .unwrap()
+        .set_attribute(ResourceAttribute::ConnectStart(connect_start));
+
     // https://url.spec.whatwg.org/#percent-encoded-bytes
     let request = HyperRequest::builder()
         .method(method)

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -452,7 +452,7 @@ pub struct ResourceFetchTiming {
     pub response_end: u64,
     pub redirect_start: u64,
     // pub redirect_end: u64,
-    // pub connect_start: u64,
+    pub connect_start: u64,
     pub connect_end: u64,
 }
 
@@ -468,6 +468,7 @@ pub enum ResourceAttribute {
     ResponseStart,
     RedirectStart(RedirectStartValue),
     FetchStart,
+    ConnectStart(u64),
     ConnectEnd(u64),
     ResponseEnd,
 }
@@ -489,6 +490,7 @@ impl ResourceFetchTiming {
             response_start: 0,
             fetch_start: 0,
             redirect_start: 0,
+            connect_start: 0,
             connect_end: 0,
             response_end: 0,
         }
@@ -510,6 +512,7 @@ impl ResourceFetchTiming {
                 },
             },
             ResourceAttribute::FetchStart => self.fetch_start = precise_time_ns(),
+            ResourceAttribute::ConnectStart(val) => self.connect_start = val,
             ResourceAttribute::ConnectEnd(val) => self.connect_end = val,
             ResourceAttribute::ResponseEnd => self.response_end = precise_time_ns(),
         }

--- a/components/script/dom/performanceresourcetiming.rs
+++ b/components/script/dom/performanceresourcetiming.rs
@@ -120,7 +120,7 @@ impl PerformanceResourceTiming {
             fetch_start: resource_timing.fetch_start as f64,
             domain_lookup_start: 0.,
             domain_lookup_end: 0.,
-            connect_start: 0.,
+            connect_start: resource_timing.connect_start as f64,
             connect_end: resource_timing.connect_end as f64,
             secure_connection_start: 0.,
             request_start: resource_timing.request_start as f64,
@@ -190,6 +190,11 @@ impl PerformanceResourceTimingMethods for PerformanceResourceTiming {
     // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-fetchstart
     fn FetchStart(&self) -> DOMHighResTimeStamp {
         Finite::wrap(self.fetch_start)
+    }
+
+    // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-connectstart
+    fn ConnectStart(&self) -> DOMHighResTimeStamp {
+        Finite::wrap(self.connect_start)
     }
 
     // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-connectend

--- a/components/script/dom/webidls/PerformanceResourceTiming.webidl
+++ b/components/script/dom/webidls/PerformanceResourceTiming.webidl
@@ -17,7 +17,7 @@ interface PerformanceResourceTiming : PerformanceEntry {
     readonly attribute DOMHighResTimeStamp fetchStart;
     // readonly attribute DOMHighResTimeStamp domainLookupStart;
     // readonly attribute DOMHighResTimeStamp domainLookupEnd;
-    // readonly attribute DOMHighResTimeStamp connectStart;
+    readonly attribute DOMHighResTimeStamp connectStart;
     readonly attribute DOMHighResTimeStamp connectEnd;
     // readonly attribute DOMHighResTimeStamp secureConnectionStart;
     readonly attribute DOMHighResTimeStamp requestStart;

--- a/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
+++ b/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
@@ -91,6 +91,9 @@
   [PerformanceResourceTiming interface: resource must inherit property "domainLookupStart" with the proper type]
     expected: FAIL
 
+  [PerformanceResourceTiming interface: resource must inherit property "connectStart" with the proper type]
+    expected: FAIL
+
   [PerformanceResourceTiming interface: attribute decodedBodySize]
     expected: FAIL
 
@@ -146,6 +149,9 @@
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute domainLookupStart]
+    expected: FAIL
+
+  [PerformanceResourceTiming interface: attribute connectStart]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute redirectEnd]

--- a/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
+++ b/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
@@ -44,16 +44,10 @@
   [PerformanceResourceTiming interface: resource must inherit property "domainLookupStart" with the proper type]
     expected: FAIL
 
-  [PerformanceResourceTiming interface: resource must inherit property "connectStart" with the proper type]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: attribute workerStart]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute domainLookupStart]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: attribute connectStart]
     expected: FAIL
 
   [PerformanceResourceTiming interface: resource must inherit property "redirectEnd" with the proper type]
@@ -95,9 +89,6 @@
     expected: FAIL
 
   [PerformanceResourceTiming interface: resource must inherit property "domainLookupStart" with the proper type]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: resource must inherit property "connectStart" with the proper type]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute decodedBodySize]
@@ -155,9 +146,6 @@
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute domainLookupStart]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: attribute connectStart]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute redirectEnd]

--- a/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
+++ b/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
@@ -44,16 +44,10 @@
   [PerformanceResourceTiming interface: resource must inherit property "domainLookupStart" with the proper type]
     expected: FAIL
 
-  [PerformanceResourceTiming interface: resource must inherit property "connectStart" with the proper type]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: attribute workerStart]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute domainLookupStart]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: attribute connectStart]
     expected: FAIL
 
   [PerformanceResourceTiming interface: resource must inherit property "redirectEnd" with the proper type]

--- a/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
+++ b/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
@@ -44,10 +44,16 @@
   [PerformanceResourceTiming interface: resource must inherit property "domainLookupStart" with the proper type]
     expected: FAIL
 
+  [PerformanceResourceTiming interface: resource must inherit property "connectStart" with the proper type]
+    expected: FAIL
+
   [PerformanceResourceTiming interface: attribute workerStart]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute domainLookupStart]
+    expected: FAIL
+
+  [PerformanceResourceTiming interface: attribute connectStart]
     expected: FAIL
 
   [PerformanceResourceTiming interface: resource must inherit property "redirectEnd" with the proper type]
@@ -149,9 +155,6 @@
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute domainLookupStart]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: attribute connectStart]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute redirectEnd]

--- a/tests/wpt/metadata/resource-timing/resource_TAO_zero.htm.ini
+++ b/tests/wpt/metadata/resource-timing/resource_TAO_zero.htm.ini
@@ -11,9 +11,6 @@
   [domainLookupStart should be 0 in cross-origin request.]
     expected: FAIL
 
-  [connectStart should be 0 in cross-origin request.]
-    expected: FAIL
-
   [redirectStart should be 0 in cross-origin request.]
     expected: PASS
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
- Added connectStart where needed (```ResourceFetchTiming```, ```ResourceAttribute```) in ```components/net_traits/lib.rs ```
- Before calling ```client.request``` in ```obtain_response```, we now add the ```connectStart``` attribute (```components/net/http_loader.rs```)
- Updated tests to reflect those changes

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] These changes fix #21261 (at least partially)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23323)
<!-- Reviewable:end -->
