### PR TITLE
Add Python 3 support for WebIDL parser

### DIFF
--- a/components/script/dom/bindings/codegen/parser/runtests.py
+++ b/components/script/dom/bindings/codegen/parser/runtests.py
@@ -62,7 +62,7 @@ def run_tests(tests, verbose):
         harness.start()
         try:
             _test.WebIDLTest.__call__(WebIDL.Parser(), harness)
-        except Exception, ex:
+        except Exception as ex:
             print("TEST-UNEXPECTED-FAIL | Unhandled exception in test %s: %s" % (testpath, ex))
             traceback.print_exc()
         finally:

--- a/components/script/dom/bindings/codegen/parser/tests/test_attr.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_attr.py
@@ -133,7 +133,7 @@ def WebIDLTest(parser, harness):
           };
         """)
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should not allow [SetterThrows] on readonly attributes")
 
@@ -146,7 +146,7 @@ def WebIDLTest(parser, harness):
           };
         """)
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should spell [Throws] correctly")
 
@@ -159,7 +159,7 @@ def WebIDLTest(parser, harness):
           };
         """)
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should not allow [SameObject] on attributes not of interface type")
 
@@ -172,6 +172,6 @@ def WebIDLTest(parser, harness):
           };
         """)
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(not threw, "Should allow [SameObject] on attributes of interface type")

--- a/components/script/dom/bindings/codegen/parser/tests/test_cereactions.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_cereactions.py
@@ -38,7 +38,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception, e:
+    except Exception as e:
         harness.ok(False, "Shouldn't have thrown for [CEReactions] used on writable attribute. %s" % e)
         threw = True
 
@@ -52,7 +52,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception, e:
+    except Exception as e:
         harness.ok(False, "Shouldn't have thrown for [CEReactions] used on regular operations. %s" % e)
         threw = True
 

--- a/components/script/dom/bindings/codegen/parser/tests/test_conditional_dictionary_member.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_conditional_dictionary_member.py
@@ -44,7 +44,7 @@ def WebIDLTest(parser, harness):
         };
       """)
       results = parser.finish()
-    except Exception, exception:
+    except Exception as exception:
         pass
 
     harness.ok(exception, "Should have thrown.")
@@ -70,7 +70,7 @@ def WebIDLTest(parser, harness):
         };
       """)
       results = parser.finish()
-    except Exception, exception:
+    except Exception as exception:
         pass
 
     harness.ok(exception, "Should have thrown (2).")
@@ -100,7 +100,7 @@ def WebIDLTest(parser, harness):
         };
       """)
       results = parser.finish()
-    except Exception, exception:
+    except Exception as exception:
         pass
 
     harness.ok(exception, "Should have thrown (3).")

--- a/components/script/dom/bindings/codegen/parser/tests/test_empty_sequence_default_value.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_empty_sequence_default_value.py
@@ -10,7 +10,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception,x:
+    except:
         threw = True
 
     harness.ok(threw, "Constant cannot have [] as a default value")

--- a/components/script/dom/bindings/codegen/parser/tests/test_error_colno.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_error_colno.py
@@ -8,7 +8,7 @@ def WebIDLTest(parser, harness):
     try:
         parser.parse(input)
         results = parser.finish()
-    except WebIDL.WebIDLError, e:
+    except WebIDL.WebIDLError as e:
         threw = True
         lines = str(e).split('\n')
 

--- a/components/script/dom/bindings/codegen/parser/tests/test_error_lineno.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_error_lineno.py
@@ -14,7 +14,7 @@ interface ?"""
     try:
         parser.parse(input)
         results = parser.finish()
-    except WebIDL.WebIDLError, e:
+    except WebIDL.WebIDLError as e:
         threw = True
         lines = str(e).split('\n')
 

--- a/components/script/dom/bindings/codegen/parser/tests/test_exposed_extended_attribute.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_exposed_extended_attribute.py
@@ -124,7 +124,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception,x:
+    except:
         threw = True
 
     harness.ok(threw, "Should have thrown on invalid Exposed value on interface.")
@@ -140,7 +140,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception,x:
+    except:
         threw = True
 
     harness.ok(threw, "Should have thrown on invalid Exposed value on attribute.")
@@ -156,7 +156,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception,x:
+    except:
         threw = True
 
     harness.ok(threw, "Should have thrown on invalid Exposed value on operation.")
@@ -172,7 +172,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception,x:
+    except:
         threw = True
 
     harness.ok(threw, "Should have thrown on invalid Exposed value on constant.")
@@ -192,7 +192,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception,x:
+    except:
         threw = True
 
     harness.ok(threw, "Should have thrown on member exposed where its interface is not.")
@@ -216,7 +216,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception,x:
+    except:
         threw = True
 
     harness.ok(threw, "Should have thrown on LHS of implements being exposed where RHS is not.")

--- a/components/script/dom/bindings/codegen/parser/tests/test_float_types.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_float_types.py
@@ -68,7 +68,7 @@ def WebIDLTest(parser, harness):
               long m(float arg);
             };
         """)
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "[LenientFloat] only allowed on void methods")
 
@@ -81,7 +81,7 @@ def WebIDLTest(parser, harness):
               void m(unrestricted float arg);
             };
         """)
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "[LenientFloat] only allowed on methods with unrestricted float args")
 
@@ -94,7 +94,7 @@ def WebIDLTest(parser, harness):
               void m(sequence<unrestricted float> arg);
             };
         """)
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "[LenientFloat] only allowed on methods with unrestricted float args (2)")
 
@@ -107,7 +107,7 @@ def WebIDLTest(parser, harness):
               void m((unrestricted float or FloatTypes) arg);
             };
         """)
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "[LenientFloat] only allowed on methods with unrestricted float args (3)")
 
@@ -120,6 +120,6 @@ def WebIDLTest(parser, harness):
               readonly attribute float foo;
             };
         """)
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "[LenientFloat] only allowed on writable attributes")

--- a/components/script/dom/bindings/codegen/parser/tests/test_identifier_conflict.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_identifier_conflict.py
@@ -9,7 +9,7 @@ def WebIDLTest(parser, harness):
         """)
         results = parser.finish()
         harness.ok(False, "Should fail to parse")
-    except Exception, e:
+    except Exception as e:
         harness.ok("Name collision" in e.message,
                    "Should have name collision for interface")
 
@@ -21,7 +21,7 @@ def WebIDLTest(parser, harness):
         """)
         results = parser.finish()
         harness.ok(False, "Should fail to parse")
-    except Exception, e:
+    except Exception as e:
         harness.ok("Name collision" in e.message,
                    "Should have name collision for dictionary")
 
@@ -33,7 +33,7 @@ def WebIDLTest(parser, harness):
         """)
         results = parser.finish()
         harness.ok(False, "Should fail to parse")
-    except Exception, e:
+    except Exception as e:
         harness.ok("Multiple unresolvable definitions" in e.message,
                    "Should have name collision for dictionary")
 

--- a/components/script/dom/bindings/codegen/parser/tests/test_interface_maplikesetlikeiterable.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_interface_maplikesetlikeiterable.py
@@ -37,10 +37,10 @@ def WebIDLTest(parser, harness):
             p.finish()
             harness.ok(False,
                        prefix + " - Interface passed when should've failed")
-        except WebIDL.WebIDLError, e:
+        except WebIDL.WebIDLError as e:
             harness.ok(True,
                        prefix + " - Interface failed as expected")
-        except Exception, e:
+        except Exception as e:
             harness.ok(False,
                        prefix + " - Interface failed but not as a WebIDLError exception: %s" % e)
 

--- a/components/script/dom/bindings/codegen/parser/tests/test_method.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_method.py
@@ -120,7 +120,7 @@ def WebIDLTest(parser, harness):
           };
         """)
         results = parser.finish()
-    except Exception, x:
+    except Exception as x:
         threw = True
     harness.ok(not threw, "Should allow integer to float type corecion")
 
@@ -133,7 +133,7 @@ def WebIDLTest(parser, harness):
           };
         """)
         results = parser.finish()
-    except Exception, x:
+    except Exception as x:
         threw = True
     harness.ok(threw, "Should not allow [GetterThrows] on methods")
 
@@ -146,7 +146,7 @@ def WebIDLTest(parser, harness):
           };
         """)
         results = parser.finish()
-    except Exception, x:
+    except Exception as x:
         threw = True
     harness.ok(threw, "Should not allow [SetterThrows] on methods")
 
@@ -159,7 +159,7 @@ def WebIDLTest(parser, harness):
           };
         """)
         results = parser.finish()
-    except Exception, x:
+    except Exception as x:
         threw = True
     harness.ok(threw, "Should spell [Throws] correctly on methods")
 
@@ -172,6 +172,6 @@ def WebIDLTest(parser, harness):
           };
         """)
         results = parser.finish()
-    except Exception, x:
+    except Exception as x:
         threw = True
     harness.ok(threw, "Should not allow __noSuchMethod__ methods")

--- a/components/script/dom/bindings/codegen/parser/tests/test_namespace.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_namespace.py
@@ -70,7 +70,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should have thrown.")
 
@@ -85,7 +85,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should have thrown.")
 
@@ -104,7 +104,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should have thrown.")
 
@@ -123,7 +123,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should have thrown.")
 
@@ -142,7 +142,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should have thrown.")
 
@@ -161,7 +161,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should have thrown.")
 
@@ -180,7 +180,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should have thrown.")
 
@@ -199,7 +199,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should have thrown.")
 
@@ -218,6 +218,6 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should have thrown.")

--- a/components/script/dom/bindings/codegen/parser/tests/test_record.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_record.py
@@ -33,7 +33,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception,x:
+    except:
         threw = True
     harness.ok(threw, "Should have thrown because record can't have void as value type.")
  
@@ -47,7 +47,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception,x:
+    except:
         threw = True
     harness.ok(threw,
                "Should have thrown on dictionary containing itself via record.")

--- a/components/script/dom/bindings/codegen/parser/tests/test_unenumerable_own_properties.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_unenumerable_own_properties.py
@@ -24,7 +24,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should have thrown.")
 
@@ -39,7 +39,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should have thrown.")
 
@@ -59,6 +59,6 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception, x:
+    except:
         threw = True
     harness.ok(threw, "Should have thrown.")

--- a/components/script/dom/bindings/codegen/parser/tests/test_unforgeable.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_unforgeable.py
@@ -111,7 +111,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception,x:
+    except:
         threw = True
     harness.ok(threw,
                "Should have thrown when shadowing unforgeable attribute on "
@@ -130,7 +130,7 @@ def WebIDLTest(parser, harness):
         """)
 
         results = parser.finish()
-    except Exception,x:
+    except:
         threw = True
     harness.ok(threw,
                "Should have thrown when shadowing unforgeable operation on "

--- a/components/script/dom/bindings/codegen/parser/tests/test_union.py
+++ b/components/script/dom/bindings/codegen/parser/tests/test_union.py
@@ -17,7 +17,7 @@ def combinations(iterable, r):
     n = len(pool)
     if r > n:
         return
-    indices = range(r)
+    indices = list(range(r))
     yield tuple(pool[i] for i in indices)
     while True:
         for i in reversed(range(r)):


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Also makes the tests run on both Python 2 and 3.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix partially #23607 

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23723)
<!-- Reviewable:end -->
