### PR TITLE
Try increasing the number of mac WPT jobs.

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -563,7 +563,7 @@ def macos_wpt():
             """)
         )
     wpt_chunks("macOS x64", macos_run_task, build_task, repo_dir="repo",
-               total_chunks=6, processes=4)
+               total_chunks=8, processes=4)
 
 
 def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,


### PR DESCRIPTION
Our macOS CI cycle time is really high. The WPT-1 job in particular is 2-3x as long as any of the rest of the jobs. My hope is that adding more jobs will allow WPT-1 to complete sooner and the workers that finish first can claim the additional unclaimed jobs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23850)
<!-- Reviewable:end -->
