### PR TITLE
Script: removed a few opts::get()

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -66,7 +66,7 @@ pub struct Opts {
 
     pub output_file: Option<String>,
 
-    /// Replace unpaires surrogates in DOM strings with U+FFFD.
+    /// Replace unpaired surrogates in DOM strings with U+FFFD.
     /// See <https://github.com/servo/servo/issues/6564>
     pub replace_surrogates: bool,
 

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -559,6 +559,17 @@ impl UnprivilegedPipelineContent {
                 layout_is_busy: layout_thread_busy_flag.clone(),
             },
             self.load_data.clone(),
+            self.opts.profile_script_events,
+            self.opts.print_pwm,
+            self.opts.relayout_event,
+            self.opts.output_file.is_some() ||
+                self.opts.exit_after_load ||
+                self.opts.webdriver_port.is_some(),
+            self.opts.unminify_js,
+            self.opts.userscripts,
+            self.opts.headless,
+            self.opts.replace_surrogates,
+            self.opts.user_agent,
         );
 
         LTF::create(

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -109,6 +109,7 @@ use servo_media::streams::MediaStreamType;
 use servo_media::webrtc::WebRtcController;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use smallvec::SmallVec;
+use std::borrow::Cow;
 use std::cell::{Cell, RefCell, UnsafeCell};
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::hash::{BuildHasher, Hash};
@@ -163,6 +164,8 @@ unsafe_no_jsmanaged_fields!(Duration);
 unsafe_no_jsmanaged_fields!(TexDataType, TexFormat);
 
 unsafe_no_jsmanaged_fields!(*mut JobQueue);
+
+unsafe_no_jsmanaged_fields!(Cow<'static, str>);
 
 /// Trace a `JSVal`.
 pub fn trace_jsval(tracer: *mut JSTracer, description: &str, val: &Heap<JSVal>) {

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -62,6 +62,8 @@ impl DissimilarOriginWindow {
                 // FIXME(nox): The microtask queue is probably not important
                 // here, but this whole DOM interface is a hack anyway.
                 global_to_clone_from.microtask_queue().clone(),
+                global_to_clone_from.is_headless(),
+                global_to_clone_from.get_user_agent(),
             ),
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -38,7 +38,6 @@ use net_traits::request::{
 use net_traits::{FetchMetadata, FetchResponseListener, Metadata, NetworkError};
 use net_traits::{ResourceFetchTiming, ResourceTimingType};
 use servo_atoms::Atom;
-use servo_config::opts;
 use servo_url::ServoUrl;
 use std::cell::Cell;
 use std::fs::File;
@@ -533,7 +532,7 @@ impl HTMLScriptElement {
     }
 
     fn unminify_js(&self, script: &mut ClassicScript) {
-        if !opts::get().unminify_js {
+        if !self.parser_document.window().unminify_js() {
             return;
         }
 

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -103,7 +103,7 @@ impl NavigatorMethods for Navigator {
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-useragent
     fn UserAgent(&self) -> DOMString {
-        navigatorinfo::UserAgent()
+        navigatorinfo::UserAgent(self.global().get_user_agent())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-appversion

--- a/components/script/dom/navigatorinfo.rs
+++ b/components/script/dom/navigatorinfo.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::str::DOMString;
-use servo_config::opts;
+use std::borrow::Cow;
 
 pub fn Product() -> DOMString {
     DOMString::from("Gecko")
@@ -53,8 +53,8 @@ pub fn Platform() -> DOMString {
     DOMString::from("iOS")
 }
 
-pub fn UserAgent() -> DOMString {
-    DOMString::from(&*opts::get().user_agent)
+pub fn UserAgent(user_agent: Cow<'static, str>) -> DOMString {
+    DOMString::from(&*user_agent)
 }
 
 pub fn AppVersion() -> DOMString {

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -21,8 +21,6 @@ use dom_struct::dom_struct;
 use js::conversions::ConversionResult;
 use js::jsapi::{JSContext, JSObject};
 use js::jsval::{ObjectValue, UndefinedValue};
-#[cfg(target_os = "linux")]
-use servo_config::opts;
 use servo_config::pref;
 use std::rc::Rc;
 #[cfg(target_os = "linux")]
@@ -269,14 +267,15 @@ impl PermissionAlgorithm for Permissions {
             // Step 3.
             PermissionState::Prompt => {
                 let perm_name = status.get_query();
-                // https://w3c.github.io/permissions/#request-permission-to-use (Step 3 - 4)
-                let state = prompt_user(&format!(
-                    "{} {} ?",
-                    REQUEST_DIALOG_MESSAGE,
-                    perm_name.clone()
-                ));
 
                 let globalscope = GlobalScope::current().expect("No current global object");
+
+                // https://w3c.github.io/permissions/#request-permission-to-use (Step 3 - 4)
+                let state = prompt_user(
+                    &format!("{} {} ?", REQUEST_DIALOG_MESSAGE, perm_name.clone()),
+                    globalscope.is_headless(),
+                );
+
                 globalscope
                     .as_window()
                     .permission_state_invocation_results()
@@ -322,10 +321,11 @@ pub fn get_descriptor_permission_state(
                 .permission_state_invocation_results()
                 .borrow_mut()
                 .remove(&permission_name.to_string());
-            prompt_user(&format!(
-                "The {} {}",
-                permission_name, NONSECURE_DIALOG_MESSAGE
-            ))
+
+            prompt_user(
+                &format!("The {} {}", permission_name, NONSECURE_DIALOG_MESSAGE),
+                settings.is_headless(),
+            )
         }
     };
 
@@ -351,8 +351,8 @@ pub fn get_descriptor_permission_state(
 }
 
 #[cfg(target_os = "linux")]
-fn prompt_user(message: &str) -> PermissionState {
-    if opts::get().headless {
+fn prompt_user(message: &str, headless: bool) -> PermissionState {
+    if headless {
         return PermissionState::Denied;
     }
     match tinyfiledialogs::message_box_yes_no(
@@ -367,7 +367,7 @@ fn prompt_user(message: &str) -> PermissionState {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn prompt_user(_message: &str) -> PermissionState {
+fn prompt_user(_message: &str, _headless: bool) -> PermissionState {
     // TODO popup only supported on linux
     PermissionState::Denied
 }

--- a/components/script/dom/userscripts.rs
+++ b/components/script/dom/userscripts.rs
@@ -8,17 +8,16 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlheadelement::HTMLHeadElement;
 use crate::dom::node::document_from_node;
 use js::jsval::UndefinedValue;
-use servo_config::opts;
 use std::fs::{read_dir, File};
 use std::io::Read;
 use std::path::PathBuf;
 
 pub fn load_script(head: &HTMLHeadElement) {
-    let path_str = match opts::get().userscripts.clone() {
+    let doc = document_from_node(head);
+    let path_str = match doc.window().get_userscripts_path() {
         Some(p) => p,
         None => return,
     };
-    let doc = document_from_node(head);
     let win = Trusted::new(doc.window());
     doc.add_delayed_task(task!(UserScriptExecute: move || {
         let win = win.root();

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -73,6 +73,8 @@ pub fn prepare_workerscope_init(
         worker_id: global.get_next_worker_id(),
         pipeline_id: global.pipeline_id(),
         origin: global.origin().immutable().clone(),
+        is_headless: global.is_headless(),
+        user_agent: global.get_user_agent(),
     };
 
     init
@@ -132,6 +134,8 @@ impl WorkerGlobalScope {
                 timer_event_chan,
                 MutableOrigin::new(init.origin),
                 runtime.microtask_queue.clone(),
+                init.is_headless,
+                init.user_agent,
             ),
             worker_id: init.worker_id,
             worker_name,

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -79,7 +79,7 @@ impl WorkerNavigatorMethods for WorkerNavigator {
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-useragent
     fn UserAgent(&self) -> DOMString {
-        navigatorinfo::UserAgent()
+        navigatorinfo::UserAgent(self.global().get_user_agent())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-appversion

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -30,6 +30,7 @@ use servo_atoms::Atom;
 use servo_url::ImmutableOrigin;
 use servo_url::MutableOrigin;
 use servo_url::ServoUrl;
+use std::borrow::Cow;
 use std::sync::Arc;
 
 #[dom_struct]
@@ -72,6 +73,8 @@ impl WorkletGlobalScope {
                 timer_event_chan,
                 MutableOrigin::new(ImmutableOrigin::new_opaque()),
                 Default::default(),
+                init.is_headless,
+                init.user_agent.clone(),
             ),
             base_url,
             to_script_thread_sender: init.to_script_thread_sender.clone(),
@@ -153,6 +156,10 @@ pub struct WorkletGlobalScopeInit {
     pub scheduler_chan: IpcSender<TimerSchedulerMsg>,
     /// The image cache
     pub image_cache: Arc<dyn ImageCache>,
+    /// True if in headless mode
+    pub is_headless: bool,
+    /// An optional string allowing the user agent to be set for testing
+    pub user_agent: Cow<'static, str>,
 }
 
 /// <https://drafts.css-houdini.org/worklets/#worklet-global-scope-type>

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -135,8 +135,8 @@ use script_traits::{ScriptToConstellationChan, TimerEvent, TimerSchedulerMsg};
 use script_traits::{TimerSource, TouchEventType, TouchId, UntrustedNodeAddress, WheelDelta};
 use script_traits::{UpdatePipelineIdReason, WindowSizeData, WindowSizeType};
 use servo_atoms::Atom;
-use servo_config::opts;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
+use std::borrow::Cow;
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::{hash_map, HashMap, HashSet};
@@ -644,6 +644,36 @@ pub struct ScriptThread {
 
     /// FIXME(victor):
     webrender_api_sender: RenderApiSender,
+
+    /// Periodically print out on which events script threads spend their processing time.
+    profile_script_events: bool,
+
+    /// Print Progressive Web Metrics to console.
+    print_pwm: bool,
+
+    /// Emits notifications when there is a relayout.
+    relayout_event: bool,
+
+    /// True if it is safe to write to the image.
+    prepare_for_screenshot: bool,
+
+    /// Unminify Javascript.
+    unminify_js: bool,
+
+    /// Where to load userscripts from, if any. An empty string will load from
+    /// the resources/user-agent-js directory, and if the option isn't passed userscripts
+    /// won't be loaded
+    userscripts_path: Option<String>,
+
+    /// True if headless mode.
+    headless: bool,
+
+    /// Replace unpaired surrogates in DOM strings with U+FFFD.
+    /// See <https://github.com/servo/servo/issues/6564>
+    replace_surrogates: bool,
+
+    /// An optional string allowing the user agent to be set for testing.
+    user_agent: Cow<'static, str>,
 }
 
 /// In the event of thread panic, all data on the stack runs its destructor. However, there
@@ -681,6 +711,15 @@ impl ScriptThreadFactory for ScriptThread {
     fn create(
         state: InitialScriptState,
         load_data: LoadData,
+        profile_script_events: bool,
+        print_pwm: bool,
+        relayout_event: bool,
+        prepare_for_screenshot: bool,
+        unminify_js: bool,
+        userscripts_path: Option<String>,
+        headless: bool,
+        replace_surrogates: bool,
+        user_agent: Cow<'static, str>,
     ) -> (Sender<message::Msg>, Receiver<message::Msg>) {
         let (script_chan, script_port) = unbounded();
 
@@ -703,7 +742,20 @@ impl ScriptThreadFactory for ScriptThread {
                 let window_size = state.window_size;
                 let layout_is_busy = state.layout_is_busy.clone();
 
-                let script_thread = ScriptThread::new(state, script_port, script_chan.clone());
+                let script_thread = ScriptThread::new(
+                    state,
+                    script_port,
+                    script_chan.clone(),
+                    profile_script_events,
+                    print_pwm,
+                    relayout_event,
+                    prepare_for_screenshot,
+                    unminify_js,
+                    userscripts_path,
+                    headless,
+                    replace_surrogates,
+                    user_agent,
+                );
 
                 SCRIPT_THREAD_ROOT.with(|root| {
                     root.set(Some(&script_thread as *const _));
@@ -963,6 +1015,8 @@ impl ScriptThread {
                         to_constellation_sender: script_thread.script_sender.clone(),
                         scheduler_chan: script_thread.scheduler_chan.clone(),
                         image_cache: script_thread.image_cache.clone(),
+                        is_headless: script_thread.headless,
+                        user_agent: script_thread.user_agent.clone(),
                     };
                     Rc::new(WorkletThreadPool::spawn(init))
                 })
@@ -1056,6 +1110,15 @@ impl ScriptThread {
         state: InitialScriptState,
         port: Receiver<MainThreadScriptMsg>,
         chan: Sender<MainThreadScriptMsg>,
+        profile_script_events: bool,
+        print_pwm: bool,
+        relayout_event: bool,
+        prepare_for_screenshot: bool,
+        unminify_js: bool,
+        userscripts_path: Option<String>,
+        headless: bool,
+        replace_surrogates: bool,
+        user_agent: Cow<'static, str>,
     ) -> ScriptThread {
         let runtime = new_rt_and_cx();
         let cx = runtime.cx();
@@ -1159,6 +1222,18 @@ impl ScriptThread {
 
             webrender_document: state.webrender_document,
             webrender_api_sender: state.webrender_api_sender,
+
+            profile_script_events,
+            print_pwm,
+
+            relayout_event,
+            prepare_for_screenshot,
+            unminify_js,
+
+            userscripts_path,
+            headless,
+            replace_surrogates,
+            user_agent,
         }
     }
 
@@ -1537,7 +1612,7 @@ impl ScriptThread {
     {
         self.notify_activity_to_hang_monitor(&category);
         let start = precise_time_ns();
-        let value = if opts::get().profile_script_events {
+        let value = if self.profile_script_events {
             let profiler_cat = match category {
                 ScriptThreadEventCategory::AttachLayout => ProfilerCategory::ScriptAttachLayout,
                 ScriptThreadEventCategory::ConstellationMsg => {
@@ -1586,7 +1661,7 @@ impl ScriptThread {
         for (doc_id, doc) in self.documents.borrow().iter() {
             if let Some(pipeline_id) = pipeline_id {
                 if pipeline_id == doc_id && end - start > MAX_TASK_NS {
-                    if opts::get().print_pwm {
+                    if self.print_pwm {
                         println!(
                             "Task took longer than max allowed ({:?}) {:?}",
                             category,
@@ -2897,6 +2972,13 @@ impl ScriptThread {
             self.webrender_document,
             self.webrender_api_sender.clone(),
             incomplete.layout_is_busy,
+            self.relayout_event,
+            self.prepare_for_screenshot,
+            self.unminify_js,
+            self.userscripts_path.clone(),
+            self.headless,
+            self.replace_surrogates,
+            self.user_agent.clone(),
         );
 
         // Initialize the browsing context for the window.

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -49,6 +49,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use servo_atoms::Atom;
 use servo_url::ImmutableOrigin;
 use servo_url::ServoUrl;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::atomic::AtomicBool;
@@ -644,6 +645,15 @@ pub trait ScriptThreadFactory {
     fn create(
         state: InitialScriptState,
         load_data: LoadData,
+        profile_script_events: bool,
+        print_pwm: bool,
+        relayout_event: bool,
+        prepare_for_screenshot: bool,
+        unminify_js: bool,
+        userscripts_path: Option<String>,
+        headless: bool,
+        replace_surrogates: bool,
+        user_agent: Cow<'static, str>,
     ) -> (Sender<Self::Message>, Receiver<Self::Message>);
 }
 
@@ -878,6 +888,10 @@ pub struct WorkerGlobalScopeInit {
     pub pipeline_id: PipelineId,
     /// The origin
     pub origin: ImmutableOrigin,
+    /// True if headless mode
+    pub is_headless: bool,
+    /// An optional string allowing the user agnet to be set for testing.
+    pub user_agent: Cow<'static, str>,
 }
 
 /// Common entities representing a network load origin


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I removed only a few opts::get() from the components/script because all other code with "opts::get()" is reused by many other parts within the same component.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix *partially* #22854 (GitHub issue number if applicable)

<!-- Either: -->
- [x] These changes do not require tests because these are cleanup changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23539)
<!-- Reviewable:end -->
