### PR TITLE
Redirect stdout/stderr on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4530,8 +4530,10 @@ version = "0.0.1"
 dependencies = [
  "cbindgen 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "simpleservo 0.0.1",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/ports/glutin/Cargo.toml
+++ b/ports/glutin/Cargo.toml
@@ -74,7 +74,7 @@ sig = "1.0"
 x11 = "2.0.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["wingdi", "winuser"] }
+winapi = { version = "0.3", features = ["wingdi", "winuser", "winnt", "winbase", "processenv", "namedpipeapi", "ntdef", "minwindef", "handleapi", "debugapi"] }
 
 [target.'cfg(any(target_os = "macos", all(target_arch = "x86_64", target_os = "linux")))'.dependencies]
 osmesa-src = {git = "https://github.com/servo/osmesa-src"}

--- a/ports/libsimpleservo/capi/Cargo.toml
+++ b/ports/libsimpleservo/capi/Cargo.toml
@@ -17,6 +17,10 @@ simpleservo = { path = "../api" }
 log = "0.4"
 env_logger = "0.6"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+libc = "0.2"
+winapi = {version = "0.3", features = ["wingdi", "winuser", "winnt", "winbase", "processenv", "namedpipeapi", "ntdef", "minwindef", "handleapi", "debugapi"]}
+
 [build-dependencies]
 cbindgen = "0.8"
 


### PR DESCRIPTION
Added function redirect_stdout_stderr() to support stdout & stderr to be redirected to OutputDebugStringA().


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `23734` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23734 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
Functionality was verified by adding logic in unsafe fn init().  By building and running ServoApp, If  redirect_stdout_stderr() failed, a warn!() message would be sent to the "output" window of VS2007 with the GetLastError() value.   If the function redirect_stdout_stderr() succeeded, the println!("Capi/lib.rs: init() function called redirect_stdout_stderr() successfully.\n") output would be seen in the "output" window of VS2007.

- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23922)
<!-- Reviewable:end -->
