### PR TITLE
Use openssl dependency that works on arm64.

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -11,6 +11,7 @@ import os
 import platform
 import shutil
 import subprocess
+import urllib
 from subprocess import PIPE
 from zipfile import BadZipfile
 
@@ -292,7 +293,7 @@ def windows_msvc(context, force=False):
 
     def prepare_file(zip_path, full_spec):
         if not os.path.isfile(zip_path):
-            zip_url = "{}{}.zip".format(deps_url, full_spec)
+            zip_url = "{}{}.zip".format(deps_url, urllib.quote(full_spec))
             download_file(full_spec, zip_url, zip_path)
 
         print("Extracting {}...".format(full_spec), end='')

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -578,7 +578,7 @@ class MachCommands(CommandBase):
                     call(["editbin", "/nologo", "/subsystem:windows", path.join(servo_exe_dir, "servo.exe")],
                          verbose=verbose)
                 # on msvc, we need to copy in some DLLs in to the servo.exe dir
-                for ssl_lib in ["libeay32.dll", "ssleay32.dll"]:
+                for ssl_lib in ["libssl.dll", "libcrypto.dll"]:
                     shutil.copy(path.join(env['OPENSSL_LIB_DIR'], "../bin", ssl_lib),
                                 servo_exe_dir)
                 # Search for the generated nspr4.dll

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -610,7 +610,7 @@ install them, let us know by filing a bug!")
             # Link openssl
             env["OPENSSL_INCLUDE_DIR"] = path.join(openssl_base_dir, "include")
             env["OPENSSL_LIB_DIR"] = path.join(openssl_base_dir, "lib")
-            env["OPENSSL_LIBS"] = "libeay32:ssleay32"
+            env["OPENSSL_LIBS"] = "libssl:libcrypto"
             # Link moztools, used for building SpiderMonkey
             env["MOZTOOLS_PATH"] = os.pathsep.join([
                 path.join(package_dir("moztools"), "bin"),

--- a/python/servo/packages.py
+++ b/python/servo/packages.py
@@ -7,5 +7,5 @@ WINDOWS_MSVC = {
     "llvm": "8.0.0",
     "moztools": "3.2",
     "ninja": "1.7.1",
-    "openssl": "1.0.2q-vs2017",
+    "openssl": "111.3.0+1.1.1c-vs2017",
 }

--- a/support/hololens/ServoApp/ServoApp.vcxproj
+++ b/support/hololens/ServoApp/ServoApp.vcxproj
@@ -297,7 +297,7 @@
     <None Include="..\..\..\target\debug\intl-8.dll">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
-    <None Include="..\..\..\target\debug\libeay32.dll">
+    <None Include="..\..\..\target\debug\libssl.dll">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\..\target\debug\libwinpthread-1.dll">
@@ -312,7 +312,7 @@
     <None Include="..\..\..\target\debug\simpleservo.dll">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
-    <None Include="..\..\..\target\debug\ssleay32.dll">
+    <None Include="..\..\..\target\debug\libcrypto.dll">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\..\target\debug\swresample-3.dll">
@@ -468,7 +468,7 @@
     <None Include="..\..\..\target\release\intl-8.dll">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
-    <None Include="..\..\..\target\release\libeay32.dll">
+    <None Include="..\..\..\target\release\libssl.dll">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\..\target\release\libwinpthread-1.dll">
@@ -483,7 +483,7 @@
     <None Include="..\..\..\target\release\simpleservo.dll">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
-    <None Include="..\..\..\target\release\ssleay32.dll">
+    <None Include="..\..\..\target\release\libcrypto.dll">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
     </None>
     <None Include="..\..\..\target\release\swresample-3.dll">

--- a/support/hololens/ServoApp/ServoApp.vcxproj.filters
+++ b/support/hololens/ServoApp/ServoApp.vcxproj.filters
@@ -234,7 +234,10 @@
     <None Include="..\..\..\target\debug\intl-8.dll">
       <Filter>DebugServoDLLs</Filter>
     </None>
-    <None Include="..\..\..\target\debug\libeay32.dll">
+    <None Include="..\..\..\target\debug\libcrypto.dll">
+      <Filter>DebugServoDLLs</Filter>
+    </None>
+    <None Include="..\..\..\target\debug\libssl.dll">
       <Filter>DebugServoDLLs</Filter>
     </None>
     <None Include="..\..\..\target\debug\libwinpthread-1.dll">
@@ -244,9 +247,6 @@
       <Filter>DebugServoDLLs</Filter>
     </None>
     <None Include="..\..\..\target\debug\orc-0.4-0.dll">
-      <Filter>DebugServoDLLs</Filter>
-    </None>
-    <None Include="..\..\..\target\debug\ssleay32.dll">
       <Filter>DebugServoDLLs</Filter>
     </None>
     <None Include="..\..\..\target\debug\swresample-3.dll">
@@ -267,9 +267,6 @@
     <None Include="..\..\..\target\release\swresample-3.dll">
       <Filter>ReleaseServoDLLs</Filter>
     </None>
-    <None Include="..\..\..\target\release\ssleay32.dll">
-      <Filter>ReleaseServoDLLs</Filter>
-    </None>
     <None Include="..\..\..\target\release\simpleservo.dll">
       <Filter>ReleaseServoDLLs</Filter>
     </None>
@@ -282,7 +279,10 @@
     <None Include="..\..\..\target\release\libwinpthread-1.dll">
       <Filter>ReleaseServoDLLs</Filter>
     </None>
-    <None Include="..\..\..\target\release\libeay32.dll">
+    <None Include="..\..\..\target\release\libssl.dll">
+      <Filter>ReleaseServoDLLs</Filter>
+    </None>
+    <None Include="..\..\..\target\release\libcrypto.dll">
       <Filter>ReleaseServoDLLs</Filter>
     </None>
     <None Include="..\..\..\target\release\intl-8.dll">


### PR DESCRIPTION
This uses binaries that I generated with https://github.com/servo/openssl-src-rs/tree/servo and https://github.com/servo/openssl/tree/servo that don't crash on arm64.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23811
- [x] These changes do not require tests can't run automated tests for arm64 windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23835)
<!-- Reviewable:end -->
