### PR TITLE
Don't process events while borrowing the event loop

### DIFF
--- a/ports/glutin/app.rs
+++ b/ports/glutin/app.rs
@@ -73,7 +73,8 @@ impl App {
         !self.event_queue.borrow().is_empty() || self.window.has_events()
     }
 
-    fn winit_event_to_servo_event(&self, event: glutin::Event) {
+    // This function decides whether the event should be handled during `run_forever`.
+    fn winit_event_to_servo_event(&self, event: glutin::Event) -> glutin::ControlFlow {
         match event {
             // App level events
             glutin::Event::Suspended(suspended) => {
@@ -94,10 +95,18 @@ impl App {
                 if Some(window_id) != self.window.id() {
                     warn!("Got an event from unknown window");
                 } else {
+                    // Resize events need to be handled during run_forever
+                    let cont = if let glutin::WindowEvent::Resized(_) = event {
+                        glutin::ControlFlow::Continue
+                    } else {
+                        glutin::ControlFlow::Break
+                    };
                     self.window.winit_event_to_servo_event(event);
+                    return cont;
                 }
             },
         }
+        glutin::ControlFlow::Break
     }
 
     fn run_loop(self) {
@@ -105,8 +114,15 @@ impl App {
             if !self.window.is_animating()  || self.suspended.get() {
                 // If there's no animations running then we block on the window event loop.
                 self.events_loop.borrow_mut().run_forever(|e| {
-                    self.winit_event_to_servo_event(e);
-                    glutin::ControlFlow::Break
+                    let cont = self.winit_event_to_servo_event(e);
+                    if cont == glutin::ControlFlow::Continue {
+                        // Note we need to be careful to make sure that any events
+                        // that are handled during run_forever aren't re-entrant,
+                        // since we are handling them while holding onto a mutable borrow
+                        // of the events loop
+                        self.handle_events();
+                    }
+                    cont
                 });
             }
             // Grab any other events that may have happened

--- a/ports/glutin/app.rs
+++ b/ports/glutin/app.rs
@@ -69,10 +69,6 @@ impl App {
         mem::replace(&mut *self.event_queue.borrow_mut(), Vec::new())
     }
 
-    fn has_events(&self) -> bool {
-        !self.event_queue.borrow().is_empty() || self.window.has_events()
-    }
-
     // This function decides whether the event should be handled during `run_forever`.
     fn winit_event_to_servo_event(&self, event: glutin::Event) -> glutin::ControlFlow {
         match event {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

At the moment, the glutin embedder holds onto a borrow of the events loop while processing events, which is dangerous if any of the event handlers end up using the events loop reentrantly. (This caused a panic while integrating https://github.com/servo/rust-webvr/pull/84.)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because this is low-level embedding code

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23574)
<!-- Reviewable:end -->
