### PR TITLE
Fix behaviour of window resizing on Windows.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -622,6 +622,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
         }
 
         self.send_window_size(WindowSizeType::Resize);
+        self.composite_if_necessary(CompositingReason::Resize);
     }
 
     pub fn on_mouse_window_event_class(&mut self, mouse_window_event: MouseWindowEvent) {
@@ -1525,4 +1526,6 @@ pub enum CompositingReason {
     NewWebRenderFrame,
     /// WebRender has processed a scroll event and has generated a new frame.
     NewWebRenderScrollFrame,
+    /// The window has been resized and will need to be synchronously repainted.
+    Resize,
 }

--- a/ports/glutin/context.rs
+++ b/ports/glutin/context.rs
@@ -19,6 +19,15 @@ impl GlContext {
             GlContext::None => unreachable!(),
         }
     }
+    pub fn resize(&mut self, size: glutin::dpi::PhysicalSize) {
+        if let GlContext::NotCurrent(_) = self {
+            self.make_current();
+        }
+        match self {
+            GlContext::Current(c) => c.resize(size),
+            _ => unreachable!(),
+        }
+    }
     pub fn make_current(&mut self) {
         *self = match std::mem::replace(self, GlContext::None) {
             GlContext::Current(c) => {

--- a/ports/glutin/headed_window.rs
+++ b/ports/glutin/headed_window.rs
@@ -441,7 +441,8 @@ impl WindowPortsMethods for Window {
                 self.event_queue.borrow_mut().push(WindowEvent::Quit);
             },
             glutin::WindowEvent::Resized(size) => {
-                self.gl_context.borrow_mut().window().set_inner_size(size);
+                let physical_size = size.to_physical(self.device_hidpi_factor().get() as f64);
+                self.gl_context.borrow_mut().resize(physical_size);
                 // window.set_inner_size() takes DeviceIndependentPixel.
                 let (width, height) = size.into();
                 let new_size = TypedSize2D::new(width, height);


### PR DESCRIPTION
This makes Windows builds usable when the window is resized.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23489
- [x] These changes do not require tests because we can't run tests on Windows CI yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23497)
<!-- Reviewable:end -->
