### PR TITLE
Update Gentoo instructions to work with 17.1 and add missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,15 +198,14 @@ sudo pacman -S --needed base-devel git python2 python2-virtualenv python2-pip me
 sudo emerge net-misc/curl \
     media-libs/freetype media-libs/mesa dev-util/gperf \
     dev-python/virtualenv dev-python/pip dev-libs/openssl \
-    media-libs/harfbuzz dev-util/ccache \
+    media-libs/harfbuzz dev-util/ccache sys-libs/libunwind \
     x11-libs/libXmu media-libs/glu x11-base/xorg-server sys-devel/clang \
     media-libs/gstreamer media-libs/gst-plugins-bad media-libs/gst-plugins-base
 ```
 
-with the following environment variable set:
-
+With the following environment variable set:
 ```sh
-export LIBCLANG_PATH="/usr/lib64/llvm/*/lib64"
+export LIBCLANG_PATH=$(llvm-config --prefix)/lib64
 ```
 #### On Windows (MSVC)
 


### PR DESCRIPTION
 * libunwind was required when building.
 * Since Gentoo 17.1 the symlink between lib and lib64 has been removed.
    - Update export so it works with both older and newer profiles.
---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's installation instructions / documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23650)
<!-- Reviewable:end -->
