### PR TITLE
Don't panic if WebGL thread can't be reached during finalization.

### DIFF
--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -140,12 +140,16 @@ impl WebGLFramebuffer {
             ));
     }
 
-    pub fn delete(&self) {
+    pub fn delete(&self, fallible: bool) {
         if !self.is_deleted.get() {
             self.is_deleted.set(true);
-            self.upcast::<WebGLObject>()
-                .context()
-                .send_command(WebGLCommand::DeleteFramebuffer(self.id));
+            let context = self.upcast::<WebGLObject>().context();
+            let cmd = WebGLCommand::DeleteFramebuffer(self.id);
+            if fallible {
+                context.send_command_ignored(cmd);
+            } else {
+                context.send_command(cmd);
+            }
         }
     }
 
@@ -588,7 +592,7 @@ impl WebGLFramebuffer {
 
 impl Drop for WebGLFramebuffer {
     fn drop(&mut self) {
-        self.delete();
+        self.delete(true);
     }
 }
 

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -339,6 +339,12 @@ impl WebGLRenderingContext {
             .unwrap();
     }
 
+    pub fn send_command_ignored(&self, command: WebGLCommand) {
+        let _ = self
+            .webgl_sender
+            .send(command, capture_webgl_backtrace(self));
+    }
+
     #[inline]
     pub fn send_vr_command(&self, command: WebVRCommand) {
         self.webgl_sender.send_vr(command).unwrap();
@@ -1039,7 +1045,7 @@ impl WebGLRenderingContext {
                 self.current_vao.set(None);
                 self.send_command(WebGLCommand::BindVertexArray(None));
             }
-            vao.delete();
+            vao.delete(false);
         }
     }
 
@@ -2172,7 +2178,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             self.bound_buffer_array.set(None);
             buffer.decrement_attached_counter();
         }
-        buffer.mark_for_deletion();
+        buffer.mark_for_deletion(false);
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
@@ -2188,7 +2194,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
                     WebGLFramebufferBindingRequest::Default
                 ))
             );
-            framebuffer.delete()
+            framebuffer.delete(false)
         }
     }
 
@@ -2205,7 +2211,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
                     None
                 ))
             );
-            renderbuffer.delete()
+            renderbuffer.delete(false)
         }
     }
 
@@ -2240,7 +2246,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
                 ));
             }
 
-            texture.delete()
+            texture.delete(false)
         }
     }
 
@@ -2248,7 +2254,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     fn DeleteProgram(&self, program: Option<&WebGLProgram>) {
         if let Some(program) = program {
             handle_potential_webgl_error!(self, self.validate_ownership(program), return);
-            program.mark_for_deletion()
+            program.mark_for_deletion(false)
         }
     }
 
@@ -2256,7 +2262,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     fn DeleteShader(&self, shader: Option<&WebGLShader>) {
         if let Some(shader) = shader {
             handle_potential_webgl_error!(self, self.validate_ownership(shader), return);
-            shader.mark_for_deletion()
+            shader.mark_for_deletion(false)
         }
     }
 

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -180,7 +180,7 @@ impl WebGLTexture {
         self.populate_mip_chain(self.base_mipmap_level, last_level)
     }
 
-    pub fn delete(&self) {
+    pub fn delete(&self, fallible: bool) {
         if !self.is_deleted.get() {
             self.is_deleted.set(true);
             let context = self.upcast::<WebGLObject>().context();
@@ -204,7 +204,12 @@ impl WebGLTexture {
                 fb.detach_texture(self);
             }
 
-            context.send_command(WebGLCommand::DeleteTexture(self.id));
+            let cmd = WebGLCommand::DeleteTexture(self.id);
+            if fallible {
+                context.send_command_ignored(cmd);
+            } else {
+                context.send_command(cmd);
+            }
         }
     }
 
@@ -404,7 +409,7 @@ impl WebGLTexture {
 
 impl Drop for WebGLTexture {
     fn drop(&mut self) {
-        self.delete();
+        self.delete(true);
     }
 }
 


### PR DESCRIPTION
Before these changes, when closing a browsing instance displaying WebGL content I would hit a bunch of panics when the WebGL objects are GCed after the WebGL thread has shut down. With these changes shutdown is panic-free.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because no tests on windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23884)
<!-- Reviewable:end -->
