### PR TITLE
Profile: removed opts::get()

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -224,6 +224,7 @@ where
         let time_profiler_chan = profile_time::Profiler::create(
             &opts.time_profiling,
             opts.time_profiler_trace_path.clone(),
+            opts.profile_heartbeats,
         );
         let mem_profiler_chan = profile_mem::Profiler::create(opts.mem_profiler_period);
         let debugger_chan = opts.debugger_port.map(|port| debugger::start_server(port));

--- a/tests/unit/profile/time.rs
+++ b/tests/unit/profile/time.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 #[test]
 fn time_profiler_smoke_test() {
-    let chan = time::Profiler::create(&None, None);
+    let chan = time::Profiler::create(&None, None, false);
     assert!(true, "Can create the profiler thread");
 
     let (ipcchan, _ipcport) = ipc::channel().unwrap();
@@ -45,7 +45,7 @@ fn time_profiler_stats_test() {
 
 #[test]
 fn channel_profiler_test() {
-    let chan = time::Profiler::create(&Some(OutputOptions::Stdout(5.0)), None);
+    let chan = time::Profiler::create(&Some(OutputOptions::Stdout(5.0)), None, false);
     let (profiled_sender, profiled_receiver) = ProfiledIpc::channel(chan.clone()).unwrap();
     thread::spawn(move || {
         thread::sleep(Duration::from_secs(2));
@@ -70,7 +70,7 @@ fn channel_profiler_test() {
 
 #[test]
 fn bytes_channel_profiler_test() {
-    let chan = time::Profiler::create(&Some(OutputOptions::Stdout(5.0)), None);
+    let chan = time::Profiler::create(&Some(OutputOptions::Stdout(5.0)), None, false);
     let (profiled_sender, profiled_receiver) = ProfiledIpc::bytes_channel(chan.clone()).unwrap();
     thread::spawn(move || {
         thread::sleep(Duration::from_secs(2));


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Removed opts::get() from `profile` component. **Note** that `profile_traits` component is the only component that uses single `opts::get().signpost` for IpcBytesReceiver and IpcReceiver structs, i.e. for recv() type method.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix *partially* #22854 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because these are cleanup changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23521)
<!-- Reviewable:end -->
