### PR TITLE
Force clang use on all platforms.

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -316,13 +316,6 @@ class MachCommands(CommandBase):
         if with_debug_assertions:
             env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C debug_assertions"
 
-        if sys.platform == "win32":
-            env["CC"] = env.get("CC", "clang-cl.exe")
-            env["CXX"] = env.get("CXX", "clang-cl.exe")
-        else:
-            env["CC"] = env.get("CC", "clang")
-            env["CXX"] = env.get("CXX", "clang++")
-
         host = host_triple()
         if 'apple-darwin' in host and (not target or target == host):
             if 'CXXFLAGS' not in env:
@@ -611,6 +604,13 @@ class MachCommands(CommandBase):
             print (["Calling", "cargo", "build"] + opts)
             for key in env:
                 print((key, env[key]))
+
+        if sys.platform == "win32":
+            env.setdefault("CC", "clang-cl.exe")
+            env.setdefault("CXX", "clang-cl.exe")
+        else:
+            env.setdefault("CC", "clang")
+            env.setdefault("CXX", "clang++")
 
         status = self.call_rustup_run(["cargo", "build"] + opts, env=env, verbose=verbose)
         elapsed = time() - build_start

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -317,8 +317,11 @@ class MachCommands(CommandBase):
             env['RUSTFLAGS'] = env.get('RUSTFLAGS', "") + " -C debug_assertions"
 
         if sys.platform == "win32":
-            env["CC"] = "clang-cl.exe"
-            env["CXX"] = "clang-cl.exe"
+            env["CC"] = env.get("CC", "clang-cl.exe")
+            env["CXX"] = env.get("CXX", "clang-cl.exe")
+        else:
+            env["CC"] = env.get("CC", "clang")
+            env["CXX"] = env.get("CXX", "clang++")
 
         host = host_triple()
         if 'apple-darwin' in host and (not target or target == host):


### PR DESCRIPTION
gcc builds are unlinkable on Linux at the moment. Let's standardize on clang.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23583)
<!-- Reviewable:end -->
