### PR TITLE
Include missing dependency requirements

### DIFF
--- a/python/tidy/setup.py
+++ b/python/tidy/setup.py
@@ -17,6 +17,8 @@ install_requires = [
     "flake8==2.4.1",
     "toml==0.9.2",
     "colorama==0.3.7",
+    "voluptuous==0.11.5",
+    "PyYAML==5.1",
 ]
 
 here = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Running `servo-tidy` in a virtualenv where all you've done is `pip install servo-tidy==0.3.0` doesn't actually work because of missing dependencies. PyYAML and voluptuous are required as well. I don't know anything about python package management but declaring these missing dependencies seems like an appropriate thing to do. Patch itself is untested because I don't know how, although with these dependencies installed in my virtualenv running `servo-tidy` works.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23400)
<!-- Reviewable:end -->
