### PR TITLE
Fix panic when running test-background-fetch-permission.html

### DIFF
--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -303,7 +303,10 @@ impl Error {
         global: &GlobalScope,
         rval: MutableHandleValue,
     ) {
-        assert!(!JS_IsExceptionPending(cx));
+        match self {
+            Error::JSFailed => (),
+            _ => assert!(!JS_IsExceptionPending(cx)),
+        }
         throw_dom_exception(cx, global, self);
         assert!(JS_IsExceptionPending(cx));
         assert!(JS_GetPendingException(cx, rval));

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -31,8 +31,6 @@ const DIALOG_TITLE: &'static str = "Permission request dialog";
 const NONSECURE_DIALOG_MESSAGE: &'static str = "feature is only safe to use in secure context,\
  but servo can't guarantee\n that the current context is secure. Do you want to proceed and grant permission?";
 const REQUEST_DIALOG_MESSAGE: &'static str = "Do you want to grant permission for";
-const ROOT_DESC_CONVERSION_ERROR: &'static str =
-    "Can't convert to an IDL value of type PermissionDescriptor";
 
 pub trait PermissionAlgorithm {
     type Descriptor;
@@ -237,7 +235,7 @@ impl PermissionAlgorithm for Permissions {
             match PermissionDescriptor::new(cx, property.handle()) {
                 Ok(ConversionResult::Success(descriptor)) => Ok(descriptor),
                 Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
-                Err(_) => Err(Error::Type(String::from(ROOT_DESC_CONVERSION_ERROR))),
+                Err(_) => Err(Error::JSFailed),
             }
         }
     }

--- a/tests/wpt/metadata/permissions/interfaces.any.js.ini
+++ b/tests/wpt/metadata/permissions/interfaces.any.js.ini
@@ -1,6 +1,10 @@
 [interfaces.any.html]
-  expected: CRASH
+  [Permissions interface: operation query(object)]
+    expected: FAIL
+
+  [Permissions interface: calling query(object) on navigator.permissions with too few arguments must throw TypeError]
+    expected: FAIL
+
 
 [interfaces.any.worker.html]
   expected: CRASH
-

--- a/tests/wpt/metadata/permissions/test-background-fetch-permission.html.ini
+++ b/tests/wpt/metadata/permissions/test-background-fetch-permission.html.ini
@@ -1,5 +1,3 @@
 [test-background-fetch-permission.html]
-  expected: CRASH
   [Test Background Fetch Permission.]
     expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
* Propagate `Error::JSFailed` in `Permissions::create_descriptor`
* In `Error::to_jsval`, only check if a JS exception is not pending if `self` is not `Error::JSFailed` 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23645 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it's a test runner, so by nature if the test runs the test runner is also working as expected.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23654)
<!-- Reviewable:end -->
