### PR TITLE
Don't enable azure canvas feature by default.

### DIFF
--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -13,7 +13,6 @@ path = "lib.rs"
 [features]
 canvas2d-azure = ["azure"]
 canvas2d-raqote = ["raqote"]
-default = ["canvas2d-azure"]
 webgl_backtrace = ["canvas_traits/webgl_backtrace"]
 no_wgl = ["offscreen_gl_context/no_wgl"]
 


### PR DESCRIPTION
This caused problems when I was trying to do a UWP build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23763)
<!-- Reviewable:end -->
