### PR TITLE
Filter intermittent wdspec tests failures

### DIFF
--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -57,7 +57,8 @@ linux-rel-wpt:
     - ./mach test-wpt --release --binary-arg=--multiprocess --processes 24 --log-raw test-wpt-mp.log --log-errorsummary wpt-mp-errorsummary.log eventsource
     - ./mach test-wpt --release --product=servodriver --headless tests/wpt/mozilla/tests/mozilla/DOMParser.html tests/wpt/mozilla/tests/css/per_glyph_font_fallback_a.html tests/wpt/mozilla/tests/css/img_simple.html tests/wpt/mozilla/tests/mozilla/secure.https.html
     - ./mach test-wpt --release --product=servodriver --headless --log-raw test-bluetooth.log --log-errorsummary bluetooth-errorsummary.log bluetooth
-    - ./mach test-wpt --release --headless --timeout-multiplier=4 --log-raw test-wdspec.log --log-errorsummary wdspec-errorsummary.log webdriver
+    - ./mach test-wpt --release --headless --timeout-multiplier=4 --log-raw test-wdspec.log --log-errorsummary wdspec-errorsummary.log --always-succeed webdriver
+    - ./mach filter-intermittents wdspec-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wdspec-errorsummary.log --tracker-api default --reporter-api default
     - ./etc/ci/clean_build_artifacts.sh
 
 linux-rel-css:

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -616,8 +616,15 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
                 time ./mach test-wpt --release --processes $PROCESSES --timeout-multiplier=4 \
                     --headless --log-raw test-wdspec.log \
                     --log-errorsummary wdspec-errorsummary.log \
+                    --always-succeed \
                     webdriver \
                     | cat
+                ./mach filter-intermittents \
+                    wdspec-errorsummary.log \
+                    --log-intermittents intermittents.log \
+                    --log-filteredsummary filtered-wdspec-errorsummary.log \
+                    --tracker-api default \
+                    --reporter-api default
             """)
         # `test-wpt` is piped into `cat` so that stdout is not a TTY
         # and wptrunner does not use "interactive mode" formatting:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
With this change, the intermittent failures for wdspec tests will be filtered and reported.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23598)
<!-- Reviewable:end -->
