### PR TITLE
compositing: removed opts-get

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,6 @@ dependencies = [
  "pixels 0.0.1",
  "profile_traits 0.0.1",
  "script_traits 0.0.1",
- "servo_config 0.0.1",
  "servo_geometry 0.0.1",
  "servo_url 0.0.1",
  "style_traits 0.0.1",

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -32,7 +32,6 @@ num-traits = "0.2"
 pixels = {path = "../pixels", optional = true}
 profile_traits = {path = "../profile_traits"}
 script_traits = {path = "../script_traits"}
-servo_config = {path = "../config"}
 servo_geometry = {path = "../geometry"}
 servo_url = {path = "../url"}
 style_traits = {path = "../style_traits"}

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -337,6 +337,11 @@ where
                 webrender_api,
                 webvr_heartbeats,
             },
+            opts.output_file.clone(),
+            opts.is_running_problem_test,
+            opts.exit_after_load,
+            opts.convert_mouse_to_touch,
+            opts.device_pixels_per_px,
         );
 
         Servo {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Removed all `opts::get()` from `compositing` component.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix *partially* #22854 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they are not feature- or bug-related changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23493)
<!-- Reviewable:end -->
