### PR TITLE
Get the glwindow test XR device to share a GL context with WebGL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5504,18 +5504,19 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#3951634a06e2f9417f04e8ada969589f5b8a01d2"
+source = "git+https://github.com/servo/webxr#abc779798259d287539347a5d2048ae745f1f2ac"
 dependencies = [
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "webxr-api 0.0.1 (git+https://github.com/servo/webxr)",
 ]
 
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#3951634a06e2f9417f04e8ada969589f5b8a01d2"
+source = "git+https://github.com/servo/webxr#abc779798259d287539347a5d2048ae745f1f2ac"
 dependencies = [
  "euclid 0.19.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ports/glutin/app.rs
+++ b/ports/glutin/app.rs
@@ -36,11 +36,12 @@ impl App {
         let window = if opts::get().headless {
             headless_window::Window::new(opts::get().initial_window_size)
         } else {
-            headed_window::Window::new(opts::get().initial_window_size, events_loop.borrow().as_winit())
+            Rc::new(headed_window::Window::new(opts::get().initial_window_size, None, events_loop.clone()))
         };
 
         // Implements embedder methods, used by libservo and constellation.
         let embedder = Box::new(EmbedderCallbacks::new(
+            window.clone(),
             events_loop.clone(),
             window.gl(),
         ));

--- a/ports/glutin/context.rs
+++ b/ports/glutin/context.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use glutin::os::ContextTraitExt;
-use glutin::{NotCurrent, PossiblyCurrent, WindowedContext};
+use glutin::{ContextBuilder, CreationError, EventsLoop, NotCurrent, PossiblyCurrent, WindowedContext, WindowBuilder};
 use servo_media::player::context::GlContext as RawContext;
 use std::os::raw;
 
@@ -133,6 +133,28 @@ impl GlContext {
                 RawContext::Unknown
             }
             GlContext::None => unreachable!(),
+        }
+    }
+
+    pub fn new_window<T>(
+        &self,
+        cb: ContextBuilder<T>,
+        wb: WindowBuilder,
+        el: &EventsLoop
+    ) -> Result<WindowedContext<NotCurrent>, CreationError>
+    where
+        T: glutin::ContextCurrentState,
+    {
+        match self {
+            GlContext::Current(ref c) => {
+                cb.with_shared_lists(c).build_windowed(wb, el)
+            },
+            GlContext::NotCurrent(ref c) => {
+                cb.with_shared_lists(c).build_windowed(wb, el)
+            },
+            GlContext::None => {
+                cb.build_windowed(wb, el)
+            },
         }
     }
 

--- a/ports/glutin/window_trait.rs
+++ b/ports/glutin/window_trait.rs
@@ -13,7 +13,7 @@ use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 // This should vary by zoom level and maybe actual text size (focused or under cursor)
 pub const LINE_HEIGHT: f32 = 38.0;
 
-pub trait WindowPortsMethods: WindowMethods {
+pub trait WindowPortsMethods: WindowMethods + webxr::glwindow::GlWindow {
     fn get_events(&self) -> Vec<WindowEvent>;
     fn id(&self) -> Option<glutin::WindowId>;
     fn has_events(&self) -> bool;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Get glutin windows able to open new windows which share GL textures. This is used by the webxr glwindow test device.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because it's plumbing

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23784)
<!-- Reviewable:end -->
