### PR TITLE
WebXr: allow for only a single raf message, until callbacks execute

### DIFF
--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -285,6 +285,9 @@ impl XRSessionMethods for XRSession {
 
     /// https://immersive-web.github.io/webxr/#dom-xrsession-requestanimationframe
     fn RequestAnimationFrame(&self, callback: Rc<XRFrameRequestCallback>) -> i32 {
+        // We only need to send a message once, until a raf callback executes.
+        let should_send = self.raf_callback_list.borrow().is_empty();
+
         // queue up RAF callback, obtain ID
         let raf_id = self.next_raf_id.get();
         self.next_raf_id.set(raf_id + 1);
@@ -315,10 +318,21 @@ impl XRSessionMethods for XRSession {
                 }),
             );
         }
-        let sender = self.raf_sender.borrow().clone().unwrap();
 
-        // request animation frame
-        self.session.borrow_mut().request_animation_frame(sender);
+        if should_send {
+            // If our callback list is empty, it either means this is the first request,
+            // or raf_callback executed, in which case we should
+            // send a message to request an animation frame.
+            //
+            // This prevents multiple messages being sent for a single call to raf_callback,
+            // and multiple message are unnecessary,
+            // since one call will already deal with multiple potentially enqueued callbacks.
+            //
+            // Allowing multiple messages could keep the main-thread,
+            // where the session thread might be running, looping on incoming messages.
+            let sender = self.raf_sender.borrow().clone().unwrap();
+            self.session.borrow_mut().request_animation_frame(sender);
+        }
 
         raf_id
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

See https://github.com/servo/servo/issues/35498 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23891)
<!-- Reviewable:end -->
