### PR TITLE
Let resources timing entries be added to performance entry buffer.

### DIFF
--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -62,7 +62,7 @@ pub fn submit_timing_data(
         PerformanceResourceTiming::new(global, url, initiator_type, None, resource_timing);
     global
         .performance()
-        .queue_entry(performance_entry.upcast::<PerformanceEntry>(), false);
+        .queue_entry(performance_entry.upcast::<PerformanceEntry>(), true);
 }
 
 impl<Listener: PreInvoke + Send + 'static> NetworkListener<Listener> {

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-img-element/srcset/avoid-reload-on-resize.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-img-element/srcset/avoid-reload-on-resize.html.ini
@@ -1,0 +1,4 @@
+[avoid-reload-on-resize.html]
+  [Avoid srcset image reloads when viewport resizes]
+    expected: FAIL
+

--- a/tests/wpt/metadata/performance-timeline/case-sensitivity.any.js.ini
+++ b/tests/wpt/metadata/performance-timeline/case-sensitivity.any.js.ini
@@ -9,6 +9,3 @@
 
 [case-sensitivity.any.html]
   type: testharness
-  [getEntriesByName values are case sensitive]
-    expected: FAIL
-

--- a/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
+++ b/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
@@ -70,9 +70,6 @@
   [PerformanceResourceTiming interface: resource must inherit property "workerStart" with the proper type]
     expected: FAIL
 
-  [PerformanceResourceTiming interface: resource must inherit property "initiatorType" with the proper type]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: attribute transferSize]
     expected: FAIL
 
@@ -82,37 +79,19 @@
   [PerformanceResourceTiming interface: resource must inherit property "secureConnectionStart" with the proper type]
     expected: FAIL
 
-  [PerformanceResourceTiming interface: resource must inherit property "requestStart" with the proper type]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: resource must inherit property "transferSize" with the proper type]
     expected: FAIL
 
   [PerformanceResourceTiming interface: resource must inherit property "domainLookupStart" with the proper type]
     expected: FAIL
 
-  [PerformanceResourceTiming interface: resource must inherit property "connectStart" with the proper type]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: attribute decodedBodySize]
-    expected: FAIL
-
-  [Stringification of resource]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: resource must inherit property "redirectStart" with the proper type]
     expected: FAIL
 
   [PerformanceResourceTiming interface: resource must inherit property "toJSON()" with the proper type]
     expected: FAIL
 
-  [PerformanceResourceTiming interface: resource must inherit property "responseEnd" with the proper type]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: resource must inherit property "redirectEnd" with the proper type]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: resource must inherit property "nextHopProtocol" with the proper type]
     expected: FAIL
 
   [PerformanceResourceTiming interface: resource must inherit property "domainLookupEnd" with the proper type]
@@ -121,25 +100,13 @@
   [PerformanceResourceTiming interface: resource must inherit property "decodedBodySize" with the proper type]
     expected: FAIL
 
-  [PerformanceResourceTiming interface: resource must inherit property "fetchStart" with the proper type]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: attribute encodedBodySize]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: resource must inherit property "connectEnd" with the proper type]
     expected: FAIL
 
   [PerformanceResourceTiming interface: resource must inherit property "encodedBodySize" with the proper type]
     expected: FAIL
 
   [PerformanceResourceTiming interface: operation toJSON()]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: resource must inherit property "responseStart" with the proper type]
-    expected: FAIL
-
-  [PerformanceResourceTiming must be primary interface of resource]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute secureConnectionStart]

--- a/tests/wpt/metadata/resource-timing/no-entries-for-cross-origin-css-fetched.sub.html.ini
+++ b/tests/wpt/metadata/resource-timing/no-entries-for-cross-origin-css-fetched.sub.html.ini
@@ -1,0 +1,4 @@
+[no-entries-for-cross-origin-css-fetched.sub.html]
+  [Make sure that resources fetched by cross origin CSS are not in the timeline.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/resource-timing/resource_TAO_origin.htm.ini
+++ b/tests/wpt/metadata/resource-timing/resource_TAO_origin.htm.ini
@@ -5,27 +5,15 @@
   [domainLookupEnd should not be 0 in timing-allow cross-origin request.]
     expected: FAIL
 
-  [connectStart should not be 0 in timing-allow cross-origin request.]
-    expected: FAIL
-
-  [connectEnd should not be 0 in timing-allow cross-origin request.]
-    expected: FAIL
-
-  [requestStart should not be 0 in timing-allow cross-origin request.]
-    expected: FAIL
-
   [responseStart should not be 0 in timing-allow cross-origin request.]
-    expected: FAIL
-
-  [fetchStart should not be 0 in timing-allow cross-origin request.]
-    expected: FAIL
-
-  [responseEnd should not be 0 in timing-allow cross-origin request.]
     expected: FAIL
 
   [redirectEnd should be 0 in cross-origin request since no redirect.]
     expected: FAIL
 
   [secureConnectionStart should be 0 in cross-origin request since no ssl!]
+    expected: FAIL
+
+  [The iframe should have one resource timing entry.]
     expected: FAIL
 

--- a/tests/wpt/metadata/resource-timing/resource_TAO_zero.htm.ini
+++ b/tests/wpt/metadata/resource-timing/resource_TAO_zero.htm.ini
@@ -1,10 +1,4 @@
 [resource_TAO_zero.htm]
-  [fetchStart should be greater than 0 in cross-origin request.]
-    expected: FAIL
-
-  [responseEnd should be greater than 0 in cross-origin request.]
-    expected: FAIL
-
   [secureConnectionStart should be 0 in cross-origin request.]
     expected: FAIL
 
@@ -15,5 +9,17 @@
     expected: FAIL
 
   [redirectEnd should be 0 in cross-origin request.]
+    expected: FAIL
+
+  [connectEnd should be 0 in cross-origin request.]
+    expected: FAIL
+
+  [connectStart should be 0 in cross-origin request.]
+    expected: FAIL
+
+  [There should be one resource timing entry.]
+    expected: FAIL
+
+  [requestStart should be 0 in cross-origin request.]
     expected: FAIL
 

--- a/tests/wpt/metadata/resource-timing/resource_connection_reuse.html.ini
+++ b/tests/wpt/metadata/resource-timing/resource_connection_reuse.html.ini
@@ -2,3 +2,18 @@
   [There should be 2 PerformanceEntries]
     expected: FAIL
 
+  [domainLookupEnd and fetchStart should be the same]
+    expected: FAIL
+
+  [connectStart and fetchStart should be the same]
+    expected: FAIL
+
+  [domainLookupStart and fetchStart should be the same]
+    expected: FAIL
+
+  [secureConnectionStart should be zero]
+    expected: FAIL
+
+  [connectEnd and fetchStart should be the same]
+    expected: FAIL
+

--- a/tests/wpt/metadata/resource-timing/resource_connection_reuse.https.html.ini
+++ b/tests/wpt/metadata/resource-timing/resource_connection_reuse.https.html.ini
@@ -2,3 +2,18 @@
   [There should be 2 PerformanceEntries]
     expected: FAIL
 
+  [secureConnectionStart and fetchStart should be the same]
+    expected: FAIL
+
+  [domainLookupEnd and fetchStart should be the same]
+    expected: FAIL
+
+  [connectStart and fetchStart should be the same]
+    expected: FAIL
+
+  [domainLookupStart and fetchStart should be the same]
+    expected: FAIL
+
+  [connectEnd and fetchStart should be the same]
+    expected: FAIL
+

--- a/tests/wpt/metadata/resource-timing/resource_connection_reuse_mixed_content.html.ini
+++ b/tests/wpt/metadata/resource-timing/resource_connection_reuse_mixed_content.html.ini
@@ -2,3 +2,18 @@
   [There should be 2 PerformanceEntries]
     expected: FAIL
 
+  [secureConnectionStart and fetchStart should be the same]
+    expected: FAIL
+
+  [domainLookupEnd and fetchStart should be the same]
+    expected: FAIL
+
+  [connectStart and fetchStart should be the same]
+    expected: FAIL
+
+  [domainLookupStart and fetchStart should be the same]
+    expected: FAIL
+
+  [connectEnd and fetchStart should be the same]
+    expected: FAIL
+

--- a/tests/wpt/metadata/resource-timing/resource_connection_reuse_mixed_content_redirect.html.ini
+++ b/tests/wpt/metadata/resource-timing/resource_connection_reuse_mixed_content_redirect.html.ini
@@ -2,3 +2,18 @@
   [There should be 2 PerformanceEntries]
     expected: FAIL
 
+  [secureConnectionStart and fetchStart should be the same]
+    expected: FAIL
+
+  [domainLookupEnd and fetchStart should be the same]
+    expected: FAIL
+
+  [connectStart and fetchStart should be the same]
+    expected: FAIL
+
+  [domainLookupStart and fetchStart should be the same]
+    expected: FAIL
+
+  [connectEnd and fetchStart should be the same]
+    expected: FAIL
+

--- a/tests/wpt/metadata/resource-timing/resource_dedicated_worker.html.ini
+++ b/tests/wpt/metadata/resource-timing/resource_dedicated_worker.html.ini
@@ -1,4 +1,0 @@
-[resource_dedicated_worker.html]
-  [There should be six entries: 4 scripts, 1 stylesheet, and the worker itself]
-    expected: FAIL
-

--- a/tests/wpt/metadata/resource-timing/test_resource_timing.html.ini
+++ b/tests/wpt/metadata/resource-timing/test_resource_timing.html.ini
@@ -15,9 +15,6 @@
   [PerformanceEntry has correct protocol attribute (iframe)]
     expected: FAIL
 
-  [window.performance.getEntriesByName() and window.performance.getEntriesByNameType() return same data (img)]
-    expected: FAIL
-
   [PerformanceEntry has correct name, initiatorType, startTime, and duration (img)]
     expected: FAIL
 

--- a/tests/wpt/metadata/resource-timing/test_resource_timing.https.html.ini
+++ b/tests/wpt/metadata/resource-timing/test_resource_timing.https.html.ini
@@ -51,9 +51,6 @@
   [PerformanceEntry has correct protocol attribute (xmlhttprequest)]
     expected: FAIL
 
-  [window.performance.getEntriesByName() and window.performance.getEntriesByNameType() return same data (img)]
-    expected: FAIL
-
   [PerformanceEntry has correct order of timing attributes (script)]
     expected: FAIL
 

--- a/tests/wpt/metadata/workers/worker-performance.worker.js.ini
+++ b/tests/wpt/metadata/workers/worker-performance.worker.js.ini
@@ -18,3 +18,9 @@
   [performance.toJSON is available in workers]
     expected: FAIL
 
+  [performance.clearResourceTimings in workers]
+    expected: FAIL
+
+  [performance.setResourceTimingBufferSize in workers]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -21110,7 +21110,7 @@
    "support"
   ],
   "mozilla/xmlhttprequest_url.html": [
-   "e5d10f27c06e1febd3bb70f8f128194fc3f63861",
+   "3a765c1e45b0ff25d9161e70f2ad0718769a4cdb",
    "testharness"
   ]
  },

--- a/tests/wpt/mozilla/tests/mozilla/xmlhttprequest_url.html
+++ b/tests/wpt/mozilla/tests/mozilla/xmlhttprequest_url.html
@@ -19,7 +19,7 @@ async_test(function(t) {
 
   request.onload = t.step_func_done(function() {
     let entries = window.performance.getEntriesByType("resource");
-    assert_equals(entries.length, 1);
+    assert_equals(entries.length, 3);
     assert_equals(entries[0].name, href);
   });
 }, "Performance entries should contain the URL where the XMLHttpRequest originated");


### PR DESCRIPTION

<!-- Please describe your changes on the following line: -->
Update relevant tests to properly report and expect failure.

These changes are the first step for #23328. Not sure if I would say they _fix_ the issue.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes: Existing tests have been updated to expect pass/failures.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23536)
<!-- Reviewable:end -->
