### PR TITLE
Add value sanitization for input[type=email]

### DIFF
--- a/tests/wpt/metadata/html/semantics/forms/the-input-element/email.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-input-element/email.html.ini
@@ -1,15 +1,6 @@
 [email.html]
   type: testharness
-  [value should be sanitized: strip line breaks]
-    expected: FAIL
-
   [Email address validity]
-    expected: FAIL
-
-  [When the multiple attribute is removed, the user agent must run the value sanitization algorithm]
-    expected: FAIL
-
-  [run the value sanitization algorithm after setting a new value]
     expected: FAIL
 
   [valid value is a set of valid email addresses separated by a single ',']

--- a/tests/wpt/metadata/html/semantics/forms/the-input-element/type-change-state.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-input-element/type-change-state.html.ini
@@ -1,15 +1,9 @@
 [type-change-state.html]
   type: testharness
-  [change state from hidden to email]
-    expected: FAIL
-
   [change state from hidden to datetime]
     expected: FAIL
 
   [change state from hidden to range]
-    expected: FAIL
-
-  [change state from text to email]
     expected: FAIL
 
   [change state from text to datetime]
@@ -18,16 +12,10 @@
   [change state from text to range]
     expected: FAIL
 
-  [change state from search to email]
-    expected: FAIL
-
   [change state from search to datetime]
     expected: FAIL
 
   [change state from search to range]
-    expected: FAIL
-
-  [change state from tel to email]
     expected: FAIL
 
   [change state from tel to datetime]
@@ -48,9 +36,6 @@
   [change state from email to range]
     expected: FAIL
 
-  [change state from password to email]
-    expected: FAIL
-
   [change state from password to datetime]
     expected: FAIL
 
@@ -67,9 +52,6 @@
     expected: FAIL
 
   [change state from datetime to url]
-    expected: FAIL
-
-  [change state from datetime to email]
     expected: FAIL
 
   [change state from datetime to password]
@@ -108,19 +90,10 @@
   [change state from number to range]
     expected: FAIL
 
-  [change state from range to email]
-    expected: FAIL
-
   [change state from range to datetime]
     expected: FAIL
 
-  [change state from checkbox to email]
-    expected: FAIL
-
   [change state from checkbox to range]
-    expected: FAIL
-
-  [change state from radio to email]
     expected: FAIL
 
   [change state from radio to datetime]
@@ -129,16 +102,10 @@
   [change state from radio to range]
     expected: FAIL
 
-  [change state from submit to email]
-    expected: FAIL
-
   [change state from submit to datetime]
     expected: FAIL
 
   [change state from submit to range]
-    expected: FAIL
-
-  [change state from image to email]
     expected: FAIL
 
   [change state from image to datetime]
@@ -147,16 +114,10 @@
   [change state from image to range]
     expected: FAIL
 
-  [change state from reset to email]
-    expected: FAIL
-
   [change state from reset to datetime]
     expected: FAIL
 
   [change state from reset to range]
-    expected: FAIL
-
-  [change state from button to email]
     expected: FAIL
 
   [change state from button to datetime]

--- a/tests/wpt/metadata/html/semantics/forms/the-input-element/valueMode.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-input-element/valueMode.html.ini
@@ -11,10 +11,3 @@
 
   [value IDL attribute of input type range with value attribute]
     expected: FAIL
-
-  [value IDL attribute of input type email without value attribute]
-    expected: FAIL
-
-  [value IDL attribute of input type email with value attribute]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Add value sanitization for input[type=email] as per the [HTML specification](https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type=email)).


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix part of #21810 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23472)
<!-- Reviewable:end -->
