### PR TITLE
Remove restrictions on cross-compiling on Windows.

### DIFF
--- a/components/script/CMakeLists.txt
+++ b/components/script/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(script)
+project(script LANGUAGES)
 cmake_minimum_required(VERSION 2.6)
 
 set(DUMMY ${CMAKE_BUILD_TYPE})

--- a/components/script/vcvars.bat
+++ b/components/script/vcvars.bat
@@ -1,2 +1,0 @@
-call "%VCVARSALL_PATH%\vcvarsall.bat" x64_x86
-set


### PR DESCRIPTION
This allows us to successfully build Servo when targeting UWP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23453)
<!-- Reviewable:end -->
