### PR TITLE
Adjust gstreamer plugins for UWP.

### DIFF
--- a/support/hololens/ServoApp.vcxproj
+++ b/support/hololens/ServoApp.vcxproj
@@ -154,9 +154,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\target\debug\api-ms-win-crt-runtime-l1-1-0.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\avcodec-58.dll">
       <DeploymentContent>false</DeploymentContent>
@@ -204,11 +204,6 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gobject-2.0-0.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\graphene-1.0-0.dll">
       <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
@@ -303,26 +298,6 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
-    <None Include="..\..\target\debug\gstnice.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\gstogg.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\gstopengl.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\gstopus.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
     <None Include="..\..\target\debug\gstpbutils-1.0-0.dll">
       <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
@@ -358,27 +333,12 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
-    <None Include="..\..\target\debug\gstrtp.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\gstsctp-1.0-0.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
     <None Include="..\..\target\debug\gstsdp-1.0-0.dll">
       <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gsttag-1.0-0.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\gsttheora.dll">
       <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
@@ -418,27 +378,12 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
-    <None Include="..\..\target\debug\gstvorbis.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\gstvpx.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
     <None Include="..\..\target\debug\gstwasapi.dll">
       <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\gstwebrtc-1.0-0.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\gstwebrtc.dll">
       <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
@@ -453,90 +398,15 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
-    <None Include="..\..\target\debug\libgmp-10.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\libgnutls-30.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\libhogweed-4.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\libjpeg-8.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\libnettle-6.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\libogg-0.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\libopus-0.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\libpng16-16.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\libtasn1-6.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\libtheora-0.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\libtheoradec-1.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\libtheoraenc-1.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\libvorbis-0.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\libvorbisenc-2.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
     <None Include="..\..\target\debug\libwinpthread-1.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\msvcp140.dll">
-      <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\debug\nice-10.dll">
-      <DeploymentContent>false</DeploymentContent>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</DeploymentContent>
     </None>
     <None Include="..\..\target\debug\orc-0.4-0.dll">
       <DeploymentContent>false</DeploymentContent>
@@ -619,11 +489,6 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\release\gobject-2.0-0.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\graphene-1.0-0.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
@@ -718,26 +583,6 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
-    <None Include="..\..\target\release\gstnice.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\gstogg.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\gstopengl.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\gstopus.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
     <None Include="..\..\target\release\gstpbutils-1.0-0.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
@@ -773,27 +618,12 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
-    <None Include="..\..\target\release\gstrtp.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\gstsctp-1.0-0.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
     <None Include="..\..\target\release\gstsdp-1.0-0.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\release\gsttag-1.0-0.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\gsttheora.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
@@ -833,27 +663,12 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
-    <None Include="..\..\target\release\gstvorbis.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\gstvpx.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
     <None Include="..\..\target\release\gstwasapi.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\release\gstwebrtc-1.0-0.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\gstwebrtc.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
@@ -868,87 +683,12 @@
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
-    <None Include="..\..\target\release\libgmp-10.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\libgnutls-30.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\libhogweed-4.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\libjpeg-8.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\libnettle-6.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\libogg-0.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\libopus-0.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\libpng16-16.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\libtasn1-6.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\libtheora-0.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\libtheoradec-1.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\libtheoraenc-1.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\libvorbis-0.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\libvorbisenc-2.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
     <None Include="..\..\target\release\libwinpthread-1.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\target\release\msvcp140.dll">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
-    </None>
-    <None Include="..\..\target\release\nice-10.dll">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</DeploymentContent>
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>

--- a/support/hololens/ServoApp.vcxproj.filters
+++ b/support/hololens/ServoApp.vcxproj.filters
@@ -88,9 +88,6 @@
     <None Include="..\..\target\debug\gobject-2.0-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
-    <None Include="..\..\target\debug\graphene-1.0-0.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
     <None Include="..\..\target\debug\gstapp.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
@@ -145,18 +142,6 @@
     <None Include="..\..\target\debug\gstlibav.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
-    <None Include="..\..\target\debug\gstnice.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\gstogg.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\gstopengl.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\gstopus.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
     <None Include="..\..\target\debug\gstpbutils-1.0-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
@@ -175,22 +160,13 @@
     <None Include="..\..\target\debug\gstriff-1.0-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
-    <None Include="..\..\target\debug\gstrtp.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
     <None Include="..\..\target\debug\gstrtp-1.0-0.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\gstsctp-1.0-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
     <None Include="..\..\target\debug\gstsdp-1.0-0.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
     <None Include="..\..\target\debug\gsttag-1.0-0.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\gsttheora.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
     <None Include="..\..\target\debug\gsttypefindfunctions.dll">
@@ -214,16 +190,7 @@
     <None Include="..\..\target\debug\gstvolume.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
-    <None Include="..\..\target\debug\gstvorbis.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\gstvpx.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
     <None Include="..\..\target\debug\gstwasapi.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\gstwebrtc.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
     <None Include="..\..\target\debug\gstwebrtc-1.0-0.dll">
@@ -235,55 +202,10 @@
     <None Include="..\..\target\debug\libeay32.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
-    <None Include="..\..\target\debug\libgmp-10.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\libgnutls-30.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\libhogweed-4.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\libjpeg-8.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\libnettle-6.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\libogg-0.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\libopus-0.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\libpng16-16.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\libtasn1-6.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\libtheora-0.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\libtheoradec-1.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\libtheoraenc-1.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\libvorbis-0.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\libvorbisenc-2.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
     <None Include="..\..\target\debug\libwinpthread-1.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
     <None Include="..\..\target\debug\msvcp140.dll">
-      <Filter>ServoDLLsDebug</Filter>
-    </None>
-    <None Include="..\..\target\debug\nice-10.dll">
       <Filter>ServoDLLsDebug</Filter>
     </None>
     <None Include="..\..\target\debug\orc-0.4-0.dll">
@@ -332,9 +254,6 @@
       <Filter>ServoDLLsRelease</Filter>
     </None>
     <None Include="..\..\target\release\gobject-2.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\graphene-1.0-0.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
     <None Include="..\..\target\release\gstapp.dll">
@@ -391,18 +310,6 @@
     <None Include="..\..\target\release\gstlibav.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
-    <None Include="..\..\target\release\gstnice.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstogg.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstopengl.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstopus.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
     <None Include="..\..\target\release\gstpbutils-1.0-0.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
@@ -421,22 +328,13 @@
     <None Include="..\..\target\release\gstriff-1.0-0.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
-    <None Include="..\..\target\release\gstrtp.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
     <None Include="..\..\target\release\gstrtp-1.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstsctp-1.0-0.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
     <None Include="..\..\target\release\gstsdp-1.0-0.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
     <None Include="..\..\target\release\gsttag-1.0-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gsttheora.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
     <None Include="..\..\target\release\gsttypefindfunctions.dll">
@@ -460,16 +358,7 @@
     <None Include="..\..\target\release\gstvolume.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
-    <None Include="..\..\target\release\gstvorbis.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstvpx.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
     <None Include="..\..\target\release\gstwasapi.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\gstwebrtc.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
     <None Include="..\..\target\release\gstwebrtc-1.0-0.dll">
@@ -481,55 +370,10 @@
     <None Include="..\..\target\release\libeay32.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
-    <None Include="..\..\target\release\libgmp-10.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libgnutls-30.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libhogweed-4.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libjpeg-8.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libnettle-6.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libogg-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libopus-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libpng16-16.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libtasn1-6.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libtheora-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libtheoradec-1.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libtheoraenc-1.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libvorbis-0.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\libvorbisenc-2.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
     <None Include="..\..\target\release\libwinpthread-1.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
     <None Include="..\..\target\release\msvcp140.dll">
-      <Filter>ServoDLLsRelease</Filter>
-    </None>
-    <None Include="..\..\target\release\nice-10.dll">
       <Filter>ServoDLLsRelease</Filter>
     </None>
     <None Include="..\..\target\release\orc-0.4-0.dll">


### PR DESCRIPTION
This excludes a set of plugins and dependencies that are currently built with MinGW and will therefore cause WACK errors. The resulting set of plugins loaded by the UWP app are still not UWP-clean, but this makes it much easier to switch over to UWP-clean binaries in the future.

These changes also allow the HoloLens 2 app to start and load again after #23712.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23757
- [x] These changes do not require tests because no tests for windows or UWP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23764)
<!-- Reviewable:end -->
