### PR TITLE
Do not use borrowed types in the selectors::Element trait.

### DIFF
--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -715,6 +715,14 @@ impl<'le> TElement for ServoLayoutElement<'le> {
                 .map(ServoShadowRoot::from_layout_js)
         }
     }
+
+    fn local_name(&self) -> &LocalName {
+        self.element.local_name()
+    }
+
+    fn namespace(&self) -> &Namespace {
+        self.element.namespace()
+    }
 }
 
 impl<'le> PartialEq for ServoLayoutElement<'le> {
@@ -879,13 +887,19 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
     }
 
     #[inline]
-    fn local_name(&self) -> &LocalName {
-        self.element.local_name()
+    fn has_local_name(&self, name: &LocalName) -> bool {
+        self.element.local_name() == name
     }
 
     #[inline]
-    fn namespace(&self) -> &Namespace {
-        self.element.namespace()
+    fn has_namespace(&self, ns: &Namespace) -> bool {
+        self.element.namespace() == ns
+    }
+
+    #[inline]
+    fn is_same_type(&self, other: &Self) -> bool {
+        self.element.local_name() == other.element.local_name() &&
+            self.element.namespace() == other.element.namespace()
     }
 
     fn match_pseudo_element(
@@ -1262,8 +1276,8 @@ where
                 loop {
                     let next_node = if let Some(ref node) = current_node {
                         if let Some(element) = node.as_element() {
-                            if element.local_name() == &local_name!("summary") &&
-                                element.namespace() == &ns!(html)
+                            if element.has_local_name(&local_name!("summary")) &&
+                                element.has_namespace(&ns!(html))
                             {
                                 self.current_node = None;
                                 return Some(node.clone());
@@ -1282,8 +1296,10 @@ where
                 let node = self.current_node.clone();
                 let node = node.and_then(|node| {
                     if node.is_element() &&
-                        node.as_element().unwrap().local_name() == &local_name!("summary") &&
-                        node.as_element().unwrap().namespace() == &ns!(html)
+                        node.as_element()
+                            .unwrap()
+                            .has_local_name(&local_name!("summary")) &&
+                        node.as_element().unwrap().has_namespace(&ns!(html))
                     {
                         unsafe { node.dangerous_next_sibling() }
                     } else {
@@ -1429,13 +1445,19 @@ impl<'le> ::selectors::Element for ServoThreadSafeLayoutElement<'le> {
     }
 
     #[inline]
-    fn local_name(&self) -> &LocalName {
-        self.element.local_name()
+    fn has_local_name(&self, name: &LocalName) -> bool {
+        self.element.local_name() == name
     }
 
     #[inline]
-    fn namespace(&self) -> &Namespace {
-        self.element.namespace()
+    fn has_namespace(&self, ns: &Namespace) -> bool {
+        self.element.namespace() == ns
+    }
+
+    #[inline]
+    fn is_same_type(&self, other: &Self) -> bool {
+        self.element.local_name() == other.element.local_name() &&
+            self.element.namespace() == other.element.namespace()
     }
 
     fn match_pseudo_element(

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3000,12 +3000,17 @@ impl<'a> SelectorsElement for DomRoot<Element> {
         })
     }
 
-    fn local_name(&self) -> &LocalName {
-        Element::local_name(self)
+    fn has_local_name(&self, local_name: &LocalName) -> bool {
+        Element::local_name(self) == local_name
     }
 
-    fn namespace(&self) -> &Namespace {
-        Element::namespace(self)
+    fn has_namespace(&self, ns: &Namespace) -> bool {
+        Element::namespace(self) == ns
+    }
+
+    fn is_same_type(&self, other: &Self) -> bool {
+        Element::local_name(self) == Element::local_name(other) &&
+            Element::namespace(self) == Element::namespace(other)
     }
 
     fn match_non_ts_pseudo_class<F>(

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -391,7 +391,7 @@ pub trait ThreadSafeLayoutElement:
 
     #[inline]
     fn get_details_summary_pseudo(&self) -> Option<Self> {
-        if self.local_name() == &local_name!("details") && self.namespace() == &ns!(html) {
+        if self.has_local_name(&local_name!("details")) && self.has_namespace(&ns!(html)) {
             Some(self.with_pseudo(PseudoElementType::DetailsSummary))
         } else {
             None
@@ -400,8 +400,8 @@ pub trait ThreadSafeLayoutElement:
 
     #[inline]
     fn get_details_content_pseudo(&self) -> Option<Self> {
-        if self.local_name() == &local_name!("details") &&
-            self.namespace() == &ns!(html) &&
+        if self.has_local_name(&local_name!("details")) &&
+            self.has_namespace(&ns!(html)) &&
             self.get_attr(&ns!(), &local_name!("open")).is_some()
         {
             Some(self.with_pseudo(PseudoElementType::DetailsContent))

--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -602,7 +602,7 @@ where
         &local_name.lower_name,
     )
     .borrow();
-    element.local_name() == name
+    element.has_local_name(name)
 }
 
 /// Determines whether the given element matches the given compound selector.
@@ -688,11 +688,11 @@ where
         Component::LocalName(ref local_name) => matches_local_name(element, local_name),
         Component::ExplicitUniversalType | Component::ExplicitAnyNamespace => true,
         Component::Namespace(_, ref url) | Component::DefaultNamespace(ref url) => {
-            element.namespace() == url.borrow()
+            element.has_namespace(&url.borrow())
         },
         Component::ExplicitNoNamespace => {
             let ns = crate::parser::namespace_empty_string::<E::Impl>();
-            element.namespace() == ns.borrow()
+            element.has_namespace(&ns.borrow())
         },
         Component::ID(ref id) => {
             element.has_id(id, context.shared.classes_and_ids_case_sensitivity())
@@ -905,11 +905,6 @@ where
 }
 
 #[inline]
-fn same_type<E: Element>(a: &E, b: &E) -> bool {
-    a.local_name() == b.local_name() && a.namespace() == b.namespace()
-}
-
-#[inline]
 fn nth_child_index<E>(
     element: &E,
     is_of_type: bool,
@@ -931,7 +926,7 @@ where
             let mut curr = element.clone();
             while let Some(e) = curr.prev_sibling_element() {
                 curr = e;
-                if !is_of_type || same_type(element, &curr) {
+                if !is_of_type || element.is_same_type(&curr) {
                     if let Some(i) = c.lookup(curr.opaque()) {
                         return i - index;
                     }
@@ -952,7 +947,7 @@ where
     };
     while let Some(e) = next(curr) {
         curr = e;
-        if !is_of_type || same_type(element, &curr) {
+        if !is_of_type || element.is_same_type(&curr) {
             // If we're computing indices from the left, check each element in the
             // cache. We handle the indices-from-the-right case at the top of this
             // function.

--- a/components/selectors/tree.rs
+++ b/components/selectors/tree.rs
@@ -58,10 +58,13 @@ pub trait Element: Sized + Clone + Debug {
 
     fn is_html_element_in_html_document(&self) -> bool;
 
-    fn local_name(&self) -> &<Self::Impl as SelectorImpl>::BorrowedLocalName;
+    fn has_local_name(&self, local_name: &<Self::Impl as SelectorImpl>::BorrowedLocalName) -> bool;
 
     /// Empty string for no namespace
-    fn namespace(&self) -> &<Self::Impl as SelectorImpl>::BorrowedNamespaceUrl;
+    fn has_namespace(&self, ns: &<Self::Impl as SelectorImpl>::BorrowedNamespaceUrl) -> bool;
+
+    /// Whether this element and the `other` element have the same local name and namespace.
+    fn is_same_type(&self, other: &Self) -> bool;
 
     fn attr_matches(
         &self,

--- a/components/style/dom.rs
+++ b/components/style/dom.rs
@@ -877,6 +877,12 @@ pub trait TElement:
         hints: &mut V,
     ) where
         V: Push<ApplicableDeclarationBlock>;
+
+    /// Returns element's local name.
+    fn local_name(&self) -> &LocalName;
+
+    /// Returns element's namespace.
+    fn namespace(&self) -> &Namespace;
 }
 
 /// TNode and TElement aren't Send because we want to be careful and explicit

--- a/components/style/invalidation/element/element_wrapper.rs
+++ b/components/style/invalidation/element/element_wrapper.rs
@@ -312,13 +312,24 @@ where
     }
 
     #[inline]
-    fn local_name(&self) -> &<Self::Impl as ::selectors::SelectorImpl>::BorrowedLocalName {
-        self.element.local_name()
+    fn has_local_name(
+        &self,
+        local_name: &<Self::Impl as ::selectors::SelectorImpl>::BorrowedLocalName,
+    ) -> bool {
+        self.element.has_local_name(local_name)
     }
 
     #[inline]
-    fn namespace(&self) -> &<Self::Impl as ::selectors::SelectorImpl>::BorrowedNamespaceUrl {
-        self.element.namespace()
+    fn has_namespace(
+        &self,
+        ns: &<Self::Impl as ::selectors::SelectorImpl>::BorrowedNamespaceUrl,
+    ) -> bool {
+        self.element.has_namespace(ns)
+    }
+
+    #[inline]
+    fn is_same_type(&self, other: &Self) -> bool {
+        self.element.is_same_type(&other.element)
     }
 
     fn attr_matches(


### PR DESCRIPTION
This change allows implementing the `selectors::Element` trait for types that doesn't support borrowed types, like [rc-tree](https://github.com/RazrFalcon/rctree).

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #22972

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23463)
<!-- Reviewable:end -->
