### PR TITLE
Move tinyfiledialog call from script to embedder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3789,7 +3789,6 @@ dependencies = [
  "swapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "tinyfiledialogs 3.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf-8 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/embedder_traits/lib.rs
+++ b/components/embedder_traits/lib.rs
@@ -154,6 +154,9 @@ pub enum EmbedderMsg {
     GetSelectedBluetoothDevice(Vec<String>, IpcSender<Option<String>>),
     /// Open file dialog to select files. Set boolean flag to true allows to select multiple files.
     SelectFiles(Vec<FilterPattern>, bool, IpcSender<Option<Vec<String>>>),
+    /// Open yes/no message for user to allow permission specified by first String.
+    /// With dialog title specified by second String.
+    PromptPermission(String, String, IpcSender<PermissionRequest>),
     /// Request to present an IME to the user when an editable element is focused.
     ShowIME(InputMethodType),
     /// Request to hide the IME when the editable element is blurred.
@@ -186,6 +189,7 @@ impl Debug for EmbedderMsg {
             EmbedderMsg::Panic(..) => write!(f, "Panic"),
             EmbedderMsg::GetSelectedBluetoothDevice(..) => write!(f, "GetSelectedBluetoothDevice"),
             EmbedderMsg::SelectFiles(..) => write!(f, "SelectFiles"),
+            EmbedderMsg::PromptPermission(..) => write!(f, "PromptPermission"),
             EmbedderMsg::ShowIME(..) => write!(f, "ShowIME"),
             EmbedderMsg::HideIME => write!(f, "HideIME"),
             EmbedderMsg::Shutdown => write!(f, "Shutdown"),
@@ -200,3 +204,10 @@ impl Debug for EmbedderMsg {
 /// the `String` content is expected to be extension (e.g, "doc", without the prefixing ".")
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FilterPattern(pub String);
+
+// Status for prompting user for permission.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum PermissionRequest {
+    Granted,
+    Denied,
+}

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -28,9 +28,6 @@ phf_codegen = "0.7"
 phf_shared = "0.7"
 serde_json = "1.0"
 
-[target.'cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))'.dependencies]
-tinyfiledialogs = "3.0"
-
 [dependencies]
 app_units = "0.7"
 backtrace = {version = "0.3", optional = true}

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -40,6 +40,7 @@ use crate::timers::{IsInterval, OneshotTimerCallback, OneshotTimerHandle};
 use crate::timers::{OneshotTimers, TimerCallback};
 use devtools_traits::{ScriptToDevtoolsControlMsg, WorkerId};
 use dom_struct::dom_struct;
+use embedder_traits::EmbedderMsg;
 use ipc_channel::ipc::IpcSender;
 use js::glue::{IsWrapper, UnwrapObjectDynamic};
 use js::jsapi::JSObject;
@@ -55,7 +56,7 @@ use msg::constellation_msg::PipelineId;
 use net_traits::image_cache::ImageCache;
 use net_traits::{CoreResourceThread, IpcSend, ResourceThreads};
 use profile_traits::{mem as profile_mem, time as profile_time};
-use script_traits::{MsDuration, ScriptToConstellationChan, TimerEvent};
+use script_traits::{MsDuration, ScriptMsg, ScriptToConstellationChan, TimerEvent};
 use script_traits::{TimerEventId, TimerSchedulerMsg, TimerSource};
 use servo_url::{MutableOrigin, ServoUrl};
 use std::borrow::Cow;
@@ -376,6 +377,14 @@ impl GlobalScope {
     /// Get a sender to the constellation thread.
     pub fn script_to_constellation_chan(&self) -> &ScriptToConstellationChan {
         &self.script_to_constellation_chan
+    }
+
+    pub fn send_to_embedder(&self, msg: EmbedderMsg) {
+        self.send_to_constellation(ScriptMsg::ForwardToEmbedder(msg));
+    }
+
+    pub fn send_to_constellation(&self, msg: ScriptMsg) {
+        self.script_to_constellation_chan().send(msg).unwrap();
     }
 
     pub fn scheduler_chan(&self) -> &IpcSender<TimerSchedulerMsg> {

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -4,6 +4,7 @@
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::EventSourceBinding::EventSourceBinding::EventSourceMethods;
+use crate::dom::bindings::codegen::Bindings::PermissionStatusBinding::PermissionState;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::codegen::Bindings::WorkerGlobalScopeBinding::WorkerGlobalScopeMethods;
 use crate::dom::bindings::conversions::{root_from_object, root_from_object_static};
@@ -125,6 +126,9 @@ pub struct GlobalScope {
     /// The origin of the globalscope
     origin: MutableOrigin,
 
+    /// A map for storing the previous permission state read results.
+    permission_state_invocation_results: DomRefCell<HashMap<String, PermissionState>>,
+
     /// The microtask queue associated with this global.
     ///
     /// It is refcounted because windows in the same script thread share the
@@ -198,6 +202,7 @@ impl GlobalScope {
             resource_threads,
             timers: OneshotTimers::new(timer_event_chan, scheduler_chan),
             origin,
+            permission_state_invocation_results: Default::default(),
             microtask_queue,
             list_auto_close_worker: Default::default(),
             event_source_tracker: DOMTracker::new(),
@@ -206,6 +211,12 @@ impl GlobalScope {
             is_headless,
             user_agent,
         }
+    }
+
+    pub fn permission_state_invocation_results(
+        &self,
+    ) -> &DomRefCell<HashMap<String, PermissionState>> {
+        &self.permission_state_invocation_results
     }
 
     pub fn track_worker(&self, closing_worker: Arc<AtomicBool>) {

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -145,7 +145,6 @@ impl Permissions {
                         // (Revoke) Step 3.
                         let globalscope = self.global();
                         globalscope
-                            .as_window()
                             .permission_state_invocation_results()
                             .borrow_mut()
                             .remove(&root_desc.name.to_string());
@@ -178,7 +177,6 @@ impl Permissions {
                         // (Revoke) Step 3.
                         let globalscope = self.global();
                         globalscope
-                            .as_window()
                             .permission_state_invocation_results()
                             .borrow_mut()
                             .remove(&root_desc.name.to_string());
@@ -272,7 +270,6 @@ impl PermissionAlgorithm for Permissions {
                 let prompt = format!("{} {} ?", REQUEST_DIALOG_MESSAGE, perm_name.clone());
                 let state = prompt_user_from_embedder(prompt, &globalscope);
                 globalscope
-                    .as_window()
                     .permission_state_invocation_results()
                     .borrow_mut()
                     .insert(perm_name.to_string(), state);
@@ -312,7 +309,6 @@ pub fn get_descriptor_permission_state(
             PermissionState::Granted
         } else {
             globalscope
-                .as_window()
                 .permission_state_invocation_results()
                 .borrow_mut()
                 .remove(&permission_name.to_string());
@@ -324,7 +320,6 @@ pub fn get_descriptor_permission_state(
 
     // Step 3.
     if let Some(prev_result) = globalscope
-        .as_window()
         .permission_state_invocation_results()
         .borrow()
         .get(&permission_name.to_string())
@@ -334,7 +329,6 @@ pub fn get_descriptor_permission_state(
 
     // Store the invocation result
     globalscope
-        .as_window()
         .permission_state_invocation_results()
         .borrow_mut()
         .insert(permission_name.to_string(), state);

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -18,15 +18,14 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::permissionstatus::PermissionStatus;
 use crate::dom::promise::Promise;
 use dom_struct::dom_struct;
+use embedder_traits::{EmbedderMsg, PermissionRequest};
+use ipc_channel::ipc;
 use js::conversions::ConversionResult;
 use js::jsapi::{JSContext, JSObject};
 use js::jsval::{ObjectValue, UndefinedValue};
 use servo_config::pref;
 use std::rc::Rc;
-#[cfg(target_os = "linux")]
-use tinyfiledialogs::{self, MessageBoxIcon, YesNo};
 
-#[cfg(target_os = "linux")]
 const DIALOG_TITLE: &'static str = "Permission request dialog";
 const NONSECURE_DIALOG_MESSAGE: &'static str = "feature is only safe to use in secure context,\
  but servo can't guarantee\n that the current context is secure. Do you want to proceed and grant permission?";
@@ -268,14 +267,10 @@ impl PermissionAlgorithm for Permissions {
             PermissionState::Prompt => {
                 let perm_name = status.get_query();
 
-                let globalscope = GlobalScope::current().expect("No current global object");
-
                 // https://w3c.github.io/permissions/#request-permission-to-use (Step 3 - 4)
-                let state = prompt_user(
-                    &format!("{} {} ?", REQUEST_DIALOG_MESSAGE, perm_name.clone()),
-                    globalscope.is_headless(),
-                );
-
+                let globalscope = GlobalScope::current().expect("No current global object");
+                let prompt = format!("{} {} ?", REQUEST_DIALOG_MESSAGE, perm_name.clone());
+                let state = prompt_user_from_embedder(prompt, &globalscope);
                 globalscope
                     .as_window()
                     .permission_state_invocation_results()
@@ -300,7 +295,7 @@ pub fn get_descriptor_permission_state(
     env_settings_obj: Option<&GlobalScope>,
 ) -> PermissionState {
     // Step 1.
-    let settings = match env_settings_obj {
+    let globalscope = match env_settings_obj {
         Some(env_settings_obj) => DomRoot::from_ref(env_settings_obj),
         None => GlobalScope::current().expect("No current global object"),
     };
@@ -316,21 +311,19 @@ pub fn get_descriptor_permission_state(
         if pref!(dom.permissions.testing.allowed_in_nonsecure_contexts) {
             PermissionState::Granted
         } else {
-            settings
+            globalscope
                 .as_window()
                 .permission_state_invocation_results()
                 .borrow_mut()
                 .remove(&permission_name.to_string());
 
-            prompt_user(
-                &format!("The {} {}", permission_name, NONSECURE_DIALOG_MESSAGE),
-                settings.is_headless(),
-            )
+            let prompt = format!("The {} {}", permission_name, NONSECURE_DIALOG_MESSAGE);
+            prompt_user_from_embedder(prompt, &globalscope)
         }
     };
 
     // Step 3.
-    if let Some(prev_result) = settings
+    if let Some(prev_result) = globalscope
         .as_window()
         .permission_state_invocation_results()
         .borrow()
@@ -340,7 +333,7 @@ pub fn get_descriptor_permission_state(
     }
 
     // Store the invocation result
-    settings
+    globalscope
         .as_window()
         .permission_state_invocation_results()
         .borrow_mut()
@@ -348,28 +341,6 @@ pub fn get_descriptor_permission_state(
 
     // Step 4.
     state
-}
-
-#[cfg(target_os = "linux")]
-fn prompt_user(message: &str, headless: bool) -> PermissionState {
-    if headless {
-        return PermissionState::Denied;
-    }
-    match tinyfiledialogs::message_box_yes_no(
-        DIALOG_TITLE,
-        message,
-        MessageBoxIcon::Question,
-        YesNo::No,
-    ) {
-        YesNo::Yes => PermissionState::Granted,
-        YesNo::No => PermissionState::Denied,
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-fn prompt_user(_message: &str, _headless: bool) -> PermissionState {
-    // TODO popup only supported on linux
-    PermissionState::Denied
 }
 
 // https://w3c.github.io/permissions/#allowed-in-non-secure-contexts
@@ -397,5 +368,23 @@ fn allowed_in_nonsecure_contexts(permission_name: &PermissionName) -> bool {
         PermissionName::Bluetooth => false,
         // https://storage.spec.whatwg.org/#dom-permissionname-persistent-storage
         PermissionName::Persistent_storage => false,
+    }
+}
+
+fn prompt_user_from_embedder(prompt: String, gs: &GlobalScope) -> PermissionState {
+    let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel!");
+    gs.send_to_embedder(EmbedderMsg::PromptPermission(
+        prompt,
+        DIALOG_TITLE.to_string(),
+        sender,
+    ));
+
+    match receiver.recv() {
+        Ok(PermissionRequest::Granted) => PermissionState::Granted,
+        Ok(PermissionRequest::Denied) => PermissionState::Denied,
+        Err(e) => {
+            warn!("Failed to receive permission state from embedder ({}).", e);
+            PermissionState::Denied
+        },
     }
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -10,7 +10,6 @@ use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
 use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use crate::dom::bindings::codegen::Bindings::HistoryBinding::HistoryBinding::HistoryMethods;
 use crate::dom::bindings::codegen::Bindings::MediaQueryListBinding::MediaQueryListBinding::MediaQueryListMethods;
-use crate::dom::bindings::codegen::Bindings::PermissionStatusBinding::PermissionState;
 use crate::dom::bindings::codegen::Bindings::RequestBinding::RequestInit;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::{
     self, FrameRequestCallback, WindowMethods,
@@ -265,9 +264,6 @@ pub struct Window {
     #[ignore_malloc_size_of = "channels are hard"]
     webvr_chan: Option<IpcSender<WebVRMsg>>,
 
-    /// A map for storing the previous permission state read results.
-    permission_state_invocation_results: DomRefCell<HashMap<String, PermissionState>>,
-
     /// All of the elements that have an outstanding image request that was
     /// initiated by layout during a reflow. They are stored in the script thread
     /// to ensure that the element can be marked dirty when the image data becomes
@@ -433,12 +429,6 @@ impl Window {
     fn new_paint_worklet(&self) -> DomRoot<Worklet> {
         debug!("Creating new paint worklet.");
         Worklet::new(self, WorkletGlobalScopeType::Paint)
-    }
-
-    pub fn permission_state_invocation_results(
-        &self,
-    ) -> &DomRefCell<HashMap<String, PermissionState>> {
-        &self.permission_state_invocation_results
     }
 
     pub fn pending_image_notification(&self, response: PendingImageResponse) {
@@ -2141,7 +2131,6 @@ impl Window {
             test_runner: Default::default(),
             webgl_chan,
             webvr_chan,
-            permission_state_invocation_results: Default::default(),
             pending_layout_images: Default::default(),
             unminified_js_dir: Default::default(),
             test_worklet: Default::default(),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Moves the tinyfiledialog call from script to embedder. 
Factored out permission_state_invocation_results API to GlobalScope Instead of Window.

I have implemented this for `ports/glutin/browser.rs` is there other ports that use this?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix  #23057 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because: I have tested it manually and it seems to work as expected. The current relevant tests seem to fail due to  https://github.com/servo/servo/issues/23645

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23651)
<!-- Reviewable:end -->
