### PR TITLE
ISSUE-21257: set redirectEnd on PerformanceResourceTiming

### DIFF
--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -450,7 +450,7 @@ pub struct ResourceFetchTiming {
     pub fetch_start: u64,
     pub response_end: u64,
     pub redirect_start: u64,
-    // pub redirect_end: u64,
+    pub redirect_end: u64,
     pub connect_start: u64,
     pub connect_end: u64,
 }
@@ -461,12 +461,18 @@ pub enum RedirectStartValue {
     FetchStart,
 }
 
+pub enum RedirectEndValue {
+    Zero,
+    ResponseEnd,
+}
+
 pub enum ResourceAttribute {
     RedirectCount(u16),
     DomainLookupStart,
     RequestStart,
     ResponseStart,
     RedirectStart(RedirectStartValue),
+    RedirectEnd(RedirectEndValue),
     FetchStart,
     ConnectStart(u64),
     ConnectEnd(u64),
@@ -491,6 +497,7 @@ impl ResourceFetchTiming {
             response_start: 0,
             fetch_start: 0,
             redirect_start: 0,
+            redirect_end: 0,
             connect_start: 0,
             connect_end: 0,
             response_end: 0,
@@ -512,6 +519,10 @@ impl ResourceFetchTiming {
                         self.redirect_start = self.fetch_start
                     }
                 },
+            },
+            ResourceAttribute::RedirectEnd(val) => match val {
+                RedirectEndValue::Zero => self.redirect_end = 0,
+                RedirectEndValue::ResponseEnd => self.redirect_end = self.response_end,
             },
             ResourceAttribute::FetchStart => self.fetch_start = precise_time_ns(),
             ResourceAttribute::ConnectStart(val) => self.connect_start = val,

--- a/components/script/dom/performanceresourcetiming.rs
+++ b/components/script/dom/performanceresourcetiming.rs
@@ -59,8 +59,6 @@ pub struct PerformanceResourceTiming {
 // TODO(#21255): duration
 // TODO(#21269): next_hop
 // TODO(#21264): worker_start
-// TODO(#21256): redirect_start
-// TODO(#21257): redirect_end
 // TODO(#21258): fetch_start
 // TODO(#21259): domain_lookup_start
 // TODO(#21260): domain_lookup_end
@@ -116,7 +114,7 @@ impl PerformanceResourceTiming {
             next_hop: next_hop,
             worker_start: 0.,
             redirect_start: resource_timing.redirect_start as f64,
-            redirect_end: 0.,
+            redirect_end: resource_timing.redirect_end as f64,
             fetch_start: resource_timing.fetch_start as f64,
             domain_lookup_start: resource_timing.domain_lookup_start as f64,
             domain_lookup_end: 0.,
@@ -185,6 +183,11 @@ impl PerformanceResourceTimingMethods for PerformanceResourceTiming {
     // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-redirectstart
     fn RedirectStart(&self) -> DOMHighResTimeStamp {
         Finite::wrap(self.redirect_start)
+    }
+
+    // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-redirectend
+    fn RedirectEnd(&self) -> DOMHighResTimeStamp {
+        Finite::wrap(self.redirect_end)
     }
 
     // https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responsestart

--- a/components/script/dom/webidls/PerformanceResourceTiming.webidl
+++ b/components/script/dom/webidls/PerformanceResourceTiming.webidl
@@ -13,7 +13,7 @@ interface PerformanceResourceTiming : PerformanceEntry {
     readonly attribute DOMString           nextHopProtocol;
     // readonly attribute DOMHighResTimeStamp workerStart;
     readonly attribute DOMHighResTimeStamp redirectStart;
-    // readonly attribute DOMHighResTimeStamp redirectEnd;
+    readonly attribute DOMHighResTimeStamp redirectEnd;
     readonly attribute DOMHighResTimeStamp fetchStart;
     readonly attribute DOMHighResTimeStamp domainLookupStart;
     // readonly attribute DOMHighResTimeStamp domainLookupEnd;

--- a/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
+++ b/tests/wpt/metadata/resource-timing/idlharness.any.js.ini
@@ -44,12 +44,6 @@
   [PerformanceResourceTiming interface: attribute workerStart]
     expected: FAIL
 
-  [PerformanceResourceTiming interface: resource must inherit property "redirectEnd" with the proper type]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: attribute redirectEnd]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: resource must inherit property "domainLookupEnd" with the proper type]
     expected: FAIL
 
@@ -82,9 +76,6 @@
   [PerformanceResourceTiming interface: resource must inherit property "toJSON()" with the proper type]
     expected: FAIL
 
-  [PerformanceResourceTiming interface: resource must inherit property "redirectEnd" with the proper type]
-    expected: FAIL
-
   [PerformanceResourceTiming interface: resource must inherit property "domainLookupEnd" with the proper type]
     expected: FAIL
 
@@ -104,9 +95,6 @@
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute workerStart]
-    expected: FAIL
-
-  [PerformanceResourceTiming interface: attribute redirectEnd]
     expected: FAIL
 
   [PerformanceResourceTiming interface: attribute domainLookupEnd]

--- a/tests/wpt/metadata/resource-timing/resource_TAO_origin.htm.ini
+++ b/tests/wpt/metadata/resource-timing/resource_TAO_origin.htm.ini
@@ -5,9 +5,6 @@
   [responseStart should not be 0 in timing-allow cross-origin request.]
     expected: FAIL
 
-  [redirectEnd should be 0 in cross-origin request since no redirect.]
-    expected: FAIL
-
   [secureConnectionStart should be 0 in cross-origin request since no ssl!]
     expected: FAIL
 

--- a/tests/wpt/metadata/resource-timing/resource_TAO_zero.htm.ini
+++ b/tests/wpt/metadata/resource-timing/resource_TAO_zero.htm.ini
@@ -5,9 +5,6 @@
   [domainLookupEnd should be 0 in cross-origin request.]
     expected: FAIL
 
-  [redirectEnd should be 0 in cross-origin request.]
-    expected: FAIL
-
   [connectEnd should be 0 in cross-origin request.]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Added the appropriate attribute and setters. Included a Timer struct with a `Drop` function to set this value to zero in error cases. Set the value to `responseEnd` on success. Eliminated tests that now pass.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #21257 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23812)
<!-- Reviewable:end -->
