### PR TITLE
Fix DOMMatrix rotate test failure

### DIFF
--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -287,22 +287,25 @@ impl DOMMatrixReadOnly {
         }
         if rotZ != 0.0 {
             // Step 5.
+            // Beware: pass negated value until https://github.com/servo/euclid/issues/354
             let rotation =
-                Transform3D::create_rotation(0.0, 0.0, 1.0, Angle::radians(rotZ.to_radians()));
+                Transform3D::create_rotation(0.0, 0.0, -1.0, Angle::radians(rotZ.to_radians()));
             let mut matrix = self.matrix.borrow_mut();
             *matrix = rotation.post_mul(&matrix);
         }
         if rotY != 0.0 {
             // Step 6.
+            // Beware: pass negated value until https://github.com/servo/euclid/issues/354
             let rotation =
-                Transform3D::create_rotation(0.0, 1.0, 0.0, Angle::radians(rotY.to_radians()));
+                Transform3D::create_rotation(0.0, -1.0, 0.0, Angle::radians(rotY.to_radians()));
             let mut matrix = self.matrix.borrow_mut();
             *matrix = rotation.post_mul(&matrix);
         }
         if rotX != 0.0 {
             // Step 7.
+            // Beware: pass negated value until https://github.com/servo/euclid/issues/354
             let rotation =
-                Transform3D::create_rotation(1.0, 0.0, 0.0, Angle::radians(rotX.to_radians()));
+                Transform3D::create_rotation(-1.0, 0.0, 0.0, Angle::radians(rotX.to_radians()));
             let mut matrix = self.matrix.borrow_mut();
             *matrix = rotation.post_mul(&matrix);
         }
@@ -315,7 +318,8 @@ impl DOMMatrixReadOnly {
         if y != 0.0 || x < 0.0 {
             // Step 1.
             let rotZ = Angle::radians(f64::atan2(y, x));
-            let rotation = Transform3D::create_rotation(0.0, 0.0, 1.0, rotZ);
+            // Beware: pass negated value until https://github.com/servo/euclid/issues/354
+            let rotation = Transform3D::create_rotation(0.0, 0.0, -1.0, rotZ);
             let mut matrix = self.matrix.borrow_mut();
             *matrix = rotation.post_mul(&matrix);
         }
@@ -326,10 +330,11 @@ impl DOMMatrixReadOnly {
     pub fn rotate_axis_angle_self(&self, x: f64, y: f64, z: f64, angle: f64) {
         // Step 1.
         let (norm_x, norm_y, norm_z) = normalize_point(x, y, z);
+        // Beware: pass negated value until https://github.com/servo/euclid/issues/354
         let rotation = Transform3D::create_rotation(
-            norm_x,
-            norm_y,
-            norm_z,
+            -norm_x,
+            -norm_y,
+            -norm_z,
             Angle::radians(angle.to_radians()),
         );
         let mut matrix = self.matrix.borrow_mut();

--- a/tests/wpt/metadata/css/geometry/DOMMatrix-003.html.ini
+++ b/tests/wpt/metadata/css/geometry/DOMMatrix-003.html.ini
@@ -1,7 +1,0 @@
-[DOMMatrix-003.html]
-  type: testharness
-  [test rotate() 2d]
-    expected: FAIL
-
-  [test rotateAxisAngle() ]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Rotation functions have been working backward because of https://github.com/servo/euclid/issues/354, so this temporarily fixes it.

cc @Manishearth

PS: How can I run bors-servo myself?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23688

<!-- Either: -->
- [x] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23694)
<!-- Reviewable:end -->
