### PR TITLE
Improve xrRigidTransform_constructor test

### DIFF
--- a/tests/wpt/metadata/webxr/xrRigidTransform_constructor.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrRigidTransform_constructor.https.html.ini
@@ -1,4 +1,0 @@
-[xrRigidTransform_constructor.https.html]
-  [XRRigidTransform constructor works]
-    expected: FAIL
-

--- a/tests/wpt/web-platform-tests/webxr/xrRigidTransform_constructor.https.html
+++ b/tests/wpt/web-platform-tests/webxr/xrRigidTransform_constructor.https.html
@@ -75,13 +75,6 @@ let testFunction =
   checkDOMPoint(identity.position, 0.0, 0.0, 0.0, 1.0);
   checkDOMPoint(identity.orientation, 0.0, 0.0, 0.0, 1.0);
 
-  // test creating transform with quaternion of length 0
-  // constructor should not crash
-  let zeroLength = new XRRigidTransform(
-      createDOMPoint([1.0, 2.0, 3.0]),
-      createDOMPoint([0.0, 0.0, 0.0, 0.0]));
-  checkTransform(zeroLength);
-
   // create transform with only position specified
   transform = new XRRigidTransform(createDOMPoint([1.0, 2.0, 3.0]));
   checkTransform(transform);
@@ -102,6 +95,15 @@ let testFunction =
       coordDict([1.1, 2.1, 3.1, 1.0]));
   checkTransform(transform);
 
+  assert_throws(new TypeError(), () => new XRRigidTransform(
+      coordDict([1.0, 2.0, 3.0, 0.5]),
+      coordDict([1.1, 2.1, 3.1, 1.0])
+  ), "Constructor should throw TypeError for non-1 position w values");
+
+  assert_throws("InvalidStateError", () => new XRRigidTransform(
+      coordDict([1.0, 2.0, 3.0, 1.0]),
+      coordDict([0, 0, 0, 0])
+  ), "Constructor should throw InvalidStateError for non-normalizeable orientation values");
   resolve();
 });
 

--- a/tests/wpt/web-platform-tests/webxr/xrRigidTransform_constructor.https.html
+++ b/tests/wpt/web-platform-tests/webxr/xrRigidTransform_constructor.https.html
@@ -41,22 +41,22 @@ let testFunction =
         (point.w * point.w));
   };
 
-  let checkDOMPoint = function(point, x, y, z, w) {
+  let checkDOMPoint = function(point, x, y, z, w, desc) {
     t.step(() => {
-      assert_approx_equals(point.x, x, FLOAT_EPSILON);
-      assert_approx_equals(point.y, y, FLOAT_EPSILON);
-      assert_approx_equals(point.z, z, FLOAT_EPSILON);
-      assert_approx_equals(point.w, w, FLOAT_EPSILON);
+      assert_approx_equals(point.x, x, FLOAT_EPSILON, `${desc}: x value`);
+      assert_approx_equals(point.y, y, FLOAT_EPSILON, `${desc}: y value`);
+      assert_approx_equals(point.z, z, FLOAT_EPSILON, `${desc}: z value`);
+      assert_approx_equals(point.w, w, FLOAT_EPSILON, `${desc}: w value`);
     });
   };
 
-  let checkTransform = function(transformObj) {
+  let checkTransform = function(transformObj, desc) {
     t.step(() => {
-      assert_not_equals(transformObj, null);
-      assert_not_equals(transformObj.position, null);
-      assert_not_equals(transformObj.orientation, null);
-      assert_not_equals(transformObj.matrix, null);
-      assert_equals(transformObj.matrix.length, 16);
+      assert_not_equals(transformObj, null, `${desc}: exists`);
+      assert_not_equals(transformObj.position, null, `${desc}: position exists`);
+      assert_not_equals(transformObj.orientation, null, `${desc}: orientation exists`);
+      assert_not_equals(transformObj.matrix, null, `${desc}: matrix exists`);
+      assert_equals(transformObj.matrix.length, 16, `${desc}: matrix of correct length`);
     });
   };
 
@@ -65,35 +65,36 @@ let testFunction =
   let transform = new XRRigidTransform(
       createDOMPoint([1.0, 2.0, 3.0]),
       createDOMPoint([1.1, 2.1, 3.1, 1.0]));
-  checkTransform(transform);
-  checkDOMPoint(transform.position, 1.0, 2.0, 3.0, 1.0);
-  assert_approx_equals(quaternionLength(transform.orientation), 1.0, FLOAT_EPSILON);
+  checkTransform(transform, "Arbitrary transform");
+  checkDOMPoint(transform.position, 1.0, 2.0, 3.0, 1.0, "Arbitrary transform position");
+  assert_approx_equals(quaternionLength(transform.orientation), 1.0, FLOAT_EPSILON,
+                       "Arbitrary transform is normalized");
 
   // test creating identity transform
   let identity = new XRRigidTransform();
-  checkTransform(identity);
-  checkDOMPoint(identity.position, 0.0, 0.0, 0.0, 1.0);
-  checkDOMPoint(identity.orientation, 0.0, 0.0, 0.0, 1.0);
+  checkTransform(identity, "Identity transform");
+  checkDOMPoint(identity.position, 0.0, 0.0, 0.0, 1.0, "Identity transform position");
+  checkDOMPoint(identity.orientation, 0.0, 0.0, 0.0, 1.0, "Identity transform orientation");
 
   // create transform with only position specified
   transform = new XRRigidTransform(createDOMPoint([1.0, 2.0, 3.0]));
-  checkTransform(transform);
+  checkTransform(transform, "Position-only");
 
   // create transform with only orientation specified
   transform = new XRRigidTransform(undefined, createDOMPoint([1.1, 2.1, 3.1, 1.0]));
-  checkTransform(transform);
+  checkTransform(transform, "orientation-only");
 
   // create transform with DOMPointReadOnly
   transform = new XRRigidTransform(
       createDOMPointReadOnly([1.0, 2.0, 3.0]),
       createDOMPointReadOnly([1.1, 2.1, 3.1, 1.0]));
-  checkTransform(transform);
+  checkTransform(transform, "Created with DOMPointReadOnly");
 
   // create transform with dictionary
   transform = new XRRigidTransform(
       coordDict([1.0, 2.0, 3.0]),
       coordDict([1.1, 2.1, 3.1, 1.0]));
-  checkTransform(transform);
+  checkTransform(transform, "Created with dict");
 
   assert_throws(new TypeError(), () => new XRRigidTransform(
       coordDict([1.0, 2.0, 3.0, 0.5]),


### PR DESCRIPTION
It contained an incorrect test attempting to construct a transform that throws. Added tests that check that it throws appropriately.

has r+ from https://github.com/servo/servo/pull/23803, created new PR
due to bug in WPT sync

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23804)
<!-- Reviewable:end -->
