### PR TITLE
Layout_thread: removed all possible opts::get()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2395,6 +2395,7 @@ name = "layout_traits"
 version = "0.0.1"
 dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx 0.0.1",
  "ipc-channel 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "metrics 0.0.1",
@@ -2402,6 +2403,7 @@ dependencies = [
  "net_traits 0.0.1",
  "profile_traits 0.0.1",
  "script_traits 0.0.1",
+ "servo_geometry 0.0.1",
  "servo_url 0.0.1",
  "webrender_api 0.60.0 (git+https://github.com/servo/webrender)",
 ]

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -54,6 +54,7 @@ pub struct Opts {
     /// and cause it to produce output on that interval (`-m`).
     pub mem_profiler_period: Option<f64>,
 
+    /// True to turn off incremental layout.
     pub nonincremental_layout: bool,
 
     /// Where to load userscripts from, if any. An empty string will load from
@@ -111,7 +112,7 @@ pub struct Opts {
     pub enable_canvas_antialiasing: bool,
 
     /// True if each step of layout is traced to an external JSON file
-    /// for debugging purposes. Settings this implies sequential layout
+    /// for debugging purposes. Setting this implies sequential layout
     /// and paint.
     pub trace_layout: bool,
 

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -580,6 +580,17 @@ impl UnprivilegedPipelineContent {
             self.webrender_document,
             paint_time_metrics,
             layout_thread_busy_flag.clone(),
+            self.opts.load_webfonts_synchronously,
+            self.opts.initial_window_size,
+            self.opts.device_pixels_per_px,
+            self.opts.dump_display_list,
+            self.opts.dump_display_list_json,
+            self.opts.dump_style_tree,
+            self.opts.dump_rule_tree,
+            self.opts.relayout_event,
+            self.opts.nonincremental_layout,
+            self.opts.trace_layout,
+            self.opts.dump_flow_tree,
         );
 
         if wait_for_completion {

--- a/components/layout_traits/Cargo.toml
+++ b/components/layout_traits/Cargo.toml
@@ -12,6 +12,7 @@ path = "lib.rs"
 
 [dependencies]
 crossbeam-channel = "0.3"
+euclid = "0.19"
 gfx = {path = "../gfx"}
 ipc-channel = "0.11"
 metrics = {path = "../metrics"}
@@ -20,4 +21,5 @@ net_traits = {path = "../net_traits"}
 profile_traits = {path = "../profile_traits"}
 script_traits = {path = "../script_traits"}
 servo_url = {path = "../url"}
+servo_geometry = {path = "../geometry"}
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -10,6 +10,7 @@
 //   that these modules won't have to depend on layout.
 
 use crossbeam_channel::{Receiver, Sender};
+use euclid::TypedSize2D;
 use gfx::font_cache_thread::FontCacheThread;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use metrics::PaintTimeMetrics;
@@ -19,6 +20,7 @@ use net_traits::image_cache::ImageCache;
 use profile_traits::{mem, time};
 use script_traits::LayoutMsg as ConstellationMsg;
 use script_traits::{ConstellationControlMsg, LayoutControlMsg};
+use servo_geometry::DeviceIndependentPixel;
 use servo_url::ServoUrl;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -46,5 +48,16 @@ pub trait LayoutThreadFactory {
         webrender_document: webrender_api::DocumentId,
         paint_time_metrics: PaintTimeMetrics,
         busy: Arc<AtomicBool>,
+        load_webfonts_synchronously: bool,
+        initial_window_size: TypedSize2D<u32, DeviceIndependentPixel>,
+        device_pixels_per_px: Option<f32>,
+        dump_display_list: bool,
+        dump_display_list_json: bool,
+        dump_style_tree: bool,
+        dump_rule_tree: bool,
+        relayout_event: bool,
+        nonincremental_layout: bool,
+        trace_layout: bool,
+        dump_flow_tree: bool,
     );
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Removed almost all `opts::get()` from components/layout_thread. The untouched one is used by [`get_ua_stylesheets()`](https://github.com/servo/servo/blob/2ad3066d7c92c504838f72aaca73bec44048cb58/components/layout_thread/lib.rs#L1924), which is in turn used by [`lazy_static!`](https://github.com/servo/servo/blob/2ad3066d7c92c504838f72aaca73bec44048cb58/components/layout_thread/lib.rs#L1998).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix *partially* #22854 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because these are cleanup changes which neither add any feature, nor fix any bug.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23515)
<!-- Reviewable:end -->
