### PR TITLE
Load GST videofilter plugins.

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -157,6 +157,7 @@ mod media_platform {
             "gsttheora.dll",
             "gsttypefindfunctions.dll",
             "gstvideoconvert.dll",
+            "gstvideofilter.dll",
             "gstvideoparsersbad.dll",
             "gstvideoscale.dll",
             "gstvolume.dll",


### PR DESCRIPTION
The video playback tries to create a videobalance element and can't find it without this plugin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23740)
<!-- Reviewable:end -->
