### PR TITLE
[WIP] Added JSContext struct with implementation

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2398,6 +2398,7 @@ def UnionTypes(descriptors, dictionaries, callbacks, typedefs, config):
         'js::rust::HandleValue',
         'js::jsapi::Heap',
         'js::jsapi::JSContext',
+        'crate::script_runtime::JSContext as SafeJSContext',
         'js::jsapi::JSObject',
         'js::rust::MutableHandleValue',
         'js::jsval::JSVal',
@@ -3251,7 +3252,7 @@ class CGDefineDOMInterfaceMethod(CGAbstractMethod):
     def __init__(self, descriptor):
         assert descriptor.interface.hasInterfaceObject()
         args = [
-            Argument('*mut JSContext', 'cx'),
+            Argument('SafeJSContext', 'cx'),
             Argument('HandleObject', 'global'),
         ]
         CGAbstractMethod.__init__(self, descriptor, 'DefineDOMInterface',
@@ -3268,7 +3269,7 @@ class CGDefineDOMInterfaceMethod(CGAbstractMethod):
         return CGGeneric("""\
 assert!(!global.get().is_null());
 
-if !ConstructorEnabled(cx, global) {
+if !ConstructorEnabled(*cx, global) {
     return;
 }
 
@@ -4153,6 +4154,7 @@ pub enum %s {
         inner = string.Template("""\
 use crate::dom::bindings::conversions::ToJSValConvertible;
 use js::jsapi::JSContext;
+use crate::script_runtime::JSContext as SafeJSContext;
 use js::rust::MutableHandleValue;
 use js::jsval::JSVal;
 
@@ -5782,6 +5784,7 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'js::jsapi::JSCLASS_RESERVED_SLOTS_SHIFT',
         'js::jsapi::JSClass',
         'js::jsapi::JSContext',
+        'crate::script_runtime::JSContext as SafeJSContext',
         'js::jsapi::JSFreeOp',
         'js::jsapi::JSFunctionSpec',
         'js::jsapi::JSITER_HIDDEN',

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -749,11 +749,12 @@ unsafe fn set_gc_zeal_options(cx: *mut RawJSContext) {
 #[cfg(not(feature = "debugmozjs"))]
 unsafe fn set_gc_zeal_options(_: *mut RawJSContext) {}
 
-struct JSContext(*mut RawJSContext);
+#[repr(transparent)]
+pub struct JSContext(*mut RawJSContext);
 
 #[allow(unsafe_code)]
 impl JSContext {
-    unsafe fn from_ptr(raw_js_context: *mut RawJSContext) -> Self {
+    pub unsafe fn from_ptr(raw_js_context: *mut RawJSContext) -> Self {
         JSContext(raw_js_context)
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Wrapping unsafe raw JSContext pointers in a safe struct. Issue #20377. 

Checklist:
- [x] Create a `struct JSContext(*mut jsapi::JSContext)` type
- [x] Implement `Deref` for this new type so it's easy to obtain the inner context pointer
- [x] Add an unsafe `from_ptr` static method that returns a new instance of the type
- [x] Make the code generator declare trait methods that accept the new type instead of `*mut JSContext` ([here](https://github.com/servo/servo/blob/797fb553bbfdece69538644da89bb0c937ece997/components/script/dom/bindings/codegen/CodegenRust.py#L5546) and [here](https://github.com/servo/servo/blob/797fb553bbfdece69538644da89bb0c937ece997/components/script/dom/bindings/codegen/CodegenRust.py#L6541); both the type )
- [ ] Adjust generated code to pass `JSContext::from_ptr(cx)` when necessary ([here](https://github.com/servo/servo/blob/797fb553bbfdece69538644da89bb0c937ece997/components/script/dom/bindings/codegen/CodegenRust.py#L3242-L3245))
- [ ] Update all of the methods defined in `components/script/dom` that need to be changed
- [ ] Remove any unnecessary uses of `#[allow(unsafe_code)]` on methods that no longer accept raw pointers

Thanks to @csmoe as I used some code from his [branch](https://github.com/csmoe/servo/tree/safe_dom_jsctxt).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23657)
<!-- Reviewable:end -->
