### PR TITLE
Constellation: removed almost all opts::get

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,6 +679,7 @@ dependencies = [
  "script_traits 0.0.1",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_config 0.0.1",
+ "servo_geometry 0.0.1",
  "servo_rand 0.0.1",
  "servo_remutex 0.0.1",
  "servo_url 0.0.1",

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -80,6 +80,7 @@ pub struct Opts {
     /// Use ANGLE to create the GL context (Windows-only).
     pub angle: bool,
 
+    /// True to exit on thread failure instead of displaying about:failure.
     pub hard_fail: bool,
 
     /// True if we should bubble intrinsic widths sequentially (`-b`). If this is true, then

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -43,6 +43,7 @@ script_traits = {path = "../script_traits"}
 serde = "1.0"
 style_traits = {path = "../style_traits"}
 servo_config = {path = "../config"}
+servo_geometry = {path = "../geometry"}
 servo_rand = {path = "../rand"}
 servo_remutex = {path = "../remutex"}
 servo_url = {path = "../url"}

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -646,7 +646,7 @@ impl UnprivilegedPipelineContent {
             .expect("Failed to create IPC one-shot server.");
 
         // If there is a sandbox, use the `gaol` API to create the child process.
-        if opts::get().sandbox {
+        if self.opts.sandbox {
             let mut command = sandbox::Command::me().expect("Failed to get current sandbox.");
             self.setup_common(&mut command, token);
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -617,6 +617,9 @@ fn create_constellation(
     window_gl: Rc<dyn gl::Gl>,
     webvr_services: Option<VRServiceManager>,
 ) -> (Sender<ConstellationMsg>, SWManagerSenders) {
+    // Global configuration options, parsed from the command line.
+    let opts = opts::get();
+
     let bluetooth_thread: IpcSender<BluetoothRequest> =
         BluetoothThreadFactory::new(embedder_proxy.clone());
 
@@ -651,7 +654,7 @@ fn create_constellation(
         };
 
     // GLContext factory used to create WebGL Contexts
-    let gl_factory = if opts::get().should_use_osmesa() {
+    let gl_factory = if opts.should_use_osmesa() {
         GLContextFactory::current_osmesa_handle()
     } else {
         GLContextFactory::current_native_handle(&compositor_proxy)
@@ -697,7 +700,16 @@ fn create_constellation(
         script_layout_interface::message::Msg,
         layout_thread::LayoutThread,
         script::script_thread::ScriptThread,
-    >::start(initial_state);
+    >::start(
+        initial_state,
+        opts.initial_window_size,
+        opts.device_pixels_per_px,
+        opts.random_pipeline_closure_probability,
+        opts.random_pipeline_closure_seed,
+        opts.is_running_problem_test,
+        opts.hard_fail,
+        opts.enable_canvas_antialiasing,
+    );
 
     if let Some(webvr_constellation_sender) = webvr_constellation_sender {
         // Set constellation channel used by WebVR thread to broadcast events


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Removed *almost* all (except 1) "opts::get()" from `constellation` component. The one untouched is in `pipeline.rs` which uses "opts::get()" as a [struct field](https://github.com/oneturkmen/servo/blob/cd153efb4acce81170927790653555c5f10929eb/components/constellation/pipeline.rs#L501) that is set [here](https://github.com/oneturkmen/servo/blob/cd153efb4acce81170927790653555c5f10929eb/components/constellation/pipeline.rs#L296).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix *partially* #22854 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because no feature (or no bug) has been added (refactoring only).

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23506)
<!-- Reviewable:end -->
