### PR TITLE
Avoid panic during shutdown when Blobs exist

### DIFF
--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -296,7 +296,7 @@ impl Blob {
 
             let msg = FileManagerThreadMsg::DecRef(f.id.clone(), origin, tx);
             self.send_to_file_manager(msg);
-            let _ = rx.recv().unwrap();
+            let _ = rx.recv();
         }
     }
 


### PR DESCRIPTION
Observed when closing the UWP app when https://www.joshmatthews.net/demos/lamp.html is the active document.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because no real shutdown tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23886)
<!-- Reviewable:end -->
