### PR TITLE
Add gst-plugins-bad homebrew formula that enables webrtc.

### DIFF
--- a/etc/taskcluster/macos/Brewfile-gstreamer
+++ b/etc/taskcluster/macos/Brewfile-gstreamer
@@ -1,6 +1,6 @@
 brew "gstreamer"
 brew "gst-plugins-base"
 brew "gst-libav"
-brew "gst-plugins-bad"
+brew "./etc/taskcluster/macos/Formula/gst-plugins-bad.rb"
 brew "gst-plugins-good"
 brew "gst-rtsp-server"

--- a/etc/taskcluster/macos/Formula/gst-plugins-bad.diff
+++ b/etc/taskcluster/macos/Formula/gst-plugins-bad.diff
@@ -1,0 +1,13 @@
+--- gst-plugins-bad.rb	2019-05-15 12:48:17.000000000 -0400
++++ gst-plugins-bad-new.rb	2019-05-15 12:49:35.000000000 -0400
+@@ -28,8 +28,10 @@
+   depends_on "libmms"
+   depends_on "openssl"
+   depends_on "opus"
+   depends_on "orc"
++  depends_on "libnice"
++  depends_on "srtp"
+ 
+   def install
+     args = %W[
+       --prefix=#{prefix}

--- a/etc/taskcluster/macos/Formula/gst-plugins-bad.rb
+++ b/etc/taskcluster/macos/Formula/gst-plugins-bad.rb
@@ -1,0 +1,61 @@
+class GstPluginsBad < Formula
+  desc "GStreamer plugins less supported, not fully tested"
+  homepage "https://gstreamer.freedesktop.org/"
+  url "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.16.0.tar.xz"
+  sha256 "22139de35626ada6090bdfa3423b27b7fc15a0198331d25c95e6b12cb1072b05"
+
+  bottle do
+    sha256 "7c27cd50644867490e5aa36860f3046889167234c4f139d56c895f9edd1c3a99" => :mojave
+    sha256 "c7b7c9586a08c3f7a1c0677165ecb0a0e9a989516eb3effdbb74dd285100dff0" => :high_sierra
+    sha256 "fc98180089cae089882fb91240280498ef33094f18b27b2cdfd9923a236e06de" => :sierra
+  end
+
+  head do
+    url "https://anongit.freedesktop.org/git/gstreamer/gst-plugins-bad.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+  end
+
+  depends_on "gobject-introspection" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "faac"
+  depends_on "faad2"
+  depends_on "gettext"
+  depends_on "gst-plugins-base"
+  depends_on "jpeg"
+  depends_on "libmms"
+  depends_on "openssl"
+  depends_on "opus"
+  depends_on "orc"
+  depends_on "libnice"
+  depends_on "srtp"
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --disable-yadif
+      --disable-examples
+      --disable-debug
+      --disable-dependency-tracking
+      --enable-introspection=yes
+    ]
+
+    if build.head?
+      # autogen is invoked in "stable" build because we patch configure.ac
+      ENV["NOCONFIGURE"] = "yes"
+      system "./autogen.sh"
+    end
+
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    gst = Formula["gstreamer"].opt_bin/"gst-inspect-1.0"
+    output = shell_output("#{gst} --plugin dvbsuboverlay")
+    assert_match version.to_s, output
+  end
+end

--- a/etc/taskcluster/macos/Formula/recreate.sh
+++ b/etc/taskcluster/macos/Formula/recreate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+FORMULAS=(gst-plugins-bad.rb)
+for i in ${FORMULAS[@]}; do
+    curl -o "${i}" "https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/${i}"
+    patch -i "${i/.rb/.diff}"
+done


### PR DESCRIPTION
This forks the upstream homebrew formula for gst-plugins-bad and re-adds two important (previously optional) dependencies. It also adds a script to regenerate the formula from upstream to make it as easy as possible to update gstreamer in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23403)
<!-- Reviewable:end -->
