### PR TITLE
Enter dom compartment wrapper

### DIFF
--- a/components/script/compartments.rs
+++ b/components/script/compartments.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::dom::bindings::reflector::DomObject;
 use crate::dom::globalscope::GlobalScope;
 use js::jsapi::{GetCurrentRealmOrNull, JSAutoRealm, JSContext};
 
@@ -38,4 +39,11 @@ impl<'a> InCompartment<'a> {
     pub fn entered(token: &JSAutoRealm) -> InCompartment {
         InCompartment::Entered(token)
     }
+}
+
+pub fn enter_realm(object: &impl DomObject) -> JSAutoRealm {
+    JSAutoRealm::new(
+        object.global().get_cx(),
+        object.reflector().get_jsobject().get(),
+    )
 }

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::enter_realm;
 use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
 use crate::dom::bindings::codegen::Bindings::DOMRectBinding::DOMRectMethods;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
@@ -9,7 +10,6 @@ use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::conversions::{jsstring_to_str, ConversionResult, FromJSValConvertible};
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::AnimationFrameCallback;
@@ -23,7 +23,6 @@ use devtools_traits::{AutoMargins, CachedConsoleMessage, CachedConsoleMessageTyp
 use devtools_traits::{ComputedNodeLayout, ConsoleAPI, PageError};
 use devtools_traits::{EvaluateJSReply, Modification, NodeInfo, TimelineMarker};
 use ipc_channel::ipc::IpcSender;
-use js::jsapi::JSAutoRealm;
 use js::jsval::UndefinedValue;
 use js::rust::wrappers::ObjectClassName;
 use msg::constellation_msg::PipelineId;
@@ -36,8 +35,7 @@ pub fn handle_evaluate_js(global: &GlobalScope, eval: String, reply: IpcSender<E
     // global.get_cx() returns a valid `JSContext` pointer, so this is safe.
     let result = unsafe {
         let cx = global.get_cx();
-        let globalhandle = global.reflector().get_jsobject();
-        let _ac = JSAutoRealm::new(cx, globalhandle.get());
+        let _ac = enter_realm(global);
         rooted!(in(cx) let mut rval = UndefinedValue());
         global.evaluate_js_on_global_with_result(&eval, rval.handle_mut());
 

--- a/components/script/dom/audiobuffer.rs
+++ b/components/script/dom/audiobuffer.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::enter_realm;
 use crate::dom::audionode::MAX_CHANNEL_COUNT;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::AudioBufferBinding::{
@@ -14,7 +15,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::window::Window;
 use dom_struct::dom_struct;
 use js::jsapi::JS_GetArrayBufferViewBuffer;
-use js::jsapi::{Heap, JSAutoRealm, JSContext, JSObject};
+use js::jsapi::{Heap, JSContext, JSObject};
 use js::rust::wrappers::DetachArrayBuffer;
 use js::rust::CustomAutoRooterGuard;
 use js::typedarray::{CreateWith, Float32Array};
@@ -126,8 +127,7 @@ impl AudioBuffer {
 
     #[allow(unsafe_code)]
     unsafe fn restore_js_channel_data(&self, cx: *mut JSContext) -> bool {
-        let global = self.global();
-        let _ac = JSAutoRealm::new(cx, global.reflector().get_jsobject().get());
+        let _ac = enter_realm(&*self);
         for (i, channel) in self.js_channels.borrow_mut().iter().enumerate() {
             if !channel.get().is_null() {
                 // Already have data in JS array.

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -5,6 +5,7 @@
 //! This module implements structured cloning, as defined by [HTML]
 //! (https://html.spec.whatwg.org/multipage/#safe-passing-of-structured-data).
 
+use crate::compartments::enter_realm;
 use crate::dom::bindings::conversions::root_from_handleobject;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::DomObject;
@@ -18,11 +19,11 @@ use js::glue::NewJSAutoStructuredCloneBuffer;
 use js::glue::WriteBytesToJSStructuredCloneData;
 use js::jsapi::CloneDataPolicy;
 use js::jsapi::HandleObject as RawHandleObject;
+use js::jsapi::JSContext;
 use js::jsapi::MutableHandleObject as RawMutableHandleObject;
 use js::jsapi::StructuredCloneScope;
 use js::jsapi::TransferableOwnership;
 use js::jsapi::JS_STRUCTURED_CLONE_VERSION;
-use js::jsapi::{JSAutoRealm, JSContext};
 use js::jsapi::{JSObject, JS_ClearPendingException};
 use js::jsapi::{JSStructuredCloneCallbacks, JSStructuredCloneReader, JSStructuredCloneWriter};
 use js::jsapi::{JS_ReadBytes, JS_WriteBytes};
@@ -307,8 +308,7 @@ impl StructuredCloneData {
     /// Panics if `JS_ReadStructuredClone` fails.
     fn read_clone(global: &GlobalScope, data: *mut u64, nbytes: size_t, rval: MutableHandleValue) {
         let cx = global.get_cx();
-        let globalhandle = global.reflector().get_jsobject();
-        let _ac = JSAutoRealm::new(cx, globalhandle.get());
+        let _ac = enter_realm(&*global);
         let mut sc_holder = StructuredCloneHolder { blob: None };
         let sc_holder_ptr = &mut sc_holder as *mut _;
         unsafe {

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::enter_realm;
 use crate::devtools;
 use crate::dom::abstractworker::{SimpleWorkerErrorHandler, WorkerScriptMsg};
 use crate::dom::abstractworkerglobalscope::{run_worker_event_loop, WorkerEventLoopMethods};
@@ -33,8 +34,8 @@ use devtools_traits::DevtoolScriptControlMsg;
 use dom_struct::dom_struct;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
+use js::jsapi::JSContext;
 use js::jsapi::JS_AddInterruptCallback;
-use js::jsapi::{JSAutoRealm, JSContext};
 use js::jsval::UndefinedValue;
 use js::rust::HandleValue;
 use msg::constellation_msg::{PipelineId, TopLevelBrowsingContextId};
@@ -462,7 +463,7 @@ impl DedicatedWorkerGlobalScope {
             WorkerScriptMsg::DOMMessage(data) => {
                 let scope = self.upcast::<WorkerGlobalScope>();
                 let target = self.upcast();
-                let _ac = JSAutoRealm::new(scope.get_cx(), scope.reflector().get_jsobject().get());
+                let _ac = enter_realm(self);
                 rooted!(in(scope.get_cx()) let mut message = UndefinedValue());
                 data.read(scope.upcast(), message.handle_mut());
                 MessageEvent::dispatch_jsval(target, scope.upcast(), message.handle(), None, None);

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::enter_realm;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::EventSourceBinding::{
     EventSourceInit, EventSourceMethods, Wrap,
@@ -28,7 +29,6 @@ use http::header::{self, HeaderName, HeaderValue};
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use js::conversions::ToJSValConvertible;
-use js::jsapi::JSAutoRealm;
 use js::jsval::UndefinedValue;
 use mime::{self, Mime};
 use net_traits::request::{CacheMode, CorsSettings, CredentialsMode};
@@ -222,10 +222,7 @@ impl EventSourceContext {
         };
         // Steps 4-5
         let event = {
-            let _ac = JSAutoRealm::new(
-                event_source.global().get_cx(),
-                event_source.reflector().get_jsobject().get(),
-            );
+            let _ac = enter_realm(&*event_source);
             rooted!(in(event_source.global().get_cx()) let mut data = UndefinedValue());
             unsafe {
                 self.data

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::enter_realm;
 use crate::dom::beforeunloadevent::BeforeUnloadEvent;
 use crate::dom::bindings::callback::{CallbackContainer, CallbackFunction, ExceptionHandling};
 use crate::dom::bindings::cell::DomRefCell;
@@ -506,7 +507,7 @@ impl EventTarget {
 
         let scopechain = AutoObjectVectorWrapper::new(cx);
 
-        let _ac = JSAutoRealm::new(cx, window.reflector().get_jsobject().get());
+        let _ac = enter_realm(&*window);
         rooted!(in(cx) let mut handler = ptr::null_mut::<JSFunction>());
         let rv = unsafe {
             CompileFunction(

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::enter_realm;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
 use crate::dom::bindings::codegen::Bindings::FileReaderBinding::{
@@ -28,7 +29,6 @@ use base64;
 use dom_struct::dom_struct;
 use encoding_rs::{Encoding, UTF_8};
 use js::jsapi::Heap;
-use js::jsapi::JSAutoRealm;
 use js::jsapi::JSContext;
 use js::jsapi::JSObject;
 use js::jsval::{self, JSVal};
@@ -262,7 +262,7 @@ impl FileReader {
                 FileReader::perform_readastext(&fr.result, data, &blob_contents)
             },
             FileReaderFunction::ReadAsArrayBuffer => {
-                let _ac = JSAutoRealm::new(fr.global().get_cx(), *fr.reflector().get_jsobject());
+                let _ac = enter_realm(&*fr);
                 FileReader::perform_readasarraybuffer(
                     &fr.result,
                     fr.global().get_cx(),

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::enter_realm;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::conversions::{root_from_handleobject, ToJSValConvertible};
 use crate::dom::bindings::error::{throw_dom_exception, Error};
@@ -548,7 +549,7 @@ impl WindowProxy {
                 ((*get_object_class(window_jsobject.get())).flags & JSCLASS_IS_GLOBAL),
                 0
             );
-            let _ac = JSAutoRealm::new(cx, window_jsobject.get());
+            let _ac = enter_realm(&*window);
 
             // The old window proxy no longer owns this browsing context.
             SetProxyReservedSlot(old_js_proxy.get(), 0, &PrivateValue(ptr::null_mut()));

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::enter_realm;
 use crate::dom::abstractworker::SimpleWorkerErrorHandler;
 use crate::dom::abstractworker::WorkerScriptMsg;
 use crate::dom::bindings::codegen::Bindings::WorkerBinding;
@@ -25,7 +26,7 @@ use crossbeam_channel::{unbounded, Sender};
 use devtools_traits::{DevtoolsPageInfo, ScriptToDevtoolsControlMsg};
 use dom_struct::dom_struct;
 use ipc_channel::ipc;
-use js::jsapi::{JSAutoRealm, JSContext, JS_RequestInterruptCallback};
+use js::jsapi::{JSContext, JS_RequestInterruptCallback};
 use js::jsval::UndefinedValue;
 use js::rust::HandleValue;
 use script_traits::WorkerScriptLoadOrigin;
@@ -144,7 +145,7 @@ impl Worker {
 
         let global = worker.global();
         let target = worker.upcast();
-        let _ac = JSAutoRealm::new(global.get_cx(), target.reflector().get_jsobject().get());
+        let _ac = enter_realm(target);
         rooted!(in(global.get_cx()) let mut message = UndefinedValue());
         data.read(&global, message.handle_mut());
         MessageEvent::dispatch_jsval(target, &global, message.handle(), None, None);


### PR DESCRIPTION
I'm still not sure if the changes are entirely correct.
Replaced occurrences:
 `JSAutoCompartment::new(global.get_cx(), global.reflector().get_jsobject().get());` with `fn enter_compartment(object: &DomObject) -> JSAutoCompartment`


There are still occurrences of `JSAutoCompartment` that i was unable to replace. Could anyone give me a hint if it is possible?
```
→ rg -Fi --type rust "JSAutoCompartment::"
components/script/compartments.rs
38:    JSAutoCompartment::new(

components/script/dom/create.rs
159:                                let _ac = JSAutoCompartment::new(

components/script/dom/eventtarget.rs
527:                let _ac = JSAutoCompartment::new(cx, self.reflector().get_jsobject().get());

components/script/dom/windowproxy.rs
223:            let _ac = JSAutoCompartment::new(cx, window_jsobject.get());

components/script/dom/customelementregistry.rs
337:            let _ac = JSAutoCompartment::new(cx, proto_object.get());
349:            let _ac = JSAutoCompartment::new(cx, constructor.get());
538:            let _ac = JSAutoCompartment::new(cx, self.constructor.callback());
668:        let _ac = JSAutoCompartment::new(cx, constructor.callback());

components/script/dom/window.rs
2216:            let _ac = JSAutoCompartment::new(cx, obj.get());

components/script/dom/paintworkletglobalscope.rs
254:        let _ac = JSAutoCompartment::new(cx, self.worklet_global.reflector().get_jsobject().get());

components/script/dom/globalscope.rs
544:                let _ac = JSAutoCompartment::new(cx, globalhandle.get());

components/script/dom/websocket.rs
573:            let _ac = JSAutoCompartment::new(cx, ws.reflector().get_jsobject().get());

components/script/dom/workerglobalscope.rs
397:                        let _ac = JSAutoCompartment::new(

components/script/dom/promise.rs
144:        let _ac = JSAutoCompartment::new(cx, global.reflector().get_jsobject().get());
156:        let _ac = JSAutoCompartment::new(cx, global.reflector().get_jsobject().get());

components/script/dom/bindings/htmlconstructor.rs
118:        let _ac = JSAutoCompartment::new(window.get_cx(), callee.get());

components/script/dom/bindings/utils.rs
411:    let _ac = JSAutoCompartment::new(cx, obj.get());

components/script/dom/bindings/callback.rs
276:                let _ac = JSAutoCompartment::new(

components/script/dom/bindings/interface.rs
163:    let _ac = JSAutoCompartment::new(cx, rval.get());
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix  #23266

<!-- Either: -->
- [X] These changes do not require tests because no logic was changed only some code extracted to wrapper function

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23344)
<!-- Reviewable:end -->
