### PR TITLE
Revert "Replace use of callbacks in webxr by channels"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,6 @@ dependencies = [
  "webrender 0.60.0 (git+https://github.com/servo/webrender)",
  "webrender_api 0.60.0 (git+https://github.com/servo/webrender)",
  "webrender_traits 0.0.1",
- "webxr-api 0.0.1 (git+https://github.com/asajeffrey/webxr?branch=optional-glsync)",
 ]
 
 [[package]]
@@ -432,7 +431,7 @@ dependencies = [
  "typetag 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_api 0.60.0 (git+https://github.com/servo/webrender)",
  "webvr_traits 0.0.1",
- "webxr-api 0.0.1 (git+https://github.com/asajeffrey/webxr?branch=optional-glsync)",
+ "webxr-api 0.0.1 (git+https://github.com/servo/webxr)",
 ]
 
 [[package]]
@@ -622,7 +621,7 @@ dependencies = [
  "webrender_api 0.60.0 (git+https://github.com/servo/webrender)",
  "webvr 0.0.1",
  "webvr_traits 0.0.1",
- "webxr-api 0.0.1 (git+https://github.com/asajeffrey/webxr?branch=optional-glsync)",
+ "webxr-api 0.0.1 (git+https://github.com/servo/webxr)",
 ]
 
 [[package]]
@@ -665,7 +664,7 @@ dependencies = [
  "style_traits 0.0.1",
  "webrender_api 0.60.0 (git+https://github.com/servo/webrender)",
  "webvr_traits 0.0.1",
- "webxr-api 0.0.1 (git+https://github.com/asajeffrey/webxr?branch=optional-glsync)",
+ "webxr-api 0.0.1 (git+https://github.com/servo/webxr)",
 ]
 
 [[package]]
@@ -1088,7 +1087,7 @@ dependencies = [
  "servo_url 0.0.1",
  "style_traits 0.0.1",
  "webrender_api 0.60.0 (git+https://github.com/servo/webrender)",
- "webxr-api 0.0.1 (git+https://github.com/asajeffrey/webxr?branch=optional-glsync)",
+ "webxr-api 0.0.1 (git+https://github.com/servo/webxr)",
 ]
 
 [[package]]
@@ -2538,7 +2537,7 @@ dependencies = [
  "webrender_traits 0.0.1",
  "webvr 0.0.1",
  "webvr_traits 0.0.1",
- "webxr-api 0.0.1 (git+https://github.com/asajeffrey/webxr?branch=optional-glsync)",
+ "webxr-api 0.0.1 (git+https://github.com/servo/webxr)",
 ]
 
 [[package]]
@@ -3913,7 +3912,7 @@ dependencies = [
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_api 0.60.0 (git+https://github.com/servo/webrender)",
  "webvr_traits 0.0.1",
- "webxr-api 0.0.1 (git+https://github.com/asajeffrey/webxr?branch=optional-glsync)",
+ "webxr-api 0.0.1 (git+https://github.com/servo/webxr)",
  "xml5ever 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4005,7 +4004,7 @@ dependencies = [
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_api 0.60.0 (git+https://github.com/servo/webrender)",
  "webvr_traits 0.0.1",
- "webxr-api 0.0.1 (git+https://github.com/asajeffrey/webxr?branch=optional-glsync)",
+ "webxr-api 0.0.1 (git+https://github.com/servo/webxr)",
 ]
 
 [[package]]
@@ -4102,8 +4101,8 @@ dependencies = [
  "servo-media 0.1.0 (git+https://github.com/servo/media)",
  "sig 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinyfiledialogs 3.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "webxr 0.0.1 (git+https://github.com/asajeffrey/webxr?branch=optional-glsync)",
- "webxr-api 0.0.1 (git+https://github.com/asajeffrey/webxr?branch=optional-glsync)",
+ "webxr 0.0.1 (git+https://github.com/servo/webxr)",
+ "webxr-api 0.0.1 (git+https://github.com/servo/webxr)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winres 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11 2.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5496,24 +5495,25 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/asajeffrey/webxr?branch=optional-glsync#da820a3ab266fce07c9a8abee3e6e9231cb93ec5"
+source = "git+https://github.com/servo/webxr#0418277175dbccf83e575c99d6b9c778bfdbe70b"
 dependencies = [
  "euclid 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "glutin 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "webxr-api 0.0.1 (git+https://github.com/asajeffrey/webxr?branch=optional-glsync)",
+ "webxr-api 0.0.1 (git+https://github.com/servo/webxr)",
 ]
 
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/asajeffrey/webxr?branch=optional-glsync#da820a3ab266fce07c9a8abee3e6e9231cb93ec5"
+source = "git+https://github.com/servo/webxr#0418277175dbccf83e575c99d6b9c778bfdbe70b"
 dependencies = [
  "euclid 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gleam 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typetag 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6142,8 +6142,8 @@ dependencies = [
 "checksum webrender 0.60.0 (git+https://github.com/servo/webrender)" = "<none>"
 "checksum webrender_api 0.60.0 (git+https://github.com/servo/webrender)" = "<none>"
 "checksum webrender_build 0.0.1 (git+https://github.com/servo/webrender)" = "<none>"
-"checksum webxr 0.0.1 (git+https://github.com/asajeffrey/webxr?branch=optional-glsync)" = "<none>"
-"checksum webxr-api 0.0.1 (git+https://github.com/asajeffrey/webxr?branch=optional-glsync)" = "<none>"
+"checksum webxr 0.0.1 (git+https://github.com/servo/webxr)" = "<none>"
+"checksum webxr-api 0.0.1 (git+https://github.com/servo/webxr)" = "<none>"
 "checksum weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,3 @@ opt-level = 3
 mio = { git = "https://github.com/servo/mio.git", branch = "servo" }
 iovec = { git = "https://github.com/servo/iovec.git", branch = "servo" }
 cmake = { git = "https://github.com/alexcrichton/cmake-rs" }
-
-[patch."https://github.com/servo/webxr"]
-webxr = { git = "https://github.com/asajeffrey/webxr", branch = "optional-glsync" }
-webxr-api = { git = "https://github.com/asajeffrey/webxr", branch = "optional-glsync" }

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -37,4 +37,3 @@ servo_config = {path = "../config"}
 webrender = {git = "https://github.com/servo/webrender"}
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}
 webrender_traits = {path = "../webrender_traits"}
-webxr-api = {git = "https://github.com/servo/webxr", features = ["ipc"]}

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -10,7 +10,7 @@ use euclid::default::Size2D;
 use fnv::FnvHashMap;
 use gleam::gl;
 use half::f16;
-use ipc_channel::ipc::{self, OpaqueIpcMessage};
+use ipc_channel::ipc::{self, IpcSender, OpaqueIpcMessage};
 use ipc_channel::router::ROUTER;
 use offscreen_gl_context::{DrawBuffer, GLContext, NativeGLContextMethods};
 use pixels::{self, PixelFormat};
@@ -284,6 +284,9 @@ impl WebGLThread {
             WebGLMsg::Lock(ctx_id, sender) => {
                 self.handle_lock(ctx_id, sender);
             },
+            WebGLMsg::LockIPC(ctx_id, sender) => {
+                self.handle_lock_ipc(ctx_id, sender);
+            },
             WebGLMsg::Unlock(ctx_id) => {
                 self.handle_unlock(ctx_id);
             },
@@ -340,6 +343,21 @@ impl WebGLThread {
         context_id: WebGLContextId,
         sender: WebGLSender<(u32, Size2D<i32>, usize)>,
     ) {
+        sender.send(self.handle_lock_sync(context_id)).unwrap();
+    }
+
+    /// handle_lock, but unconditionally IPC (used by webxr)
+    fn handle_lock_ipc(
+        &mut self,
+        context_id: WebGLContextId,
+        sender: IpcSender<(u32, Size2D<i32>, usize)>,
+    ) {
+        sender.send(self.handle_lock_sync(context_id)).unwrap();
+    }
+
+    /// Shared code between handle_lock and handle_lock_ipc, does the actual syncing/flushing
+    /// but the caller must send the response back
+    fn handle_lock_sync(&mut self, context_id: WebGLContextId) -> (u32, Size2D<i32>, usize) {
         let data =
             Self::make_current_if_needed(context_id, &self.contexts, &mut self.bound_context_id)
                 .expect("WebGLContext not found in a WebGLMsg::Lock message");
@@ -356,7 +374,7 @@ impl WebGLThread {
         data.ctx.gl().flush();
         debug_assert!(data.ctx.gl().get_error() == gl::NO_ERROR);
 
-        let _ = sender.send((info.texture_id, info.size, gl_sync as usize));
+        (info.texture_id, info.size, gl_sync as usize)
     }
 
     /// A version of locking that doesn't return a GLsync object,

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -4,8 +4,10 @@
 
 use euclid::default::{Rect, Size2D};
 use gleam::gl;
+use gleam::gl::GLsync;
+use gleam::gl::GLuint;
 use gleam::gl::Gl;
-use ipc_channel::ipc::{IpcBytesReceiver, IpcBytesSender, IpcSharedMemory};
+use ipc_channel::ipc::{self, IpcBytesReceiver, IpcBytesSender, IpcSender, IpcSharedMemory};
 use pixels::PixelFormat;
 use std::borrow::Cow;
 use std::fmt;
@@ -59,6 +61,8 @@ pub enum WebGLMsg {
     /// The WR client should not change the shared texture content until the Unlock call.
     /// Currently OpenGL Sync Objects are used to implement the synchronization mechanism.
     Lock(WebGLContextId, WebGLSender<(u32, Size2D<i32>, usize)>),
+    /// Lock(), but unconditionally IPC (used by webxr)
+    LockIPC(WebGLContextId, IpcSender<(u32, Size2D<i32>, usize)>),
     /// Unlocks a specific WebGLContext. Unlock messages are used for a correct synchronization
     /// with WebRender external image API.
     /// The WR unlocks a context when it finished reading the shared texture contents.
@@ -180,6 +184,39 @@ impl WebGLMsgSender {
 
     pub fn send_dom_to_texture(&self, command: DOMToTextureCommand) -> WebGLSendResult {
         self.sender.send(WebGLMsg::DOMToTextureCommand(command))
+    }
+
+    pub fn webxr_external_image_api(&self) -> impl webxr_api::WebGLExternalImageApi {
+        SerializableWebGLMsgSender {
+            ctx_id: self.ctx_id,
+            sender: self.sender.to_ipc(),
+        }
+    }
+}
+
+// WegGLMsgSender isn't actually serializable, despite what it claims.
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+struct SerializableWebGLMsgSender {
+    ctx_id: WebGLContextId,
+    #[ignore_malloc_size_of = "channels are hard"]
+    sender: IpcSender<WebGLMsg>,
+}
+
+#[typetag::serde]
+impl webxr_api::WebGLExternalImageApi for SerializableWebGLMsgSender {
+    fn lock(&self) -> Result<(GLuint, Size2D<i32>, GLsync), webxr_api::Error> {
+        let (sender, receiver) = ipc::channel().or(Err(webxr_api::Error::CommunicationError))?;
+        self.sender
+            .send(WebGLMsg::LockIPC(self.ctx_id, sender))
+            .or(Err(webxr_api::Error::CommunicationError))?;
+        let (texture, size, sync) = receiver
+            .recv()
+            .or(Err(webxr_api::Error::CommunicationError))?;
+        Ok((texture, size, sync as GLsync))
+    }
+
+    fn unlock(&self) {
+        let _ = self.sender.send(WebGLMsg::Unlock(self.ctx_id));
     }
 }
 

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -328,10 +328,6 @@ impl WebGLRenderingContext {
         self.webgl_sender.clone()
     }
 
-    pub fn context_id(&self) -> WebGLContextId {
-        self.webgl_sender.context_id()
-    }
-
     #[inline]
     pub fn send_command(&self, command: WebGLCommand) {
         self.webgl_sender
@@ -4380,5 +4376,9 @@ impl WebGLMessageSender {
 
     pub fn send_dom_to_texture(&self, command: DOMToTextureCommand) -> WebGLSendResult {
         self.wake_after_send(|| self.sender.send_dom_to_texture(command))
+    }
+
+    pub fn webxr_external_image_api(&self) -> impl webxr_api::WebGLExternalImageApi {
+        self.sender.webxr_external_image_api()
     }
 }

--- a/components/script/dom/xr.rs
+++ b/components/script/dom/xr.rs
@@ -108,6 +108,18 @@ impl Into<SessionMode> for XRSessionMode {
 impl XRMethods for XR {
     /// https://immersive-web.github.io/webxr/#dom-xr-supportssessionmode
     fn SupportsSession(&self, mode: XRSessionMode) -> Rc<Promise> {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        pub struct SupportsSession {
+            sender: IpcSender<bool>,
+        }
+
+        #[typetag::serde]
+        impl webxr_api::SessionSupportCallback for SupportsSession {
+            fn callback(&mut self, result: Result<(), XRError>) {
+                let _ = self.sender.send(result.is_ok());
+            }
+        }
+
         // XXXManishearth this should select an XR device first
         let promise = Promise::new(&self.global());
         let mut trusted = Some(TrustedPromise::new(promise.clone()));
@@ -127,13 +139,13 @@ impl XRMethods for XR {
                     error!("supportsSession callback called twice!");
                     return;
                 };
-                let message: Result<(), webxr_api::Error> = if let Ok(message) = message.to() {
+                let message = if let Ok(message) = message.to() {
                     message
                 } else {
                     error!("supportsSession callback given incorrect payload");
                     return;
                 };
-                if let Ok(()) = message {
+                if message {
                     let _ = task_source.queue_with_canceller(trusted.resolve_task(()), &canceller);
                 } else {
                     let _ = task_source
@@ -143,7 +155,7 @@ impl XRMethods for XR {
         );
         window
             .webxr_registry()
-            .supports_session(mode.into(), sender);
+            .supports_session(mode.into(), SupportsSession { sender });
 
         promise
     }
@@ -155,6 +167,17 @@ impl XRMethods for XR {
         _: &XRSessionInit,
         comp: InCompartment,
     ) -> Rc<Promise> {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        pub struct RequestSession {
+            sender: IpcSender<Result<Session, XRError>>,
+        }
+
+        #[typetag::serde]
+        impl webxr_api::SessionRequestCallback for RequestSession {
+            fn callback(&mut self, result: Result<Session, XRError>) {
+                let _ = self.sender.send(result);
+            }
+        }
         let promise = Promise::new_in_current_compartment(&self.global(), comp);
         if mode != XRSessionMode::Immersive_vr {
             promise.reject_error(Error::NotSupported);
@@ -183,7 +206,7 @@ impl XRMethods for XR {
                 // router doesn't know this is only called once
                 let trusted = trusted.take().unwrap();
                 let this = this.clone();
-                let message: Result<Session, webxr_api::Error> = if let Ok(message) = message.to() {
+                let message = if let Ok(message) = message.to() {
                     message
                 } else {
                     error!("requestSession callback given incorrect payload");
@@ -197,7 +220,9 @@ impl XRMethods for XR {
                 );
             }),
         );
-        window.webxr_registry().request_session(mode.into(), sender);
+        window
+            .webxr_registry()
+            .request_session(mode.into(), RequestSession { sender });
 
         promise
     }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -427,25 +427,21 @@ where
 
         // Initialize WebGL Thread entry point.
         let webgl_result = gl_factory.map(|factory| {
-            let (webgl_threads, thread_data, webxr_handler, image_handler, output_handler) =
-                WebGLThreads::new(
-                    factory,
-                    window.gl(),
-                    webrender_api_sender.clone(),
-                    webvr_compositor.map(|c| c as Box<_>),
-                    external_images.clone(),
-                    if run_webgl_on_main_thread {
-                        ThreadMode::MainThread(embedder.create_event_loop_waker())
-                    } else {
-                        ThreadMode::OffThread
-                    },
-                );
+            let (webgl_threads, thread_data, image_handler, output_handler) = WebGLThreads::new(
+                factory,
+                window.gl(),
+                webrender_api_sender.clone(),
+                webvr_compositor.map(|c| c as Box<_>),
+                external_images.clone(),
+                if run_webgl_on_main_thread {
+                    ThreadMode::MainThread(embedder.create_event_loop_waker())
+                } else {
+                    ThreadMode::OffThread
+                },
+            );
 
             // Set webrender external image handler for WebGL textures
             external_image_handlers.set_handler(image_handler, WebrenderImageHandlerType::WebGL);
-
-            // Set webxr external image handler for WebGL textures
-            webxr_main_thread.set_webgl(webxr_handler);
 
             // Set DOM to texture handler, if enabled.
             if let Some(output_handler) = output_handler {


### PR DESCRIPTION
This backs out commit 133a17e15c4110fe7a5f0933bb50842bb3eeeccb / PR #23848 because it relies on a git branch that was apparently removed:

```
$ cargo fetch
    Updating git repository `https://github.com/asajeffrey/webxr`
error: failed to resolve patches for `https://github.com/servo/webxr`

Caused by:
  failed to load source for a dependency on `webxr`

Caused by:
  Unable to update https://github.com/asajeffrey/webxr?branch=optional-glsync#da820a3a

Caused by:
  revspec 'da820a3ab266fce07c9a8abee3e6e9231cb93ec5' not found; class=Reference (4); code=NotFound (-3)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23874)
<!-- Reviewable:end -->
