### PR TITLE
Remove unsupported homebrew options

### DIFF
--- a/etc/taskcluster/macos/Brewfile-gstreamer
+++ b/etc/taskcluster/macos/Brewfile-gstreamer
@@ -1,6 +1,6 @@
 brew "gstreamer"
 brew "gst-plugins-base"
 brew "gst-libav"
-brew "gst-plugins-bad", args: ["with-libnice", "with-srtp"]
+brew "gst-plugins-bad"
 brew "gst-plugins-good"
 brew "gst-rtsp-server"


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/commit/452f458438c07e18c60fb44f732b0457bc965135 removed these options as part of a purge of support for building from source from the package manager.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23401)
<!-- Reviewable:end -->
