### PR TITLE
Build Linux Nightly with OpenSSL 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,12 @@ If this doesn't work, file a bug, and, run the commands below:
 sudo apt install git curl autoconf libx11-dev \
     libfreetype6-dev libgl1-mesa-dri libglib2.0-dev xorg-dev \
     gperf g++ build-essential cmake virtualenv python-pip \
-    libssl1.0-dev libbz2-dev liblzma-dev libosmesa6-dev libxmu6 libxmu-dev \
+    libssl-dev libbz2-dev liblzma-dev libosmesa6-dev libxmu6 libxmu-dev \
     libglu1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev \
     libharfbuzz-dev ccache clang libunwind-dev \
     libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev autoconf2.13
 ```
 
-If you using a version prior to **Ubuntu 17.04**, **Linux Mint 19** or **Debian Sid**, replace `libssl1.0-dev` with `libssl-dev`.
 Additionally, you'll need a local copy of GStreamer with a version later than 12.0. You can place it in `support/linux/gstreamer/gstreamer`, or run `./mach bootstrap-gstreamer` to set it up.
 
 If you are using **Ubuntu 16.04** or **Linux Mint 18.&#42;** run `export HARFBUZZ_SYS_NO_PKG_CONFIG=1` before building to avoid an error with harfbuzz.

--- a/etc/taskcluster/docker/build.dockerfile
+++ b/etc/taskcluster/docker/build.dockerfile
@@ -24,7 +24,7 @@ RUN \
         libgstreamer-plugins-bad1.0-dev \
         #
         # OpenSSL
-        libssl1.0-dev \
+        libssl-dev \
         #
         # blurz
         libdbus-1-dev \

--- a/etc/taskcluster/docker/run.dockerfile
+++ b/etc/taskcluster/docker/run.dockerfile
@@ -3,7 +3,7 @@
 # Servo’s runtime dependencies
 RUN apt-get install -qy --no-install-recommends \
     libgl1 \
-    libssl1.0.0 \
+    libssl1.1 \
     libdbus-1-3 \
     libgstreamer-plugins-bad1.0-0 \
     gstreamer1.0-plugins-good

--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -110,7 +110,7 @@ def linux(context, force=False):
     # Please keep these in sync with the packages in README.md
     pkgs_apt = ['git', 'curl', 'autoconf', 'libx11-dev', 'libfreetype6-dev',
                 'libgl1-mesa-dri', 'libglib2.0-dev', 'xorg-dev', 'gperf', 'g++',
-                'build-essential', 'cmake', 'python-pip',
+                'build-essential', 'cmake', 'python-pip', "libssl-dev",
                 'libbz2-dev', 'liblzma-dev',
                 'libosmesa6-dev', 'libxmu6', 'libxmu-dev', 'libglu1-mesa-dev',
                 'libgles2-mesa-dev', 'libegl1-mesa-dev', 'libdbus-1-dev', 'libharfbuzz-dev',
@@ -124,24 +124,12 @@ def linux(context, force=False):
                 'ccache', 'mesa-libGLU-devel', 'clang', 'clang-libs', 'gstreamer1-devel',
                 'gstreamer1-plugins-base-devel', 'gstreamer1-plugins-bad-free-devel', 'autoconf213']
     if context.distro == "Ubuntu":
-        if context.distro_version in ["17.04", "19.04"]:
-            pkgs_apt += ["libssl-dev"]
-        elif int(context.distro_version.split(".")[0]) < 17:
-            pkgs_apt += ["libssl-dev"]
-        else:
-            pkgs_apt += ["libssl1.0-dev"]
-
         if context.distro_version == "14.04":
             pkgs_apt += ["python-virtualenv"]
         else:
             pkgs_apt += ["virtualenv"]
             pkgs_apt += ['libgstreamer1.0-dev', 'libgstreamer-plugins-base1.0-dev',
                          'libgstreamer-plugins-bad1.0-dev']
-
-    elif context.distro == "Debian" and context.distro_version == "Sid":
-        pkgs_apt += ["libssl-dev"]
-    else:
-        pkgs_apt += ["libssl1.0-dev"]
 
     installed_something = install_linux_deps(context, pkgs_apt, pkgs_dnf, force)
 


### PR DESCRIPTION
Servo Nightly fails to run on Ubuntu 19.04 (disco) as it doesn't have a libssl1.0.0 package.
OpenSSL 1.1.x is supported since [Debian Stretch](https://packages.debian.org/en/stretch/libssl1.1) (currently Debian Stable) and [Ubuntu 18.04](https://packages.ubuntu.com/bionic/libssl1.1) (used by base.dockerfile).
Ancient Debian + Ubuntu releases are still able to compile Servo using their most recent OpenSSL (1.0.x).

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #12015, fix #21778 and fix #22110

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23392)
<!-- Reviewable:end -->
