### PR TITLE
Bump Windows build tasks time out

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -406,7 +406,8 @@ def windows_nightly():
         .with_treeherder("Windows x64", "Nightly")
         .with_features("taskclusterProxy")
         .with_scopes("secrets:get:project/servo/s3-upload-credentials")
-        .with_script("mach build --release",
+        .with_script("mach fetch",
+                     "mach build --release",
                      "mach package --release",
                      "mach upload-nightly windows-msvc --secret-from-taskcluster")
         .with_artifacts("repo/target/release/msi/Servo.exe",
@@ -701,7 +702,7 @@ def windows_build_task(name, package=True, arch="x86_64"):
     version = "1.14.3"
     task = (
         windows_task(name)
-        .with_max_run_time_minutes(60)
+        .with_max_run_time_minutes(90)
         .with_env(
             **build_env,
             **windows_build_env[arch],


### PR DESCRIPTION
Before:

https://tools.taskcluster.net/groups/L8mSy2kiT9qzVt9r6b2bnQ/tasks/IkU0GgVJReGIEp3wUrzpHg/runs/0/logs/public%2Flogs%2Flive.log#L1100

After:

https://tools.taskcluster.net/groups/TDkbydkZSCOeb3z7ap-24g/tasks/HIS8WSMjRUe05nXOgssfzQ/runs/0/logs/public%2Flogs%2Flive.log#L1180

(Well that second one happened to only take 58 minutes, but still.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23395)
<!-- Reviewable:end -->
