### PR TITLE
HTTP Cache parallelism experiment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,6 +2941,7 @@ dependencies = [
  "msg 0.0.1",
  "net_traits 0.0.1",
  "openssl 0.10.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pixels 0.0.1",
  "profile_traits 0.0.1",
  "rayon 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -42,6 +42,7 @@ mime_guess = "2.0.0-alpha.6"
 msg = {path = "../msg"}
 net_traits = {path = "../net_traits"}
 openssl = "0.10"
+parking_lot = "0.8"
 pixels = {path = "../pixels"}
 profile_traits = {path = "../profile_traits"}
 rayon = "1"

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -611,7 +611,6 @@ impl HttpCache {
     /// Invalidation.
     /// <https://tools.ietf.org/html/rfc7234#section-4.4>
     pub fn invalidate(&mut self, request: &Request, response: &Response) {
-        // TODO(eijebong): Once headers support typed_get, update this to use them
         if let Some(Ok(location)) = response
             .headers
             .get(header::LOCATION)
@@ -777,50 +776,48 @@ impl HttpCacheEntry {
         assert_eq!(entry_key, self.key);
         assert_eq!(response.status.map(|s| s.0), Some(StatusCode::NOT_MODIFIED));
         for cached_resource in self.resources.read().clone().iter_mut() {
-            let constructed_response = {
-                let cached_resource = cached_resource.read();
-                // done_chan will have been set to Some(..) by http_network_fetch.
-                // If the body is not receiving data, set the done_chan back to None.
-                // Otherwise, create a new dedicated channel to update the consumer.
-                // The response constructed here will replace the 304 one from the network.
-                let in_progress_channel = match *cached_resource.body.lock().unwrap() {
-                    ResponseBody::Receiving(..) => Some(unbounded()),
-                    ResponseBody::Empty | ResponseBody::Done(..) => None,
-                };
-                match in_progress_channel {
-                    Some((done_sender, done_receiver)) => {
-                        *done_chan = Some((done_sender.clone(), done_receiver));
-                        cached_resource
-                            .awaiting_body
-                            .lock()
-                            .unwrap()
-                            .push(done_sender);
-                    },
-                    None => *done_chan = None,
-                }
-                // Received a response with 304 status code, in response to a request that matches a cached resource.
-                // 1. update the headers of the cached resource.
-                // 2. return a response, constructed from the cached resource.
-                let resource_timing = ResourceFetchTiming::new(request.timing_type());
-                let mut constructed_response = Response::new(
-                    cached_resource.data.metadata.data.final_url.clone(),
-                    resource_timing,
-                );
-                constructed_response.body = cached_resource.body.clone();
-                constructed_response.status = cached_resource.data.status.clone();
-                constructed_response.https_state = cached_resource.data.https_state.clone();
-                constructed_response.referrer = request.referrer.to_url().cloned();
-                constructed_response.referrer_policy = request.referrer_policy.clone();
-                constructed_response.raw_status = cached_resource.data.raw_status.clone();
-                constructed_response.url_list = cached_resource.data.url_list.clone();
-
-                let mut stored_headers = cached_resource.data.metadata.headers.lock().unwrap();
-                stored_headers.extend(response.headers);
-                constructed_response.headers = stored_headers.clone();
-                constructed_response
+            let mut cached_resource = cached_resource.write();
+            // done_chan will have been set to Some(..) by http_network_fetch.
+            // If the body is not receiving data, set the done_chan back to None.
+            // Otherwise, create a new dedicated channel to update the consumer.
+            // The response constructed here will replace the 304 one from the network.
+            let in_progress_channel = match *cached_resource.body.lock().unwrap() {
+                ResponseBody::Receiving(..) => Some(unbounded()),
+                ResponseBody::Empty | ResponseBody::Done(..) => None,
             };
+            match in_progress_channel {
+                Some((done_sender, done_receiver)) => {
+                    *done_chan = Some((done_sender.clone(), done_receiver));
+                    cached_resource
+                        .awaiting_body
+                        .lock()
+                        .unwrap()
+                        .push(done_sender);
+                },
+                None => *done_chan = None,
+            }
+            // Received a response with 304 status code, in response to a request that matches a cached resource.
+            // 1. update the headers of the cached resource.
+            // 2. return a response, constructed from the cached resource.
+            let resource_timing = ResourceFetchTiming::new(request.timing_type());
+            let mut constructed_response = Response::new(
+                cached_resource.data.metadata.data.final_url.clone(),
+                resource_timing,
+            );
 
-            cached_resource.write().data.expires = get_response_expiry(&constructed_response);
+            constructed_response.body = cached_resource.body.clone();
+            constructed_response.status = cached_resource.data.status.clone();
+            constructed_response.https_state = cached_resource.data.https_state.clone();
+            constructed_response.referrer = request.referrer.to_url().cloned();
+            constructed_response.referrer_policy = request.referrer_policy.clone();
+            constructed_response.raw_status = cached_resource.data.raw_status.clone();
+            constructed_response.url_list = cached_resource.data.url_list.clone();
+
+            cached_resource.data.expires = get_response_expiry(&constructed_response);
+
+            let mut stored_headers = cached_resource.data.metadata.headers.lock().unwrap();
+            stored_headers.extend(response.headers);
+            constructed_response.headers = stored_headers.clone();
 
             return Some(constructed_response);
         }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -12,7 +12,7 @@ use crate::fetch::methods::{
 };
 use crate::fetch::methods::{Data, DoneChannel, FetchContext, Target};
 use crate::hsts::HstsList;
-use crate::http_cache::HttpCache;
+use crate::http_cache::{HttpCache, HttpCacheEntry};
 use crate::resource_thread::AuthCache;
 use crossbeam_channel::{unbounded, Sender};
 use devtools_traits::{
@@ -469,6 +469,7 @@ pub fn http_fetch(
     target: Target,
     done_chan: &mut DoneChannel,
     context: &FetchContext,
+    cache_entry: &Option<HttpCacheEntry>,
 ) -> Response {
     // This is a new async fetch, reset the channel we are waiting on
     *done_chan = None;
@@ -521,7 +522,7 @@ pub fn http_fetch(
 
             // Sub-substep 1
             if method_mismatch || header_mismatch {
-                let preflight_result = cors_preflight_fetch(&request, cache, context);
+                let preflight_result = cors_preflight_fetch(&request, cache, context, cache_entry);
                 // Sub-substep 2
                 if let Some(e) = preflight_result.get_network_error() {
                     return Response::network_error(e.clone());
@@ -551,6 +552,7 @@ pub fn http_fetch(
             cors_flag,
             done_chan,
             context,
+            cache_entry,
         );
 
         // Substep 4
@@ -786,6 +788,7 @@ fn http_network_or_cache_fetch(
     cors_flag: bool,
     done_chan: &mut DoneChannel,
     context: &FetchContext,
+    cache_entry: &Option<HttpCacheEntry>,
 ) -> Response {
     // Step 2
     let mut response: Option<Response> = None;
@@ -969,8 +972,8 @@ fn http_network_or_cache_fetch(
     // TODO If there’s a proxy-authentication entry, use it as appropriate.
 
     // Step 5.19
-    if let Ok(http_cache) = context.state.http_cache.read() {
-        if let Some(response_from_cache) = http_cache.construct_response(&http_request, done_chan) {
+    if let Some(entry) = cache_entry {
+        if let Some(response_from_cache) = entry.construct_response(&http_request, done_chan) {
             let response_headers = response_from_cache.response.headers.clone();
             // Substep 1, 2, 3, 4
             let (cached_response, needs_revalidation) =
@@ -1068,8 +1071,8 @@ fn http_network_or_cache_fetch(
                 .as_ref()
                 .map_or(false, |s| s.0 == StatusCode::NOT_MODIFIED)
         {
-            if let Ok(mut http_cache) = context.state.http_cache.write() {
-                response = http_cache.refresh(&http_request, forward_response.clone(), done_chan);
+            if let Some(entry) = cache_entry {
+                response = entry.refresh(&http_request, forward_response.clone(), done_chan);
                 wait_for_cached_response(done_chan, &mut response);
             }
         }
@@ -1078,8 +1081,8 @@ fn http_network_or_cache_fetch(
         if response.is_none() {
             if http_request.cache_mode != CacheMode::NoStore {
                 // Subsubstep 2, doing it first to avoid a clone of forward_response.
-                if let Ok(mut http_cache) = context.state.http_cache.write() {
-                    http_cache.store(&http_request, &forward_response);
+                if let Some(entry) = cache_entry {
+                    entry.store(&http_request, &forward_response);
                 }
             }
             // Subsubstep 1
@@ -1125,6 +1128,7 @@ fn http_network_or_cache_fetch(
             cors_flag,
             done_chan,
             context,
+            cache_entry,
         );
     }
 
@@ -1382,12 +1386,8 @@ fn http_network_fetch(
     // Step 13
     // TODO this step isn't possible yet (CSP)
 
-    // Step 14
-    if !response.is_network_error() && request.cache_mode != CacheMode::NoStore {
-        if let Ok(mut http_cache) = context.state.http_cache.write() {
-            http_cache.store(&request, &response);
-        }
-    }
+    // Step 14, update the cached response, done via the shared response body.
+    // The initial storing in the cache is done as part of http_network_or_cache_fetch.
 
     // TODO this step isn't possible yet
     // Step 15
@@ -1418,6 +1418,7 @@ fn cors_preflight_fetch(
     request: &Request,
     cache: &mut CorsCache,
     context: &FetchContext,
+    cache_entry: &Option<HttpCacheEntry>,
 ) -> Response {
     // Step 1
     let mut preflight = Request::new(
@@ -1460,7 +1461,14 @@ fn cors_preflight_fetch(
     }
 
     // Step 5
-    let response = http_network_or_cache_fetch(&mut preflight, false, false, &mut None, context);
+    let response = http_network_or_cache_fetch(
+        &mut preflight,
+        false,
+        false,
+        &mut None,
+        context,
+        cache_entry,
+    );
 
     // Step 6
     if cors_check(&request, &response).is_ok() &&

--- a/components/net/tests/http_cache.rs
+++ b/components/net/tests/http_cache.rs
@@ -2,48 +2,50 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use hyper::header::{Expires, HttpDate};
-use hyper::method::Method;
-use hyper::status::StatusCode;
+use crossbeam_channel::unbounded;
+use http::header::{HeaderValue, EXPIRES};
+use http::StatusCode;
 use msg::constellation_msg::TEST_PIPELINE_ID;
 use net::http_cache::HttpCache;
-use net_traits::request::{Destination, Request, RequestInit};
+use net_traits::request::{Origin, Request};
 use net_traits::response::{Response, ResponseBody};
+use net_traits::{ResourceFetchTiming, ResourceTimingType};
 use servo_url::ServoUrl;
-use std::sync::mpsc::channel;
-
 
 #[test]
 fn test_refreshing_resource_sets_done_chan_the_appropriate_value() {
-    let response_bodies = vec![ResponseBody::Receiving(vec![]),
-                               ResponseBody::Empty,
-                               ResponseBody::Done(vec![])];
+    let response_bodies = vec![
+        ResponseBody::Receiving(vec![]),
+        ResponseBody::Empty,
+        ResponseBody::Done(vec![]),
+    ];
     let url = ServoUrl::parse("https://servo.org").unwrap();
-    let request = Request::from_init(RequestInit {
-        url: url.clone(),
-        method: Method::Get,
-        destination: Destination::Document,
-        origin: url.clone().origin(),
-        pipeline_id: Some(TEST_PIPELINE_ID),
-        .. RequestInit::default()
-    });
-    let mut response = Response::new(url.clone());
+    let request = Request::new(
+        url.clone(),
+        Some(Origin::Origin(url.clone().origin())),
+        Some(TEST_PIPELINE_ID),
+    );
+    let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
+    let mut response = Response::new(url.clone(), timing);
     // Expires header makes the response cacheable.
-    response.headers.set(Expires(HttpDate(time::now())));
+    response
+        .headers
+        .insert(EXPIRES, HeaderValue::from_str("-10").unwrap());
+    let mut cache = HttpCache::new();
+    let entry = cache.get_entry(&request).unwrap();
     response_bodies.iter().for_each(|body| {
-        let mut cache = HttpCache::new();
-        *response.body.lock().unwrap() = body;
+        *response.body.lock().unwrap() = body.clone();
         // First, store the 'normal' response.
-        cache.store(&request, &response);
+        entry.store(&request, &response);
         // Second, mutate the response into a 304 response, and refresh the stored one.
-        response.status = Some(StatusCode::NotModified);
-        let mut done_chan = Some(channel());
-        let refreshed_response = cache.refresh(&request, response, &mut done_chan);
+        response.status = Some((StatusCode::NOT_MODIFIED, String::from("304")));
+        let mut done_chan = Some(unbounded());
+        let refreshed_response = entry.refresh(&request, response.clone(), &mut done_chan);
         // Ensure a resource was found, and refreshed.
         assert!(refreshed_response.is_some());
         match body {
             ResponseBody::Receiving(_) => assert!(done_chan.is_some()),
-            ResponseBody::Empty | ResponseBody::Done(_) => assert!(done_chan.is_none())
+            ResponseBody::Empty | ResponseBody::Done(_) => assert!(done_chan.is_none()),
         }
     })
 }

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -14,6 +14,7 @@ mod fetch;
 mod file_loader;
 mod filemanager_thread;
 mod hsts;
+mod http_cache;
 mod http_loader;
 mod mime_classifier;
 mod resource_thread;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Experiment to see if the parallelism of the cache can be improved, by having parallel fetches not content on the cache for each operation, instead just getting an entry corresponding to their request, and then operation on the entry, which should thus only be contented by fetches for similar resources.  Also trying to have the various resources in an entry have their own locks, so that there will be less contention even in the case of requests for similar resources(which could further be reduced if entries are double keyed by top-level origin). 

I'm only worried that requests urls change during a fetch, which would complicate matters...

Part of https://github.com/servo/servo/issues/23495

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23553)
<!-- Reviewable:end -->
