### PR TITLE
Fix `#[webidl_must_inherit]` building when cwd is not servo crate root

### DIFF
--- a/components/script_plugins/webidl_must_inherit.rs
+++ b/components/script_plugins/webidl_must_inherit.rs
@@ -73,12 +73,14 @@ fn get_manifest_dir() -> io::Result<path::PathBuf> {
             dir.push(var);
             Ok(dir)
         },
-        Err(env::VarError::NotPresent) => {
-            Err(io::Error::new(io::ErrorKind::NotFound, "CARGO_MANIFEST_DIR environment variable was not found"))
-        },
-        Err(env::VarError::NotUnicode(_)) => {
-            Err(io::Error::new(io::ErrorKind::InvalidData, "CARGO_MANIFEST_DIR environment variable's contents are non valid UTF-8"))
-        },
+        Err(env::VarError::NotPresent) => Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "CARGO_MANIFEST_DIR environment variable was not found",
+        )),
+        Err(env::VarError::NotUnicode(_)) => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "CARGO_MANIFEST_DIR environment variable's contents are non valid UTF-8",
+        )),
     }
 }
 

--- a/components/script_plugins/webidl_must_inherit.rs
+++ b/components/script_plugins/webidl_must_inherit.rs
@@ -66,9 +66,25 @@ fn get_ty_name(ty: &str) -> &str {
     }
 }
 
+fn get_manifest_dir() -> io::Result<path::PathBuf> {
+    match env::var("CARGO_MANIFEST_DIR") {
+        Ok(var) => {
+            let mut dir = path::PathBuf::new();
+            dir.push(var);
+            Ok(dir)
+        },
+        Err(env::VarError::NotPresent) => {
+            Err(io::Error::new(io::ErrorKind::NotFound, "CARGO_MANIFEST_DIR environment variable was not found"))
+        },
+        Err(env::VarError::NotUnicode(_)) => {
+            Err(io::Error::new(io::ErrorKind::InvalidData, "CARGO_MANIFEST_DIR environment variable's contents are non valid UTF-8"))
+        },
+    }
+}
+
 fn get_webidl_path(struct_name: &str) -> io::Result<path::PathBuf> {
-    let mut dir = env::current_dir()?;
-    dir.push("components/script/dom/webidls/");
+    let mut dir = get_manifest_dir()?;
+    dir.push("dom/webidls/");
     dir.push(format!("{}.webidl", struct_name));
 
     Ok(dir)


### PR DESCRIPTION
Manifest dir should be more stable than current dir.

<!-- Please describe your changes on the following line: -->
I was trying to embed servo.

The directory layout of mine was the following:
```
/
*-servo
*-src
*-Cargo.toml
...
```

When I tried to build, cargo reported an error, in `#[webidl_must_inherit]` (Os error: 2).

After some research I have found that it failed to find `.webidl` files, because it used a path relative to `current_dir`.

I replaced current dir with manifest dir to make it more reliable.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (Not applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

I am unsure if these changes require tests. If they do, how should they be implemented?

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23512)
<!-- Reviewable:end -->
