### PR TITLE
Make GL/GLES decisions based on the API in use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
  "cssparser 0.25.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "half 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -418,7 +418,7 @@ version = "0.0.1"
 dependencies = [
  "cssparser 0.25.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "malloc_size_of 0.0.1",
@@ -485,7 +485,7 @@ name = "cgl"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -598,7 +598,7 @@ dependencies = [
  "embedder_traits 0.0.1",
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "gfx_traits 0.0.1",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "keyboard-types 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "gleam"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2198,7 +2198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "leaky-cow 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2530,7 +2530,7 @@ dependencies = [
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "gaol 0.2.0 (git+https://github.com/servo/gaol)",
  "gfx 0.0.1",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "keyboard-types 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "layout_thread_2013 0.0.1",
@@ -3191,7 +3191,7 @@ dependencies = [
  "core-foundation 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3754,7 +3754,7 @@ dependencies = [
  "bindgen 0.49.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gvr-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3770,7 +3770,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_injected_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3855,7 +3855,7 @@ dependencies = [
  "enum-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "headers 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "html5ever 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4095,7 +4095,7 @@ dependencies = [
  "clipboard 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "keyboard-types 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4299,7 +4299,7 @@ dependencies = [
  "cmake 0.1.40 (git+https://github.com/alexcrichton/cmake-rs)",
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "expat-sys 2.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glx 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "io-surface 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5410,7 +5410,7 @@ dependencies = [
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "freetype 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5479,7 +5479,7 @@ dependencies = [
  "canvas_traits 0.0.1",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "msg 0.0.1",
@@ -5506,7 +5506,7 @@ version = "0.0.1"
 source = "git+https://github.com/servo/webxr#3951634a06e2f9417f04e8ada969589f5b8a01d2"
 dependencies = [
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webxr-api 0.0.1 (git+https://github.com/servo/webxr)",
 ]
@@ -5517,7 +5517,7 @@ version = "0.0.1"
 source = "git+https://github.com/servo/webxr#3951634a06e2f9417f04e8ada969589f5b8a01d2"
 dependencies = [
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "typetag 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5846,7 +5846,7 @@ dependencies = [
 "checksum gif 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff3414b424657317e708489d2857d9575f4403698428b040b609b9d1c1a84a2c"
 "checksum gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0ffaf173cf76c73a73e080366bf556b4776ece104b06961766ff11449f38604"
 "checksum gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39a23d5e872a275135d66895d954269cf5e8661d234eb1c2480f4ce0d586acbd"
-"checksum gleam 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7f46fd8874e043ffac0d638ed1567a2584f7814f6d72b4db37ab1689004a26c4"
+"checksum gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)" = "c8a455b5a3ccd35daeb89fdb8a89ebb0a1fe23c05c7a7f9017840bc3ae176f71"
 "checksum glib 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d70d737019da0473a7cd6d9240571cf58c6897dcb10edf32b90774f4ba237c1b"
 "checksum glib-sys 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b86a9169fbc9cf9a0ef315039c2304b09d5c575c5fde7defba3576a0311b863"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -138,9 +138,13 @@ impl<VR: WebVRRenderHandler + 'static> WebGLThread<VR> {
                         )
                         .expect("WebGLContext not found");
                         let glsl_version = Self::get_glsl_version(&data.ctx);
+                        let api_type = match data.ctx.gl().get_type() {
+                            gl::GlType::Gl => GlType::Gl,
+                            gl::GlType::Gles => GlType::Gles,
+                        };
 
                         // FIXME(nox): Should probably be done by offscreen_gl_context.
-                        if !is_gles() {
+                        if api_type != GlType::Gles {
                             // Points sprites are enabled by default in OpenGL 3.2 core
                             // and in GLES. Rather than doing version detection, it does
                             // not hurt to enable them anyways.
@@ -163,6 +167,7 @@ impl<VR: WebVRRenderHandler + 'static> WebGLThread<VR> {
                             limits,
                             share_mode,
                             glsl_version,
+                            api_type,
                         }
                     }))
                     .unwrap();

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -76,6 +76,12 @@ pub enum WebGLMsg {
     Exit,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
+pub enum GlType {
+    Gl,
+    Gles,
+}
+
 /// Contains the WebGLCommand sender and information about a WebGLContext
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct WebGLCreateContextResult {
@@ -87,6 +93,8 @@ pub struct WebGLCreateContextResult {
     pub share_mode: WebGLContextShareMode,
     /// The GLSL version supported by the context.
     pub glsl_version: WebGLSLVersion,
+    /// The GL API used by the context.
+    pub api_type: GlType,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, Serialize)]
@@ -759,12 +767,6 @@ parameters! {
             TextureWrapT = gl::TEXTURE_WRAP_T,
         }),
     }
-}
-
-pub fn is_gles() -> bool {
-    // TODO: align this with the actual kind of graphics context in use, rather than
-    // making assumptions based on platform
-    cfg!(any(target_os = "android", target_os = "ios"))
 }
 
 #[macro_export]

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -46,7 +46,7 @@ use canvas_traits::canvas::{
 };
 use canvas_traits::canvas::{CompositionOrBlending, LineCapStyle, LineJoinStyle, RepetitionStyle};
 use canvas_traits::webgl::GLLimits;
-use canvas_traits::webgl::{ActiveAttribInfo, ActiveUniformInfo, TexDataType, TexFormat};
+use canvas_traits::webgl::{ActiveAttribInfo, ActiveUniformInfo, GlType, TexDataType, TexFormat};
 use canvas_traits::webgl::{WebGLBufferId, WebGLChan, WebGLContextShareMode, WebGLError};
 use canvas_traits::webgl::{WebGLFramebufferId, WebGLMsgSender, WebGLPipeline, WebGLProgramId};
 use canvas_traits::webgl::{WebGLReceiver, WebGLRenderbufferId, WebGLSLVersion, WebGLSender};
@@ -439,7 +439,7 @@ unsafe_no_jsmanaged_fields!(StorageType);
 unsafe_no_jsmanaged_fields!(CanvasGradientStop, LinearGradientStyle, RadialGradientStyle);
 unsafe_no_jsmanaged_fields!(LineCapStyle, LineJoinStyle, CompositionOrBlending);
 unsafe_no_jsmanaged_fields!(RepetitionStyle);
-unsafe_no_jsmanaged_fields!(WebGLError, GLLimits);
+unsafe_no_jsmanaged_fields!(WebGLError, GLLimits, GlType);
 unsafe_no_jsmanaged_fields!(TimeProfilerChan);
 unsafe_no_jsmanaged_fields!(MemProfilerChan);
 unsafe_no_jsmanaged_fields!(PseudoElement);

--- a/components/script/dom/webgl_extensions/ext/extshadertexturelod.rs
+++ b/components/script/dom/webgl_extensions/ext/extshadertexturelod.rs
@@ -7,7 +7,7 @@ use crate::dom::bindings::codegen::Bindings::EXTShaderTextureLodBinding;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
-use canvas_traits::webgl::{is_gles, WebGLVersion};
+use canvas_traits::webgl::WebGLVersion;
 use dom_struct::dom_struct;
 
 #[dom_struct]
@@ -40,7 +40,7 @@ impl WebGLExtension for EXTShaderTextureLod {
 
     fn is_supported(ext: &WebGLExtensions) -> bool {
         // This extension is always available on desktop GL.
-        !is_gles() || ext.supports_gl_extension("GL_EXT_shader_texture_lod")
+        !ext.is_gles() || ext.supports_gl_extension("GL_EXT_shader_texture_lod")
     }
 
     fn enable(_ext: &WebGLExtensions) {}

--- a/components/script/dom/webgl_extensions/ext/oeselementindexuint.rs
+++ b/components/script/dom/webgl_extensions/ext/oeselementindexuint.rs
@@ -7,7 +7,7 @@ use crate::dom::bindings::codegen::Bindings::OESElementIndexUintBinding;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
-use canvas_traits::webgl::{is_gles, WebGLVersion};
+use canvas_traits::webgl::WebGLVersion;
 use dom_struct::dom_struct;
 
 #[dom_struct]
@@ -40,7 +40,7 @@ impl WebGLExtension for OESElementIndexUint {
 
     fn is_supported(ext: &WebGLExtensions) -> bool {
         // This extension is always available in desktop OpenGL.
-        !is_gles() || ext.supports_gl_extension("GL_OES_element_index_uint")
+        !ext.is_gles() || ext.supports_gl_extension("GL_OES_element_index_uint")
     }
 
     fn enable(ext: &WebGLExtensions) {

--- a/components/script/dom/webgl_extensions/ext/oesstandardderivatives.rs
+++ b/components/script/dom/webgl_extensions/ext/oesstandardderivatives.rs
@@ -8,7 +8,7 @@ use crate::dom::bindings::codegen::Bindings::OESStandardDerivativesBinding::OESS
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
-use canvas_traits::webgl::{is_gles, WebGLVersion};
+use canvas_traits::webgl::WebGLVersion;
 use dom_struct::dom_struct;
 
 #[dom_struct]
@@ -40,7 +40,7 @@ impl WebGLExtension for OESStandardDerivatives {
 
     fn is_supported(ext: &WebGLExtensions) -> bool {
         // The standard derivatives are always available in desktop OpenGL.
-        !is_gles() || ext.supports_any_gl_extension(&["GL_OES_standard_derivatives"])
+        !ext.is_gles() || ext.supports_any_gl_extension(&["GL_OES_standard_derivatives"])
     }
 
     fn enable(ext: &WebGLExtensions) {

--- a/components/script/dom/webgl_extensions/extensions.rs
+++ b/components/script/dom/webgl_extensions/extensions.rs
@@ -18,7 +18,7 @@ use crate::dom::oestexturehalffloat::OESTextureHalfFloat;
 use crate::dom::webglcolorbufferfloat::WEBGLColorBufferFloat;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
 use crate::dom::webgltexture::TexCompression;
-use canvas_traits::webgl::WebGLVersion;
+use canvas_traits::webgl::{GlType, WebGLVersion};
 use fnv::{FnvHashMap, FnvHashSet};
 use gleam::gl::{self, GLenum};
 use js::jsapi::JSObject;
@@ -146,14 +146,16 @@ pub struct WebGLExtensions {
     extensions: DomRefCell<HashMap<String, Box<dyn WebGLExtensionWrapper>>>,
     features: DomRefCell<WebGLExtensionFeatures>,
     webgl_version: WebGLVersion,
+    api_type: GlType,
 }
 
 impl WebGLExtensions {
-    pub fn new(webgl_version: WebGLVersion) -> WebGLExtensions {
+    pub fn new(webgl_version: WebGLVersion, api_type: GlType) -> WebGLExtensions {
         Self {
             extensions: DomRefCell::new(HashMap::new()),
             features: DomRefCell::new(WebGLExtensionFeatures::new(webgl_version)),
             webgl_version,
+            api_type,
         }
     }
 
@@ -424,6 +426,10 @@ impl WebGLExtensions {
             }
         }
         type_
+    }
+
+    pub fn is_gles(&self) -> bool {
+        self.api_type == GlType::Gles
     }
 }
 

--- a/components/script/dom/webglrenderbuffer.rs
+++ b/components/script/dom/webglrenderbuffer.rs
@@ -14,7 +14,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::webglobject::WebGLObject;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
 use canvas_traits::webgl::{
-    is_gles, webgl_channel, WebGLCommand, WebGLError, WebGLRenderbufferId, WebGLResult,
+    webgl_channel, GlType, WebGLCommand, WebGLError, WebGLRenderbufferId, WebGLResult,
 };
 use dom_struct::dom_struct;
 use std::cell::Cell;
@@ -120,7 +120,15 @@ impl WebGLRenderbuffer {
         self.ever_bound.get()
     }
 
-    pub fn storage(&self, internal_format: u32, width: i32, height: i32) -> WebGLResult<()> {
+    pub fn storage(
+        &self,
+        api_type: GlType,
+        internal_format: u32,
+        width: i32,
+        height: i32,
+    ) -> WebGLResult<()> {
+        let is_gles = api_type == GlType::Gles;
+
         // Validate the internal_format, and save it for completeness
         // validation.
         let actual_format = match internal_format {
@@ -131,7 +139,7 @@ impl WebGLRenderbuffer {
             constants::DEPTH_STENCIL => WebGL2RenderingContextConstants::DEPTH24_STENCIL8,
             constants::RGB5_A1 => {
                 // 16-bit RGBA formats are not supported on desktop GL.
-                if is_gles() {
+                if is_gles {
                     constants::RGB5_A1
                 } else {
                     WebGL2RenderingContextConstants::RGBA8
@@ -139,7 +147,7 @@ impl WebGLRenderbuffer {
             },
             constants::RGB565 => {
                 // RGB565 is not supported on desktop GL.
-                if is_gles() {
+                if is_gles {
                     constants::RGB565
                 } else {
                     WebGL2RenderingContextConstants::RGB8

--- a/components/script/dom/webglshader.rs
+++ b/components/script/dom/webglshader.rs
@@ -14,7 +14,7 @@ use crate::dom::webgl_extensions::ext::oesstandardderivatives::OESStandardDeriva
 use crate::dom::webgl_extensions::WebGLExtensions;
 use crate::dom::webglobject::WebGLObject;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
-use canvas_traits::webgl::{webgl_channel, WebGLVersion};
+use canvas_traits::webgl::{webgl_channel, GlType, WebGLVersion};
 use canvas_traits::webgl::{GLLimits, WebGLCommand, WebGLError};
 use canvas_traits::webgl::{WebGLResult, WebGLSLVersion, WebGLShaderId};
 use dom_struct::dom_struct;
@@ -93,6 +93,7 @@ impl WebGLShader {
     /// glCompileShader
     pub fn compile(
         &self,
+        api_type: GlType,
         webgl_version: WebGLVersion,
         glsl_version: WebGLSLVersion,
         limits: &GLLimits,
@@ -122,7 +123,7 @@ impl WebGLShader {
         };
         let validator = match webgl_version {
             WebGLVersion::WebGL1 => {
-                let output_format = if cfg!(any(target_os = "android", target_os = "ios")) {
+                let output_format = if api_type == GlType::Gles {
                     Output::Essl
                 } else {
                     Output::Glsl
@@ -130,7 +131,7 @@ impl WebGLShader {
                 ShaderValidator::for_webgl(self.gl_type, output_format, &params).unwrap()
             },
             WebGLVersion::WebGL2 => {
-                let output_format = if cfg!(any(target_os = "android", target_os = "ios")) {
+                let output_format = if api_type == GlType::Gles {
                     Output::Essl
                 } else {
                     match (glsl_version.major, glsl_version.minor) {

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -747,7 +747,7 @@ fn create_constellation(
         GLContextFactory::current_osmesa_handle()
     } else {
         let dispatcher = Box::new(MainThreadDispatcher::new(compositor_proxy.clone())) as Box<_>;
-        GLContextFactory::current_native_handle(dispatcher)
+        GLContextFactory::current_native_handle(dispatcher, window_gl.get_type())
     };
 
     let (external_image_handlers, external_images) = WebrenderExternalImageHandlers::new();


### PR DESCRIPTION
These changes remove a number of assumptions about whether GL/GLES is in use, improving the support for running WebGL in Servo under ANGLE.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because no tests on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23744)
<!-- Reviewable:end -->
