### PR TITLE
More https

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
         - sudo apt-get update -q
         - sudo apt-get install clang-3.9 llvm-3.9-dev llvm-3.9-runtime libunwind8-dev -y
         - pip install virtualenv
-        - curl -L http://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-1.14-x86_64-linux-gnu.20190213.tar.gz | tar xz
+        - curl -L https://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-1.14-x86_64-linux-gnu.20190213.tar.gz | tar xz
         - sed -i "s;prefix=/opt/gst;prefix=$PWD/gst;g" $PWD/gst/lib/pkgconfig/*.pc
         - export PKG_CONFIG_PATH=$PWD/gst/lib/pkgconfig
         - export GST_PLUGIN_SYSTEM_PATH=$PWD/gst/lib/gstreamer-1.0

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -77,8 +77,13 @@ pub fn create_ssl_connector_builder(certs: &str) -> SslConnectorBuilder {
     ssl_connector_builder
         .set_cipher_list(DEFAULT_CIPHERS)
         .expect("could not set ciphers");
-    ssl_connector_builder
-        .set_options(SslOptions::NO_SSLV2 | SslOptions::NO_SSLV3 | SslOptions::NO_COMPRESSION);
+    ssl_connector_builder.set_options(
+        SslOptions::NO_SSLV2 |
+            SslOptions::NO_SSLV3 |
+            SslOptions::NO_TLSV1 |
+            SslOptions::NO_TLSV1_1 |
+            SslOptions::NO_COMPRESSION,
+    );
     ssl_connector_builder
 }
 

--- a/components/script/dom/bindings/codegen/parser/WebIDL.py
+++ b/components/script/dom/bindings/codegen/parser/WebIDL.py
@@ -1,6 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 """ A WebIDL parser. """
 

--- a/components/script/dom/bindings/codegen/parser/tests/test_lenientSetter.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_lenientSetter.py
@@ -1,6 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 def should_throw(parser, harness, message, code):
     parser = parser.reset();

--- a/components/script/dom/bindings/codegen/parser/tests/test_replaceable.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_replaceable.py
@@ -1,6 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 def should_throw(parser, harness, message, code):
     parser = parser.reset();

--- a/components/script/dom/navigationpreloadmanager.rs
+++ b/components/script/dom/navigationpreloadmanager.rs
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::compartments::{AlreadyInCompartment, InCompartment};
 use crate::dom::bindings::codegen::Bindings::NavigationPreloadManagerBinding::NavigationPreloadState;

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::OffscreenCanvasBinding::{

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::codegen::Bindings::OffscreenCanvasRenderingContext2DBinding;
 use crate::dom::bindings::codegen::Bindings::OffscreenCanvasRenderingContext2DBinding::OffscreenCanvasRenderingContext2DMethods;

--- a/components/script/dom/webidls/NavigationPreloadManager.webidl
+++ b/components/script/dom/webidls/NavigationPreloadManager.webidl
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // https://w3c.github.io/ServiceWorker/#navigation-preload-manager
 [Pref="dom.serviceworker.enabled", SecureContext, Exposed=(Window,Worker)]

--- a/components/script/dom/webidls/OffscreenCanvas.webidl
+++ b/components/script/dom/webidls/OffscreenCanvas.webidl
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // https://html.spec.whatwg.org/multipage/#the-offscreencanvas-interface
 typedef (OffscreenCanvasRenderingContext2D or WebGLRenderingContext or WebGL2RenderingContext)

--- a/components/script/dom/webidls/OffscreenCanvasRenderingContext2D.webidl
+++ b/components/script/dom/webidls/OffscreenCanvasRenderingContext2D.webidl
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // https://html.spec.whatwg.org/multipage/#the-offscreen-2d-rendering-context
 [Exposed=(Window,Worker), Pref="dom.offscreen_canvas.enabled"]

--- a/components/style/gecko/boxed_types.rs
+++ b/components/style/gecko/boxed_types.rs
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 //! FFI implementations for types listed in ServoBoxedTypeList.h.
 

--- a/components/to_shmem_derive/to_shmem.rs
+++ b/components/to_shmem_derive/to_shmem.rs
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use derive_common::cg;
 use proc_macro2::TokenStream;

--- a/ports/glutin/browser.rs
+++ b/ports/glutin/browser.rs
@@ -491,7 +491,7 @@ fn sanitize_url(request: &str) -> Option<ServoUrl> {
         .ok()
         .or_else(|| {
             if request.contains('/') || is_reg_domain(request) {
-                ServoUrl::parse(&format!("http://{}", request)).ok()
+                ServoUrl::parse(&format!("https://{}", request)).ok()
             } else {
                 None
             }

--- a/support/linux/gstreamer/gstreamer.sh
+++ b/support/linux/gstreamer/gstreamer.sh
@@ -6,5 +6,5 @@
 
 set -o errexit
 
-curl -L http://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-1.14-x86_64-linux-gnu.20190213.tar.gz | tar xz
+curl -L https://servo-deps.s3.amazonaws.com/gstreamer/gstreamer-1.14-x86_64-linux-gnu.20190213.tar.gz | tar xz
 sed -i "s;prefix=/opt/gst;prefix=$PWD/gst;g" $PWD/gst/lib/pkgconfig/*.pc


### PR DESCRIPTION
* Disabled unused legacy TLS.
It will be disabled for Nightly 72 or 73 in 5-7 months and ride the [trains](https://wiki.mozilla.org/Release_Management/Calendar).
https://blog.mozilla.org/security/2018/10/15/removing-old-versions-of-tls/
* Updated MPL license in a few files.
It would be nice if a new version of https://pypi.org/project/servo_tidy/ could be released to update WebRender as well.
* Switched servo-deps.s3.amazonaws.com back to https.
This was recently regressed by 10585be25c334bd15710d1a6d93391a9acb6d543 and fc28073dfba05cb2d3fda624c135b2125c1b90af.
* Made https the default protocol for address bar on desktop.
Press Ctrl+L on the Glutin port and enter `example.com`:
Servo previously assumed you meant `http://example.com/`, now it is `https://example.com/`.

---

- [x] `./mach build --release` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23363)
<!-- Reviewable:end -->
