### PR TITLE
Drop webgl main thread data during shutdown.

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -112,12 +112,14 @@ impl WebGLMainThread {
 
         // Any context could be current when we start.
         self.thread_data.borrow_mut().bound_context_id = None;
-        self.shut_down.set(
-            !self
-                .thread_data
-                .borrow_mut()
-                .process(EventLoop::Nonblocking),
-        );
+        let result = self
+            .thread_data
+            .borrow_mut()
+            .process(EventLoop::Nonblocking);
+        if !result {
+            self.shut_down.set(true);
+            WEBGL_MAIN_THREAD.with(|thread_data| thread_data.borrow_mut().take());
+        }
     }
 
     /// Returns the main GL thread if called from the main thread,


### PR DESCRIPTION
Before this change I get a panic late in shutdown because we end up trying to communicate with webrender during TLS teardown. 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because no tests on windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23883)
<!-- Reviewable:end -->
