### PR TITLE
Refactor ImageCache::find_image_or_metadata -> ImageCache::{get_image, track_image}

### DIFF
--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -11,7 +11,7 @@ use gfx::font_cache_thread::FontCacheThread;
 use gfx::font_context::FontContext;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use msg::constellation_msg::PipelineId;
-use net_traits::image_cache::{CanRequestImages, ImageCache, ImageState};
+use net_traits::image_cache::{CanRequestImages, ImageCache, ImageCacheResult};
 use net_traits::image_cache::{ImageOrMetadataAvailable, UsePlaceholder};
 use parking_lot::RwLock;
 use script_layout_interface::{PendingImage, PendingImageState};
@@ -122,24 +122,40 @@ impl<'a> LayoutContext<'a> {
             CanRequestImages::No
         };
 
-        // See if the image is already available
-        let result = self.image_cache.find_image_or_metadata(
+        // Check for available image or start tracking.
+        let cache_result = self.image_cache.get_cached_image_status(
             url.clone(),
             self.origin.clone(),
             None,
             use_placeholder,
             can_request,
         );
-        match result {
-            Ok(image_or_metadata) => Some(image_or_metadata),
-            // Image failed to load, so just return nothing
-            Err(ImageState::LoadError) => None,
+
+        match cache_result {
+            ImageCacheResult::Available(img_or_meta) => Some(img_or_meta),
+            // Image has been requested, is still pending. Return no image for this paint loop.
+            // When the image loads it will trigger a reflow and/or repaint.
+            ImageCacheResult::Pending(id) => {
+                //XXXjdm if self.pending_images is not available, we should make sure that
+                //       this node gets marked dirty again so it gets a script-initiated
+                //       reflow that deals with this properly.
+                if let Some(ref pending_images) = self.pending_images {
+                    let image = PendingImage {
+                        state: PendingImageState::PendingResponse,
+                        node: node.to_untrusted_node_address(),
+                        id,
+                        origin: self.origin.clone(),
+                    };
+                    pending_images.lock().unwrap().push(image);
+                }
+                None
+            },
             // Not yet requested - request image or metadata from the cache
-            Err(ImageState::NotRequested(id)) => {
+            ImageCacheResult::ReadyForRequest(id) => {
                 let image = PendingImage {
                     state: PendingImageState::Unrequested(url),
                     node: node.to_untrusted_node_address(),
-                    id: id,
+                    id,
                     origin: self.origin.clone(),
                 };
                 self.pending_images
@@ -150,23 +166,8 @@ impl<'a> LayoutContext<'a> {
                     .push(image);
                 None
             },
-            // Image has been requested, is still pending. Return no image for this paint loop.
-            // When the image loads it will trigger a reflow and/or repaint.
-            Err(ImageState::Pending(id)) => {
-                //XXXjdm if self.pending_images is not available, we should make sure that
-                //       this node gets marked dirty again so it gets a script-initiated
-                //       reflow that deals with this properly.
-                if let Some(ref pending_images) = self.pending_images {
-                    let image = PendingImage {
-                        state: PendingImageState::PendingResponse,
-                        node: node.to_untrusted_node_address(),
-                        id: id,
-                        origin: self.origin.clone(),
-                    };
-                    pending_images.lock().unwrap().push(image);
-                }
-                None
-            },
+            // Image failed to load, so just return nothing
+            ImageCacheResult::LoadError => None,
         }
     }
 

--- a/components/layout_2020/context.rs
+++ b/components/layout_2020/context.rs
@@ -3,11 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::display_list::WebRenderImageInfo;
+use crate::opaque_node::OpaqueNodeMethods;
 use fnv::FnvHashMap;
 use gfx::font_cache_thread::FontCacheThread;
 use gfx::font_context::FontContext;
 use msg::constellation_msg::PipelineId;
-use net_traits::image_cache::{CanRequestImages, ImageCache, ImageState};
+use net_traits::image_cache::{CanRequestImages, ImageCache, ImageCacheResult};
 use net_traits::image_cache::{ImageOrMetadataAvailable, UsePlaceholder};
 use parking_lot::RwLock;
 use script_layout_interface::{PendingImage, PendingImageState};
@@ -70,24 +71,40 @@ impl<'a> LayoutContext<'a> {
             CanRequestImages::No
         };
 
-        // See if the image is already available
-        let result = self.image_cache.find_image_or_metadata(
+        // Check for available image or start tracking.
+        let cache_result = self.image_cache.get_cached_image_status(
             url.clone(),
             self.origin.clone(),
             None,
             use_placeholder,
             can_request,
         );
-        match result {
-            Ok(image_or_metadata) => Some(image_or_metadata),
-            // Image failed to load, so just return nothing
-            Err(ImageState::LoadError) => None,
+
+        match cache_result {
+            ImageCacheResult::Available(img_or_meta) => Some(img_or_meta),
+            // Image has been requested, is still pending. Return no image for this paint loop.
+            // When the image loads it will trigger a reflow and/or repaint.
+            ImageCacheResult::Pending(id) => {
+                //XXXjdm if self.pending_images is not available, we should make sure that
+                //       this node gets marked dirty again so it gets a script-initiated
+                //       reflow that deals with this properly.
+                if let Some(ref pending_images) = self.pending_images {
+                    let image = PendingImage {
+                        state: PendingImageState::PendingResponse,
+                        node: node.to_untrusted_node_address(),
+                        id,
+                        origin: self.origin.clone(),
+                    };
+                    pending_images.lock().unwrap().push(image);
+                }
+                None
+            },
             // Not yet requested - request image or metadata from the cache
-            Err(ImageState::NotRequested(id)) => {
+            ImageCacheResult::ReadyForRequest(id) => {
                 let image = PendingImage {
                     state: PendingImageState::Unrequested(url),
-                    node: node.into(),
-                    id: id,
+                    node: node.to_untrusted_node_address(),
+                    id,
                     origin: self.origin.clone(),
                 };
                 self.pending_images
@@ -98,23 +115,8 @@ impl<'a> LayoutContext<'a> {
                     .push(image);
                 None
             },
-            // Image has been requested, is still pending. Return no image for this paint loop.
-            // When the image loads it will trigger a reflow and/or repaint.
-            Err(ImageState::Pending(id)) => {
-                //XXXjdm if self.pending_images is not available, we should make sure that
-                //       this node gets marked dirty again so it gets a script-initiated
-                //       reflow that deals with this properly.
-                if let Some(ref pending_images) = self.pending_images {
-                    let image = PendingImage {
-                        state: PendingImageState::PendingResponse,
-                        node: node.into(),
-                        id: id,
-                        origin: self.origin.clone(),
-                    };
-                    pending_images.lock().unwrap().push(image);
-                }
-                None
-            },
+            // Image failed to load, so just return nothing
+            ImageCacheResult::LoadError => None,
         }
     }
 

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -4,8 +4,12 @@
 
 use embedder_traits::resources::{self, Resource};
 use immeta::load_from_buf;
+use ipc_channel::ipc::IpcSender;
 use net_traits::image::base::{load_from_memory, Image, ImageMetadata};
-use net_traits::image_cache::{CanRequestImages, CorsStatus, ImageCache, ImageResponder};
+use net_traits::image_cache::{
+    CanRequestImages, CorsStatus, ImageCache, ImageCacheResult, ImageResponder,
+    PendingImageResponse,
+};
 use net_traits::image_cache::{ImageOrMetadataAvailable, ImageResponse, ImageState};
 use net_traits::image_cache::{PendingImageId, UsePlaceholder};
 use net_traits::request::CorsSettings;
@@ -16,7 +20,6 @@ use pixels::PixelFormat;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
-use std::io;
 use std::mem;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -45,13 +48,10 @@ fn decode_bytes_sync(key: LoadKey, bytes: &[u8], cors: CorsStatus) -> DecoderMsg
     }
 }
 
-fn get_placeholder_image(
-    webrender_api: &WebrenderIpcSender,
-    data: &[u8],
-) -> io::Result<Arc<Image>> {
+fn get_placeholder_image(webrender_api: &WebrenderIpcSender, data: &[u8]) -> Arc<Image> {
     let mut image = load_from_memory(&data, CorsStatus::Unsafe).unwrap();
     set_webrender_image_key(webrender_api, &mut image);
-    Ok(Arc::new(image))
+    Arc::new(image)
 }
 
 fn set_webrender_image_key(webrender_api: &WebrenderIpcSender, image: &mut Image) {
@@ -335,7 +335,7 @@ struct ImageCacheStore {
     completed_loads: HashMap<ImageKey, CompletedLoad>,
 
     // The placeholder image used when an image fails to load
-    placeholder_image: Option<Arc<Image>>,
+    placeholder_image: Arc<Image>,
 
     // The URL used for the placeholder image
     placeholder_url: ServoUrl,
@@ -436,34 +436,45 @@ impl ImageCache for ImageCacheImpl {
             store: Arc::new(Mutex::new(ImageCacheStore {
                 pending_loads: AllPendingLoads::new(),
                 completed_loads: HashMap::new(),
-                placeholder_image: get_placeholder_image(&webrender_api, &rippy_data).ok(),
+                placeholder_image: get_placeholder_image(&webrender_api, &rippy_data),
                 placeholder_url: ServoUrl::parse("chrome://resources/rippy.png").unwrap(),
                 webrender_api: webrender_api,
             })),
         }
     }
 
-    /// Return any available metadata or image for the given URL,
-    /// or an indication that the image is not yet available if it is in progress,
-    /// or else reserve a slot in the cache for the URL if the consumer can request images.
-    fn find_image_or_metadata(
+    fn get_image(
+        &self,
+        url: ServoUrl,
+        origin: ImmutableOrigin,
+        cors_setting: Option<CorsSettings>,
+    ) -> Option<Arc<Image>> {
+        let store = self.store.lock().unwrap();
+        let result =
+            store.get_completed_image_if_available(url, origin, cors_setting, UsePlaceholder::No);
+        match result {
+            Some(Ok(ImageOrMetadataAvailable::ImageAvailable(img, _))) => Some(img),
+            _ => None,
+        }
+    }
+
+    fn get_cached_image_status(
         &self,
         url: ServoUrl,
         origin: ImmutableOrigin,
         cors_setting: Option<CorsSettings>,
         use_placeholder: UsePlaceholder,
         can_request: CanRequestImages,
-    ) -> Result<ImageOrMetadataAvailable, ImageState> {
-        debug!("Find image or metadata for {} ({:?})", url, origin);
+    ) -> ImageCacheResult {
         let mut store = self.store.lock().unwrap();
-        if let Some(result) = store.get_completed_image_if_available(
+        if let Some(Ok(result)) = store.get_completed_image_if_available(
             url.clone(),
             origin.clone(),
             cors_setting,
             use_placeholder,
         ) {
             debug!("{} is available", url);
-            return result;
+            return ImageCacheResult::Available(result);
         }
 
         let decoded = {
@@ -481,20 +492,22 @@ impl ImageCache for ImageCacheImpl {
                     },
                     (&None, &Some(ref meta)) => {
                         debug!("Metadata available for {} ({:?})", url, key);
-                        return Ok(ImageOrMetadataAvailable::MetadataAvailable(meta.clone()));
+                        return ImageCacheResult::Available(
+                            ImageOrMetadataAvailable::MetadataAvailable(meta.clone()),
+                        );
                     },
                     (&Some(Err(_)), _) | (&None, &None) => {
                         debug!("{} ({:?}) is still pending", url, key);
-                        return Err(ImageState::Pending(key));
+                        return ImageCacheResult::Pending(key);
                     },
                 },
                 CacheResult::Miss(Some((key, _pl))) => {
                     debug!("Should be requesting {} ({:?})", url, key);
-                    return Err(ImageState::NotRequested(key));
+                    return ImageCacheResult::ReadyForRequest(key);
                 },
                 CacheResult::Miss(None) => {
                     debug!("Couldn't find an entry for {}", url);
-                    return Err(ImageState::LoadError);
+                    return ImageCacheResult::LoadError;
                 },
             }
         };
@@ -505,9 +518,46 @@ impl ImageCache for ImageCacheImpl {
         // TODO: make this behaviour configurable according to the caller's needs.
         store.handle_decoder(decoded);
         match store.get_completed_image_if_available(url, origin, cors_setting, use_placeholder) {
-            Some(result) => result,
-            None => Err(ImageState::LoadError),
+            Some(Ok(result)) => ImageCacheResult::Available(result),
+            _ => ImageCacheResult::LoadError,
         }
+    }
+
+    fn track_image(
+        &self,
+        url: ServoUrl,
+        origin: ImmutableOrigin,
+        cors_setting: Option<CorsSettings>,
+        sender: IpcSender<PendingImageResponse>,
+        use_placeholder: UsePlaceholder,
+        can_request: CanRequestImages,
+    ) -> ImageCacheResult {
+        debug!("Track image for {} ({:?})", url, origin);
+        let cache_result = self.get_cached_image_status(
+            url.clone(),
+            origin.clone(),
+            cors_setting,
+            use_placeholder,
+            can_request,
+        );
+
+        match cache_result {
+            ImageCacheResult::Available(ImageOrMetadataAvailable::MetadataAvailable(_)) => {
+                let store = self.store.lock().unwrap();
+                let id = store
+                    .pending_loads
+                    .url_to_load_key
+                    .get(&(url, origin, cors_setting))
+                    .unwrap();
+                self.add_listener(*id, ImageResponder::new(sender, *id));
+            },
+            ImageCacheResult::Pending(id) | ImageCacheResult::ReadyForRequest(id) => {
+                self.add_listener(id, ImageResponder::new(sender, id));
+            },
+            _ => {},
+        }
+
+        cache_result
     }
 
     /// Add a new listener for the given pending image id. If the image is already present,
@@ -600,13 +650,8 @@ impl ImageCache for ImageCacheImpl {
                     Err(_) => {
                         debug!("Processing error for {:?}", key);
                         let mut store = self.store.lock().unwrap();
-                        match store.placeholder_image.clone() {
-                            Some(placeholder_image) => store.complete_load(
-                                id,
-                                LoadResult::PlaceholderLoaded(placeholder_image),
-                            ),
-                            None => store.complete_load(id, LoadResult::None),
-                        }
+                        let placeholder_image = store.placeholder_image.clone();
+                        store.complete_load(id, LoadResult::PlaceholderLoaded(placeholder_image))
                     },
                 }
             },

--- a/components/net_traits/image_cache.rs
+++ b/components/net_traits/image_cache.rs
@@ -101,22 +101,50 @@ pub enum UsePlaceholder {
 // ImageCache public API.
 // ======================================================================
 
+pub enum ImageCacheResult {
+    Available(ImageOrMetadataAvailable),
+    LoadError,
+    Pending(PendingImageId),
+    ReadyForRequest(PendingImageId),
+}
+
 pub trait ImageCache: Sync + Send {
     fn new(webrender_api: WebrenderIpcSender) -> Self
     where
         Self: Sized;
 
-    /// Return any available metadata or image for the given URL,
-    /// or an indication that the image is not yet available if it is in progress,
-    /// or else reserve a slot in the cache for the URL if the consumer can request images.
-    fn find_image_or_metadata(
+    /// Definitively check whether there is a cached, fully loaded image available.
+    fn get_image(
+        &self,
+        url: ServoUrl,
+        origin: ImmutableOrigin,
+        cors_setting: Option<CorsSettings>,
+    ) -> Option<Arc<Image>>;
+
+    fn get_cached_image_status(
         &self,
         url: ServoUrl,
         origin: ImmutableOrigin,
         cors_setting: Option<CorsSettings>,
         use_placeholder: UsePlaceholder,
         can_request: CanRequestImages,
-    ) -> Result<ImageOrMetadataAvailable, ImageState>;
+    ) -> ImageCacheResult;
+
+    /// Add a listener for the provided pending image id, eventually called by
+    /// ImageCacheStore::complete_load.
+    /// If only metadata is available, Available(ImageOrMetadataAvailable) will
+    /// be returned.
+    /// If Available(ImageOrMetadataAvailable::Image) or LoadError is the final value,
+    /// the provided listener will be dropped (consumed & not added to PendingLoad).
+    fn track_image(
+        &self,
+        url: ServoUrl,
+        origin: ImmutableOrigin,
+        cors_setting: Option<CorsSettings>,
+        sender: IpcSender<PendingImageResponse>,
+        use_placeholder: UsePlaceholder,
+        can_request: CanRequestImages,
+    ) -> ImageCacheResult;
 
     /// Add a new listener for the given pending image id. If the image is already present,
     /// the responder will still receive the expected response.

--- a/components/net_traits/image_cache.rs
+++ b/components/net_traits/image_cache.rs
@@ -73,14 +73,6 @@ pub enum ImageResponse {
     None,
 }
 
-/// The current state of an image in the cache.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
-pub enum ImageState {
-    Pending(PendingImageId),
-    LoadError,
-    NotRequested(PendingImageId),
-}
-
 /// The unique id for an image that has previously been requested.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct PendingImageId(pub u64);

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -432,8 +432,7 @@ impl<'a> From<&'a WebGLContextAttributes> for GLContextAttributes {
 
 pub mod utils {
     use crate::dom::window::Window;
-    use net_traits::image_cache::CanRequestImages;
-    use net_traits::image_cache::{ImageOrMetadataAvailable, ImageResponse, UsePlaceholder};
+    use net_traits::image_cache::ImageResponse;
     use net_traits::request::CorsSettings;
     use servo_url::ServoUrl;
 
@@ -443,18 +442,15 @@ pub mod utils {
         cors_setting: Option<CorsSettings>,
     ) -> ImageResponse {
         let image_cache = window.image_cache();
-        let response = image_cache.find_image_or_metadata(
-            url.into(),
+        let result = image_cache.get_image(
+            url.clone(),
             window.origin().immutable().clone(),
             cors_setting,
-            UsePlaceholder::No,
-            CanRequestImages::No,
         );
-        match response {
-            Ok(ImageOrMetadataAvailable::ImageAvailable(image, url)) => {
-                ImageResponse::Loaded(image, url)
-            },
-            _ => ImageResponse::None,
+
+        match result {
+            Some(image) => ImageResponse::Loaded(image, url),
+            None => ImageResponse::None,
         }
     }
 }

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -19,16 +19,17 @@ use crate::dom::node::{document_from_node, window_from_node, Node};
 use crate::dom::performanceresourcetiming::InitiatorType;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::fetch::FetchCanceller;
-use crate::image_listener::{add_cache_listener_for_element, ImageCacheListener};
+use crate::image_listener::{generate_cache_listener_for_element, ImageCacheListener};
 use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingListener};
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use html5ever::{LocalName, Prefix};
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
-use net_traits::image_cache::UsePlaceholder;
-use net_traits::image_cache::{CanRequestImages, ImageCache, ImageOrMetadataAvailable};
-use net_traits::image_cache::{ImageResponse, ImageState, PendingImageId};
+use net_traits::image_cache::{
+    CanRequestImages, ImageCache, ImageCacheResult, ImageOrMetadataAvailable, ImageResponse,
+    PendingImageId, UsePlaceholder,
+};
 use net_traits::request::{CredentialsMode, Destination, RequestBuilder};
 use net_traits::{
     CoreResourceMsg, FetchChannels, FetchMetadata, FetchResponseListener, FetchResponseMsg,
@@ -155,27 +156,23 @@ impl HTMLVideoElement {
         // network activity as possible.
         let window = window_from_node(self);
         let image_cache = window.image_cache();
-        let response = image_cache.find_image_or_metadata(
-            poster_url.clone().into(),
+        let sender = generate_cache_listener_for_element(self);
+        let cache_result = image_cache.track_image(
+            poster_url.clone(),
             window.origin().immutable().clone(),
             None,
+            sender,
             UsePlaceholder::No,
             CanRequestImages::Yes,
         );
-        match response {
-            Ok(ImageOrMetadataAvailable::ImageAvailable(image, url)) => {
-                self.process_image_response(ImageResponse::Loaded(image, url));
-            },
 
-            Err(ImageState::Pending(id)) => {
-                add_cache_listener_for_element(image_cache, id, self);
+        match cache_result {
+            ImageCacheResult::Available(ImageOrMetadataAvailable::ImageAvailable(img, url)) => {
+                self.process_image_response(ImageResponse::Loaded(img, url));
             },
-
-            Err(ImageState::NotRequested(id)) => {
-                add_cache_listener_for_element(image_cache, id, self);
-                self.do_fetch_poster_frame(poster_url, id, cancel_receiver);
+            ImageCacheResult::ReadyForRequest(id) => {
+                self.do_fetch_poster_frame(poster_url, id, cancel_receiver)
             },
-
             _ => (),
         }
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Updated the `ImageCache` trait to replace `find_image_or_metadata` with two new functions `track_image` and `get_image`, as well as a new enum (`ImageCacheResult`).

As a result, I was able to refactor the functions that previously called `find_image_or_metadata` pretty cleanly. For a list of these functions, please see the commit information.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21289  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because tests already exist for these components. I ran `cargo test` in `net`, `net_traits`, `layout`, and `script` successfully.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23661)
<!-- Reviewable:end -->
