### PR TITLE
Support running WebGL in its own thread or on the main thread.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,7 @@ dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "canvas_traits 0.0.1",
  "cssparser 0.25.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "embedder_traits 0.0.1",
  "euclid 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -21,6 +21,7 @@ azure = {git = "https://github.com/servo/rust-azure", optional = true}
 byteorder = "1"
 canvas_traits = {path = "../canvas_traits"}
 cssparser = "0.25"
+embedder_traits = {path = "../embedder_traits"}
 euclid = "0.20"
 fnv = "1.0"
 gleam = "0.6.7"

--- a/components/canvas/webgl_mode/inprocess.rs
+++ b/components/canvas/webgl_mode/inprocess.rs
@@ -3,15 +3,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::gl_context::GLContextFactory;
-use crate::webgl_thread::WebGLThread;
+use crate::webgl_thread::{TexturesMap, WebGLMainThread, WebGLThread, WebGLThreadInit};
 use canvas_traits::webgl::webgl_channel;
 use canvas_traits::webgl::DOMToTextureCommand;
 use canvas_traits::webgl::{WebGLChan, WebGLContextId, WebGLMsg, WebGLPipeline, WebGLReceiver};
-use canvas_traits::webgl::{WebGLSender, WebVRCommand, WebVRRenderHandler};
+use canvas_traits::webgl::{WebGLSender, WebVRRenderHandler};
+use embedder_traits::EventLoopWaker;
 use euclid::default::Size2D;
 use fnv::FnvHashMap;
 use gleam::gl;
 use servo_config::pref;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::default::Default;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use webrender_traits::{WebrenderExternalImageApi, WebrenderExternalImageRegistry};
@@ -19,37 +23,70 @@ use webrender_traits::{WebrenderExternalImageApi, WebrenderExternalImageRegistry
 /// WebGL Threading API entry point that lives in the constellation.
 pub struct WebGLThreads(WebGLSender<WebGLMsg>);
 
+pub enum ThreadMode {
+    MainThread(Box<dyn EventLoopWaker>),
+    OffThread(Rc<dyn gl::Gl>),
+}
+
 impl WebGLThreads {
     /// Creates a new WebGLThreads object
     pub fn new(
         gl_factory: GLContextFactory,
-        webrender_gl: Rc<dyn gl::Gl>,
         webrender_api_sender: webrender_api::RenderApiSender,
         webvr_compositor: Option<Box<dyn WebVRRenderHandler>>,
         external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
+        mode: ThreadMode,
     ) -> (
         WebGLThreads,
+        Option<WebGLMainThread>,
         Box<dyn WebrenderExternalImageApi>,
         Option<Box<dyn webrender::OutputImageHandler>>,
     ) {
+        let (sender, receiver) = webgl_channel::<WebGLMsg>().unwrap();
         // This implementation creates a single `WebGLThread` for all the pipelines.
-        let channel = WebGLThread::start(
+        let init = WebGLThreadInit {
             gl_factory,
             webrender_api_sender,
-            webvr_compositor.map(|c| WebVRRenderWrapper(c)),
+            webvr_compositor,
             external_images,
-        );
+            sender: sender.clone(),
+            receiver,
+        };
+
         let output_handler = if pref!(dom.webgl.dom_to_texture.enabled) {
-            Some(Box::new(OutputHandler::new(
-                webrender_gl.clone(),
-                channel.clone(),
-            )))
+            Some(Box::new(match mode {
+                ThreadMode::MainThread(..) => OutputHandler::new_main_thread(),
+                ThreadMode::OffThread(ref webrender_gl) => {
+                    OutputHandler::new_off_thread(webrender_gl.clone(), sender.clone())
+                },
+            }))
         } else {
             None
         };
-        let external = WebGLExternalImages::new(webrender_gl, channel.clone());
+
+        let (external, webgl_thread) = match mode {
+            ThreadMode::MainThread(event_loop_waker) => {
+                let textures = Rc::new(RefCell::new(HashMap::new()));
+                let thread_data =
+                    WebGLThread::run_on_current_thread(init, event_loop_waker, textures.clone());
+                (
+                    WebGLExternalImages::new_main_thread(textures),
+                    Some(thread_data),
+                )
+            },
+
+            ThreadMode::OffThread(webrender_gl) => {
+                WebGLThread::run_on_own_thread(init);
+                (
+                    WebGLExternalImages::new_off_thread(webrender_gl, sender.clone()),
+                    None,
+                )
+            },
+        };
+
         (
-            WebGLThreads(channel),
+            WebGLThreads(sender),
+            webgl_thread,
             Box::new(external),
             output_handler.map(|b| b as Box<_>),
         )
@@ -70,87 +107,112 @@ impl WebGLThreads {
 }
 
 /// Bridge between the webrender::ExternalImage callbacks and the WebGLThreads.
-struct WebGLExternalImages {
-    webrender_gl: Rc<dyn gl::Gl>,
-    webgl_channel: WebGLSender<WebGLMsg>,
-    // Used to avoid creating a new channel on each received WebRender request.
-    lock_channel: (
-        WebGLSender<(u32, Size2D<i32>, usize)>,
-        WebGLReceiver<(u32, Size2D<i32>, usize)>,
-    ),
+enum WebGLExternalImages {
+    OffThread {
+        webrender_gl: Rc<dyn gl::Gl>,
+        webgl_channel: WebGLSender<WebGLMsg>,
+        // Used to avoid creating a new channel on each received WebRender request.
+        lock_channel: (
+            WebGLSender<(u32, Size2D<i32>, usize)>,
+            WebGLReceiver<(u32, Size2D<i32>, usize)>,
+        ),
+    },
+    MainThread {
+        textures: TexturesMap,
+    },
 }
 
 impl WebGLExternalImages {
-    fn new(webrender_gl: Rc<dyn gl::Gl>, channel: WebGLSender<WebGLMsg>) -> Self {
-        Self {
+    fn new_off_thread(webrender_gl: Rc<dyn gl::Gl>, channel: WebGLSender<WebGLMsg>) -> Self {
+        WebGLExternalImages::OffThread {
             webrender_gl,
             webgl_channel: channel,
             lock_channel: webgl_channel().unwrap(),
         }
+    }
+
+    fn new_main_thread(textures: TexturesMap) -> Self {
+        WebGLExternalImages::MainThread { textures }
     }
 }
 
 impl WebrenderExternalImageApi for WebGLExternalImages {
     fn lock(&mut self, id: u64) -> (u32, Size2D<i32>) {
-        // WebGL Thread has it's own GL command queue that we need to synchronize with the WR GL command queue.
-        // The WebGLMsg::Lock message inserts a fence in the WebGL command queue.
-        self.webgl_channel
-            .send(WebGLMsg::Lock(
-                WebGLContextId(id as usize),
-                self.lock_channel.0.clone(),
-            ))
-            .unwrap();
-        let (image_id, size, gl_sync) = self.lock_channel.1.recv().unwrap();
-        // The next glWaitSync call is run on the WR thread and it's used to synchronize the two
-        // flows of OpenGL commands in order to avoid WR using a semi-ready WebGL texture.
-        // glWaitSync doesn't block WR thread, it affects only internal OpenGL subsystem.
-        self.webrender_gl
-            .wait_sync(gl_sync as gl::GLsync, 0, gl::TIMEOUT_IGNORED);
-        (image_id, size)
+        match *self {
+            WebGLExternalImages::OffThread {
+                ref webgl_channel,
+                ref webrender_gl,
+                ref lock_channel,
+            } => {
+                // WebGL Thread has it's own GL command queue that we need to synchronize with the WR GL command queue.
+                // The WebGLMsg::Lock message inserts a fence in the WebGL command queue.
+                webgl_channel
+                    .send(WebGLMsg::Lock(
+                        WebGLContextId(id as usize),
+                        lock_channel.0.clone(),
+                    ))
+                    .unwrap();
+                let (image_id, size, gl_sync) = lock_channel.1.recv().unwrap();
+                // The next glWaitSync call is run on the WR thread and it's used to synchronize the two
+                // flows of OpenGL commands in order to avoid WR using a semi-ready WebGL texture.
+                // glWaitSync doesn't block WR thread, it affects only internal OpenGL subsystem.
+                webrender_gl.wait_sync(gl_sync as gl::GLsync, 0, gl::TIMEOUT_IGNORED);
+                (image_id, size)
+            },
+
+            WebGLExternalImages::MainThread { ref textures } => {
+                let textures = textures.borrow();
+                let entry = textures
+                    .get(&WebGLContextId(id as usize))
+                    .expect("no texture entry???");
+                (entry.0, entry.1)
+            },
+        }
     }
 
     fn unlock(&mut self, id: u64) {
-        self.webgl_channel
-            .send(WebGLMsg::Unlock(WebGLContextId(id as usize)))
-            .unwrap();
-    }
-}
+        match *self {
+            WebGLExternalImages::OffThread {
+                ref webgl_channel, ..
+            } => {
+                webgl_channel
+                    .send(WebGLMsg::Unlock(WebGLContextId(id as usize)))
+                    .unwrap();
+            },
 
-/// Wrapper to send WebVR commands used in `WebGLThread`.
-struct WebVRRenderWrapper(Box<dyn WebVRRenderHandler>);
-
-impl WebVRRenderHandler for WebVRRenderWrapper {
-    fn handle(
-        &mut self,
-        gl: &dyn gl::Gl,
-        command: WebVRCommand,
-        texture: Option<(u32, Size2D<i32>)>,
-    ) {
-        self.0.handle(gl, command, texture);
+            WebGLExternalImages::MainThread { .. } => {},
+        }
     }
 }
 
 /// struct used to implement DOMToTexture feature and webrender::OutputImageHandler trait.
 type OutputHandlerData = Option<(u32, Size2D<i32>)>;
-struct OutputHandler {
-    webrender_gl: Rc<dyn gl::Gl>,
-    webgl_channel: WebGLSender<WebGLMsg>,
-    // Used to avoid creating a new channel on each received WebRender request.
-    lock_channel: (
-        WebGLSender<OutputHandlerData>,
-        WebGLReceiver<OutputHandlerData>,
-    ),
-    sync_objects: FnvHashMap<webrender_api::PipelineId, gl::GLsync>,
+enum OutputHandler {
+    OffThread {
+        webrender_gl: Rc<dyn gl::Gl>,
+        webgl_channel: WebGLSender<WebGLMsg>,
+        // Used to avoid creating a new channel on each received WebRender request.
+        lock_channel: (
+            WebGLSender<OutputHandlerData>,
+            WebGLReceiver<OutputHandlerData>,
+        ),
+        sync_objects: FnvHashMap<webrender_api::PipelineId, gl::GLsync>,
+    },
+    MainThread,
 }
 
 impl OutputHandler {
-    fn new(webrender_gl: Rc<dyn gl::Gl>, channel: WebGLSender<WebGLMsg>) -> Self {
-        Self {
+    fn new_off_thread(webrender_gl: Rc<dyn gl::Gl>, channel: WebGLSender<WebGLMsg>) -> Self {
+        OutputHandler::OffThread {
             webrender_gl,
             webgl_channel: channel,
             lock_channel: webgl_channel().unwrap(),
             sync_objects: Default::default(),
         }
+    }
+
+    fn new_main_thread() -> Self {
+        OutputHandler::MainThread
     }
 }
 
@@ -160,29 +222,49 @@ impl webrender::OutputImageHandler for OutputHandler {
         &mut self,
         id: webrender_api::PipelineId,
     ) -> Option<(u32, webrender_api::units::FramebufferIntSize)> {
-        // Insert a fence in the WR command queue
-        let gl_sync = self
-            .webrender_gl
-            .fence_sync(gl::SYNC_GPU_COMMANDS_COMPLETE, 0);
-        // The lock command adds a WaitSync call on the WebGL command flow.
-        let command = DOMToTextureCommand::Lock(id, gl_sync as usize, self.lock_channel.0.clone());
-        self.webgl_channel
-            .send(WebGLMsg::DOMToTextureCommand(command))
-            .unwrap();
-        self.lock_channel.1.recv().unwrap().map(|(tex_id, size)| {
-            (
-                tex_id,
-                webrender_api::units::FramebufferIntSize::new(size.width, size.height),
-            )
-        })
+        match *self {
+            OutputHandler::OffThread {
+                ref webrender_gl,
+                ref lock_channel,
+                ref webgl_channel,
+                ..
+            } => {
+                // Insert a fence in the WR command queue
+                let gl_sync = webrender_gl.fence_sync(gl::SYNC_GPU_COMMANDS_COMPLETE, 0);
+                // The lock command adds a WaitSync call on the WebGL command flow.
+                let command =
+                    DOMToTextureCommand::Lock(id, gl_sync as usize, lock_channel.0.clone());
+                webgl_channel
+                    .send(WebGLMsg::DOMToTextureCommand(command))
+                    .unwrap();
+                lock_channel.1.recv().unwrap().map(|(tex_id, size)| {
+                    (
+                        tex_id,
+                        webrender_api::units::FramebufferIntSize::new(size.width, size.height),
+                    )
+                })
+            },
+
+            OutputHandler::MainThread => unimplemented!(),
+        }
     }
 
     fn unlock(&mut self, id: webrender_api::PipelineId) {
-        if let Some(gl_sync) = self.sync_objects.remove(&id) {
-            // Flush the Sync object into the GPU's command queue to guarantee that it it's signaled.
-            self.webrender_gl.flush();
-            // Mark the sync object for deletion.
-            self.webrender_gl.delete_sync(gl_sync);
+        match *self {
+            OutputHandler::OffThread {
+                ref webrender_gl,
+                ref mut sync_objects,
+                ..
+            } => {
+                if let Some(gl_sync) = sync_objects.remove(&id) {
+                    // Flush the Sync object into the GPU's command queue to guarantee that it it's signaled.
+                    webrender_gl.flush();
+                    // Mark the sync object for deletion.
+                    webrender_gl.delete_sync(gl_sync);
+                }
+            },
+
+            OutputHandler::MainThread => {},
         }
     }
 }

--- a/components/canvas/webgl_mode/mod.rs
+++ b/components/canvas/webgl_mode/mod.rs
@@ -3,4 +3,4 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 mod inprocess;
-pub use self::inprocess::WebGLThreads;
+pub use self::inprocess::{ThreadMode, WebGLThreads};

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -5,6 +5,7 @@
 use super::gl_context::{map_attrs_to_script_attrs, GLContextFactory, GLContextWrapper};
 use byteorder::{ByteOrder, NativeEndian, WriteBytesExt};
 use canvas_traits::webgl::*;
+use embedder_traits::EventLoopWaker;
 use euclid::default::Size2D;
 use fnv::FnvHashMap;
 use gleam::gl;
@@ -13,13 +14,17 @@ use ipc_channel::ipc::IpcSender;
 use offscreen_gl_context::{DrawBuffer, GLContext, NativeGLContextMethods};
 use pixels::{self, PixelFormat};
 use std::borrow::Cow;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::mem;
+use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use webrender_traits::{WebrenderExternalImageRegistry, WebrenderImageHandlerType};
 
 /// WebGL Threading API entry point that lives in the constellation.
 /// It allows to get a WebGLThread handle for each script pipeline.
-pub use crate::webgl_mode::WebGLThreads;
+pub use crate::webgl_mode::{ThreadMode, WebGLThreads};
 
 struct GLContextData {
     ctx: GLContextWrapper,
@@ -50,7 +55,7 @@ impl Default for GLState {
 
 /// A WebGLThread manages the life cycle and message multiplexing of
 /// a set of WebGLContexts living in the same thread.
-pub struct WebGLThread<VR: WebVRRenderHandler + 'static> {
+pub(crate) struct WebGLThread {
     /// Factory used to create a new GLContext shared with the WR/Main thread.
     gl_factory: GLContextFactory,
     /// Channel used to generate/update or delete `webrender_api::ImageKey`s.
@@ -62,20 +67,74 @@ pub struct WebGLThread<VR: WebVRRenderHandler + 'static> {
     /// Current bound context.
     bound_context_id: Option<WebGLContextId>,
     /// Handler user to send WebVR commands.
-    webvr_compositor: Option<VR>,
+    webvr_compositor: Option<Box<dyn WebVRRenderHandler>>,
     /// Texture ids and sizes used in DOM to texture outputs.
     dom_outputs: FnvHashMap<webrender_api::PipelineId, DOMToTextureData>,
     /// List of registered webrender external images.
     /// We use it to get an unique ID for new WebGLContexts.
     external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
+    /// The receiver that will be used for processing WebGL messages.
+    receiver: WebGLReceiver<WebGLMsg>,
+    /// The receiver that should be used to send WebGL messages for processing.
+    sender: WebGLSender<WebGLMsg>,
 }
 
-impl<VR: WebVRRenderHandler + 'static> WebGLThread<VR> {
-    pub fn new(
-        gl_factory: GLContextFactory,
-        webrender_api_sender: webrender_api::RenderApiSender,
-        webvr_compositor: Option<VR>,
-        external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
+/// A map of GL contexts to backing textures and their sizes.
+/// Only used for accessing this information when the WebGL processing is run
+/// on the main thread and the compositor needs access to this information
+/// synchronously.
+pub(crate) type TexturesMap = Rc<RefCell<HashMap<WebGLContextId, (u32, Size2D<i32>)>>>;
+
+#[derive(PartialEq)]
+enum EventLoop {
+    Blocking,
+    Nonblocking,
+}
+
+/// The data required to initialize an instance of the WebGLThread type.
+pub(crate) struct WebGLThreadInit {
+    pub gl_factory: GLContextFactory,
+    pub webrender_api_sender: webrender_api::RenderApiSender,
+    pub webvr_compositor: Option<Box<dyn WebVRRenderHandler>>,
+    pub external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
+    pub sender: WebGLSender<WebGLMsg>,
+    pub receiver: WebGLReceiver<WebGLMsg>,
+}
+
+/// The extra data required to run an instance of WebGLThread when it is
+/// not running in its own thread.
+pub struct WebGLMainThread {
+    thread_data: WebGLThread,
+    shut_down: bool,
+    textures: TexturesMap,
+}
+
+impl WebGLMainThread {
+    /// Synchronously process all outstanding WebGL messages.
+    pub fn process(&mut self) {
+        if self.shut_down {
+            return;
+        }
+
+        // Any context could be current when we start.
+        self.thread_data.bound_context_id = None;
+        self.shut_down = !self
+            .thread_data
+            .process(EventLoop::Nonblocking, Some(self.textures.clone()))
+    }
+}
+
+impl WebGLThread {
+    /// Create a new instance of WebGLThread.
+    pub(crate) fn new(
+        WebGLThreadInit {
+            gl_factory,
+            webrender_api_sender,
+            webvr_compositor,
+            external_images,
+            sender,
+            receiver,
+        }: WebGLThreadInit,
     ) -> Self {
         WebGLThread {
             gl_factory,
@@ -86,49 +145,83 @@ impl<VR: WebVRRenderHandler + 'static> WebGLThread<VR> {
             webvr_compositor,
             dom_outputs: Default::default(),
             external_images,
+            sender,
+            receiver,
         }
     }
 
-    /// Creates a new `WebGLThread` and returns a Sender to
-    /// communicate with it.
-    pub fn start(
-        gl_factory: GLContextFactory,
-        webrender_api_sender: webrender_api::RenderApiSender,
-        webvr_compositor: Option<VR>,
-        external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
-    ) -> WebGLSender<WebGLMsg> {
-        let (sender, receiver) = webgl_channel::<WebGLMsg>().unwrap();
-        let result = sender.clone();
+    /// Perform all initialization required to run an instance of WebGLThread
+    /// concurrently on the current thread. Returns a `WebGLMainThread` instance
+    /// that can be used to process any outstanding WebGL messages at any given
+    /// point in time.
+    pub(crate) fn run_on_current_thread(
+        mut init: WebGLThreadInit,
+        event_loop_waker: Box<dyn EventLoopWaker>,
+        textures: TexturesMap,
+    ) -> WebGLMainThread {
+        // Interpose a new channel in between the existing WebGL channel endpoints.
+        // This will bounce all WebGL messages through a second thread adding a small
+        // delay, but this will also ensure that the main thread will wake up and
+        // process the WebGL message when it arrives.
+        let (from_router_sender, from_router_receiver) = webgl_channel::<WebGLMsg>().unwrap();
+        let receiver = mem::replace(&mut init.receiver, from_router_receiver);
+
+        let thread_data = WebGLThread::new(init);
+
         thread::Builder::new()
-            .name("WebGLThread".to_owned())
+            .name("WebGL main thread pump".to_owned())
             .spawn(move || {
-                let mut renderer = WebGLThread::new(
-                    gl_factory,
-                    webrender_api_sender,
-                    webvr_compositor,
-                    external_images,
-                );
-                let webgl_chan = WebGLChan(sender);
-                loop {
-                    let msg = receiver.recv().unwrap();
-                    let exit = renderer.handle_msg(msg, &webgl_chan);
-                    if exit {
-                        return;
-                    }
+                while let Ok(msg) = receiver.recv() {
+                    let _ = from_router_sender.send(msg);
+                    event_loop_waker.wake();
                 }
             })
             .expect("Thread spawning failed");
 
-        result
+        WebGLMainThread {
+            thread_data,
+            textures,
+            shut_down: false,
+        }
+    }
+
+    /// Perform all initialization required to run an instance of WebGLThread
+    /// in parallel on its own dedicated thread.
+    pub(crate) fn run_on_own_thread(init: WebGLThreadInit) {
+        thread::Builder::new()
+            .name("WebGL thread".to_owned())
+            .spawn(move || {
+                let mut data = WebGLThread::new(init);
+                data.process(EventLoop::Blocking, None);
+            })
+            .expect("Thread spawning failed");
+    }
+
+    fn process(&mut self, loop_type: EventLoop, textures: Option<TexturesMap>) -> bool {
+        let webgl_chan = WebGLChan(self.sender.clone());
+        while let Ok(msg) = match loop_type {
+            EventLoop::Blocking => self.receiver.recv(),
+            EventLoop::Nonblocking => self.receiver.try_recv(),
+        } {
+            let exit = self.handle_msg(msg, &webgl_chan, textures.as_ref());
+            if exit {
+                return false;
+            }
+        }
+        true
     }
 
     /// Handles a generic WebGLMsg message
-    #[inline]
-    fn handle_msg(&mut self, msg: WebGLMsg, webgl_chan: &WebGLChan) -> bool {
+    fn handle_msg(
+        &mut self,
+        msg: WebGLMsg,
+        webgl_chan: &WebGLChan,
+        textures: Option<&TexturesMap>,
+    ) -> bool {
         trace!("processing {:?}", msg);
         match msg {
             WebGLMsg::CreateContext(version, size, attributes, result_sender) => {
-                let result = self.create_webgl_context(version, size, attributes);
+                let result = self.create_webgl_context(version, size, attributes, textures);
                 result_sender
                     .send(result.map(|(id, limits, share_mode)| {
                         let data = Self::make_current_if_needed(
@@ -173,10 +266,10 @@ impl<VR: WebVRRenderHandler + 'static> WebGLThread<VR> {
                     .unwrap();
             },
             WebGLMsg::ResizeContext(ctx_id, size, sender) => {
-                self.resize_webgl_context(ctx_id, size, sender);
+                self.resize_webgl_context(ctx_id, size, sender, textures);
             },
             WebGLMsg::RemoveContext(ctx_id) => {
-                self.remove_webgl_context(ctx_id);
+                self.remove_webgl_context(ctx_id, textures);
             },
             WebGLMsg::WebGLCommand(ctx_id, command, backtrace) => {
                 self.handle_webgl_command(ctx_id, command, backtrace);
@@ -296,6 +389,7 @@ impl<VR: WebVRRenderHandler + 'static> WebGLThread<VR> {
         version: WebGLVersion,
         size: Size2D<u32>,
         attributes: GLContextAttributes,
+        textures: Option<&TexturesMap>,
     ) -> Result<(WebGLContextId, GLLimits, WebGLContextShareMode), String> {
         // Creating a new GLContext may make the current bound context_id dirty.
         // Clear it to ensure that  make_current() is called in subsequent commands.
@@ -332,6 +426,11 @@ impl<VR: WebVRRenderHandler + 'static> WebGLThread<VR> {
                 state: Default::default(),
             },
         );
+
+        if let Some(ref textures) = textures {
+            textures.borrow_mut().insert(id, (texture_id, size));
+        }
+
         self.cached_context_info.insert(
             id,
             WebGLContextInfo {
@@ -354,6 +453,7 @@ impl<VR: WebVRRenderHandler + 'static> WebGLThread<VR> {
         context_id: WebGLContextId,
         size: Size2D<u32>,
         sender: WebGLSender<Result<(), String>>,
+        textures: Option<&TexturesMap>,
     ) {
         let data = Self::make_current_if_needed_mut(
             context_id,
@@ -378,6 +478,13 @@ impl<VR: WebVRRenderHandler + 'static> WebGLThread<VR> {
                 // Update webgl texture size. Texture id may change too.
                 info.texture_id = texture_id;
                 info.size = real_size;
+
+                if let Some(ref textures) = textures {
+                    textures
+                        .borrow_mut()
+                        .insert(context_id, (texture_id, real_size));
+                }
+
                 // Update WR image if needed. Resize image updates are only required for SharedTexture mode.
                 // Readback mode already updates the image every frame to send the raw pixels.
                 // See `handle_update_wr_image`.
@@ -403,7 +510,7 @@ impl<VR: WebVRRenderHandler + 'static> WebGLThread<VR> {
     }
 
     /// Removes a WebGLContext and releases attached resources.
-    fn remove_webgl_context(&mut self, context_id: WebGLContextId) {
+    fn remove_webgl_context(&mut self, context_id: WebGLContextId, textures: Option<&TexturesMap>) {
         // Release webrender image keys.
         if let Some(info) = self.cached_context_info.remove(&context_id) {
             let mut txn = webrender_api::Transaction::new();
@@ -421,6 +528,10 @@ impl<VR: WebVRRenderHandler + 'static> WebGLThread<VR> {
 
         // Release GL context.
         self.contexts.remove(&context_id);
+
+        if let Some(ref textures) = textures {
+            textures.borrow_mut().remove(&context_id);
+        }
 
         // Removing a GLContext may make the current bound context_id dirty.
         self.bound_context_id = None;
@@ -729,12 +840,12 @@ impl<VR: WebVRRenderHandler + 'static> WebGLThread<VR> {
     }
 }
 
-impl<VR: WebVRRenderHandler + 'static> Drop for WebGLThread<VR> {
+impl Drop for WebGLThread {
     fn drop(&mut self) {
         // Call remove_context functions in order to correctly delete WebRender image keys.
         let context_ids: Vec<WebGLContextId> = self.contexts.keys().map(|id| *id).collect();
         for id in context_ids {
-            self.remove_webgl_context(id);
+            self.remove_webgl_context(id, None);
         }
     }
 }

--- a/components/canvas_traits/webgl_channel/mod.rs
+++ b/components/canvas_traits/webgl_channel/mod.rs
@@ -71,6 +71,13 @@ where
             WebGLReceiver::Mpsc(ref receiver) => receiver.recv().map_err(|_| ()),
         }
     }
+
+    pub fn try_recv(&self) -> Result<T, ()> {
+        match *self {
+            WebGLReceiver::Ipc(ref receiver) => receiver.try_recv().map_err(|_| ()),
+            WebGLReceiver::Mpsc(ref receiver) => receiver.try_recv().map_err(|_| ()),
+        }
+    }
 }
 
 pub fn webgl_channel<T>() -> Result<(WebGLSender<T>, WebGLReceiver<T>), ()>

--- a/components/canvas_traits/webgl_channel/mpsc.rs
+++ b/components/canvas_traits/webgl_channel/mpsc.rs
@@ -47,6 +47,10 @@ impl<T> WebGLReceiver<T> {
     pub fn recv(&self) -> Result<T, mpsc::RecvError> {
         self.0.recv()
     }
+    #[inline]
+    pub fn try_recv(&self) -> Result<T, mpsc::TryRecvError> {
+        self.0.try_recv()
+    }
 }
 
 pub fn webgl_channel<T>() -> Result<(WebGLSender<T>, WebGLReceiver<T>), ()> {

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -54,6 +54,7 @@ use canvas_traits::webgl::{WebGLShaderId, WebGLTextureId, WebGLVersion, WebGLVer
 use crossbeam_channel::{Receiver, Sender};
 use cssparser::RGBA;
 use devtools_traits::{CSSError, TimelineMarkerType, WorkerId};
+use embedder_traits::EventLoopWaker;
 use encoding_rs::{Decoder, Encoding};
 use euclid::default::{Point2D, Rect, Rotation3D, Transform2D, Transform3D};
 use euclid::Length as EuclidLength;
@@ -146,7 +147,7 @@ pub unsafe trait JSTraceable {
     unsafe fn trace(&self, trc: *mut JSTracer);
 }
 
-unsafe_no_jsmanaged_fields!(Box<dyn TaskBox>);
+unsafe_no_jsmanaged_fields!(Box<dyn TaskBox>, Box<dyn EventLoopWaker>);
 
 unsafe_no_jsmanaged_fields!(CSSError);
 

--- a/components/script/dom/vrdisplay.rs
+++ b/components/script/dom/vrdisplay.rs
@@ -32,11 +32,11 @@ use crate::dom::vreyeparameters::VREyeParameters;
 use crate::dom::vrframedata::VRFrameData;
 use crate::dom::vrpose::VRPose;
 use crate::dom::vrstageparameters::VRStageParameters;
-use crate::dom::webglrenderingcontext::WebGLRenderingContext;
+use crate::dom::webglrenderingcontext::{WebGLMessageSender, WebGLRenderingContext};
 use crate::script_runtime::CommonScriptMsg;
 use crate::script_runtime::ScriptThreadEventCategory::WebVREvent;
 use crate::task_source::{TaskSource, TaskSourceName};
-use canvas_traits::webgl::{webgl_channel, WebGLMsgSender, WebGLReceiver, WebVRCommand};
+use canvas_traits::webgl::{webgl_channel, WebGLReceiver, WebVRCommand};
 use crossbeam_channel::{unbounded, Sender};
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
@@ -102,7 +102,7 @@ struct VRRAFUpdate {
     depth_near: f64,
     depth_far: f64,
     /// WebGL API sender
-    api_sender: Option<WebGLMsgSender>,
+    api_sender: Option<WebGLMessageSender>,
     /// Number uniquely identifying the WebGL context
     /// so that we may setup/tear down VR compositors as things change
     context_id: usize,
@@ -583,7 +583,7 @@ impl VRDisplay {
             .fire(self.global().upcast::<EventTarget>());
     }
 
-    fn api_sender(&self) -> Option<WebGLMsgSender> {
+    fn api_sender(&self) -> Option<WebGLMessageSender> {
         self.layer_ctx.get().map(|c| c.webgl_sender())
     }
 

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -24,7 +24,7 @@ use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::WebGLPipeline;
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, WorkerId};
-use embedder_traits::Cursor;
+use embedder_traits::{Cursor, EventLoopWaker};
 use euclid::{
     default::{Point2D, Rect},
     Length, Scale, Size2D, Vector2D,
@@ -666,6 +666,8 @@ pub struct InitialScriptState {
     pub layout_is_busy: Arc<AtomicBool>,
     /// Application window's GL Context for Media player
     pub player_context: WindowGLContext,
+    /// Mechanism to force the compositor to process events.
+    pub event_loop_waker: Option<Box<dyn EventLoopWaker>>,
 }
 
 /// This trait allows creating a `ScriptThread` without depending on the `script`

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -60,9 +60,9 @@ layout_thread_2020 = {path = "../layout_thread_2020", optional = true}
 log = "0.4"
 media = {path = "../media"}
 msg = {path = "../msg"}
-offscreen_gl_context = "0.23"
 net = {path = "../net"}
 net_traits = {path = "../net_traits"}
+offscreen_gl_context = "0.23"
 profile = {path = "../profile"}
 profile_traits = {path = "../profile_traits"}
 script = {path = "../script"}

--- a/etc/ci/buildbot_steps.yml
+++ b/etc/ci/buildbot_steps.yml
@@ -52,6 +52,8 @@ linux-rel-css:
     - ./mach build --release --with-debug-assertions -p servo
     - ./mach test-wpt --release --processes 24 --total-chunks 2 --this-chunk 2 --log-raw test-wpt.log --log-errorsummary wpt-errorsummary.log --always-succeed
     - ./mach filter-intermittents wpt-errorsummary.log --log-intermittents intermittents.log --log-filteredsummary filtered-wpt-errorsummary.log --tracker-api default --reporter-api default
+    - env SERVO_WEBGL_MAIN_THREAD=1 ./mach test-wpt --release --processes 24 --log-raw test-wpt-webgl.log --log-errorsummary webgl-errorsummary.log --always-succeed tests/wpt/webgl/tests/conformance
+    - ./mach filter-intermittents webgl-errorsummary.log --log-intermittents webgl-intermittents.log --log-filteredsummary filtered-webgl-errorsummary.log --tracker-api default --reporter-api default
     - bash ./etc/ci/lockfile_changed.sh
     - ./etc/ci/clean_build_artifacts.sh
 

--- a/ports/glutin/events_loop.rs
+++ b/ports/glutin/events_loop.rs
@@ -7,27 +7,36 @@
 
 use glutin;
 use servo::embedder_traits::EventLoopWaker;
-use std::sync::Arc;
+use std::sync::{Arc, Condvar, Mutex};
 use std::rc::Rc;
 use std::cell::RefCell;
-use std::thread;
 use std::time;
 
-pub struct EventsLoop(Option<glutin::EventsLoop>);
+#[allow(dead_code)]
+enum EventLoop {
+    /// A real Glutin windowing event loop.
+    Glutin(Option<glutin::EventsLoop>),
+    /// A fake event loop which contains a signalling flag used to ensure
+    /// that pending events get processed in a timely fashion, and a condition
+    /// variable to allow waiting on that flag changing state.
+    Headless(Arc<(Mutex<bool>, Condvar)>),
+}
+
+pub struct EventsLoop(EventLoop);
 
 impl EventsLoop {
     // Ideally, we could use the winit event loop in both modes,
     // but on Linux, the event loop requires a X11 server.
     #[cfg(not(target_os = "linux"))]
     pub fn new(_headless: bool) -> Rc<RefCell<EventsLoop>> {
-        Rc::new(RefCell::new(EventsLoop(Some(glutin::EventsLoop::new()))))
+        Rc::new(RefCell::new(EventsLoop(EventLoop::Glutin(Some(glutin::EventsLoop::new())))))
     }
     #[cfg(target_os = "linux")]
     pub fn new(headless: bool) -> Rc<RefCell<EventsLoop>> {
         let events_loop = if headless {
-            None
+            EventLoop::Headless(Arc::new((Mutex::new(false), Condvar::new())))
         } else {
-            Some(glutin::EventsLoop::new())
+            EventLoop::Glutin(Some(glutin::EventsLoop::new()))
         };
         Rc::new(RefCell::new(EventsLoop(events_loop)))
     }
@@ -35,39 +44,79 @@ impl EventsLoop {
 
 impl EventsLoop {
     pub fn create_event_loop_waker(&self) -> Box<dyn EventLoopWaker> {
-        if let Some(ref events_loop) = self.0 {
-            Box::new(HeadedEventLoopWaker::new(&events_loop))
-        } else {
-            Box::new(HeadlessEventLoopWaker)
+        match self.0 {
+            EventLoop::Glutin(ref events_loop) => {
+                let events_loop = events_loop
+                    .as_ref()
+                    .expect("Can't create waker for unavailable event loop.");
+                Box::new(HeadedEventLoopWaker::new(&events_loop))
+            },
+            EventLoop::Headless(ref data) =>
+                Box::new(HeadlessEventLoopWaker(data.clone())),
         }
     }
     pub fn as_winit(&self) -> &glutin::EventsLoop {
-        &self.0.as_ref().expect("Can't access winit event loop while using the fake headless event loop")
+        match self.0 {
+            EventLoop::Glutin(Some(ref event_loop)) => event_loop,
+            EventLoop::Glutin(None) | EventLoop::Headless(..) =>
+                panic!("Can't access winit event loop while using the fake headless event loop"),
+        }
     }
     pub fn take(&mut self) -> Option<glutin::EventsLoop> {
-        self.0.take()
+        match self.0 {
+            EventLoop::Glutin(ref mut event_loop) => event_loop.take(),
+            EventLoop::Headless(..) => None,
+        }
     }
     pub fn poll_events<F>(&mut self, callback: F) where F: FnMut(glutin::Event) {
-        if let Some(ref mut events_loop) = self.0 {
-            events_loop.poll_events(callback);
-        } else {
-            self.sleep();
+        match self.0 {
+            EventLoop::Glutin(Some(ref mut events_loop)) => events_loop.poll_events(callback),
+            EventLoop::Glutin(None) => (),
+            EventLoop::Headless(ref data) => {
+                // This is subtle - the use of the event loop in App::run_loop
+                // optionally calls run_forever, then always calls poll_events.
+                // If our signalling flag is true before we call run_forever,
+                // we don't want to reset it before poll_events is called or
+                // we'll end up sleeping even though there are events waiting
+                // to be handled. We compromise by only resetting the flag here
+                // in poll_events, so that both poll_events and run_forever can
+                // check it first and avoid sleeping unnecessarily.
+                self.sleep(&data.0, &data.1);
+                *data.0.lock().unwrap() = false;
+            }
         }
     }
     pub fn run_forever<F>(&mut self, mut callback: F) where F: FnMut(glutin::Event) -> glutin::ControlFlow {
-        if let Some(ref mut events_loop) = self.0 {
-            events_loop.run_forever(callback);
-        } else {
-            loop {
-                self.sleep();
-                if callback(glutin::Event::Awakened) == glutin::ControlFlow::Break {
-                    break;
+        match self.0 {
+            EventLoop::Glutin(ref mut events_loop) => {
+                let events_loop = events_loop
+                    .as_mut()
+                    .expect("Can't run an unavailable event loop.");
+                events_loop.run_forever(callback);
+            }
+            EventLoop::Headless(ref data) => {
+                let &(ref flag, ref condvar) = &**data;
+                while { !*flag.lock().unwrap() } {
+                    self.sleep(flag, condvar);
+                    if callback(glutin::Event::Awakened) == glutin::ControlFlow::Break {
+                        break;
+                    }
                 }
             }
         }
     }
-    fn sleep(&self) {
-        thread::sleep(time::Duration::from_millis(5));
+    fn sleep(&self, lock: &Mutex<bool>, condvar: &Condvar) {
+        // To avoid sleeping when we should be processing events, do two things:
+        // * before sleeping, check whether our signalling flag has been set
+        // * wait on a condition variable with a maximum timeout, to allow
+        //   being woken up by any signals that occur while sleeping.
+        let guard = lock.lock().unwrap();
+        if *guard {
+            return;
+        }
+        let _ = condvar.wait_timeout(
+            guard, time::Duration::from_millis(5)
+        ).unwrap();
     }
 }
 
@@ -94,8 +143,19 @@ impl EventLoopWaker for HeadedEventLoopWaker {
     }
 }
 
-struct HeadlessEventLoopWaker;
+struct HeadlessEventLoopWaker(Arc<(Mutex<bool>, Condvar)>);
 impl EventLoopWaker for HeadlessEventLoopWaker {
-    fn wake(&self) {}
-    fn clone_box(&self) -> Box<dyn EventLoopWaker> { Box::new(HeadlessEventLoopWaker) }
+    fn wake(&self) {
+        // Set the signalling flag and notify the condition variable.
+        // This ensures that any sleep operation is interrupted,
+        // and any non-sleeping operation will have a change to check
+        // the flag before going to sleep.
+        let (ref flag, ref condvar) = *self.0;
+        let mut flag = flag.lock().unwrap();
+        *flag = true;
+        condvar.notify_all();
+    }
+    fn clone_box(&self) -> Box<dyn EventLoopWaker> {
+        Box::new(HeadlessEventLoopWaker(self.0.clone()))
+    }
 }

--- a/ports/glutin/headless_window.rs
+++ b/ports/glutin/headless_window.rs
@@ -17,6 +17,8 @@ use servo::webrender_api::units::{DeviceIntRect, DeviceIntSize};
 use servo_media::player::context as MediaPlayerCtxt;
 use std::cell::Cell;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
+use std::cell::RefCell;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::ffi::CString;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use std::mem;
@@ -28,8 +30,8 @@ use std::rc::Rc;
 struct HeadlessContext {
     width: u32,
     height: u32,
-    _context: osmesa_sys::OSMesaContext,
-    _buffer: Vec<u32>,
+    context: osmesa_sys::OSMesaContext,
+    buffer: RefCell<Vec<u32>>,
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
@@ -57,24 +59,11 @@ impl HeadlessContext {
 
         assert!(!context.is_null());
 
-        let mut buffer = vec![0; (width * height) as usize];
-
-        unsafe {
-            let ret = osmesa_sys::OSMesaMakeCurrent(
-                context,
-                buffer.as_mut_ptr() as *mut _,
-                gl::UNSIGNED_BYTE,
-                width as i32,
-                height as i32,
-            );
-            assert_ne!(ret, 0);
-        };
-
         HeadlessContext {
             width: width,
             height: height,
-            _context: context,
-            _buffer: buffer,
+            context: context,
+            buffer: RefCell::new(vec![0; (width * height) as usize]),
         }
     }
 
@@ -196,7 +185,23 @@ impl WindowMethods for Window {
         self.animation_state.set(state);
     }
 
-    fn prepare_for_composite(&self) { }
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn prepare_for_composite(&self) {
+        unsafe {
+            let mut buffer = self.context.buffer.borrow_mut();
+            let ret = osmesa_sys::OSMesaMakeCurrent(
+                self.context.context,
+                buffer.as_mut_ptr() as *mut _,
+                gl::UNSIGNED_BYTE,
+                self.context.width as i32,
+                self.context.height as i32,
+            );
+            assert_ne!(ret, 0);
+        };
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    fn prepare_for_composite(&self) {}
 
     fn get_gl_context(&self) -> MediaPlayerCtxt::GlContext {
         MediaPlayerCtxt::GlContext::Unknown

--- a/ports/glutin/headless_window.rs
+++ b/ports/glutin/headless_window.rs
@@ -51,7 +51,7 @@ impl HeadlessContext {
         attribs.push(3);
         attribs.push(0);
 
-        let share = share.map_or(ptr::null_mut(), |share| share._context as *mut _);
+        let share = share.map_or(ptr::null_mut(), |share| share.context as *mut _);
 
         let context = unsafe { osmesa_sys::OSMesaCreateContextAttribs(attribs.as_ptr(), share) };
 

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -251,7 +251,9 @@ impl ServoGlue {
         debug!("perform_updates");
         let events = mem::replace(&mut self.events, Vec::new());
         self.servo.handle_events(events);
-        self.handle_servo_events()
+        let r = self.handle_servo_events();
+        debug!("done perform_updates");
+        r
     }
 
     /// In batch mode, Servo won't call perform_updates automatically.
@@ -628,7 +630,7 @@ impl WindowMethods for ServoWindowCallbacks {
     }
 
     fn set_animation_state(&self, state: AnimationState) {
-        debug!("WindowMethods::set_animation_state");
+        debug!("WindowMethods::set_animation_state: {:?}", state);
         self.host_callbacks
             .on_animating_changed(state == AnimationState::Animating);
     }

--- a/tests/wpt/webgl/meta/MANIFEST.json
+++ b/tests/wpt/webgl/meta/MANIFEST.json
@@ -10622,7 +10622,9 @@
    "conformance/context/context-creation-and-destruction.html": [
     [
      "conformance/context/context-creation-and-destruction.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/context/context-creation.html": [
@@ -10672,7 +10674,9 @@
    "conformance/context/context-release-with-workers.html": [
     [
      "conformance/context/context-release-with-workers.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/context/context-size-change.html": [
@@ -11208,7 +11212,9 @@
    "conformance/glsl/bugs/temp-expressions-should-not-crash.html": [
     [
      "conformance/glsl/bugs/temp-expressions-should-not-crash.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/glsl/bugs/unary-minus-operator-float-bug.html": [
@@ -12392,7 +12398,9 @@
    "conformance/glsl/misc/shader-with-non-reserved-words.html": [
     [
      "conformance/glsl/misc/shader-with-non-reserved-words.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/glsl/misc/shader-with-precision.frag.html": [
@@ -13298,7 +13306,9 @@
    "conformance/ogles/GL/abs/abs_001_to_006.html": [
     [
      "conformance/ogles/GL/abs/abs_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/acos/acos_001_to_006.html": [
@@ -13312,19 +13322,25 @@
    "conformance/ogles/GL/all/all_001_to_004.html": [
     [
      "conformance/ogles/GL/all/all_001_to_004.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/any/any_001_to_004.html": [
     [
      "conformance/ogles/GL/any/any_001_to_004.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/array/array_001_to_006.html": [
     [
      "conformance/ogles/GL/array/array_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/asin/asin_001_to_006.html": [
@@ -13338,439 +13354,585 @@
    "conformance/ogles/GL/atan/atan_001_to_008.html": [
     [
      "conformance/ogles/GL/atan/atan_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/atan/atan_009_to_012.html": [
     [
      "conformance/ogles/GL/atan/atan_009_to_012.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/biConstants/biConstants_001_to_008.html": [
     [
      "conformance/ogles/GL/biConstants/biConstants_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/biConstants/biConstants_009_to_016.html": [
     [
      "conformance/ogles/GL/biConstants/biConstants_009_to_016.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html": [
     [
      "conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_001_to_008.html": [
     [
      "conformance/ogles/GL/build/build_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_009_to_016.html": [
     [
      "conformance/ogles/GL/build/build_009_to_016.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_017_to_024.html": [
     [
      "conformance/ogles/GL/build/build_017_to_024.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_025_to_032.html": [
     [
      "conformance/ogles/GL/build/build_025_to_032.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_033_to_040.html": [
     [
      "conformance/ogles/GL/build/build_033_to_040.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_041_to_048.html": [
     [
      "conformance/ogles/GL/build/build_041_to_048.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_049_to_056.html": [
     [
      "conformance/ogles/GL/build/build_049_to_056.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_057_to_064.html": [
     [
      "conformance/ogles/GL/build/build_057_to_064.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_065_to_072.html": [
     [
      "conformance/ogles/GL/build/build_065_to_072.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_073_to_080.html": [
     [
      "conformance/ogles/GL/build/build_073_to_080.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_081_to_088.html": [
     [
      "conformance/ogles/GL/build/build_081_to_088.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_089_to_096.html": [
     [
      "conformance/ogles/GL/build/build_089_to_096.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_097_to_104.html": [
     [
      "conformance/ogles/GL/build/build_097_to_104.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_105_to_112.html": [
     [
      "conformance/ogles/GL/build/build_105_to_112.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_113_to_120.html": [
     [
      "conformance/ogles/GL/build/build_113_to_120.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_121_to_128.html": [
     [
      "conformance/ogles/GL/build/build_121_to_128.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_129_to_136.html": [
     [
      "conformance/ogles/GL/build/build_129_to_136.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_137_to_144.html": [
     [
      "conformance/ogles/GL/build/build_137_to_144.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_145_to_152.html": [
     [
      "conformance/ogles/GL/build/build_145_to_152.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_153_to_160.html": [
     [
      "conformance/ogles/GL/build/build_153_to_160.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_161_to_168.html": [
     [
      "conformance/ogles/GL/build/build_161_to_168.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_169_to_176.html": [
     [
      "conformance/ogles/GL/build/build_169_to_176.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/build/build_177_to_178.html": [
     [
      "conformance/ogles/GL/build/build_177_to_178.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/built_in_varying_array_out_of_bounds/built_in_varying_array_out_of_bounds_001_to_001.html": [
     [
      "conformance/ogles/GL/built_in_varying_array_out_of_bounds/built_in_varying_array_out_of_bounds_001_to_001.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/ceil/ceil_001_to_006.html": [
     [
      "conformance/ogles/GL/ceil/ceil_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/clamp/clamp_001_to_006.html": [
     [
      "conformance/ogles/GL/clamp/clamp_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/control_flow/control_flow_001_to_008.html": [
     [
      "conformance/ogles/GL/control_flow/control_flow_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/control_flow/control_flow_009_to_010.html": [
     [
      "conformance/ogles/GL/control_flow/control_flow_009_to_010.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/cos/cos_001_to_006.html": [
     [
      "conformance/ogles/GL/cos/cos_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/cross/cross_001_to_002.html": [
     [
      "conformance/ogles/GL/cross/cross_001_to_002.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/default/default_001_to_001.html": [
     [
      "conformance/ogles/GL/default/default_001_to_001.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/degrees/degrees_001_to_006.html": [
     [
      "conformance/ogles/GL/degrees/degrees_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/discard/discard_001_to_002.html": [
     [
      "conformance/ogles/GL/discard/discard_001_to_002.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/distance/distance_001_to_006.html": [
     [
      "conformance/ogles/GL/distance/distance_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/dot/dot_001_to_006.html": [
     [
      "conformance/ogles/GL/dot/dot_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/equal/equal_001_to_008.html": [
     [
      "conformance/ogles/GL/equal/equal_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/equal/equal_009_to_012.html": [
     [
      "conformance/ogles/GL/equal/equal_009_to_012.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/exp/exp_001_to_008.html": [
     [
      "conformance/ogles/GL/exp/exp_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/exp/exp_009_to_012.html": [
     [
      "conformance/ogles/GL/exp/exp_009_to_012.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/exp2/exp2_001_to_008.html": [
     [
      "conformance/ogles/GL/exp2/exp2_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/exp2/exp2_009_to_012.html": [
     [
      "conformance/ogles/GL/exp2/exp2_009_to_012.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/faceforward/faceforward_001_to_006.html": [
     [
      "conformance/ogles/GL/faceforward/faceforward_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/floor/floor_001_to_006.html": [
     [
      "conformance/ogles/GL/floor/floor_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/fract/fract_001_to_006.html": [
     [
      "conformance/ogles/GL/fract/fract_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_001_to_008.html": [
     [
      "conformance/ogles/GL/functions/functions_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_009_to_016.html": [
     [
      "conformance/ogles/GL/functions/functions_009_to_016.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_017_to_024.html": [
     [
      "conformance/ogles/GL/functions/functions_017_to_024.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_025_to_032.html": [
     [
      "conformance/ogles/GL/functions/functions_025_to_032.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_033_to_040.html": [
     [
      "conformance/ogles/GL/functions/functions_033_to_040.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_041_to_048.html": [
     [
      "conformance/ogles/GL/functions/functions_041_to_048.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_049_to_056.html": [
     [
      "conformance/ogles/GL/functions/functions_049_to_056.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_057_to_064.html": [
     [
      "conformance/ogles/GL/functions/functions_057_to_064.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_065_to_072.html": [
     [
      "conformance/ogles/GL/functions/functions_065_to_072.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_073_to_080.html": [
     [
      "conformance/ogles/GL/functions/functions_073_to_080.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_081_to_088.html": [
     [
      "conformance/ogles/GL/functions/functions_081_to_088.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_089_to_096.html": [
     [
      "conformance/ogles/GL/functions/functions_089_to_096.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_097_to_104.html": [
     [
      "conformance/ogles/GL/functions/functions_097_to_104.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_105_to_112.html": [
     [
      "conformance/ogles/GL/functions/functions_105_to_112.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_113_to_120.html": [
     [
      "conformance/ogles/GL/functions/functions_113_to_120.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/functions/functions_121_to_126.html": [
     [
      "conformance/ogles/GL/functions/functions_121_to_126.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/gl_FragCoord/gl_FragCoord_001_to_003.html": [
     [
      "conformance/ogles/GL/gl_FragCoord/gl_FragCoord_001_to_003.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/gl_FrontFacing/gl_FrontFacing_001_to_001.html": [
     [
      "conformance/ogles/GL/gl_FrontFacing/gl_FrontFacing_001_to_001.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/greaterThan/greaterThan_001_to_008.html": [
     [
      "conformance/ogles/GL/greaterThan/greaterThan_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/greaterThanEqual/greaterThanEqual_001_to_008.html": [
     [
      "conformance/ogles/GL/greaterThanEqual/greaterThanEqual_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/inversesqrt/inversesqrt_001_to_006.html": [
     [
      "conformance/ogles/GL/inversesqrt/inversesqrt_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/length/length_001_to_006.html": [
     [
      "conformance/ogles/GL/length/length_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/lessThan/lessThan_001_to_008.html": [
     [
      "conformance/ogles/GL/lessThan/lessThan_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/lessThanEqual/lessThanEqual_001_to_008.html": [
     [
      "conformance/ogles/GL/lessThanEqual/lessThanEqual_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/log/log_001_to_008.html": [
@@ -13784,7 +13946,9 @@
    "conformance/ogles/GL/log/log_009_to_012.html": [
     [
      "conformance/ogles/GL/log/log_009_to_012.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/log2/log2_001_to_008.html": [
@@ -13798,355 +13962,473 @@
    "conformance/ogles/GL/log2/log2_009_to_012.html": [
     [
      "conformance/ogles/GL/log2/log2_009_to_012.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/mat/mat_001_to_008.html": [
     [
      "conformance/ogles/GL/mat/mat_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/mat/mat_009_to_016.html": [
     [
      "conformance/ogles/GL/mat/mat_009_to_016.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/mat/mat_017_to_024.html": [
     [
      "conformance/ogles/GL/mat/mat_017_to_024.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/mat/mat_025_to_032.html": [
     [
      "conformance/ogles/GL/mat/mat_025_to_032.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/mat/mat_033_to_040.html": [
     [
      "conformance/ogles/GL/mat/mat_033_to_040.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/mat/mat_041_to_046.html": [
     [
      "conformance/ogles/GL/mat/mat_041_to_046.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/mat3/mat3_001_to_006.html": [
     [
      "conformance/ogles/GL/mat3/mat3_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/matrixCompMult/matrixCompMult_001_to_004.html": [
     [
      "conformance/ogles/GL/matrixCompMult/matrixCompMult_001_to_004.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/max/max_001_to_006.html": [
     [
      "conformance/ogles/GL/max/max_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/min/min_001_to_006.html": [
     [
      "conformance/ogles/GL/min/min_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/mix/mix_001_to_006.html": [
     [
      "conformance/ogles/GL/mix/mix_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/mod/mod_001_to_008.html": [
     [
      "conformance/ogles/GL/mod/mod_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/normalize/normalize_001_to_006.html": [
     [
      "conformance/ogles/GL/normalize/normalize_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/not/not_001_to_004.html": [
     [
      "conformance/ogles/GL/not/not_001_to_004.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/notEqual/notEqual_001_to_008.html": [
     [
      "conformance/ogles/GL/notEqual/notEqual_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/notEqual/notEqual_009_to_012.html": [
     [
      "conformance/ogles/GL/notEqual/notEqual_009_to_012.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/operators/operators_001_to_008.html": [
     [
      "conformance/ogles/GL/operators/operators_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/operators/operators_009_to_016.html": [
     [
      "conformance/ogles/GL/operators/operators_009_to_016.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/operators/operators_017_to_024.html": [
     [
      "conformance/ogles/GL/operators/operators_017_to_024.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/operators/operators_025_to_026.html": [
     [
      "conformance/ogles/GL/operators/operators_025_to_026.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/pow/pow_001_to_008.html": [
     [
      "conformance/ogles/GL/pow/pow_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/pow/pow_009_to_016.html": [
     [
      "conformance/ogles/GL/pow/pow_009_to_016.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/pow/pow_017_to_024.html": [
     [
      "conformance/ogles/GL/pow/pow_017_to_024.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/radians/radians_001_to_006.html": [
     [
      "conformance/ogles/GL/radians/radians_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/reflect/reflect_001_to_006.html": [
     [
      "conformance/ogles/GL/reflect/reflect_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/refract/refract_001_to_006.html": [
     [
      "conformance/ogles/GL/refract/refract_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/sign/sign_001_to_006.html": [
     [
      "conformance/ogles/GL/sign/sign_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/sin/sin_001_to_006.html": [
     [
      "conformance/ogles/GL/sin/sin_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/smoothstep/smoothstep_001_to_006.html": [
     [
      "conformance/ogles/GL/smoothstep/smoothstep_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/sqrt/sqrt_001_to_006.html": [
     [
      "conformance/ogles/GL/sqrt/sqrt_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/step/step_001_to_006.html": [
     [
      "conformance/ogles/GL/step/step_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/struct/struct_001_to_008.html": [
     [
      "conformance/ogles/GL/struct/struct_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/struct/struct_009_to_016.html": [
     [
      "conformance/ogles/GL/struct/struct_009_to_016.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/struct/struct_017_to_024.html": [
     [
      "conformance/ogles/GL/struct/struct_017_to_024.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/struct/struct_025_to_032.html": [
     [
      "conformance/ogles/GL/struct/struct_025_to_032.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/struct/struct_033_to_040.html": [
     [
      "conformance/ogles/GL/struct/struct_033_to_040.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/struct/struct_041_to_048.html": [
     [
      "conformance/ogles/GL/struct/struct_041_to_048.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/struct/struct_049_to_056.html": [
     [
      "conformance/ogles/GL/struct/struct_049_to_056.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_001_to_008.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_009_to_016.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_009_to_016.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_017_to_024.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_017_to_024.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_025_to_032.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_025_to_032.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_033_to_040.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_033_to_040.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_041_to_048.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_041_to_048.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_049_to_056.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_049_to_056.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_057_to_064.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_057_to_064.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_065_to_072.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_065_to_072.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_073_to_080.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_073_to_080.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_081_to_088.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_081_to_088.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_089_to_096.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_089_to_096.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_097_to_104.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_097_to_104.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_105_to_112.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_105_to_112.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/swizzlers/swizzlers_113_to_120.html": [
     [
      "conformance/ogles/GL/swizzlers/swizzlers_113_to_120.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/tan/tan_001_to_006.html": [
     [
      "conformance/ogles/GL/tan/tan_001_to_006.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/vec/vec_001_to_008.html": [
     [
      "conformance/ogles/GL/vec/vec_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/vec/vec_009_to_016.html": [
     [
      "conformance/ogles/GL/vec/vec_009_to_016.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/vec/vec_017_to_018.html": [
     [
      "conformance/ogles/GL/vec/vec_017_to_018.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/ogles/GL/vec3/vec3_001_to_008.html": [
     [
      "conformance/ogles/GL/vec3/vec3_001_to_008.html",
-     {}
+     {
+      "timeout": "long"
+     }
     ]
    ],
    "conformance/programs/get-active-test.html": [
@@ -27627,7 +27909,7 @@
    "testharness"
   ],
   "conformance/context/context-creation-and-destruction.html": [
-   "a3912fcf7eaaf2992ec4a82de0c7262d929b035d",
+   "3ad7a02d79cfbae4b9d7b6f6ee16cdc5d1a829dd",
    "testharness"
   ],
   "conformance/context/context-creation.html": [
@@ -27659,7 +27941,7 @@
    "testharness"
   ],
   "conformance/context/context-release-with-workers.html": [
-   "74127d165d37b9d8f030ade68e802dc19580d513",
+   "8610525b0fe4985b52dd065ca28a8f29c6a578a2",
    "testharness"
   ],
   "conformance/context/context-size-change.html": [
@@ -28043,7 +28325,7 @@
    "testharness"
   ],
   "conformance/glsl/bugs/temp-expressions-should-not-crash.html": [
-   "535739ff7b10b5c6632c1628b45e2c983ee2bf3a",
+   "30a734c642071ebf5232c2a46ea98a1a79b2581b",
    "testharness"
   ],
   "conformance/glsl/bugs/unary-minus-operator-float-bug.html": [
@@ -28859,7 +29141,7 @@
    "testharness"
   ],
   "conformance/glsl/misc/shader-with-non-reserved-words.html": [
-   "6aee7c6eba6745a65c8944d4399d2629084704e8",
+   "29d891e0d11799b6e2adb12eaf979c0083b37c8b",
    "testharness"
   ],
   "conformance/glsl/misc/shader-with-precision.frag.html": [
@@ -29575,7 +29857,7 @@
    "support"
   ],
   "conformance/ogles/GL/abs/abs_001_to_006.html": [
-   "5c2ae1d05b35d49850bda3a012ba0d4479444f9e",
+   "2af0dd4b9c53fc3be5044bb7d88c7b3775b8d16f",
    "testharness"
   ],
   "conformance/ogles/GL/abs/abs_float_frag_xvary.frag": [
@@ -29687,7 +29969,7 @@
    "support"
   ],
   "conformance/ogles/GL/all/all_001_to_004.html": [
-   "226d9c0825b719250492c99f2f4a5f49be283cae",
+   "a00461f8bac17fc190b1c1093fc3c7f45934223a",
    "testharness"
   ],
   "conformance/ogles/GL/all/all_bvec2_frag.frag": [
@@ -29727,7 +30009,7 @@
    "support"
   ],
   "conformance/ogles/GL/any/any_001_to_004.html": [
-   "53bd5a86adbd47b1cce8d5b9730b42f90d00ff86",
+   "780b3b54329bb3bfe17bad5e6d28b3f3c2931925",
    "testharness"
   ],
   "conformance/ogles/GL/any/any_bvec2_frag.frag": [
@@ -29767,7 +30049,7 @@
    "support"
   ],
   "conformance/ogles/GL/array/array_001_to_006.html": [
-   "acb3839137ab3e1ff06df66faa8121e67d5af95f",
+   "21a550687805083985d85ce0a6f3f3264027c244",
    "testharness"
   ],
   "conformance/ogles/GL/array/empty_empty_array_float_frag.frag": [
@@ -29855,11 +30137,11 @@
    "support"
   ],
   "conformance/ogles/GL/atan/atan_001_to_008.html": [
-   "96811c9a934c581364d4257cbd1e9ab1bfbf24dc",
+   "207db792c33f1cdc196c2d973e28a6277559d678",
    "testharness"
   ],
   "conformance/ogles/GL/atan/atan_009_to_012.html": [
-   "f82f4fc8c6ce4490c0e468eb72250e0229407db8",
+   "2d74d0cc759dcebb77547529b382a293f7df920f",
    "testharness"
   ],
   "conformance/ogles/GL/atan/atan_float_frag_xvary.frag": [
@@ -29963,11 +30245,11 @@
    "support"
   ],
   "conformance/ogles/GL/biConstants/biConstants_001_to_008.html": [
-   "362ca8f55393979dbd19a4e438282659bbf87ece",
+   "65706aa293513da08184f11b685646bf74081096",
    "testharness"
   ],
   "conformance/ogles/GL/biConstants/biConstants_009_to_016.html": [
-   "5409dda25a7eeac74c83923afcea0fddcb48c3ea",
+   "510748658222736691509b2fa7e032d0700fe183",
    "testharness"
   ],
   "conformance/ogles/GL/biConstants/gl_MaxCombinedTextureImageUnits_frag.frag": [
@@ -30047,7 +30329,7 @@
    "support"
   ],
   "conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html": [
-   "d968a2a825b7495a0d39e2a920fb4cbb67554778",
+   "45d0523982e0ca9b0fbe5907359a12a1de718a0e",
    "testharness"
   ],
   "conformance/ogles/GL/biuDepthRange/input.run.txt": [
@@ -30279,95 +30561,95 @@
    "support"
   ],
   "conformance/ogles/GL/build/build_001_to_008.html": [
-   "1883b6a8145507e6fa1ee698698ae086893cf7ba",
+   "c0c33c424a73161475dd6ea88bd391416cf03caa",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_009_to_016.html": [
-   "4afb29be74193935adf200f94215739ce5347f63",
+   "496fdb332ff74e54cc9261ba0593f369cc54a888",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_017_to_024.html": [
-   "10b3d6636ccd00feffc8069685934b2ae4b866d8",
+   "48d22fd4ce1762ab707a031a949c044dfa43f82f",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_025_to_032.html": [
-   "8ee6bdee381325c4a4c96d981ec38a02dd62cfca",
+   "bce572cd24138f5c56d0e9efc169053fb2b581e1",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_033_to_040.html": [
-   "6667f89bb3548fd087b324a40d48dae808733bd4",
+   "91c0ea47de5b857279d1967984d64b9646b04c15",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_041_to_048.html": [
-   "ac62a696181fb397cea3c7d0d6ea198237b4141b",
+   "28d3221fee311fa7ba50a6b63d1308905f4022cc",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_049_to_056.html": [
-   "62358b0c6e4fb4af837064dee8982521e9077613",
+   "be3df66d129262853322fb90704903c42b089193",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_057_to_064.html": [
-   "f194ecf17bec163b152db661b0ee1f475244c9f3",
+   "aa7b633b9f6852a9a21415268d02453f3966d9f9",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_065_to_072.html": [
-   "16372f8862a063c36cb5eaf2097f3afa4006063d",
+   "1d68894b990680ac8ed1f49756562a45cd9e5f3b",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_073_to_080.html": [
-   "0259cae9292446f9cbce9801b96177bec26ce4a6",
+   "58328dba2afd9cff0afbc2f96cf9f1a49a610db1",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_081_to_088.html": [
-   "ce86db8586e8589a141d4e49aea5e62df15c0673",
+   "e02ad3dbe457e9e233f5f4a53a218bd09fafea53",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_089_to_096.html": [
-   "23561488613f7b555b204bb8bd50a0a979a73232",
+   "db801551e64620cf015becbb25c335d58d78fada",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_097_to_104.html": [
-   "2a4f2abcea515533375c73ef4f263b5100cbe3a4",
+   "7b555c682ea258e5543e1771475837cfc86b0058",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_105_to_112.html": [
-   "cd5dabddc62377f33a58ac13379582219079fcf7",
+   "b0f3958ac4d560f8a152734167c7f6a0f2af5ccb",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_113_to_120.html": [
-   "a93b6e6eade0b8057291315c58842c158a44d188",
+   "e6aa88e08fca5cfcc35bb3b391ff136e674abaaf",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_121_to_128.html": [
-   "f13e0656d8b627e7b39fc1695aadfc0aba8b1d32",
+   "cbc49130c181cf68e6cee82353c9bb5bdbb05247",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_129_to_136.html": [
-   "34eaa4352af6821771e3ad4b6249d653de1fe4ed",
+   "c3ec7500d6f24794f3d3b168fd907eb4ca163780",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_137_to_144.html": [
-   "acb4502de59fb63ea492380fa66deab68db06990",
+   "8f1275fe0d0cd87335ba2e368353af2d0965b9a2",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_145_to_152.html": [
-   "ff3ea37f3b7c6565aab729a32bb860157b480ecf",
+   "e77616897e5e203525c90953a5db5a124058361e",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_153_to_160.html": [
-   "844e548a47f021574d358923c933432d9e16989a",
+   "467590650d78c7eab0848b45cbfd3a26f2d38a10",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_161_to_168.html": [
-   "3bbcddaadcd7434132c45958bd52aae6eabb0b89",
+   "ec7a9bb05c31921b008abc8612692d61f53c1d52",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_169_to_176.html": [
-   "f00fa582c6753f5c7f12741dc380cdfdea62065b",
+   "406cab463cb7ca3554c60346318b41cfd082d746",
    "testharness"
   ],
   "conformance/ogles/GL/build/build_177_to_178.html": [
-   "a2406d8ed5b50766f18f4cac0c87eafed6acc15e",
+   "7c0a718ad0616a87c066c448582b55a09224f52f",
    "testharness"
   ],
   "conformance/ogles/GL/build/comma1_vert.vert": [
@@ -30871,7 +31153,7 @@
    "support"
   ],
   "conformance/ogles/GL/built_in_varying_array_out_of_bounds/built_in_varying_array_out_of_bounds_001_to_001.html": [
-   "e6542bfe8d64d97143dac4ca44f11a17ce24f3d0",
+   "d5a93f05ff53eec0941585a1acd68fa68ddcca36",
    "testharness"
   ],
   "conformance/ogles/GL/built_in_varying_array_out_of_bounds/gl_Color_array_index_out_of_bounds_frag.frag": [
@@ -30883,7 +31165,7 @@
    "support"
   ],
   "conformance/ogles/GL/ceil/ceil_001_to_006.html": [
-   "c8b3a25732f9482e08d2ca899a6edbb152b248b7",
+   "9068d26a5d99e0a7e2b02cdb2e4938de1b3edc59",
    "testharness"
   ],
   "conformance/ogles/GL/ceil/ceil_float_frag_xvary.frag": [
@@ -30939,7 +31221,7 @@
    "support"
   ],
   "conformance/ogles/GL/clamp/clamp_001_to_006.html": [
-   "9abe66de09bb106117665e1668e7e220f73487ad",
+   "8cdaad9e20ac77599088369fbe904e9f917f4202",
    "testharness"
   ],
   "conformance/ogles/GL/clamp/clamp_float_frag_xvary_yconstquarter.frag": [
@@ -30995,11 +31277,11 @@
    "support"
   ],
   "conformance/ogles/GL/control_flow/control_flow_001_to_008.html": [
-   "76f9859b88e911b79c648b41bbdca1a28687ba90",
+   "2b5e39031a3f27626ccd8aa15baa6e9d0475bd44",
    "testharness"
   ],
   "conformance/ogles/GL/control_flow/control_flow_009_to_010.html": [
-   "3845a8d9fd587c8becd9d21c7163a12ffa8be736",
+   "018843b589f162e73b0bf169e65249a4baecdc28",
    "testharness"
   ],
   "conformance/ogles/GL/control_flow/for_break_frag.frag": [
@@ -31047,7 +31329,7 @@
    "support"
   ],
   "conformance/ogles/GL/cos/cos_001_to_006.html": [
-   "6da1573843700749bc5da3845dcbcacb39ea1fe9",
+   "fc6b6fd42d5a8655cc83389bcdfb615f41097ab0",
    "testharness"
   ],
   "conformance/ogles/GL/cos/cos_float_frag_xvary.frag": [
@@ -31103,7 +31385,7 @@
    "support"
   ],
   "conformance/ogles/GL/cross/cross_001_to_002.html": [
-   "c0c5bc44c566a9b96da4cec6d1713b014fe21de4",
+   "6b45928307e5e49615cacf5792c13b28c00bd3f1",
    "testharness"
   ],
   "conformance/ogles/GL/cross/cross_vec3_frag_xvaryyconst.frag": [
@@ -31135,7 +31417,7 @@
    "support"
   ],
   "conformance/ogles/GL/default/default_001_to_001.html": [
-   "1a9e6c32143e9469ab30e5af5221c884b0f6219b",
+   "9f2456cfcb25abb666003fdb301dedc32051cdb4",
    "testharness"
   ],
   "conformance/ogles/GL/default/default_textured.frag": [
@@ -31155,7 +31437,7 @@
    "support"
   ],
   "conformance/ogles/GL/degrees/degrees_001_to_006.html": [
-   "1e29130a3dc007742914f49e36eee1dbc0d715d4",
+   "6f9c14d119b6b24788e159ef292f83ac66781092",
    "testharness"
   ],
   "conformance/ogles/GL/degrees/degrees_float_frag_xvary.frag": [
@@ -31211,7 +31493,7 @@
    "support"
   ],
   "conformance/ogles/GL/discard/discard_001_to_002.html": [
-   "0efbe81fb4950589e5e430d89039778b245e794c",
+   "bda9a2d99acdb993793853750671df8e10f18534",
    "testharness"
   ],
   "conformance/ogles/GL/discard/discard_cond_frag.frag": [
@@ -31231,7 +31513,7 @@
    "support"
   ],
   "conformance/ogles/GL/distance/distance_001_to_006.html": [
-   "7ad48ff83b81c7e8a1101c40eb7e1269d57b7f39",
+   "39441600eb1c4eb499d5c23b762dcdfcf6f5ced8",
    "testharness"
   ],
   "conformance/ogles/GL/distance/distance_float_frag_xvaryyhalf.frag": [
@@ -31287,7 +31569,7 @@
    "support"
   ],
   "conformance/ogles/GL/dot/dot_001_to_006.html": [
-   "35af74a12af3c91d57061ff920c7eff96cd36bca",
+   "a75839bf2973009d2ed575d52b2f479dde4c573d",
    "testharness"
   ],
   "conformance/ogles/GL/dot/dot_float_frag_xvaryyone.frag": [
@@ -31343,11 +31625,11 @@
    "support"
   ],
   "conformance/ogles/GL/equal/equal_001_to_008.html": [
-   "4266061afe90e0847db3a6003f7e8549f05443b0",
+   "5b63f08e78c1de60c3508ec9e5ea3f850982d849",
    "testharness"
   ],
   "conformance/ogles/GL/equal/equal_009_to_012.html": [
-   "f5af33c3dba71f4b5f2ab5889540b273f4fdcba8",
+   "e32f98986978cd4a4d5bfd8bf34344afa232a694",
    "testharness"
   ],
   "conformance/ogles/GL/equal/equal_bvec2_frag.frag": [
@@ -31451,11 +31733,11 @@
    "support"
   ],
   "conformance/ogles/GL/exp/exp_001_to_008.html": [
-   "a0ce6c06418e15a1da50701c95db6569f49f4533",
+   "497dc16a87f0f76a6ddc635f44fd476c690b0e1e",
    "testharness"
   ],
   "conformance/ogles/GL/exp/exp_009_to_012.html": [
-   "ddf15b619a126cff7e19550b5536e219133de8c5",
+   "ea46abd3e3682a7afad8d65821b7feea7b193d6a",
    "testharness"
   ],
   "conformance/ogles/GL/exp/exp_float_frag_xvary.frag": [
@@ -31559,11 +31841,11 @@
    "support"
   ],
   "conformance/ogles/GL/exp2/exp2_001_to_008.html": [
-   "7b64d838de89cda134ef3c4e4db56804f17d7d48",
+   "a07d1e5743d1e5c66f06a04de4afebfb2429861e",
    "testharness"
   ],
   "conformance/ogles/GL/exp2/exp2_009_to_012.html": [
-   "2b29d52bd01e750547f56d364fb01f4cce37ebf3",
+   "c771195266dfbd55687c5d7ba578b3b648f3cadf",
    "testharness"
   ],
   "conformance/ogles/GL/exp2/exp2_float_frag_xvary.frag": [
@@ -31667,7 +31949,7 @@
    "support"
   ],
   "conformance/ogles/GL/faceforward/faceforward_001_to_006.html": [
-   "c70334794cc606821ea7244dc7b7a198f5555c47",
+   "c9eb36114237e463a9bc6e58b6a7e637838cff4c",
    "testharness"
   ],
   "conformance/ogles/GL/faceforward/faceforward_float_frag_nvaryiconst.frag": [
@@ -31723,7 +32005,7 @@
    "support"
   ],
   "conformance/ogles/GL/floor/floor_001_to_006.html": [
-   "75d2d91675ccbf46e8478b11d4d5fd746482d4c6",
+   "30438dd7fdbedf445d681a0d8d058c31e64576f3",
    "testharness"
   ],
   "conformance/ogles/GL/floor/floor_float_frag_xvary.frag": [
@@ -31779,7 +32061,7 @@
    "support"
   ],
   "conformance/ogles/GL/fract/fract_001_to_006.html": [
-   "0fde847696ae0cfe29938db385e470495170bc86",
+   "fd28dcff493e22ec1515a0892ebda5f284fe3990",
    "testharness"
   ],
   "conformance/ogles/GL/fract/fract_float_frag_xvary.frag": [
@@ -32043,67 +32325,67 @@
    "support"
   ],
   "conformance/ogles/GL/functions/functions_001_to_008.html": [
-   "309e4b491787524e5304a8e13ba2fe183b43f079",
+   "89af11776db98346fa78a6619b5d92e0ebff4866",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_009_to_016.html": [
-   "3a055a2e567daf2700a43efda9407414eef06dce",
+   "dbf4b719e33f6c4b6d96b05522fd9058f47a8973",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_017_to_024.html": [
-   "72e2585af436f23b5fa277803ccccd8b795691f0",
+   "e90105b2d9db173048afdfee2963248bc7f9112c",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_025_to_032.html": [
-   "32a7ef534dfecf7b5f7ef06fae8f83bd15559620",
+   "0a000a8ddf228a526b3474921b4104b8c1fa2464",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_033_to_040.html": [
-   "4a8723664b26b1cc180f4c5f850e7f15d51c0533",
+   "6c89d834f8c88519d077caf163c32b22f23e4218",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_041_to_048.html": [
-   "0d3aee927835181214e450d2ad06ca0cc4bd56e3",
+   "4800ca94daaabc9a0e0e34f76ddae7b0c256867c",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_049_to_056.html": [
-   "4cbdf62fc97f5ba5492b8eb5c23878a6d0d33667",
+   "ea65d15ce4d3acc2312dd6fbba849034b11474f8",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_057_to_064.html": [
-   "2c2545718b72e0d89ec6094028d849936db0a8bd",
+   "62782be16ac3f062da0b0dbd363e2c1b2cd6e306",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_065_to_072.html": [
-   "d01ded0bd32d9757e68d56e93ecde9bf534290dd",
+   "05e9864c9c076bfc699400fb8f2f5d1f36ea6fb8",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_073_to_080.html": [
-   "969754f71efcf7a3138f54b4de6dd73a8b69aeaa",
+   "a871c24f66d3a761b4ecd9dad7b9b3168ec36cea",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_081_to_088.html": [
-   "08c0e1163e4c0639fd083c102199eae1e8f97024",
+   "3142c5cd00b0cd185d8ad7ea7f7dd8a51781b763",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_089_to_096.html": [
-   "35158155869e4a7c89d33a8bf6f300e98eed5769",
+   "2413ca6df9f9a9d6c2191b509d87fe449955fd5b",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_097_to_104.html": [
-   "2d5ef101d9f8db8535222f0fcecc4f5d235e27d8",
+   "ba4e22d67e92c638764e446cddcddc71755cdeb3",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_105_to_112.html": [
-   "7d826450fd458e4925380bc76a482c6d28b4bde3",
+   "c3ce334d457aea471d95bb981e5628cbe6393c69",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_113_to_120.html": [
-   "c97b0c2d4a23d72aa242d99a3d0e7fd946290e01",
+   "fd84f794893fa7b112d551229ed0d2c24ab0a9f4",
    "testharness"
   ],
   "conformance/ogles/GL/functions/functions_121_to_126.html": [
-   "10eaee12a889bc9b5baff5f8c02e55c4007051bb",
+   "7c343c192beb567ef9632da8f294218866cf48a3",
    "testharness"
   ],
   "conformance/ogles/GL/functions/input.run.txt": [
@@ -32407,7 +32689,7 @@
    "support"
   ],
   "conformance/ogles/GL/gl_FragCoord/gl_FragCoord_001_to_003.html": [
-   "674ce26dc7733cae9b568e5bcd87818fcab19dd6",
+   "2fa27d8089f525da3febeebbf4a84493760075bd",
    "testharness"
   ],
   "conformance/ogles/GL/gl_FragCoord/gl_FragCoord_w_frag.frag": [
@@ -32439,7 +32721,7 @@
    "support"
   ],
   "conformance/ogles/GL/gl_FrontFacing/gl_FrontFacing_001_to_001.html": [
-   "ace8b2aa6a0a95fc05464d4ecae5bc52c95699b6",
+   "8abc04d7af826b94a0e29aeb895a729b9836dc30",
    "testharness"
   ],
   "conformance/ogles/GL/gl_FrontFacing/gl_FrontFacing_frag.frag": [
@@ -32451,7 +32733,7 @@
    "support"
   ],
   "conformance/ogles/GL/greaterThan/greaterThan_001_to_008.html": [
-   "7fee4bb8e35621843fc60d783dc4b5400f299632",
+   "db5145078d4b567e752cd1e8118c132f855d824d",
    "testharness"
   ],
   "conformance/ogles/GL/greaterThan/greaterThan_ivec2_frag.frag": [
@@ -32523,7 +32805,7 @@
    "support"
   ],
   "conformance/ogles/GL/greaterThanEqual/greaterThanEqual_001_to_008.html": [
-   "2d854b04380685f139fd9312ffbc27d6a5feea03",
+   "73310f3b6b03f216ab8761fe9e06d02fc3e11c11",
    "testharness"
   ],
   "conformance/ogles/GL/greaterThanEqual/greaterThanEqual_ivec2_frag.frag": [
@@ -32599,7 +32881,7 @@
    "support"
   ],
   "conformance/ogles/GL/inversesqrt/inversesqrt_001_to_006.html": [
-   "c48b075aeb92ad98a7a5c57b728d216d5afdf973",
+   "0b1ed4a6456accf77b3c8a7f0b20cdf58d361034",
    "testharness"
   ],
   "conformance/ogles/GL/inversesqrt/inversesqrt_float_frag_xvary.frag": [
@@ -32655,7 +32937,7 @@
    "support"
   ],
   "conformance/ogles/GL/length/length_001_to_006.html": [
-   "d5848dce1f3fb6b5be7efafc313d7ba6e6a5fb50",
+   "9d67dcc6216bcf303f739892b8d7dff3df01f3e7",
    "testharness"
   ],
   "conformance/ogles/GL/length/length_float_frag_xvary.frag": [
@@ -32711,7 +32993,7 @@
    "support"
   ],
   "conformance/ogles/GL/lessThan/lessThan_001_to_008.html": [
-   "0c4b5d7c87c4904f1f18558f9b12ae016b77f15e",
+   "9f134c35a49cb01b6c0f1e41d7d095b8d6c0264f",
    "testharness"
   ],
   "conformance/ogles/GL/lessThan/lessThan_ivec2_frag.frag": [
@@ -32783,7 +33065,7 @@
    "support"
   ],
   "conformance/ogles/GL/lessThanEqual/lessThanEqual_001_to_008.html": [
-   "aca9d7b94d1c991834718f6db0a23a40093b544c",
+   "9fb90921f87caf581bbb2cf47c3f420b48526884",
    "testharness"
   ],
   "conformance/ogles/GL/lessThanEqual/lessThanEqual_ivec2_frag.frag": [
@@ -32859,7 +33141,7 @@
    "testharness"
   ],
   "conformance/ogles/GL/log/log_009_to_012.html": [
-   "1e362043d8599d16ab6c2bb53793fcc6ecbf405d",
+   "a01d5ae7e959501a2e6323c759b38c0521436259",
    "testharness"
   ],
   "conformance/ogles/GL/log/log_float_frag_xvary.frag": [
@@ -32967,7 +33249,7 @@
    "testharness"
   ],
   "conformance/ogles/GL/log2/log2_009_to_012.html": [
-   "e7abb0ba78fa60b721a8ecee8e3a3a78953292aa",
+   "19cb80b8ea92fe62eb572936256d7c4854b6b2f2",
    "testharness"
   ],
   "conformance/ogles/GL/log2/log2_float_frag_xvary.frag": [
@@ -33255,27 +33537,27 @@
    "support"
   ],
   "conformance/ogles/GL/mat/mat_001_to_008.html": [
-   "2010cbe02ca03422f51860d756255162abdbf05f",
+   "de9093445cff00476b75658317b13a0b714bdf29",
    "testharness"
   ],
   "conformance/ogles/GL/mat/mat_009_to_016.html": [
-   "0d73540a867e21a70dc7387e76b35ca309792d0c",
+   "9e5c894705bc3922349568c477b94e0edfcc64f1",
    "testharness"
   ],
   "conformance/ogles/GL/mat/mat_017_to_024.html": [
-   "2e3a4867655d17af4c369b2b6d21a916a025897a",
+   "d5b52de1bb56d354499f8c73991750a7bb298cef",
    "testharness"
   ],
   "conformance/ogles/GL/mat/mat_025_to_032.html": [
-   "8862968e9acd29a95dac32e7ac1fede0a31925d9",
+   "cfe59573d871d9a3570790fccbfb664a95f4db3e",
    "testharness"
   ],
   "conformance/ogles/GL/mat/mat_033_to_040.html": [
-   "66267c5343d58ff89285cbdb9a425269e037f969",
+   "9f367a24de72e8411b8e116b61b141be0e98d195",
    "testharness"
   ],
   "conformance/ogles/GL/mat/mat_041_to_046.html": [
-   "42616f0bfeef2810b91349ee1c3891d0688b070a",
+   "a38b73e06103bb58f9030ac625855d18da2932ed",
    "testharness"
   ],
   "conformance/ogles/GL/mat3/input.run.txt": [
@@ -33283,7 +33565,7 @@
    "support"
   ],
   "conformance/ogles/GL/mat3/mat3_001_to_006.html": [
-   "60f522593372901b166ef1c52219faad00931d0b",
+   "2600512ff125e76c05f610eb56cca0aecddc5f40",
    "testharness"
   ],
   "conformance/ogles/GL/mat3/mat3arrayindirect0_frag.frag": [
@@ -33315,7 +33597,7 @@
    "support"
   ],
   "conformance/ogles/GL/matrixCompMult/matrixCompMult_001_to_004.html": [
-   "bacbc87b42172d1ed723b0705083ab072b8229e1",
+   "caf777df83ca66972ebe0590f4b37623414e9470",
    "testharness"
   ],
   "conformance/ogles/GL/matrixCompMult/matrixMultComp_mat2_frag.frag": [
@@ -33355,7 +33637,7 @@
    "support"
   ],
   "conformance/ogles/GL/max/max_001_to_006.html": [
-   "8cc3f478f3786bd2062495f5fb8cc34b16395507",
+   "e79f3cced4c8e107ceb04151e1055183cbc8c7fe",
    "testharness"
   ],
   "conformance/ogles/GL/max/max_float_frag_xvary_yconsthalf.frag": [
@@ -33411,7 +33693,7 @@
    "support"
   ],
   "conformance/ogles/GL/min/min_001_to_006.html": [
-   "a9dd90c99e9350e3c7383c519226943cd80ea773",
+   "5d927dd73dc549a2c9059dc2e0d416536d75582e",
    "testharness"
   ],
   "conformance/ogles/GL/min/min_float_frag_xvary_yconsthalf.frag": [
@@ -33467,7 +33749,7 @@
    "support"
   ],
   "conformance/ogles/GL/mix/mix_001_to_006.html": [
-   "abeb8c20e9f2e089cc8f1553676cfa5e6913ecd4",
+   "fbe3846b09179f0431a9602b1fe8e46f27e16188",
    "testharness"
   ],
   "conformance/ogles/GL/mix/mix_float_frag_xvary_yconsthalf_aconsthalf.frag": [
@@ -33523,7 +33805,7 @@
    "support"
   ],
   "conformance/ogles/GL/mod/mod_001_to_008.html": [
-   "dcf5ac2405ee0facdd82d0c756a28209d8226b8a",
+   "833b1774a1ac7f46ff75b3b87913a7d04c377da5",
    "testharness"
   ],
   "conformance/ogles/GL/mod/mod_float_frag_xvary_yconst1.frag": [
@@ -33587,7 +33869,7 @@
    "support"
   ],
   "conformance/ogles/GL/normalize/normalize_001_to_006.html": [
-   "d711520fa49827f609146162b607ff9166372ad6",
+   "dab9e4a21eeb70abcb6019ab9d42aaa2a1a8b4a0",
    "testharness"
   ],
   "conformance/ogles/GL/normalize/normalize_float_frag_xvary.frag": [
@@ -33643,7 +33925,7 @@
    "support"
   ],
   "conformance/ogles/GL/not/not_001_to_004.html": [
-   "2376898aba72785e88ecacbac5b9b240ddff57ea",
+   "a3826ed0bb68755a2e9d8259922d8ae588b5aab5",
    "testharness"
   ],
   "conformance/ogles/GL/not/not_bvec2_frag.frag": [
@@ -33683,11 +33965,11 @@
    "support"
   ],
   "conformance/ogles/GL/notEqual/notEqual_001_to_008.html": [
-   "ea39e3045a1fb80884bb5391f58e13c44c6c92fb",
+   "d023cfd46211b9d1f377a608cfa2a917a6ac93cc",
    "testharness"
   ],
   "conformance/ogles/GL/notEqual/notEqual_009_to_012.html": [
-   "3c2b81ee9d00e16799a8dd41097147c62e01235d",
+   "966fd13c915a97a57b72b6d1209ffb5d38687eb0",
    "testharness"
   ],
   "conformance/ogles/GL/notEqual/notEqual_bvec2_frag.frag": [
@@ -33839,19 +34121,19 @@
    "support"
   ],
   "conformance/ogles/GL/operators/operators_001_to_008.html": [
-   "8e59e71d2d1e09fa15305698fba3c6ecace3f13b",
+   "a90031de6acc1cc3574d9f3d0419cf25498e1b94",
    "testharness"
   ],
   "conformance/ogles/GL/operators/operators_009_to_016.html": [
-   "e19f146b757934ad4de74790eaccace479ef1492",
+   "60692b9a321f3b75a0f7b79a7e11a2e2558d8c5d",
    "testharness"
   ],
   "conformance/ogles/GL/operators/operators_017_to_024.html": [
-   "14da8ea63e8dc5c4aaae5da2ac01a9627a3cf667",
+   "dd6e17de738dea45812049a14d09be79e336f585",
    "testharness"
   ],
   "conformance/ogles/GL/operators/operators_025_to_026.html": [
-   "812f24dc9a36a21edab5240c08a5144d641ae7b9",
+   "97a27906101ba71dda163927c288c91124eb997e",
    "testharness"
   ],
   "conformance/ogles/GL/operators/postfixdecrement_frag.frag": [
@@ -33915,15 +34197,15 @@
    "support"
   ],
   "conformance/ogles/GL/pow/pow_001_to_008.html": [
-   "cfd6e3b4f870587a106c17cdce49021d5a26d907",
+   "b4c6eb3ce5b40a7ad12bc876e8e75d95bd740b7a",
    "testharness"
   ],
   "conformance/ogles/GL/pow/pow_009_to_016.html": [
-   "1ae02f1f31c7c61fe569a9329d7028ae12f18e2c",
+   "22634ccd42c8b6183fcde1fd164baaf95fc33b3a",
    "testharness"
   ],
   "conformance/ogles/GL/pow/pow_017_to_024.html": [
-   "06420c91960788321099f0b986d82fede1b314eb",
+   "eb018051f0b31fe175adc4e7df7972a92f5fe9ca",
    "testharness"
   ],
   "conformance/ogles/GL/pow/pow_float_frag_xconst2_yvary.frag": [
@@ -34123,7 +34405,7 @@
    "support"
   ],
   "conformance/ogles/GL/radians/radians_001_to_006.html": [
-   "3d03c34a79a744aac609a94c2ecb18dda8f2e274",
+   "dbcb357a587804a467938e0c3ec1e6ac3965b89d",
    "testharness"
   ],
   "conformance/ogles/GL/radians/radians_float_frag_xvary.frag": [
@@ -34179,7 +34461,7 @@
    "support"
   ],
   "conformance/ogles/GL/reflect/reflect_001_to_006.html": [
-   "e41fa79800989e6c282a25f18d23385598de322e",
+   "03b6a647e93ee3bd57d6b9b94ad13d6a7af33ac6",
    "testharness"
   ],
   "conformance/ogles/GL/reflect/reflect_float_frag_ivarynconst.frag": [
@@ -34235,7 +34517,7 @@
    "support"
   ],
   "conformance/ogles/GL/refract/refract_001_to_006.html": [
-   "3fdad36dabf06566edfc21a8c67f9fcba3252e0f",
+   "594b82158ebdd3a7d290b16edd72b520296f543c",
    "testharness"
   ],
   "conformance/ogles/GL/refract/refract_float_frag_ivarynconst.frag": [
@@ -34291,7 +34573,7 @@
    "support"
   ],
   "conformance/ogles/GL/sign/sign_001_to_006.html": [
-   "0e4a56dbcd112c72f32a266b58ce4fb545c3d7d8",
+   "86bfd7bbeb14bec1c7f10fe273630ce60f92d1dd",
    "testharness"
   ],
   "conformance/ogles/GL/sign/sign_float_frag_xvary.frag": [
@@ -34347,7 +34629,7 @@
    "support"
   ],
   "conformance/ogles/GL/sin/sin_001_to_006.html": [
-   "ae6a80723b5ed6f78a362418635769820fb36d42",
+   "8ea1a134f2f92252d64607f1bc7f0579679d6c80",
    "testharness"
   ],
   "conformance/ogles/GL/sin/sin_float_frag_xvary.frag": [
@@ -34403,7 +34685,7 @@
    "support"
   ],
   "conformance/ogles/GL/smoothstep/smoothstep_001_to_006.html": [
-   "06731acc3148d5fa52cde73bdd8e5a431d6a47e5",
+   "891835904ba10cc4d9bba87cade96fa0152dab89",
    "testharness"
   ],
   "conformance/ogles/GL/smoothstep/smoothstep_float_frag_xvary_edgeconstquarter.frag": [
@@ -34459,7 +34741,7 @@
    "support"
   ],
   "conformance/ogles/GL/sqrt/sqrt_001_to_006.html": [
-   "ff5fb1cee9905a9cd7786aec45f2fbecad49f332",
+   "bc865852bb53e1dd21b4b9cf391c654aba140cd2",
    "testharness"
   ],
   "conformance/ogles/GL/sqrt/sqrt_float_frag_xvary.frag": [
@@ -34515,7 +34797,7 @@
    "support"
   ],
   "conformance/ogles/GL/step/step_001_to_006.html": [
-   "b2572d445b5314dabda93f09541772ed572ea868",
+   "6125e525a3ec485a5286b174305b09297eefb693",
    "testharness"
   ],
   "conformance/ogles/GL/step/step_float_frag_xvary_edgeconsthalf.frag": [
@@ -34579,31 +34861,31 @@
    "support"
   ],
   "conformance/ogles/GL/struct/struct_001_to_008.html": [
-   "28691b789711b9af05ef20076d12749da7d5bbc2",
+   "0b51124eee9141812edbe9563ace6b02c6ac57d2",
    "testharness"
   ],
   "conformance/ogles/GL/struct/struct_009_to_016.html": [
-   "ce9ea01c22c605197b1160d3256209237da71fae",
+   "85b91c16a1a99eb74b41d70325725838745da015",
    "testharness"
   ],
   "conformance/ogles/GL/struct/struct_017_to_024.html": [
-   "5e64ae4210b703d9647cdae42cbda4d6abfb79cb",
+   "c8608a4b0a3e031767f010f3a0e75a2faf7ea218",
    "testharness"
   ],
   "conformance/ogles/GL/struct/struct_025_to_032.html": [
-   "1cd3af91d66ee57e9af7dcdb1c0dce594c06a5d7",
+   "111e7b51ae6360477b20cf37355a09c1fc2d7e52",
    "testharness"
   ],
   "conformance/ogles/GL/struct/struct_033_to_040.html": [
-   "e81478b8bafdf283b22b5af4c3516b57af7ae0ed",
+   "6fbb77a59bdfb820af604668ed9e43af8f991784",
    "testharness"
   ],
   "conformance/ogles/GL/struct/struct_041_to_048.html": [
-   "8aaa8da8e80bf8d0867b360cb2fbd76ce4eecaef",
+   "1101504a4ef8df6b2587062c1a681fdd322c8f3b",
    "testharness"
   ],
   "conformance/ogles/GL/struct/struct_049_to_056.html": [
-   "831ad2fb3714eddd7415187e5e1afa0a2c6bb11d",
+   "83597ef3f686abe4102f231be27bf7382499ba77",
    "testharness"
   ],
   "conformance/ogles/GL/struct/struct_bool_frag.frag": [
@@ -34827,63 +35109,63 @@
    "support"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_001_to_008.html": [
-   "022d14cab701918476589500ea36804ec92dae7e",
+   "2ad45f6be5a57387c668d97439d48b137d78d0c7",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_009_to_016.html": [
-   "b4894c019ee2d8824e2563438a1a27c30bdc55d1",
+   "f85523127ed70a58edfe5c878892db51417454c9",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_017_to_024.html": [
-   "76e6a9a97e66715e6092af82ecce098569bcf914",
+   "0d692208aa5e1dd2e51beb6faae2d6cfe53a80a5",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_025_to_032.html": [
-   "6a38d1f9e330ba764fe5478ecc14bb660a4f8047",
+   "43f871ca6e41c1a51bc9daff7a4cf0f306c31c83",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_033_to_040.html": [
-   "27b9a25bd09bd21f0f264ea841145ce87df298e3",
+   "fa0e139fa4c122a94d339cd841be3e6f4a593c98",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_041_to_048.html": [
-   "0258666257052969f53bfc4c43bf55400a30c09d",
+   "4153e79b16fd83050e03630806e31114c94430a3",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_049_to_056.html": [
-   "e0953edc174c6f0f3c0befe79e7c3262ab52749f",
+   "d4610d6a6c62072285915373dcea5f03e07b7426",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_057_to_064.html": [
-   "6932dca56936fd85a17ad3b1ddc80b9bc1397995",
+   "ec697a92dbc81f5d595f7e9f1346ad4a7cd579d4",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_065_to_072.html": [
-   "8687c5dbde538322dde378f761247aee7d2a7f98",
+   "04c139c0eac317e44b1a59cf83ff14cacf721597",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_073_to_080.html": [
-   "5df7f6e3bfe574c615befcc5de2dcb10b2801a41",
+   "baafeeee8cce64a8555e3108ea4143e0ee6d77f7",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_081_to_088.html": [
-   "f2705dd6559fe3b354bc9f3e41161d5c3c5e3c16",
+   "a61fcb84974915363e8985aa2574a9fdb19ccbd0",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_089_to_096.html": [
-   "7f4e8ffbd31474d1e7ed94967e5d816ddc13b058",
+   "eab21a8d4733290dcfb8687a0b253c50e2f8ea41",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_097_to_104.html": [
-   "44ad2ab8a82aebb139648cc5050df271730bff33",
+   "1661b5ffe5826b457e745db38acd44b88826ad75",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_105_to_112.html": [
-   "27f01167c4804364bd21cc16f33d90612c67a5c0",
+   "198d434663226f2a760cf3a607b5f98decfdd9a7",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/swizzlers_113_to_120.html": [
-   "23528dea2a74c9cff0c3b99fd6300565d0a626a0",
+   "dcf962e1b32c9d2155e72ab767cb2fa5cfad9a43",
    "testharness"
   ],
   "conformance/ogles/GL/swizzlers/vec3_bgr_1vec3_frag.frag": [
@@ -35371,7 +35653,7 @@
    "support"
   ],
   "conformance/ogles/GL/tan/tan_001_to_006.html": [
-   "0d8b1d70a87f91f54d1f9391283a60d5bd710c35",
+   "60c92f42992b04eb1691d05beee071c743f28d50",
    "testharness"
   ],
   "conformance/ogles/GL/tan/tan_float_frag_xvary.frag": [
@@ -35499,15 +35781,15 @@
    "support"
   ],
   "conformance/ogles/GL/vec/vec_001_to_008.html": [
-   "5f55e7321768b944a13e6979caa0898740c3d821",
+   "6e31e1fa3688d2dfb97bbf94ea711bbd7d973d0c",
    "testharness"
   ],
   "conformance/ogles/GL/vec/vec_009_to_016.html": [
-   "d8573af715c5ec2530babdbd5933ab3fc4276dfe",
+   "cb28ecaeb8485b8b5ec6f116f03304fb5c272c07",
    "testharness"
   ],
   "conformance/ogles/GL/vec/vec_017_to_018.html": [
-   "0b4c05e43092c1989c642c3a3c7c78d43fc6905e",
+   "492bacd604de0941fc931440486a38a83d7d1f5b",
    "testharness"
   ],
   "conformance/ogles/GL/vec3/input.run.txt": [
@@ -35515,7 +35797,7 @@
    "support"
   ],
   "conformance/ogles/GL/vec3/vec3_001_to_008.html": [
-   "b88ba393ff64480bf0e33191c5106c3104111432",
+   "29476159cee4321a1d64fe595284ef65b63f635d",
    "testharness"
   ],
   "conformance/ogles/GL/vec3/vec3array_frag.frag": [

--- a/tests/wpt/webgl/tests/conformance/context/context-creation-and-destruction.html
+++ b/tests/wpt/webgl/tests/conformance/context/context-creation-and-destruction.html
@@ -29,6 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>Test that contexts are freed and garbage collected reasonably</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src=/resources/testharness.js></script>

--- a/tests/wpt/webgl/tests/conformance/context/context-release-with-workers.html
+++ b/tests/wpt/webgl/tests/conformance/context/context-release-with-workers.html
@@ -29,6 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL Context Release Test</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src=/resources/testharness.js></script>

--- a/tests/wpt/webgl/tests/conformance/glsl/bugs/temp-expressions-should-not-crash.html
+++ b/tests/wpt/webgl/tests/conformance/glsl/bugs/temp-expressions-should-not-crash.html
@@ -29,6 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>Driver Bug - temp experssions should not crash</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src=/resources/testharness.js></script>

--- a/tests/wpt/webgl/tests/conformance/glsl/misc/shader-with-non-reserved-words.html
+++ b/tests/wpt/webgl/tests/conformance/glsl/misc/shader-with-non-reserved-words.html
@@ -29,6 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL Conformance Tests - Non Reserved Words</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <link rel="stylesheet" href="../../../resources/glsl-feature-tests.css"/>

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/abs/abs_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/abs/abs_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: abs_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/all/all_001_to_004.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/all/all_001_to_004.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: all_001_to_004.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/any/any_001_to_004.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/any/any_001_to_004.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: any_001_to_004.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/array/array_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/array/array_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: array_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/atan/atan_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/atan/atan_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: atan_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/atan/atan_009_to_012.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/atan/atan_009_to_012.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: atan_009_to_012.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/biConstants/biConstants_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/biConstants/biConstants_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: biConstants_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/biConstants/biConstants_009_to_016.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/biConstants/biConstants_009_to_016.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: biConstants_009_to_016.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: biuDepthRange_001_to_002.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_009_to_016.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_009_to_016.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_009_to_016.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_017_to_024.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_017_to_024.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_017_to_024.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_025_to_032.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_025_to_032.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_025_to_032.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_033_to_040.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_033_to_040.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_033_to_040.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_041_to_048.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_041_to_048.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_041_to_048.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_049_to_056.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_049_to_056.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_049_to_056.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_057_to_064.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_057_to_064.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_057_to_064.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_065_to_072.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_065_to_072.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_065_to_072.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_073_to_080.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_073_to_080.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_073_to_080.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_081_to_088.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_081_to_088.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_081_to_088.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_089_to_096.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_089_to_096.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_089_to_096.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_097_to_104.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_097_to_104.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_097_to_104.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_105_to_112.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_105_to_112.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_105_to_112.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_113_to_120.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_113_to_120.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_113_to_120.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_121_to_128.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_121_to_128.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_121_to_128.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_129_to_136.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_129_to_136.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_129_to_136.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_137_to_144.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_137_to_144.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_137_to_144.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_145_to_152.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_145_to_152.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_145_to_152.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_153_to_160.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_153_to_160.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_153_to_160.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_161_to_168.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_161_to_168.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_161_to_168.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_169_to_176.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_169_to_176.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_169_to_176.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_177_to_178.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/build/build_177_to_178.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: build_177_to_178.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/built_in_varying_array_out_of_bounds/built_in_varying_array_out_of_bounds_001_to_001.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/built_in_varying_array_out_of_bounds/built_in_varying_array_out_of_bounds_001_to_001.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: built_in_varying_array_out_of_bounds_001_to_001.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/ceil/ceil_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/ceil/ceil_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: ceil_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/clamp/clamp_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/clamp/clamp_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: clamp_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/control_flow/control_flow_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/control_flow/control_flow_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: control_flow_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/control_flow/control_flow_009_to_010.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/control_flow/control_flow_009_to_010.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: control_flow_009_to_010.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/cos/cos_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/cos/cos_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: cos_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/cross/cross_001_to_002.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/cross/cross_001_to_002.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: cross_001_to_002.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/default/default_001_to_001.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/default/default_001_to_001.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: default_001_to_001.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/degrees/degrees_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/degrees/degrees_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: degrees_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/discard/discard_001_to_002.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/discard/discard_001_to_002.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: discard_001_to_002.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/distance/distance_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/distance/distance_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: distance_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/dot/dot_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/dot/dot_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: dot_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/equal/equal_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/equal/equal_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: equal_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/equal/equal_009_to_012.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/equal/equal_009_to_012.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: equal_009_to_012.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/exp/exp_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/exp/exp_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: exp_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/exp/exp_009_to_012.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/exp/exp_009_to_012.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: exp_009_to_012.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/exp2/exp2_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/exp2/exp2_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: exp2_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/exp2/exp2_009_to_012.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/exp2/exp2_009_to_012.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: exp2_009_to_012.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/faceforward/faceforward_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/faceforward/faceforward_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: faceforward_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/floor/floor_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/floor/floor_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: floor_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/fract/fract_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/fract/fract_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: fract_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_009_to_016.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_009_to_016.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_009_to_016.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_017_to_024.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_017_to_024.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_017_to_024.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_025_to_032.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_025_to_032.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_025_to_032.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_033_to_040.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_033_to_040.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_033_to_040.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_041_to_048.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_041_to_048.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_041_to_048.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_049_to_056.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_049_to_056.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_049_to_056.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_057_to_064.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_057_to_064.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_057_to_064.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_065_to_072.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_065_to_072.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_065_to_072.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_073_to_080.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_073_to_080.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_073_to_080.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_081_to_088.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_081_to_088.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_081_to_088.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_089_to_096.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_089_to_096.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_089_to_096.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_097_to_104.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_097_to_104.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_097_to_104.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_105_to_112.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_105_to_112.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_105_to_112.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_113_to_120.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_113_to_120.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_113_to_120.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_121_to_126.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/functions/functions_121_to_126.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: functions_121_to_126.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/gl_FragCoord/gl_FragCoord_001_to_003.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/gl_FragCoord/gl_FragCoord_001_to_003.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: gl_FragCoord_001_to_003.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/gl_FrontFacing/gl_FrontFacing_001_to_001.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/gl_FrontFacing/gl_FrontFacing_001_to_001.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: gl_FrontFacing_001_to_001.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/greaterThan/greaterThan_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/greaterThan/greaterThan_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: greaterThan_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/greaterThanEqual/greaterThanEqual_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/greaterThanEqual/greaterThanEqual_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: greaterThanEqual_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/inversesqrt/inversesqrt_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/inversesqrt/inversesqrt_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: inversesqrt_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/length/length_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/length/length_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: length_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/lessThan/lessThan_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/lessThan/lessThan_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: lessThan_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/lessThanEqual/lessThanEqual_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/lessThanEqual/lessThanEqual_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: lessThanEqual_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/log/log_009_to_012.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/log/log_009_to_012.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: log_009_to_012.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/log2/log2_009_to_012.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/log2/log2_009_to_012.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: log2_009_to_012.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/mat/mat_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/mat/mat_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: mat_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/mat/mat_009_to_016.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/mat/mat_009_to_016.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: mat_009_to_016.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/mat/mat_017_to_024.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/mat/mat_017_to_024.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: mat_017_to_024.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/mat/mat_025_to_032.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/mat/mat_025_to_032.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: mat_025_to_032.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/mat/mat_033_to_040.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/mat/mat_033_to_040.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: mat_033_to_040.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/mat/mat_041_to_046.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/mat/mat_041_to_046.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: mat_041_to_046.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/mat3/mat3_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/mat3/mat3_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: mat3_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/matrixCompMult/matrixCompMult_001_to_004.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/matrixCompMult/matrixCompMult_001_to_004.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: matrixCompMult_001_to_004.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/max/max_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/max/max_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: max_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/min/min_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/min/min_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: min_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/mix/mix_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/mix/mix_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: mix_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/mod/mod_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/mod/mod_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: mod_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/normalize/normalize_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/normalize/normalize_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: normalize_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/not/not_001_to_004.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/not/not_001_to_004.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: not_001_to_004.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/notEqual/notEqual_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/notEqual/notEqual_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: notEqual_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/notEqual/notEqual_009_to_012.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/notEqual/notEqual_009_to_012.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: notEqual_009_to_012.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/operators/operators_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/operators/operators_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: operators_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/operators/operators_009_to_016.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/operators/operators_009_to_016.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: operators_009_to_016.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/operators/operators_017_to_024.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/operators/operators_017_to_024.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: operators_017_to_024.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/operators/operators_025_to_026.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/operators/operators_025_to_026.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: operators_025_to_026.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/pow/pow_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/pow/pow_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: pow_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/pow/pow_009_to_016.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/pow/pow_009_to_016.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: pow_009_to_016.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/pow/pow_017_to_024.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/pow/pow_017_to_024.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: pow_017_to_024.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/radians/radians_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/radians/radians_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: radians_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/reflect/reflect_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/reflect/reflect_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: reflect_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/refract/refract_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/refract/refract_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: refract_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/sign/sign_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/sign/sign_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: sign_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/sin/sin_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/sin/sin_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: sin_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/smoothstep/smoothstep_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/smoothstep/smoothstep_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: smoothstep_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/sqrt/sqrt_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/sqrt/sqrt_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: sqrt_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/step/step_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/step/step_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: step_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/struct/struct_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/struct/struct_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: struct_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/struct/struct_009_to_016.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/struct/struct_009_to_016.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: struct_009_to_016.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/struct/struct_017_to_024.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/struct/struct_017_to_024.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: struct_017_to_024.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/struct/struct_025_to_032.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/struct/struct_025_to_032.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: struct_025_to_032.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/struct/struct_033_to_040.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/struct/struct_033_to_040.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: struct_033_to_040.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/struct/struct_041_to_048.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/struct/struct_041_to_048.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: struct_041_to_048.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/struct/struct_049_to_056.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/struct/struct_049_to_056.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: struct_049_to_056.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_009_to_016.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_009_to_016.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_009_to_016.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_017_to_024.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_017_to_024.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_017_to_024.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_025_to_032.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_025_to_032.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_025_to_032.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_033_to_040.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_033_to_040.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_033_to_040.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_041_to_048.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_041_to_048.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_041_to_048.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_049_to_056.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_049_to_056.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_049_to_056.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_057_to_064.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_057_to_064.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_057_to_064.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_065_to_072.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_065_to_072.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_065_to_072.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_073_to_080.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_073_to_080.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_073_to_080.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_081_to_088.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_081_to_088.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_081_to_088.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_089_to_096.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_089_to_096.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_089_to_096.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_097_to_104.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_097_to_104.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_097_to_104.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_105_to_112.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_105_to_112.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_105_to_112.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_113_to_120.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/swizzlers/swizzlers_113_to_120.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: swizzlers_113_to_120.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/tan/tan_001_to_006.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/tan/tan_001_to_006.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: tan_001_to_006.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/vec/vec_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/vec/vec_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: vec_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/vec/vec_009_to_016.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/vec/vec_009_to_016.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: vec_009_to_016.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/vec/vec_017_to_018.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/vec/vec_017_to_018.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: vec_017_to_018.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tests/conformance/ogles/GL/vec3/vec3_001_to_008.html
+++ b/tests/wpt/webgl/tests/conformance/ogles/GL/vec3/vec3_001_to_008.html
@@ -28,6 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>WebGL GLSL conformance test: vec3_001_to_008.html</title>
 <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
 <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />

--- a/tests/wpt/webgl/tools/timeout.patch
+++ b/tests/wpt/webgl/tools/timeout.patch
@@ -104,3 +104,1695 @@ index 28e3cfc562..308e8577a8 100644
  <link rel="stylesheet" href="../../resources/js-test-style.css"/>
  <script src=/resources/testharness.js></script>
  <script src=/resources/testharnessreport.js></script>
+diff --git a/conformance/context/context-creation-and-destruction.html b/conformance/context/context-creation-and-destruction.html
+index a3912fcf7e..3ad7a02d79 100644
+--- a/conformance/context/context-creation-and-destruction.html
++++ b/conformance/context/context-creation-and-destruction.html
+@@ -29,6 +29,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>Test that contexts are freed and garbage collected reasonably</title>
+ <link rel="stylesheet" href="../../resources/js-test-style.css"/>
+ <script src=/resources/testharness.js></script>
+diff --git a/conformance/context/context-release-with-workers.html b/conformance/context/context-release-with-workers.html
+index 74127d165d..8610525b0f 100644
+--- a/conformance/context/context-release-with-workers.html
++++ b/conformance/context/context-release-with-workers.html
+@@ -29,6 +29,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL Context Release Test</title>
+ <link rel="stylesheet" href="../../resources/js-test-style.css"/>
+ <script src=/resources/testharness.js></script>
+diff --git a/conformance/glsl/bugs/temp-expressions-should-not-crash.html b/conformance/glsl/bugs/temp-expressions-should-not-crash.html
+index 535739ff7b..30a734c642 100644
+--- a/conformance/glsl/bugs/temp-expressions-should-not-crash.html
++++ b/conformance/glsl/bugs/temp-expressions-should-not-crash.html
+@@ -29,6 +29,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>Driver Bug - temp experssions should not crash</title>
+ <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+ <script src=/resources/testharness.js></script>
+diff --git a/conformance/glsl/misc/shader-with-non-reserved-words.html b/conformance/glsl/misc/shader-with-non-reserved-words.html
+index 6aee7c6eba..29d891e0d1 100644
+--- a/conformance/glsl/misc/shader-with-non-reserved-words.html
++++ b/conformance/glsl/misc/shader-with-non-reserved-words.html
+@@ -29,6 +29,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL Conformance Tests - Non Reserved Words</title>
+ <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+ <link rel="stylesheet" href="../../../resources/glsl-feature-tests.css"/>
+diff --git a/conformance/ogles/GL/atan/atan_001_to_008.html b/conformance/ogles/GL/atan/atan_001_to_008.html
+index 96811c9a93..207db792c3 100644
+--- a/conformance/ogles/GL/atan/atan_001_to_008.html
++++ b/conformance/ogles/GL/atan/atan_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: atan_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/control_flow/control_flow_001_to_008.html b/conformance/ogles/GL/control_flow/control_flow_001_to_008.html
+index 76f9859b88..2b5e39031a 100644
+--- a/conformance/ogles/GL/control_flow/control_flow_001_to_008.html
++++ b/conformance/ogles/GL/control_flow/control_flow_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: control_flow_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/exp/exp_001_to_008.html b/conformance/ogles/GL/exp/exp_001_to_008.html
+index a0ce6c0641..497dc16a87 100644
+--- a/conformance/ogles/GL/exp/exp_001_to_008.html
++++ b/conformance/ogles/GL/exp/exp_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: exp_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_105_to_112.html b/conformance/ogles/GL/functions/functions_105_to_112.html
+index 7d826450fd..c3ce334d45 100644
+--- a/conformance/ogles/GL/functions/functions_105_to_112.html
++++ b/conformance/ogles/GL/functions/functions_105_to_112.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_105_to_112.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/greaterThan/greaterThan_001_to_008.html b/conformance/ogles/GL/greaterThan/greaterThan_001_to_008.html
+index 7fee4bb8e3..db5145078d 100644
+--- a/conformance/ogles/GL/greaterThan/greaterThan_001_to_008.html
++++ b/conformance/ogles/GL/greaterThan/greaterThan_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: greaterThan_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/lessThanEqual/lessThanEqual_001_to_008.html b/conformance/ogles/GL/lessThanEqual/lessThanEqual_001_to_008.html
+index aca9d7b94d..9fb90921f8 100644
+--- a/conformance/ogles/GL/lessThanEqual/lessThanEqual_001_to_008.html
++++ b/conformance/ogles/GL/lessThanEqual/lessThanEqual_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: lessThanEqual_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/mod/mod_001_to_008.html b/conformance/ogles/GL/mod/mod_001_to_008.html
+index dcf5ac2405..833b1774a1 100644
+--- a/conformance/ogles/GL/mod/mod_001_to_008.html
++++ b/conformance/ogles/GL/mod/mod_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: mod_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/notEqual/notEqual_001_to_008.html b/conformance/ogles/GL/notEqual/notEqual_001_to_008.html
+index ea39e3045a..d023cfd462 100644
+--- a/conformance/ogles/GL/notEqual/notEqual_001_to_008.html
++++ b/conformance/ogles/GL/notEqual/notEqual_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: notEqual_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/pow/pow_009_to_016.html b/conformance/ogles/GL/pow/pow_009_to_016.html
+index 1ae02f1f31..22634ccd42 100644
+--- a/conformance/ogles/GL/pow/pow_009_to_016.html
++++ b/conformance/ogles/GL/pow/pow_009_to_016.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: pow_009_to_016.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/sin/sin_001_to_006.html b/conformance/ogles/GL/sin/sin_001_to_006.html
+index ae6a80723b..8ea1a134f2 100644
+--- a/conformance/ogles/GL/sin/sin_001_to_006.html
++++ b/conformance/ogles/GL/sin/sin_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: sin_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/struct/struct_001_to_008.html b/conformance/ogles/GL/struct/struct_001_to_008.html
+index 28691b7897..0b51124eee 100644
+--- a/conformance/ogles/GL/struct/struct_001_to_008.html
++++ b/conformance/ogles/GL/struct/struct_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: struct_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/clamp/clamp_001_to_006.html b/conformance/ogles/GL/clamp/clamp_001_to_006.html
+index 9abe66de09..8cdaad9e20 100644
+--- a/conformance/ogles/GL/clamp/clamp_001_to_006.html
++++ b/conformance/ogles/GL/clamp/clamp_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: clamp_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_001_to_008.html b/conformance/ogles/GL/functions/functions_001_to_008.html
+index 309e4b4917..89af11776d 100644
+--- a/conformance/ogles/GL/functions/functions_001_to_008.html
++++ b/conformance/ogles/GL/functions/functions_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_009_to_016.html b/conformance/ogles/GL/functions/functions_009_to_016.html
+index 3a055a2e56..dbf4b719e3 100644
+--- a/conformance/ogles/GL/functions/functions_009_to_016.html
++++ b/conformance/ogles/GL/functions/functions_009_to_016.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_009_to_016.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_113_to_120.html b/conformance/ogles/GL/functions/functions_113_to_120.html
+index c97b0c2d4a..fd84f79489 100644
+--- a/conformance/ogles/GL/functions/functions_113_to_120.html
++++ b/conformance/ogles/GL/functions/functions_113_to_120.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_113_to_120.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/reflect/reflect_001_to_006.html b/conformance/ogles/GL/reflect/reflect_001_to_006.html
+index e41fa79800..03b6a647e9 100644
+--- a/conformance/ogles/GL/reflect/reflect_001_to_006.html
++++ b/conformance/ogles/GL/reflect/reflect_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: reflect_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/struct/struct_017_to_024.html b/conformance/ogles/GL/struct/struct_017_to_024.html
+index 5e64ae4210..c8608a4b0a 100644
+--- a/conformance/ogles/GL/struct/struct_017_to_024.html
++++ b/conformance/ogles/GL/struct/struct_017_to_024.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: struct_017_to_024.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_105_to_112.html b/conformance/ogles/GL/swizzlers/swizzlers_105_to_112.html
+index 27f01167c4..198d434663 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_105_to_112.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_105_to_112.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_105_to_112.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/greaterThanEqual/greaterThanEqual_001_to_008.html b/conformance/ogles/GL/greaterThanEqual/greaterThanEqual_001_to_008.html
+index 2d854b0438..73310f3b6b 100644
+--- a/conformance/ogles/GL/greaterThanEqual/greaterThanEqual_001_to_008.html
++++ b/conformance/ogles/GL/greaterThanEqual/greaterThanEqual_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: greaterThanEqual_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_009_to_016.html b/conformance/ogles/GL/swizzlers/swizzlers_009_to_016.html
+index b4894c019e..f85523127e 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_009_to_016.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_009_to_016.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_009_to_016.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/abs/abs_001_to_006.html b/conformance/ogles/GL/abs/abs_001_to_006.html
+index 5c2ae1d05b..2af0dd4b9c 100644
+--- a/conformance/ogles/GL/abs/abs_001_to_006.html
++++ b/conformance/ogles/GL/abs/abs_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: abs_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/all/all_001_to_004.html b/conformance/ogles/GL/all/all_001_to_004.html
+index 226d9c0825..a00461f8ba 100644
+--- a/conformance/ogles/GL/all/all_001_to_004.html
++++ b/conformance/ogles/GL/all/all_001_to_004.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: all_001_to_004.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/any/any_001_to_004.html b/conformance/ogles/GL/any/any_001_to_004.html
+index 53bd5a86ad..780b3b5432 100644
+--- a/conformance/ogles/GL/any/any_001_to_004.html
++++ b/conformance/ogles/GL/any/any_001_to_004.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: any_001_to_004.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/array/array_001_to_006.html b/conformance/ogles/GL/array/array_001_to_006.html
+index acb3839137..21a5506878 100644
+--- a/conformance/ogles/GL/array/array_001_to_006.html
++++ b/conformance/ogles/GL/array/array_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: array_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/atan/atan_009_to_012.html b/conformance/ogles/GL/atan/atan_009_to_012.html
+index f82f4fc8c6..2d74d0cc75 100644
+--- a/conformance/ogles/GL/atan/atan_009_to_012.html
++++ b/conformance/ogles/GL/atan/atan_009_to_012.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: atan_009_to_012.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/biConstants/biConstants_001_to_008.html b/conformance/ogles/GL/biConstants/biConstants_001_to_008.html
+index 362ca8f553..65706aa293 100644
+--- a/conformance/ogles/GL/biConstants/biConstants_001_to_008.html
++++ b/conformance/ogles/GL/biConstants/biConstants_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: biConstants_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/biConstants/biConstants_009_to_016.html b/conformance/ogles/GL/biConstants/biConstants_009_to_016.html
+index 5409dda25a..5107486582 100644
+--- a/conformance/ogles/GL/biConstants/biConstants_009_to_016.html
++++ b/conformance/ogles/GL/biConstants/biConstants_009_to_016.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: biConstants_009_to_016.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html b/conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html
+index d968a2a825..45d0523982 100644
+--- a/conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html
++++ b/conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: biuDepthRange_001_to_002.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_001_to_008.html b/conformance/ogles/GL/build/build_001_to_008.html
+index 1883b6a814..c0c33c424a 100644
+--- a/conformance/ogles/GL/build/build_001_to_008.html
++++ b/conformance/ogles/GL/build/build_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_009_to_016.html b/conformance/ogles/GL/build/build_009_to_016.html
+index 4afb29be74..496fdb332f 100644
+--- a/conformance/ogles/GL/build/build_009_to_016.html
++++ b/conformance/ogles/GL/build/build_009_to_016.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_009_to_016.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_017_to_024.html b/conformance/ogles/GL/build/build_017_to_024.html
+index 10b3d6636c..48d22fd4ce 100644
+--- a/conformance/ogles/GL/build/build_017_to_024.html
++++ b/conformance/ogles/GL/build/build_017_to_024.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_017_to_024.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_025_to_032.html b/conformance/ogles/GL/build/build_025_to_032.html
+index 8ee6bdee38..bce572cd24 100644
+--- a/conformance/ogles/GL/build/build_025_to_032.html
++++ b/conformance/ogles/GL/build/build_025_to_032.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_025_to_032.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_033_to_040.html b/conformance/ogles/GL/build/build_033_to_040.html
+index 6667f89bb3..91c0ea47de 100644
+--- a/conformance/ogles/GL/build/build_033_to_040.html
++++ b/conformance/ogles/GL/build/build_033_to_040.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_033_to_040.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_041_to_048.html b/conformance/ogles/GL/build/build_041_to_048.html
+index ac62a69618..28d3221fee 100644
+--- a/conformance/ogles/GL/build/build_041_to_048.html
++++ b/conformance/ogles/GL/build/build_041_to_048.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_041_to_048.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_049_to_056.html b/conformance/ogles/GL/build/build_049_to_056.html
+index 62358b0c6e..be3df66d12 100644
+--- a/conformance/ogles/GL/build/build_049_to_056.html
++++ b/conformance/ogles/GL/build/build_049_to_056.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_049_to_056.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_057_to_064.html b/conformance/ogles/GL/build/build_057_to_064.html
+index f194ecf17b..aa7b633b9f 100644
+--- a/conformance/ogles/GL/build/build_057_to_064.html
++++ b/conformance/ogles/GL/build/build_057_to_064.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_057_to_064.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_065_to_072.html b/conformance/ogles/GL/build/build_065_to_072.html
+index 16372f8862..1d68894b99 100644
+--- a/conformance/ogles/GL/build/build_065_to_072.html
++++ b/conformance/ogles/GL/build/build_065_to_072.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_065_to_072.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_073_to_080.html b/conformance/ogles/GL/build/build_073_to_080.html
+index 0259cae929..58328dba2a 100644
+--- a/conformance/ogles/GL/build/build_073_to_080.html
++++ b/conformance/ogles/GL/build/build_073_to_080.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_073_to_080.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_081_to_088.html b/conformance/ogles/GL/build/build_081_to_088.html
+index ce86db8586..e02ad3dbe4 100644
+--- a/conformance/ogles/GL/build/build_081_to_088.html
++++ b/conformance/ogles/GL/build/build_081_to_088.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_081_to_088.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_089_to_096.html b/conformance/ogles/GL/build/build_089_to_096.html
+index 2356148861..db801551e6 100644
+--- a/conformance/ogles/GL/build/build_089_to_096.html
++++ b/conformance/ogles/GL/build/build_089_to_096.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_089_to_096.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_097_to_104.html b/conformance/ogles/GL/build/build_097_to_104.html
+index 2a4f2abcea..7b555c682e 100644
+--- a/conformance/ogles/GL/build/build_097_to_104.html
++++ b/conformance/ogles/GL/build/build_097_to_104.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_097_to_104.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_105_to_112.html b/conformance/ogles/GL/build/build_105_to_112.html
+index cd5dabddc6..b0f3958ac4 100644
+--- a/conformance/ogles/GL/build/build_105_to_112.html
++++ b/conformance/ogles/GL/build/build_105_to_112.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_105_to_112.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_113_to_120.html b/conformance/ogles/GL/build/build_113_to_120.html
+index a93b6e6ead..e6aa88e08f 100644
+--- a/conformance/ogles/GL/build/build_113_to_120.html
++++ b/conformance/ogles/GL/build/build_113_to_120.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_113_to_120.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_121_to_128.html b/conformance/ogles/GL/build/build_121_to_128.html
+index f13e0656d8..cbc49130c1 100644
+--- a/conformance/ogles/GL/build/build_121_to_128.html
++++ b/conformance/ogles/GL/build/build_121_to_128.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_121_to_128.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_129_to_136.html b/conformance/ogles/GL/build/build_129_to_136.html
+index 34eaa4352a..c3ec7500d6 100644
+--- a/conformance/ogles/GL/build/build_129_to_136.html
++++ b/conformance/ogles/GL/build/build_129_to_136.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_129_to_136.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_137_to_144.html b/conformance/ogles/GL/build/build_137_to_144.html
+index acb4502de5..8f1275fe0d 100644
+--- a/conformance/ogles/GL/build/build_137_to_144.html
++++ b/conformance/ogles/GL/build/build_137_to_144.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_137_to_144.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_145_to_152.html b/conformance/ogles/GL/build/build_145_to_152.html
+index ff3ea37f3b..e77616897e 100644
+--- a/conformance/ogles/GL/build/build_145_to_152.html
++++ b/conformance/ogles/GL/build/build_145_to_152.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_145_to_152.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_153_to_160.html b/conformance/ogles/GL/build/build_153_to_160.html
+index 844e548a47..467590650d 100644
+--- a/conformance/ogles/GL/build/build_153_to_160.html
++++ b/conformance/ogles/GL/build/build_153_to_160.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_153_to_160.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_161_to_168.html b/conformance/ogles/GL/build/build_161_to_168.html
+index 3bbcddaadc..ec7a9bb05c 100644
+--- a/conformance/ogles/GL/build/build_161_to_168.html
++++ b/conformance/ogles/GL/build/build_161_to_168.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_161_to_168.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_169_to_176.html b/conformance/ogles/GL/build/build_169_to_176.html
+index f00fa582c6..406cab463c 100644
+--- a/conformance/ogles/GL/build/build_169_to_176.html
++++ b/conformance/ogles/GL/build/build_169_to_176.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_169_to_176.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/build/build_177_to_178.html b/conformance/ogles/GL/build/build_177_to_178.html
+index a2406d8ed5..7c0a718ad0 100644
+--- a/conformance/ogles/GL/build/build_177_to_178.html
++++ b/conformance/ogles/GL/build/build_177_to_178.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: build_177_to_178.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/built_in_varying_array_out_of_bounds/built_in_varying_array_out_of_bounds_001_to_001.html b/conformance/ogles/GL/built_in_varying_array_out_of_bounds/built_in_varying_array_out_of_bounds_001_to_001.html
+index e6542bfe8d..d5a93f05ff 100644
+--- a/conformance/ogles/GL/built_in_varying_array_out_of_bounds/built_in_varying_array_out_of_bounds_001_to_001.html
++++ b/conformance/ogles/GL/built_in_varying_array_out_of_bounds/built_in_varying_array_out_of_bounds_001_to_001.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: built_in_varying_array_out_of_bounds_001_to_001.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/ceil/ceil_001_to_006.html b/conformance/ogles/GL/ceil/ceil_001_to_006.html
+index c8b3a25732..9068d26a5d 100644
+--- a/conformance/ogles/GL/ceil/ceil_001_to_006.html
++++ b/conformance/ogles/GL/ceil/ceil_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: ceil_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/control_flow/control_flow_009_to_010.html b/conformance/ogles/GL/control_flow/control_flow_009_to_010.html
+index 3845a8d9fd..018843b589 100644
+--- a/conformance/ogles/GL/control_flow/control_flow_009_to_010.html
++++ b/conformance/ogles/GL/control_flow/control_flow_009_to_010.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: control_flow_009_to_010.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/cos/cos_001_to_006.html b/conformance/ogles/GL/cos/cos_001_to_006.html
+index 6da1573843..fc6b6fd42d 100644
+--- a/conformance/ogles/GL/cos/cos_001_to_006.html
++++ b/conformance/ogles/GL/cos/cos_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: cos_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/cross/cross_001_to_002.html b/conformance/ogles/GL/cross/cross_001_to_002.html
+index c0c5bc44c5..6b45928307 100644
+--- a/conformance/ogles/GL/cross/cross_001_to_002.html
++++ b/conformance/ogles/GL/cross/cross_001_to_002.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: cross_001_to_002.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/default/default_001_to_001.html b/conformance/ogles/GL/default/default_001_to_001.html
+index 1a9e6c3214..9f2456cfcb 100644
+--- a/conformance/ogles/GL/default/default_001_to_001.html
++++ b/conformance/ogles/GL/default/default_001_to_001.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: default_001_to_001.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/degrees/degrees_001_to_006.html b/conformance/ogles/GL/degrees/degrees_001_to_006.html
+index 1e29130a3d..6f9c14d119 100644
+--- a/conformance/ogles/GL/degrees/degrees_001_to_006.html
++++ b/conformance/ogles/GL/degrees/degrees_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: degrees_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/discard/discard_001_to_002.html b/conformance/ogles/GL/discard/discard_001_to_002.html
+index 0efbe81fb4..bda9a2d99a 100644
+--- a/conformance/ogles/GL/discard/discard_001_to_002.html
++++ b/conformance/ogles/GL/discard/discard_001_to_002.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: discard_001_to_002.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/distance/distance_001_to_006.html b/conformance/ogles/GL/distance/distance_001_to_006.html
+index 7ad48ff83b..39441600eb 100644
+--- a/conformance/ogles/GL/distance/distance_001_to_006.html
++++ b/conformance/ogles/GL/distance/distance_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: distance_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/dot/dot_001_to_006.html b/conformance/ogles/GL/dot/dot_001_to_006.html
+index 35af74a12a..a75839bf29 100644
+--- a/conformance/ogles/GL/dot/dot_001_to_006.html
++++ b/conformance/ogles/GL/dot/dot_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: dot_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/equal/equal_001_to_008.html b/conformance/ogles/GL/equal/equal_001_to_008.html
+index 4266061afe..5b63f08e78 100644
+--- a/conformance/ogles/GL/equal/equal_001_to_008.html
++++ b/conformance/ogles/GL/equal/equal_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: equal_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/equal/equal_009_to_012.html b/conformance/ogles/GL/equal/equal_009_to_012.html
+index f5af33c3db..e32f989869 100644
+--- a/conformance/ogles/GL/equal/equal_009_to_012.html
++++ b/conformance/ogles/GL/equal/equal_009_to_012.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: equal_009_to_012.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/exp/exp_009_to_012.html b/conformance/ogles/GL/exp/exp_009_to_012.html
+index ddf15b619a..ea46abd3e3 100644
+--- a/conformance/ogles/GL/exp/exp_009_to_012.html
++++ b/conformance/ogles/GL/exp/exp_009_to_012.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: exp_009_to_012.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/exp2/exp2_001_to_008.html b/conformance/ogles/GL/exp2/exp2_001_to_008.html
+index 7b64d838de..a07d1e5743 100644
+--- a/conformance/ogles/GL/exp2/exp2_001_to_008.html
++++ b/conformance/ogles/GL/exp2/exp2_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: exp2_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/exp2/exp2_009_to_012.html b/conformance/ogles/GL/exp2/exp2_009_to_012.html
+index 2b29d52bd0..c771195266 100644
+--- a/conformance/ogles/GL/exp2/exp2_009_to_012.html
++++ b/conformance/ogles/GL/exp2/exp2_009_to_012.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: exp2_009_to_012.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/faceforward/faceforward_001_to_006.html b/conformance/ogles/GL/faceforward/faceforward_001_to_006.html
+index c70334794c..c9eb361142 100644
+--- a/conformance/ogles/GL/faceforward/faceforward_001_to_006.html
++++ b/conformance/ogles/GL/faceforward/faceforward_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: faceforward_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/floor/floor_001_to_006.html b/conformance/ogles/GL/floor/floor_001_to_006.html
+index 75d2d91675..30438dd7fd 100644
+--- a/conformance/ogles/GL/floor/floor_001_to_006.html
++++ b/conformance/ogles/GL/floor/floor_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: floor_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/fract/fract_001_to_006.html b/conformance/ogles/GL/fract/fract_001_to_006.html
+index 0fde847696..fd28dcff49 100644
+--- a/conformance/ogles/GL/fract/fract_001_to_006.html
++++ b/conformance/ogles/GL/fract/fract_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: fract_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_017_to_024.html b/conformance/ogles/GL/functions/functions_017_to_024.html
+index 72e2585af4..e90105b2d9 100644
+--- a/conformance/ogles/GL/functions/functions_017_to_024.html
++++ b/conformance/ogles/GL/functions/functions_017_to_024.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_017_to_024.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_025_to_032.html b/conformance/ogles/GL/functions/functions_025_to_032.html
+index 32a7ef534d..0a000a8ddf 100644
+--- a/conformance/ogles/GL/functions/functions_025_to_032.html
++++ b/conformance/ogles/GL/functions/functions_025_to_032.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_025_to_032.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_033_to_040.html b/conformance/ogles/GL/functions/functions_033_to_040.html
+index 4a8723664b..6c89d834f8 100644
+--- a/conformance/ogles/GL/functions/functions_033_to_040.html
++++ b/conformance/ogles/GL/functions/functions_033_to_040.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_033_to_040.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_041_to_048.html b/conformance/ogles/GL/functions/functions_041_to_048.html
+index 0d3aee9278..4800ca94da 100644
+--- a/conformance/ogles/GL/functions/functions_041_to_048.html
++++ b/conformance/ogles/GL/functions/functions_041_to_048.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_041_to_048.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_049_to_056.html b/conformance/ogles/GL/functions/functions_049_to_056.html
+index 4cbdf62fc9..ea65d15ce4 100644
+--- a/conformance/ogles/GL/functions/functions_049_to_056.html
++++ b/conformance/ogles/GL/functions/functions_049_to_056.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_049_to_056.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_057_to_064.html b/conformance/ogles/GL/functions/functions_057_to_064.html
+index 2c2545718b..62782be16a 100644
+--- a/conformance/ogles/GL/functions/functions_057_to_064.html
++++ b/conformance/ogles/GL/functions/functions_057_to_064.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_057_to_064.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_065_to_072.html b/conformance/ogles/GL/functions/functions_065_to_072.html
+index d01ded0bd3..05e9864c9c 100644
+--- a/conformance/ogles/GL/functions/functions_065_to_072.html
++++ b/conformance/ogles/GL/functions/functions_065_to_072.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_065_to_072.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_073_to_080.html b/conformance/ogles/GL/functions/functions_073_to_080.html
+index 969754f71e..a871c24f66 100644
+--- a/conformance/ogles/GL/functions/functions_073_to_080.html
++++ b/conformance/ogles/GL/functions/functions_073_to_080.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_073_to_080.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_081_to_088.html b/conformance/ogles/GL/functions/functions_081_to_088.html
+index 08c0e1163e..3142c5cd00 100644
+--- a/conformance/ogles/GL/functions/functions_081_to_088.html
++++ b/conformance/ogles/GL/functions/functions_081_to_088.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_081_to_088.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_089_to_096.html b/conformance/ogles/GL/functions/functions_089_to_096.html
+index 3515815586..2413ca6df9 100644
+--- a/conformance/ogles/GL/functions/functions_089_to_096.html
++++ b/conformance/ogles/GL/functions/functions_089_to_096.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_089_to_096.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_097_to_104.html b/conformance/ogles/GL/functions/functions_097_to_104.html
+index 2d5ef101d9..ba4e22d67e 100644
+--- a/conformance/ogles/GL/functions/functions_097_to_104.html
++++ b/conformance/ogles/GL/functions/functions_097_to_104.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_097_to_104.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/functions/functions_121_to_126.html b/conformance/ogles/GL/functions/functions_121_to_126.html
+index 10eaee12a8..7c343c192b 100644
+--- a/conformance/ogles/GL/functions/functions_121_to_126.html
++++ b/conformance/ogles/GL/functions/functions_121_to_126.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: functions_121_to_126.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/gl_FragCoord/gl_FragCoord_001_to_003.html b/conformance/ogles/GL/gl_FragCoord/gl_FragCoord_001_to_003.html
+index 674ce26dc7..2fa27d8089 100644
+--- a/conformance/ogles/GL/gl_FragCoord/gl_FragCoord_001_to_003.html
++++ b/conformance/ogles/GL/gl_FragCoord/gl_FragCoord_001_to_003.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: gl_FragCoord_001_to_003.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/gl_FrontFacing/gl_FrontFacing_001_to_001.html b/conformance/ogles/GL/gl_FrontFacing/gl_FrontFacing_001_to_001.html
+index ace8b2aa6a..8abc04d7af 100644
+--- a/conformance/ogles/GL/gl_FrontFacing/gl_FrontFacing_001_to_001.html
++++ b/conformance/ogles/GL/gl_FrontFacing/gl_FrontFacing_001_to_001.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: gl_FrontFacing_001_to_001.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/inversesqrt/inversesqrt_001_to_006.html b/conformance/ogles/GL/inversesqrt/inversesqrt_001_to_006.html
+index c48b075aeb..0b1ed4a645 100644
+--- a/conformance/ogles/GL/inversesqrt/inversesqrt_001_to_006.html
++++ b/conformance/ogles/GL/inversesqrt/inversesqrt_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: inversesqrt_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/length/length_001_to_006.html b/conformance/ogles/GL/length/length_001_to_006.html
+index d5848dce1f..9d67dcc621 100644
+--- a/conformance/ogles/GL/length/length_001_to_006.html
++++ b/conformance/ogles/GL/length/length_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: length_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/lessThan/lessThan_001_to_008.html b/conformance/ogles/GL/lessThan/lessThan_001_to_008.html
+index 0c4b5d7c87..9f134c35a4 100644
+--- a/conformance/ogles/GL/lessThan/lessThan_001_to_008.html
++++ b/conformance/ogles/GL/lessThan/lessThan_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: lessThan_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/log/log_009_to_012.html b/conformance/ogles/GL/log/log_009_to_012.html
+index 1e362043d8..a01d5ae7e9 100644
+--- a/conformance/ogles/GL/log/log_009_to_012.html
++++ b/conformance/ogles/GL/log/log_009_to_012.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: log_009_to_012.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/log2/log2_009_to_012.html b/conformance/ogles/GL/log2/log2_009_to_012.html
+index e7abb0ba78..19cb80b8ea 100644
+--- a/conformance/ogles/GL/log2/log2_009_to_012.html
++++ b/conformance/ogles/GL/log2/log2_009_to_012.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: log2_009_to_012.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/mat/mat_001_to_008.html b/conformance/ogles/GL/mat/mat_001_to_008.html
+index 2010cbe02c..de9093445c 100644
+--- a/conformance/ogles/GL/mat/mat_001_to_008.html
++++ b/conformance/ogles/GL/mat/mat_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: mat_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/mat/mat_009_to_016.html b/conformance/ogles/GL/mat/mat_009_to_016.html
+index 0d73540a86..9e5c894705 100644
+--- a/conformance/ogles/GL/mat/mat_009_to_016.html
++++ b/conformance/ogles/GL/mat/mat_009_to_016.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: mat_009_to_016.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/mat/mat_017_to_024.html b/conformance/ogles/GL/mat/mat_017_to_024.html
+index 2e3a486765..d5b52de1bb 100644
+--- a/conformance/ogles/GL/mat/mat_017_to_024.html
++++ b/conformance/ogles/GL/mat/mat_017_to_024.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: mat_017_to_024.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/mat/mat_025_to_032.html b/conformance/ogles/GL/mat/mat_025_to_032.html
+index 8862968e9a..cfe59573d8 100644
+--- a/conformance/ogles/GL/mat/mat_025_to_032.html
++++ b/conformance/ogles/GL/mat/mat_025_to_032.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: mat_025_to_032.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/mat/mat_033_to_040.html b/conformance/ogles/GL/mat/mat_033_to_040.html
+index 66267c5343..9f367a24de 100644
+--- a/conformance/ogles/GL/mat/mat_033_to_040.html
++++ b/conformance/ogles/GL/mat/mat_033_to_040.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: mat_033_to_040.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/mat/mat_041_to_046.html b/conformance/ogles/GL/mat/mat_041_to_046.html
+index 42616f0bfe..a38b73e061 100644
+--- a/conformance/ogles/GL/mat/mat_041_to_046.html
++++ b/conformance/ogles/GL/mat/mat_041_to_046.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: mat_041_to_046.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/mat3/mat3_001_to_006.html b/conformance/ogles/GL/mat3/mat3_001_to_006.html
+index 60f5225933..2600512ff1 100644
+--- a/conformance/ogles/GL/mat3/mat3_001_to_006.html
++++ b/conformance/ogles/GL/mat3/mat3_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: mat3_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/matrixCompMult/matrixCompMult_001_to_004.html b/conformance/ogles/GL/matrixCompMult/matrixCompMult_001_to_004.html
+index bacbc87b42..caf777df83 100644
+--- a/conformance/ogles/GL/matrixCompMult/matrixCompMult_001_to_004.html
++++ b/conformance/ogles/GL/matrixCompMult/matrixCompMult_001_to_004.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: matrixCompMult_001_to_004.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/max/max_001_to_006.html b/conformance/ogles/GL/max/max_001_to_006.html
+index 8cc3f478f3..e79f3cced4 100644
+--- a/conformance/ogles/GL/max/max_001_to_006.html
++++ b/conformance/ogles/GL/max/max_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: max_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/min/min_001_to_006.html b/conformance/ogles/GL/min/min_001_to_006.html
+index a9dd90c99e..5d927dd73d 100644
+--- a/conformance/ogles/GL/min/min_001_to_006.html
++++ b/conformance/ogles/GL/min/min_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: min_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/mix/mix_001_to_006.html b/conformance/ogles/GL/mix/mix_001_to_006.html
+index abeb8c20e9..fbe3846b09 100644
+--- a/conformance/ogles/GL/mix/mix_001_to_006.html
++++ b/conformance/ogles/GL/mix/mix_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: mix_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/normalize/normalize_001_to_006.html b/conformance/ogles/GL/normalize/normalize_001_to_006.html
+index d711520fa4..dab9e4a21e 100644
+--- a/conformance/ogles/GL/normalize/normalize_001_to_006.html
++++ b/conformance/ogles/GL/normalize/normalize_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: normalize_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/not/not_001_to_004.html b/conformance/ogles/GL/not/not_001_to_004.html
+index 2376898aba..a3826ed0bb 100644
+--- a/conformance/ogles/GL/not/not_001_to_004.html
++++ b/conformance/ogles/GL/not/not_001_to_004.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: not_001_to_004.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/notEqual/notEqual_009_to_012.html b/conformance/ogles/GL/notEqual/notEqual_009_to_012.html
+index 3c2b81ee9d..966fd13c91 100644
+--- a/conformance/ogles/GL/notEqual/notEqual_009_to_012.html
++++ b/conformance/ogles/GL/notEqual/notEqual_009_to_012.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: notEqual_009_to_012.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/operators/operators_001_to_008.html b/conformance/ogles/GL/operators/operators_001_to_008.html
+index 8e59e71d2d..a90031de6a 100644
+--- a/conformance/ogles/GL/operators/operators_001_to_008.html
++++ b/conformance/ogles/GL/operators/operators_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: operators_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/operators/operators_009_to_016.html b/conformance/ogles/GL/operators/operators_009_to_016.html
+index e19f146b75..60692b9a32 100644
+--- a/conformance/ogles/GL/operators/operators_009_to_016.html
++++ b/conformance/ogles/GL/operators/operators_009_to_016.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: operators_009_to_016.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/operators/operators_017_to_024.html b/conformance/ogles/GL/operators/operators_017_to_024.html
+index 14da8ea63e..dd6e17de73 100644
+--- a/conformance/ogles/GL/operators/operators_017_to_024.html
++++ b/conformance/ogles/GL/operators/operators_017_to_024.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: operators_017_to_024.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/operators/operators_025_to_026.html b/conformance/ogles/GL/operators/operators_025_to_026.html
+index 812f24dc9a..97a2790610 100644
+--- a/conformance/ogles/GL/operators/operators_025_to_026.html
++++ b/conformance/ogles/GL/operators/operators_025_to_026.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: operators_025_to_026.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/pow/pow_001_to_008.html b/conformance/ogles/GL/pow/pow_001_to_008.html
+index cfd6e3b4f8..b4c6eb3ce5 100644
+--- a/conformance/ogles/GL/pow/pow_001_to_008.html
++++ b/conformance/ogles/GL/pow/pow_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: pow_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/pow/pow_017_to_024.html b/conformance/ogles/GL/pow/pow_017_to_024.html
+index 06420c9196..eb018051f0 100644
+--- a/conformance/ogles/GL/pow/pow_017_to_024.html
++++ b/conformance/ogles/GL/pow/pow_017_to_024.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: pow_017_to_024.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/radians/radians_001_to_006.html b/conformance/ogles/GL/radians/radians_001_to_006.html
+index 3d03c34a79..dbcb357a58 100644
+--- a/conformance/ogles/GL/radians/radians_001_to_006.html
++++ b/conformance/ogles/GL/radians/radians_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: radians_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/refract/refract_001_to_006.html b/conformance/ogles/GL/refract/refract_001_to_006.html
+index 3fdad36dab..594b82158e 100644
+--- a/conformance/ogles/GL/refract/refract_001_to_006.html
++++ b/conformance/ogles/GL/refract/refract_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: refract_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/sign/sign_001_to_006.html b/conformance/ogles/GL/sign/sign_001_to_006.html
+index 0e4a56dbcd..86bfd7bbeb 100644
+--- a/conformance/ogles/GL/sign/sign_001_to_006.html
++++ b/conformance/ogles/GL/sign/sign_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: sign_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/smoothstep/smoothstep_001_to_006.html b/conformance/ogles/GL/smoothstep/smoothstep_001_to_006.html
+index 06731acc31..891835904b 100644
+--- a/conformance/ogles/GL/smoothstep/smoothstep_001_to_006.html
++++ b/conformance/ogles/GL/smoothstep/smoothstep_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: smoothstep_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/sqrt/sqrt_001_to_006.html b/conformance/ogles/GL/sqrt/sqrt_001_to_006.html
+index ff5fb1cee9..bc865852bb 100644
+--- a/conformance/ogles/GL/sqrt/sqrt_001_to_006.html
++++ b/conformance/ogles/GL/sqrt/sqrt_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: sqrt_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/step/step_001_to_006.html b/conformance/ogles/GL/step/step_001_to_006.html
+index b2572d445b..6125e525a3 100644
+--- a/conformance/ogles/GL/step/step_001_to_006.html
++++ b/conformance/ogles/GL/step/step_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: step_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/struct/struct_009_to_016.html b/conformance/ogles/GL/struct/struct_009_to_016.html
+index ce9ea01c22..85b91c16a1 100644
+--- a/conformance/ogles/GL/struct/struct_009_to_016.html
++++ b/conformance/ogles/GL/struct/struct_009_to_016.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: struct_009_to_016.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/struct/struct_025_to_032.html b/conformance/ogles/GL/struct/struct_025_to_032.html
+index 1cd3af91d6..111e7b51ae 100644
+--- a/conformance/ogles/GL/struct/struct_025_to_032.html
++++ b/conformance/ogles/GL/struct/struct_025_to_032.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: struct_025_to_032.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/struct/struct_033_to_040.html b/conformance/ogles/GL/struct/struct_033_to_040.html
+index e81478b8ba..6fbb77a59b 100644
+--- a/conformance/ogles/GL/struct/struct_033_to_040.html
++++ b/conformance/ogles/GL/struct/struct_033_to_040.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: struct_033_to_040.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/struct/struct_041_to_048.html b/conformance/ogles/GL/struct/struct_041_to_048.html
+index 8aaa8da8e8..1101504a4e 100644
+--- a/conformance/ogles/GL/struct/struct_041_to_048.html
++++ b/conformance/ogles/GL/struct/struct_041_to_048.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: struct_041_to_048.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/struct/struct_049_to_056.html b/conformance/ogles/GL/struct/struct_049_to_056.html
+index 831ad2fb37..83597ef3f6 100644
+--- a/conformance/ogles/GL/struct/struct_049_to_056.html
++++ b/conformance/ogles/GL/struct/struct_049_to_056.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: struct_049_to_056.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_001_to_008.html b/conformance/ogles/GL/swizzlers/swizzlers_001_to_008.html
+index 022d14cab7..2ad45f6be5 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_001_to_008.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_017_to_024.html b/conformance/ogles/GL/swizzlers/swizzlers_017_to_024.html
+index 76e6a9a97e..0d692208aa 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_017_to_024.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_017_to_024.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_017_to_024.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_025_to_032.html b/conformance/ogles/GL/swizzlers/swizzlers_025_to_032.html
+index 6a38d1f9e3..43f871ca6e 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_025_to_032.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_025_to_032.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_025_to_032.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_033_to_040.html b/conformance/ogles/GL/swizzlers/swizzlers_033_to_040.html
+index 27b9a25bd0..fa0e139fa4 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_033_to_040.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_033_to_040.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_033_to_040.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_041_to_048.html b/conformance/ogles/GL/swizzlers/swizzlers_041_to_048.html
+index 0258666257..4153e79b16 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_041_to_048.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_041_to_048.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_041_to_048.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_049_to_056.html b/conformance/ogles/GL/swizzlers/swizzlers_049_to_056.html
+index e0953edc17..d4610d6a6c 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_049_to_056.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_049_to_056.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_049_to_056.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_057_to_064.html b/conformance/ogles/GL/swizzlers/swizzlers_057_to_064.html
+index 6932dca569..ec697a92db 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_057_to_064.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_057_to_064.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_057_to_064.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_065_to_072.html b/conformance/ogles/GL/swizzlers/swizzlers_065_to_072.html
+index 8687c5dbde..04c139c0ea 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_065_to_072.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_065_to_072.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_065_to_072.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_073_to_080.html b/conformance/ogles/GL/swizzlers/swizzlers_073_to_080.html
+index 5df7f6e3bf..baafeeee8c 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_073_to_080.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_073_to_080.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_073_to_080.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_081_to_088.html b/conformance/ogles/GL/swizzlers/swizzlers_081_to_088.html
+index f2705dd655..a61fcb8497 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_081_to_088.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_081_to_088.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_081_to_088.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_089_to_096.html b/conformance/ogles/GL/swizzlers/swizzlers_089_to_096.html
+index 7f4e8ffbd3..eab21a8d47 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_089_to_096.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_089_to_096.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_089_to_096.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_097_to_104.html b/conformance/ogles/GL/swizzlers/swizzlers_097_to_104.html
+index 44ad2ab8a8..1661b5ffe5 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_097_to_104.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_097_to_104.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_097_to_104.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/swizzlers/swizzlers_113_to_120.html b/conformance/ogles/GL/swizzlers/swizzlers_113_to_120.html
+index 23528dea2a..dcf962e1b3 100644
+--- a/conformance/ogles/GL/swizzlers/swizzlers_113_to_120.html
++++ b/conformance/ogles/GL/swizzlers/swizzlers_113_to_120.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: swizzlers_113_to_120.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/tan/tan_001_to_006.html b/conformance/ogles/GL/tan/tan_001_to_006.html
+index 0d8b1d70a8..60c92f4299 100644
+--- a/conformance/ogles/GL/tan/tan_001_to_006.html
++++ b/conformance/ogles/GL/tan/tan_001_to_006.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: tan_001_to_006.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/vec/vec_001_to_008.html b/conformance/ogles/GL/vec/vec_001_to_008.html
+index 5f55e73217..6e31e1fa36 100644
+--- a/conformance/ogles/GL/vec/vec_001_to_008.html
++++ b/conformance/ogles/GL/vec/vec_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: vec_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/vec/vec_009_to_016.html b/conformance/ogles/GL/vec/vec_009_to_016.html
+index d8573af715..cb28ecaeb8 100644
+--- a/conformance/ogles/GL/vec/vec_009_to_016.html
++++ b/conformance/ogles/GL/vec/vec_009_to_016.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: vec_009_to_016.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/vec/vec_017_to_018.html b/conformance/ogles/GL/vec/vec_017_to_018.html
+index 0b4c05e430..492bacd604 100644
+--- a/conformance/ogles/GL/vec/vec_017_to_018.html
++++ b/conformance/ogles/GL/vec/vec_017_to_018.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: vec_017_to_018.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />
+diff --git a/conformance/ogles/GL/vec3/vec3_001_to_008.html b/conformance/ogles/GL/vec3/vec3_001_to_008.html
+index b88ba393ff..29476159ce 100644
+--- a/conformance/ogles/GL/vec3/vec3_001_to_008.html
++++ b/conformance/ogles/GL/vec3/vec3_001_to_008.html
+@@ -28,6 +28,7 @@
+ <html>
+ <head>
+ <meta charset="utf-8">
++<meta name="timeout" content="long">
+ <title>WebGL GLSL conformance test: vec3_001_to_008.html</title>
+ <link rel="stylesheet" href="../../../../resources/js-test-style.css" />
+ <link rel="stylesheet" href="../../../../resources/ogles-tests.css" />


### PR DESCRIPTION
This is the final missing piece to support WebGL in ANGLE on Windows. ANGLE doesn't support multiple GL contexts on separate threads using the same underlying Direct3d device, so we need to process all GL operations for WebGL on the same thread as the compositor. These changes try to retain enough flexibility to support both approaches so we can get WebGL working on Windows ASAP.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23697
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23777)
<!-- Reviewable:end -->
