### PR TITLE
Basic XR Testing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "rust-webvr"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.49.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3603,12 +3603,12 @@ dependencies = [
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ovr-mobile-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-webvr-api 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr-api 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rust-webvr-api"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_injected_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3948,7 +3948,7 @@ dependencies = [
  "mozangle 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-src 0.1.0 (git+https://github.com/servo/osmesa-src)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rust-webvr 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sig 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinyfiledialogs 3.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5266,7 +5266,7 @@ dependencies = [
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "rust-webvr 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
  "servo_config 0.0.1",
  "webvr_traits 0.0.1",
@@ -5278,7 +5278,7 @@ version = "0.0.1"
 dependencies = [
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
- "rust-webvr-api 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-webvr-api 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5781,8 +5781,8 @@ dependencies = [
 "checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "da06feaa07f69125ab9ddc769b11de29090122170b402547f64b86fe16ebc399"
-"checksum rust-webvr 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c5b30e882ddadf407de2229bf6bf0f1adde250b6dee10357ba4f8c4a51c0ab15"
-"checksum rust-webvr-api 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5208a3b3f0b02abf17e66c0fe1e0cd3a4f5172c9bf6d1a3e1ac6338a3d218d3"
+"checksum rust-webvr 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7a171c39fdd52c5b461f2384a04e2d75555c7ed657c057c45ea9d69d68b5f9fb"
+"checksum rust-webvr-api 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c5611b60f8a26ad5af2b8d6ac072f9e1b396305e8eb19efd5a6df84c588b1429"
 "checksum rustc-demangle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3058a43ada2c2d0b92b3ae38007a2d0fa5e9db971be260e0171408a4ff471c95"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusttype 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b8eb11f5b0a98c8eca2fb1483f42646d8c340e83e46ab416f8a063a0fd0eeb20"

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -294,6 +294,8 @@ mod gen {
                 webxr: {
                     #[serde(default)]
                     enabled: bool,
+                    #[serde(default)]
+                    test: bool,
                 },
                 worklet: {
                     blockingsleep: {

--- a/components/script/dom/fakexrdevicecontroller.rs
+++ b/components/script/dom/fakexrdevicecontroller.rs
@@ -48,7 +48,7 @@ impl FakeXRDeviceController {
 }
 
 impl FakeXRDeviceControllerMethods for FakeXRDeviceController {
-    // check-tidy: no specs after this line
+    /// https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md
     fn SetViews(&self, views: Vec<FakeXRViewInit>) -> Fallible<()> {
         if views.len() != 2 {
             return Err(Error::NotSupported);
@@ -87,6 +87,7 @@ impl FakeXRDeviceControllerMethods for FakeXRDeviceController {
         Ok(())
     }
 
+    /// https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md
     fn SetViewerOrigin(&self, origin: &FakeXRRigidTransform) -> Fallible<()> {
         if origin.position.len() != 4 || origin.orientation.len() != 4 {
             return Err(Error::Type("Incorrectly sized array".into()));

--- a/components/script/dom/fakexrdevicecontroller.rs
+++ b/components/script/dom/fakexrdevicecontroller.rs
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::bindings::codegen::Bindings::FakeXRDeviceControllerBinding;
+use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::globalscope::GlobalScope;
+use dom_struct::dom_struct;
+
+#[dom_struct]
+pub struct FakeXRDeviceController {
+    reflector: Reflector,
+}
+
+impl FakeXRDeviceController {
+    pub fn new_inherited() -> FakeXRDeviceController {
+        FakeXRDeviceController {
+            reflector: Reflector::new(),
+        }
+    }
+
+    pub fn new(global: &GlobalScope) -> DomRoot<FakeXRDeviceController> {
+        reflect_dom_object(
+            Box::new(FakeXRDeviceController::new_inherited()),
+            global,
+            FakeXRDeviceControllerBinding::Wrap,
+        )
+    }
+}

--- a/components/script/dom/fakexrdevicecontroller.rs
+++ b/components/script/dom/fakexrdevicecontroller.rs
@@ -6,11 +6,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::dom::bindings::codegen::Bindings::FakeXRDeviceControllerBinding;
-use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
+use crate::dom::bindings::codegen::Bindings::FakeXRDeviceControllerBinding::{
+    self, FakeXRDeviceControllerMethods, FakeXRViewInit,
+};
+use crate::dom::bindings::codegen::Bindings::XRViewBinding::XREye;
+use crate::dom::bindings::error::{Error, Fallible};
+use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
+use webvr_traits::{MockVRControlMsg, WebVREyeParameters, WebVRMsg};
 
 #[dom_struct]
 pub struct FakeXRDeviceController {
@@ -30,5 +35,54 @@ impl FakeXRDeviceController {
             global,
             FakeXRDeviceControllerBinding::Wrap,
         )
+    }
+
+    pub fn send_msg(&self, msg: MockVRControlMsg) {
+        self.global()
+            .as_window()
+            .webvr_thread()
+            .unwrap()
+            .send(WebVRMsg::MessageMockDisplay(msg));
+    }
+}
+
+impl FakeXRDeviceControllerMethods for FakeXRDeviceController {
+    // check-tidy: no specs after this line
+    fn SetViews(&self, views: Vec<FakeXRViewInit>) -> Fallible<()> {
+        if views.len() != 2 {
+            return Err(Error::NotSupported);
+        }
+
+        let (left, right) = match (views[0].eye, views[1].eye) {
+            (XREye::Left, XREye::Right) => (&views[0], &views[1]),
+            (XREye::Right, XREye::Left) => (&views[1], &views[0]),
+            _ => return Err(Error::NotSupported),
+        };
+
+        if left.projectionMatrix.len() != 16 ||
+            right.projectionMatrix.len() != 16 ||
+            left.viewOffset.position.len() != 4 ||
+            right.viewOffset.position.len() != 4
+        {
+            return Err(Error::Type("Incorrectly sized matrix".into()));
+        }
+
+        let mut proj_l = [0.; 16];
+        let mut proj_r = [0.; 16];
+        let v: Vec<_> = left.projectionMatrix.iter().map(|x| **x).collect();
+        proj_l.copy_from_slice(&v);
+        let v: Vec<_> = right.projectionMatrix.iter().map(|x| **x).collect();
+        proj_r.copy_from_slice(&v);
+
+        let mut params_l = WebVREyeParameters::default();
+        let mut params_r = WebVREyeParameters::default();
+        let v: Vec<_> = left.viewOffset.position.iter().map(|x| **x).collect();
+        params_l.offset.copy_from_slice(&v);
+        let v: Vec<_> = right.viewOffset.position.iter().map(|x| **x).collect();
+        params_r.offset.copy_from_slice(&v);
+
+        self.send_msg(MockVRControlMsg::SetProjectionMatrices(proj_l, proj_r));
+        self.send_msg(MockVRControlMsg::SetEyeParameters(params_l, params_r));
+        Ok(())
     }
 }

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -551,6 +551,7 @@ pub mod xrrigidtransform;
 pub mod xrsession;
 pub mod xrspace;
 pub mod xrstationaryreferencespace;
+pub mod xrtest;
 pub mod xrview;
 pub mod xrviewerpose;
 pub mod xrviewport;

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -301,6 +301,7 @@ pub mod eventsource;
 pub mod eventtarget;
 pub mod extendableevent;
 pub mod extendablemessageevent;
+pub mod fakexrdevicecontroller;
 pub mod file;
 pub mod filelist;
 pub mod filereader;

--- a/components/script/dom/webidls/FakeXRDeviceController.webidl
+++ b/components/script/dom/webidls/FakeXRDeviceController.webidl
@@ -13,7 +13,7 @@ interface FakeXRDeviceController {
   // // requestAnimationFrame() callbacks.
   [Throws] void setViews(sequence<FakeXRViewInit> views);
 
-  // void setViewerOrigin(FakeXRRigidTransform origin);
+  [Throws] void setViewerOrigin(FakeXRRigidTransform origin);
 
   // Simulates the user activating the reset pose on a device.
   // void simulateResetPose();

--- a/components/script/dom/webidls/FakeXRDeviceController.webidl
+++ b/components/script/dom/webidls/FakeXRDeviceController.webidl
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://github.com/immersive-web/webxr-test-api/
+
+[Exposed=Window, Pref="dom.webxr.test"]
+interface FakeXRDeviceController {
+  // Creates and attaches a XRFrameOfReference of the type specified to the device.
+  // void setFrameOfReference(XRFrameOfReferenceType,  FakeXRFrameOfReferenceInit);
+
+  // // Sets the values to be used for subsequent
+  // // requestAnimationFrame() callbacks.
+  // void setViews(Array<FakeXRViewInit> views);
+
+  // void setViewerOrigin(FakeXRRigidTransform origin);
+
+  // Simulates the user activating the reset pose on a device.
+  // void simulateResetPose();
+
+  // Simulates the platform ending the sessions.
+  // void simulateForcedEndSessions();
+
+  // Simulates devices focusing and blurring sessions.
+  // void simulateBlurSession(XRSession);
+  // void simulateFocusSession(XRSession);
+
+  // void setBoundsGeometry(Array<FakeXRBoundsPoint> boundsCoodinates)l
+
+  // Promise<FakeXRInputSourceController>
+  //     simulateInputSourceConnection(FakeXRInputSourceInit);
+};
+
+dictionary FakeXRViewInit {
+  required XREye eye;
+  // https://immersive-web.github.io/webxr/#view-projection-matrix
+  required sequence<float> projectionMatrix;
+  // https://immersive-web.github.io/webxr/#view-offset
+  required FakeXRRigidTransform viewOffset;
+};
+
+dictionary FakeXRBoundsPoint {
+  double x; double z;
+};
+
+dictionary FakeXRRigidTransform {
+    required sequence<float> position;
+    required sequence<float> orientation;
+};

--- a/components/script/dom/webidls/FakeXRDeviceController.webidl
+++ b/components/script/dom/webidls/FakeXRDeviceController.webidl
@@ -11,7 +11,7 @@ interface FakeXRDeviceController {
 
   // // Sets the values to be used for subsequent
   // // requestAnimationFrame() callbacks.
-  // void setViews(Array<FakeXRViewInit> views);
+  [Throws] void setViews(sequence<FakeXRViewInit> views);
 
   // void setViewerOrigin(FakeXRRigidTransform origin);
 

--- a/components/script/dom/webidls/XR.webidl
+++ b/components/script/dom/webidls/XR.webidl
@@ -28,3 +28,8 @@ dictionary XRSessionCreationOptions {
   XRSessionMode mode = "inline";
   // XRPresentationContext outputContext;
 };
+
+partial interface XR {
+  // https://github.com/immersive-web/webxr-test-api/
+  [SameObject, Pref="dom.webxr.test"] readonly attribute XRTest test;
+};

--- a/components/script/dom/webidls/XRTest.webidl
+++ b/components/script/dom/webidls/XRTest.webidl
@@ -6,9 +6,9 @@
 
 [Exposed=Window, Pref="dom.webxr.test"]
 interface XRTest {
-  // // Simulates connecting a device to the system.
-  // // Used to instantiate a fake device for use in tests.
-  // Promise<FakeXRDeviceController> simulateDeviceConnection(FakeXRDeviceInit);
+  // Simulates connecting a device to the system.
+  // Used to instantiate a fake device for use in tests.
+  Promise<FakeXRDeviceController> simulateDeviceConnection(FakeXRDeviceInit init);
 
   // // Simulates a device being disconnected from the system.
   // Promise<void> simulateDeviceDisconnection(XRDevice);
@@ -17,4 +17,9 @@ interface XRTest {
   // // The activation is only guaranteed to be valid in the provided function and only applies to WebXR
   // // Device API methods.
   // void simulateUserActivation(Function);
+};
+
+dictionary FakeXRDeviceInit {
+    // TODO: Subject to change to match spec changes.
+    required boolean supportsImmersive;
 };

--- a/components/script/dom/webidls/XRTest.webidl
+++ b/components/script/dom/webidls/XRTest.webidl
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://github.com/immersive-web/webxr-test-api/
+
+[Exposed=Window, Pref="dom.webxr.test"]
+interface XRTest {
+  // // Simulates connecting a device to the system.
+  // // Used to instantiate a fake device for use in tests.
+  // Promise<FakeXRDeviceController> simulateDeviceConnection(FakeXRDeviceInit);
+
+  // // Simulates a device being disconnected from the system.
+  // Promise<void> simulateDeviceDisconnection(XRDevice);
+
+  // // Simulates a user activation (aka user gesture) for the current scope.
+  // // The activation is only guaranteed to be valid in the provided function and only applies to WebXR
+  // // Device API methods.
+  // void simulateUserActivation(Function);
+};

--- a/components/script/dom/xr.rs
+++ b/components/script/dom/xr.rs
@@ -21,6 +21,7 @@ use crate::dom::promise::Promise;
 use crate::dom::vrdisplay::VRDisplay;
 use crate::dom::vrdisplayevent::VRDisplayEvent;
 use crate::dom::xrsession::XRSession;
+use crate::dom::xrtest::XRTest;
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
 use profile_traits::ipc;
@@ -36,6 +37,7 @@ pub struct XR {
     gamepads: DomRefCell<Vec<Dom<Gamepad>>>,
     pending_immersive_session: Cell<bool>,
     active_immersive_session: MutNullableDom<VRDisplay>,
+    test: MutNullableDom<XRTest>,
 }
 
 impl XR {
@@ -46,6 +48,7 @@ impl XR {
             gamepads: DomRefCell::new(Vec::new()),
             pending_immersive_session: Cell::new(false),
             active_immersive_session: Default::default(),
+            test: Default::default(),
         }
     }
 
@@ -140,6 +143,11 @@ impl XRMethods for XR {
         let session = XRSession::new(&self.global(), &displays[0]);
         session.xr_present(promise.clone());
         promise
+    }
+
+    // https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md
+    fn Test(&self) -> DomRoot<XRTest> {
+        self.test.or_init(|| XRTest::new(&self.global()))
     }
 }
 

--- a/components/script/dom/xrspace.rs
+++ b/components/script/dom/xrspace.rs
@@ -99,7 +99,8 @@ impl XRSpace {
             orient[1] as f64,
             orient[2] as f64,
             orient[3] as f64,
-        );
+        )
+        .normalize();
         RigidTransform3D::new(rotation, translation)
     }
 

--- a/components/script/dom/xrtest.rs
+++ b/components/script/dom/xrtest.rs
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::bindings::codegen::Bindings::XRTestBinding;
+use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::globalscope::GlobalScope;
+use dom_struct::dom_struct;
+
+#[dom_struct]
+pub struct XRTest {
+    reflector: Reflector,
+}
+
+impl XRTest {
+    pub fn new_inherited() -> XRTest {
+        XRTest {
+            reflector: Reflector::new(),
+        }
+    }
+
+    pub fn new(global: &GlobalScope) -> DomRoot<XRTest> {
+        reflect_dom_object(
+            Box::new(XRTest::new_inherited()),
+            global,
+            XRTestBinding::Wrap,
+        )
+    }
+}

--- a/components/script/dom/xrtest.rs
+++ b/components/script/dom/xrtest.rs
@@ -6,21 +6,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::dom::bindings::codegen::Bindings::XRTestBinding;
-use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
+use crate::dom::bindings::codegen::Bindings::XRTestBinding::{
+    self, FakeXRDeviceInit, XRTestMethods,
+};
+use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::DomRoot;
+use crate::dom::fakexrdevicecontroller::FakeXRDeviceController;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::promise::Promise;
 use dom_struct::dom_struct;
+use std::cell::Cell;
+use std::rc::Rc;
+use webvr_traits::WebVRMsg;
 
 #[dom_struct]
 pub struct XRTest {
     reflector: Reflector,
+    session_started: Cell<bool>,
 }
 
 impl XRTest {
     pub fn new_inherited() -> XRTest {
         XRTest {
             reflector: Reflector::new(),
+            session_started: Cell::new(false),
         }
     }
 
@@ -30,5 +39,26 @@ impl XRTest {
             global,
             XRTestBinding::Wrap,
         )
+    }
+}
+
+impl XRTestMethods for XRTest {
+    fn SimulateDeviceConnection(&self, init: &FakeXRDeviceInit) -> Rc<Promise> {
+        let p = Promise::new(&self.global());
+
+        if !init.supportsImmersive || self.session_started.get() {
+            p.reject_native(&());
+            return p;
+        }
+
+        self.session_started.set(true);
+        self.global()
+            .as_window()
+            .webvr_thread()
+            .unwrap()
+            .send(WebVRMsg::CreateMockDisplay);
+        p.resolve_native(&FakeXRDeviceController::new(&self.global()));
+
+        p
     }
 }

--- a/components/script/dom/xrtest.rs
+++ b/components/script/dom/xrtest.rs
@@ -56,7 +56,8 @@ impl XRTestMethods for XRTest {
             .as_window()
             .webvr_thread()
             .unwrap()
-            .send(WebVRMsg::CreateMockDisplay);
+            .send(WebVRMsg::CreateMockDisplay)
+            .unwrap();
         p.resolve_native(&FakeXRDeviceController::new(&self.global()));
 
         p

--- a/components/script/dom/xrtest.rs
+++ b/components/script/dom/xrtest.rs
@@ -43,6 +43,7 @@ impl XRTest {
 }
 
 impl XRTestMethods for XRTest {
+    /// https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md
     fn SimulateDeviceConnection(&self, init: &FakeXRDeviceInit) -> Rc<Promise> {
         let p = Promise::new(&self.global());
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -285,7 +285,7 @@ where
         script::init();
 
         let mut webvr_heartbeats = Vec::new();
-        let webvr_services = if pref!(dom.webvr.enabled) {
+        let webvr_services = if pref!(dom.webvr.enabled) || pref!(dom.webxr.enabled) {
             let mut services = VRServiceManager::new();
             services.register_defaults();
             embedder.register_vr_services(&mut services, &mut webvr_heartbeats);

--- a/components/webvr/Cargo.toml
+++ b/components/webvr/Cargo.toml
@@ -19,10 +19,10 @@ canvas_traits = {path = "../canvas_traits"}
 crossbeam-channel = "0.3"
 euclid = "0.19"
 gleam = "0.6"
-ipc-channel = "0.11"
+ipc-channel = "0.11.2"
 log = "0.4"
 msg = {path = "../msg"}
-rust-webvr = {version = "0.11", features = ["openvr", "vrexternal"]}
+rust-webvr = {version = "0.11.3", features = ["mock", "openvr", "vrexternal"]}
 script_traits = {path = "../script_traits"}
 servo_config = {path = "../config"}
 webvr_traits = {path = "../webvr_traits" }

--- a/components/webvr_traits/Cargo.toml
+++ b/components/webvr_traits/Cargo.toml
@@ -13,5 +13,5 @@ path = "lib.rs"
 [dependencies]
 ipc-channel = "0.11"
 msg = {path = "../msg"}
-rust-webvr-api = {version = "0.11.3", features = ["ipc"]}
+rust-webvr-api = {version = "0.11.1", features = ["ipc"]}
 serde = "1.0"

--- a/components/webvr_traits/Cargo.toml
+++ b/components/webvr_traits/Cargo.toml
@@ -13,5 +13,5 @@ path = "lib.rs"
 [dependencies]
 ipc-channel = "0.11"
 msg = {path = "../msg"}
-rust-webvr-api = {version = "0.11", features = ["ipc"]}
+rust-webvr-api = {version = "0.11.3", features = ["ipc"]}
 serde = "1.0"

--- a/components/webvr_traits/lib.rs
+++ b/components/webvr_traits/lib.rs
@@ -11,6 +11,7 @@ mod webvr_traits;
 
 pub use crate::webvr_traits::{WebVRMsg, WebVRResult};
 pub use rust_webvr_api as webvr;
+pub use rust_webvr_api::MockVRControlMsg;
 pub use rust_webvr_api::VRDisplayCapabilities as WebVRDisplayCapabilities;
 pub use rust_webvr_api::VRDisplayData as WebVRDisplayData;
 pub use rust_webvr_api::VRDisplayEvent as WebVRDisplayEvent;

--- a/components/webvr_traits/webvr_traits.rs
+++ b/components/webvr_traits/webvr_traits.rs
@@ -26,6 +26,8 @@ pub enum WebVRMsg {
     RequestPresent(PipelineId, u32, IpcSender<WebVRResult<()>>),
     ExitPresent(PipelineId, u32, Option<IpcSender<WebVRResult<()>>>),
     CreateCompositor(u32),
+    CreateMockDisplay,
+    MessageMockDisplay(MockVRControlMsg),
     GetGamepads(
         Vec<u32>,
         IpcSender<WebVRResult<Vec<(Option<VRGamepadData>, VRGamepadState)>>>,

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -98,6 +98,7 @@ WEBIDL_STANDARDS = [
     "//wicg.github.io",
     "//webaudio.github.io",
     "//immersive-web.github.io/",
+    "//github.com/immersive-web/webxr-test-api/",
     # Not a URL
     "// This interface is entirely internal to Servo, and should not be" +
     " accessible to\n// web pages."

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -31,6 +31,7 @@
   "dom.webvr.event_polling_interval": 500,
   "dom.webvr.test": false,
   "dom.webxr.enabled": false,
+  "dom.webxr.test": false,
   "dom.worklet.timeout_ms": 10,
   "gfx.subpixel-text-antialiasing.enabled": true,
   "js.asmjs.enabled": true,


### PR DESCRIPTION
This adds support for the XRTest and FakeXRDeviceController APIs from https://github.com/immersive-web/webxr-test-api, and plugs them into the `mock` backend of rust-webvr.

Tested with [a modified webxr test page](https://github.com/immersive-web/webxr-test-api)


r? @jdm @asajeffrey

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23485)
<!-- Reviewable:end -->
