### PR TITLE
Net: removed opts::get() usage

### DIFF
--- a/components/net/tests/resource_thread.rs
+++ b/components/net/tests/resource_thread.rs
@@ -27,6 +27,7 @@ fn test_exit() {
         MemProfilerChan(mtx),
         create_embedder_proxy(),
         None,
+        None,
     );
     resource_thread.send(CoreResourceMsg::Exit(sender)).unwrap();
     receiver.recv().unwrap();

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -630,6 +630,7 @@ fn create_constellation(
         mem_profiler_chan.clone(),
         embedder_proxy.clone(),
         config_dir,
+        opts.certificate_path.clone(),
     );
     let font_cache_thread = FontCacheThread::new(
         public_resource_threads.sender(),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Removed usage of opts::get() in components/net.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix *partially* #22854 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because these are cleanup/refactoring changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23520)
<!-- Reviewable:end -->
