### PR TITLE
Updated README with MacPorts dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ pip install virtualenv
 ##### On macOS (MacPorts)
 
 ``` sh
-sudo port install python27 py27-virtualenv cmake yasm llvm
+sudo port install python27 py27-virtualenv cmake yasm llvm \
+    gstreamer1 gstreamer1-gst-plugins-base  gstreamer1-gst-libav \
+    gstreamer1-gst-plugins-bad gstreamer1-gst-plugins-good autoconf213
 ```
 ##### On macOS >= 10.11 (El Capitan), you also have to install OpenSSL
 


### PR DESCRIPTION
Added to the README are dependencies included in the Homebrew files for installation but missing in the list of dependencies for MacPorts.

This was based off of me building Servo yesterday for OSX 10.14.5.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it is a README update.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23743)
<!-- Reviewable:end -->
