### PR TITLE
Add source module to UWP logging output

### DIFF
--- a/ports/libsimpleservo/capi/src/vslogger.rs
+++ b/ports/libsimpleservo/capi/src/vslogger.rs
@@ -17,7 +17,12 @@ impl log::Log for VSLogger {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            let log = format!("RUST: {} - {}\r\n\0", record.level(), record.args());
+            let log = format!(
+                "RUST: {} - {} - {}\r\n\0",
+                record.level(),
+                record.target(),
+                record.args()
+            );
             unsafe {
                 OutputDebugStringA(log.as_ptr());
             };

--- a/support/hololens/Servo.cpp
+++ b/support/hololens/Servo.cpp
@@ -46,7 +46,7 @@ Servo::Servo(GLsizei width, GLsizei height)
 
   CInitOptions o;
   o.args = NULL;
-  o.url = "http://example.com";
+  o.url = "http://google.com";
   o.width = mWindowWidth;
   o.height = mWindowHeight;
   o.density = 1.0;


### PR DESCRIPTION
Updated  support/hololens/Servo.cpp to use url: google.com

New debug output:
```
RUST: DEBUG - html5ever::tokenizer - got characters None
RUST: DEBUG - script::script_thread - Processing event FromConstellation(ConstellationControlMsg::NavigationResponse).
RUST: DEBUG - html5ever::tokenizer - processing in state RawData(ScriptData)
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23755
- [x] These changes do not require tests because we can't automatically test logging output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23783)
<!-- Reviewable:end -->
