### PR TITLE
Support WebAudio on Windows

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -122,8 +122,54 @@ pub use servo_url as url;
     target_arch = "x86_64"
 ))]
 mod media_platform {
-    pub use self::servo_media_gstreamer::GStreamerBackend as MediaBackend;
-    use servo_media_gstreamer;
+    use super::ServoMedia;
+    use servo_media_gstreamer::GStreamerBackend;
+
+    #[cfg(windows)]
+    pub fn init() {
+        let mut plugin_dir = std::env::current_exe().unwrap();
+        plugin_dir.pop();
+
+        let plugins = &[
+            "gstapp.dll",
+            "gstaudioconvert.dll",
+            "gstaudiofx.dll",
+            "gstaudioparsers.dll",
+            "gstaudioresample.dll",
+            "gstautodetect.dll",
+            "gstcoreelements.dll",
+            "gstdeinterlace.dll",
+            "gstplayback.dll",
+            "gstinterleave.dll",
+            "gstisomp4.dll",
+            "gstlibav.dll",
+            "gstnice.dll",
+            "gstogg.dll",
+            "gstopengl.dll",
+            "gstopus.dll",
+            "gstproxy.dll",
+            "gstrtp.dll",
+            "gsttheora.dll",
+            "gsttypefindfunctions.dll",
+            "gstvideoconvert.dll",
+            "gstvideoparsersbad.dll",
+            "gstvideoscale.dll",
+            "gstvolume.dll",
+            "gstvorbis.dll",
+            "gstvpx.dll",
+            "gstwasapi.dll",
+            "gstwebrtc.dll",
+        ];
+
+        let backend = GStreamerBackend::init_with_plugins(plugin_dir, plugins)
+            .expect("Error initializing GStreamer");
+        ServoMedia::init_with_backend(backend);
+    }
+
+    #[cfg(not(windows))]
+    pub fn init() {
+        ServoMedia::init::<GStreamerBackend>();
+    }
 }
 
 #[cfg(not(any(
@@ -131,11 +177,11 @@ mod media_platform {
     target_arch = "x86_64"
 )))]
 mod media_platform {
-    pub use self::servo_media_dummy::DummyBackend as MediaBackend;
-    use servo_media_dummy;
+    use super::ServoMedia;
+    pub fn init() {
+        ServoMedia::init::<servo_media_dummy::DummyBackend>();
+    }
 }
-
-type MediaBackend = media_platform::MediaBackend;
 
 /// The in-process interface to Servo.
 ///
@@ -204,7 +250,7 @@ where
         let opts = opts::get();
 
         if !opts.multiprocess {
-            ServoMedia::init::<MediaBackend>();
+            media_platform::init();
         }
 
         // Make sure the gl context is made current.
@@ -810,7 +856,7 @@ pub fn run_content_process(token: String) {
     script::init();
     script::init_service_workers(sw_senders);
 
-    ServoMedia::init::<MediaBackend>();
+    media_platform::init();
 
     unprivileged_content.start_all::<script_layout_interface::message::Msg,
                                      layout_thread::LayoutThread,

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -28,7 +28,6 @@ def main(task_for):
         all_tests = [
             linux_tidy_unit_docs,
             windows_unit,
-            windows_x86,
             windows_arm64,
             macos_unit,
             magicleap_dev,
@@ -55,7 +54,7 @@ def main(task_for):
 
             "try-mac": [macos_unit],
             "try-linux": [linux_tidy_unit_docs, linux_release],
-            "try-windows": [windows_unit, windows_x86, windows_arm64],
+            "try-windows": [windows_unit, windows_arm64],
             "try-magicleap": [magicleap_dev],
             "try-arm": [windows_arm64],
             "try-wpt": [linux_wpt],
@@ -125,10 +124,6 @@ linux_build_env = {
 }
 macos_build_env = {}
 windows_build_env = {
-    "x86": {
-        "LIB": "%HOMEDRIVE%%HOMEPATH%\\gst\\gstreamer\\1.0\\x86\\lib;%LIB%",
-        "GSTREAMER_1_0_ROOT_X86": "%HOMEDRIVE%%HOMEPATH%\\gst\\gstreamer\\1.0\\x86\\",
-    },
     "x86_64": {
         "LIB": "%HOMEDRIVE%%HOMEPATH%\\gst\\gstreamer\\1.0\\x86_64\\lib;%LIB%",
         "GSTREAMER_1_0_ROOT_X86_64": "%HOMEDRIVE%%HOMEPATH%\\gst\\gstreamer\\1.0\\x86_64\\",
@@ -376,20 +371,6 @@ def android_x86_wpt():
                 /_mozilla/mozilla/webgl/context_creation_error.html
         """)
         .find_or_create("android_x86_release." + CONFIG.task_id())
-    )
-
-
-def windows_x86():
-    return (
-        windows_cross_build_task("Dev build", arch="x86", package=True)
-        .with_treeherder("Windows x86")
-        .with_script(
-            "python mach build --dev --target i686-pc-windows-msvc",
-            "python mach package --dev --target i686-pc-windows-msvc",
-        )
-        .with_artifacts("repo/target/i686-pc-windows-msvc/debug/msi/Servo.exe",
-                        "repo/target/i686-pc-windows-msvc/debug/msi/Servo.zip")
-        .find_or_create("build.windows_x86_dev." + CONFIG.task_id())
     )
 
 
@@ -774,16 +755,13 @@ def windows_build_task(name, package=True, arch="x86_64"):
     hashes = {
         "devel": {
             "x86_64": "c136cbfb0330041d52fe6ec4e3e468563176333c857f6ed71191ebc37fc9d605",
-            "x86": "fed862659360b4fbc77920bdc28f1a7da56bb953b88044834db5161c0ee05eb3",
         },
         "non-devel": {
             "x86_64": "0744a8ef2a4ba393dacb7927d741df871400a85bab5aecf7905f63bf52c405e4",
-            "x86": "f36df8ba7a3858c2299162312cb939e3fe8ff65c704f988c497405ba8d9cb275",
         },
     }
     prefix = {
         "x86_64": "msvc",
-        "x86": "mingw",
     }
     version = "1.16.0"
     task = (

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -664,50 +664,122 @@ def package_gstreamer_dlls(servo_exe_dir, target):
     gst_root = ""
     gst_default_path = path.join("C:\\gstreamer\\1.0", gst_x64)
     gst_env = "GSTREAMER_1_0_ROOT_" + gst_x64
-    if os.path.exists(path.join(gst_default_path, "bin", "libffi-7.dll")) or \
-       os.path.exists(path.join(gst_default_path, "bin", "ffi-7.dll")):
-        gst_root = gst_default_path
-    elif os.environ.get(gst_env) is not None:
+    if os.environ.get(gst_env) is not None:
         gst_root = os.environ.get(gst_env)
+    elif os.path.exists(path.join(gst_default_path, "bin", "ffi-7.dll")):
+        gst_root = gst_default_path
     else:
-        print("Could not found GStreamer installation directory.")
+        print("Could not find GStreamer installation directory.")
         return False
 
+    # All the shared libraries required for starting up and loading plugins.
     gst_dlls = [
-        ["libffi-7.dll", "ffi-7.dll"],
-        ["libgio-2.0-0.dll", "gio-2.0-0.dll"],
-        ["libglib-2.0-0.dll", "glib-2.0-0.dll"],
-        ["libgmodule-2.0-0.dll", "gmodule-2.0-0.dll"],
-        ["libgobject-2.0-0.dll", "gobject-2.0-0.dll"],
-        ["libgstapp-1.0-0.dll", "gstapp-1.0-0.dll"],
-        ["libgstaudio-1.0-0.dll", "gstaudio-1.0-0.dll"],
-        ["libgstbase-1.0-0.dll", "gstbase-1.0-0.dll"],
-        ["libgstgl-1.0-0.dll", "gstgl-1.0-0.dll"],
-        ["libgstpbutils-1.0-0.dll", "gstpbutils-1.0-0.dll"],
-        ["libgstplayer-1.0-0.dll", "gstplayer-1.0-0.dll"],
-        ["libgstreamer-1.0-0.dll", "gstreamer-1.0-0.dll"],
-        ["libgstrtp-1.0-0.dll", "gstrtp-1.0-0.dll"],
-        ["libgstsdp-1.0-0.dll", "gstsdp-1.0-0.dll"],
-        ["libgsttag-1.0-0.dll", "gsttag-1.0-0.dll"],
-        ["libgstvideo-1.0-0.dll", "gstvideo-1.0-0.dll"],
-        ["libgstwebrtc-1.0-0.dll", "gstwebrtc-1.0-0.dll"],
-        ["libintl-8.dll", "intl-8.dll"],
-        ["liborc-0.4-0.dll", "orc-0.4-0.dll"],
-        ["libwinpthread-1.dll", "winpthread-1.dll"],
-        ["libz.dll", "libz-1.dll", "z-1.dll"]
+        "avfilter-7.dll",
+        "avformat-58.dll",
+        "avcodec-58.dll",
+        "avutil-56.dll",
+        "bz2.dll",
+        "ffi-7.dll",
+        "gio-2.0-0.dll",
+        "glib-2.0-0.dll",
+        "gmodule-2.0-0.dll",
+        "gobject-2.0-0.dll",
+        "graphene-1.0-0.dll",
+        "gstapp-1.0-0.dll",
+        "gstaudio-1.0-0.dll",
+        "gstbase-1.0-0.dll",
+        "gstcodecparsers-1.0-0.dll",
+        "gstcontroller-1.0-0.dll",
+        "gstfft-1.0-0.dll",
+        "gstgl-1.0-0.dll",
+        "gstpbutils-1.0-0.dll",
+        "gstplayer-1.0-0.dll",
+        "gstreamer-1.0-0.dll",
+        "gstriff-1.0-0.dll",
+        "gstrtp-1.0-0.dll",
+        "gstsctp-1.0-0.dll",
+        "gstsdp-1.0-0.dll",
+        "gsttag-1.0-0.dll",
+        "gstvideo-1.0-0.dll",
+        "gstwebrtc-1.0-0.dll",
+        "intl-8.dll",
+        "libgmp-10.dll",
+        "libgnutls-30.dll",
+        "libhogweed-4.dll",
+        "libjpeg-8.dll",
+        "libnettle-6.dll.",
+        "libpng16-16.dll",
+        "libogg-0.dll",
+        "libopus-0.dll",
+        "libtasn1-6.dll",
+        "libtheora-0.dll",
+        "libtheoradec-1.dll",
+        "libtheoraenc-1.dll",
+        "libvorbis-0.dll",
+        "libvorbisenc-2.dll",
+        "libwinpthread-1.dll",
+        "nice-10.dll",
+        "orc-0.4-0.dll",
+        "swresample-3.dll",
+        "z-1.dll",
     ]
 
     missing = []
     for gst_lib in gst_dlls:
-        if isinstance(gst_lib, str):
-            gst_lib = [gst_lib]
-        for lib in gst_lib:
-            try:
-                shutil.copy(path.join(gst_root, "bin", lib), servo_exe_dir)
-                break
-            except:
-                pass
-        else:
+        try:
+            shutil.copy(path.join(gst_root, "bin", gst_lib), servo_exe_dir)
+        except:
+            missing += [str(gst_lib)]
+
+    for gst_lib in missing:
+        print("ERROR: could not find required GStreamer DLL: " + gst_lib)
+    if missing:
+        return False
+
+    # Only copy a subset of the available plugins.
+    gst_dlls = [
+        "gstapp.dll",
+        "gstaudioconvert.dll",
+        "gstaudiofx.dll",
+        "gstaudioparsers.dll",
+        "gstaudioresample.dll",
+        "gstautodetect.dll",
+        "gstcoreelements.dll",
+        "gstdeinterlace.dll",
+        "gstplayback.dll",
+        "gstinterleave.dll",
+        "gstisomp4.dll",
+        "gstnice.dll",
+        "gstogg.dll",
+        "gstopengl.dll",
+        "gstopus.dll",
+        "gstproxy.dll",
+        "gstrtp.dll",
+        "gsttheora.dll",
+        "gsttypefindfunctions.dll",
+        "gstvideoconvert.dll",
+        "gstvideofilter.dll",
+        "gstvideoparsersbad.dll",
+        "gstvideoscale.dll",
+        "gstvolume.dll",
+        "gstvorbis.dll",
+        "gstvpx.dll",
+        "gstwebrtc.dll",
+        "gstwasapi.dll",
+        "gstlibav.dll",
+    ]
+
+    gst_plugin_path_root = os.environ.get("GSTREAMER_PACKAGE_PLUGIN_PATH") or gst_root
+    gst_plugin_path = path.join(gst_plugin_path_root, "lib", "gstreamer-1.0")
+    if not os.path.exists(gst_plugin_path):
+        print("ERROR: couldn't find gstreamer plugins at " + gst_plugin_path)
+        return False
+
+    missing = []
+    for gst_lib in gst_dlls:
+        try:
+            shutil.copy(path.join(gst_plugin_path, gst_lib), servo_exe_dir)
+        except:
             missing += [str(gst_lib)]
 
     for gst_lib in missing:

--- a/support/hololens/ServoApp.vcxproj
+++ b/support/hololens/ServoApp.vcxproj
@@ -154,141 +154,447 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\target\debug\api-ms-win-crt-runtime-l1-1-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\avcodec-58.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\avfilter-7.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\avformat-58.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\avutil-56.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\bz2.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\ffi-7.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gio-2.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\glib-2.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gmodule-2.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gobject-2.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\graphene-1.0-0.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gstapp-1.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstapp.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gstaudio-1.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstaudioconvert.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstaudiofx.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstaudioparsers.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstaudioresample.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstautodetect.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gstbase-1.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstcodecparsers-1.0-0.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstcontroller-1.0-0.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstcoreelements.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstdeinterlace.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstfft-1.0-0.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gstgl-1.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstinterleave.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstisomp4.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstlibav.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstnice.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstogg.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstopengl.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstopus.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gstpbutils-1.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstplayback.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gstplayer-1.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstproxy.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gstreamer-1.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstriff-1.0-0.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gstrtp-1.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstrtp.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstsctp-1.0-0.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gstsdp-1.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gsttag-1.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gsttheora.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gsttypefindfunctions.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gstvideo-1.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstvideoconvert.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstvideofilter.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstvideoparsersbad.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstvideoscale.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstvolume.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstvorbis.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstvpx.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstwasapi.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gstwebrtc-1.0-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\gstwebrtc.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\intl-8.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\libeay32.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\libgmp-10.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\libgnutls-30.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\libhogweed-4.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\libjpeg-8.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\libnettle-6.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\libogg-0.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\libopus-0.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\libpng16-16.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\libtasn1-6.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\libtheora-0.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\libtheoradec-1.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\libtheoraenc-1.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\libvorbis-0.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\libvorbisenc-2.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\libwinpthread-1.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\msvcp140.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\nice-10.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\orc-0.4-0.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\simpleservo.dll">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent>false</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\ssleay32.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\debug\swresample-3.dll">
+      <DeploymentContent>false</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\vcruntime140.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\z-1.dll">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
+      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\release\api-ms-win-crt-runtime-l1-1-0.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\avcodec-58.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\avfilter-7.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\avformat-58.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\avutil-56.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\bz2.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
@@ -318,7 +624,17 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
+    <None Include="..\..\target\release\graphene-1.0-0.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
     <None Include="..\..\target\release\gstapp-1.0-0.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstapp.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
@@ -328,7 +644,57 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
+    <None Include="..\..\target\release\gstaudioconvert.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstaudiofx.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstaudioparsers.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstaudioresample.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstautodetect.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
     <None Include="..\..\target\release\gstbase-1.0-0.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstcodecparsers-1.0-0.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstcontroller-1.0-0.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstcoreelements.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstdeinterlace.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstfft-1.0-0.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
@@ -338,7 +704,47 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
+    <None Include="..\..\target\release\gstinterleave.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstisomp4.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstlibav.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstnice.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstogg.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstopengl.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstopus.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
     <None Include="..\..\target\release\gstpbutils-1.0-0.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstplayback.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
@@ -348,12 +754,32 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
+    <None Include="..\..\target\release\gstproxy.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
     <None Include="..\..\target\release\gstreamer-1.0-0.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
+    <None Include="..\..\target\release\gstriff-1.0-0.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
     <None Include="..\..\target\release\gstrtp-1.0-0.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstrtp.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstsctp-1.0-0.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
@@ -368,12 +794,67 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
+    <None Include="..\..\target\release\gsttheora.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gsttypefindfunctions.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
     <None Include="..\..\target\release\gstvideo-1.0-0.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
+    <None Include="..\..\target\release\gstvideoconvert.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstvideofilter.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstvideoparsersbad.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstvideoscale.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstvolume.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstvorbis.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstvpx.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstwasapi.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
     <None Include="..\..\target\release\gstwebrtc-1.0-0.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\gstwebrtc.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
@@ -388,12 +869,87 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
+    <None Include="..\..\target\release\libgmp-10.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\libgnutls-30.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\libhogweed-4.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\libjpeg-8.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\libnettle-6.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\libogg-0.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\libopus-0.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\libpng16-16.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\libtasn1-6.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\libtheora-0.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\libtheoradec-1.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\libtheoraenc-1.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\libvorbis-0.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\libvorbisenc-2.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
     <None Include="..\..\target\release\libwinpthread-1.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\release\msvcp140.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\nice-10.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
@@ -409,6 +965,11 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\release\ssleay32.dll">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+    </None>
+    <None Include="..\..\target\release\swresample-3.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>

--- a/support/hololens/ServoApp.vcxproj.filters
+++ b/support/hololens/ServoApp.vcxproj.filters
@@ -55,7 +55,25 @@
   <ItemGroup>
     <None Include="ServoApp_TemporaryKey.pfx" />
     <None Include="packages.config" />
+    <None Include="..\..\target\debug\simpleservo.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
     <None Include="..\..\target\debug\api-ms-win-crt-runtime-l1-1-0.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\avcodec-58.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\avfilter-7.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\avformat-58.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\avutil-56.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\bz2.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
     <None Include="..\..\target\debug\ffi-7.dll">
@@ -73,28 +91,100 @@
     <None Include="..\..\target\debug\gobject-2.0-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
+    <None Include="..\..\target\debug\graphene-1.0-0.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstapp.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
     <None Include="..\..\target\debug\gstapp-1.0-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
     <None Include="..\..\target\debug\gstaudio-1.0-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
+    <None Include="..\..\target\debug\gstaudioconvert.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstaudiofx.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstaudioparsers.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstaudioresample.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstautodetect.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
     <None Include="..\..\target\debug\gstbase-1.0-0.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstcodecparsers-1.0-0.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstcontroller-1.0-0.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstcoreelements.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstdeinterlace.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstfft-1.0-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
     <None Include="..\..\target\debug\gstgl-1.0-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
+    <None Include="..\..\target\debug\gstinterleave.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstisomp4.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstlibav.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstnice.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstogg.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstopengl.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstopus.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
     <None Include="..\..\target\debug\gstpbutils-1.0-0.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstplayback.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
     <None Include="..\..\target\debug\gstplayer-1.0-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
+    <None Include="..\..\target\debug\gstproxy.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
     <None Include="..\..\target\debug\gstreamer-1.0-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
+    <None Include="..\..\target\debug\gstriff-1.0-0.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstrtp.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
     <None Include="..\..\target\debug\gstrtp-1.0-0.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstsctp-1.0-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
     <None Include="..\..\target\debug\gstsdp-1.0-0.dll">
@@ -103,7 +193,40 @@
     <None Include="..\..\target\debug\gsttag-1.0-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
+    <None Include="..\..\target\debug\gsttheora.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gsttypefindfunctions.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
     <None Include="..\..\target\debug\gstvideo-1.0-0.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstvideoconvert.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstvideofilter.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstvideoparsersbad.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstvideoscale.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstvolume.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstvorbis.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstvpx.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstwasapi.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\gstwebrtc.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
     <None Include="..\..\target\debug\gstwebrtc-1.0-0.dll">
@@ -115,19 +238,64 @@
     <None Include="..\..\target\debug\libeay32.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
+    <None Include="..\..\target\debug\libgmp-10.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\libgnutls-30.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\libhogweed-4.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\libjpeg-8.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\libnettle-6.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\libogg-0.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\libopus-0.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\libpng16-16.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\libtasn1-6.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\libtheora-0.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\libtheoradec-1.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\libtheoraenc-1.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\libvorbis-0.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
+    <None Include="..\..\target\debug\libvorbisenc-2.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
     <None Include="..\..\target\debug\libwinpthread-1.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
     <None Include="..\..\target\debug\msvcp140.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
+    <None Include="..\..\target\debug\nice-10.dll">
+      <Filter>ServoDLLsDebug</Filter>
+    </None>
     <None Include="..\..\target\debug\orc-0.4-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
-    <None Include="..\..\target\debug\simpleservo.dll">
+    <None Include="..\..\target\debug\ssleay32.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
-    <None Include="..\..\target\debug\ssleay32.dll">
+    <None Include="..\..\target\debug\swresample-3.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
     <None Include="..\..\target\debug\vcruntime140.dll">
@@ -136,85 +304,253 @@
     <None Include="..\..\target\debug\z-1.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
-    <None Include="..\..\target\release\z-1.dll">
+    <None Include="..\..\target\release\api-ms-win-crt-runtime-l1-1-0.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
-    <None Include="..\..\target\release\vcruntime140.dll">
+    <None Include="..\..\target\release\avcodec-58.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
-    <None Include="..\..\target\release\ssleay32.dll">
+    <None Include="..\..\target\release\avfilter-7.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
-    <None Include="..\..\target\release\simpleservo.dll">
+    <None Include="..\..\target\release\avformat-58.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
-    <None Include="..\..\target\release\orc-0.4-0.dll">
+    <None Include="..\..\target\release\avutil-56.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
-    <None Include="..\..\target\release\msvcp140.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libwinpthread-1.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libeay32.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\intl-8.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstwebrtc-1.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstvideo-1.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gsttag-1.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstsdp-1.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstrtp-1.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstreamer-1.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstplayer-1.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstpbutils-1.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstgl-1.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstbase-1.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstaudio-1.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstapp-1.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gobject-2.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gmodule-2.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\glib-2.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gio-2.0-0.dll">
+    <None Include="..\..\target\release\bz2.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
     <None Include="..\..\target\release\ffi-7.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
-    <None Include="..\..\target\release\api-ms-win-crt-runtime-l1-1-0.dll">
+    <None Include="..\..\target\release\gio-2.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\glib-2.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gmodule-2.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gobject-2.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\graphene-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstapp.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstapp-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstaudio-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstaudioconvert.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstaudiofx.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstaudioparsers.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstaudioresample.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstautodetect.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstbase-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstcodecparsers-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstcontroller-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstcoreelements.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstdeinterlace.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstfft-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstgl-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstinterleave.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstisomp4.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstlibav.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstnice.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstogg.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstopengl.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstopus.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstpbutils-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstplayback.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstplayer-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstproxy.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstreamer-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstriff-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstrtp.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstrtp-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstsctp-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstsdp-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gsttag-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gsttheora.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gsttypefindfunctions.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstvideo-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstvideoconvert.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstvideofilter.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstvideoparsersbad.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstvideoscale.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstvolume.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstvorbis.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstvpx.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstwasapi.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstwebrtc.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\gstwebrtc-1.0-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\intl-8.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libeay32.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libgmp-10.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libgnutls-30.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libhogweed-4.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libjpeg-8.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libnettle-6.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libogg-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libopus-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libpng16-16.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libtasn1-6.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libtheora-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libtheoradec-1.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libtheoraenc-1.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libvorbis-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libvorbisenc-2.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\libwinpthread-1.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\msvcp140.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\nice-10.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\orc-0.4-0.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\simpleservo.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\ssleay32.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\swresample-3.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\vcruntime140.dll">
+      <Filter>ServoDLLsRelease</Filter>
+    </None>
+    <None Include="..\..\target\release\z-1.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
   </ItemGroup>


### PR DESCRIPTION
These changes improve the GStreamer experience on Windows in several ways:
* we package the set of plugins and their dependencies that Servo requires for media support
* we explicitly load those plugins when starting the media engine rather than relying on an existing gstreamer installation

These changes do not affect the experience on non-Windows platforms, but the path is clear to do so in order to fix problems like #23519. With these changes I can successfully hear a tone when loading https://joshmatthews.net/osc.html in both a desktop build and a UWP build.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23631 and fix #23698
- [x] These changes do not require tests because no tests on windows ;_;

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23712)
<!-- Reviewable:end -->
