### PR TITLE
Make prepare_for_composite return void

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -48,7 +48,6 @@ use webvr_traits::WebVRMainThreadHeartbeat;
 
 #[derive(Debug, PartialEq)]
 enum UnableToComposite {
-    WindowUnprepared,
     NotReadyToPaintImage(NotReadyToPaint),
 }
 
@@ -1212,10 +1211,8 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             .framebuffer
             .to_u32()
             .height_typed();
-        if !self.window.prepare_for_composite() {
-            return Err(UnableToComposite::WindowUnprepared);
-        }
 
+        self.window.prepare_for_composite();
         self.webrender.update();
 
         let wait_for_stable_image = match target {

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -142,9 +142,8 @@ pub trait WindowMethods {
     /// Presents the window to the screen (perhaps by page flipping).
     fn present(&self);
     /// Requests that the window system prepare a composite. Typically this will involve making
-    /// some type of platform-specific graphics context current. Returns true if the composite may
-    /// proceed and false if it should not.
-    fn prepare_for_composite(&self) -> bool;
+    /// some type of platform-specific graphics context current.
+    fn prepare_for_composite(&self);
     /// Return the GL function pointer trait.
     #[cfg(feature = "gl")]
     fn gl(&self) -> Rc<dyn gl::Gl>;

--- a/ports/glutin/headed_window.rs
+++ b/ports/glutin/headed_window.rs
@@ -510,9 +510,8 @@ impl WindowMethods for Window {
         self.animation_state.set(state);
     }
 
-    fn prepare_for_composite(&self) -> bool {
+    fn prepare_for_composite(&self) {
         self.gl_context.borrow_mut().make_current();
-        true
     }
 }
 

--- a/ports/glutin/headless_window.rs
+++ b/ports/glutin/headless_window.rs
@@ -194,7 +194,5 @@ impl WindowMethods for Window {
         self.animation_state.set(state);
     }
 
-    fn prepare_for_composite(&self) -> bool {
-        true
-    }
+    fn prepare_for_composite(&self) { }
 }

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -580,10 +580,9 @@ impl EmbedderMethods for ServoEmbedderCallbacks {
 }
 
 impl WindowMethods for ServoWindowCallbacks {
-    fn prepare_for_composite(&self) -> bool {
+    fn prepare_for_composite(&self) {
         debug!("WindowMethods::prepare_for_composite");
         self.host_callbacks.make_current();
-        true
     }
 
     fn present(&self) {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Changed the signature of `fn prepare_for_composite(...)` to return void (unit) instead of boolean.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23492 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because these are clean-up changes (do not include new feature or fixed bug).

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23517)
<!-- Reviewable:end -->
