### PR TITLE
spec update: window.name deals with lack of browsing context

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1160,12 +1160,17 @@ impl WindowMethods for Window {
 
     // https://html.spec.whatwg.org/multipage/#dom-name
     fn SetName(&self, name: DOMString) {
-        self.window_proxy().set_name(name);
+        if let Some(proxy) = self.undiscarded_window_proxy() {
+            proxy.set_name(name);
+        }
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-name
     fn Name(&self) -> DOMString {
-        self.window_proxy().get_name()
+        match self.undiscarded_window_proxy() {
+            Some(proxy) => proxy.get_name(),
+            None => "".into(),
+        }
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-origin

--- a/tests/wpt/metadata/html/browsers/the-window-object/name-attribute.window.js.ini
+++ b/tests/wpt/metadata/html/browsers/the-window-object/name-attribute.window.js.ini
@@ -1,4 +1,0 @@
-[name-attribute.window.html]
-  [Window object's name IDL attribute]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
new [spec](https://html.spec.whatwg.org/multipage/window-object.html#dom-name):

The name attribute's getter must run these steps:

1. If this Window object's browsing context is null, then return the empty string.
2. Return this Window object's browsing context's name.

The name attribute's setter must run these steps:

1.  If this Window object's browsing context is null, then return.
2. Set this Window object's browsing context's name to the given value.

What is `null` here? According to [spec](https://html.spec.whatwg.org/multipage/browsers.html#concept-document-bc)
>  A Document's browsing context is the browsing context whose session history contains the Document, if any such browsing context exists and has not been discarded, and null otherwise. 




---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] passed ` tests/wpt/web-platform-tests/html/browsers/the-window-object/name-attribute.window.js`
- [X] These changes fix #22915

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23410)
<!-- Reviewable:end -->
