### PR TITLE
Ensure GL context is prepared for deinitialization.

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -353,6 +353,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     }
 
     pub fn deinit(self) {
+        self.window.prepare_for_composite();
         self.webrender.deinit();
     }
 


### PR DESCRIPTION
I tested shutdown on Windows numerous times before and after this change, and I have not seen any further panics in debug builds in builds with the GL context made active before deinitializing WebRender.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23706 and fix #23614.
- [x] These changes do not require tests because no tests on windows ;_;

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23707)
<!-- Reviewable:end -->
