### PR TITLE
Check for python's version in mach

### DIFF
--- a/mach
+++ b/mach
@@ -15,6 +15,13 @@ from __future__ import print_function, unicode_literals
 import os
 import sys
 
+# Check for the current python version as some users (especially on archlinux)
+# may not have python 2 installed and their /bin/python binary symlinked to
+# python 3.
+if sys.version_info >= (3, 0):
+    print("mach does not support python 3, please install python 2")
+    sys.exit(1)
+
 
 def main(args):
     topdir = os.path.abspath(os.path.dirname(sys.argv[0]))


### PR DESCRIPTION
On archlinux, python 2 isn't installed by default and it leads to some
really confusing error messages when running mach

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23505)
<!-- Reviewable:end -->
