### PR TITLE
Change XHRContext and resource timing information to use request URL

### DIFF
--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -98,6 +98,7 @@ struct XHRContext {
     gen_id: GenerationId,
     sync_status: DomRefCell<Option<ErrorResult>>,
     resource_timing: ResourceFetchTiming,
+    url: ServoUrl,
 }
 
 #[derive(Clone)]
@@ -284,10 +285,7 @@ impl XMLHttpRequest {
 
         impl ResourceTimingListener for XHRContext {
             fn resource_timing_information(&self) -> (InitiatorType, ServoUrl) {
-                (
-                    InitiatorType::XMLHttpRequest,
-                    self.resource_timing_global().get_url().clone(),
-                )
+                (InitiatorType::XMLHttpRequest, self.url.clone())
             }
 
             fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
@@ -1466,6 +1464,7 @@ impl XMLHttpRequest {
             gen_id: self.generation_id.get(),
             sync_status: DomRefCell::new(None),
             resource_timing: ResourceFetchTiming::new(ResourceTimingType::Resource),
+            url: init.url.clone(),
         }));
 
         let (task_source, script_port) = if self.sync.get() {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1,5 +1,11 @@
 {
  "items": {
+  "conformancechecker": {
+   "mozilla/xmlhttprequest_url.html": []
+  },
+  "manual": {
+   "mozilla/xmlhttprequest_url.html": []
+  },
   "reftest": {
    "css/abs-overflow-stackingcontext.html": [
     [
@@ -7624,7 +7630,8 @@
      ],
      {}
     ]
-   ]
+   ],
+   "mozilla/xmlhttprequest_url.html": []
   },
   "reftest_node": {
    "css/border_black_groove.html": [
@@ -7638,7 +7645,11 @@
      ],
      {}
     ]
-   ]
+   ],
+   "mozilla/xmlhttprequest_url.html": []
+  },
+  "stub": {
+   "mozilla/xmlhttprequest_url.html": []
   },
   "support": {
    ".gitignore": [
@@ -11210,7 +11221,8 @@
     [
      {}
     ]
-   ]
+   ],
+   "mozilla/xmlhttprequest_url.html": []
   },
   "testharness": {
    "bluetooth/advertisingEvent/watchAdvertisements-succeeds.html": [
@@ -13909,7 +13921,19 @@
      "mozilla/worklets/test_worklet.html",
      {}
     ]
+   ],
+   "mozilla/xmlhttprequest_url.html": [
+    [
+     "mozilla/xmlhttprequest_url.html",
+     {}
+    ]
    ]
+  },
+  "visual": {
+   "mozilla/xmlhttprequest_url.html": []
+  },
+  "wdspec": {
+   "mozilla/xmlhttprequest_url.html": []
   }
  },
  "paths": {
@@ -21084,6 +21108,10 @@
   "mozilla/worklets/throw_exception.js": [
    "6ca4f80fc2728c00848bb4474b62fa3596ed2f18",
    "support"
+  ],
+  "mozilla/xmlhttprequest_url.html": [
+   "e5d10f27c06e1febd3bb70f8f128194fc3f63861",
+   "testharness"
   ]
  },
  "url_base": "/_mozilla/",

--- a/tests/wpt/mozilla/tests/mozilla/xmlhttprequest_url.html
+++ b/tests/wpt/mozilla/tests/mozilla/xmlhttprequest_url.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>XMLHttpRequest Origin</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+function resolve(path) {
+  let a = document.createElement("a");
+  a.href = path;
+  return a.href;
+}
+
+async_test(function(t) {
+  let href = window.location.href;
+  let request = new XMLHttpRequest();
+  let url = resolve("./test.txt");
+  request.open('GET', url, true);
+  request.send();
+
+  request.onload = t.step_func_done(function() {
+    let entries = window.performance.getEntriesByType("resource");
+    assert_equals(entries.length, 1);
+    assert_equals(entries[0].name, href);
+  });
+}, "Performance entries should contain the URL where the XMLHttpRequest originated");
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Change resource timing information to return the URL used to create the XHR and store the URL in XHRContext.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23329 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23372)
<!-- Reviewable:end -->
