### PR TITLE
Enable uwp feature when building with --uwp.

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -846,6 +846,7 @@ install them, let us know by filing a bug!")
         if uwp:
             features.append("canvas2d-raqote")
             features.append("no_wgl")
+            features.append("uwp")
         else:
             # Non-UWP builds provide their own libEGL via mozangle.
             features.append("egl")


### PR DESCRIPTION
This removes some dependencies that trigger WACK errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23736)
<!-- Reviewable:end -->
