### PR TITLE
Fix modes for fetching classic worker script and introduce parser metadata for request

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -37,7 +37,8 @@ use js::jsapi::{JSAutoCompartment, JSContext};
 use js::jsval::UndefinedValue;
 use js::rust::HandleValue;
 use msg::constellation_msg::{PipelineId, TopLevelBrowsingContextId};
-use net_traits::request::{CredentialsMode, Destination, Referrer, RequestBuilder, RequestMode};
+use net_traits::request::{CredentialsMode, Destination, ParserMetadata};
+use net_traits::request::{Referrer, RequestBuilder, RequestMode};
 use net_traits::IpcSend;
 use script_traits::{TimerEvent, TimerSource, WorkerGlobalScopeInit, WorkerScriptLoadOrigin};
 use servo_rand::random;
@@ -312,6 +313,7 @@ impl DedicatedWorkerGlobalScope {
                     .destination(Destination::Worker)
                     .mode(RequestMode::SameOrigin)
                     .credentials_mode(CredentialsMode::CredentialsSameOrigin)
+                    .parser_metadata(ParserMetadata::NotParserInserted)
                     .use_url_credentials(true)
                     .pipeline_id(pipeline_id)
                     .referrer(referrer)

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -37,7 +37,7 @@ use js::jsapi::{JSAutoCompartment, JSContext};
 use js::jsval::UndefinedValue;
 use js::rust::HandleValue;
 use msg::constellation_msg::{PipelineId, TopLevelBrowsingContextId};
-use net_traits::request::{CredentialsMode, Destination, Referrer, RequestBuilder};
+use net_traits::request::{CredentialsMode, Destination, Referrer, RequestBuilder, RequestMode};
 use net_traits::IpcSend;
 use script_traits::{TimerEvent, TimerSource, WorkerGlobalScopeInit, WorkerScriptLoadOrigin};
 use servo_rand::random;
@@ -310,7 +310,8 @@ impl DedicatedWorkerGlobalScope {
 
                 let request = RequestBuilder::new(worker_url.clone())
                     .destination(Destination::Worker)
-                    .credentials_mode(CredentialsMode::Include)
+                    .mode(RequestMode::SameOrigin)
+                    .credentials_mode(CredentialsMode::CredentialsSameOrigin)
                     .use_url_credentials(true)
                     .pipeline_id(pipeline_id)
                     .referrer(referrer)

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -31,7 +31,7 @@ use ipc_channel::router::ROUTER;
 use js::jsapi::{JSAutoCompartment, JSContext, JS_AddInterruptCallback};
 use js::jsval::UndefinedValue;
 use msg::constellation_msg::PipelineId;
-use net_traits::request::{CredentialsMode, Destination, Referrer, RequestBuilder};
+use net_traits::request::{CredentialsMode, Destination, ParserMetadata, Referrer, RequestBuilder};
 use net_traits::{CustomResponseMediator, IpcSend};
 use script_traits::{
     ScopeThings, ServiceWorkerMsg, TimerEvent, WorkerGlobalScopeInit, WorkerScriptLoadOrigin,
@@ -287,6 +287,7 @@ impl ServiceWorkerGlobalScope {
                 let request = RequestBuilder::new(script_url.clone())
                     .destination(Destination::ServiceWorker)
                     .credentials_mode(CredentialsMode::Include)
+                    .parser_metadata(ParserMetadata::NotParserInserted)
                     .use_url_credentials(true)
                     .pipeline_id(pipeline_id)
                     .referrer(referrer)

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -42,7 +42,9 @@ use js::jsval::UndefinedValue;
 use js::panic::maybe_resume_unwind;
 use js::rust::{HandleValue, ParentRuntime};
 use msg::constellation_msg::PipelineId;
-use net_traits::request::{CredentialsMode, Destination, RequestBuilder as NetRequestInit};
+use net_traits::request::{
+    CredentialsMode, Destination, ParserMetadata, RequestBuilder as NetRequestInit,
+};
 use net_traits::IpcSend;
 use script_traits::WorkerGlobalScopeInit;
 use script_traits::{TimerEvent, TimerEventId};
@@ -216,6 +218,7 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
             let request = NetRequestInit::new(url.clone())
                 .destination(Destination::Script)
                 .credentials_mode(CredentialsMode::Include)
+                .parser_metadata(ParserMetadata::NotParserInserted)
                 .use_url_credentials(true)
                 .origin(global_scope.origin().immutable().clone())
                 .pipeline_id(Some(self.upcast::<GlobalScope>().pipeline_id()))

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -124,6 +124,7 @@ fn request_init_from_request(request: NetTraitsRequest) -> RequestBuilder {
         redirect_mode: request.redirect_mode,
         integrity_metadata: "".to_owned(),
         url_list: vec![],
+        parser_metadata: request.parser_metadata,
     }
 }
 

--- a/tests/wpt/metadata/workers/constructors/Worker/same-origin.html.ini
+++ b/tests/wpt/metadata/workers/constructors/Worker/same-origin.html.ini
@@ -1,3 +1,9 @@
 [same-origin.html]
   type: testharness
-  disabled: intermittent failures
+  expected: TIMEOUT
+  [unsupported_scheme]
+    expected: FAIL
+
+  [about_blank]
+    expected: TIMEOUT
+


### PR DESCRIPTION
While reading [the spec](https://html.spec.whatwg.org/multipage/#fetch-a-classic-worker-script) for `fetch a classic worker script`, I found the `mode` and `credential-mode` are opposite to the spec. So, the first commit will fix it.

Also, I found there's a `parser metadata` for `request` so I tried to introduce it in this PR as well.

For WPT, I found there's a `/workers/constructors/Worker/same-origin.html` which was disabled in  #3180. We pass most of the tests now.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23351)
<!-- Reviewable:end -->
