### PR TITLE
Reintroduce parallelism in the bluetooth tests

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -569,7 +569,7 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
                     tests/wpt/mozilla/tests/css/img_simple.html \
                     tests/wpt/mozilla/tests/mozilla/secure.https.html \
                     | cat
-                time ./mach test-wpt --release --processes 1 --product=servodriver \
+                time ./mach test-wpt --release --processes $PROCESSES --product=servodriver \
                     --headless --log-raw test-bluetooth.log \
                     --log-errorsummary bluetooth-errorsummary.log \
                     bluetooth \


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
With https://github.com/web-platform-tests/wpt/pull/16819 in place, https://github.com/servo/servo/issues/22619 should be fixed, so the changes introduced by https://github.com/servo/servo/pull/22662 can be reverted.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23407)
<!-- Reviewable:end -->
