### PR TITLE
Maybe improve the parallelism of the HTTP Cache

### DIFF
--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -32,6 +32,7 @@ hashglobe = { path = "../hashglobe" }
 hyper = { version = "0.12", optional = true }
 hyper_serde = { version = "0.9", optional = true }
 keyboard-types = {version = "0.4.3", optional = true}
+parking_lot = "0.8"
 selectors = { path = "../selectors" }
 serde = { version = "1.0.27", optional = true }
 serde_bytes = { version = "0.10", optional = true }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -609,6 +609,19 @@ impl<T: MallocSizeOf> MallocSizeOf for std::sync::Mutex<T> {
     }
 }
 
+impl<T: MallocSizeOf> MallocSizeOf for parking_lot::Mutex<T> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        (*self.lock()).size_of(ops)
+    }
+}
+
+impl<T: MallocSizeOf> MallocSizeOf for parking_lot::RwLock<T> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        (*self.read()).size_of(ops) +
+        (*self.read()).size_of(ops)
+    }
+}
+
 impl MallocSizeOf for smallbitvec::SmallBitVec {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         if let Some(ptr) = self.heap_ptr() {

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -42,6 +42,7 @@ mime_guess = "2.0.0-alpha.6"
 msg = {path = "../msg"}
 net_traits = {path = "../net_traits"}
 openssl = "0.10"
+parking_lot = "0.8"
 pixels = {path = "../pixels"}
 profile_traits = {path = "../profile_traits"}
 rayon = "1"

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -458,9 +458,7 @@ pub fn main_fetch(
     target.process_response_eof(&response);
 
     if !response.is_network_error() {
-        if let Ok(mut http_cache) = context.state.http_cache.write() {
-            http_cache.update_awaiting_consumers(&request, &response);
-        }
+        context.state.http_cache.update_awaiting_consumers(&request, &response);
     }
 
     // Steps 25-27.

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -64,7 +64,7 @@ lazy_static! {
 pub struct HttpState {
     pub hsts_list: RwLock<HstsList>,
     pub cookie_jar: RwLock<CookieStorage>,
-    pub http_cache: RwLock<HttpCache>,
+    pub http_cache: HttpCache,
     pub auth_cache: RwLock<AuthCache>,
     pub history_states: RwLock<HashMap<HistoryStateId, Vec<u8>>>,
     pub client: Client<Connector, Body>,
@@ -77,7 +77,7 @@ impl HttpState {
             cookie_jar: RwLock::new(CookieStorage::new(150)),
             auth_cache: RwLock::new(AuthCache::new()),
             history_states: RwLock::new(HashMap::new()),
-            http_cache: RwLock::new(HttpCache::new()),
+            http_cache: HttpCache::new(),
             client: create_http_client(ssl_connector_builder, HANDLE.lock().unwrap().executor()),
         }
     }
@@ -969,42 +969,40 @@ fn http_network_or_cache_fetch(
     // TODO If there’s a proxy-authentication entry, use it as appropriate.
 
     // Step 5.19
-    if let Ok(http_cache) = context.state.http_cache.read() {
-        if let Some(response_from_cache) = http_cache.construct_response(&http_request, done_chan) {
-            let response_headers = response_from_cache.response.headers.clone();
-            // Substep 1, 2, 3, 4
-            let (cached_response, needs_revalidation) =
-                match (http_request.cache_mode, &http_request.mode) {
-                    (CacheMode::ForceCache, _) => (Some(response_from_cache.response), false),
-                    (CacheMode::OnlyIfCached, &RequestMode::SameOrigin) => {
-                        (Some(response_from_cache.response), false)
-                    },
-                    (CacheMode::OnlyIfCached, _) |
-                    (CacheMode::NoStore, _) |
-                    (CacheMode::Reload, _) => (None, false),
-                    (_, _) => (
-                        Some(response_from_cache.response),
-                        response_from_cache.needs_validation,
-                    ),
-                };
-            if needs_revalidation {
-                revalidating_flag = true;
-                // Substep 5
-                if let Some(http_date) = response_headers.typed_get::<LastModified>() {
-                    let http_date: SystemTime = http_date.into();
-                    http_request
-                        .headers
-                        .typed_insert(IfModifiedSince::from(http_date));
-                }
-                if let Some(entity_tag) = response_headers.get(header::ETAG) {
-                    http_request
-                        .headers
-                        .insert(header::IF_NONE_MATCH, entity_tag.clone());
-                }
-            } else {
-                // Substep 6
-                response = cached_response;
+    if let Some(response_from_cache) = context.state.http_cache.construct_response(&http_request, done_chan) {
+        let response_headers = response_from_cache.response.headers.clone();
+        // Substep 1, 2, 3, 4
+        let (cached_response, needs_revalidation) =
+            match (http_request.cache_mode, &http_request.mode) {
+                (CacheMode::ForceCache, _) => (Some(response_from_cache.response), false),
+                (CacheMode::OnlyIfCached, &RequestMode::SameOrigin) => {
+                    (Some(response_from_cache.response), false)
+                },
+                (CacheMode::OnlyIfCached, _) |
+                (CacheMode::NoStore, _) |
+                (CacheMode::Reload, _) => (None, false),
+                (_, _) => (
+                    Some(response_from_cache.response),
+                    response_from_cache.needs_validation,
+                ),
+            };
+        if needs_revalidation {
+            revalidating_flag = true;
+            // Substep 5
+            if let Some(http_date) = response_headers.typed_get::<LastModified>() {
+                let http_date: SystemTime = http_date.into();
+                http_request
+                    .headers
+                    .typed_insert(IfModifiedSince::from(http_date));
             }
+            if let Some(entity_tag) = response_headers.get(header::ETAG) {
+                http_request
+                    .headers
+                    .insert(header::IF_NONE_MATCH, entity_tag.clone());
+            }
+        } else {
+            // Substep 6
+            response = cached_response;
         }
     }
 
@@ -1056,9 +1054,7 @@ fn http_network_or_cache_fetch(
         // Substep 3
         if let Some((200...399, _)) = forward_response.raw_status {
             if !http_request.method.is_safe() {
-                if let Ok(mut http_cache) = context.state.http_cache.write() {
-                    http_cache.invalidate(&http_request, &forward_response);
-                }
+                context.state.http_cache.invalidate(&http_request, &forward_response);
             }
         }
         // Substep 4
@@ -1068,19 +1064,15 @@ fn http_network_or_cache_fetch(
                 .as_ref()
                 .map_or(false, |s| s.0 == StatusCode::NOT_MODIFIED)
         {
-            if let Ok(mut http_cache) = context.state.http_cache.write() {
-                response = http_cache.refresh(&http_request, forward_response.clone(), done_chan);
-                wait_for_cached_response(done_chan, &mut response);
-            }
+            response = context.state.http_cache.refresh(&http_request, forward_response.clone(), done_chan);
+            wait_for_cached_response(done_chan, &mut response);
         }
 
         // Substep 5
         if response.is_none() {
             if http_request.cache_mode != CacheMode::NoStore {
                 // Subsubstep 2, doing it first to avoid a clone of forward_response.
-                if let Ok(mut http_cache) = context.state.http_cache.write() {
-                    http_cache.store(&http_request, &forward_response);
-                }
+                context.state.http_cache.store(&http_request, &forward_response);
             }
             // Subsubstep 1
             response = Some(forward_response);
@@ -1384,9 +1376,7 @@ fn http_network_fetch(
 
     // Step 14
     if !response.is_network_error() && request.cache_mode != CacheMode::NoStore {
-        if let Ok(mut http_cache) = context.state.http_cache.write() {
-            http_cache.store(&request, &response);
-        }
+        context.state.http_cache.store(&request, &response);
     }
 
     // TODO this step isn't possible yet

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -134,7 +134,7 @@ fn create_http_states(config_dir: Option<&Path>) -> (Arc<HttpState>, Arc<HttpSta
     let http_state = HttpState {
         cookie_jar: RwLock::new(cookie_jar),
         auth_cache: RwLock::new(auth_cache),
-        http_cache: RwLock::new(http_cache),
+        http_cache: http_cache,
         hsts_list: RwLock::new(hsts_list),
         history_states: RwLock::new(HashMap::new()),
         client: create_http_client(ssl_connector_builder, HANDLE.lock().unwrap().executor()),
@@ -200,19 +200,17 @@ impl ResourceChannelManager {
         private_http_state: &Arc<HttpState>,
     ) {
         let mut ops = MallocSizeOfOps::new(servo_allocator::usable_size, None, None);
-        let public_cache = public_http_state.http_cache.read().unwrap();
-        let private_cache = private_http_state.http_cache.read().unwrap();
 
         let public_report = Report {
             path: path!["memory-cache", "public"],
             kind: ReportKind::ExplicitJemallocHeapSize,
-            size: public_cache.size_of(&mut ops),
+            size: public_http_state.http_cache.size_of(&mut ops),
         };
 
         let private_report = Report {
             path: path!["memory-cache", "private"],
             kind: ReportKind::ExplicitJemallocHeapSize,
-            size: private_cache.size_of(&mut ops),
+            size: private_http_state.http_cache.size_of(&mut ops),
         };
 
         msg.send(vec![public_report, private_report]);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Trying to make the cache operations more parallel across fetches. 

Assumptions:

1. Cache misses are the most likely operation, and shouldn't have to wait on accessing the cache and finding out it's a miss when another thread is actually doing a cache operation. So we introduce a `HashSet<CacheKey>` that is likely to see little contention, next to the `HashMap<CacheKey, Vec<CachedResource>>` that probably will be contented. The cost is the double storage for each key.
2. Some of the algorithms in the cache, or at least an initial setup phase, don't require locking the cache, since only the result of the algorithm affects the internal state of it(example: storing a cache entry requires checking whether it is cacheable, and then creating the entry, and finally storing it in the cache). So even if we don't go for the `HashSet<CacheKey>`, we still benefit from a slightly more granular locking inside the cache versus outside of it.
3. This are still very simple locking antics involving the entire state of the cache, so it doesn't seem to be introducing any complications. 

I can't say that I have done any measurement to validate those assumptions, any ideas on how to do so are welcome, or perhaps we can just use acceptable heuristics.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23488)
<!-- Reviewable:end -->
