### PR TITLE
Generate simpleservo.h in appropriate target directory.

### DIFF
--- a/ports/libsimpleservo/capi/build.rs
+++ b/ports/libsimpleservo/capi/build.rs
@@ -3,17 +3,25 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::env;
+use std::path::PathBuf;
 
 fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let target_dir = env::var("CARGO_TARGET_DIR").unwrap();
+    let mut path: PathBuf = [crate_dir.clone(), target_dir].iter().collect();
+    let target = env::var("TARGET").unwrap();
+    let host = env::var("HOST").unwrap();
+    if target != host {
+        path.push(target);
+    }
     let profile_dir = env::var("PROFILE").unwrap();
-    let dest = format!("{}/{}/{}", target_dir, profile_dir, "simpleservo.h");
+    path.push(profile_dir);
+    path.push("simpleservo.h");
     cbindgen::Builder::new()
         .with_crate(crate_dir)
         .with_language(cbindgen::Language::C)
         .exclude_item("OutputDebugStringA")
         .generate()
         .expect("Unable to generate bindings")
-        .write_to_file(dest);
+        .write_to_file(path);
 }


### PR DESCRIPTION
This change makes the C API's build script take the the actual build target into account when generating the C header.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23794
- [x] These changes do not require tests because no tests for UWP build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23830)
<!-- Reviewable:end -->
