### PR TITLE
[WIP] Experiment with some thread local task sources 

### DIFF
--- a/components/script/dom/abstractworkerglobalscope.rs
+++ b/components/script/dom/abstractworkerglobalscope.rs
@@ -11,11 +11,11 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::worker::TrustedWorkerAddress;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::script_runtime::{CommonScriptMsg, LocalScriptChan, ScriptChan, ScriptPort};
-use std::collections::VecDeque;
-use std::rc::Rc;
 use crate::task_queue::{QueuedTaskConversion, TaskQueue};
 use crossbeam_channel::{Receiver, Sender};
 use devtools_traits::DevtoolScriptControlMsg;
+use std::collections::VecDeque;
+use std::rc::Rc;
 
 /// A ScriptChan that can be cloned freely and will silently send a TrustedWorkerAddress with
 /// common event loop messages. While this SendableWorkerScriptChan is alive, the associated
@@ -82,7 +82,7 @@ impl LocalScriptChan for ThreadLocalWorkerChan {
             WorkerScriptMsg::Common(msg),
         );
         self.sender.borrow_mut().push_back(msg);
-		Ok(())
+        Ok(())
     }
 
     fn clone(&self) -> Box<dyn LocalScriptChan> {
@@ -184,4 +184,5 @@ pub fn run_worker_event_loop<T, TimerMsg, WorkerMsg, Event>(
             .upcast::<GlobalScope>()
             .perform_a_microtask_checkpoint();
     }
+    task_queue.ensure_wake_up();
 }

--- a/components/script/dom/analysernode.rs
+++ b/components/script/dom/analysernode.rs
@@ -99,7 +99,7 @@ impl AnalyserNode {
         let object = reflect_dom_object(Box::new(node), window, AnalyserNodeBinding::Wrap);
         let (source, canceller) = window
             .task_manager()
-            .dom_manipulation_task_source_with_canceller();
+            .media_element_task_source_with_canceller();
         let this = Trusted::new(&*object);
 
         ROUTER.add_route(

--- a/components/script/dom/audioscheduledsourcenode.rs
+++ b/components/script/dom/audioscheduledsourcenode.rs
@@ -73,14 +73,14 @@ impl AudioScheduledSourceNodeMethods for AudioScheduledSourceNode {
         let window = global.as_window();
         let (task_source, canceller) = window
             .task_manager()
-            .dom_manipulation_task_source_with_canceller();
+            .media_element_task_source_with_canceller();
         let callback = OnEndedCallback::new(move || {
             let _ = task_source.queue_with_canceller(
                 task!(ended: move || {
                     let this = this.root();
                     let global = this.global();
                     let window = global.as_window();
-                    window.task_manager().dom_manipulation_task_source().queue_simple_event(
+                    window.task_manager().media_element_task_source().queue_simple_event(
                         this.upcast(),
                         atom!("ended"),
                         &window

--- a/components/script/dom/baseaudiocontext.rs
+++ b/components/script/dom/baseaudiocontext.rs
@@ -460,10 +460,10 @@ impl BaseAudioContextMethods for BaseAudioContext {
             let this_ = this.clone();
             let (task_source, canceller) = window
                 .task_manager()
-                .dom_manipulation_task_source_with_canceller();
+                .media_element_task_source_with_canceller();
             let (task_source_, canceller_) = window
                 .task_manager()
-                .dom_manipulation_task_source_with_canceller();
+                .media_element_task_source_with_canceller();
             let callbacks = AudioDecoderCallbacks::new()
                 .ready(move |channel_count| {
                     decoded_audio

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -5,7 +5,9 @@
 use crate::devtools;
 use crate::dom::abstractworker::{SimpleWorkerErrorHandler, WorkerScriptMsg};
 use crate::dom::abstractworkerglobalscope::{run_worker_event_loop, WorkerEventLoopMethods};
-use crate::dom::abstractworkerglobalscope::{SendableWorkerScriptChan, ThreadLocalWorkerChan, WorkerThreadWorkerChan};
+use crate::dom::abstractworkerglobalscope::{
+    SendableWorkerScriptChan, ThreadLocalWorkerChan, WorkerThreadWorkerChan,
+};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::DedicatedWorkerGlobalScopeBinding;
 use crate::dom::bindings::codegen::Bindings::DedicatedWorkerGlobalScopeBinding::DedicatedWorkerGlobalScopeMethods;
@@ -25,7 +27,9 @@ use crate::dom::worker::{TrustedWorkerAddress, Worker};
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::fetch::load_whole_resource;
 use crate::script_runtime::ScriptThreadEventCategory::WorkerEvent;
-use crate::script_runtime::{new_child_runtime, CommonScriptMsg, LocalScriptChan, Runtime, ScriptChan, ScriptPort};
+use crate::script_runtime::{
+    new_child_runtime, CommonScriptMsg, LocalScriptChan, Runtime, ScriptChan, ScriptPort,
+};
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
 use crate::task_source::TaskSourceName;
 use crossbeam_channel::{unbounded, Receiver, Sender};

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1229,7 +1229,7 @@ impl HTMLMediaElement {
         let window = window_from_node(self);
         let (task_source, canceller) = window
             .task_manager()
-            .dom_manipulation_task_source_with_canceller();
+            .media_element_task_source_with_canceller();
         ROUTER.add_route(
             action_receiver.to_opaque(),
             Box::new(move |message| {

--- a/components/script/dom/offlineaudiocontext.rs
+++ b/components/script/dom/offlineaudiocontext.rs
@@ -147,7 +147,7 @@ impl OfflineAudioContextMethods for OfflineAudioContext {
         let window = global.as_window();
         let (task_source, canceller) = window
             .task_manager()
-            .dom_manipulation_task_source_with_canceller();
+            .media_element_task_source_with_canceller();
         Builder::new()
             .name("OfflineAudioContextResolver".to_owned())
             .spawn(move || {

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -149,11 +149,11 @@ pub struct ServiceWorkerLocalChan {
 impl LocalScriptChan for ServiceWorkerLocalChan {
     fn send(&self, msg: CommonScriptMsg) -> Result<(), ()> {
         self.sender
-			.borrow_mut()
+            .borrow_mut()
             .push_back(ServiceWorkerScriptMsg::CommonWorker(
                 WorkerScriptMsg::Common(msg),
             ));
-		Ok(())
+        Ok(())
     }
 
     fn clone(&self) -> Box<dyn LocalScriptChan> {

--- a/components/script/dom/vrdisplay.rs
+++ b/components/script/dom/vrdisplay.rs
@@ -534,9 +534,10 @@ impl VRDisplay {
         let ctx = ctx.map(|c| Trusted::new(c));
         let global = self.global();
         let window = global.as_window();
+		// FIXME: use a dedicated VR task-source.
         let (task_source, canceller) = window
             .task_manager()
-            .dom_manipulation_task_source_with_canceller();
+            .media_element_task_source_with_canceller();
         thread::spawn(move || {
             let recv = receiver.recv().unwrap();
             let _ = task_source.queue_with_canceller(

--- a/components/script/dom/vrdisplay.rs
+++ b/components/script/dom/vrdisplay.rs
@@ -534,7 +534,7 @@ impl VRDisplay {
         let ctx = ctx.map(|c| Trusted::new(c));
         let global = self.global();
         let window = global.as_window();
-		// FIXME: use a dedicated VR task-source.
+        // FIXME: use a dedicated VR task-source.
         let (task_source, canceller) = window
             .task_manager()
             .media_element_task_source_with_canceller();

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -459,11 +459,11 @@ impl WorkerGlobalScope {
     }
 
     pub fn performance_timeline_task_source(&self) -> PerformanceTimelineTaskSource {
-        PerformanceTimelineTaskSource(self.script_chan(), self.pipeline_id())
+        PerformanceTimelineTaskSource(self.local_script_chan(), self.pipeline_id())
     }
 
     pub fn remote_event_task_source(&self) -> RemoteEventTaskSource {
-        RemoteEventTaskSource(self.script_chan(), self.pipeline_id())
+        RemoteEventTaskSource(self.local_script_chan(), self.pipeline_id())
     }
 
     pub fn websocket_task_source(&self) -> WebsocketTaskSource {

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -25,7 +25,9 @@ use crate::dom::window::{base64_atob, base64_btoa};
 use crate::dom::workerlocation::WorkerLocation;
 use crate::dom::workernavigator::WorkerNavigator;
 use crate::fetch;
-use crate::script_runtime::{get_reports, CommonScriptMsg, LocalScriptChan, Runtime, ScriptChan, ScriptPort};
+use crate::script_runtime::{
+    get_reports, CommonScriptMsg, LocalScriptChan, Runtime, ScriptChan, ScriptPort,
+};
 use crate::task::TaskCanceller;
 use crate::task_source::dom_manipulation::DOMManipulationTaskSource;
 use crate::task_source::file_reading::FileReadingTaskSource;

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -97,6 +97,14 @@ pub trait ScriptChan: JSTraceable {
     fn clone(&self) -> Box<dyn ScriptChan + Send>;
 }
 
+/// A cloneable interface for communicating with an event loop, from the event-loop itself.
+pub trait LocalScriptChan: JSTraceable {
+    /// Send a message to the associated event loop.
+    fn send(&self, msg: CommonScriptMsg) -> Result<(), ()>;
+    /// Clone this handle.
+    fn clone(&self) -> Box<dyn LocalScriptChan>;
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, JSTraceable, PartialEq)]
 pub enum ScriptThreadEventCategory {
     AttachLayout,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2460,7 +2460,10 @@ impl ScriptThread {
         &self,
         pipeline_id: PipelineId,
     ) -> PerformanceTimelineTaskSource {
-        PerformanceTimelineTaskSource(self.performance_timeline_task_sender.clone(), pipeline_id)
+        PerformanceTimelineTaskSource(
+            Box::new(ThreadLocalScriptChan(self.task_queue.local_port())),
+            pipeline_id,
+        )
     }
 
     pub fn history_traversal_task_source(
@@ -2474,7 +2477,10 @@ impl ScriptThread {
         &self,
         pipeline_id: PipelineId,
     ) -> UserInteractionTaskSource {
-        UserInteractionTaskSource(self.user_interaction_task_sender.clone(), pipeline_id)
+        UserInteractionTaskSource(
+            Box::new(ThreadLocalScriptChan(self.task_queue.local_port())),
+            pipeline_id,
+        )
     }
 
     pub fn networking_task_source(&self, pipeline_id: PipelineId) -> NetworkingTaskSource {
@@ -2486,11 +2492,14 @@ impl ScriptThread {
     }
 
     pub fn remote_event_task_source(&self, pipeline_id: PipelineId) -> RemoteEventTaskSource {
-        RemoteEventTaskSource(self.remote_event_task_sender.clone(), pipeline_id)
+        RemoteEventTaskSource(
+            Box::new(ThreadLocalScriptChan(self.task_queue.local_port())),
+            pipeline_id,
+        )
     }
 
     pub fn websocket_task_source(&self, pipeline_id: PipelineId) -> WebsocketTaskSource {
-        WebsocketTaskSource(self.remote_event_task_sender.clone(), pipeline_id)
+        WebsocketTaskSource(self.file_reading_task_sender.clone(), pipeline_id)
     }
 
     /// Handles a request for the window title.

--- a/components/script/task_source/dom_manipulation.rs
+++ b/components/script/task_source/dom_manipulation.rs
@@ -7,7 +7,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::event::{EventBubbles, EventCancelable, EventTask, SimpleEventTask};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::window::Window;
-use crate::script_runtime::{CommonScriptMsg, ScriptChan, ScriptThreadEventCategory};
+use crate::script_runtime::{CommonScriptMsg, LocalScriptChan, ScriptThreadEventCategory};
 use crate::task::{TaskCanceller, TaskOnce};
 use crate::task_source::{TaskSource, TaskSourceName};
 use msg::constellation_msg::PipelineId;
@@ -16,7 +16,7 @@ use std::fmt;
 use std::result::Result;
 
 #[derive(JSTraceable)]
-pub struct DOMManipulationTaskSource(pub Box<dyn ScriptChan + Send>, pub PipelineId);
+pub struct DOMManipulationTaskSource(pub Box<dyn LocalScriptChan>, pub PipelineId);
 
 impl Clone for DOMManipulationTaskSource {
     fn clone(&self) -> DOMManipulationTaskSource {

--- a/components/script/task_source/performance_timeline.rs
+++ b/components/script/task_source/performance_timeline.rs
@@ -8,7 +8,7 @@
 
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::{CommonScriptMsg, ScriptChan, ScriptThreadEventCategory};
+use crate::script_runtime::{CommonScriptMsg, LocalScriptChan, ScriptThreadEventCategory};
 use crate::task::{TaskCanceller, TaskOnce};
 use crate::task_source::{TaskSource, TaskSourceName};
 use msg::constellation_msg::PipelineId;
@@ -16,7 +16,7 @@ use std::fmt;
 use std::result::Result;
 
 #[derive(JSTraceable)]
-pub struct PerformanceTimelineTaskSource(pub Box<dyn ScriptChan + Send + 'static>, pub PipelineId);
+pub struct PerformanceTimelineTaskSource(pub Box<dyn LocalScriptChan>, pub PipelineId);
 
 impl Clone for PerformanceTimelineTaskSource {
     fn clone(&self) -> PerformanceTimelineTaskSource {

--- a/components/script/task_source/remote_event.rs
+++ b/components/script/task_source/remote_event.rs
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::script_runtime::{CommonScriptMsg, ScriptChan, ScriptThreadEventCategory};
+use crate::script_runtime::{CommonScriptMsg, LocalScriptChan, ScriptThreadEventCategory};
 use crate::task::{TaskCanceller, TaskOnce};
 use crate::task_source::{TaskSource, TaskSourceName};
 use msg::constellation_msg::PipelineId;
 
 #[derive(JSTraceable)]
-pub struct RemoteEventTaskSource(pub Box<dyn ScriptChan + Send + 'static>, pub PipelineId);
+pub struct RemoteEventTaskSource(pub Box<dyn LocalScriptChan>, pub PipelineId);
 
 impl Clone for RemoteEventTaskSource {
     fn clone(&self) -> RemoteEventTaskSource {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Trying to see if we can make some of the tasks mechanism local to a script-thread, in some cases. For example, it seems that the DOM manipulation task-source is always used from steps running on the event-loop itself, as opposed to from parallel ones...

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23369)
<!-- Reviewable:end -->
