### PR TITLE
Update SpiderMonkey to avoid Windows arm64 crash.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2877,25 +2877,26 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.12.0"
-source = "git+https://github.com/servo/rust-mozjs#124e5243a02ddaa879f2988313cee738c435f8b1"
+source = "git+https://github.com/servo/rust-mozjs#07eec81ec4b6a81663acf29d567807eaf2a558a8"
 dependencies = [
  "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mozjs_sys 0.67.0 (git+https://github.com/servo/mozjs?rev=b2f83932fe9d361face14efd03f2465b9262e687)",
+ "mozjs_sys 0.67.0 (git+https://github.com/servo/mozjs?rev=6dff1046a0d5e486f841d1b858da7b2ef33d801b)",
  "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mozjs_sys"
 version = "0.67.0"
-source = "git+https://github.com/servo/mozjs?rev=b2f83932fe9d361face14efd03f2465b9262e687#b2f83932fe9d361face14efd03f2465b9262e687"
+source = "git+https://github.com/servo/mozjs?rev=6dff1046a0d5e486f841d1b858da7b2ef33d801b#6dff1046a0d5e486f841d1b858da7b2ef33d801b"
 dependencies = [
  "bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5910,7 +5911,7 @@ dependencies = [
 "checksum mitochondria 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9de3eca27871df31c33b807f834b94ef7d000956f57aa25c5aed9c5f0aae8f6f"
 "checksum mozangle 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c16c861307809350d6ebf120bb43fa081ddde85c32b1a8c205c7a2287ada24e7"
 "checksum mozjs 0.12.0 (git+https://github.com/servo/rust-mozjs)" = "<none>"
-"checksum mozjs_sys 0.67.0 (git+https://github.com/servo/mozjs?rev=b2f83932fe9d361face14efd03f2465b9262e687)" = "<none>"
+"checksum mozjs_sys 0.67.0 (git+https://github.com/servo/mozjs?rev=6dff1046a0d5e486f841d1b858da7b2ef33d801b)" = "<none>"
 "checksum msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729"
 "checksum muldiv 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "451a9a05d2a32c566c897835e0ea95cf79ed2fdfe957924045a1721a36c9980f"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"


### PR DESCRIPTION
This allows the Windows arm64 build to load pages correctly.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because no win arm64 testing!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23840)
<!-- Reviewable:end -->
