### PR TITLE
Split getter for mutation_observers() into two methods.

### DIFF
--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -132,7 +132,12 @@ impl MutationObserver {
 
         // Step 2 & 3
         for node in target.inclusive_ancestors(ShadowIncluding::No) {
-            for registered in &*node.registered_mutation_observers() {
+            let registered = node.registered_mutation_observers();
+            if registered.is_none() {
+                continue;
+            }
+
+            for registered in &*registered.unwrap() {
                 if &*node != target && !registered.options.subtree {
                     continue;
                 }
@@ -297,7 +302,7 @@ impl MutationObserverMethods for MutationObserver {
         // Step 7
         let add_new_observer = {
             let mut replaced = false;
-            for registered in &mut *target.registered_mutation_observers() {
+            for registered in &mut *target.registered_mutation_observers_mut() {
                 if &*registered.observer as *const MutationObserver !=
                     self as *const MutationObserver
                 {


### PR DESCRIPTION
Please let me know if these API changes look good:

registered_mutation_observers() returns immutable references and does
not init mutation observers.

registered_mutation_observers_mut() lazily initializes raredata if it
does not exist.

Updated code that uses this methods to call appropriate method when
mutation is not necessary.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23286 

<!-- Either: -->
- [X] These changes do not require tests because: this is a small change to the API, and existing tests for Partial ShadowDOM support cover this API use/changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23529)
<!-- Reviewable:end -->
