### PR TITLE
Assert incumbent global is always some in get_incumbent_global hook

### DIFF
--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -142,7 +142,11 @@ pub trait ScriptPort {
 unsafe extern "C" fn get_incumbent_global(_: *const c_void, _: *mut RawJSContext) -> *mut JSObject {
     wrap_panic(
         AssertUnwindSafe(|| {
-            GlobalScope::incumbent()
+            let incumbent_global = GlobalScope::incumbent();
+
+            assert!(incumbent_global.is_some());
+
+            incumbent_global
                 .map(|g| g.reflector().get_jsobject().get())
                 .unwrap_or(ptr::null_mut())
         }),


### PR DESCRIPTION
While working on module script, I'd like to use Promise with a custom
callback with type `Box<dyn TaskBox>` which means we didn't use web API
callbacks as native handlers. However, we'll get a panic from
`enqueue_promise_job` and the panic says we have a `null` incumbent
global. The main problem here is, the Promise API is strongly tied to JS
engine and it always assumes there's a meaningful answer for "what
specific global is this promise associated with". So, when I don't use
the Promise for a specific web API, our engine cannot find a proper
incumbent global for us so that we get the `null` incumbent global
panic.

To make us catch this case easier in the future, we should add the
assertion inside `get_incumbent_global` hook so that we can know this
quickly next time.

Ref: https://mozilla.logbot.info/servo/20190807#c16525481

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it should just add assertion inside the hook

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23930)
<!-- Reviewable:end -->
