### PR TITLE
Disable video if audio element

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1224,10 +1224,14 @@ impl HTMLMediaElement {
         };
 
         let (action_sender, action_receiver) = ipc::channel().unwrap();
+        let renderer: Option<Arc<Mutex<FrameRenderer>>> = match self.media_type_id() {
+            HTMLMediaElementTypeId::HTMLAudioElement => None,
+            HTMLMediaElementTypeId::HTMLVideoElement => Some(self.frame_renderer.clone()),
+        };
         let player = ServoMedia::get().unwrap().create_player(
             stream_type,
             action_sender,
-            Some(self.frame_renderer.clone()),
+            renderer,
             Box::new(PlayerContextDummy()),
         );
 


### PR DESCRIPTION
And register frame renderer only if video element

Requires the merge of https://github.com/servo/media/pull/257

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23336 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23350)
<!-- Reviewable:end -->
