### PR TITLE
Use IOSurface for texture sharing on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
  "ipc-channel 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "offscreen_gl_context 0.23.0 (git+https://github.com/servo/rust-offscreen-rendering-context?rev=92f0e697ef9cae815dff87909a75e5e43a541428)",
+ "offscreen_gl_context 0.23.0 (git+https://github.com/zakorgy/rust-offscreen-rendering-context?branch=texture-backing)",
  "pixels 0.0.1",
  "raqote 0.6.1-alpha.0 (git+https://github.com/jrmuizel/raqote)",
  "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -426,6 +426,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "malloc_size_of 0.0.1",
  "malloc_size_of_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "offscreen_gl_context 0.23.0 (git+https://github.com/zakorgy/rust-offscreen-rendering-context?branch=texture-backing)",
  "pixels 0.0.1",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -569,7 +570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -679,15 +680,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.6.4"
 source = "git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha#8a15cb91c4ee05b2098ee16c5fcd930b084f3150"
 dependencies = [
@@ -701,17 +693,12 @@ version = "0.6.2"
 source = "git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha#8a15cb91c4ee05b2098ee16c5fcd930b084f3150"
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "core-graphics"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -721,7 +708,7 @@ name = "core-text"
 version = "13.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1291,7 +1278,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1421,7 +1408,7 @@ dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dwrote 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1549,7 +1536,7 @@ dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin_egl_sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2200,7 +2187,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
  "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "leaky-cow 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2590,7 +2577,7 @@ dependencies = [
  "msg 0.0.1",
  "net 0.0.1",
  "net_traits 0.0.1",
- "offscreen_gl_context 0.23.0 (git+https://github.com/servo/rust-offscreen-rendering-context?rev=92f0e697ef9cae815dff87909a75e5e43a541428)",
+ "offscreen_gl_context 0.23.0 (git+https://github.com/zakorgy/rust-offscreen-rendering-context?branch=texture-backing)",
  "profile 0.0.1",
  "profile_traits 0.0.1",
  "script 0.0.1",
@@ -3227,10 +3214,10 @@ dependencies = [
 [[package]]
 name = "offscreen_gl_context"
 version = "0.23.0"
-source = "git+https://github.com/servo/rust-offscreen-rendering-context?rev=92f0e697ef9cae815dff87909a75e5e43a541428#92f0e697ef9cae815dff87909a75e5e43a541428"
+source = "git+https://github.com/zakorgy/rust-offscreen-rendering-context?branch=texture-backing#02345d40c5c3e5b3024664775494f8c69b08ec18"
 dependencies = [
  "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
  "euclid 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4541,7 +4528,7 @@ source = "git+https://github.com/pcwalton/signpost.git#7ed712507f343c38646b9d1fe
 name = "simpleservo"
 version = "0.0.1"
 dependencies = [
- "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5469,7 +5456,7 @@ dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-text 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cstr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5508,7 +5495,7 @@ dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5655,7 +5642,7 @@ dependencies = [
  "backtrace 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5841,10 +5828,8 @@ dependencies = [
 "checksum color_quant 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a475fc4af42d83d28adf72968d9bcfaf035a1a9381642d8e85d8a04957767b0d"
 "checksum combine 3.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54cedd8056314afe0d844a37a207007edf8a45f2cc452fd77629cd63c221740e"
 "checksum cookie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1465f8134efa296b4c19db34d909637cb2bf0f7aaf21299e23e18fa29ac557cf"
-"checksum core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "58667b9a618a37ea8c4c4cb5298703e5dfadcd3698c79f54fc43e6a2e94733ea"
 "checksum core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)" = "<none>"
 "checksum core-foundation-sys 0.6.2 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)" = "<none>"
-"checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"
 "checksum core-text 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d95a72b5e50e549969dd88eff3047495fe5b8c6f028635442c2b708be707e669"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
@@ -6042,7 +6027,7 @@ dependencies = [
 "checksum objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "31d20fd2b37e07cf5125be68357b588672e8cefe9a96f8c17a9d46053b3e590d"
 "checksum objc-foundation 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
 "checksum objc_id 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e4730aa1c64d722db45f7ccc4113a3e2c465d018de6db4d3e7dfe031e8c8a297"
-"checksum offscreen_gl_context 0.23.0 (git+https://github.com/servo/rust-offscreen-rendering-context?rev=92f0e697ef9cae815dff87909a75e5e43a541428)" = "<none>"
+"checksum offscreen_gl_context 0.23.0 (git+https://github.com/zakorgy/rust-offscreen-rendering-context?branch=texture-backing)" = "<none>"
 "checksum opaque-debug 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "51ecbcb821e1bd256d456fe858aaa7f380b63863eab2eb86eee1bd9f33dd6682"
 "checksum openssl 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)" = "6c24d3508b4fb6da175c10baac54c578b33f09c89ae90c6fe9788b3b4768efdc"
 "checksum openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)" = "912f301a749394e1025d9dcddef6106ddee9252620e6d0a0e5f8d0681de9b129"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,10 +400,11 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "half 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io-surface 0.11.1 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
  "ipc-channel 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "offscreen_gl_context 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "offscreen_gl_context 0.23.0 (git+https://github.com/servo/rust-offscreen-rendering-context?rev=92f0e697ef9cae815dff87909a75e5e43a541428)",
  "pixels 0.0.1",
  "raqote 0.6.1-alpha.0 (git+https://github.com/jrmuizel/raqote)",
  "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -684,6 +685,20 @@ dependencies = [
  "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.6.4"
+source = "git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha#8a15cb91c4ee05b2098ee16c5fcd930b084f3150"
+dependencies = [
+ "core-foundation-sys 0.6.2 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
+ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.6.2"
+source = "git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha#8a15cb91c4ee05b2098ee16c5fcd930b084f3150"
 
 [[package]]
 name = "core-foundation-sys"
@@ -2170,6 +2185,18 @@ dependencies = [
 [[package]]
 name = "io-surface"
 version = "0.11.1"
+source = "git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha#8a15cb91c4ee05b2098ee16c5fcd930b084f3150"
+dependencies = [
+ "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "leaky-cow 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "io-surface"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2563,7 +2590,7 @@ dependencies = [
  "msg 0.0.1",
  "net 0.0.1",
  "net_traits 0.0.1",
- "offscreen_gl_context 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "offscreen_gl_context 0.23.0 (git+https://github.com/servo/rust-offscreen-rendering-context?rev=92f0e697ef9cae815dff87909a75e5e43a541428)",
  "profile 0.0.1",
  "profile_traits 0.0.1",
  "script 0.0.1",
@@ -3200,13 +3227,14 @@ dependencies = [
 [[package]]
 name = "offscreen_gl_context"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/servo/rust-offscreen-rendering-context?rev=92f0e697ef9cae815dff87909a75e5e43a541428#92f0e697ef9cae815dff87909a75e5e43a541428"
 dependencies = [
  "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io-surface 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4340,7 +4368,7 @@ dependencies = [
  "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glx 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "io-surface 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io-surface 0.11.1 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-egl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-fontconfig-sys 4.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5814,6 +5842,8 @@ dependencies = [
 "checksum combine 3.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54cedd8056314afe0d844a37a207007edf8a45f2cc452fd77629cd63c221740e"
 "checksum cookie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1465f8134efa296b4c19db34d909637cb2bf0f7aaf21299e23e18fa29ac557cf"
 "checksum core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "58667b9a618a37ea8c4c4cb5298703e5dfadcd3698c79f54fc43e6a2e94733ea"
+"checksum core-foundation 0.6.4 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)" = "<none>"
+"checksum core-foundation-sys 0.6.2 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)" = "<none>"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"
 "checksum core-text 13.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d95a72b5e50e549969dd88eff3047495fe5b8c6f028635442c2b708be707e669"
@@ -5943,7 +5973,8 @@ dependencies = [
 "checksum influent 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c75b206f14630274457146294c0e01297ed555176306fd074d5c34a30bb348"
 "checksum inventory 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21df85981fe094480bc2267723d3dc0fd1ae0d1f136affc659b7398be615d922"
 "checksum inventory-impl 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8a877ae8bce77402d5e9ed870730939e097aad827b2a932b361958fa9d6e75aa"
-"checksum io-surface 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9a33981dff54baaff80f4decb487a65d148a3c00facc97820d0f09128f74dd"
+"checksum io-surface 0.11.1 (git+https://github.com/zakorgy/core-foundation-rs?branch=io-surface-alpha)" = "<none>"
+"checksum io-surface 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f5a64038dc1dd3cbe84042e8b50619e06884ebf7eea03608b683dfa017a01d9"
 "checksum iovec 0.1.3 (git+https://github.com/servo/iovec.git?branch=servo)" = "<none>"
 "checksum ipc-channel 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f82db24b0c53ee2d54b420bb9258f2b787611fe3e7a28d514b5ea54fe65cd365"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
@@ -6011,7 +6042,7 @@ dependencies = [
 "checksum objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "31d20fd2b37e07cf5125be68357b588672e8cefe9a96f8c17a9d46053b3e590d"
 "checksum objc-foundation 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
 "checksum objc_id 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e4730aa1c64d722db45f7ccc4113a3e2c465d018de6db4d3e7dfe031e8c8a297"
-"checksum offscreen_gl_context 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b6b1df447af7a71721bfc33697b364831d59c0c8668dae0e570a7993ca84bc8"
+"checksum offscreen_gl_context 0.23.0 (git+https://github.com/servo/rust-offscreen-rendering-context?rev=92f0e697ef9cae815dff87909a75e5e43a541428)" = "<none>"
 "checksum opaque-debug 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "51ecbcb821e1bd256d456fe858aaa7f380b63863eab2eb86eee1bd9f33dd6682"
 "checksum openssl 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)" = "6c24d3508b4fb6da175c10baac54c578b33f09c89ae90c6fe9788b3b4768efdc"
 "checksum openssl-sys 0.9.35 (registry+https://github.com/rust-lang/crates.io-index)" = "912f301a749394e1025d9dcddef6106ddee9252620e6d0a0e5f8d0681de9b129"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ opt-level = 3
 mio = { git = "https://github.com/servo/mio.git", branch = "servo" }
 iovec = { git = "https://github.com/servo/iovec.git", branch = "servo" }
 cmake = { git = "https://github.com/alexcrichton/cmake-rs" }
+
+offscreen_gl_context = { git = "https://github.com/servo/rust-offscreen-rendering-context", rev = "92f0e697ef9cae815dff87909a75e5e43a541428" }
+core-foundation = { git = "https://github.com/zakorgy/core-foundation-rs", branch = "io-surface-alpha" }
+io-surface = { git = "https://github.com/zakorgy/core-foundation-rs", branch = "io-surface-alpha" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,6 @@ mio = { git = "https://github.com/servo/mio.git", branch = "servo" }
 iovec = { git = "https://github.com/servo/iovec.git", branch = "servo" }
 cmake = { git = "https://github.com/alexcrichton/cmake-rs" }
 
-offscreen_gl_context = { git = "https://github.com/servo/rust-offscreen-rendering-context", rev = "92f0e697ef9cae815dff87909a75e5e43a541428" }
+offscreen_gl_context = { git = "https://github.com/zakorgy/rust-offscreen-rendering-context", branch = "texture-backing" }
 core-foundation = { git = "https://github.com/zakorgy/core-foundation-rs", branch = "io-surface-alpha" }
 io-surface = { git = "https://github.com/zakorgy/core-foundation-rs", branch = "io-surface-alpha" }

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -38,3 +38,6 @@ webrender = {git = "https://github.com/servo/webrender"}
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
 webrender_traits = {path = "../webrender_traits"}
 webxr-api = {git = "https://github.com/servo/webxr", features = ["ipc"]}
+
+[target.x86_64-apple-darwin.dependencies]
+io-surface = "0.11.1"

--- a/components/canvas/gl_context.rs
+++ b/components/canvas/gl_context.rs
@@ -15,6 +15,7 @@ use offscreen_gl_context::{
 use offscreen_gl_context::{GLLimits as RawGLLimits, GLVersion};
 use offscreen_gl_context::{NativeGLContext, NativeGLContextHandle, NativeGLContextMethods};
 use offscreen_gl_context::{OSMesaContext, OSMesaContextHandle};
+use servo_config::opts;
 
 pub trait CloneableDispatcher: GLContextDispatcher {
     fn clone(&self) -> Box<dyn GLContextDispatcher>;
@@ -66,7 +67,23 @@ impl GLContextFactory {
     ) -> Result<GLContextWrapper, &'static str> {
         let attributes = map_attrs(attributes);
         Ok(match *self {
-            GLContextFactory::Native(ref handle, ref dispatcher, ref api_type) => {
+            GLContextFactory::Native(ref _handle, ref _dispatcher, ref api_type) => {
+                #[cfg(target_os = "macos")]
+                {
+                    if opts::get().with_io_surface {
+                        return GLContext::new_shared_with_dispatcher(
+                            // FIXME(nox): Why are those i32 values?
+                            size.to_i32(),
+                            attributes,
+                            ColorAttachmentType::IOSurface,
+                            *api_type,
+                            Self::gl_version(webgl_version),
+                            None,
+                            None,
+                        )
+                        .map(|ctx| GLContextWrapper::NativeWithIOSurface(ctx));
+                    }
+                }
                 GLContextWrapper::Native(GLContext::new_shared_with_dispatcher(
                     // FIXME(nox): Why are those i32 values?
                     size.to_i32(),
@@ -74,21 +91,23 @@ impl GLContextFactory {
                     ColorAttachmentType::Texture,
                     *api_type,
                     Self::gl_version(webgl_version),
-                    Some(handle),
-                    dispatcher.as_ref().map(|d| (**d).clone()),
+                    Some(_handle),
+                    _dispatcher.as_ref().map(|d| (**d).clone()),
                 )?)
             },
-            GLContextFactory::OSMesa(ref handle) => {
-                GLContextWrapper::OSMesa(GLContext::new_shared_with_dispatcher(
-                    // FIXME(nox): Why are those i32 values?
-                    size.to_i32(),
-                    attributes,
-                    ColorAttachmentType::Texture,
-                    gl::GlType::default(),
-                    Self::gl_version(webgl_version),
-                    Some(handle),
-                    None,
-                )?)
+            GLContextFactory::OSMesa(ref _handle) => {
+                {
+                    GLContextWrapper::OSMesa(GLContext::new_shared_with_dispatcher(
+                        // FIXME(nox): Why are those i32 values?
+                        size.to_i32(),
+                        attributes,
+                        ColorAttachmentType::Texture,
+                        gl::GlType::default(),
+                        Self::gl_version(webgl_version),
+                        Some(_handle),
+                        None,
+                    )?)
+                }
             },
         })
     }
@@ -141,6 +160,8 @@ impl GLContextFactory {
 pub enum GLContextWrapper {
     Native(GLContext<NativeGLContext>),
     OSMesa(GLContext<OSMesaContext>),
+    #[cfg(target_os = "macos")]
+    NativeWithIOSurface(GLContext<NativeGLContext>),
 }
 
 impl GLContextWrapper {
@@ -150,6 +171,10 @@ impl GLContextWrapper {
                 ctx.make_current().unwrap();
             },
             GLContextWrapper::OSMesa(ref ctx) => {
+                ctx.make_current().unwrap();
+            },
+            #[cfg(target_os = "macos")]
+            GLContextWrapper::NativeWithIOSurface(ref ctx) => {
                 ctx.make_current().unwrap();
             },
         }
@@ -168,6 +193,10 @@ impl GLContextWrapper {
             GLContextWrapper::OSMesa(ref ctx) => {
                 WebGLImpl::apply(ctx, state, cmd, backtrace);
             },
+            #[cfg(target_os = "macos")]
+            GLContextWrapper::NativeWithIOSurface(ref ctx) => {
+                WebGLImpl::apply(ctx, state, cmd, backtrace);
+            },
         }
     }
 
@@ -175,37 +204,90 @@ impl GLContextWrapper {
         match *self {
             GLContextWrapper::Native(ref ctx) => ctx.gl(),
             GLContextWrapper::OSMesa(ref ctx) => ctx.gl(),
+            #[cfg(target_os = "macos")]
+            GLContextWrapper::NativeWithIOSurface(ref ctx) => ctx.gl(),
         }
     }
 
-    pub fn get_info(&self) -> (Size2D<i32>, u32, GLLimits) {
+    pub fn get_info(&self) -> (Size2D<i32>, u32, Option<u32>, GLLimits) {
         match *self {
             GLContextWrapper::Native(ref ctx) => {
-                let (real_size, texture_id) = {
+                let (real_size, texture_id, io_surface_id) = {
                     let draw_buffer = ctx.borrow_draw_buffer().unwrap();
                     (
                         draw_buffer.size(),
                         draw_buffer.get_bound_texture_id().unwrap(),
+                        None,
                     )
                 };
 
                 let limits = ctx.borrow_limits().clone();
 
-                (real_size, texture_id, map_limits(limits))
+                (real_size, texture_id, io_surface_id, map_limits(limits))
             },
             GLContextWrapper::OSMesa(ref ctx) => {
-                let (real_size, texture_id) = {
+                let (real_size, texture_id, io_surface_id) = {
                     let draw_buffer = ctx.borrow_draw_buffer().unwrap();
                     (
                         draw_buffer.size(),
                         draw_buffer.get_bound_texture_id().unwrap(),
+                        None,
                     )
                 };
 
                 let limits = ctx.borrow_limits().clone();
 
-                (real_size, texture_id, map_limits(limits))
+                (real_size, texture_id, io_surface_id, map_limits(limits))
             },
+            #[cfg(target_os = "macos")]
+            GLContextWrapper::NativeWithIOSurface(ref ctx) => {
+                let (real_size, texture_id, io_surface_id) = {
+                    let draw_buffer = ctx.borrow_draw_buffer().unwrap();
+                    (
+                        draw_buffer.size(),
+                        draw_buffer.get_bound_texture_id().unwrap(),
+                        draw_buffer.get_active_io_surface_id(),
+                    )
+                };
+
+                let limits = ctx.borrow_limits().clone();
+
+                (real_size, texture_id, io_surface_id, map_limits(limits))
+            },
+        }
+    }
+
+    pub fn get_active_io_surface_id(&self) -> Option<u32> {
+        match *self {
+            #[cfg(target_os = "macos")]
+            GLContextWrapper::NativeWithIOSurface(ref ctx) => {
+                ctx.borrow_draw_buffer().unwrap().get_active_io_surface_id()
+            },
+            _ => None,
+        }
+    }
+
+    /// Swap the backing texture for the draw buffer, returning the id of the IOsurface
+    /// now used for reading.
+    pub fn swap_draw_buffer(
+        &mut self,
+        _clear_color: (f32, f32, f32, f32),
+        _mask: u32,
+    ) -> Option<u32> {
+        match *self {
+            #[cfg(target_os = "macos")]
+            GLContextWrapper::NativeWithIOSurface(ref mut ctx) => {
+                ctx.swap_draw_buffer(_clear_color, _mask)
+            },
+            _ => None,
+        }
+    }
+
+    pub fn handle_lock(&mut self) -> Option<u32> {
+        match *self {
+            #[cfg(target_os = "macos")]
+            GLContextWrapper::NativeWithIOSurface(ref mut ctx) => ctx.handle_lock(),
+            _ => None,
         }
     }
 
@@ -216,6 +298,11 @@ impl GLContextWrapper {
                 ctx.resize(size.to_i32())
             },
             GLContextWrapper::OSMesa(ref mut ctx) => {
+                // FIXME(nox): Why are those i32 values?
+                ctx.resize(size.to_i32())
+            },
+            #[cfg(target_os = "macos")]
+            GLContextWrapper::NativeWithIOSurface(ref mut ctx) => {
                 // FIXME(nox): Why are those i32 values?
                 ctx.resize(size.to_i32())
             },

--- a/components/canvas/webgl_mode/inprocess.rs
+++ b/components/canvas/webgl_mode/inprocess.rs
@@ -224,7 +224,8 @@ impl WebrenderExternalImageApi for WebGLExternalImages {
                 // flows of OpenGL commands in order to avoid WR using a semi-ready WebGL texture.
                 // glWaitSync doesn't block WR thread, it affects only internal OpenGL subsystem.
                 if let Some(gl_sync) = gl_sync {
-                    self.webrender_gl.wait_sync(gl_sync as _, 0, gl::TIMEOUT_IGNORED);
+                    self.webrender_gl
+                        .wait_sync(gl_sync as _, 0, gl::TIMEOUT_IGNORED);
                 }
                 texture_id
             },

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -368,14 +368,13 @@ impl WebGLThread {
         }
     }
     /// Handles a lock external callback received from webrender::ExternalImageHandler
-    fn handle_lock(
-        &mut self,
-        context_id: WebGLContextId,
-        sender: WebGLSender<WebGLLockMessage>,
-    ) {
-        let data =
-            Self::make_current_if_needed_mut(context_id, &mut self.contexts, &mut self.bound_context_id)
-                .expect("WebGLContext not found in a WebGLMsg::Lock message");
+    fn handle_lock(&mut self, context_id: WebGLContextId, sender: WebGLSender<WebGLLockMessage>) {
+        let data = Self::make_current_if_needed_mut(
+            context_id,
+            &mut self.contexts,
+            &mut self.bound_context_id,
+        )
+        .expect("WebGLContext not found in a WebGLMsg::Lock message");
         let info = self.cached_context_info.get_mut(&context_id).unwrap();
         info.render_state = ContextRenderState::Locked(None);
         // Insert a OpenGL Fence sync object that sends a signal when all the WebGL commands are finished.
@@ -396,13 +395,12 @@ impl WebGLThread {
         }
         debug_assert!(data.ctx.gl().get_error() == gl::NO_ERROR);
 
-        let _ = sender
-            .send(WebGLLockMessage {
-                texture_backing: info.texture_backing,
-                size: info.size,
-                gl_sync: Some(gl_sync as usize),
-                alpha: info.alpha,
-            });
+        let _ = sender.send(WebGLLockMessage {
+            texture_backing: info.texture_backing,
+            size: info.size,
+            gl_sync: Some(gl_sync as usize),
+            alpha: info.alpha,
+        });
     }
 
     /// A version of locking that doesn't return a GLsync object,
@@ -939,7 +937,7 @@ struct WebGLContextInfo {
 impl WebGLContextInfo {
     fn texture_target(&self) -> webrender_api::TextureTarget {
         match self.texture_backing {
-            #[cfg(target_os="macos")]
+            #[cfg(target_os = "macos")]
             TextureBacking::IOSurface(..) => webrender_api::TextureTarget::Rect,
             _ => webrender_api::TextureTarget::Default,
         }

--- a/components/canvas_traits/Cargo.toml
+++ b/components/canvas_traits/Cargo.toml
@@ -21,6 +21,7 @@ gleam = "0.6.7"
 lazy_static = "1"
 malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = "0.1"
+offscreen_gl_context = {version = "0.23", features = ["serde"]}
 pixels = {path = "../pixels"}
 serde = "1.0"
 serde_bytes = "0.10"

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -35,6 +35,15 @@ pub struct WebGLCommandBacktrace {
     pub js_backtrace: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub struct WebGLLockMessage {
+    pub texture_id: u32,
+    pub size: Size2D<i32>,
+    pub io_surface_id: Option<u32>,
+    pub gl_sync: Option<usize>,
+    pub alpha: bool,
+}
+
 /// WebGL Message API
 #[derive(Debug, Deserialize, Serialize)]
 pub enum WebGLMsg {
@@ -58,7 +67,7 @@ pub enum WebGLMsg {
     /// WR locks a external texture when it wants to use the shared texture contents.
     /// The WR client should not change the shared texture content until the Unlock call.
     /// Currently OpenGL Sync Objects are used to implement the synchronization mechanism.
-    Lock(WebGLContextId, WebGLSender<(u32, Size2D<i32>, usize)>),
+    Lock(WebGLContextId, WebGLSender<WebGLLockMessage>),
     /// Unlocks a specific WebGLContext. Unlock messages are used for a correct synchronization
     /// with WebRender external image API.
     /// The WR unlocks a context when it finished reading the shared texture contents.
@@ -68,6 +77,8 @@ pub enum WebGLMsg {
     UpdateWebRenderImage(WebGLContextId, WebGLSender<ImageKey>),
     /// Commands used for the DOMToTexture feature.
     DOMToTextureCommand(DOMToTextureCommand),
+    /// Tells the WebGL contexts to swap their underlying texture targets
+    Swap(WebGLSender<()>),
     /// Frees all resources and closes the thread.
     Exit,
 }

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -6,6 +6,7 @@ use euclid::default::{Rect, Size2D};
 use gleam::gl;
 use gleam::gl::Gl;
 use ipc_channel::ipc::{IpcBytesReceiver, IpcBytesSender, IpcSharedMemory};
+use offscreen_gl_context::TextureBacking;
 use pixels::PixelFormat;
 use std::borrow::Cow;
 use std::fmt;
@@ -37,9 +38,8 @@ pub struct WebGLCommandBacktrace {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct WebGLLockMessage {
-    pub texture_id: u32,
+    pub texture_backing: TextureBacking,
     pub size: Size2D<i32>,
-    pub io_surface_id: Option<u32>,
     pub gl_sync: Option<usize>,
     pub alpha: bool,
 }

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -234,6 +234,9 @@ pub struct Opts {
 
     /// Only shutdown once all theads are finished.
     pub clean_shutdown: bool,
+
+    /// Use IOSurfaces for texture sharing for WebGL on macOS
+    pub with_io_surface: bool,
 }
 
 fn print_usage(app: &str, opts: &Options) {
@@ -610,6 +613,7 @@ pub fn default_opts() -> Opts {
         unminify_js: false,
         print_pwm: false,
         clean_shutdown: false,
+        with_io_surface: false,
     }
 }
 
@@ -778,6 +782,11 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
     opts.optopt("", "profiler-db-pass", "Profiler database password", "");
     opts.optopt("", "profiler-db-name", "Profiler database name", "");
     opts.optflag("", "print-pwm", "Print Progressive Web Metrics");
+    opts.optflag(
+        "",
+        "io-surface",
+        "Use IOSurfaces for WebGL to share textures with WebRender (macOS-only)",
+    );
 
     let opt_match = match opts.parse(args) {
         Ok(m) => m,
@@ -1056,6 +1065,7 @@ pub fn from_cmdline_args(args: &[String]) -> ArgumentParsingResult {
         unminify_js: opt_match.opt_present("unminify-js"),
         print_pwm: opt_match.opt_present("print-pwm"),
         clean_shutdown: opt_match.opt_present("clean-shutdown"),
+        with_io_surface: opt_match.opt_present("io-surface"),
     };
 
     set_options(opts);

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -109,6 +109,7 @@ use crate::stylesheet_set::StylesheetSetRef;
 use crate::task::TaskBox;
 use crate::task_source::{TaskSource, TaskSourceName};
 use crate::timers::OneshotTimerCallback;
+use canvas_traits::webgl::{webgl_channel, WebGLChan, WebGLMsg};
 use cookie::Cookie;
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use dom_struct::dom_struct;
@@ -4653,6 +4654,8 @@ pub enum AnimationFrameCallback {
     FrameRequestCallback {
         #[ignore_malloc_size_of = "Rc is hard"]
         callback: Rc<FrameRequestCallback>,
+        #[ignore_malloc_size_of = "channels are hard"]
+        webgl_chan: Option<WebGLChan>,
     },
 }
 
@@ -4668,7 +4671,15 @@ impl AnimationFrameCallback {
                     .unwrap();
                 devtools_sender.send(msg).unwrap();
             },
-            AnimationFrameCallback::FrameRequestCallback { ref callback } => {
+            AnimationFrameCallback::FrameRequestCallback {
+                ref callback,
+                ref webgl_chan,
+            } => {
+                if let Some(webgl_chan) = webgl_chan {
+                    let (sender, receiver) = webgl_channel().unwrap();
+                    webgl_chan.send(WebGLMsg::Swap(sender)).unwrap();
+                    let _ = receiver.recv().unwrap();
+                }
                 // TODO(jdm): The spec says that any exceptions should be suppressed:
                 // https://github.com/servo/servo/issues/6928
                 let _ = callback.Call__(Finite::wrap(now), ExceptionHandling::Report);

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -107,6 +107,7 @@ use script_traits::{ConstellationControlMsg, DocumentState, HistoryEntryReplacem
 use script_traits::{ScriptMsg, ScriptToConstellationChan, ScrollState, TimerEvent, TimerEventId};
 use script_traits::{TimerSchedulerMsg, WindowSizeData, WindowSizeType};
 use selectors::attr::CaseSensitivity;
+use servo_config::opts;
 use servo_geometry::{f32_rect_to_au_rect, MaxRect};
 use servo_url::{Host, ImmutableOrigin, MutableOrigin, ServoUrl};
 use std::borrow::Cow;
@@ -902,7 +903,14 @@ impl WindowMethods for Window {
     /// <https://html.spec.whatwg.org/multipage/#dom-window-requestanimationframe>
     fn RequestAnimationFrame(&self, callback: Rc<FrameRequestCallback>) -> u32 {
         self.Document()
-            .request_animation_frame(AnimationFrameCallback::FrameRequestCallback { callback })
+            .request_animation_frame(AnimationFrameCallback::FrameRequestCallback {
+                callback,
+                webgl_chan: if cfg!(target_os = "macos") && opts::get().with_io_surface {
+                    self.webgl_chan.as_ref().map(|chan| chan.clone())
+                } else {
+                    None
+                },
+            })
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-window-cancelanimationframe>

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -107,7 +107,6 @@ use script_traits::{ConstellationControlMsg, DocumentState, HistoryEntryReplacem
 use script_traits::{ScriptMsg, ScriptToConstellationChan, ScrollState, TimerEvent, TimerEventId};
 use script_traits::{TimerSchedulerMsg, WindowSizeData, WindowSizeType};
 use selectors::attr::CaseSensitivity;
-use servo_config::opts;
 use servo_geometry::{f32_rect_to_au_rect, MaxRect};
 use servo_url::{Host, ImmutableOrigin, MutableOrigin, ServoUrl};
 use std::borrow::Cow;
@@ -905,11 +904,7 @@ impl WindowMethods for Window {
         self.Document()
             .request_animation_frame(AnimationFrameCallback::FrameRequestCallback {
                 callback,
-                webgl_chan: if cfg!(target_os = "macos") && opts::get().with_io_surface {
-                    self.webgl_chan.as_ref().map(|chan| chan.clone())
-                } else {
-                    None
-                },
+                webgl_chan: self.webgl_chan.as_ref().map(|chan| chan.clone()),
             })
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Use a non-shared GL context for the WebGL threads, with triple buffered IOSurfaces bound to the Framebuffer. Using a simple IOSurface resulted in flickering since both the WR and the WebGL thread uses it, using three gave me the proper result.
When we receive a `Lock` message, we send the id of a finished IOSurface to the WR thread where we bind it to a texture, which WR can use.
The synchronization of the IOSurfaces is a little hacky, since there are no clue in GL that we started rendering a new frame and we can swap the surfaces: if the document process a `FrameRequestCallback` callback (which comes from `requestAnimationFrame`), we send a message to the WebGL thread to notify about the start of the new frame. This is where we swap the underlying IOsurfaces of the WebGL contexts.
I have checked the performance on several WebGL samples and the FPS numbers where promising.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #11138 (GitHub issue number if applicable)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23509)
<!-- Reviewable:end -->
