### PR TITLE
Prevent CRLF conversion on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+* text=auto eol=lf
 tests/* linguist-vendored


### PR DESCRIPTION
@jdm Do you prefer `text=auto` or `-text` (seems to be default on Linux, not sure on macOS)?

Closes #23608

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23613)
<!-- Reviewable:end -->
