### PR TITLE
Pass the event loop waker into WebXR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,6 +1086,7 @@ dependencies = [
  "servo_url 0.0.1",
  "style_traits 0.0.1",
  "webrender_api 0.60.0 (git+https://github.com/servo/webrender)",
+ "webxr-api 0.0.1 (git+https://github.com/servo/webxr)",
 ]
 
 [[package]]
@@ -5492,7 +5493,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#43a54f4cbe0ed3037e5e2bf34769241a5bd3da60"
+source = "git+https://github.com/servo/webxr#0418277175dbccf83e575c99d6b9c778bfdbe70b"
 dependencies = [
  "euclid 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5504,7 +5505,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#43a54f4cbe0ed3037e5e2bf34769241a5bd3da60"
+source = "git+https://github.com/servo/webxr#0418277175dbccf83e575c99d6b9c778bfdbe70b"
 dependencies = [
  "euclid 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/embedder_traits/Cargo.toml
+++ b/components/embedder_traits/Cargo.toml
@@ -23,3 +23,4 @@ serde = "1.0"
 servo_url = {path = "../url"}
 style_traits = {path = "../style_traits", features = ["servo"]}
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
+webxr-api = {git = "https://github.com/servo/webxr", features = ["ipc"]}

--- a/components/embedder_traits/lib.rs
+++ b/components/embedder_traits/lib.rs
@@ -21,6 +21,8 @@ use servo_url::ServoUrl;
 use std::fmt::{Debug, Error, Formatter};
 use webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 
+pub use webxr_api::MainThreadWaker as EventLoopWaker;
+
 /// A cursor for the window. This is different from a CSS cursor (see
 /// `CursorKind`) in that it has no `Auto` value.
 #[repr(u8)]
@@ -61,12 +63,6 @@ pub enum Cursor {
     AllScroll,
     ZoomIn,
     ZoomOut,
-}
-
-/// Used to wake up the event loop, provided by the servo port/embedder.
-pub trait EventLoopWaker: 'static + Send {
-    fn clone(&self) -> Box<dyn EventLoopWaker + Send>;
-    fn wake(&self);
 }
 
 /// Sends messages to the embedder.

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -67,7 +67,7 @@ fn create_embedder_proxy() -> EmbedderProxy {
         }
         impl EventLoopWaker for DummyEventLoopWaker {
             fn wake(&self) {}
-            fn clone(&self) -> Box<dyn EventLoopWaker + Send> {
+            fn clone_box(&self) -> Box<dyn EventLoopWaker> {
                 Box::new(DummyEventLoopWaker {})
             }
         }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -289,10 +289,10 @@ where
         // the client window and the compositor. This channel is unique because
         // messages to client may need to pump a platform-specific event loop
         // to deliver the message.
+        let event_loop_waker = embedder.create_event_loop_waker();
         let (compositor_proxy, compositor_receiver) =
-            create_compositor_channel(embedder.create_event_loop_waker());
-        let (embedder_proxy, embedder_receiver) =
-            create_embedder_channel(embedder.create_event_loop_waker());
+            create_compositor_channel(event_loop_waker.clone());
+        let (embedder_proxy, embedder_receiver) = create_embedder_channel(event_loop_waker.clone());
         let time_profiler_chan = profile_time::Profiler::create(
             &opts.time_profiling,
             opts.time_profiler_trace_path.clone(),
@@ -368,8 +368,8 @@ where
 
         // For the moment, we enable use both the webxr crate and the rust-webvr crate,
         // but we are migrating over to just using webxr.
-        let mut webxr_main_thread =
-            webxr_api::MainThreadRegistry::new().expect("Failed to create WebXR device registry");
+        let mut webxr_main_thread = webxr_api::MainThreadRegistry::new(event_loop_waker)
+            .expect("Failed to create WebXR device registry");
         if pref!(dom.webvr.enabled) || pref!(dom.webxr.enabled) {
             embedder.register_webxr(&mut webxr_main_thread);
         }

--- a/ports/glutin/events_loop.rs
+++ b/ports/glutin/events_loop.rs
@@ -87,7 +87,7 @@ impl EventLoopWaker for HeadedEventLoopWaker {
             warn!("Failed to wake up event loop ({}).", err);
         }
     }
-    fn clone(&self) -> Box<dyn EventLoopWaker + Send> {
+    fn clone_box(&self) -> Box<dyn EventLoopWaker> {
         Box::new(HeadedEventLoopWaker {
             proxy: self.proxy.clone(),
         })
@@ -97,5 +97,5 @@ impl EventLoopWaker for HeadedEventLoopWaker {
 struct HeadlessEventLoopWaker;
 impl EventLoopWaker for HeadlessEventLoopWaker {
     fn wake(&self) {}
-    fn clone(&self) -> Box<dyn EventLoopWaker + Send> { Box::new(HeadlessEventLoopWaker) }
+    fn clone_box(&self) -> Box<dyn EventLoopWaker> { Box::new(HeadlessEventLoopWaker) }
 }

--- a/ports/libmlservo/src/lib.rs
+++ b/ports/libmlservo/src/lib.rs
@@ -403,7 +403,7 @@ enum ScrollState {
 struct EventLoopWakerInstance;
 
 impl EventLoopWaker for EventLoopWakerInstance {
-    fn clone(&self) -> Box<dyn EventLoopWaker + Send> {
+    fn clone_box(&self) -> Box<dyn EventLoopWaker> {
         Box::new(EventLoopWakerInstance)
     }
 

--- a/ports/libsimpleservo/capi/src/lib.rs
+++ b/ports/libsimpleservo/capi/src/lib.rs
@@ -373,7 +373,7 @@ impl WakeupCallback {
 }
 
 impl EventLoopWaker for WakeupCallback {
-    fn clone(&self) -> Box<dyn EventLoopWaker + Send> {
+    fn clone_box(&self) -> Box<dyn EventLoopWaker> {
         Box::new(WakeupCallback(self.0))
     }
     fn wake(&self) {

--- a/ports/libsimpleservo/jniapi/src/lib.rs
+++ b/ports/libsimpleservo/jniapi/src/lib.rs
@@ -339,7 +339,7 @@ impl WakeupCallback {
 }
 
 impl EventLoopWaker for WakeupCallback {
-    fn clone(&self) -> Box<dyn EventLoopWaker + Send> {
+    fn clone_box(&self) -> Box<dyn EventLoopWaker> {
         Box::new(WakeupCallback {
             callback: self.callback.clone(),
             jvm: self.jvm.clone(),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR passes the event loop waker into webxr so it can wake the main thread up when needed.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23796 
- [X] These changes do not require tests because existing tests do the job

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23847)
<!-- Reviewable:end -->
