### PR TITLE
Enable XR WPT tests

### DIFF
--- a/components/script/dom/webidls/XR.webidl
+++ b/components/script/dom/webidls/XR.webidl
@@ -6,8 +6,8 @@
 [SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]
 interface XR: EventTarget {
   // Methods
-  Promise<void> supportsSessionMode(XRSessionMode mode);
-  Promise<XRSession> requestSession(optional XRSessionCreationOptions parameters = {});
+  Promise<void> supportsSession(XRSessionMode mode);
+  Promise<XRSession> requestSession(XRSessionMode mode, optional  XRSessionInit parameters = {});
 
   // Events
   // attribute EventHandler ondevicechange;
@@ -24,9 +24,9 @@ enum XRSessionMode {
   "immersive-ar"
 };
 
-dictionary XRSessionCreationOptions {
-  XRSessionMode mode = "inline";
-  // XRPresentationContext outputContext;
+dictionary XRSessionInit {
+  sequence<DOMString> requiredFeatures;
+  sequence<DOMString> optionalFeatures;
 };
 
 partial interface XR {

--- a/components/script/dom/webidls/XRSession.webidl
+++ b/components/script/dom/webidls/XRSession.webidl
@@ -33,7 +33,7 @@ interface XRSession : EventTarget {
   long requestAnimationFrame(XRFrameRequestCallback callback);
   void cancelAnimationFrame(long handle);
 
-  // Promise<void> end();
+  Promise<void> end();
 
   // // Events
   // attribute EventHandler onblur;

--- a/components/script/dom/webidls/XRTest.webidl
+++ b/components/script/dom/webidls/XRTest.webidl
@@ -16,7 +16,7 @@ interface XRTest {
   void simulateUserActivation(Function f);
 
   // // Disconnect all fake devices
-  // Promise<void> disconnectAllDevices();
+  Promise<void> disconnectAllDevices();
 };
 
 dictionary FakeXRDeviceInit {

--- a/components/script/dom/webidls/XRTest.webidl
+++ b/components/script/dom/webidls/XRTest.webidl
@@ -13,7 +13,7 @@ interface XRTest {
   // // Simulates a user activation (aka user gesture) for the current scope.
   // // The activation is only guaranteed to be valid in the provided function and only applies to WebXR
   // // Device API methods.
-  // void simulateUserActivation(Function);
+  void simulateUserActivation(Function f);
 
   // // Disconnect all fake devices
   // Promise<void> disconnectAllDevices();

--- a/components/script/dom/webidls/XRView.webidl
+++ b/components/script/dom/webidls/XRView.webidl
@@ -7,7 +7,7 @@
 enum XREye {
   "left",
   "right",
-  "unknown",
+  "none",
 };
 
 [SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -151,7 +151,7 @@ impl XRSession {
             }
         }
 
-        // Step 9: XXXManishearth unset `active` bool on `frame`
+        frame.set_active(false);
         self.session.borrow_mut().render_animation_frame();
     }
 }

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -288,6 +288,14 @@ impl XRSessionMethods for XRSession {
             .map(|x| DomRoot::from_ref(&**x))
             .collect()
     }
+
+    /// https://immersive-web.github.io/webxr/#dom-xrsession-end
+    fn End(&self) -> Rc<Promise> {
+        // XXXManishearth implement device disconnection and session ending
+        let p = Promise::new(&self.global());
+        p.resolve_native(&());
+        p
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/components/script/dom/xrtest.rs
+++ b/components/script/dom/xrtest.rs
@@ -6,6 +6,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::dom::bindings::callback::ExceptionHandling;
+use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use crate::dom::bindings::codegen::Bindings::XRTestBinding::{
     self, FakeXRDeviceInit, XRTestMethods,
 };
@@ -161,5 +163,11 @@ impl XRTestMethods for XRTest {
             .simulate_device_connection(init, MockDevice { sender });
 
         p
+    }
+
+    /// https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md
+    fn SimulateUserActivation(&self, f: Rc<Function>) {
+        // XXXManishearth actually check for activation in XRSession
+        let _ = f.Call__(vec![], ExceptionHandling::Rethrow);
     }
 }

--- a/components/script/dom/xrtest.rs
+++ b/components/script/dom/xrtest.rs
@@ -170,4 +170,12 @@ impl XRTestMethods for XRTest {
         // XXXManishearth actually check for activation in XRSession
         let _ = f.Call__(vec![], ExceptionHandling::Rethrow);
     }
+
+    /// https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md
+    fn DisconnectAllDevices(&self) -> Rc<Promise> {
+        // XXXManishearth implement device disconnection and session ending
+        let p = Promise::new(&self.global());
+        p.resolve_native(&());
+        p
+    }
 }

--- a/components/script/dom/xrviewerpose.rs
+++ b/components/script/dom/xrviewerpose.rs
@@ -42,7 +42,7 @@ impl XRViewerPose {
         rooted_vec!(let mut views);
         session.with_session(|s| match s.views() {
             Views::Mono(view) => {
-                views.push(XRView::new(global, session, &view, XREye::Unknown, &pose))
+                views.push(XRView::new(global, session, &view, XREye::None, &pose))
             },
             Views::Stereo(left, right) => {
                 views.push(XRView::new(global, session, &left, XREye::Left, &pose));

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -131,6 +131,8 @@ skip: true
   skip: false
 [webvr]
   skip: false
+[webxr]
+  skip: false
 [WebIDL]
   skip: false
 [websockets]

--- a/tests/wpt/metadata/webxr/__dir__.ini
+++ b/tests/wpt/metadata/webxr/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: ["dom.webxr.enabled:true", "dom.webxr.test:true"]

--- a/tests/wpt/metadata/webxr/events_referenceSpace_reset.https.html.ini
+++ b/tests/wpt/metadata/webxr/events_referenceSpace_reset.https.html.ini
@@ -1,0 +1,7 @@
+[events_referenceSpace_reset.https.html]
+  [XRSession resetpose from a device properly fires off the right events for non-immersive sessions]
+    expected: FAIL
+
+  [XRSession resetpose from a device properly fires off the right events for immersive sessions]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/metadata/webxr/idlharness.https.window.js.ini
@@ -1,0 +1,262 @@
+[idlharness.https.window.html]
+  [XR interface: attribute ondevicechange]
+    expected: FAIL
+
+  [XRInputSourcesChangeEvent interface: attribute session]
+    expected: FAIL
+
+  [XRInputSourcesChangeEvent interface object name]
+    expected: FAIL
+
+  [XRInputSourceArray interface: iterable<XRInputSource>]
+    expected: FAIL
+
+  [XR interface: calling supportsSession(XRSessionMode) on navigator.xr with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [XRSession interface: attribute onvisibilitychange]
+    expected: FAIL
+
+  [XRInputSourceArray interface object name]
+    expected: FAIL
+
+  [XRSession interface: attribute inputSources]
+    expected: FAIL
+
+  [XRInputSourcesChangeEvent interface object length]
+    expected: FAIL
+
+  [XRReferenceSpaceEvent interface: attribute referenceSpace]
+    expected: FAIL
+
+  [XR interface: navigator.xr must inherit property "ondevicechange" with the proper type]
+    expected: FAIL
+
+  [XRReferenceSpaceEvent interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [XRRay interface object length]
+    expected: FAIL
+
+  [XRPose interface: attribute emulatedPosition]
+    expected: FAIL
+
+  [XRInputSourceArray interface: attribute length]
+    expected: FAIL
+
+  [XRSessionEvent interface: existence and properties of interface object]
+    expected: FAIL
+
+  [XRInputSource interface: attribute targetRayMode]
+    expected: FAIL
+
+  [XRBoundedReferenceSpace interface object length]
+    expected: FAIL
+
+  [XRSessionEvent interface object length]
+    expected: FAIL
+
+  [XRWebGLLayer interface: operation getNativeFramebufferScaleFactor(XRSession)]
+    expected: FAIL
+
+  [XRSession interface: attribute onselectend]
+    expected: FAIL
+
+  [XRInputSourceEvent interface: attribute frame]
+    expected: FAIL
+
+  [XRRay interface: attribute matrix]
+    expected: FAIL
+
+  [XRSession interface: attribute onselect]
+    expected: FAIL
+
+  [XRReferenceSpaceEvent interface object length]
+    expected: FAIL
+
+  [XRSessionEvent interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [WebGLRenderingContext interface: operation makeXRCompatible()]
+    expected: FAIL
+
+  [XRInputSourcesChangeEvent interface: attribute added]
+    expected: FAIL
+
+  [XRSessionEvent interface object name]
+    expected: FAIL
+
+  [XRWebGLLayer interface: attribute framebufferHeight]
+    expected: FAIL
+
+  [XRInputSourceEvent interface: attribute inputSource]
+    expected: FAIL
+
+  [XRBoundedReferenceSpace interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [XRInputSourceEvent interface object name]
+    expected: FAIL
+
+  [XRInputSourcesChangeEvent interface: attribute removed]
+    expected: FAIL
+
+  [XRSessionEvent interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [XRSession interface: attribute onselectstart]
+    expected: FAIL
+
+  [XRInputSourceEvent interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [XRSessionEvent interface: attribute session]
+    expected: FAIL
+
+  [XRReferenceSpaceEvent interface: existence and properties of interface object]
+    expected: FAIL
+
+  [XRReferenceSpaceEvent interface: attribute transform]
+    expected: FAIL
+
+  [XRBoundedReferenceSpace interface: existence and properties of interface object]
+    expected: FAIL
+
+  [XRRay interface: attribute direction]
+    expected: FAIL
+
+  [XRRay interface object name]
+    expected: FAIL
+
+  [XRWebGLLayer interface: attribute framebufferWidth]
+    expected: FAIL
+
+  [XRInputSourceArray interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [XRInputSourceEvent interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [XRRay interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [XRRay interface: existence and properties of interface object]
+    expected: FAIL
+
+  [XRBoundedReferenceSpace interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [XRInputSourcesChangeEvent interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [XRInputSourceArray interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [XRBoundedReferenceSpace interface: attribute boundsGeometry]
+    expected: FAIL
+
+  [XRWebGLLayer interface: existence and properties of interface object]
+    expected: FAIL
+
+  [XRWebGLLayer interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [XRReferenceSpaceEvent interface object name]
+    expected: FAIL
+
+  [XRReferenceSpaceEvent interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [XRInputSource interface: attribute gamepad]
+    expected: FAIL
+
+  [XRInputSourcesChangeEvent interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [XRInputSourcesChangeEvent interface: existence and properties of interface object]
+    expected: FAIL
+
+  [XRReferenceSpace interface: attribute onreset]
+    expected: FAIL
+
+  [XRRenderState interface: attribute inlineVerticalFieldOfView]
+    expected: FAIL
+
+  [XRRay interface: attribute origin]
+    expected: FAIL
+
+  [XRSession interface: operation requestReferenceSpace(XRReferenceSpaceType)]
+    expected: FAIL
+
+  [XRRay interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [XRRay interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [XRInputSourceEvent interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [XRInputSourceEvent interface: existence and properties of interface object]
+    expected: FAIL
+
+  [XRInputSourceArray interface object length]
+    expected: FAIL
+
+  [XRInputSource interface: attribute gripSpace]
+    expected: FAIL
+
+  [XRInputSourceArray interface: existence and properties of interface object]
+    expected: FAIL
+
+  [XRReferenceSpaceEvent interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [XRInputSource interface: attribute profiles]
+    expected: FAIL
+
+  [XRInputSourcesChangeEvent interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [XR interface: operation requestSession(XRSessionMode, XRSessionInit)]
+    expected: FAIL
+
+  [XR interface: operation supportsSession(XRSessionMode)]
+    expected: FAIL
+
+  [XRBoundedReferenceSpace interface object name]
+    expected: FAIL
+
+  [XRSession interface: attribute visibilityState]
+    expected: FAIL
+
+  [XRWebGLLayer interface: attribute ignoreDepthValues]
+    expected: FAIL
+
+  [XRInputSourceArray interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [XRWebGLLayer interface: attribute framebuffer]
+    expected: FAIL
+
+  [XRInputSourceEvent interface object length]
+    expected: FAIL
+
+  [XRSession interface: attribute oninputsourceschange]
+    expected: FAIL
+
+  [XRSessionEvent interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [XRBoundedReferenceSpace interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [XR interface: calling requestSession(XRSessionMode, XRSessionInit) on navigator.xr with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [XRSession interface: attribute onend]
+    expected: FAIL
+
+  [XRSession interface: operation end()]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/webGLCanvasContext_create_xrcompatible.https.html.ini
+++ b/tests/wpt/metadata/webxr/webGLCanvasContext_create_xrcompatible.https.html.ini
@@ -1,0 +1,4 @@
+[webGLCanvasContext_create_xrcompatible.https.html]
+  [An XR-compatible webglCanvasContext can be created]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/webGLCanvasContext_makecompatible_contextlost.https.html.ini
+++ b/tests/wpt/metadata/webxr/webGLCanvasContext_makecompatible_contextlost.https.html.ini
@@ -1,0 +1,4 @@
+[webGLCanvasContext_makecompatible_contextlost.https.html]
+  [A lost webglCanvasContext should not be able to set xr compatibility]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/webxr-supported-by-feature-policy.html.ini
+++ b/tests/wpt/metadata/webxr/webxr-supported-by-feature-policy.html.ini
@@ -1,0 +1,4 @@
+[webxr-supported-by-feature-policy.html]
+  [document.featurePolicy.features should advertise xr.]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/webxr_availability.http.sub.html.ini
+++ b/tests/wpt/metadata/webxr/webxr_availability.http.sub.html.ini
@@ -1,0 +1,7 @@
+[webxr_availability.http.sub.html]
+  [Test webxr not available in secure context in insecure context]
+    expected: FAIL
+
+  [Test webxr not available in insecure context]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrBoundedReferenceSpace_updates.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrBoundedReferenceSpace_updates.https.html.ini
@@ -1,0 +1,5 @@
+[xrBoundedReferenceSpace_updates.https.html]
+  expected: ERROR
+  ['XRBoundedReferenceSpace updates properly when the changes are applied]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/webxr/xrDevice_disconnect_ends.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrDevice_disconnect_ends.https.html.ini
@@ -1,0 +1,4 @@
+[xrDevice_disconnect_ends.https.html]
+  [Immersive session ends when device is disconnected]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrDevice_requestSession_immersive_no_gesture.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrDevice_requestSession_immersive_no_gesture.https.html.ini
@@ -1,0 +1,4 @@
+[xrDevice_requestSession_immersive_no_gesture.https.html]
+  [Requesting immersive session outside of a user gesture rejects]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrDevice_requestSession_immersive_unsupported.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrDevice_requestSession_immersive_unsupported.https.html.ini
@@ -1,0 +1,4 @@
+[xrDevice_requestSession_immersive_unsupported.https.html]
+  [Requesting an immersive session when unsupported rejects]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrDevice_requestSession_no_mode.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrDevice_requestSession_no_mode.https.html.ini
@@ -1,0 +1,4 @@
+[xrDevice_requestSession_no_mode.https.html]
+  [Requesting a session with no mode rejects]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrDevice_requestSession_non_immersive_no_gesture.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrDevice_requestSession_non_immersive_no_gesture.https.html.ini
@@ -1,0 +1,4 @@
+[xrDevice_requestSession_non_immersive_no_gesture.https.html]
+  [Requesting non-immersive session outside of a user gesture succeeds]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrDevice_supportsSession_immersive_unsupported.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrDevice_supportsSession_immersive_unsupported.https.html.ini
@@ -1,0 +1,4 @@
+[xrDevice_supportsSession_immersive_unsupported.https.html]
+  [supportsSession rejects when options not supported]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrFrame_getPose.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrFrame_getPose.https.html.ini
@@ -1,0 +1,8 @@
+[xrFrame_getPose.https.html]
+  expected: ERROR
+  [XRFrame.getPose works for immersive sessions]
+    expected: TIMEOUT
+
+  [XRFrame.getPose works for non-immersive sessions]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/webxr/xrFrame_lifetime.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrFrame_lifetime.https.html.ini
@@ -1,0 +1,4 @@
+[xrFrame_lifetime.https.html]
+  [XRFrame methods throw exceptions outside of the requestAnimationFrame callback for non-immersive sessions]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrRay_constructor.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrRay_constructor.https.html.ini
@@ -1,0 +1,4 @@
+[xrRay_constructor.https.html]
+  [XRRay constructors work]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrRay_matrix.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrRay_matrix.https.html.ini
@@ -1,0 +1,4 @@
+[xrRay_matrix.https.html]
+  [XRRay matrix works]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrRigidTransform_constructor.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrRigidTransform_constructor.https.html.ini
@@ -1,0 +1,4 @@
+[xrRigidTransform_constructor.https.html]
+  [XRRigidTransform constructor works]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrSession_cancelAnimationFrame.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_cancelAnimationFrame.https.html.ini
@@ -1,0 +1,7 @@
+[xrSession_cancelAnimationFrame.https.html]
+  [XRSession requestAnimationFrame callbacks can be unregistered with cancelAnimationFrame for non-immersive sessions]
+    expected: FAIL
+
+  [XRSession requestAnimationFrame callbacks can be unregistered with cancelAnimationFrame for immersive sessions]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrSession_cancelAnimationFrame_invalidhandle.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_cancelAnimationFrame_invalidhandle.https.html.ini
@@ -1,0 +1,8 @@
+[xrSession_cancelAnimationFrame_invalidhandle.https.html]
+  expected: TIMEOUT
+  [XRSession cancelAnimationFrame does not have unexpected behavior when given invalid handles on immersive testSession]
+    expected: TIMEOUT
+
+  [XRSession cancelAnimationFrame does not have unexpected behavior when given invalid handles on non-immersive testSession]
+    expected: NOTRUN
+

--- a/tests/wpt/metadata/webxr/xrSession_end.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_end.https.html.ini
@@ -1,0 +1,8 @@
+[xrSession_end.https.html]
+  expected: TIMEOUT
+  [end event fires when non-immersive session ends]
+    expected: NOTRUN
+
+  [end event fires when immersive session ends]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/webxr/xrSession_prevent_multiple_exclusive.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_prevent_multiple_exclusive.https.html.ini
@@ -1,0 +1,4 @@
+[xrSession_prevent_multiple_exclusive.https.html]
+  [Test prevention of multiple simultaneous immersive sessions]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrSession_requestAnimationFrame_callback_calls.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_requestAnimationFrame_callback_calls.https.html.ini
@@ -1,0 +1,4 @@
+[xrSession_requestAnimationFrame_callback_calls.https.html]
+  [XRSession requestAnimationFrame calls the provided callback a non-immersive session]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrSession_requestAnimationFrame_getViewerPose.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_requestAnimationFrame_getViewerPose.https.html.ini
@@ -1,0 +1,7 @@
+[xrSession_requestAnimationFrame_getViewerPose.https.html]
+  [XRFrame getViewerPose updates on the next frame for non-immersive sessions]
+    expected: FAIL
+
+  [XRFrame getViewerPose updates on the next frame for immersive sessions]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrSession_requestReferenceSpace.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_requestReferenceSpace.https.html.ini
@@ -1,0 +1,7 @@
+[xrSession_requestReferenceSpace.https.html]
+  [Non-immersive XRSession requestReferenceSpace returns expected objects]
+    expected: FAIL
+
+  [Immersive XRSession requestReferenceSpace returns expected objects]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrSession_viewer_referenceSpace.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_viewer_referenceSpace.https.html.ini
@@ -1,0 +1,7 @@
+[xrSession_viewer_referenceSpace.https.html]
+  [Identity reference space provides correct poses for immersive sessions]
+    expected: FAIL
+
+  [Identity reference space provides correct poses for inline sessions]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrStationaryReferenceSpace_floorlevel_updates.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrStationaryReferenceSpace_floorlevel_updates.https.html.ini
@@ -1,0 +1,7 @@
+[xrStationaryReferenceSpace_floorlevel_updates.https.html]
+  ['floor-level' XRStationaryReferenceSpace updates properly when the transform changes for immersive sessions]
+    expected: FAIL
+
+  ['floor-level' XRStationaryReferenceSpace updates properly when the transform changes for non-immersive sessions]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrView_eyes.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrView_eyes.https.html.ini
@@ -1,0 +1,4 @@
+[xrView_eyes.https.html]
+  [XRView.eye is correct for non-immersive sessions]
+    expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrWebGLLayer_viewports.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrWebGLLayer_viewports.https.html.ini
@@ -1,0 +1,4 @@
+[xrWebGLLayer_viewports.https.html]
+  [XRWebGLLayer reports a valid viewports for inline sessions]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -19690,11 +19690,11 @@
    "testharness"
   ],
   "webxr/create_session.html": [
-   "ddec5add27b84e8e2febe3789d326f1e9fb7f508",
+   "e68ea81893a65793094f9086cdd6d73800ee1c14",
    "testharness"
   ],
   "webxr/obtain_frame.html": [
-   "063008c7ebc0df9997b8286296b4f7fe4663b331",
+   "39698805b476c7e469548d25ece59560a596604d",
    "testharness"
   ],
   "webxr/resources/webxr-util.js": [

--- a/tests/wpt/mozilla/tests/webxr/create_session.html
+++ b/tests/wpt/mozilla/tests/webxr/create_session.html
@@ -12,7 +12,7 @@
               views: TEST_VIEWS,
               viewerOrigin: {position: [0.5, 0.1, 0.1], orientation: [1, 0, 0, 1] }
             }).then((m) => {
-                return navigator.xr.requestSession({mode: "immersive-vr"})
+                return navigator.xr.requestSession("immersive-vr")
               }).then(() => t.done());
           });
         </script>

--- a/tests/wpt/mozilla/tests/webxr/obtain_frame.html
+++ b/tests/wpt/mozilla/tests/webxr/obtain_frame.html
@@ -16,7 +16,7 @@
               views: TEST_VIEWS,
               viewerOrigin: {position: [0.5, 0.1, 0.1], orientation: [1, 0, 0, 1] }
             });
-            let session = await navigator.xr.requestSession({mode: "immersive-vr"});
+            let session = await navigator.xr.requestSession("immersive-vr");
             await session.updateRenderState({"baseLayer": new XRWebGLLayer(session, gl, {})});
             let resolve;
 

--- a/tests/wpt/web-platform-tests/webxr/xrFrame_getPose.https.html
+++ b/tests/wpt/web-platform-tests/webxr/xrFrame_getPose.https.html
@@ -31,7 +31,7 @@ let testFunction = function(session, fakeDeviceController, t) {
           x : 0,
           y : 1,
           z : 0,
-          w : 0
+          w : 1
         }),
         DOMPointReadOnly.fromPoint({
           x : Math.sin(radians / 2),
@@ -47,7 +47,7 @@ let testFunction = function(session, fakeDeviceController, t) {
           x : 1,
           y : 0,
           z : 0,
-          w : 0
+          w : 1
         }),
         DOMPointReadOnly.fromPoint({
           x : 0,


### PR DESCRIPTION
This enables the tests. Most still fail, I plan to go through the
failures more soon.


xrFrame_getPose's failure seems to indicate we have broken matrix math.
I'm not sure what, the bug seems to not come from a simple matrix
inversion/ordering mishap.



This does add empty stubs for session ending since the test infra relies on these existing for almost every test (https://github.com/servo/servo/issues/23788). We will need to add support for this from the webxr repo side. We also need to add support for user activation (https://github.com/servo/servo/issues/23787).

r? @asajeffrey

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23786)
<!-- Reviewable:end -->
