### PR TITLE
Wrapping unsafe raw JSContext pointers in a safe struct. Part 1.

### DIFF
--- a/components/script/build.rs
+++ b/components/script/build.rs
@@ -47,7 +47,7 @@ fn main() {
     let mut phf = File::create(&phf).unwrap();
     write!(
         &mut phf,
-        "pub static MAP: phf::Map<&'static [u8], unsafe fn(*mut JSContext, HandleObject)> = "
+        "pub static MAP: phf::Map<&'static [u8], unsafe fn(JSContext, HandleObject)> = "
     )
     .unwrap();
     map.build(&mut phf).unwrap();

--- a/components/script/compartments.rs
+++ b/components/script/compartments.rs
@@ -12,7 +12,7 @@ impl AlreadyInCompartment {
     #![allow(unsafe_code)]
     pub fn assert(global: &GlobalScope) -> AlreadyInCompartment {
         unsafe {
-            assert!(!GetCurrentRealmOrNull(global.get_cx()).is_null());
+            assert!(!GetCurrentRealmOrNull(*global.get_cx()).is_null());
         }
         AlreadyInCompartment(())
     }
@@ -43,7 +43,7 @@ impl<'a> InCompartment<'a> {
 
 pub fn enter_realm(object: &impl DomObject) -> JSAutoRealm {
     JSAutoRealm::new(
-        object.global().get_cx(),
+        *object.global().get_cx(),
         object.reflector().get_jsobject().get(),
     )
 }

--- a/components/script/dom/audiobuffer.rs
+++ b/components/script/dom/audiobuffer.rs
@@ -173,15 +173,15 @@ impl AudioBuffer {
 
             // Step 2.
             let channel_data = unsafe {
-                typedarray!(in(cx) let array: Float32Array = channel.get());
+                typedarray!(in(*cx) let array: Float32Array = channel.get());
                 if let Ok(array) = array {
                     let data = array.to_vec();
                     let mut is_shared = false;
-                    rooted!(in (cx) let view_buffer =
-                        JS_GetArrayBufferViewBuffer(cx, channel.handle(), &mut is_shared));
+                    rooted!(in (*cx) let view_buffer =
+                        JS_GetArrayBufferViewBuffer(*cx, channel.handle(), &mut is_shared));
                     // This buffer is always created unshared
                     debug_assert!(!is_shared);
-                    let _ = DetachArrayBuffer(cx, view_buffer.handle());
+                    let _ = DetachArrayBuffer(*cx, view_buffer.handle());
                     data
                 } else {
                     return None;
@@ -272,7 +272,7 @@ impl AudioBufferMethods for AudioBuffer {
         // We either copy form js_channels or shared_channels.
         let js_channel = self.js_channels.borrow()[channel_number].get();
         if !js_channel.is_null() {
-            typedarray!(in(cx) let array: Float32Array = js_channel);
+            typedarray!(in(*cx) let array: Float32Array = js_channel);
             if let Ok(array) = array {
                 let data = unsafe { array.as_slice() };
                 dest.extend_from_slice(&data[offset..offset + bytes_to_copy]);
@@ -307,7 +307,7 @@ impl AudioBufferMethods for AudioBuffer {
         }
 
         let cx = self.global().get_cx();
-        if unsafe { !self.restore_js_channel_data(cx) } {
+        if unsafe { !self.restore_js_channel_data(*cx) } {
             return Err(Error::JSFailed);
         }
 
@@ -317,7 +317,7 @@ impl AudioBufferMethods for AudioBuffer {
             return Err(Error::IndexSize);
         }
 
-        typedarray!(in(cx) let js_channel: Float32Array = js_channel);
+        typedarray!(in(*cx) let js_channel: Float32Array = js_channel);
         if let Ok(mut js_channel) = js_channel {
             let bytes_to_copy = min(self.length - start_in_channel, source.len() as u32) as usize;
             let js_channel_data = unsafe { js_channel.as_mut_slice() };

--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -255,8 +255,8 @@ impl CallSetup {
         let ais = callback.incumbent().map(AutoIncumbentScript::new);
         CallSetup {
             exception_global: global,
-            cx: cx,
-            old_realm: unsafe { EnterRealm(cx, callback.callback()) },
+            cx: *cx,
+            old_realm: unsafe { EnterRealm(*cx, callback.callback()) },
             handling: handling,
             entry_script: Some(aes),
             incumbent_script: ais,

--- a/components/script/dom/bindings/callback.rs
+++ b/components/script/dom/bindings/callback.rs
@@ -13,6 +13,7 @@ use crate::dom::bindings::settings_stack::{AutoEntryScript, AutoIncumbentScript}
 use crate::dom::bindings::utils::AsCCharPtrPtr;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
+use crate::script_runtime::JSContext as SafeJSContext;
 use js::jsapi::Heap;
 use js::jsapi::JSAutoRealm;
 use js::jsapi::{AddRawValueRoot, IsCallable, JSContext, JSObject};
@@ -112,7 +113,7 @@ impl PartialEq for CallbackObject {
 /// callback interface types.
 pub trait CallbackContainer {
     /// Create a new CallbackContainer object for the given `JSObject`.
-    unsafe fn new(cx: *mut JSContext, callback: *mut JSObject) -> Rc<Self>;
+    unsafe fn new(cx: SafeJSContext, callback: *mut JSObject) -> Rc<Self>;
     /// Returns the underlying `CallbackObject`.
     fn callback_holder(&self) -> &CallbackObject;
     /// Returns the underlying `JSObject`.
@@ -151,8 +152,8 @@ impl CallbackFunction {
 
     /// Initialize the callback function with a value.
     /// Should be called once this object is done moving.
-    pub unsafe fn init(&mut self, cx: *mut JSContext, callback: *mut JSObject) {
-        self.object.init(cx, callback);
+    pub unsafe fn init(&mut self, cx: SafeJSContext, callback: *mut JSObject) {
+        self.object.init(*cx, callback);
     }
 }
 
@@ -178,8 +179,8 @@ impl CallbackInterface {
 
     /// Initialize the callback function with a value.
     /// Should be called once this object is done moving.
-    pub unsafe fn init(&mut self, cx: *mut JSContext, callback: *mut JSObject) {
-        self.object.init(cx, callback);
+    pub unsafe fn init(&mut self, cx: SafeJSContext, callback: *mut JSObject) {
+        self.object.init(*cx, callback);
     }
 
     /// Returns the property with the given `name`, if it is a callable object,

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -3332,7 +3332,7 @@ class CGCallGenerator(CGThing):
         needsCx = needCx(returnType, (a for (a, _) in arguments), True)
 
         if "cx" not in argsPre and needsCx:
-            args.prepend(CGGeneric("*cx"))
+            args.prepend(CGGeneric("cx"))
         if nativeMethodName in descriptor.inCompartmentMethods:
             args.append(CGGeneric("InCompartment::in_compartment(&AlreadyInCompartment::assert_for_cx(*cx))"))
 
@@ -5649,7 +5649,7 @@ class CGInterfaceTrait(CGThing):
 
         def attribute_arguments(needCx, argument=None, inCompartment=False):
             if needCx:
-                yield "cx", "*mut JSContext"
+                yield "cx", "SafeJSContext"
 
             if argument:
                 yield "value", argument_type(descriptor, argument)
@@ -6720,7 +6720,7 @@ def argument_type(descriptorProvider, ty, optional=False, defaultValue=None, var
 
 def method_arguments(descriptorProvider, returnType, arguments, passJSBits=True, trailing=None, inCompartment=False):
     if needCx(returnType, arguments, passJSBits):
-        yield "cx", "*mut JSContext"
+        yield "cx", "SafeJSContext"
 
     for argument in arguments:
         ty = argument_type(descriptorProvider, argument.type, argument.optional,

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2586,7 +2586,7 @@ class CGConstructorEnabled(CGAbstractMethod):
     def __init__(self, descriptor):
         CGAbstractMethod.__init__(self, descriptor,
                                   'ConstructorEnabled', 'bool',
-                                  [Argument("*mut JSContext", "aCx"),
+                                  [Argument("SafeJSContext", "aCx"),
                                    Argument("HandleObject", "aObj")],
                                   unsafe=True)
 
@@ -3285,7 +3285,7 @@ class CGDefineDOMInterfaceMethod(CGAbstractMethod):
         return CGGeneric("""\
 assert!(!global.get().is_null());
 
-if !ConstructorEnabled(cx, global) {
+if !ConstructorEnabled(SafeJSContext::from_ptr(cx), global) {
     return;
 }
 
@@ -6006,6 +6006,7 @@ def generate_imports(config, cgthings, descriptors, callbacks=None, dictionaries
         'crate::mem::malloc_size_of_including_raw_self',
         'crate::compartments::InCompartment',
         'crate::compartments::AlreadyInCompartment',
+        'crate::script_runtime::JSContext as SafeJSContext',
         'libc',
         'servo_config::pref',
         'servo_config::prefs',

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -3268,7 +3268,7 @@ class CGDefineDOMInterfaceMethod(CGAbstractMethod):
     def __init__(self, descriptor):
         assert descriptor.interface.hasInterfaceObject()
         args = [
-            Argument('*mut JSContext', 'cx'),
+            Argument('SafeJSContext', 'cx'),
             Argument('HandleObject', 'global'),
         ]
         CGAbstractMethod.__init__(self, descriptor, 'DefineDOMInterface',
@@ -3285,12 +3285,12 @@ class CGDefineDOMInterfaceMethod(CGAbstractMethod):
         return CGGeneric("""\
 assert!(!global.get().is_null());
 
-if !ConstructorEnabled(SafeJSContext::from_ptr(cx), global) {
+if !ConstructorEnabled(cx, global) {
     return;
 }
 
-rooted!(in(cx) let mut proto = ptr::null_mut::<JSObject>());
-%s(SafeJSContext::from_ptr(cx), global, proto.handle_mut());
+rooted!(in(*cx) let mut proto = ptr::null_mut::<JSObject>());
+%s(cx, global, proto.handle_mut());
 assert!(!proto.is_null());""" % (function,))
 
 
@@ -7312,7 +7312,7 @@ class GlobalGenRoots():
     def InterfaceObjectMap(config):
         mods = [
             "crate::dom::bindings::codegen",
-            "js::jsapi::JSContext",
+            "crate::script_runtime::JSContext",
             "js::rust::HandleObject",
             "phf",
         ]

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2650,8 +2650,8 @@ def InitUnforgeablePropertiesOnHolder(descriptor, properties):
     """
     unforgeables = []
 
-    defineUnforgeableAttrs = "define_guarded_properties(cx, unforgeable_holder.handle(), %s, global);"
-    defineUnforgeableMethods = "define_guarded_methods(cx, unforgeable_holder.handle(), %s, global);"
+    defineUnforgeableAttrs = "define_guarded_properties(*cx, unforgeable_holder.handle(), %s, global);"
+    defineUnforgeableMethods = "define_guarded_methods(*cx, unforgeable_holder.handle(), %s, global);"
 
     unforgeableMembers = [
         (defineUnforgeableAttrs, properties.unforgeable_attrs),
@@ -2888,7 +2888,7 @@ class CGCreateInterfaceObjectsMethod(CGAbstractMethod):
     properties should be a PropertyArrays instance.
     """
     def __init__(self, descriptor, properties, haveUnscopables):
-        args = [Argument('*mut JSContext', 'cx'), Argument('HandleObject', 'global'),
+        args = [Argument('SafeJSContext', 'cx'), Argument('HandleObject', 'global'),
                 Argument('*mut ProtoOrIfaceArray', 'cache')]
         CGAbstractMethod.__init__(self, descriptor, 'CreateInterfaceObjects', 'void', args,
                                   unsafe=True)
@@ -2899,18 +2899,18 @@ class CGCreateInterfaceObjectsMethod(CGAbstractMethod):
         name = self.descriptor.interface.identifier.name
         if self.descriptor.interface.isNamespace():
             if self.descriptor.interface.getExtendedAttribute("ProtoObjectHack"):
-                proto = "GetRealmObjectPrototype(cx)"
+                proto = "GetRealmObjectPrototype(*cx)"
             else:
-                proto = "JS_NewPlainObject(cx)"
+                proto = "JS_NewPlainObject(*cx)"
             if self.properties.static_methods.length():
                 methods = self.properties.static_methods.variableName()
             else:
                 methods = "&[]"
             return CGGeneric("""\
-rooted!(in(cx) let proto = %(proto)s);
+rooted!(in(*cx) let proto = %(proto)s);
 assert!(!proto.is_null());
-rooted!(in(cx) let mut namespace = ptr::null_mut::<JSObject>());
-create_namespace_object(cx, global, proto.handle(), &NAMESPACE_OBJECT_CLASS,
+rooted!(in(*cx) let mut namespace = ptr::null_mut::<JSObject>());
+create_namespace_object(*cx, global, proto.handle(), &NAMESPACE_OBJECT_CLASS,
                         %(methods)s, %(name)s, namespace.handle_mut());
 assert!(!namespace.is_null());
 assert!((*cache)[PrototypeList::Constructor::%(id)s as usize].is_null());
@@ -2922,8 +2922,8 @@ assert!((*cache)[PrototypeList::Constructor::%(id)s as usize].is_null());
         if self.descriptor.interface.isCallback():
             assert not self.descriptor.interface.ctor() and self.descriptor.interface.hasConstants()
             return CGGeneric("""\
-rooted!(in(cx) let mut interface = ptr::null_mut::<JSObject>());
-create_callback_interface_object(cx, global, sConstants, %(name)s, interface.handle_mut());
+rooted!(in(*cx) let mut interface = ptr::null_mut::<JSObject>());
+create_callback_interface_object(*cx, global, sConstants, %(name)s, interface.handle_mut());
 assert!(!interface.is_null());
 assert!((*cache)[PrototypeList::Constructor::%(id)s as usize].is_null());
 (*cache)[PrototypeList::Constructor::%(id)s as usize] = interface.get();
@@ -2940,13 +2940,13 @@ assert!((*cache)[PrototypeList::Constructor::%(id)s as usize].is_null());
                 protoGetter = "GetRealmIteratorPrototype"
             else:
                 protoGetter = "GetRealmObjectPrototype"
-            getPrototypeProto = "prototype_proto.set(%s(cx))" % protoGetter
+            getPrototypeProto = "prototype_proto.set(%s(*cx))" % protoGetter
         else:
-            getPrototypeProto = ("%s::GetProtoObject(cx, global, prototype_proto.handle_mut())" %
+            getPrototypeProto = ("%s::GetProtoObject(*cx, global, prototype_proto.handle_mut())" %
                                  toBindingNamespace(parentName))
 
         code = [CGGeneric("""\
-rooted!(in(cx) let mut prototype_proto = ptr::null_mut::<JSObject>());
+rooted!(in(*cx) let mut prototype_proto = ptr::null_mut::<JSObject>());
 %s;
 assert!(!prototype_proto.is_null());""" % getPrototypeProto)]
 
@@ -2974,8 +2974,8 @@ assert!(!prototype_proto.is_null());""" % getPrototypeProto)]
             proto_properties = properties
 
         code.append(CGGeneric("""
-rooted!(in(cx) let mut prototype = ptr::null_mut::<JSObject>());
-create_interface_prototype_object(cx,
+rooted!(in(*cx) let mut prototype = ptr::null_mut::<JSObject>());
+create_interface_prototype_object(*cx,
                                   global.into(),
                                   prototype_proto.handle().into(),
                                   &PrototypeClass,
@@ -2999,18 +2999,18 @@ assert!((*cache)[PrototypeList::ID::%(id)s as usize].is_null());
             else:
                 properties["length"] = 0
             parentName = self.descriptor.getParentName()
-            code.append(CGGeneric("rooted!(in(cx) let mut interface_proto = ptr::null_mut::<JSObject>());"))
+            code.append(CGGeneric("rooted!(in(*cx) let mut interface_proto = ptr::null_mut::<JSObject>());"))
             if parentName:
                 parentName = toBindingNamespace(parentName)
                 code.append(CGGeneric("""
-%s::GetConstructorObject(cx, global, interface_proto.handle_mut());""" % parentName))
+%s::GetConstructorObject(*cx, global, interface_proto.handle_mut());""" % parentName))
             else:
-                code.append(CGGeneric("interface_proto.set(GetRealmFunctionPrototype(cx));"))
+                code.append(CGGeneric("interface_proto.set(GetRealmFunctionPrototype(*cx));"))
             code.append(CGGeneric("""\
 assert!(!interface_proto.is_null());
 
-rooted!(in(cx) let mut interface = ptr::null_mut::<JSObject>());
-create_noncallback_interface_object(cx,
+rooted!(in(*cx) let mut interface = ptr::null_mut::<JSObject>());
+create_noncallback_interface_object(*cx,
                                     global.into(),
                                     interface_proto.handle(),
                                     &INTERFACE_OBJECT_CLASS,
@@ -3035,8 +3035,8 @@ assert!((*cache)[PrototypeList::Constructor::%(id)s as usize].is_null());
         if aliasedMembers:
             def defineAlias(alias):
                 if alias == "@@iterator":
-                    symbolJSID = "RUST_SYMBOL_TO_JSID(GetWellKnownSymbol(cx, SymbolCode::iterator))"
-                    getSymbolJSID = CGGeneric(fill("rooted!(in(cx) let iteratorId = ${symbolJSID});",
+                    symbolJSID = "RUST_SYMBOL_TO_JSID(GetWellKnownSymbol(*cx, SymbolCode::iterator))"
+                    getSymbolJSID = CGGeneric(fill("rooted!(in(*cx) let iteratorId = ${symbolJSID});",
                                                    symbolJSID=symbolJSID))
                     defineFn = "JS_DefinePropertyById2"
                     prop = "iteratorId.handle()"
@@ -3053,7 +3053,7 @@ assert!((*cache)[PrototypeList::Constructor::%(id)s as usize].is_null());
                     #     match the enumerability of the property being aliased.
                     CGGeneric(fill(
                         """
-                        assert!(${defineFn}(cx, prototype.handle(), ${prop}, aliasedVal.handle(),
+                        assert!(${defineFn}(*cx, prototype.handle(), ${prop}, aliasedVal.handle(),
                                             JSPROP_ENUMERATE as u32));
                         """,
                         defineFn=defineFn,
@@ -3064,7 +3064,7 @@ assert!((*cache)[PrototypeList::Constructor::%(id)s as usize].is_null());
                 return CGList([
                     CGGeneric(fill(
                         """
-                        assert!(JS_GetProperty(cx, prototype.handle(),
+                        assert!(JS_GetProperty(*cx, prototype.handle(),
                                                ${prop} as *const u8 as *const _,
                                                aliasedVal.handle_mut()));
                         """,
@@ -3076,7 +3076,7 @@ assert!((*cache)[PrototypeList::Constructor::%(id)s as usize].is_null());
                     // Set up aliases on the interface prototype object we just created.
 
                     """)),
-                CGGeneric("rooted!(in(cx) let mut aliasedVal = UndefinedValue());\n\n")
+                CGGeneric("rooted!(in(*cx) let mut aliasedVal = UndefinedValue());\n\n")
             ] + [defineAliasesFor(m) for m in sorted(aliasedMembers)])
             code.append(defineAliases)
 
@@ -3091,7 +3091,7 @@ assert!((*cache)[PrototypeList::Constructor::%(id)s as usize].is_null());
                 specs.append(CGGeneric("(%s as ConstructorClassHook, %s, %d)" % (hook, name, length)))
             values = CGIndenter(CGList(specs, "\n"), 4)
             code.append(CGWrapper(values, pre="%s = [\n" % decl, post="\n];"))
-            code.append(CGGeneric("create_named_constructors(cx, global, &named_constructors, prototype.handle());"))
+            code.append(CGGeneric("create_named_constructors(*cx, global, &named_constructors, prototype.handle());"))
 
         if self.descriptor.hasUnforgeableMembers:
             # We want to use the same JSClass and prototype as the object we'll
@@ -3112,9 +3112,9 @@ assert!((*cache)[PrototypeList::Constructor::%(id)s as usize].is_null());
                 holderClass = "&Class.base as *const JSClass"
                 holderProto = "prototype.handle()"
             code.append(CGGeneric("""
-rooted!(in(cx) let mut unforgeable_holder = ptr::null_mut::<JSObject>());
+rooted!(in(*cx) let mut unforgeable_holder = ptr::null_mut::<JSObject>());
 unforgeable_holder.handle_mut().set(
-    JS_NewObjectWithoutMetadata(cx, %(holderClass)s, %(holderProto)s));
+    JS_NewObjectWithoutMetadata(*cx, %(holderClass)s, %(holderProto)s));
 assert!(!unforgeable_holder.is_null());
 """ % {'holderClass': holderClass, 'holderProto': holderProto}))
             code.append(InitUnforgeablePropertiesOnHolder(self.descriptor, self.properties))
@@ -3149,7 +3149,7 @@ if !rval.get().is_null() {
     return;
 }
 
-CreateInterfaceObjects(cx, global, proto_or_iface_array);
+CreateInterfaceObjects(SafeJSContext::from_ptr(cx), global, proto_or_iface_array);
 rval.set((*proto_or_iface_array)[%(id)s as usize]);
 assert!(!rval.get().is_null());
 """ % {"id": self.id})

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -323,7 +323,7 @@ class CGMethodCall(CGThing):
             if requiredArgs > 0:
                 code = (
                     "if argc < %d {\n"
-                    "    throw_type_error(cx, \"Not enough arguments to %s.\");\n"
+                    "    throw_type_error(*cx, \"Not enough arguments to %s.\");\n"
                     "    return false;\n"
                     "}" % (requiredArgs, methodName))
                 self.cgRoot.prepend(
@@ -448,7 +448,7 @@ class CGMethodCall(CGThing):
             # XXXbz Now we're supposed to check for distinguishingArg being
             # an array or a platform object that supports indexed
             # properties... skip that last for now.  It's a bit of a pain.
-            pickFirstSignature("%s.get().is_object() && is_array_like(cx, %s)" %
+            pickFirstSignature("%s.get().is_object() && is_array_like(*cx, %s)" %
                                (distinguishingArg, distinguishingArg),
                                lambda s:
                                    (s[1][distinguishingIndex].type.isSequence() or
@@ -457,9 +457,9 @@ class CGMethodCall(CGThing):
             # Check for Date objects
             # XXXbz Do we need to worry about security wrappers around the Date?
             pickFirstSignature("%s.get().is_object() && "
-                               "{ rooted!(in(cx) let obj = %s.get().to_object()); "
+                               "{ rooted!(in(*cx) let obj = %s.get().to_object()); "
                                "let mut is_date = false; "
-                               "assert!(ObjectIsDate(cx, obj.handle(), &mut is_date)); "
+                               "assert!(ObjectIsDate(*cx, obj.handle(), &mut is_date)); "
                                "is_date }" %
                                (distinguishingArg, distinguishingArg),
                                lambda s: (s[1][distinguishingIndex].type.isDate() or
@@ -467,7 +467,7 @@ class CGMethodCall(CGThing):
 
             # Check for vanilla JS objects
             # XXXbz Do we need to worry about security wrappers?
-            pickFirstSignature("%s.get().is_object() && !is_platform_object(%s.get().to_object(), cx)" %
+            pickFirstSignature("%s.get().is_object() && !is_platform_object(%s.get().to_object(), *cx)" %
                                (distinguishingArg, distinguishingArg),
                                lambda s: (s[1][distinguishingIndex].type.isCallback() or
                                           s[1][distinguishingIndex].type.isCallbackInterface() or
@@ -492,7 +492,7 @@ class CGMethodCall(CGThing):
             else:
                 # Just throw; we have no idea what we're supposed to
                 # do with this.
-                caseBody.append(CGGeneric("throw_internal_error(cx, \"Could not convert JavaScript argument\");\n"
+                caseBody.append(CGGeneric("throw_internal_error(*cx, \"Could not convert JavaScript argument\");\n"
                                           "return false;"))
 
             argCountCases.append(CGCase(str(argCount),
@@ -505,7 +505,7 @@ class CGMethodCall(CGThing):
         overloadCGThings.append(
             CGSwitch("argcount",
                      argCountCases,
-                     CGGeneric("throw_type_error(cx, \"Not enough arguments to %s.\");\n"
+                     CGGeneric("throw_type_error(*cx, \"Not enough arguments to %s.\");\n"
                                "return false;" % methodName)))
         # XXXjdm Avoid unreachable statement warnings
         # overloadCGThings.append(
@@ -638,7 +638,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         exceptionCode = "return false;\n"
 
     if failureCode is None:
-        failOrPropagate = "throw_type_error(cx, &error);\n%s" % exceptionCode
+        failOrPropagate = "throw_type_error(*cx, &error);\n%s" % exceptionCode
     else:
         failOrPropagate = failureCode
 
@@ -657,20 +657,20 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         return CGWrapper(
             CGGeneric(
                 failureCode or
-                ('throw_type_error(cx, "%s is not an object.");\n'
+                ('throw_type_error(*cx, "%s is not an object.");\n'
                  '%s' % (firstCap(sourceDescription), exceptionCode))),
             post="\n")
 
     def onFailureInvalidEnumValue(failureCode, passedVarName):
         return CGGeneric(
             failureCode or
-            ('throw_type_error(cx, &format!("\'{}\' is not a valid enum value for enumeration \'%s\'.", %s)); %s'
+            ('throw_type_error(*cx, &format!("\'{}\' is not a valid enum value for enumeration \'%s\'.", %s)); %s'
              % (type.name, passedVarName, exceptionCode)))
 
     def onFailureNotCallable(failureCode):
         return CGGeneric(
             failureCode or
-            ('throw_type_error(cx, \"%s is not callable.\");\n'
+            ('throw_type_error(*cx, \"%s is not callable.\");\n'
              '%s' % (firstCap(sourceDescription), exceptionCode)))
 
     # A helper function for handling default values.
@@ -723,7 +723,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         if type.nullable():
             declType = CGWrapper(declType, pre="Option<", post=" >")
 
-        templateBody = ("match FromJSValConvertible::from_jsval(cx, ${val}, %s) {\n"
+        templateBody = ("match FromJSValConvertible::from_jsval(*cx, ${val}, %s) {\n"
                         "    Ok(ConversionResult::Success(value)) => value,\n"
                         "    Ok(ConversionResult::Failure(error)) => {\n"
                         "%s\n"
@@ -738,7 +738,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         if type.nullable():
             declType = CGWrapper(declType, pre="Option<", post=" >")
 
-        templateBody = ("match FromJSValConvertible::from_jsval(cx, ${val}, ()) {\n"
+        templateBody = ("match FromJSValConvertible::from_jsval(*cx, ${val}, ()) {\n"
                         "    Ok(ConversionResult::Success(value)) => value,\n"
                         "    Ok(ConversionResult::Failure(error)) => {\n"
                         "%s\n"
@@ -803,17 +803,17 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
             """
             { // Scope for our JSAutoRealm.
 
-                rooted!(in(cx) let globalObj = CurrentGlobalOrNull(cx));
-                let promiseGlobal = GlobalScope::from_object_maybe_wrapped(globalObj.handle().get(), cx);
+                rooted!(in(*cx) let globalObj = CurrentGlobalOrNull(*cx));
+                let promiseGlobal = GlobalScope::from_object_maybe_wrapped(globalObj.handle().get(), *cx);
 
-                rooted!(in(cx) let mut valueToResolve = $${val}.get());
-                if !JS_WrapValue(cx, valueToResolve.handle_mut()) {
+                rooted!(in(*cx) let mut valueToResolve = $${val}.get());
+                if !JS_WrapValue(*cx, valueToResolve.handle_mut()) {
                 $*{exceptionCode}
                 }
-                match Promise::new_resolved(&promiseGlobal, cx, valueToResolve.handle()) {
+                match Promise::new_resolved(&promiseGlobal, *cx, valueToResolve.handle()) {
                     Ok(value) => value,
                     Err(error) => {
-                    throw_dom_exception(cx, &promiseGlobal, error);
+                    throw_dom_exception(*cx, &promiseGlobal, error);
                     $*{exceptionCode}
                     }
                 }
@@ -836,7 +836,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         if descriptor.interface.isCallback():
             name = descriptor.nativeType
             declType = CGWrapper(CGGeneric(name), pre="Rc<", post=">")
-            template = "%s::new(SafeJSContext::from_ptr(cx), ${val}.get().to_object())" % name
+            template = "%s::new(cx, ${val}.get().to_object())" % name
             if type.nullable():
                 declType = CGWrapper(declType, pre="Option<", post=">")
                 template = wrapObjectTemplate("Some(%s)" % template, "None",
@@ -864,7 +864,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
                 "exceptionCode": exceptionCode,
             }
             unwrapFailureCode = string.Template(
-                'throw_type_error(cx, "${sourceDescription} does not '
+                'throw_type_error(*cx, "${sourceDescription} does not '
                 'implement interface ${interface}.");\n'
                 '${exceptionCode}').substitute(substitutions)
         else:
@@ -872,7 +872,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
 
         templateBody = fill(
             """
-            match ${function}($${val}, cx) {
+            match ${function}($${val}, *cx) {
                 Ok(val) => val,
                 Err(()) => {
                     $*{failureCode}
@@ -899,7 +899,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
                 "exceptionCode": exceptionCode,
             }
             unwrapFailureCode = string.Template(
-                'throw_type_error(cx, "${sourceDescription} is not a typed array.");\n'
+                'throw_type_error(*cx, "${sourceDescription} is not a typed array.");\n'
                 '${exceptionCode}').substitute(substitutions)
         else:
             unwrapFailureCode = failureCode
@@ -942,7 +942,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         nullBehavior = getConversionConfigForType(type, isEnforceRange, isClamp, treatNullAs)
 
         conversionCode = (
-            "match FromJSValConvertible::from_jsval(cx, ${val}, %s) {\n"
+            "match FromJSValConvertible::from_jsval(*cx, ${val}, %s) {\n"
             "    Ok(ConversionResult::Success(strval)) => strval,\n"
             "    Ok(ConversionResult::Failure(error)) => {\n"
             "%s\n"
@@ -971,7 +971,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         assert not isEnforceRange and not isClamp
 
         conversionCode = (
-            "match FromJSValConvertible::from_jsval(cx, ${val}, ()) {\n"
+            "match FromJSValConvertible::from_jsval(*cx, ${val}, ()) {\n"
             "    Ok(ConversionResult::Success(strval)) => strval,\n"
             "    Ok(ConversionResult::Failure(error)) => {\n"
             "%s\n"
@@ -1000,7 +1000,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         assert not isEnforceRange and not isClamp
 
         conversionCode = (
-            "match FromJSValConvertible::from_jsval(cx, ${val}, ()) {\n"
+            "match FromJSValConvertible::from_jsval(*cx, ${val}, ()) {\n"
             "    Ok(ConversionResult::Success(strval)) => strval,\n"
             "    Ok(ConversionResult::Failure(error)) => {\n"
             "%s\n"
@@ -1038,7 +1038,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
             handleInvalidEnumValueCode = "return true;"
 
         template = (
-            "match find_enum_value(cx, ${val}, %(pairs)s) {\n"
+            "match find_enum_value(*cx, ${val}, %(pairs)s) {\n"
             "    Err(_) => { %(exceptionCode)s },\n"
             "    Ok((None, search)) => { %(handleInvalidEnumValueCode)s },\n"
             "    Ok((Some(&value), _)) => value,\n"
@@ -1174,7 +1174,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         if type_needs_tracing(type):
             declType = CGTemplatedType("RootedTraceableBox", declType)
 
-        template = ("match FromJSValConvertible::from_jsval(cx, ${val}, ()) {\n"
+        template = ("match FromJSValConvertible::from_jsval(*cx, ${val}, ()) {\n"
                     "    Ok(ConversionResult::Success(dictionary)) => dictionary,\n"
                     "    Ok(ConversionResult::Failure(error)) => {\n"
                     "%s\n"
@@ -1202,7 +1202,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         declType = CGWrapper(declType, pre="Option<", post=">")
 
     template = (
-        "match FromJSValConvertible::from_jsval(cx, ${val}, %s) {\n"
+        "match FromJSValConvertible::from_jsval(*cx, ${val}, %s) {\n"
         "    Ok(ConversionResult::Success(v)) => v,\n"
         "    Ok(ConversionResult::Failure(error)) => {\n"
         "%s\n"
@@ -1260,7 +1260,7 @@ def instantiateJSToNativeConversionTemplate(templateBody, replacements,
         result.append(conversion)
 
     if needsAutoRoot:
-        result.append(CGGeneric("auto_root!(in(cx) let %s = %s);" % (declName, declName)))
+        result.append(CGGeneric("auto_root!(in(*cx) let %s = %s);" % (declName, declName)))
     # Add an empty CGGeneric to get an extra newline after the argument
     # conversion.
     result.append(CGGeneric(""))
@@ -1383,7 +1383,7 @@ def wrapForType(jsvalRef, result='result', successCode='return true;', pre=''):
       * 'successCode': the code to run once we have done the conversion.
       * 'pre': code to run before the conversion if rooting is necessary
     """
-    wrap = "%s\n(%s).to_jsval(cx, %s);" % (pre, result, jsvalRef)
+    wrap = "%s\n(%s).to_jsval(*cx, %s);" % (pre, result, jsvalRef)
     if successCode:
         wrap += "\n%s" % successCode
     return wrap
@@ -2364,7 +2364,7 @@ class CGGeneric(CGThing):
 
 class CGCallbackTempRoot(CGGeneric):
     def __init__(self, name):
-        CGGeneric.__init__(self, "%s::new(SafeJSContext::from_ptr(cx), ${val}.get().to_object())" % name)
+        CGGeneric.__init__(self, "%s::new(cx, ${val}.get().to_object())" % name)
 
 
 def getAllTypes(descriptors, dictionaries, callbacks, typedefs):
@@ -2410,6 +2410,7 @@ def UnionTypes(descriptors, dictionaries, callbacks, typedefs, config):
         'crate::dom::bindings::str::USVString',
         'crate::dom::bindings::trace::RootedTraceableBox',
         'crate::dom::types::*',
+        'crate::script_runtime::JSContext as SafeJSContext',
         'js::error::throw_type_error',
         'js::rust::HandleValue',
         'js::jsapi::Heap',
@@ -3331,9 +3332,9 @@ class CGCallGenerator(CGThing):
         needsCx = needCx(returnType, (a for (a, _) in arguments), True)
 
         if "cx" not in argsPre and needsCx:
-            args.prepend(CGGeneric("cx"))
+            args.prepend(CGGeneric("*cx"))
         if nativeMethodName in descriptor.inCompartmentMethods:
-            args.append(CGGeneric("InCompartment::in_compartment(&AlreadyInCompartment::assert_for_cx(cx))"))
+            args.append(CGGeneric("InCompartment::in_compartment(&AlreadyInCompartment::assert_for_cx(*cx))"))
 
         # Build up our actual call
         self.cgRoot = CGList([], "\n")
@@ -3369,7 +3370,7 @@ class CGCallGenerator(CGThing):
                 "let result = match result {\n"
                 "    Ok(result) => result,\n"
                 "    Err(e) => {\n"
-                "        throw_dom_exception(cx, %s, e);\n"
+                "        throw_dom_exception(*cx, %s, e);\n"
                 "        return%s;\n"
                 "    },\n"
                 "};" % (glob, errorResult)))
@@ -3593,7 +3594,7 @@ class CGSpecializedMethod(CGAbstractExternMethod):
     def __init__(self, descriptor, method):
         self.method = method
         name = method.identifier.name
-        args = [Argument('*mut JSContext', 'cx'), Argument('HandleObject', '_obj'),
+        args = [Argument('SafeJSContext', 'cx'), Argument('HandleObject', '_obj'),
                 Argument('*const %s' % descriptor.concreteType, 'this'),
                 Argument('*const JSJitMethodCallArgs', 'args')]
         CGAbstractExternMethod.__init__(self, descriptor, name, 'bool', args)
@@ -3628,9 +3629,10 @@ class CGStaticMethod(CGAbstractStaticBindingMethod):
     def generate_code(self):
         nativeName = CGSpecializedMethod.makeNativeName(self.descriptor,
                                                         self.method)
+        safeContext = CGGeneric("let cx = SafeJSContext::from_ptr(cx);\n")
         setupArgs = CGGeneric("let args = CallArgs::from_vp(vp, argc);\n")
         call = CGMethodCall(["&global"], nativeName, True, self.descriptor, self.method)
-        return CGList([setupArgs, call])
+        return CGList([safeContext, setupArgs, call])
 
 
 class CGSpecializedGetter(CGAbstractExternMethod):
@@ -3641,7 +3643,7 @@ class CGSpecializedGetter(CGAbstractExternMethod):
     def __init__(self, descriptor, attr):
         self.attr = attr
         name = 'get_' + descriptor.internalNameFor(attr.identifier.name)
-        args = [Argument('*mut JSContext', 'cx'),
+        args = [Argument('SafeJSContext', 'cx'),
                 Argument('HandleObject', '_obj'),
                 Argument('*const %s' % descriptor.concreteType, 'this'),
                 Argument('JSJitGetterCallArgs', 'args')]
@@ -3682,10 +3684,11 @@ class CGStaticGetter(CGAbstractStaticBindingMethod):
     def generate_code(self):
         nativeName = CGSpecializedGetter.makeNativeName(self.descriptor,
                                                         self.attr)
+        safeContext = CGGeneric("let cx = SafeJSContext::from_ptr(cx);\n")
         setupArgs = CGGeneric("let args = CallArgs::from_vp(vp, argc);\n")
         call = CGGetterCall(["&global"], self.attr.type, nativeName, self.descriptor,
                             self.attr)
-        return CGList([setupArgs, call])
+        return CGList([safeContext, setupArgs, call])
 
 
 class CGSpecializedSetter(CGAbstractExternMethod):
@@ -3696,7 +3699,7 @@ class CGSpecializedSetter(CGAbstractExternMethod):
     def __init__(self, descriptor, attr):
         self.attr = attr
         name = 'set_' + descriptor.internalNameFor(attr.identifier.name)
-        args = [Argument('*mut JSContext', 'cx'),
+        args = [Argument('SafeJSContext', 'cx'),
                 Argument('HandleObject', 'obj'),
                 Argument('*const %s' % descriptor.concreteType, 'this'),
                 Argument('JSJitSetterCallArgs', 'args')]
@@ -3730,15 +3733,16 @@ class CGStaticSetter(CGAbstractStaticBindingMethod):
     def generate_code(self):
         nativeName = CGSpecializedSetter.makeNativeName(self.descriptor,
                                                         self.attr)
+        safeContext = CGGeneric("let cx = SafeJSContext::from_ptr(cx);\n")
         checkForArg = CGGeneric(
             "let args = CallArgs::from_vp(vp, argc);\n"
             "if argc == 0 {\n"
-            "    throw_type_error(cx, \"Not enough arguments to %s setter.\");\n"
+            "    throw_type_error(*cx, \"Not enough arguments to %s setter.\");\n"
             "    return false;\n"
             "}" % self.attr.identifier.name)
         call = CGSetterCall(["&global"], self.attr.type, nativeName, self.descriptor,
                             self.attr)
-        return CGList([checkForArg, call])
+        return CGList([safeContext, checkForArg, call])
 
 
 class CGSpecializedForwardingSetter(CGSpecializedSetter):
@@ -3755,16 +3759,16 @@ class CGSpecializedForwardingSetter(CGSpecializedSetter):
         assert all(ord(c) < 128 for c in attrName)
         assert all(ord(c) < 128 for c in forwardToAttrName)
         return CGGeneric("""\
-rooted!(in(cx) let mut v = UndefinedValue());
-if !JS_GetProperty(cx, obj, %s as *const u8 as *const libc::c_char, v.handle_mut()) {
+rooted!(in(*cx) let mut v = UndefinedValue());
+if !JS_GetProperty(*cx, obj, %s as *const u8 as *const libc::c_char, v.handle_mut()) {
     return false;
 }
 if !v.is_object() {
-    throw_type_error(cx, "Value.%s is not an object.");
+    throw_type_error(*cx, "Value.%s is not an object.");
     return false;
 }
-rooted!(in(cx) let target_obj = v.to_object());
-JS_SetProperty(cx, target_obj.handle(), %s as *const u8 as *const libc::c_char, HandleValue::from_raw(args.get(0)))
+rooted!(in(*cx) let target_obj = v.to_object());
+JS_SetProperty(*cx, target_obj.handle(), %s as *const u8 as *const libc::c_char, HandleValue::from_raw(args.get(0)))
 """ % (str_to_const_array(attrName), attrName, str_to_const_array(forwardToAttrName)))
 
 
@@ -3781,7 +3785,7 @@ class CGSpecializedReplaceableSetter(CGSpecializedSetter):
         # JS_DefineProperty can only deal with ASCII.
         assert all(ord(c) < 128 for c in name)
         return CGGeneric("""\
-JS_DefineProperty(cx, obj, %s as *const u8 as *const libc::c_char,
+JS_DefineProperty(*cx, obj, %s as *const u8 as *const libc::c_char,
                   HandleValue::from_raw(args.get(0)), JSPROP_ENUMERATE as u32)""" % name)
 
 
@@ -4370,7 +4374,7 @@ class CGUnionConversionStruct(CGThing):
 
         def get_match(name):
             return (
-                "match %s::TryConvertTo%s(cx, value) {\n"
+                "match %s::TryConvertTo%s(SafeJSContext::from_ptr(cx), value) {\n"
                 "    Err(_) => return Err(()),\n"
                 "    Ok(Some(value)) => return Ok(ConversionResult::Success(%s::%s(value))),\n"
                 "    Ok(None) => (),\n"
@@ -4510,7 +4514,7 @@ class CGUnionConversionStruct(CGThing):
 
         return CGWrapper(
             CGIndenter(jsConversion, 4),
-            pre="unsafe fn TryConvertTo%s(cx: *mut JSContext, value: HandleValue) -> %s {\n"
+            pre="unsafe fn TryConvertTo%s(cx: SafeJSContext, value: HandleValue) -> %s {\n"
                 % (t.name, returnType),
             post="\n}")
 
@@ -4903,7 +4907,7 @@ class CGProxySpecialOperation(CGPerSignatureCall):
             }
             self.cgRoot.prepend(instantiateJSToNativeConversionTemplate(
                 template, templateValues, declType, argument.identifier.name))
-            self.cgRoot.prepend(CGGeneric("rooted!(in(cx) let value = desc.value);"))
+            self.cgRoot.prepend(CGGeneric("rooted!(in(*cx) let value = desc.value);"))
 
     def getArguments(self):
         args = [(a, process_arg(a.identifier.name, a)) for a in self.arguments]
@@ -4946,7 +4950,7 @@ class CGProxyNamedOperation(CGProxySpecialOperation):
     def define(self):
         # Our first argument is the id we're getting.
         argName = self.arguments[0].identifier.name
-        return ("let %s = jsid_to_string(cx, Handle::from_raw(id)).expect(\"Not a string-convertible JSID?\");\n"
+        return ("let %s = jsid_to_string(*cx, Handle::from_raw(id)).expect(\"Not a string-convertible JSID?\");\n"
                 "let this = UnwrapProxy(proxy);\n"
                 "let this = &*this;\n" % argName +
                 CGProxySpecialOperation.define(self))
@@ -5015,9 +5019,9 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
     def getBody(self):
         indexedGetter = self.descriptor.operations['IndexedGetter']
 
-        get = ""
+        get = "let cx = SafeJSContext::from_ptr(cx);\n"
         if indexedGetter:
-            get = "let index = get_array_index_from_id(cx, Handle::from_raw(id));\n"
+            get += "let index = get_array_index_from_id(*cx, Handle::from_raw(id));\n"
 
             attrs = "JSPROP_ENUMERATE"
             if self.descriptor.operations['IndexedSetter'] is None:
@@ -5029,7 +5033,7 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
             templateValues = {
                 'jsvalRef': 'result_root.handle_mut()',
                 'successCode': fillDescriptor,
-                'pre': 'rooted!(in(cx) let mut result_root = UndefinedValue());'
+                'pre': 'rooted!(in(*cx) let mut result_root = UndefinedValue());'
             }
             get += ("if let Some(index) = index {\n" +
                     "    let this = UnwrapProxy(proxy);\n" +
@@ -5055,7 +5059,7 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
             templateValues = {
                 'jsvalRef': 'result_root.handle_mut()',
                 'successCode': fillDescriptor,
-                'pre': 'rooted!(in(cx) let mut result_root = UndefinedValue());'
+                'pre': 'rooted!(in(*cx) let mut result_root = UndefinedValue());'
             }
 
             # See the similar-looking in CGDOMJSProxyHandler_get for the spec quote.
@@ -5068,7 +5072,7 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
             namedGet = """
 if %s {
     let mut has_on_proto = false;
-    if !has_property_on_prototype(cx, proxy_lt, id_lt, &mut has_on_proto) {
+    if !has_property_on_prototype(*cx, proxy_lt, id_lt, &mut has_on_proto) {
         return false;
     }
     if !has_on_proto {
@@ -5080,13 +5084,13 @@ if %s {
             namedGet = ""
 
         return get + """\
-rooted!(in(cx) let mut expando = ptr::null_mut::<JSObject>());
+rooted!(in(*cx) let mut expando = ptr::null_mut::<JSObject>());
 get_expando_object(proxy, expando.handle_mut());
 //if (!xpc::WrapperFactory::IsXrayWrapper(proxy) && (expando = GetExpandoObject(proxy))) {
 let proxy_lt = Handle::from_raw(proxy);
 let id_lt = Handle::from_raw(id);
 if !expando.is_null() {
-    if !JS_GetPropertyDescriptorById(cx, expando.handle().into(), id, desc) {
+    if !JS_GetPropertyDescriptorById(*cx, expando.handle().into(), id, desc) {
         return false;
     }
     if !desc.obj.is_null() {
@@ -5113,11 +5117,11 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
         self.descriptor = descriptor
 
     def getBody(self):
-        set = ""
+        set = "let cx = SafeJSContext::from_ptr(cx);\n"
 
         indexedSetter = self.descriptor.operations['IndexedSetter']
         if indexedSetter:
-            set += ("let index = get_array_index_from_id(cx, Handle::from_raw(id));\n" +
+            set += ("let index = get_array_index_from_id(*cx, Handle::from_raw(id));\n" +
                     "if let Some(index) = index {\n" +
                     "    let this = UnwrapProxy(proxy);\n" +
                     "    let this = &*this;\n" +
@@ -5125,7 +5129,7 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
                     "    return (*opresult).succeed();\n" +
                     "}\n")
         elif self.descriptor.operations['IndexedGetter']:
-            set += ("if get_array_index_from_id(cx, Handle::from_raw(id)).is_some() {\n" +
+            set += ("if get_array_index_from_id(*cx, Handle::from_raw(id)).is_some() {\n" +
                     "    return (*opresult).failNoIndexedSetter();\n" +
                     "}\n")
 
@@ -5145,7 +5149,7 @@ class CGDOMJSProxyHandler_defineProperty(CGAbstractExternMethod):
                     "        return (*opresult).failNoNamedSetter();\n"
                     "    }\n"
                     "}\n")
-        set += "return proxyhandler::define_property(%s);" % ", ".join(a.name for a in self.args)
+        set += "return proxyhandler::define_property(*cx, %s);" % ", ".join(a.name for a in self.args[1:])
         return set
 
     def definition_body(self):
@@ -5161,13 +5165,13 @@ class CGDOMJSProxyHandler_delete(CGAbstractExternMethod):
         self.descriptor = descriptor
 
     def getBody(self):
-        set = ""
+        set = "let cx = SafeJSContext::from_ptr(cx);\n"
         if self.descriptor.operations['NamedDeleter']:
             if self.descriptor.hasUnforgeableMembers:
                 raise TypeError("Can't handle a deleter on an interface that has "
                                 "unforgeables. Figure out how that should work!")
             set += CGProxyNamedDeleter(self.descriptor).define()
-        set += "return proxyhandler::delete(%s);" % ", ".join(a.name for a in self.args)
+        set += "return proxyhandler::delete(*cx, %s);" % ", ".join(a.name for a in self.args[1:])
         return set
 
     def definition_body(self):
@@ -5185,6 +5189,7 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
     def getBody(self):
         body = dedent(
             """
+            let cx = SafeJSContext::from_ptr(cx);
             let unwrapped_proxy = UnwrapProxy(proxy);
             """)
 
@@ -5192,7 +5197,7 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
             body += dedent(
                 """
                 for i in 0..(*unwrapped_proxy).Length() {
-                    rooted!(in(cx) let rooted_jsid = int_to_jsid(i as i32));
+                    rooted!(in(*cx) let rooted_jsid = int_to_jsid(i as i32));
                     AppendToAutoIdVector(props, rooted_jsid.handle().get());
                 }
                 """)
@@ -5202,20 +5207,20 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
                 """
                 for name in (*unwrapped_proxy).SupportedPropertyNames() {
                     let cstring = CString::new(name).unwrap();
-                    let jsstring = JS_AtomizeAndPinString(cx, cstring.as_ptr());
-                    rooted!(in(cx) let rooted = jsstring);
-                    let jsid = INTERNED_STRING_TO_JSID(cx, rooted.handle().get());
-                    rooted!(in(cx) let rooted_jsid = jsid);
+                    let jsstring = JS_AtomizeAndPinString(*cx, cstring.as_ptr());
+                    rooted!(in(*cx) let rooted = jsstring);
+                    let jsid = INTERNED_STRING_TO_JSID(*cx, rooted.handle().get());
+                    rooted!(in(*cx) let rooted_jsid = jsid);
                     AppendToAutoIdVector(props, rooted_jsid.handle().get());
                 }
                 """)
 
         body += dedent(
             """
-            rooted!(in(cx) let mut expando = ptr::null_mut::<JSObject>());
+            rooted!(in(*cx) let mut expando = ptr::null_mut::<JSObject>());
             get_expando_object(proxy, expando.handle_mut());
             if !expando.is_null() {
-                GetPropertyKeys(cx, expando.handle(), JSITER_OWNONLY | JSITER_HIDDEN | JSITER_SYMBOLS, props);
+                GetPropertyKeys(*cx, expando.handle(), JSITER_OWNONLY | JSITER_HIDDEN | JSITER_SYMBOLS, props);
             }
 
             return true;
@@ -5241,6 +5246,7 @@ class CGDOMJSProxyHandler_getOwnEnumerablePropertyKeys(CGAbstractExternMethod):
     def getBody(self):
         body = dedent(
             """
+            let cx = SafeJSContext::from_ptr(cx);
             let unwrapped_proxy = UnwrapProxy(proxy);
             """)
 
@@ -5248,17 +5254,17 @@ class CGDOMJSProxyHandler_getOwnEnumerablePropertyKeys(CGAbstractExternMethod):
             body += dedent(
                 """
                 for i in 0..(*unwrapped_proxy).Length() {
-                    rooted!(in(cx) let rooted_jsid = int_to_jsid(i as i32));
+                    rooted!(in(*cx) let rooted_jsid = int_to_jsid(i as i32));
                     AppendToAutoIdVector(props, rooted_jsid.handle().get());
                 }
                 """)
 
         body += dedent(
             """
-            rooted!(in(cx) let mut expando = ptr::null_mut::<JSObject>());
+            rooted!(in(*cx) let mut expando = ptr::null_mut::<JSObject>());
             get_expando_object(proxy, expando.handle_mut());
             if !expando.is_null() {
-                GetPropertyKeys(cx, expando.handle(), JSITER_OWNONLY | JSITER_HIDDEN | JSITER_SYMBOLS, props);
+                GetPropertyKeys(*cx, expando.handle(), JSITER_OWNONLY | JSITER_HIDDEN | JSITER_SYMBOLS, props);
             }
 
             return true;
@@ -5279,17 +5285,16 @@ class CGDOMJSProxyHandler_hasOwn(CGAbstractExternMethod):
 
     def getBody(self):
         indexedGetter = self.descriptor.operations['IndexedGetter']
+        indexed = "let cx = SafeJSContext::from_ptr(cx);\n"
         if indexedGetter:
-            indexed = ("let index = get_array_index_from_id(cx, Handle::from_raw(id));\n" +
-                       "if let Some(index) = index {\n" +
-                       "    let this = UnwrapProxy(proxy);\n" +
-                       "    let this = &*this;\n" +
-                       CGIndenter(CGProxyIndexedGetter(self.descriptor)).define() + "\n" +
-                       "    *bp = result.is_some();\n" +
-                       "    return true;\n" +
-                       "}\n\n")
-        else:
-            indexed = ""
+            indexed += ("let index = get_array_index_from_id(*cx, Handle::from_raw(id));\n" +
+                        "if let Some(index) = index {\n" +
+                        "    let this = UnwrapProxy(proxy);\n" +
+                        "    let this = &*this;\n" +
+                        CGIndenter(CGProxyIndexedGetter(self.descriptor)).define() + "\n" +
+                        "    *bp = result.is_some();\n" +
+                        "    return true;\n" +
+                        "}\n\n")
 
         namedGetter = self.descriptor.operations['NamedGetter']
         condition = "RUST_JSID_IS_STRING(id) || RUST_JSID_IS_INT(id)"
@@ -5299,7 +5304,7 @@ class CGDOMJSProxyHandler_hasOwn(CGAbstractExternMethod):
             named = """\
 if %s {
     let mut has_on_proto = false;
-    if !has_property_on_prototype(cx, proxy_lt, id_lt, &mut has_on_proto) {
+    if !has_property_on_prototype(*cx, proxy_lt, id_lt, &mut has_on_proto) {
         return false;
     }
     if !has_on_proto {
@@ -5314,12 +5319,12 @@ if %s {
             named = ""
 
         return indexed + """\
-rooted!(in(cx) let mut expando = ptr::null_mut::<JSObject>());
+rooted!(in(*cx) let mut expando = ptr::null_mut::<JSObject>());
 let proxy_lt = Handle::from_raw(proxy);
 let id_lt = Handle::from_raw(id);
 get_expando_object(proxy, expando.handle_mut());
 if !expando.is_null() {
-    let ok = JS_HasPropertyById(cx, expando.handle().into(), id, bp);
+    let ok = JS_HasPropertyById(*cx, expando.handle().into(), id, bp);
     if !ok || *bp {
         return ok;
     }
@@ -5343,16 +5348,16 @@ class CGDOMJSProxyHandler_get(CGAbstractExternMethod):
     # https://heycam.github.io/webidl/#LegacyPlatformObjectGetOwnProperty
     def getBody(self):
         getFromExpando = """\
-rooted!(in(cx) let mut expando = ptr::null_mut::<JSObject>());
+rooted!(in(*cx) let mut expando = ptr::null_mut::<JSObject>());
 get_expando_object(proxy, expando.handle_mut());
 if !expando.is_null() {
     let mut hasProp = false;
-    if !JS_HasPropertyById(cx, expando.handle().into(), id, &mut hasProp) {
+    if !JS_HasPropertyById(*cx, expando.handle().into(), id, &mut hasProp) {
         return false;
     }
 
     if hasProp {
-        return JS_ForwardGetPropertyTo(cx, expando.handle().into(), id, receiver, vp);
+        return JS_ForwardGetPropertyTo(*cx, expando.handle().into(), id, receiver, vp);
     }
 }"""
 
@@ -5363,7 +5368,7 @@ if !expando.is_null() {
 
         indexedGetter = self.descriptor.operations['IndexedGetter']
         if indexedGetter:
-            getIndexedOrExpando = ("let index = get_array_index_from_id(cx, id_lt);\n" +
+            getIndexedOrExpando = ("let index = get_array_index_from_id(*cx, id_lt);\n" +
                                    "if let Some(index) = index {\n" +
                                    "    let this = UnwrapProxy(proxy);\n" +
                                    "    let this = &*this;\n" +
@@ -5396,6 +5401,7 @@ if !expando.is_null() {
         return """\
 //MOZ_ASSERT(!xpc::WrapperFactory::IsXrayWrapper(proxy),
 //"Should not have a XrayWrapper here");
+let cx = SafeJSContext::from_ptr(cx);
 let proxy_lt = Handle::from_raw(proxy);
 let vp_lt = MutableHandle::from_raw(vp);
 let id_lt = Handle::from_raw(id);
@@ -5403,7 +5409,7 @@ let receiver_lt = Handle::from_raw(receiver);
 
 %s
 let mut found = false;
-if !get_property_on_prototype(cx, proxy_lt, receiver_lt, id_lt, &mut found, vp_lt) {
+if !get_property_on_prototype(*cx, proxy_lt, receiver_lt, id_lt, &mut found, vp_lt) {
     return false;
 }
 
@@ -5526,7 +5532,9 @@ class CGClassConstructHook(CGAbstractExternMethod):
         self.exposureSet = descriptor.interface.exposureSet
 
     def definition_body(self):
-        preamble = """let global = GlobalScope::from_object(JS_CALLEE(cx, vp).to_object());\n"""
+        preamble = """let cx = SafeJSContext::from_ptr(cx);
+let global = GlobalScope::from_object(JS_CALLEE(*cx, vp).to_object());
+"""
         if len(self.exposureSet) == 1:
             preamble += """\
 let global = DomRoot::downcast::<dom::types::%s>(global).unwrap();
@@ -5542,24 +5550,24 @@ let global = DomRoot::downcast::<dom::types::%s>(global).unwrap();
 
 // The new_target might be a cross-compartment wrapper. Get the underlying object
 // so we can do the spec's object-identity checks.
-rooted!(in(cx) let new_target = UnwrapObjectDynamic(args.new_target().to_object(), cx, 1));
+rooted!(in(*cx) let new_target = UnwrapObjectDynamic(args.new_target().to_object(), *cx, 1));
 if new_target.is_null() {
-    throw_dom_exception(cx, global.upcast::<GlobalScope>(), Error::Type("new.target is null".to_owned()));
+    throw_dom_exception(*cx, global.upcast::<GlobalScope>(), Error::Type("new.target is null".to_owned()));
     return false;
 }
 
 if args.callee() == new_target.get() {
-    throw_dom_exception(cx, global.upcast::<GlobalScope>(),
+    throw_dom_exception(*cx, global.upcast::<GlobalScope>(),
         Error::Type("new.target must not be the active function object".to_owned()));
     return false;
 }
 
 // Step 6
-rooted!(in(cx) let mut prototype = ptr::null_mut::<JSObject>());
+rooted!(in(*cx) let mut prototype = ptr::null_mut::<JSObject>());
 {
-    rooted!(in(cx) let mut proto_val = UndefinedValue());
-    let _ac = JSAutoRealm::new(cx, new_target.get());
-    if !JS_GetProperty(cx, new_target.handle(), b"prototype\\0".as_ptr() as *const _, proto_val.handle_mut()) {
+    rooted!(in(*cx) let mut proto_val = UndefinedValue());
+    let _ac = JSAutoRealm::new(*cx, new_target.get());
+    if !JS_GetProperty(*cx, new_target.handle(), b"prototype\\0".as_ptr() as *const _, proto_val.handle_mut()) {
         return false;
     }
 
@@ -5573,8 +5581,8 @@ rooted!(in(cx) let mut prototype = ptr::null_mut::<JSObject>());
         // whose target is not same-compartment with the proxy, or bound functions, etc).
         // https://bugzilla.mozilla.org/show_bug.cgi?id=1317658
 
-        rooted!(in(cx) let global_object = CurrentGlobalOrNull(cx));
-        GetProtoObject(SafeJSContext::from_ptr(cx), global_object.handle(), prototype.handle_mut());
+        rooted!(in(*cx) let global_object = CurrentGlobalOrNull(*cx));
+        GetProtoObject(cx, global_object.handle(), prototype.handle_mut());
     } else {
         // Step 6
         prototype.set(proto_val.to_object());
@@ -5582,7 +5590,7 @@ rooted!(in(cx) let mut prototype = ptr::null_mut::<JSObject>());
 }
 
 // Wrap prototype in this context since it is from the newTarget compartment
-if !JS_WrapObject(cx, prototype.handle_mut()) {
+if !JS_WrapObject(*cx, prototype.handle_mut()) {
     return false;
 }
 
@@ -5590,19 +5598,19 @@ let result: Result<DomRoot<%s>, Error> = html_constructor(&global, &args);
 let result = match result {
     Ok(result) => result,
     Err(e) => {
-        throw_dom_exception(cx, global.upcast::<GlobalScope>(), e);
+        throw_dom_exception(*cx, global.upcast::<GlobalScope>(), e);
         return false;
     },
 };
 
-rooted!(in(cx) let mut element = result.reflector().get_jsobject().get());
-if !JS_WrapObject(cx, element.handle_mut()) {
+rooted!(in(*cx) let mut element = result.reflector().get_jsobject().get());
+if !JS_WrapObject(*cx, element.handle_mut()) {
     return false;
 }
 
-JS_SetPrototype(cx, element.handle(), prototype.handle());
+JS_SetPrototype(*cx, element.handle(), prototype.handle());
 
-(result).to_jsval(cx, MutableHandleValue::from_raw(args.rval()));
+(result).to_jsval(*cx, MutableHandleValue::from_raw(args.rval()));
 return true;
 """ % self.descriptor.name)
         else:
@@ -6290,7 +6298,7 @@ class CGDictionary(CGThing):
                           "    match r#try!(%s::%s::new(cx, val)) {\n"
                           "        ConversionResult::Success(v) => v,\n"
                           "        ConversionResult::Failure(error) => {\n"
-                          "            throw_type_error(cx, &error);\n"
+                          "            throw_type_error(*cx, &error);\n"
                           "            return Err(());\n"
                           "        }\n"
                           "    }\n"
@@ -6344,7 +6352,7 @@ class CGDictionary(CGThing):
         return string.Template(
             "impl ${selfName} {\n"
             "${empty}\n"
-            "    pub unsafe fn new(cx: *mut JSContext, val: HandleValue) \n"
+            "    pub unsafe fn new(cx: SafeJSContext, val: HandleValue) \n"
             "                      -> Result<ConversionResult<${actualType}>, ()> {\n"
             "        let object = if val.get().is_null_or_undefined() {\n"
             "            ptr::null_mut()\n"
@@ -6353,7 +6361,7 @@ class CGDictionary(CGThing):
             "        } else {\n"
             "            return Ok(ConversionResult::Failure(\"Value is not an object.\".into()));\n"
             "        };\n"
-            "        rooted!(in(cx) let object = object);\n"
+            "        rooted!(in(*cx) let object = object);\n"
             "${preInitial}"
             "${initParent}"
             "${initMembers}"
@@ -6366,7 +6374,7 @@ class CGDictionary(CGThing):
             "    type Config = ();\n"
             "    unsafe fn from_jsval(cx: *mut JSContext, value: HandleValue, _option: ())\n"
             "                         -> Result<ConversionResult<${actualType}>, ()> {\n"
-            "        ${selfName}::new(cx, value)\n"
+            "        ${selfName}::new(SafeJSContext::from_ptr(cx), value)\n"
             "    }\n"
             "}\n"
             "\n"
@@ -6424,7 +6432,7 @@ class CGDictionary(CGThing):
         assert (member.defaultValue is None) == (default is None)
         if not member.optional:
             assert default is None
-            default = ("throw_type_error(cx, \"Missing required member \\\"%s\\\".\");\n"
+            default = ("throw_type_error(*cx, \"Missing required member \\\"%s\\\".\");\n"
                        "return Err(());") % member.identifier.name
         elif not default:
             default = "None"
@@ -6432,8 +6440,8 @@ class CGDictionary(CGThing):
 
         conversion = (
             "{\n"
-            "    rooted!(in(cx) let mut rval = UndefinedValue());\n"
-            "    if r#try!(get_dictionary_property(cx, object.handle(), \"%s\", rval.handle_mut()))"
+            "    rooted!(in(*cx) let mut rval = UndefinedValue());\n"
+            "    if r#try!(get_dictionary_property(*cx, object.handle(), \"%s\", rval.handle_mut()))"
             " && !rval.is_undefined() {\n"
             "%s\n"
             "    } else {\n"
@@ -6808,14 +6816,14 @@ class CGCallback(CGClass):
         args = list(method.args)
         # Strip out the JSContext*/JSObject* args
         # that got added.
-        assert args[0].name == "cx" and args[0].argType == "*mut JSContext"
+        assert args[0].name == "cx" and args[0].argType == "SafeJSContext"
         assert args[1].name == "aThisObj" and args[1].argType == "HandleObject"
         args = args[2:]
         # Record the names of all the arguments, so we can use them when we call
         # the private method.
         argnames = [arg.name for arg in args]
-        argnamesWithThis = ["s.get_context()", "thisObjJS.handle()"] + argnames
-        argnamesWithoutThis = ["s.get_context()", "thisObjJS.handle()"] + argnames
+        argnamesWithThis = ["SafeJSContext::from_ptr(s.get_context())", "thisObjJS.handle()"] + argnames
+        argnamesWithoutThis = ["SafeJSContext::from_ptr(s.get_context())", "thisObjJS.handle()"] + argnames
         # Now that we've recorded the argnames for our call to our private
         # method, insert our optional argument for deciding whether the
         # CallSetup should re-throw exceptions on aRv.
@@ -7066,7 +7074,7 @@ class CallbackMember(CGNativeMember):
                          "*arg = Heap::default();\n" +
                          "arg.set(argv_root.get());\n" +
                          "}") % jsvalIndex,
-            pre="rooted!(in(cx) let mut argv_root = UndefinedValue());")
+            pre="rooted!(in(*cx) let mut argv_root = UndefinedValue());")
         if arg.variadic:
             conversion = string.Template(
                 "for idx in 0..${arg}.len() {\n" +
@@ -7095,7 +7103,7 @@ class CallbackMember(CGNativeMember):
             return args
         # We want to allow the caller to pass in a "this" object, as
         # well as a JSContext.
-        return [Argument("*mut JSContext", "cx"),
+        return [Argument("SafeJSContext", "cx"),
                 Argument("HandleObject", "aThisObj")] + args
 
     def getCallSetup(self):
@@ -7136,7 +7144,7 @@ class CallbackMethod(CallbackMember):
                                 needThisHandling)
 
     def getRvalDecl(self):
-        return "rooted!(in(cx) let mut rval = UndefinedValue());\n"
+        return "rooted!(in(*cx) let mut rval = UndefinedValue());\n"
 
     def getCall(self):
         replacements = {
@@ -7152,9 +7160,9 @@ class CallbackMethod(CallbackMember):
             replacements["argc"] = "0"
         return string.Template(
             "${getCallable}"
-            "rooted!(in(cx) let rootedThis = ${thisObj});\n"
+            "rooted!(in(*cx) let rootedThis = ${thisObj});\n"
             "let ok = ${callGuard}JS_CallFunctionValue(\n"
-            "    cx, rootedThis.handle(), callable.handle(),\n"
+            "    *cx, rootedThis.handle(), callable.handle(),\n"
             "    &HandleValueArray {\n"
             "        length_: ${argc} as ::libc::size_t,\n"
             "        elements_: ${argv}\n"
@@ -7175,7 +7183,7 @@ class CallCallback(CallbackMethod):
         return "aThisObj.get()"
 
     def getCallableDecl(self):
-        return "rooted!(in(cx) let callable = ObjectValue(self.callback()));\n"
+        return "rooted!(in(*cx) let callable = ObjectValue(self.callback()));\n"
 
     def getCallGuard(self):
         if self.callback._treatNonObjectAsNull:
@@ -7205,13 +7213,13 @@ class CallbackOperationBase(CallbackMethod):
             "methodName": self.methodName
         }
         getCallableFromProp = string.Template(
-            'r#try!(self.parent.get_callable_property(cx, "${methodName}"))'
+            'r#try!(self.parent.get_callable_property(*cx, "${methodName}"))'
         ).substitute(replacements)
         if not self.singleOperation:
-            return 'rooted!(in(cx) let callable =\n' + getCallableFromProp + ');\n'
+            return 'rooted!(in(*cx) let callable =\n' + getCallableFromProp + ');\n'
         return (
             'let isCallable = IsCallable(self.callback());\n'
-            'rooted!(in(cx) let callable =\n' +
+            'rooted!(in(*cx) let callable =\n' +
             CGIndenter(
                 CGIfElseWrapper('isCallable',
                                 CGGeneric('ObjectValue(self.callback())'),
@@ -7246,21 +7254,21 @@ class CGIterableMethodGenerator(CGGeneric):
             CGGeneric.__init__(self, fill(
                 """
                 if !IsCallable(arg0) {
-                  throw_type_error(cx, "Argument 1 of ${ifaceName}.forEach is not callable.");
+                  throw_type_error(*cx, "Argument 1 of ${ifaceName}.forEach is not callable.");
                   return false;
                 }
-                rooted!(in(cx) let arg0 = ObjectValue(arg0));
-                rooted!(in(cx) let mut call_arg1 = UndefinedValue());
-                rooted!(in(cx) let mut call_arg2 = UndefinedValue());
+                rooted!(in(*cx) let arg0 = ObjectValue(arg0));
+                rooted!(in(*cx) let mut call_arg1 = UndefinedValue());
+                rooted!(in(*cx) let mut call_arg2 = UndefinedValue());
                 let mut call_args = vec![UndefinedValue(), UndefinedValue(), ObjectValue(*_obj)];
-                rooted!(in(cx) let mut ignoredReturnVal = UndefinedValue());
+                rooted!(in(*cx) let mut ignoredReturnVal = UndefinedValue());
                 for i in 0..(*this).get_iterable_length() {
-                  (*this).get_value_at_index(i).to_jsval(cx, call_arg1.handle_mut());
-                  (*this).get_key_at_index(i).to_jsval(cx, call_arg2.handle_mut());
+                  (*this).get_value_at_index(i).to_jsval(*cx, call_arg1.handle_mut());
+                  (*this).get_key_at_index(i).to_jsval(*cx, call_arg2.handle_mut());
                   call_args[0] = call_arg1.handle().get();
                   call_args[1] = call_arg2.handle().get();
                   let call_args = HandleValueArray { length_: 3, elements_: call_args.as_ptr() };
-                  if !Call(cx, arg1, arg0.handle(), &call_args,
+                  if !Call(*cx, arg1, arg0.handle(), &call_args,
                            ignoredReturnVal.handle_mut()) {
                     return false;
                   }

--- a/components/script/dom/bindings/htmlconstructor.rs
+++ b/components/script/dom/bindings/htmlconstructor.rs
@@ -76,6 +76,7 @@ use crate::dom::customelementregistry::{ConstructionStackEntry, CustomElementSta
 use crate::dom::element::{Element, ElementCreator};
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::window::Window;
+use crate::script_runtime::JSContext as SafeJSContext;
 use crate::script_thread::ScriptThread;
 use html5ever::interface::QualName;
 use html5ever::LocalName;
@@ -125,7 +126,7 @@ where
 
             // Retrieve the constructor object for HTMLElement
             HTMLElementBinding::GetConstructorObject(
-                window.get_cx(),
+                SafeJSContext::from_ptr(window.get_cx()),
                 global_object.handle(),
                 constructor.handle_mut(),
             );
@@ -201,7 +202,7 @@ pub fn get_constructor_object_from_local_name(
 ) -> bool {
     macro_rules! get_constructor(
         ($binding:ident) => ({
-            unsafe { $binding::GetConstructorObject(cx, global, rval); }
+            unsafe { $binding::GetConstructorObject(SafeJSContext::from_ptr(cx), global, rval); }
             true
         })
     );

--- a/components/script/dom/bindings/htmlconstructor.rs
+++ b/components/script/dom/bindings/htmlconstructor.rs
@@ -100,7 +100,7 @@ where
     // Step 2 is checked in the generated caller code
 
     // Step 3
-    rooted!(in(window.get_cx()) let new_target = call_args.new_target().to_object());
+    rooted!(in(*window.get_cx()) let new_target = call_args.new_target().to_object());
     let definition = match registry.lookup_definition_by_constructor(new_target.handle()) {
         Some(definition) => definition,
         None => {
@@ -110,15 +110,15 @@ where
         },
     };
 
-    rooted!(in(window.get_cx()) let callee = UnwrapObjectStatic(call_args.callee()));
+    rooted!(in(*window.get_cx()) let callee = UnwrapObjectStatic(call_args.callee()));
     if callee.is_null() {
         return Err(Error::Security);
     }
 
     {
-        let _ac = JSAutoRealm::new(window.get_cx(), callee.get());
-        rooted!(in(window.get_cx()) let mut constructor = ptr::null_mut::<JSObject>());
-        rooted!(in(window.get_cx()) let global_object = CurrentGlobalOrNull(window.get_cx()));
+        let _ac = JSAutoRealm::new(*window.get_cx(), callee.get());
+        rooted!(in(*window.get_cx()) let mut constructor = ptr::null_mut::<JSObject>());
+        rooted!(in(*window.get_cx()) let global_object = CurrentGlobalOrNull(*window.get_cx()));
 
         if definition.is_autonomous() {
             // Step 4
@@ -126,7 +126,7 @@ where
 
             // Retrieve the constructor object for HTMLElement
             HTMLElementBinding::GetConstructorObject(
-                SafeJSContext::from_ptr(window.get_cx()),
+                window.get_cx(),
                 global_object.handle(),
                 constructor.handle_mut(),
             );
@@ -134,7 +134,7 @@ where
             // Step 5
             get_constructor_object_from_local_name(
                 definition.local_name.clone(),
-                window.get_cx(),
+                *window.get_cx(),
                 global_object.handle(),
                 constructor.handle_mut(),
             );

--- a/components/script/dom/bindings/iterable.rs
+++ b/components/script/dom/bindings/iterable.rs
@@ -76,41 +76,41 @@ impl<T: DomObject + JSTraceable + Iterable> IterableIterator<T> {
 
     /// Return the next value from the iterable object.
     #[allow(non_snake_case)]
-    pub fn Next(&self, cx: *mut JSContext) -> Fallible<NonNull<JSObject>> {
+    pub fn Next(&self, cx: SafeJSContext) -> Fallible<NonNull<JSObject>> {
         let index = self.index.get();
-        rooted!(in(cx) let mut value = UndefinedValue());
-        rooted!(in(cx) let mut rval = ptr::null_mut::<JSObject>());
+        rooted!(in(*cx) let mut value = UndefinedValue());
+        rooted!(in(*cx) let mut rval = ptr::null_mut::<JSObject>());
         let result = if index >= self.iterable.get_iterable_length() {
-            dict_return(cx, rval.handle_mut(), true, value.handle())
+            dict_return(*cx, rval.handle_mut(), true, value.handle())
         } else {
             match self.type_ {
                 IteratorType::Keys => {
                     unsafe {
                         self.iterable
                             .get_key_at_index(index)
-                            .to_jsval(cx, value.handle_mut());
+                            .to_jsval(*cx, value.handle_mut());
                     }
-                    dict_return(cx, rval.handle_mut(), false, value.handle())
+                    dict_return(*cx, rval.handle_mut(), false, value.handle())
                 },
                 IteratorType::Values => {
                     unsafe {
                         self.iterable
                             .get_value_at_index(index)
-                            .to_jsval(cx, value.handle_mut());
+                            .to_jsval(*cx, value.handle_mut());
                     }
-                    dict_return(cx, rval.handle_mut(), false, value.handle())
+                    dict_return(*cx, rval.handle_mut(), false, value.handle())
                 },
                 IteratorType::Entries => {
-                    rooted!(in(cx) let mut key = UndefinedValue());
+                    rooted!(in(*cx) let mut key = UndefinedValue());
                     unsafe {
                         self.iterable
                             .get_key_at_index(index)
-                            .to_jsval(cx, key.handle_mut());
+                            .to_jsval(*cx, key.handle_mut());
                         self.iterable
                             .get_value_at_index(index)
-                            .to_jsval(cx, value.handle_mut());
+                            .to_jsval(*cx, value.handle_mut());
                     }
-                    key_and_value_return(cx, rval.handle_mut(), key.handle(), value.handle())
+                    key_and_value_return(*cx, rval.handle_mut(), key.handle(), value.handle())
                 },
             }
         };

--- a/components/script/dom/bindings/iterable.rs
+++ b/components/script/dom/bindings/iterable.rs
@@ -13,6 +13,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::trace::{JSTraceable, RootedTraceableBox};
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::JSContext as SafeJSContext;
 use dom_struct::dom_struct;
 use js::conversions::ToJSValConvertible;
 use js::jsapi::{Heap, JSContext, JSObject};
@@ -62,7 +63,7 @@ impl<T: DomObject + JSTraceable + Iterable> IterableIterator<T> {
     pub fn new(
         iterable: &T,
         type_: IteratorType,
-        wrap: unsafe fn(*mut JSContext, &GlobalScope, Box<IterableIterator<T>>) -> DomRoot<Self>,
+        wrap: unsafe fn(SafeJSContext, &GlobalScope, Box<IterableIterator<T>>) -> DomRoot<Self>,
     ) -> DomRoot<Self> {
         let iterator = Box::new(IterableIterator {
             reflector: Reflector::new(),

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -7,7 +7,8 @@
 use crate::dom::bindings::conversions::DerivedFrom;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
-use js::jsapi::{Heap, JSContext, JSObject};
+use crate::script_runtime::JSContext as SafeJSContext;
+use js::jsapi::{Heap, JSObject};
 use js::rust::HandleObject;
 use std::default::Default;
 
@@ -16,14 +17,20 @@ use std::default::Default;
 pub fn reflect_dom_object<T, U>(
     obj: Box<T>,
     global: &U,
-    wrap_fn: unsafe fn(*mut JSContext, &GlobalScope, Box<T>) -> DomRoot<T>,
+    wrap_fn: unsafe fn(SafeJSContext, &GlobalScope, Box<T>) -> DomRoot<T>,
 ) -> DomRoot<T>
 where
     T: DomObject,
     U: DerivedFrom<GlobalScope>,
 {
     let global_scope = global.upcast();
-    unsafe { wrap_fn(global_scope.get_cx(), global_scope, obj) }
+    unsafe {
+        wrap_fn(
+            SafeJSContext::from_ptr(global_scope.get_cx()),
+            global_scope,
+            obj,
+        )
+    }
 }
 
 /// A struct to store a reference to the reflector of a DOM object.

--- a/components/script/dom/bindings/reflector.rs
+++ b/components/script/dom/bindings/reflector.rs
@@ -7,7 +7,7 @@
 use crate::dom::bindings::conversions::DerivedFrom;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext as SafeJSContext;
+use crate::script_runtime::JSContext;
 use js::jsapi::{Heap, JSObject};
 use js::rust::HandleObject;
 use std::default::Default;
@@ -17,20 +17,14 @@ use std::default::Default;
 pub fn reflect_dom_object<T, U>(
     obj: Box<T>,
     global: &U,
-    wrap_fn: unsafe fn(SafeJSContext, &GlobalScope, Box<T>) -> DomRoot<T>,
+    wrap_fn: unsafe fn(JSContext, &GlobalScope, Box<T>) -> DomRoot<T>,
 ) -> DomRoot<T>
 where
     T: DomObject,
     U: DerivedFrom<GlobalScope>,
 {
     let global_scope = global.upcast();
-    unsafe {
-        wrap_fn(
-            SafeJSContext::from_ptr(global_scope.get_cx()),
-            global_scope,
-            obj,
-        )
-    }
+    unsafe { wrap_fn(global_scope.get_cx(), global_scope, obj) }
 }
 
 /// A struct to store a reference to the reflector of a DOM object.

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -321,7 +321,7 @@ impl StructuredCloneData {
             WriteBytesToJSStructuredCloneData(data as *const u8, nbytes, scdata);
 
             assert!(JS_ReadStructuredClone(
-                cx,
+                *cx,
                 scdata,
                 JS_STRUCTURED_CLONE_VERSION,
                 StructuredCloneScope::DifferentProcess,

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -13,6 +13,7 @@ use crate::dom::bindings::inheritance::TopTypeId;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::trace_object;
 use crate::dom::windowproxy;
+use crate::script_runtime::JSContext as SafeJSContext;
 use js::glue::{CallJitGetterOp, CallJitMethodOp, CallJitSetterOp, IsWrapper};
 use js::glue::{GetCrossCompartmentWrapper, JS_GetReservedSlot, WrapperNew};
 use js::glue::{UnwrapObjectDynamic, RUST_JSID_TO_INT, RUST_JSID_TO_STRING};
@@ -353,7 +354,7 @@ pub unsafe extern "C" fn enumerate_global(
         return false;
     }
     for init_fun in InterfaceObjectMap::MAP.values() {
-        init_fun(cx, Handle::from_raw(obj));
+        init_fun(SafeJSContext::from_ptr(cx), Handle::from_raw(obj));
     }
     true
 }
@@ -388,7 +389,7 @@ pub unsafe extern "C" fn resolve_global(
     let bytes = slice::from_raw_parts(ptr, length as usize);
 
     if let Some(init_fun) = InterfaceObjectMap::MAP.get(bytes) {
-        init_fun(cx, Handle::from_raw(obj));
+        init_fun(SafeJSContext::from_ptr(cx), Handle::from_raw(obj));
         *rval = true;
     } else {
         *rval = false;

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -30,6 +30,7 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::permissions::{get_descriptor_permission_state, PermissionAlgorithm};
 use crate::dom::promise::Promise;
+use crate::script_runtime::JSContext as SafeJSContext;
 use crate::task::TaskOnce;
 use dom_struct::dom_struct;
 use ipc_channel::ipc::{self, IpcSender};
@@ -625,7 +626,8 @@ impl PermissionAlgorithm for Bluetooth {
             .handle_mut()
             .set(ObjectValue(permission_descriptor_obj));
         unsafe {
-            match BluetoothPermissionDescriptor::new(cx, property.handle()) {
+            match BluetoothPermissionDescriptor::new(SafeJSContext::from_ptr(cx), property.handle())
+            {
                 Ok(ConversionResult::Success(descriptor)) => Ok(descriptor),
                 Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
                 Err(_) => Err(Error::Type(String::from(BT_DESC_CONVERSION_ERROR))),

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -157,9 +157,9 @@ fn create_html_element(
                             // Step 6.1.1
                             unsafe {
                                 let _ac =
-                                    JSAutoRealm::new(cx, global.reflector().get_jsobject().get());
-                                throw_dom_exception(cx, &global, error);
-                                report_pending_exception(cx, true);
+                                    JSAutoRealm::new(*cx, global.reflector().get_jsobject().get());
+                                throw_dom_exception(*cx, &global, error);
+                                report_pending_exception(*cx, true);
                             }
 
                             // Step 6.1.2

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -9,9 +9,10 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
+use js::jsapi::JSObject;
 use js::jsapi::Type;
-use js::jsapi::{JSContext, JSObject};
 use js::rust::CustomAutoRooterGuard;
 use js::typedarray::ArrayBufferView;
 use servo_rand::{Rng, ServoRng};
@@ -47,9 +48,9 @@ impl Crypto {
 impl CryptoMethods for Crypto {
     #[allow(unsafe_code)]
     // https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html#Crypto-method-getRandomValues
-    unsafe fn GetRandomValues(
+    fn GetRandomValues(
         &self,
-        _cx: *mut JSContext,
+        _cx: JSContext,
         mut input: CustomAutoRooterGuard<ArrayBufferView>,
     ) -> Fallible<NonNull<JSObject>> {
         let array_type = input.get_array_type();
@@ -57,14 +58,14 @@ impl CryptoMethods for Crypto {
         if !is_integer_buffer(array_type) {
             return Err(Error::TypeMismatch);
         } else {
-            let mut data = input.as_mut_slice();
+            let mut data = unsafe { input.as_mut_slice() };
             if data.len() > 65536 {
                 return Err(Error::QuotaExceeded);
             }
             self.rng.borrow_mut().fill_bytes(&mut data);
         }
 
-        Ok(NonNull::new_unchecked(*input.underlying_object()))
+        unsafe { Ok(NonNull::new_unchecked(*input.underlying_object())) }
     }
 }
 

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -31,6 +31,7 @@ use crate::dom::node::{document_from_node, window_from_node, Node, ShadowIncludi
 use crate::dom::promise::Promise;
 use crate::dom::window::Window;
 use crate::microtask::Microtask;
+use crate::script_runtime::JSContext as SafeJSContext;
 use crate::script_thread::ScriptThread;
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Namespace, Prefix};
@@ -238,7 +239,10 @@ unsafe fn get_callback(
         if !callback.is_object() || !IsCallable(callback.to_object()) {
             return Err(Error::Type("Lifecycle callback is not callable".to_owned()));
         }
-        Ok(Some(Function::new(cx, callback.to_object())))
+        Ok(Some(Function::new(
+            SafeJSContext::from_ptr(cx),
+            callback.to_object(),
+        )))
     } else {
         Ok(None)
     }

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -405,13 +405,13 @@ impl CustomElementRegistryMethods for CustomElementRegistry {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-get>
     #[allow(unsafe_code)]
-    unsafe fn Get(&self, cx: *mut JSContext, name: DOMString) -> JSVal {
+    fn Get(&self, cx: SafeJSContext, name: DOMString) -> JSVal {
         match self.definitions.borrow().get(&LocalName::from(&*name)) {
-            Some(definition) => {
-                rooted!(in(cx) let mut constructor = UndefinedValue());
+            Some(definition) => unsafe {
+                rooted!(in(*cx) let mut constructor = UndefinedValue());
                 definition
                     .constructor
-                    .to_jsval(cx, constructor.handle_mut());
+                    .to_jsval(*cx, constructor.handle_mut());
                 constructor.get()
             },
             None => UndefinedValue(),

--- a/components/script/dom/customevent.rs
+++ b/components/script/dom/customevent.rs
@@ -13,8 +13,9 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSContext};
+use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::HandleValue;
 use servo_atoms::Atom;
@@ -87,17 +88,15 @@ impl CustomEvent {
 }
 
 impl CustomEventMethods for CustomEvent {
-    #[allow(unsafe_code)]
     // https://dom.spec.whatwg.org/#dom-customevent-detail
-    unsafe fn Detail(&self, _cx: *mut JSContext) -> JSVal {
+    fn Detail(&self, _cx: JSContext) -> JSVal {
         self.detail.get()
     }
 
-    #[allow(unsafe_code)]
     // https://dom.spec.whatwg.org/#dom-customevent-initcustomevent
-    unsafe fn InitCustomEvent(
+    fn InitCustomEvent(
         &self,
-        _cx: *mut JSContext,
+        _cx: JSContext,
         type_: DOMString,
         can_bubble: bool,
         cancelable: bool,

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -26,7 +26,9 @@ use crate::dom::worker::{TrustedWorkerAddress, Worker};
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::fetch::load_whole_resource;
 use crate::script_runtime::ScriptThreadEventCategory::WorkerEvent;
-use crate::script_runtime::{new_child_runtime, CommonScriptMsg, Runtime, ScriptChan, ScriptPort};
+use crate::script_runtime::{
+    new_child_runtime, CommonScriptMsg, JSContext as SafeJSContext, Runtime, ScriptChan, ScriptPort,
+};
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
 use crate::task_source::TaskSourceName;
 use crossbeam_channel::{unbounded, Receiver, Sender};
@@ -283,7 +285,7 @@ impl DedicatedWorkerGlobalScope {
             closing,
             image_cache,
         ));
-        unsafe { DedicatedWorkerGlobalScopeBinding::Wrap(cx, scope) }
+        unsafe { DedicatedWorkerGlobalScopeBinding::Wrap(SafeJSContext::from_ptr(cx), scope) }
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -560,10 +560,9 @@ unsafe extern "C" fn interrupt_callback(cx: *mut JSContext) -> bool {
 }
 
 impl DedicatedWorkerGlobalScopeMethods for DedicatedWorkerGlobalScope {
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-dedicatedworkerglobalscope-postmessage
-    unsafe fn PostMessage(&self, cx: *mut JSContext, message: HandleValue) -> ErrorResult {
-        let data = StructuredCloneData::write(cx, message)?;
+    fn PostMessage(&self, cx: SafeJSContext, message: HandleValue) -> ErrorResult {
+        let data = StructuredCloneData::write(*cx, message)?;
         let worker = self.worker.borrow().as_ref().unwrap().clone();
         let pipeline_id = self.upcast::<GlobalScope>().pipeline_id();
         let task = Box::new(task!(post_worker_message: move || {

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -405,7 +405,7 @@ impl DedicatedWorkerGlobalScope {
 
                 unsafe {
                     // Handle interrupt requests
-                    JS_AddInterruptCallback(scope.get_cx(), Some(interrupt_callback));
+                    JS_AddInterruptCallback(*scope.get_cx(), Some(interrupt_callback));
                 }
 
                 if scope.is_closing() {
@@ -466,7 +466,7 @@ impl DedicatedWorkerGlobalScope {
                 let scope = self.upcast::<WorkerGlobalScope>();
                 let target = self.upcast();
                 let _ac = enter_realm(self);
-                rooted!(in(scope.get_cx()) let mut message = UndefinedValue());
+                rooted!(in(*scope.get_cx()) let mut message = UndefinedValue());
                 data.read(scope.upcast(), message.handle_mut());
                 MessageEvent::dispatch_jsval(target, scope.upcast(), message.handle(), None, None);
             },

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -11,6 +11,7 @@ use crate::dom::bindings::structuredclone::StructuredCloneData;
 use crate::dom::dissimilaroriginlocation::DissimilarOriginLocation;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::windowproxy::WindowProxy;
+use crate::script_runtime::JSContext as SafeJSContext;
 use dom_struct::dom_struct;
 use ipc_channel::ipc;
 use js::jsapi::JSContext;
@@ -68,7 +69,7 @@ impl DissimilarOriginWindow {
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),
         });
-        unsafe { DissimilarOriginWindowBinding::Wrap(cx, win) }
+        unsafe { DissimilarOriginWindowBinding::Wrap(SafeJSContext::from_ptr(cx), win) }
     }
 
     pub fn window_proxy(&self) -> DomRoot<WindowProxy> {

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -68,7 +68,7 @@ impl DissimilarOriginWindow {
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),
         });
-        unsafe { DissimilarOriginWindowBinding::Wrap(JSContext::from_ptr(cx), win) }
+        unsafe { DissimilarOriginWindowBinding::Wrap(cx, win) }
     }
 
     pub fn window_proxy(&self) -> DomRoot<WindowProxy> {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -102,6 +102,7 @@ use crate::dom::wheelevent::WheelEvent;
 use crate::dom::window::{ReflowReason, Window};
 use crate::dom::windowproxy::WindowProxy;
 use crate::fetch::FetchCanceller;
+use crate::script_runtime::JSContext;
 use crate::script_runtime::{CommonScriptMsg, ScriptThreadEventCategory};
 use crate::script_thread::{MainThreadScriptMsg, ScriptThread};
 use crate::stylesheet_set::StylesheetSetRef;
@@ -117,7 +118,7 @@ use euclid::default::Point2D;
 use html5ever::{LocalName, Namespace, QualName};
 use hyper_serde::Serde;
 use ipc_channel::ipc::{self, IpcSender};
-use js::jsapi::{JSContext, JSObject, JSRuntime};
+use js::jsapi::{JSObject, JSRuntime};
 use keyboard_types::{Key, KeyState, Modifiers};
 use metrics::{
     InteractiveFlag, InteractiveMetrics, InteractiveWindow, ProfilerMetadataFactory,
@@ -4218,11 +4219,7 @@ impl DocumentMethods for Document {
 
     #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-tree-accessors:dom-document-nameditem-filter
-    unsafe fn NamedGetter(
-        &self,
-        _cx: *mut JSContext,
-        name: DOMString,
-    ) -> Option<NonNull<JSObject>> {
+    fn NamedGetter(&self, _cx: JSContext, name: DOMString) -> Option<NonNull<JSObject>> {
         #[derive(JSTraceable, MallocSizeOf)]
         struct NamedElementFilter {
             name: Atom,
@@ -4270,7 +4267,7 @@ impl DocumentMethods for Document {
         }
         let name = Atom::from(name);
         let root = self.upcast::<Node>();
-        {
+        unsafe {
             // Step 1.
             let mut elements = root
                 .traverse_preorder(ShadowIncluding::No)
@@ -4291,9 +4288,11 @@ impl DocumentMethods for Document {
         // Step 4.
         let filter = NamedElementFilter { name: name };
         let collection = HTMLCollection::create(self.window(), root, Box::new(filter));
-        Some(NonNull::new_unchecked(
-            collection.reflector().get_jsobject().get(),
-        ))
+        unsafe {
+            Some(NonNull::new_unchecked(
+                collection.reflector().get_jsobject().get(),
+            ))
+        }
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tree-accessors:supported-property-names

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -131,7 +131,7 @@ impl DocumentOrShadowRoot {
             .first()
         {
             Some(address) => {
-                let js_runtime = unsafe { JS_GetRuntime(self.window.get_cx()) };
+                let js_runtime = unsafe { JS_GetRuntime(*self.window.get_cx()) };
                 let node = unsafe { node::from_untrusted_node_address(js_runtime, *address) };
                 let parent_node = node.GetParentNode().unwrap();
                 let element_ref = node
@@ -167,7 +167,7 @@ impl DocumentOrShadowRoot {
             return vec![];
         }
 
-        let js_runtime = unsafe { JS_GetRuntime(self.window.get_cx()) };
+        let js_runtime = unsafe { JS_GetRuntime(*self.window.get_cx()) };
 
         // Step 1 and Step 3
         let nodes = self.nodes_from_point(point, NodesFromPointQueryType::All);

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -18,10 +18,11 @@ use crate::dom::dommatrix::DOMMatrix;
 use crate::dom::dompoint::DOMPoint;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
+use crate::script_runtime::JSContext;
 use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use euclid::{default::Transform3D, Angle};
-use js::jsapi::{JSContext, JSObject};
+use js::jsapi::JSObject;
 use js::rust::CustomAutoRooterGuard;
 use js::typedarray::CreateWith;
 use js::typedarray::{Float32Array, Float64Array};
@@ -667,7 +668,7 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-tofloat32array
     #[allow(unsafe_code)]
-    unsafe fn ToFloat32Array(&self, cx: *mut JSContext) -> NonNull<JSObject> {
+    fn ToFloat32Array(&self, cx: JSContext) -> NonNull<JSObject> {
         let vec: Vec<f32> = self
             .matrix
             .borrow()
@@ -675,18 +676,22 @@ impl DOMMatrixReadOnlyMethods for DOMMatrixReadOnly {
             .iter()
             .map(|&x| x as f32)
             .collect();
-        rooted!(in (cx) let mut array = ptr::null_mut::<JSObject>());
-        let _ = Float32Array::create(cx, CreateWith::Slice(&vec), array.handle_mut()).unwrap();
-        NonNull::new_unchecked(array.get())
+        unsafe {
+            rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
+            let _ = Float32Array::create(*cx, CreateWith::Slice(&vec), array.handle_mut()).unwrap();
+            NonNull::new_unchecked(array.get())
+        }
     }
 
     // https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-tofloat64array
     #[allow(unsafe_code)]
-    unsafe fn ToFloat64Array(&self, cx: *mut JSContext) -> NonNull<JSObject> {
+    fn ToFloat64Array(&self, cx: JSContext) -> NonNull<JSObject> {
         let arr = self.matrix.borrow().to_row_major_array();
-        rooted!(in (cx) let mut array = ptr::null_mut::<JSObject>());
-        let _ = Float64Array::create(cx, CreateWith::Slice(&arr), array.handle_mut()).unwrap();
-        NonNull::new_unchecked(array.get())
+        unsafe {
+            rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
+            let _ = Float64Array::create(*cx, CreateWith::Slice(&arr), array.handle_mut()).unwrap();
+            NonNull::new_unchecked(array.get())
+        }
     }
 }
 

--- a/components/script/dom/errorevent.rs
+++ b/components/script/dom/errorevent.rs
@@ -14,8 +14,9 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSContext};
+use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::HandleValue;
 use servo_atoms::Atom;
@@ -135,9 +136,8 @@ impl ErrorEventMethods for ErrorEvent {
         self.filename.borrow().clone()
     }
 
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-errorevent-error
-    unsafe fn Error(&self, _cx: *mut JSContext) -> JSVal {
+    fn Error(&self, _cx: JSContext) -> JSVal {
         self.error.get()
     }
 

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -223,10 +223,10 @@ impl EventSourceContext {
         // Steps 4-5
         let event = {
             let _ac = enter_realm(&*event_source);
-            rooted!(in(event_source.global().get_cx()) let mut data = UndefinedValue());
+            rooted!(in(*event_source.global().get_cx()) let mut data = UndefinedValue());
             unsafe {
                 self.data
-                    .to_jsval(event_source.global().get_cx(), data.handle_mut())
+                    .to_jsval(*event_source.global().get_cx(), data.handle_mut())
             };
             MessageEvent::new(
                 &*event_source.global(),

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -169,7 +169,7 @@ impl CompiledEventListener {
                     CommonEventHandler::ErrorEventHandler(ref handler) => {
                         if let Some(event) = event.downcast::<ErrorEvent>() {
                             let cx = object.global().get_cx();
-                            rooted!(in(cx) let error = unsafe { event.Error(cx) });
+                            rooted!(in(cx) let error = unsafe { event.Error(JSContext::from_ptr(cx)) });
                             let return_value = handler.Call_(
                                 object,
                                 EventOrString::String(event.Message()),

--- a/components/script/dom/extendableevent.rs
+++ b/components/script/dom/extendableevent.rs
@@ -11,8 +11,8 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::JSContext;
 use js::rust::HandleValue;
 use servo_atoms::Atom;
 
@@ -62,7 +62,7 @@ impl ExtendableEvent {
     }
 
     // https://w3c.github.io/ServiceWorker/#wait-until-method
-    pub fn WaitUntil(&self, _cx: *mut JSContext, _val: HandleValue) -> ErrorResult {
+    pub fn WaitUntil(&self, _cx: JSContext, _val: HandleValue) -> ErrorResult {
         // Step 1
         if !self.extensions_allowed {
             return Err(Error::InvalidState);

--- a/components/script/dom/extendablemessageevent.rs
+++ b/components/script/dom/extendablemessageevent.rs
@@ -15,8 +15,9 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::extendableevent::ExtendableEvent;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSContext};
+use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::HandleValue;
 use servo_atoms::Atom;
@@ -91,9 +92,8 @@ impl ExtendableMessageEvent {
 }
 
 impl ExtendableMessageEventMethods for ExtendableMessageEvent {
-    #[allow(unsafe_code)]
     // https://w3c.github.io/ServiceWorker/#extendablemessage-event-data-attribute
-    unsafe fn Data(&self, _cx: *mut JSContext) -> JSVal {
+    fn Data(&self, _cx: JSContext) -> JSVal {
         self.data.get()
     }
 

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -266,7 +266,7 @@ impl FileReader {
                 let _ac = enter_realm(&*fr);
                 FileReader::perform_readasarraybuffer(
                     &fr.result,
-                    fr.global().get_cx(),
+                    *fr.global().get_cx(),
                     data,
                     &blob_contents,
                 )

--- a/components/script/dom/filereadersync.rs
+++ b/components/script/dom/filereadersync.rs
@@ -13,8 +13,9 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::blob::Blob;
 use crate::dom::filereader::FileReaderSharedFunctionality;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::{JSContext, JSObject};
+use js::jsapi::JSObject;
 use js::typedarray::{ArrayBuffer, CreateWith};
 use std::ptr;
 use std::ptr::NonNull;
@@ -87,23 +88,21 @@ impl FileReaderSyncMethods for FileReaderSync {
 
     #[allow(unsafe_code)]
     // https://w3c.github.io/FileAPI/#readAsArrayBufferSyncSection
-    unsafe fn ReadAsArrayBuffer(
-        &self,
-        cx: *mut JSContext,
-        blob: &Blob,
-    ) -> Fallible<NonNull<JSObject>> {
+    fn ReadAsArrayBuffer(&self, cx: JSContext, blob: &Blob) -> Fallible<NonNull<JSObject>> {
         // step 1
         let blob_contents = FileReaderSync::get_blob_bytes(blob)?;
 
         // step 2
-        rooted!(in(cx) let mut array_buffer = ptr::null_mut::<JSObject>());
-        assert!(ArrayBuffer::create(
-            cx,
-            CreateWith::Slice(&blob_contents),
-            array_buffer.handle_mut()
-        )
-        .is_ok());
+        unsafe {
+            rooted!(in(*cx) let mut array_buffer = ptr::null_mut::<JSObject>());
+            assert!(ArrayBuffer::create(
+                *cx,
+                CreateWith::Slice(&blob_contents),
+                array_buffer.handle_mut()
+            )
+            .is_ok());
 
-        Ok(NonNull::new_unchecked(array_buffer.get()))
+            Ok(NonNull::new_unchecked(array_buffer.get()))
+        }
     }
 }

--- a/components/script/dom/gamepad.rs
+++ b/components/script/dom/gamepad.rs
@@ -99,9 +99,9 @@ impl Gamepad {
         );
 
         let cx = global.get_cx();
-        rooted!(in (cx) let mut array = ptr::null_mut::<JSObject>());
+        rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
         unsafe {
-            let _ = Float64Array::create(cx, CreateWith::Slice(&state.axes), array.handle_mut());
+            let _ = Float64Array::create(*cx, CreateWith::Slice(&state.axes), array.handle_mut());
         }
         gamepad.axes.set(array.get());
 
@@ -173,7 +173,7 @@ impl Gamepad {
         self.timestamp.set(state.timestamp);
         unsafe {
             let cx = self.global().get_cx();
-            typedarray!(in(cx) let axes: Float64Array = self.axes.get());
+            typedarray!(in(*cx) let axes: Float64Array = self.axes.get());
             if let Ok(mut array) = axes {
                 array.update(&state.axes);
             }

--- a/components/script/dom/gamepad.rs
+++ b/components/script/dom/gamepad.rs
@@ -15,8 +15,9 @@ use crate::dom::gamepadbuttonlist::GamepadButtonList;
 use crate::dom::gamepadevent::{GamepadEvent, GamepadEventType};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::vrpose::VRPose;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSContext, JSObject};
+use js::jsapi::{Heap, JSObject};
 use js::typedarray::{CreateWith, Float64Array};
 use std::cell::Cell;
 use std::ptr;
@@ -136,8 +137,8 @@ impl GamepadMethods for Gamepad {
 
     #[allow(unsafe_code)]
     // https://w3c.github.io/gamepad/#dom-gamepad-axes
-    unsafe fn Axes(&self, _cx: *mut JSContext) -> NonNull<JSObject> {
-        NonNull::new_unchecked(self.axes.get())
+    fn Axes(&self, _cx: JSContext) -> NonNull<JSObject> {
+        unsafe { NonNull::new_unchecked(self.axes.get()) }
     }
 
     // https://w3c.github.io/gamepad/#dom-gamepad-buttons

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -117,7 +117,7 @@ impl History {
         match serialized_data {
             Some(serialized_data) => {
                 let global_scope = self.window.upcast::<GlobalScope>();
-                rooted!(in(global_scope.get_cx()) let mut state = UndefinedValue());
+                rooted!(in(*global_scope.get_cx()) let mut state = UndefinedValue());
                 StructuredCloneData::Vector(serialized_data)
                     .read(&global_scope, state.handle_mut());
                 self.state.set(state.get());

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -18,6 +18,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::hashchangeevent::HashChangeEvent;
 use crate::dom::popstateevent::PopStateEvent;
 use crate::dom::window::Window;
+use crate::script_runtime::JSContext as SafeJSContext;
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSContext};
 use js::jsval::{JSVal, NullValue, UndefinedValue};
@@ -279,8 +280,7 @@ impl History {
 
 impl HistoryMethods for History {
     // https://html.spec.whatwg.org/multipage/#dom-history-state
-    #[allow(unsafe_code)]
-    unsafe fn GetState(&self, _cx: *mut JSContext) -> Fallible<JSVal> {
+    fn GetState(&self, _cx: SafeJSContext) -> Fallible<JSVal> {
         if !self.window.Document().is_fully_active() {
             return Err(Error::Security);
         }
@@ -327,26 +327,24 @@ impl HistoryMethods for History {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-history-pushstate
-    #[allow(unsafe_code)]
-    unsafe fn PushState(
+    fn PushState(
         &self,
-        cx: *mut JSContext,
+        cx: SafeJSContext,
         data: HandleValue,
         title: DOMString,
         url: Option<USVString>,
     ) -> ErrorResult {
-        self.push_or_replace_state(cx, data, title, url, PushOrReplace::Push)
+        self.push_or_replace_state(*cx, data, title, url, PushOrReplace::Push)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-history-replacestate
-    #[allow(unsafe_code)]
-    unsafe fn ReplaceState(
+    fn ReplaceState(
         &self,
-        cx: *mut JSContext,
+        cx: SafeJSContext,
         data: HandleValue,
         title: DOMString,
         url: Option<USVString>,
     ) -> ErrorResult {
-        self.push_or_replace_state(cx, data, title, url, PushOrReplace::Replace)
+        self.push_or_replace_state(*cx, data, title, url, PushOrReplace::Replace)
     }
 }

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -330,9 +330,9 @@ impl HTMLCanvasElementMethods for HTMLCanvasElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-canvas-getcontext
     #[allow(unsafe_code)]
-    unsafe fn GetContext(
+    fn GetContext(
         &self,
-        cx: *mut JSContext,
+        cx: SafeJSContext,
         id: DOMString,
         options: HandleValue,
     ) -> Option<RenderingContext> {
@@ -340,21 +340,22 @@ impl HTMLCanvasElementMethods for HTMLCanvasElement {
             "2d" => self
                 .get_or_init_2d_context()
                 .map(RenderingContext::CanvasRenderingContext2D),
-            "webgl" | "experimental-webgl" => self
-                .get_or_init_webgl_context(cx, options)
-                .map(RenderingContext::WebGLRenderingContext),
-            "webgl2" | "experimental-webgl2" => self
-                .get_or_init_webgl2_context(cx, options)
-                .map(RenderingContext::WebGL2RenderingContext),
+            "webgl" | "experimental-webgl" => unsafe {
+                self.get_or_init_webgl_context(*cx, options)
+                    .map(RenderingContext::WebGLRenderingContext)
+            },
+            "webgl2" | "experimental-webgl2" => unsafe {
+                self.get_or_init_webgl2_context(*cx, options)
+                    .map(RenderingContext::WebGL2RenderingContext)
+            },
             _ => None,
         }
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-canvas-todataurl
-    #[allow(unsafe_code)]
-    unsafe fn ToDataURL(
+    fn ToDataURL(
         &self,
-        _context: *mut JSContext,
+        _context: SafeJSContext,
         _mime_type: Option<DOMString>,
         _quality: HandleValue,
     ) -> Fallible<USVString> {

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -28,6 +28,7 @@ use crate::dom::webgl2renderingcontext::WebGL2RenderingContext;
 use crate::dom::webglrenderingcontext::{
     LayoutCanvasWebGLRenderingContextHelpers, WebGLRenderingContext,
 };
+use crate::script_runtime::JSContext as SafeJSContext;
 use base64;
 use canvas_traits::canvas::{CanvasId, CanvasMsg, FromScriptMsg};
 use canvas_traits::webgl::{GLContextAttributes, WebGLVersion};
@@ -263,7 +264,7 @@ impl HTMLCanvasElement {
         cx: *mut JSContext,
         options: HandleValue,
     ) -> Option<GLContextAttributes> {
-        match WebGLContextAttributes::new(cx, options) {
+        match WebGLContextAttributes::new(SafeJSContext::from_ptr(cx), options) {
             Ok(ConversionResult::Success(ref attrs)) => Some(From::from(attrs)),
             Ok(ConversionResult::Failure(ref error)) => {
                 throw_type_error(cx, &error);

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -654,7 +654,7 @@ impl HTMLScriptElement {
         } else {
             self.line_number as u32
         };
-        rooted!(in(window.get_cx()) let mut rval = UndefinedValue());
+        rooted!(in(*window.get_cx()) let mut rval = UndefinedValue());
         let global = window.upcast::<GlobalScope>();
         global.evaluate_script_on_global_with_result(
             &script.text,

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -8,10 +8,11 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
 use euclid::default::{Rect, Size2D};
 use ipc_channel::ipc::IpcSharedMemory;
-use js::jsapi::{Heap, JSContext, JSObject};
+use js::jsapi::{Heap, JSObject};
 use js::rust::Runtime;
 use js::typedarray::{CreateWith, Uint8ClampedArray};
 use std::borrow::Cow;
@@ -131,7 +132,7 @@ impl ImageData {
     #[allow(unsafe_code)]
     #[allow(unused_variables)]
     pub unsafe fn Constructor_(
-        cx: *mut JSContext,
+        cx: JSContext,
         global: &GlobalScope,
         jsobject: *mut JSObject,
         width: u32,
@@ -183,9 +184,8 @@ impl ImageDataMethods for ImageData {
         self.height
     }
 
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-imagedata-data
-    unsafe fn Data(&self, _: *mut JSContext) -> NonNull<JSObject> {
+    fn Data(&self, _: JSContext) -> NonNull<JSObject> {
         NonNull::new(self.data.get()).expect("got a null pointer")
     }
 }

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -41,7 +41,7 @@ impl ImageData {
         let len = width * height * 4;
         unsafe {
             let cx = global.get_cx();
-            rooted!(in (cx) let mut js_object = ptr::null_mut::<JSObject>());
+            rooted!(in (*cx) let mut js_object = ptr::null_mut::<JSObject>());
             let data = match data {
                 Some(ref mut d) => {
                     d.resize(len as usize, 0);
@@ -49,7 +49,7 @@ impl ImageData {
                 },
                 None => CreateWith::Length(len),
             };
-            Uint8ClampedArray::create(cx, data, js_object.handle_mut()).unwrap();
+            Uint8ClampedArray::create(*cx, data, js_object.handle_mut()).unwrap();
             Self::new_with_jsobject(global, width, Some(height), Some(js_object.get()))
         }
     }
@@ -70,7 +70,7 @@ impl ImageData {
         // checking jsobject type and verifying (height * width * 4 == jsobject.byte_len())
         if let Some(jsobject) = opt_jsobject {
             let cx = global.get_cx();
-            typedarray!(in(cx) let array_res: Uint8ClampedArray = jsobject);
+            typedarray!(in(*cx) let array_res: Uint8ClampedArray = jsobject);
             let array = array_res.map_err(|_| {
                 Error::Type("Argument to Image data is not an Uint8ClampedArray".to_owned())
             })?;
@@ -110,8 +110,8 @@ impl ImageData {
         } else {
             let len = width * height * 4;
             let cx = global.get_cx();
-            rooted!(in (cx) let mut array = ptr::null_mut::<JSObject>());
-            Uint8ClampedArray::create(cx, CreateWith::Length(len), array.handle_mut()).unwrap();
+            rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
+            Uint8ClampedArray::create(*cx, CreateWith::Length(len), array.handle_mut()).unwrap();
             (*imagedata).data.set(array.get());
         }
 

--- a/components/script/dom/messageevent.rs
+++ b/components/script/dom/messageevent.rs
@@ -15,8 +15,9 @@ use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::windowproxy::WindowProxy;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSContext, JSObject};
+use js::jsapi::{Heap, JSObject};
 use js::jsval::JSVal;
 use js::rust::HandleValue;
 use servo_atoms::Atom;
@@ -127,9 +128,8 @@ impl MessageEvent {
 }
 
 impl MessageEventMethods for MessageEvent {
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-messageevent-data
-    unsafe fn Data(&self, _cx: *mut JSContext) -> JSVal {
+    fn Data(&self, _cx: JSContext) -> JSVal {
         self.data.get()
     }
 
@@ -139,8 +139,7 @@ impl MessageEventMethods for MessageEvent {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-messageevent-source
-    #[allow(unsafe_code)]
-    unsafe fn GetSource(&self, _cx: *mut JSContext) -> Option<NonNull<JSObject>> {
+    fn GetSource(&self, _cx: JSContext) -> Option<NonNull<JSObject>> {
         self.source
             .as_ref()
             .and_then(|source| NonNull::new(source.reflector().get_jsobject().get()))

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -60,13 +60,14 @@ use crate::dom::svgsvgelement::{LayoutSVGSVGElementHelpers, SVGSVGElement};
 use crate::dom::text::Text;
 use crate::dom::virtualmethods::{vtable_for, VirtualMethods};
 use crate::dom::window::Window;
+use crate::script_runtime::JSContext;
 use crate::script_thread::ScriptThread;
 use app_units::Au;
 use devtools_traits::NodeInfo;
 use dom_struct::dom_struct;
 use euclid::default::{Point2D, Rect, Size2D, Vector2D};
 use html5ever::{Namespace, Prefix, QualName};
-use js::jsapi::{JSContext, JSObject, JSRuntime};
+use js::jsapi::{JSObject, JSRuntime};
 use libc::{self, c_void, uintptr_t};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use msg::constellation_msg::{BrowsingContextId, PipelineId};
@@ -1630,7 +1631,7 @@ impl Node {
     pub fn reflect_node<N>(
         node: Box<N>,
         document: &Document,
-        wrap_fn: unsafe fn(*mut JSContext, &GlobalScope, Box<N>) -> DomRoot<N>,
+        wrap_fn: unsafe fn(JSContext, &GlobalScope, Box<N>) -> DomRoot<N>,
     ) -> DomRoot<N>
     where
         N: DerivedFrom<Node> + DomObject,

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -15,9 +15,9 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlcanvaselement::HTMLCanvasElement;
 use crate::dom::offscreencanvasrenderingcontext2d::OffscreenCanvasRenderingContext2D;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
-use js::jsapi::JSContext;
 use js::rust::HandleValue;
 use ref_filter_map;
 use std::cell::Cell;
@@ -108,10 +108,9 @@ impl OffscreenCanvas {
 
 impl OffscreenCanvasMethods for OffscreenCanvas {
     // https://html.spec.whatwg.org/multipage/#dom-offscreencanvas-getcontext
-    #[allow(unsafe_code)]
-    unsafe fn GetContext(
+    fn GetContext(
         &self,
-        _cx: *mut JSContext,
+        _cx: JSContext,
         id: DOMString,
         _options: HandleValue,
     ) -> Option<OffscreenRenderingContext> {

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -253,12 +253,12 @@ impl PaintWorkletGlobalScope {
         );
 
         let cx = self.worklet_global.get_cx();
-        let _ac = JSAutoRealm::new(cx, self.worklet_global.reflector().get_jsobject().get());
+        let _ac = JSAutoRealm::new(*cx, self.worklet_global.reflector().get_jsobject().get());
 
         // TODO: Steps 1-2.1.
         // Step 2.2-5.1.
-        rooted!(in(cx) let mut class_constructor = UndefinedValue());
-        rooted!(in(cx) let mut paint_function = UndefinedValue());
+        rooted!(in(*cx) let mut class_constructor = UndefinedValue());
+        rooted!(in(*cx) let mut paint_function = UndefinedValue());
         let rendering_context = match self.paint_definitions.borrow().get(name) {
             None => {
                 // Step 2.2.
@@ -282,21 +282,21 @@ impl PaintWorkletGlobalScope {
         // prepopulate the paint instance in `RegisterPaint`, to avoid calling it in
         // the primary worklet thread.
         // https://github.com/servo/servo/issues/17377
-        rooted!(in(cx) let mut paint_instance = UndefinedValue());
+        rooted!(in(*cx) let mut paint_instance = UndefinedValue());
         match self.paint_class_instances.borrow_mut().entry(name.clone()) {
             Entry::Occupied(entry) => paint_instance.set(entry.get().get()),
             Entry::Vacant(entry) => {
                 // Step 5.2-5.3
                 let args = HandleValueArray::new();
-                rooted!(in(cx) let mut result = null_mut::<JSObject>());
+                rooted!(in(*cx) let mut result = null_mut::<JSObject>());
                 unsafe {
-                    Construct1(cx, class_constructor.handle(), &args, result.handle_mut());
+                    Construct1(*cx, class_constructor.handle(), &args, result.handle_mut());
                 }
                 paint_instance.set(ObjectValue(result.get()));
-                if unsafe { JS_IsExceptionPending(cx) } {
+                if unsafe { JS_IsExceptionPending(*cx) } {
                     debug!("Paint constructor threw an exception {}.", name);
                     unsafe {
-                        JS_ClearPendingException(cx);
+                        JS_ClearPendingException(*cx);
                     }
                     self.paint_definitions
                         .borrow_mut()
@@ -333,7 +333,7 @@ impl PaintWorkletGlobalScope {
             .collect();
         let arguments_value_array =
             unsafe { HandleValueArray::from_rooted_slice(&*arguments_value_vec) };
-        rooted!(in(cx) let argument_object = unsafe { JS_NewArrayObject(cx, &arguments_value_array) });
+        rooted!(in(*cx) let argument_object = unsafe { JS_NewArrayObject(*cx, &arguments_value_array) });
 
         let args_slice = [
             ObjectValue(rendering_context.reflector().get_jsobject().get()),
@@ -343,10 +343,10 @@ impl PaintWorkletGlobalScope {
         ];
         let args = unsafe { HandleValueArray::from_rooted_slice(&args_slice) };
 
-        rooted!(in(cx) let mut result = UndefinedValue());
+        rooted!(in(*cx) let mut result = UndefinedValue());
         unsafe {
             Call(
-                cx,
+                *cx,
                 paint_instance.handle(),
                 paint_function.handle(),
                 &args,
@@ -356,10 +356,10 @@ impl PaintWorkletGlobalScope {
         let missing_image_urls = rendering_context.take_missing_image_urls();
 
         // Step 13.
-        if unsafe { JS_IsExceptionPending(cx) } {
+        if unsafe { JS_IsExceptionPending(*cx) } {
             debug!("Paint function threw an exception {}.", name);
             unsafe {
-                JS_ClearPendingException(cx);
+                JS_ClearPendingException(*cx);
             }
             return self.invalid_image(size_in_dpx, missing_image_urls);
         }
@@ -518,8 +518,8 @@ impl PaintWorkletGlobalScopeMethods for PaintWorkletGlobalScope {
     fn RegisterPaint(&self, name: DOMString, paint_ctor: Rc<VoidFunction>) -> Fallible<()> {
         let name = Atom::from(name);
         let cx = self.worklet_global.get_cx();
-        rooted!(in(cx) let paint_obj = paint_ctor.callback_holder().get());
-        rooted!(in(cx) let paint_val = ObjectValue(paint_obj.get()));
+        rooted!(in(*cx) let paint_obj = paint_ctor.callback_holder().get());
+        rooted!(in(*cx) let paint_val = ObjectValue(paint_obj.get()));
 
         debug!("Registering paint image name {}.", name);
 
@@ -535,20 +535,20 @@ impl PaintWorkletGlobalScopeMethods for PaintWorkletGlobalScope {
 
         // Step 4-6.
         let mut property_names: Vec<String> =
-            unsafe { get_property(cx, paint_obj.handle(), "inputProperties", ()) }?
+            unsafe { get_property(*cx, paint_obj.handle(), "inputProperties", ()) }?
                 .unwrap_or_default();
         let properties = property_names.drain(..).map(Atom::from).collect();
 
         // Step 7-9.
         let input_arguments: Vec<String> =
-            unsafe { get_property(cx, paint_obj.handle(), "inputArguments", ()) }?
+            unsafe { get_property(*cx, paint_obj.handle(), "inputArguments", ()) }?
                 .unwrap_or_default();
 
         // TODO: Steps 10-11.
 
         // Steps 12-13.
         let alpha: bool =
-            unsafe { get_property(cx, paint_obj.handle(), "alpha", ()) }?.unwrap_or(true);
+            unsafe { get_property(*cx, paint_obj.handle(), "alpha", ()) }?.unwrap_or(true);
 
         // Step 14
         if unsafe { !IsConstructor(paint_obj.get()) } {
@@ -556,19 +556,24 @@ impl PaintWorkletGlobalScopeMethods for PaintWorkletGlobalScope {
         }
 
         // Steps 15-16
-        rooted!(in(cx) let mut prototype = UndefinedValue());
+        rooted!(in(*cx) let mut prototype = UndefinedValue());
         unsafe {
-            get_property_jsval(cx, paint_obj.handle(), "prototype", prototype.handle_mut())?;
+            get_property_jsval(*cx, paint_obj.handle(), "prototype", prototype.handle_mut())?;
         }
         if !prototype.is_object() {
             return Err(Error::Type(String::from("Prototype is not an object.")));
         }
-        rooted!(in(cx) let prototype = prototype.to_object());
+        rooted!(in(*cx) let prototype = prototype.to_object());
 
         // Steps 17-18
-        rooted!(in(cx) let mut paint_function = UndefinedValue());
+        rooted!(in(*cx) let mut paint_function = UndefinedValue());
         unsafe {
-            get_property_jsval(cx, prototype.handle(), "paint", paint_function.handle_mut())?;
+            get_property_jsval(
+                *cx,
+                prototype.handle(),
+                "paint",
+                paint_function.handle_mut(),
+            )?;
         }
         if !paint_function.is_object() || unsafe { !IsCallable(paint_function.to_object()) } {
             return Err(Error::Type(String::from("Paint function is not callable.")));

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -23,6 +23,7 @@ use crate::dom::worklet::WorkletExecutor;
 use crate::dom::workletglobalscope::WorkletGlobalScope;
 use crate::dom::workletglobalscope::WorkletGlobalScopeInit;
 use crate::dom::workletglobalscope::WorkletTask;
+use crate::script_runtime::JSContext;
 use crossbeam_channel::{unbounded, Sender};
 use dom_struct::dom_struct;
 use euclid::Scale;
@@ -128,7 +129,7 @@ impl PaintWorkletGlobalScope {
                 missing_image_urls: Vec::new(),
             }),
         });
-        unsafe { PaintWorkletGlobalScopeBinding::Wrap(runtime.cx(), global) }
+        unsafe { PaintWorkletGlobalScopeBinding::Wrap(JSContext::from_ptr(runtime.cx()), global) }
     }
 
     pub fn image_cache(&self) -> Arc<dyn ImageCache> {

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -17,6 +17,7 @@ use crate::dom::bluetoothpermissionresult::BluetoothPermissionResult;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::permissionstatus::PermissionStatus;
 use crate::dom::promise::Promise;
+use crate::script_runtime::JSContext as SafeJSContext;
 use dom_struct::dom_struct;
 use js::conversions::ConversionResult;
 use js::jsapi::{JSContext, JSObject};
@@ -232,7 +233,7 @@ impl PermissionAlgorithm for Permissions {
             .handle_mut()
             .set(ObjectValue(permission_descriptor_obj));
         unsafe {
-            match PermissionDescriptor::new(cx, property.handle()) {
+            match PermissionDescriptor::new(SafeJSContext::from_ptr(cx), property.handle()) {
                 Ok(ConversionResult::Success(descriptor)) => Ok(descriptor),
                 Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),
                 Err(_) => Err(Error::JSFailed),

--- a/components/script/dom/permissions.rs
+++ b/components/script/dom/permissions.rs
@@ -200,22 +200,19 @@ impl Permissions {
 }
 
 impl PermissionsMethods for Permissions {
-    #[allow(unsafe_code)]
     // https://w3c.github.io/permissions/#dom-permissions-query
-    unsafe fn Query(&self, cx: *mut JSContext, permissionDesc: *mut JSObject) -> Rc<Promise> {
-        self.manipulate(Operation::Query, cx, permissionDesc, None)
+    fn Query(&self, cx: SafeJSContext, permissionDesc: *mut JSObject) -> Rc<Promise> {
+        self.manipulate(Operation::Query, *cx, permissionDesc, None)
     }
 
-    #[allow(unsafe_code)]
     // https://w3c.github.io/permissions/#dom-permissions-request
-    unsafe fn Request(&self, cx: *mut JSContext, permissionDesc: *mut JSObject) -> Rc<Promise> {
-        self.manipulate(Operation::Request, cx, permissionDesc, None)
+    fn Request(&self, cx: SafeJSContext, permissionDesc: *mut JSObject) -> Rc<Promise> {
+        self.manipulate(Operation::Request, *cx, permissionDesc, None)
     }
 
-    #[allow(unsafe_code)]
     // https://w3c.github.io/permissions/#dom-permissions-revoke
-    unsafe fn Revoke(&self, cx: *mut JSContext, permissionDesc: *mut JSObject) -> Rc<Promise> {
-        self.manipulate(Operation::Revoke, cx, permissionDesc, None)
+    fn Revoke(&self, cx: SafeJSContext, permissionDesc: *mut JSObject) -> Rc<Promise> {
+        self.manipulate(Operation::Revoke, *cx, permissionDesc, None)
     }
 }
 

--- a/components/script/dom/popstateevent.rs
+++ b/components/script/dom/popstateevent.rs
@@ -14,8 +14,9 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::window::Window;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSContext};
+use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::HandleValue;
 use servo_atoms::Atom;
@@ -81,9 +82,8 @@ impl PopStateEvent {
 }
 
 impl PopStateEventMethods for PopStateEvent {
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-popstateevent-state
-    unsafe fn State(&self, _cx: *mut JSContext) -> JSVal {
+    fn State(&self, _cx: JSContext) -> JSVal {
         self.state.get()
     }
 

--- a/components/script/dom/promiserejectionevent.rs
+++ b/components/script/dom/promiserejectionevent.rs
@@ -14,8 +14,9 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSContext};
+use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::HandleValue;
 use servo_atoms::Atom;
@@ -100,9 +101,8 @@ impl PromiseRejectionEventMethods for PromiseRejectionEvent {
         self.promise.clone()
     }
 
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-promiserejectionevent-reason
-    unsafe fn Reason(&self, _cx: *mut JSContext) -> JSVal {
+    fn Reason(&self, _cx: JSContext) -> JSVal {
         self.reason.get()
     }
 

--- a/components/script/dom/rtcsessiondescription.rs
+++ b/components/script/dom/rtcsessiondescription.rs
@@ -14,9 +14,10 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
 use js::conversions::ToJSValConvertible;
-use js::jsapi::{JSContext, JSObject};
+use js::jsapi::JSObject;
 use js::jsval::UndefinedValue;
 use std::ptr::NonNull;
 
@@ -73,13 +74,15 @@ impl RTCSessionDescriptionMethods for RTCSessionDescription {
 
     #[allow(unsafe_code)]
     /// https://w3c.github.io/webrtc-pc/#dom-rtcsessiondescription-tojson
-    unsafe fn ToJSON(&self, cx: *mut JSContext) -> NonNull<JSObject> {
+    fn ToJSON(&self, cx: JSContext) -> NonNull<JSObject> {
         let init = RTCSessionDescriptionInit {
             type_: self.ty,
             sdp: self.sdp.clone(),
         };
-        rooted!(in(cx) let mut jsval = UndefinedValue());
-        init.to_jsval(cx, jsval.handle_mut());
-        NonNull::new(jsval.to_object()).unwrap()
+        unsafe {
+            rooted!(in(*cx) let mut jsval = UndefinedValue());
+            init.to_jsval(*cx, jsval.handle_mut());
+            NonNull::new(jsval.to_object()).unwrap()
+        }
     }
 }

--- a/components/script/dom/serviceworker.rs
+++ b/components/script/dom/serviceworker.rs
@@ -16,9 +16,9 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::bindings::structuredclone::StructuredCloneData;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::JSContext;
 use crate::task::TaskOnce;
 use dom_struct::dom_struct;
-use js::jsapi::JSContext;
 use js::rust::HandleValue;
 use script_traits::{DOMMessage, ScriptMsg};
 use servo_url::ServoUrl;
@@ -90,15 +90,14 @@ impl ServiceWorkerMethods for ServiceWorker {
         USVString(self.script_url.borrow().clone())
     }
 
-    #[allow(unsafe_code)]
     // https://w3c.github.io/ServiceWorker/#service-worker-postmessage
-    unsafe fn PostMessage(&self, cx: *mut JSContext, message: HandleValue) -> ErrorResult {
+    fn PostMessage(&self, cx: JSContext, message: HandleValue) -> ErrorResult {
         // Step 1
         if let ServiceWorkerState::Redundant = self.state.get() {
             return Err(Error::InvalidState);
         }
         // Step 7
-        let data = StructuredCloneData::write(cx, message)?;
+        let data = StructuredCloneData::write(*cx, message)?;
         let msg_vec = DOMMessage(data.move_to_arraybuffer());
         let _ = self
             .global()

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -21,7 +21,9 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::worker::TrustedWorkerAddress;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::fetch::load_whole_resource;
-use crate::script_runtime::{new_rt_and_cx, CommonScriptMsg, Runtime, ScriptChan};
+use crate::script_runtime::{
+    new_rt_and_cx, CommonScriptMsg, JSContext as SafeJSContext, Runtime, ScriptChan,
+};
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
 use crate::task_source::TaskSourceName;
 use crossbeam_channel::{unbounded, Receiver, Sender};
@@ -246,7 +248,7 @@ impl ServiceWorkerGlobalScope {
             swmanager_sender,
             scope_url,
         ));
-        unsafe { ServiceWorkerGlobalScopeBinding::Wrap(cx, scope) }
+        unsafe { ServiceWorkerGlobalScopeBinding::Wrap(SafeJSContext::from_ptr(cx), scope) }
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -337,7 +337,7 @@ impl ServiceWorkerGlobalScope {
 
                 unsafe {
                     // Handle interrupt requests
-                    JS_AddInterruptCallback(scope.get_cx(), Some(interrupt_callback));
+                    JS_AddInterruptCallback(*scope.get_cx(), Some(interrupt_callback));
                 }
 
                 scope.execute_script(DOMString::from(source));
@@ -413,7 +413,7 @@ impl ServiceWorkerGlobalScope {
                 let scope = self.upcast::<WorkerGlobalScope>();
                 let target = self.upcast();
                 let _ac = enter_realm(&*scope);
-                rooted!(in(scope.get_cx()) let mut message = UndefinedValue());
+                rooted!(in(*scope.get_cx()) let mut message = UndefinedValue());
                 data.read(scope.upcast(), message.handle_mut());
                 ExtendableMessageEvent::dispatch_jsval(target, scope.upcast(), message.handle());
             },

--- a/components/script/dom/testworkletglobalscope.rs
+++ b/components/script/dom/testworkletglobalscope.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::worklet::WorkletExecutor;
 use crate::dom::workletglobalscope::WorkletGlobalScope;
 use crate::dom::workletglobalscope::WorkletGlobalScopeInit;
+use crate::script_runtime::JSContext;
 use crossbeam_channel::Sender;
 use dom_struct::dom_struct;
 use js::rust::Runtime;
@@ -49,7 +50,7 @@ impl TestWorkletGlobalScope {
             ),
             lookup_table: Default::default(),
         });
-        unsafe { TestWorkletGlobalScopeBinding::Wrap(runtime.cx(), global) }
+        unsafe { TestWorkletGlobalScopeBinding::Wrap(JSContext::from_ptr(runtime.cx()), global) }
     }
 
     pub fn perform_a_worklet_task(&self, task: TestWorkletTask) {

--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -9,8 +9,9 @@ use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::{JSContext, JSObject};
+use js::jsapi::JSObject;
 use js::typedarray::{CreateWith, Uint8Array};
 use std::ptr;
 use std::ptr::NonNull;
@@ -49,14 +50,17 @@ impl TextEncoderMethods for TextEncoder {
 
     #[allow(unsafe_code)]
     // https://encoding.spec.whatwg.org/#dom-textencoder-encode
-    unsafe fn Encode(&self, cx: *mut JSContext, input: USVString) -> NonNull<JSObject> {
+    fn Encode(&self, cx: JSContext, input: USVString) -> NonNull<JSObject> {
         let encoded = input.0.as_bytes();
 
-        rooted!(in(cx) let mut js_object = ptr::null_mut::<JSObject>());
-        assert!(
-            Uint8Array::create(cx, CreateWith::Slice(&encoded), js_object.handle_mut()).is_ok()
-        );
+        unsafe {
+            rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
+            assert!(
+                Uint8Array::create(*cx, CreateWith::Slice(&encoded), js_object.handle_mut())
+                    .is_ok()
+            );
 
-        NonNull::new_unchecked(js_object.get())
+            NonNull::new_unchecked(js_object.get())
+        }
     }
 }

--- a/components/script/dom/userscripts.rs
+++ b/components/script/dom/userscripts.rs
@@ -22,7 +22,7 @@ pub fn load_script(head: &HTMLHeadElement) {
     doc.add_delayed_task(task!(UserScriptExecute: move || {
         let win = win.root();
         let cx = win.get_cx();
-        rooted!(in(cx) let mut rval = UndefinedValue());
+        rooted!(in(*cx) let mut rval = UndefinedValue());
 
         let path = PathBuf::from(&path_str);
         let mut files = read_dir(&path)

--- a/components/script/dom/vreyeparameters.rs
+++ b/components/script/dom/vreyeparameters.rs
@@ -9,8 +9,9 @@ use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::vrfieldofview::VRFieldOfView;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSContext, JSObject};
+use js::jsapi::{Heap, JSObject};
 use js::typedarray::{CreateWith, Float32Array};
 use std::default::Default;
 use std::ptr;
@@ -67,8 +68,8 @@ impl VREyeParameters {
 impl VREyeParametersMethods for VREyeParameters {
     #[allow(unsafe_code)]
     // https://w3c.github.io/webvr/#dom-vreyeparameters-offset
-    unsafe fn Offset(&self, _cx: *mut JSContext) -> NonNull<JSObject> {
-        NonNull::new_unchecked(self.offset.get())
+    fn Offset(&self, _cx: JSContext) -> NonNull<JSObject> {
+        unsafe { NonNull::new_unchecked(self.offset.get()) }
     }
 
     // https://w3c.github.io/webvr/#dom-vreyeparameters-fieldofview

--- a/components/script/dom/vreyeparameters.rs
+++ b/components/script/dom/vreyeparameters.rs
@@ -45,10 +45,10 @@ impl VREyeParameters {
         let fov = VRFieldOfView::new(&global, parameters.field_of_view.clone());
 
         let cx = global.get_cx();
-        rooted!(in (cx) let mut array = ptr::null_mut::<JSObject>());
+        rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
         unsafe {
             let _ = Float32Array::create(
-                cx,
+                *cx,
                 CreateWith::Slice(&parameters.offset),
                 array.handle_mut(),
             );

--- a/components/script/dom/vrframedata.rs
+++ b/components/script/dom/vrframedata.rs
@@ -62,7 +62,7 @@ impl VRFrameData {
             global,
             VRFrameDataBinding::Wrap,
         );
-        let cx = unsafe { JSContext::from_ptr(global.get_cx()) };
+        let cx = global.get_cx();
         create_typed_array(cx, &matrix, &root.left_proj);
         create_typed_array(cx, &matrix, &root.left_view);
         create_typed_array(cx, &matrix, &root.right_proj);
@@ -90,7 +90,7 @@ impl VRFrameData {
     #[allow(unsafe_code)]
     pub fn update(&self, data: &WebVRFrameData) {
         unsafe {
-            let cx = JSContext::from_ptr(self.global().get_cx());
+            let cx = self.global().get_cx();
             typedarray!(in(*cx) let left_proj_array: Float32Array = self.left_proj.get());
             if let Ok(mut array) = left_proj_array {
                 array.update(&data.left_projection_matrix);

--- a/components/script/dom/vrframedata.rs
+++ b/components/script/dom/vrframedata.rs
@@ -11,8 +11,9 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::vrpose::VRPose;
 use crate::dom::window::Window;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSContext, JSObject};
+use js::jsapi::{Heap, JSObject};
 use js::typedarray::{CreateWith, Float32Array};
 use std::cell::Cell;
 use std::ptr;
@@ -61,13 +62,11 @@ impl VRFrameData {
             global,
             VRFrameDataBinding::Wrap,
         );
-        let cx = global.get_cx();
-        unsafe {
-            create_typed_array(cx, &matrix, &root.left_proj);
-            create_typed_array(cx, &matrix, &root.left_view);
-            create_typed_array(cx, &matrix, &root.right_proj);
-            create_typed_array(cx, &matrix, &root.right_view);
-        }
+        let cx = unsafe { JSContext::from_ptr(global.get_cx()) };
+        create_typed_array(cx, &matrix, &root.left_proj);
+        create_typed_array(cx, &matrix, &root.left_view);
+        create_typed_array(cx, &matrix, &root.right_proj);
+        create_typed_array(cx, &matrix, &root.right_view);
 
         root
     }
@@ -79,9 +78,11 @@ impl VRFrameData {
 
 /// FIXME(#22526) this should be in a better place
 #[allow(unsafe_code)]
-pub unsafe fn create_typed_array(cx: *mut JSContext, src: &[f32], dst: &Heap<*mut JSObject>) {
-    rooted!(in (cx) let mut array = ptr::null_mut::<JSObject>());
-    let _ = Float32Array::create(cx, CreateWith::Slice(src), array.handle_mut());
+pub fn create_typed_array(cx: JSContext, src: &[f32], dst: &Heap<*mut JSObject>) {
+    rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
+    unsafe {
+        let _ = Float32Array::create(*cx, CreateWith::Slice(src), array.handle_mut());
+    }
     (*dst).set(array.get());
 }
 
@@ -89,28 +90,28 @@ impl VRFrameData {
     #[allow(unsafe_code)]
     pub fn update(&self, data: &WebVRFrameData) {
         unsafe {
-            let cx = self.global().get_cx();
-            typedarray!(in(cx) let left_proj_array: Float32Array = self.left_proj.get());
+            let cx = JSContext::from_ptr(self.global().get_cx());
+            typedarray!(in(*cx) let left_proj_array: Float32Array = self.left_proj.get());
             if let Ok(mut array) = left_proj_array {
                 array.update(&data.left_projection_matrix);
             }
-            typedarray!(in(cx) let left_view_array: Float32Array = self.left_view.get());
+            typedarray!(in(*cx) let left_view_array: Float32Array = self.left_view.get());
             if let Ok(mut array) = left_view_array {
                 array.update(&data.left_view_matrix);
             }
-            typedarray!(in(cx) let right_proj_array: Float32Array = self.right_proj.get());
+            typedarray!(in(*cx) let right_proj_array: Float32Array = self.right_proj.get());
             if let Ok(mut array) = right_proj_array {
                 array.update(&data.right_projection_matrix);
             }
-            typedarray!(in(cx) let right_view_array: Float32Array = self.right_view.get());
+            typedarray!(in(*cx) let right_view_array: Float32Array = self.right_view.get());
             if let Ok(mut array) = right_view_array {
                 array.update(&data.right_view_matrix);
             }
-        }
-        self.pose.update(&data.pose);
-        self.timestamp.set(data.timestamp);
-        if self.first_timestamp.get() == 0.0 {
-            self.first_timestamp.set(data.timestamp);
+            self.pose.update(&data.pose);
+            self.timestamp.set(data.timestamp);
+            if self.first_timestamp.get() == 0.0 {
+                self.first_timestamp.set(data.timestamp);
+            }
         }
     }
 }
@@ -123,26 +124,26 @@ impl VRFrameDataMethods for VRFrameData {
 
     #[allow(unsafe_code)]
     // https://w3c.github.io/webvr/#dom-vrframedata-leftprojectionmatrix
-    unsafe fn LeftProjectionMatrix(&self, _cx: *mut JSContext) -> NonNull<JSObject> {
-        NonNull::new_unchecked(self.left_proj.get())
+    fn LeftProjectionMatrix(&self, _cx: JSContext) -> NonNull<JSObject> {
+        unsafe { NonNull::new_unchecked(self.left_proj.get()) }
     }
 
     #[allow(unsafe_code)]
     // https://w3c.github.io/webvr/#dom-vrframedata-leftviewmatrix
-    unsafe fn LeftViewMatrix(&self, _cx: *mut JSContext) -> NonNull<JSObject> {
-        NonNull::new_unchecked(self.left_view.get())
+    fn LeftViewMatrix(&self, _cx: JSContext) -> NonNull<JSObject> {
+        unsafe { NonNull::new_unchecked(self.left_view.get()) }
     }
 
     #[allow(unsafe_code)]
     // https://w3c.github.io/webvr/#dom-vrframedata-rightprojectionmatrix
-    unsafe fn RightProjectionMatrix(&self, _cx: *mut JSContext) -> NonNull<JSObject> {
-        NonNull::new_unchecked(self.right_proj.get())
+    fn RightProjectionMatrix(&self, _cx: JSContext) -> NonNull<JSObject> {
+        unsafe { NonNull::new_unchecked(self.right_proj.get()) }
     }
 
     #[allow(unsafe_code)]
     // https://w3c.github.io/webvr/#dom-vrframedata-rightviewmatrix
-    unsafe fn RightViewMatrix(&self, _cx: *mut JSContext) -> NonNull<JSObject> {
-        NonNull::new_unchecked(self.right_view.get())
+    fn RightViewMatrix(&self, _cx: JSContext) -> NonNull<JSObject> {
+        unsafe { NonNull::new_unchecked(self.right_view.get()) }
     }
 
     // https://w3c.github.io/webvr/#dom-vrframedata-pose

--- a/components/script/dom/vrpose.rs
+++ b/components/script/dom/vrpose.rs
@@ -7,9 +7,9 @@ use crate::dom::bindings::codegen::Bindings::VRPoseBinding::VRPoseMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
-use crate::script_runtime::JSContext as SafeJSContext;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSContext, JSObject};
+use js::jsapi::{Heap, JSObject};
 use js::typedarray::{CreateWith, Float32Array};
 use std::ptr;
 use std::ptr::NonNull;
@@ -33,21 +33,19 @@ pub struct VRPose {
 }
 
 #[allow(unsafe_code)]
-unsafe fn update_or_create_typed_array(
-    cx: *mut JSContext,
-    src: Option<&[f32]>,
-    dst: &Heap<*mut JSObject>,
-) {
+fn update_or_create_typed_array(cx: JSContext, src: Option<&[f32]>, dst: &Heap<*mut JSObject>) {
     match src {
         Some(data) => {
             if dst.get().is_null() {
-                rooted!(in (cx) let mut array = ptr::null_mut::<JSObject>());
-                let _ = Float32Array::create(cx, CreateWith::Slice(data), array.handle_mut());
+                rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
+                let _ = unsafe {
+                    Float32Array::create(*cx, CreateWith::Slice(data), array.handle_mut())
+                };
                 (*dst).set(array.get());
             } else {
-                typedarray!(in(cx) let array: Float32Array = dst.get());
+                typedarray!(in(*cx) let array: Float32Array = dst.get());
                 if let Ok(mut array) = array {
-                    array.update(data);
+                    unsafe { array.update(data) };
                 }
             }
         },
@@ -96,69 +94,63 @@ impl VRPose {
     #[allow(unsafe_code)]
     pub fn update(&self, pose: &webvr::VRPose) {
         let cx = self.global().get_cx();
-        unsafe {
-            update_or_create_typed_array(
-                cx,
-                pose.position.as_ref().map(|v| &v[..]),
-                &self.position,
-            );
-            update_or_create_typed_array(
-                cx,
-                pose.orientation.as_ref().map(|v| &v[..]),
-                &self.orientation,
-            );
-            update_or_create_typed_array(
-                cx,
-                pose.linear_velocity.as_ref().map(|v| &v[..]),
-                &self.linear_vel,
-            );
-            update_or_create_typed_array(
-                cx,
-                pose.angular_velocity.as_ref().map(|v| &v[..]),
-                &self.angular_vel,
-            );
-            update_or_create_typed_array(
-                cx,
-                pose.linear_acceleration.as_ref().map(|v| &v[..]),
-                &self.linear_acc,
-            );
-            update_or_create_typed_array(
-                cx,
-                pose.angular_acceleration.as_ref().map(|v| &v[..]),
-                &self.angular_acc,
-            );
-        }
+        update_or_create_typed_array(cx, pose.position.as_ref().map(|v| &v[..]), &self.position);
+        update_or_create_typed_array(
+            cx,
+            pose.orientation.as_ref().map(|v| &v[..]),
+            &self.orientation,
+        );
+        update_or_create_typed_array(
+            cx,
+            pose.linear_velocity.as_ref().map(|v| &v[..]),
+            &self.linear_vel,
+        );
+        update_or_create_typed_array(
+            cx,
+            pose.angular_velocity.as_ref().map(|v| &v[..]),
+            &self.angular_vel,
+        );
+        update_or_create_typed_array(
+            cx,
+            pose.linear_acceleration.as_ref().map(|v| &v[..]),
+            &self.linear_acc,
+        );
+        update_or_create_typed_array(
+            cx,
+            pose.angular_acceleration.as_ref().map(|v| &v[..]),
+            &self.angular_acc,
+        );
     }
 }
 
 impl VRPoseMethods for VRPose {
     // https://w3c.github.io/webvr/#dom-vrpose-position
-    fn GetPosition(&self, _cx: SafeJSContext) -> Option<NonNull<JSObject>> {
+    fn GetPosition(&self, _cx: JSContext) -> Option<NonNull<JSObject>> {
         heap_to_option(&self.position)
     }
 
     // https://w3c.github.io/webvr/#dom-vrpose-linearvelocity
-    fn GetLinearVelocity(&self, _cx: SafeJSContext) -> Option<NonNull<JSObject>> {
+    fn GetLinearVelocity(&self, _cx: JSContext) -> Option<NonNull<JSObject>> {
         heap_to_option(&self.linear_vel)
     }
 
     // https://w3c.github.io/webvr/#dom-vrpose-linearacceleration
-    fn GetLinearAcceleration(&self, _cx: SafeJSContext) -> Option<NonNull<JSObject>> {
+    fn GetLinearAcceleration(&self, _cx: JSContext) -> Option<NonNull<JSObject>> {
         heap_to_option(&self.linear_acc)
     }
 
     // https://w3c.github.io/webvr/#dom-vrpose-orientation
-    fn GetOrientation(&self, _cx: SafeJSContext) -> Option<NonNull<JSObject>> {
+    fn GetOrientation(&self, _cx: JSContext) -> Option<NonNull<JSObject>> {
         heap_to_option(&self.orientation)
     }
 
     // https://w3c.github.io/webvr/#dom-vrpose-angularvelocity
-    fn GetAngularVelocity(&self, _cx: SafeJSContext) -> Option<NonNull<JSObject>> {
+    fn GetAngularVelocity(&self, _cx: JSContext) -> Option<NonNull<JSObject>> {
         heap_to_option(&self.angular_vel)
     }
 
     // https://w3c.github.io/webvr/#dom-vrpose-angularacceleration
-    fn GetAngularAcceleration(&self, _cx: SafeJSContext) -> Option<NonNull<JSObject>> {
+    fn GetAngularAcceleration(&self, _cx: JSContext) -> Option<NonNull<JSObject>> {
         heap_to_option(&self.angular_acc)
     }
 }

--- a/components/script/dom/vrpose.rs
+++ b/components/script/dom/vrpose.rs
@@ -7,6 +7,7 @@ use crate::dom::bindings::codegen::Bindings::VRPoseBinding::VRPoseMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::JSContext as SafeJSContext;
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSContext, JSObject};
 use js::typedarray::{CreateWith, Float32Array};
@@ -131,39 +132,33 @@ impl VRPose {
 }
 
 impl VRPoseMethods for VRPose {
-    #[allow(unsafe_code)]
     // https://w3c.github.io/webvr/#dom-vrpose-position
-    unsafe fn GetPosition(&self, _cx: *mut JSContext) -> Option<NonNull<JSObject>> {
+    fn GetPosition(&self, _cx: SafeJSContext) -> Option<NonNull<JSObject>> {
         heap_to_option(&self.position)
     }
 
-    #[allow(unsafe_code)]
     // https://w3c.github.io/webvr/#dom-vrpose-linearvelocity
-    unsafe fn GetLinearVelocity(&self, _cx: *mut JSContext) -> Option<NonNull<JSObject>> {
+    fn GetLinearVelocity(&self, _cx: SafeJSContext) -> Option<NonNull<JSObject>> {
         heap_to_option(&self.linear_vel)
     }
 
-    #[allow(unsafe_code)]
     // https://w3c.github.io/webvr/#dom-vrpose-linearacceleration
-    unsafe fn GetLinearAcceleration(&self, _cx: *mut JSContext) -> Option<NonNull<JSObject>> {
+    fn GetLinearAcceleration(&self, _cx: SafeJSContext) -> Option<NonNull<JSObject>> {
         heap_to_option(&self.linear_acc)
     }
 
-    #[allow(unsafe_code)]
     // https://w3c.github.io/webvr/#dom-vrpose-orientation
-    unsafe fn GetOrientation(&self, _cx: *mut JSContext) -> Option<NonNull<JSObject>> {
+    fn GetOrientation(&self, _cx: SafeJSContext) -> Option<NonNull<JSObject>> {
         heap_to_option(&self.orientation)
     }
 
-    #[allow(unsafe_code)]
     // https://w3c.github.io/webvr/#dom-vrpose-angularvelocity
-    unsafe fn GetAngularVelocity(&self, _cx: *mut JSContext) -> Option<NonNull<JSObject>> {
+    fn GetAngularVelocity(&self, _cx: SafeJSContext) -> Option<NonNull<JSObject>> {
         heap_to_option(&self.angular_vel)
     }
 
-    #[allow(unsafe_code)]
     // https://w3c.github.io/webvr/#dom-vrpose-angularacceleration
-    unsafe fn GetAngularAcceleration(&self, _cx: *mut JSContext) -> Option<NonNull<JSObject>> {
+    fn GetAngularAcceleration(&self, _cx: SafeJSContext) -> Option<NonNull<JSObject>> {
         heap_to_option(&self.angular_acc)
     }
 }

--- a/components/script/dom/vrstageparameters.rs
+++ b/components/script/dom/vrstageparameters.rs
@@ -43,10 +43,10 @@ impl VRStageParameters {
         global: &GlobalScope,
     ) -> DomRoot<VRStageParameters> {
         let cx = global.get_cx();
-        rooted!(in (cx) let mut array = ptr::null_mut::<JSObject>());
+        rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
         unsafe {
             let _ = Float32Array::create(
-                cx,
+                *cx,
                 CreateWith::Slice(&parameters.sitting_to_standing_transform),
                 array.handle_mut(),
             );
@@ -67,7 +67,7 @@ impl VRStageParameters {
     pub fn update(&self, parameters: &WebVRStageParameters) {
         unsafe {
             let cx = self.global().get_cx();
-            typedarray!(in(cx) let array: Float32Array = self.transform.get());
+            typedarray!(in(*cx) let array: Float32Array = self.transform.get());
             if let Ok(mut array) = array {
                 array.update(&parameters.sitting_to_standing_transform);
             }

--- a/components/script/dom/vrstageparameters.rs
+++ b/components/script/dom/vrstageparameters.rs
@@ -9,8 +9,9 @@ use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSContext, JSObject};
+use js::jsapi::{Heap, JSObject};
 use js::typedarray::{CreateWith, Float32Array};
 use std::ptr;
 use std::ptr::NonNull;
@@ -78,8 +79,8 @@ impl VRStageParameters {
 impl VRStageParametersMethods for VRStageParameters {
     #[allow(unsafe_code)]
     // https://w3c.github.io/webvr/#dom-vrstageparameters-sittingtostandingtransform
-    unsafe fn SittingToStandingTransform(&self, _cx: *mut JSContext) -> NonNull<JSObject> {
-        NonNull::new_unchecked(self.transform.get())
+    fn SittingToStandingTransform(&self, _cx: JSContext) -> NonNull<JSObject> {
+        unsafe { NonNull::new_unchecked(self.transform.get()) }
     }
 
     // https://w3c.github.io/webvr/#dom-vrstageparameters-sizex

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -29,11 +29,12 @@ use crate::dom::webglshaderprecisionformat::WebGLShaderPrecisionFormat;
 use crate::dom::webgltexture::WebGLTexture;
 use crate::dom::webgluniformlocation::WebGLUniformLocation;
 use crate::dom::window::Window;
+use crate::script_runtime::JSContext;
 /// https://www.khronos.org/registry/webgl/specs/latest/2.0/webgl.idl
 use canvas_traits::webgl::{GLContextAttributes, WebGLVersion};
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
-use js::jsapi::{JSContext, JSObject};
+use js::jsapi::JSObject;
 use js::jsval::JSVal;
 use js::rust::CustomAutoRooterGuard;
 use js::typedarray::ArrayBufferView;
@@ -109,21 +110,19 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.DrawingBufferHeight()
     }
 
-    #[allow(unsafe_code)]
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
-    unsafe fn GetBufferParameter(&self, _cx: *mut JSContext, target: u32, parameter: u32) -> JSVal {
-        self.base.GetBufferParameter(_cx, target, parameter)
+    fn GetBufferParameter(&self, cx: JSContext, target: u32, parameter: u32) -> JSVal {
+        self.base.GetBufferParameter(cx, target, parameter)
     }
 
     #[allow(unsafe_code)]
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
-    unsafe fn GetParameter(&self, cx: *mut JSContext, parameter: u32) -> JSVal {
+    fn GetParameter(&self, cx: JSContext, parameter: u32) -> JSVal {
         self.base.GetParameter(cx, parameter)
     }
 
-    #[allow(unsafe_code)]
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
-    unsafe fn GetTexParameter(&self, cx: *mut JSContext, target: u32, pname: u32) -> JSVal {
+    fn GetTexParameter(&self, cx: JSContext, target: u32, pname: u32) -> JSVal {
         self.base.GetTexParameter(cx, target, pname)
     }
 
@@ -142,21 +141,15 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.GetSupportedExtensions()
     }
 
-    #[allow(unsafe_code)]
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14
-    unsafe fn GetExtension(
-        &self,
-        cx: *mut JSContext,
-        name: DOMString,
-    ) -> Option<NonNull<JSObject>> {
+    fn GetExtension(&self, cx: JSContext, name: DOMString) -> Option<NonNull<JSObject>> {
         self.base.GetExtension(cx, name)
     }
 
-    #[allow(unsafe_code)]
     /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4
-    unsafe fn GetFramebufferAttachmentParameter(
+    fn GetFramebufferAttachmentParameter(
         &self,
-        cx: *mut JSContext,
+        cx: JSContext,
         target: u32,
         attachment: u32,
         pname: u32,
@@ -165,14 +158,8 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             .GetFramebufferAttachmentParameter(cx, target, attachment, pname)
     }
 
-    #[allow(unsafe_code)]
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.7
-    unsafe fn GetRenderbufferParameter(
-        &self,
-        cx: *mut JSContext,
-        target: u32,
-        pname: u32,
-    ) -> JSVal {
+    fn GetRenderbufferParameter(&self, cx: JSContext, target: u32, pname: u32) -> JSVal {
         self.base.GetRenderbufferParameter(cx, target, pname)
     }
 
@@ -505,14 +492,8 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.GetProgramInfoLog(program)
     }
 
-    #[allow(unsafe_code)]
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
-    unsafe fn GetProgramParameter(
-        &self,
-        cx: *mut JSContext,
-        program: &WebGLProgram,
-        param_id: u32,
-    ) -> JSVal {
+    fn GetProgramParameter(&self, cx: JSContext, program: &WebGLProgram, param_id: u32) -> JSVal {
         self.base.GetProgramParameter(cx, program, param_id)
     }
 
@@ -521,14 +502,8 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.GetShaderInfoLog(shader)
     }
 
-    #[allow(unsafe_code)]
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
-    unsafe fn GetShaderParameter(
-        &self,
-        cx: *mut JSContext,
-        shader: &WebGLShader,
-        param_id: u32,
-    ) -> JSVal {
+    fn GetShaderParameter(&self, cx: JSContext, shader: &WebGLShader, param_id: u32) -> JSVal {
         self.base.GetShaderParameter(cx, shader, param_id)
     }
 
@@ -551,9 +526,8 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.GetUniformLocation(program, name)
     }
 
-    #[allow(unsafe_code)]
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
-    unsafe fn GetVertexAttrib(&self, cx: *mut JSContext, index: u32, pname: u32) -> JSVal {
+    fn GetVertexAttrib(&self, cx: JSContext, index: u32, pname: u32) -> JSVal {
         self.base.GetVertexAttrib(cx, index, pname)
     }
 
@@ -815,10 +789,9 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
-    #[allow(unsafe_code)]
-    unsafe fn GetUniform(
+    fn GetUniform(
         &self,
-        cx: *mut JSContext,
+        cx: JSContext,
         program: &WebGLProgram,
         location: &WebGLUniformLocation,
     ) -> JSVal {

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -569,26 +569,26 @@ impl TaskOnce for MessageReceivedTask {
         // global.get_cx() returns a valid `JSContext` pointer, so this is safe.
         unsafe {
             let cx = global.get_cx();
-            let _ac = JSAutoRealm::new(cx, ws.reflector().get_jsobject().get());
-            rooted!(in(cx) let mut message = UndefinedValue());
+            let _ac = JSAutoRealm::new(*cx, ws.reflector().get_jsobject().get());
+            rooted!(in(*cx) let mut message = UndefinedValue());
             match self.message {
-                MessageData::Text(text) => text.to_jsval(cx, message.handle_mut()),
+                MessageData::Text(text) => text.to_jsval(*cx, message.handle_mut()),
                 MessageData::Binary(data) => match ws.binary_type.get() {
                     BinaryType::Blob => {
                         let blob =
                             Blob::new(&global, BlobImpl::new_from_bytes(data), "".to_owned());
-                        blob.to_jsval(cx, message.handle_mut());
+                        blob.to_jsval(*cx, message.handle_mut());
                     },
                     BinaryType::Arraybuffer => {
-                        rooted!(in(cx) let mut array_buffer = ptr::null_mut::<JSObject>());
+                        rooted!(in(*cx) let mut array_buffer = ptr::null_mut::<JSObject>());
                         assert!(ArrayBuffer::create(
-                            cx,
+                            *cx,
                             CreateWith::Slice(&data),
                             array_buffer.handle_mut()
                         )
                         .is_ok());
 
-                        (*array_buffer).to_jsval(cx, message.handle_mut());
+                        (*array_buffer).to_jsval(*cx, message.handle_mut());
                     },
                 },
             }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -615,26 +615,28 @@ impl WindowMethods for Window {
 
     #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-opener
-    unsafe fn Opener(&self, cx: *mut JSContext) -> JSVal {
-        self.window_proxy().opener(cx)
+    fn Opener(&self, cx: SafeJSContext) -> JSVal {
+        unsafe { self.window_proxy().opener(*cx) }
     }
 
     #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-opener
-    unsafe fn SetOpener(&self, cx: *mut JSContext, value: HandleValue) {
+    fn SetOpener(&self, cx: SafeJSContext, value: HandleValue) {
         // Step 1.
         if value.is_null() {
             return self.window_proxy().disown();
         }
         // Step 2.
         let obj = self.reflector().get_jsobject();
-        assert!(JS_DefineProperty(
-            cx,
-            obj,
-            "opener\0".as_ptr() as *const libc::c_char,
-            value,
-            JSPROP_ENUMERATE as u32
-        ));
+        unsafe {
+            assert!(JS_DefineProperty(
+                *cx,
+                obj,
+                "opener\0".as_ptr() as *const libc::c_char,
+                value,
+                JSPROP_ENUMERATE as u32
+            ));
+        }
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-window-closed
@@ -739,11 +741,10 @@ impl WindowMethods for Window {
         self.navigator.or_init(|| Navigator::new(self))
     }
 
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-settimeout
-    unsafe fn SetTimeout(
+    fn SetTimeout(
         &self,
-        _cx: *mut JSContext,
+        _cx: SafeJSContext,
         callback: Rc<Function>,
         timeout: i32,
         args: Vec<HandleValue>,
@@ -756,11 +757,10 @@ impl WindowMethods for Window {
         )
     }
 
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-settimeout
-    unsafe fn SetTimeout_(
+    fn SetTimeout_(
         &self,
-        _cx: *mut JSContext,
+        _cx: SafeJSContext,
         callback: DOMString,
         timeout: i32,
         args: Vec<HandleValue>,
@@ -779,11 +779,10 @@ impl WindowMethods for Window {
             .clear_timeout_or_interval(handle);
     }
 
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-setinterval
-    unsafe fn SetInterval(
+    fn SetInterval(
         &self,
-        _cx: *mut JSContext,
+        _cx: SafeJSContext,
         callback: Rc<Function>,
         timeout: i32,
         args: Vec<HandleValue>,
@@ -796,11 +795,10 @@ impl WindowMethods for Window {
         )
     }
 
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-setinterval
-    unsafe fn SetInterval_(
+    fn SetInterval_(
         &self,
-        _cx: *mut JSContext,
+        _cx: SafeJSContext,
         callback: DOMString,
         timeout: i32,
         args: Vec<HandleValue>,
@@ -903,11 +901,10 @@ impl WindowMethods for Window {
         doc.cancel_animation_frame(ident);
     }
 
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-window-postmessage
-    unsafe fn PostMessage(
+    fn PostMessage(
         &self,
-        cx: *mut JSContext,
+        cx: SafeJSContext,
         message: HandleValue,
         origin: DOMString,
     ) -> ErrorResult {
@@ -926,7 +923,7 @@ impl WindowMethods for Window {
 
         // Step 1-2, 6-8.
         // TODO(#12717): Should implement the `transfer` argument.
-        let data = StructuredCloneData::write(cx, message)?;
+        let data = StructuredCloneData::write(*cx, message)?;
 
         // Step 9.
         self.post_message(origin, &*source.window_proxy(), data);
@@ -961,8 +958,8 @@ impl WindowMethods for Window {
     }
 
     #[allow(unsafe_code)]
-    unsafe fn WebdriverCallback(&self, cx: *mut JSContext, val: HandleValue) {
-        let rv = jsval_to_webdriver(cx, val);
+    fn WebdriverCallback(&self, cx: SafeJSContext, val: HandleValue) {
+        let rv = unsafe { jsval_to_webdriver(*cx, val) };
         let opt_chan = self.webdriver_script_chan.borrow_mut().take();
         if let Some(chan) = opt_chan {
             chan.send(rv).unwrap();

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -57,7 +57,8 @@ use crate::fetch;
 use crate::layout_image::fetch_image_for_layout;
 use crate::microtask::MicrotaskQueue;
 use crate::script_runtime::{
-    CommonScriptMsg, Runtime, ScriptChan, ScriptPort, ScriptThreadEventCategory,
+    CommonScriptMsg, JSContext as SafeJSContext, Runtime, ScriptChan, ScriptPort,
+    ScriptThreadEventCategory,
 };
 use crate::script_thread::{ImageCacheMsg, MainThreadScriptChan, MainThreadScriptMsg};
 use crate::script_thread::{ScriptThread, SendableMainThreadScriptChan};
@@ -2179,7 +2180,7 @@ impl Window {
             player_context,
         });
 
-        unsafe { WindowBinding::Wrap(runtime.cx(), win) }
+        unsafe { WindowBinding::Wrap(SafeJSContext::from_ptr(runtime.cx()), win) }
     }
 
     pub fn pipeline_id(&self) -> Option<PipelineId> {

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -152,10 +152,10 @@ impl WindowProxy {
                 ((*get_object_class(window_jsobject.get())).flags & JSCLASS_IS_GLOBAL),
                 0
             );
-            let _ac = JSAutoRealm::new(cx, window_jsobject.get());
+            let _ac = JSAutoRealm::new(*cx, window_jsobject.get());
 
             // Create a new window proxy.
-            rooted!(in(cx) let js_proxy = NewWindowProxy(cx, window_jsobject, handler));
+            rooted!(in(*cx) let js_proxy = NewWindowProxy(*cx, window_jsobject, handler));
             assert!(!js_proxy.is_null());
 
             // Create a new browsing context.
@@ -178,7 +178,7 @@ impl WindowProxy {
             );
 
             // Notify the JS engine about the new window proxy binding.
-            SetWindowProxy(cx, window_jsobject, js_proxy.handle());
+            SetWindowProxy(*cx, window_jsobject, js_proxy.handle());
 
             // Set the reflector.
             debug!(
@@ -223,10 +223,10 @@ impl WindowProxy {
                 ((*get_object_class(window_jsobject.get())).flags & JSCLASS_IS_GLOBAL),
                 0
             );
-            let _ac = JSAutoRealm::new(cx, window_jsobject.get());
+            let _ac = JSAutoRealm::new(*cx, window_jsobject.get());
 
             // Create a new window proxy.
-            rooted!(in(cx) let js_proxy = NewWindowProxy(cx, window_jsobject, handler));
+            rooted!(in(*cx) let js_proxy = NewWindowProxy(*cx, window_jsobject, handler));
             assert!(!js_proxy.is_null());
 
             // The window proxy owns the browsing context.
@@ -238,7 +238,7 @@ impl WindowProxy {
             );
 
             // Notify the JS engine about the new window proxy binding.
-            SetWindowProxy(cx, window_jsobject, js_proxy.handle());
+            SetWindowProxy(*cx, window_jsobject, js_proxy.handle());
 
             // Set the reflector.
             debug!(
@@ -576,20 +576,20 @@ impl WindowProxy {
             // of the old window proxy to the new window proxy, then
             // making the old window proxy a cross-compartment wrapper
             // pointing to the new window proxy.
-            rooted!(in(cx) let new_js_proxy = NewWindowProxy(cx, window_jsobject, handler));
+            rooted!(in(*cx) let new_js_proxy = NewWindowProxy(*cx, window_jsobject, handler));
             debug!(
                 "Transplanting proxy from {:p} to {:p}.",
                 old_js_proxy.get(),
                 new_js_proxy.get()
             );
-            rooted!(in(cx) let new_js_proxy = JS_TransplantObject(cx, old_js_proxy, new_js_proxy.handle()));
+            rooted!(in(*cx) let new_js_proxy = JS_TransplantObject(*cx, old_js_proxy, new_js_proxy.handle()));
             debug!("Transplanted proxy is {:p}.", new_js_proxy.get());
 
             // Transfer ownership of this browsing context from the old window proxy to the new one.
             SetProxyReservedSlot(new_js_proxy.get(), 0, &PrivateValue(self.as_void_ptr()));
 
             // Notify the JS engine about the new window proxy binding.
-            SetWindowProxy(cx, window_jsobject, new_js_proxy.handle());
+            SetWindowProxy(*cx, window_jsobject, new_js_proxy.handle());
 
             // Update the reflector.
             debug!(

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -147,7 +147,7 @@ impl Worker {
         let global = worker.global();
         let target = worker.upcast();
         let _ac = enter_realm(target);
-        rooted!(in(global.get_cx()) let mut message = UndefinedValue());
+        rooted!(in(*global.get_cx()) let mut message = UndefinedValue());
         data.read(&global, message.handle_mut());
         MessageEvent::dispatch_jsval(target, &global, message.handle(), None, None);
     }
@@ -186,7 +186,7 @@ impl WorkerMethods for Worker {
 
         // Step 3
         let cx = self.global().get_cx();
-        unsafe { JS_RequestInterruptCallback(cx) };
+        unsafe { JS_RequestInterruptCallback(*cx) };
     }
 
     // https://html.spec.whatwg.org/multipage/#handler-worker-onmessage

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -21,12 +21,13 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageevent::MessageEvent;
 use crate::dom::workerglobalscope::prepare_workerscope_init;
+use crate::script_runtime::JSContext;
 use crate::task::TaskOnce;
 use crossbeam_channel::{unbounded, Sender};
 use devtools_traits::{DevtoolsPageInfo, ScriptToDevtoolsControlMsg};
 use dom_struct::dom_struct;
 use ipc_channel::ipc;
-use js::jsapi::{JSContext, JS_RequestInterruptCallback};
+use js::jsapi::JS_RequestInterruptCallback;
 use js::jsval::UndefinedValue;
 use js::rust::HandleValue;
 use script_traits::WorkerScriptLoadOrigin;
@@ -158,10 +159,9 @@ impl Worker {
 }
 
 impl WorkerMethods for Worker {
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-worker-postmessage
-    unsafe fn PostMessage(&self, cx: *mut JSContext, message: HandleValue) -> ErrorResult {
-        let data = StructuredCloneData::write(cx, message)?;
+    fn PostMessage(&self, cx: JSContext, message: HandleValue) -> ErrorResult {
+        let data = StructuredCloneData::write(*cx, message)?;
         let address = Trusted::new(self);
 
         // NOTE: step 9 of https://html.spec.whatwg.org/multipage/#dom-messageport-postmessage

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -26,6 +26,7 @@ use crate::dom::window::{base64_atob, base64_btoa};
 use crate::dom::workerlocation::WorkerLocation;
 use crate::dom::workernavigator::WorkerNavigator;
 use crate::fetch;
+use crate::script_runtime::JSContext as SafeJSContext;
 use crate::script_runtime::{get_reports, CommonScriptMsg, Runtime, ScriptChan, ScriptPort};
 use crate::task::TaskCanceller;
 use crate::task_source::dom_manipulation::DOMManipulationTaskSource;
@@ -288,11 +289,10 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
         base64_atob(atob)
     }
 
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-settimeout
-    unsafe fn SetTimeout(
+    fn SetTimeout(
         &self,
-        _cx: *mut JSContext,
+        _cx: SafeJSContext,
         callback: Rc<Function>,
         timeout: i32,
         args: Vec<HandleValue>,
@@ -305,11 +305,10 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
         )
     }
 
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-settimeout
-    unsafe fn SetTimeout_(
+    fn SetTimeout_(
         &self,
-        _cx: *mut JSContext,
+        _cx: SafeJSContext,
         callback: DOMString,
         timeout: i32,
         args: Vec<HandleValue>,
@@ -328,11 +327,10 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
             .clear_timeout_or_interval(handle);
     }
 
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-setinterval
-    unsafe fn SetInterval(
+    fn SetInterval(
         &self,
-        _cx: *mut JSContext,
+        _cx: SafeJSContext,
         callback: Rc<Function>,
         timeout: i32,
         args: Vec<HandleValue>,
@@ -345,11 +343,10 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
         )
     }
 
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-setinterval
-    unsafe fn SetInterval_(
+    fn SetInterval_(
         &self,
-        _cx: *mut JSContext,
+        _cx: SafeJSContext,
         callback: DOMString,
         timeout: i32,
         args: Vec<HandleValue>,

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -10,13 +10,13 @@ use crate::dom::paintworkletglobalscope::PaintWorkletTask;
 use crate::dom::testworkletglobalscope::TestWorkletGlobalScope;
 use crate::dom::testworkletglobalscope::TestWorkletTask;
 use crate::dom::worklet::WorkletExecutor;
+use crate::script_runtime::JSContext;
 use crate::script_thread::MainThreadScriptMsg;
 use crossbeam_channel::Sender;
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use dom_struct::dom_struct;
 use ipc_channel::ipc;
 use ipc_channel::ipc::IpcSender;
-use js::jsapi::JSContext;
 use js::jsval::UndefinedValue;
 use js::rust::Runtime;
 use msg::constellation_msg::PipelineId;
@@ -83,14 +83,14 @@ impl WorkletGlobalScope {
     }
 
     /// Get the JS context.
-    pub fn get_cx(&self) -> *mut JSContext {
+    pub fn get_cx(&self) -> JSContext {
         self.globalscope.get_cx()
     }
 
     /// Evaluate a JS script in this global.
     pub fn evaluate_js(&self, script: &str) -> bool {
         debug!("Evaluating Dom.");
-        rooted!(in (self.globalscope.get_cx()) let mut rval = UndefinedValue());
+        rooted!(in (*self.globalscope.get_cx()) let mut rval = UndefinedValue());
         self.globalscope
             .evaluate_js_on_global_with_result(&*script, rval.handle_mut())
     }

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -13,8 +13,8 @@ use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLD
 use crate::dom::location::Location;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::JSContext;
 use js::jsapi::JSObject;
 use mime::Mime;
 use script_traits::DocumentActivity;
@@ -106,13 +106,8 @@ impl XMLDocumentMethods for XMLDocument {
         self.upcast::<Document>().SupportedPropertyNames()
     }
 
-    #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-tree-accessors:dom-document-nameditem-filter
-    unsafe fn NamedGetter(
-        &self,
-        _cx: *mut JSContext,
-        name: DOMString,
-    ) -> Option<NonNull<JSObject>> {
+    fn NamedGetter(&self, _cx: JSContext, name: DOMString) -> Option<NonNull<JSObject>> {
         self.upcast::<Document>().NamedGetter(_cx, name)
     }
 }

--- a/components/script/dom/xrrigidtransform.rs
+++ b/components/script/dom/xrrigidtransform.rs
@@ -119,10 +119,9 @@ impl XRRigidTransformMethods for XRRigidTransform {
         })
     }
     // https://immersive-web.github.io/webxr/#dom-xrrigidtransform-matrix
-    #[allow(unsafe_code)]
     fn Matrix(&self, _cx: JSContext) -> NonNull<JSObject> {
         if self.matrix.get().is_null() {
-            let cx = unsafe { JSContext::from_ptr(self.global().get_cx()) };
+            let cx = self.global().get_cx();
             // According to the spec all matrices are column-major,
             // however euclid uses row vectors so we use .to_row_major_array()
             let arr = self.transform.to_transform().to_row_major_array();

--- a/components/script/dom/xrrigidtransform.rs
+++ b/components/script/dom/xrrigidtransform.rs
@@ -15,9 +15,10 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::vrframedata::create_typed_array;
 use crate::dom::window::Window;
 use crate::dom::xrsession::ApiRigidTransform;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
 use euclid::{RigidTransform3D, Rotation3D, Vector3D};
-use js::jsapi::{Heap, JSContext, JSObject};
+use js::jsapi::{Heap, JSObject};
 use std::ptr::NonNull;
 
 #[dom_struct]
@@ -119,9 +120,9 @@ impl XRRigidTransformMethods for XRRigidTransform {
     }
     // https://immersive-web.github.io/webxr/#dom-xrrigidtransform-matrix
     #[allow(unsafe_code)]
-    unsafe fn Matrix(&self, _cx: *mut JSContext) -> NonNull<JSObject> {
+    fn Matrix(&self, _cx: JSContext) -> NonNull<JSObject> {
         if self.matrix.get().is_null() {
-            let cx = self.global().get_cx();
+            let cx = unsafe { JSContext::from_ptr(self.global().get_cx()) };
             // According to the spec all matrices are column-major,
             // however euclid uses row vectors so we use .to_row_major_array()
             let arr = self.transform.to_transform().to_row_major_array();

--- a/components/script/dom/xrview.rs
+++ b/components/script/dom/xrview.rs
@@ -10,8 +10,9 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::vrframedata::create_typed_array;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::{cast_transform, ApiViewerPose, XRSession};
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSContext, JSObject};
+use js::jsapi::{Heap, JSObject};
 use std::ptr::NonNull;
 use webxr_api::View;
 
@@ -64,10 +65,8 @@ impl XRView {
 
         // row_major since euclid uses row vectors
         let proj = view.projection.to_row_major_array();
-        let cx = global.get_cx();
-        unsafe {
-            create_typed_array(cx, &proj, &ret.proj);
-        }
+        let cx = unsafe { JSContext::from_ptr(global.get_cx()) };
+        create_typed_array(cx, &proj, &ret.proj);
         ret
     }
 
@@ -82,9 +81,8 @@ impl XRViewMethods for XRView {
         self.eye
     }
 
-    #[allow(unsafe_code)]
     /// https://immersive-web.github.io/webxr/#dom-xrview-projectionmatrix
-    unsafe fn ProjectionMatrix(&self, _cx: *mut JSContext) -> NonNull<JSObject> {
+    fn ProjectionMatrix(&self, _cx: JSContext) -> NonNull<JSObject> {
         NonNull::new(self.proj.get()).unwrap()
     }
 

--- a/components/script/dom/xrview.rs
+++ b/components/script/dom/xrview.rs
@@ -40,7 +40,6 @@ impl XRView {
         }
     }
 
-    #[allow(unsafe_code)]
     pub fn new<V: Copy>(
         global: &GlobalScope,
         session: &XRSession,
@@ -65,7 +64,7 @@ impl XRView {
 
         // row_major since euclid uses row vectors
         let proj = view.projection.to_row_major_array();
-        let cx = unsafe { JSContext::from_ptr(global.get_cx()) };
+        let cx = global.get_cx();
         create_typed_array(cx, &proj, &ret.proj);
         ret
     }

--- a/components/script/dom/xrviewerpose.rs
+++ b/components/script/dom/xrviewerpose.rs
@@ -12,9 +12,10 @@ use crate::dom::xrpose::XRPose;
 use crate::dom::xrrigidtransform::XRRigidTransform;
 use crate::dom::xrsession::{cast_transform, ApiViewerPose, XRSession};
 use crate::dom::xrview::XRView;
+use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
 use js::conversions::ToJSValConvertible;
-use js::jsapi::{Heap, JSContext};
+use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
 use webxr_api::Views;
 
@@ -69,8 +70,7 @@ impl XRViewerPose {
 
 impl XRViewerPoseMethods for XRViewerPose {
     /// https://immersive-web.github.io/webxr/#dom-xrviewerpose-views
-    #[allow(unsafe_code)]
-    unsafe fn Views(&self, _cx: *mut JSContext) -> JSVal {
+    fn Views(&self, _cx: JSContext) -> JSVal {
         self.views.get()
     }
 }

--- a/components/script/dom/xrviewerpose.rs
+++ b/components/script/dom/xrviewerpose.rs
@@ -57,10 +57,10 @@ impl XRViewerPose {
             XRViewerPoseBinding::Wrap,
         );
 
+        let cx = global.get_cx();
         unsafe {
-            let cx = global.get_cx();
-            rooted!(in(cx) let mut jsval = UndefinedValue());
-            views.to_jsval(cx, jsval.handle_mut());
+            rooted!(in(*cx) let mut jsval = UndefinedValue());
+            views.to_jsval(*cx, jsval.handle_mut());
             pose.views.set(jsval.get());
         }
 

--- a/components/script/dom/xrwebgllayer.rs
+++ b/components/script/dom/xrwebgllayer.rs
@@ -115,7 +115,7 @@ impl XRWebGLLayer {
             0,
             constants::RGBA,
             constants::UNSIGNED_BYTE,
-            pixels.root(cx),
+            pixels.root(*cx),
         );
 
         // Bind the new texture to the framebuffer

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -29,7 +29,7 @@ use js::glue::{CollectServoSizes, CreateJobQueue, DeleteJobQueue, JobQueueTraps,
 use js::jsapi::ContextOptionsRef;
 use js::jsapi::{BuildIdCharVector, DisableIncrementalGC, GCDescription, GCProgress};
 use js::jsapi::{HandleObject, Heap, JobQueue};
-use js::jsapi::{JSContext, JSTracer, SetDOMCallbacks, SetGCSliceCallback};
+use js::jsapi::{JSContext as RawJSContext, JSTracer, SetDOMCallbacks, SetGCSliceCallback};
 use js::jsapi::{JSGCInvocationKind, JSGCStatus, JS_AddExtraGCRootsTracer, JS_SetGCCallback};
 use js::jsapi::{JSGCMode, JSGCParamKey, JS_SetGCParameter, JS_SetGlobalJitCompilerOption};
 use js::jsapi::{
@@ -139,7 +139,7 @@ pub trait ScriptPort {
 }
 
 #[allow(unsafe_code)]
-unsafe extern "C" fn get_incumbent_global(_: *const c_void, _: *mut JSContext) -> *mut JSObject {
+unsafe extern "C" fn get_incumbent_global(_: *const c_void, _: *mut RawJSContext) -> *mut JSObject {
     wrap_panic(
         AssertUnwindSafe(|| {
             GlobalScope::incumbent()
@@ -166,7 +166,7 @@ unsafe extern "C" fn empty(extra: *const c_void) -> bool {
 #[allow(unsafe_code)]
 unsafe extern "C" fn enqueue_promise_job(
     extra: *const c_void,
-    cx: *mut JSContext,
+    cx: *mut RawJSContext,
     _promise: HandleObject,
     job: HandleObject,
     _allocation_site: HandleObject,
@@ -193,7 +193,7 @@ unsafe extern "C" fn enqueue_promise_job(
 #[allow(unsafe_code, unrooted_must_root)]
 /// https://html.spec.whatwg.org/multipage/#the-hostpromiserejectiontracker-implementation
 unsafe extern "C" fn promise_rejection_tracker(
-    cx: *mut JSContext,
+    cx: *mut RawJSContext,
     promise: HandleObject,
     state: PromiseRejectionHandlingState,
     _data: *mut c_void,
@@ -401,7 +401,7 @@ unsafe fn new_rt_and_cx_with_parent(parent: Option<ParentRuntime>) -> Runtime {
         SetGCSliceCallback(cx, Some(gc_slice_callback));
     }
 
-    unsafe extern "C" fn empty_wrapper_callback(_: *mut JSContext, _: HandleObject) -> bool {
+    unsafe extern "C" fn empty_wrapper_callback(_: *mut RawJSContext, _: HandleObject) -> bool {
         true
     }
     SetDOMCallbacks(cx, &DOM_CALLBACKS);
@@ -589,7 +589,7 @@ unsafe extern "C" fn get_size(obj: *mut JSObject) -> usize {
 }
 
 #[allow(unsafe_code)]
-pub fn get_reports(cx: *mut JSContext, path_seg: String) -> Vec<Report> {
+pub fn get_reports(cx: *mut RawJSContext, path_seg: String) -> Vec<Report> {
     let mut reports = vec![];
 
     unsafe {
@@ -655,7 +655,7 @@ thread_local!(static GC_SLICE_START: Cell<Option<Tm>> = Cell::new(None));
 
 #[allow(unsafe_code)]
 unsafe extern "C" fn gc_slice_callback(
-    _cx: *mut JSContext,
+    _cx: *mut RawJSContext,
     progress: GCProgress,
     desc: *const GCDescription,
 ) {
@@ -695,7 +695,7 @@ unsafe extern "C" fn gc_slice_callback(
 
 #[allow(unsafe_code)]
 unsafe extern "C" fn debug_gc_callback(
-    _cx: *mut JSContext,
+    _cx: *mut RawJSContext,
     status: JSGCStatus,
     _data: *mut os::raw::c_void,
 ) {
@@ -731,7 +731,7 @@ unsafe extern "C" fn servo_build_id(build_id: *mut BuildIdCharVector) -> bool {
 
 #[allow(unsafe_code)]
 #[cfg(feature = "debugmozjs")]
-unsafe fn set_gc_zeal_options(cx: *mut JSContext) {
+unsafe fn set_gc_zeal_options(cx: *mut RawJSContext) {
     use js::jsapi::{JS_SetGCZeal, JS_DEFAULT_ZEAL_FREQ};
 
     let level = match pref!(js.mem.gc.zeal.level) {
@@ -747,4 +747,4 @@ unsafe fn set_gc_zeal_options(cx: *mut JSContext) {
 
 #[allow(unsafe_code)]
 #[cfg(not(feature = "debugmozjs"))]
-unsafe fn set_gc_zeal_options(_: *mut JSContext) {}
+unsafe fn set_gc_zeal_options(_: *mut RawJSContext) {}

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -748,3 +748,22 @@ unsafe fn set_gc_zeal_options(cx: *mut RawJSContext) {
 #[allow(unsafe_code)]
 #[cfg(not(feature = "debugmozjs"))]
 unsafe fn set_gc_zeal_options(_: *mut RawJSContext) {}
+
+#[derive(Clone, Copy)]
+pub struct JSContext(*mut RawJSContext);
+
+#[allow(unsafe_code)]
+impl JSContext {
+    pub unsafe fn from_ptr(raw_js_context: *mut RawJSContext) -> Self {
+        JSContext(raw_js_context)
+    }
+}
+
+#[allow(unsafe_code)]
+impl Deref for JSContext {
+    type Target = *mut RawJSContext;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -245,7 +245,7 @@ unsafe extern "C" fn promise_rejection_tracker(
                         let cx = target.global().get_cx();
                         let root_promise = trusted_promise.root();
 
-                        rooted!(in(cx) let reason = GetPromiseResult(root_promise.reflector().get_jsobject()));
+                        rooted!(in(*cx) let reason = GetPromiseResult(root_promise.reflector().get_jsobject()));
 
                         let event = PromiseRejectionEvent::new(
                             &target.global(),
@@ -270,9 +270,8 @@ unsafe extern "C" fn promise_rejection_tracker(
 #[allow(unsafe_code, unrooted_must_root)]
 /// https://html.spec.whatwg.org/multipage/#notify-about-rejected-promises
 pub fn notify_about_rejected_promises(global: &GlobalScope) {
+    let cx = global.get_cx();
     unsafe {
-        let cx = global.get_cx();
-
         // Step 2.
         if global.get_uncaught_rejections().borrow().len() > 0 {
             // Step 1.
@@ -282,7 +281,7 @@ pub fn notify_about_rejected_promises(global: &GlobalScope) {
                 .iter()
                 .map(|promise| {
                     let promise =
-                        Promise::new_with_js_promise(Handle::from_raw(promise.handle()), cx);
+                        Promise::new_with_js_promise(Handle::from_raw(promise.handle()), *cx);
 
                     TrustedPromise::new(promise)
                 })
@@ -309,7 +308,7 @@ pub fn notify_about_rejected_promises(global: &GlobalScope) {
                         }
 
                         // Step 4-2.
-                        rooted!(in(cx) let reason = GetPromiseResult(promise.reflector().get_jsobject()));
+                        rooted!(in(*cx) let reason = GetPromiseResult(promise.reflector().get_jsobject()));
 
                         let event = PromiseRejectionEvent::new(
                             &target.global(),

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -179,7 +179,7 @@ unsafe extern "C" fn enqueue_promise_job(
             let pipeline = global.pipeline_id();
             microtask_queue.enqueue(
                 Microtask::Promise(EnqueuedPromiseCallback {
-                    callback: PromiseJobCallback::new(cx, job.get()),
+                    callback: PromiseJobCallback::new(JSContext::from_ptr(cx), job.get()),
                     pipeline,
                 }),
                 cx,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -70,7 +70,7 @@ use crate::dom::worklet::WorkletThreadPool;
 use crate::dom::workletglobalscope::WorkletGlobalScopeInit;
 use crate::fetch::FetchCanceller;
 use crate::microtask::{Microtask, MicrotaskQueue};
-use crate::script_runtime::{get_reports, new_rt_and_cx, Runtime, ScriptPort};
+use crate::script_runtime::{get_reports, new_rt_and_cx, JSContext, Runtime, ScriptPort};
 use crate::script_runtime::{CommonScriptMsg, ScriptChan, ScriptThreadEventCategory};
 use crate::serviceworkerjob::{Job, JobQueue};
 use crate::task_manager::TaskManager;
@@ -102,7 +102,7 @@ use hyper_serde::Serde;
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
 use js::glue::GetWindowProxyClass;
-use js::jsapi::{JSContext, JS_SetWrapObjectCallbacks};
+use js::jsapi::JS_SetWrapObjectCallbacks;
 use js::jsapi::{JSTracer, SetWindowProxyClass};
 use js::jsval::UndefinedValue;
 use js::rust::ParentRuntime;
@@ -915,7 +915,7 @@ impl ScriptThread {
                     let script_thread = &*script_thread;
                     script_thread
                         .microtask_queue
-                        .enqueue(task, script_thread.get_cx());
+                        .enqueue(task, *script_thread.get_cx());
                 }
             }
         });
@@ -1317,8 +1317,9 @@ impl ScriptThread {
         }
     }
 
-    pub fn get_cx(&self) -> *mut JSContext {
-        self.js_runtime.cx()
+    #[allow(unsafe_code)]
+    pub fn get_cx(&self) -> JSContext {
+        unsafe { JSContext::from_ptr(self.js_runtime.cx()) }
     }
 
     /// Starts the script thread. After calling this method, the script thread will loop receiving
@@ -2349,7 +2350,7 @@ impl ScriptThread {
         let path_seg = format!("url({})", urls);
 
         let mut reports = vec![];
-        reports.extend(get_reports(self.get_cx(), path_seg));
+        reports.extend(get_reports(*self.get_cx(), path_seg));
         reports_chan.send(reports);
     }
 
@@ -3540,13 +3541,13 @@ impl ScriptThread {
 
         // Script source is ready to be evaluated (11.)
         let _ac = enter_realm(global_scope);
-        rooted!(in(global_scope.get_cx()) let mut jsval = UndefinedValue());
+        rooted!(in(*global_scope.get_cx()) let mut jsval = UndefinedValue());
         global_scope.evaluate_js_on_global_with_result(&script_source, jsval.handle_mut());
 
         load_data.js_eval_result = if jsval.get().is_string() {
             unsafe {
                 let strval = DOMString::from_jsval(
-                    global_scope.get_cx(),
+                    *global_scope.get_cx(),
                     jsval.handle(),
                     StringificationBehavior::Empty,
                 );
@@ -3776,7 +3777,7 @@ impl ScriptThread {
             let script_thread = &*root.get().unwrap();
             script_thread
                 .microtask_queue
-                .enqueue(job, script_thread.get_cx());
+                .enqueue(job, *script_thread.get_cx());
         });
     }
 
@@ -3791,7 +3792,7 @@ impl ScriptThread {
 
         unsafe {
             self.microtask_queue.checkpoint(
-                self.get_cx(),
+                *self.get_cx(),
                 |id| self.documents.borrow().find_global(id),
                 globals,
             )

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -517,7 +517,7 @@ impl JsTimerTask {
             InternalTimerCallback::StringTimerCallback(ref code_str) => {
                 let global = this.global();
                 let cx = global.get_cx();
-                rooted!(in(cx) let mut rval = UndefinedValue());
+                rooted!(in(*cx) let mut rval = UndefinedValue());
 
                 global.evaluate_js_on_global_with_result(code_str, rval.handle_mut());
             },


### PR DESCRIPTION
Wrapping unsafe raw JSContext pointers in a safe struct. Issue #20377.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] create a struct JSContext(*mut jsapi::JSContext) type
- [x] implement Deref for this new type so it's easy to obtain the inner context pointer
- [x] add an unsafe from_ptr static method that returns a new instance of the type
- [x] start by changing various Argument uses in CodegenRust.py for python classes that inherit from CGAbstractMethod
- [x] convert the python code that interacts with CGClass (CGCallback, CGCallbackFunction, CGCallbackFunctionImpl, CGCallbackInterface) and any rust code that interacts with it
- [x] update CGDictionary and any rust code that interacts with it
- [x] make the code generator declare trait methods that accept the new type instead of *mut JSContext (CGInterfaceTrait)
- [x] modify GlobalScope::get_cx to return a SafeJSContext 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23816)
<!-- Reviewable:end -->
