### PR TITLE
Taskcluster: use current rustup.rs on Windows

### DIFF
--- a/etc/taskcluster/decisionlib.py
+++ b/etc/taskcluster/decisionlib.py
@@ -485,11 +485,7 @@ class WindowsGenericWorkerTask(GenericWorkerTask):
         .with_early_script(
             "%HOMEDRIVE%%HOMEPATH%\\rustup-init.exe --default-toolchain none -y"
         ) \
-        .with_file_mount(
-            "https://static.rust-lang.org/rustup/archive/" +
-                "1.17.0/x86_64-pc-windows-msvc/rustup-init.exe",
-            sha256="002127adeaaee6ef8d82711b5c2881a1db873262f63aea60cee9632f207e8f29",
-        )
+        .with_file_mount("https://win.rustup.rs/x86_64", path="rustup-init.exe")
 
     def with_repacked_msi(self, url, sha256, path):
         """


### PR DESCRIPTION
1.18.3 includes speed improvements when excracting tarballs:
https://github.com/rust-lang/rustup.rs/blob/1.18.3/CHANGELOG.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23445)
<!-- Reviewable:end -->
