### PR TITLE
Changed DOMString usages to string in MediaFragmentParser

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1526,13 +1526,13 @@ impl HTMLMediaElement {
                         if let Some(servo_url) = self.resource_url.borrow().as_ref() {
                             let fragment = MediaFragmentParser::from(servo_url);
                             if let Some(id) = fragment.id() {
-                                if audio_track.id() == id {
+                                if audio_track.id() == DOMString::from(id) {
                                     self.AudioTracks()
                                         .set_enabled(self.AudioTracks().len() - 1, true);
                                 }
                             }
 
-                            if fragment.tracks().contains(&audio_track.kind()) {
+                            if fragment.tracks().contains(&audio_track.kind().into()) {
                                 self.AudioTracks()
                                     .set_enabled(self.AudioTracks().len() - 1, true);
                             }
@@ -1582,10 +1582,10 @@ impl HTMLMediaElement {
                             if let Some(servo_url) = self.resource_url.borrow().as_ref() {
                                 let fragment = MediaFragmentParser::from(servo_url);
                                 if let Some(id) = fragment.id() {
-                                    if track.id() == id {
+                                    if track.id() == DOMString::from(id) {
                                         self.VideoTracks().set_selected(0, true);
                                     }
-                                } else if fragment.tracks().contains(&track.kind()) {
+                                } else if fragment.tracks().contains(&track.kind().into()) {
                                     self.VideoTracks().set_selected(0, true);
                                 }
                             }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Changed `DOMString` usages to `String`/`&str`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23834 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23855)
<!-- Reviewable:end -->
