### PR TITLE
Update rand to 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "peek-poke"
 version = "0.2.0"
-source = "git+https://github.com/servo/webrender#964a2eb8d9ed25cfffe6dd446cfa21a37eefe9c7"
+source = "git+https://github.com/servo/webrender#9e35bec12890c1136607ff218789f20d956adb81"
 dependencies = [
  "euclid 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "peek-poke-derive 0.2.0 (git+https://github.com/servo/webrender)",
@@ -3433,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "peek-poke-derive"
 version = "0.2.0"
-source = "git+https://github.com/servo/webrender#964a2eb8d9ed25cfffe6dd446cfa21a37eefe9c7"
+source = "git+https://github.com/servo/webrender#9e35bec12890c1136607ff218789f20d956adb81"
 dependencies = [
  "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3513,7 +3513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "plane-split"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "binary-space-partition 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3627,25 +3627,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3669,12 +3657,12 @@ name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3699,7 +3687,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3711,7 +3699,7 @@ dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.53 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3722,7 +3710,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4517,7 +4505,9 @@ version = "0.0.1"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -5573,7 +5563,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.60.0"
-source = "git+https://github.com/servo/webrender#964a2eb8d9ed25cfffe6dd446cfa21a37eefe9c7"
+source = "git+https://github.com/servo/webrender#9e35bec12890c1136607ff218789f20d956adb81"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5595,7 +5585,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "malloc_size_of_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "plane-split 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plane-split 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ron 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5614,7 +5604,7 @@ dependencies = [
 [[package]]
 name = "webrender_api"
 version = "0.60.0"
-source = "git+https://github.com/servo/webrender#964a2eb8d9ed25cfffe6dd446cfa21a37eefe9c7"
+source = "git+https://github.com/servo/webrender#9e35bec12890c1136607ff218789f20d956adb81"
 dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5636,7 +5626,7 @@ dependencies = [
 [[package]]
 name = "webrender_build"
 version = "0.0.1"
-source = "git+https://github.com/servo/webrender#964a2eb8d9ed25cfffe6dd446cfa21a37eefe9c7"
+source = "git+https://github.com/servo/webrender#9e35bec12890c1136607ff218789f20d956adb81"
 dependencies = [
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5791,7 +5781,7 @@ dependencies = [
 [[package]]
 name = "wr_malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/webrender#964a2eb8d9ed25cfffe6dd446cfa21a37eefe9c7"
+source = "git+https://github.com/servo/webrender#9e35bec12890c1136607ff218789f20d956adb81"
 dependencies = [
  "app_units 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "euclid 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6183,7 +6173,7 @@ dependencies = [
 "checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
-"checksum plane-split 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91821c7436aefc1b912552d494232efcaf9810c0189918749532be1e9dbace59"
+"checksum plane-split 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "68a117c887fbcd9af8dfc1b8b12ee19ba9dec0b2a91d0a9d2bd9114e459f9c78"
 "checksum png 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9adebf7fb91ccf5eac9da1a8e00e83cb8ae882c3e8d8e4ad59da73cb8c82a2c9"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
@@ -6192,11 +6182,10 @@ dependencies = [
 "checksum procedural-masquerade 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9a1574a51c3fd37b26d2c0032b649d08a7d51d4cca9c41bbc5bf7118fa4509d0"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
-"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
+"checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
 "checksum rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832"

--- a/components/rand/Cargo.toml
+++ b/components/rand/Cargo.toml
@@ -13,5 +13,7 @@ path = "lib.rs"
 [dependencies]
 lazy_static = "1"
 log = "0.4"
-rand = "0.4"
+rand = "0.6"
+rand_core = "0.4"
+rand_isaac = "0.1"
 uuid = "0.7"

--- a/components/rand/lib.rs
+++ b/components/rand/lib.rs
@@ -17,31 +17,17 @@ extern crate lazy_static;
 #[macro_use]
 extern crate log;
 
-#[cfg(target_pointer_width = "64")]
-use rand::isaac::Isaac64Rng as IsaacWordRng;
-#[cfg(target_pointer_width = "32")]
-use rand::isaac::IsaacRng as IsaacWordRng;
-use rand::os::OsRng;
-use rand::reseeding::{Reseeder, ReseedingRng};
-pub use rand::{Rand, Rng, SeedableRng};
+use rand::distributions::{Distribution, Standard};
+use rand::rngs::adapter::ReseedingRng;
+use rand::rngs::OsRng;
+pub use rand::seq::SliceRandom;
+pub use rand::{Rng, RngCore, SeedableRng};
+use rand_isaac::isaac::IsaacCore;
 use std::cell::RefCell;
-use std::mem;
 use std::rc::Rc;
 use std::sync::Mutex;
 use std::u64;
 use uuid::{Builder, Uuid, Variant, Version};
-
-// Slightly annoying having to cast between sizes.
-
-#[cfg(target_pointer_width = "64")]
-fn as_isaac_seed(seed: &[usize]) -> &[u64] {
-    unsafe { mem::transmute(seed) }
-}
-
-#[cfg(target_pointer_width = "32")]
-fn as_isaac_seed(seed: &[usize]) -> &[u32] {
-    unsafe { mem::transmute(seed) }
-}
 
 // The shared RNG which may hold on to a file descriptor
 lazy_static! {
@@ -56,10 +42,10 @@ const RESEED_THRESHOLD: u64 = 32_768;
 
 // An in-memory RNG that only uses the shared file descriptor for seeding and reseeding.
 pub struct ServoRng {
-    rng: ReseedingRng<IsaacWordRng, ServoReseeder>,
+    rng: ReseedingRng<IsaacCore, ServoReseeder>,
 }
 
-impl Rng for ServoRng {
+impl RngCore for ServoRng {
     #[inline]
     fn next_u32(&mut self) -> u32 {
         self.rng.next_u32()
@@ -69,23 +55,54 @@ impl Rng for ServoRng {
     fn next_u64(&mut self) -> u64 {
         self.rng.next_u64()
     }
+
+    #[inline]
+    fn fill_bytes(&mut self, bytes: &mut [u8]) {
+        self.rng.fill_bytes(bytes)
+    }
+
+    fn try_fill_bytes(&mut self, bytes: &mut [u8]) -> std::result::Result<(), rand_core::Error> {
+        self.rng.try_fill_bytes(bytes)
+    }
 }
 
-impl<'a> SeedableRng<&'a [usize]> for ServoRng {
-    /// Create a manually-reseeding instane of `ServoRng`.
+pub struct Seed([u8; 32]);
+
+impl Default for Seed {
+    fn default() -> Self {
+        Seed([0; 32])
+    }
+}
+
+impl AsMut<[u8]> for Seed {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+impl SeedableRng for ServoRng {
+    type Seed = Seed;
+
+    // This function is used in the reseeding process of rand hence why the RESEED_THRESHOLD is
+    // used.
+    fn from_seed(seed: Seed) -> ServoRng {
+        trace!("Creating a new ServoRng.");
+        let isaac_rng = IsaacCore::from_seed(seed.0);
+        let reseeding_rng = ReseedingRng::new(isaac_rng, RESEED_THRESHOLD, ServoReseeder);
+        ServoRng { rng: reseeding_rng }
+    }
+}
+
+impl ServoRng {
+    /// Create a manually-reseeding instance of `ServoRng`.
     ///
     /// Note that this RNG does not reseed itself, so care is needed to reseed the RNG
     /// is required to be cryptographically sound.
-    fn from_seed(seed: &[usize]) -> ServoRng {
-        trace!("Creating new manually-reseeded ServoRng.");
-        let isaac_rng = IsaacWordRng::from_seed(as_isaac_seed(seed));
+    pub fn new_manually_reseeded(seed: u64) -> ServoRng {
+        trace!("Creating a new manually-reseeded ServoRng.");
+        let isaac_rng = IsaacCore::seed_from_u64(seed);
         let reseeding_rng = ReseedingRng::new(isaac_rng, u64::MAX, ServoReseeder);
         ServoRng { rng: reseeding_rng }
-    }
-    /// Reseed the RNG.
-    fn reseed(&mut self, seed: &'a [usize]) {
-        trace!("Manually reseeding ServoRng.");
-        self.rng.reseed((ServoReseeder, as_isaac_seed(seed)))
     }
 }
 
@@ -97,7 +114,7 @@ impl ServoRng {
     pub fn new() -> ServoRng {
         trace!("Creating new ServoRng.");
         let mut os_rng = OS_RNG.lock().expect("Poisoned lock.");
-        let isaac_rng = IsaacWordRng::rand(&mut *os_rng);
+        let isaac_rng = IsaacCore::from_rng(&mut *os_rng).unwrap();
         let reseeding_rng = ReseedingRng::new(isaac_rng, RESEED_THRESHOLD, ServoReseeder);
         ServoRng { rng: reseeding_rng }
     }
@@ -106,11 +123,29 @@ impl ServoRng {
 // The reseeder for the in-memory RNG.
 struct ServoReseeder;
 
-impl Reseeder<IsaacWordRng> for ServoReseeder {
-    fn reseed(&mut self, rng: &mut IsaacWordRng) {
-        trace!("Reseeding ServoRng.");
+impl RngCore for ServoReseeder {
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
         let mut os_rng = OS_RNG.lock().expect("Poisoned lock.");
-        *rng = IsaacWordRng::rand(&mut *os_rng);
+        os_rng.next_u32()
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        let mut os_rng = OS_RNG.lock().expect("Poisoned lock.");
+        os_rng.next_u64()
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, bytes: &mut [u8]) {
+        let mut os_rng = OS_RNG.lock().expect("Poisoned lock.");
+        os_rng.fill_bytes(bytes)
+    }
+
+    #[inline]
+    fn try_fill_bytes(&mut self, bytes: &mut [u8]) -> std::result::Result<(), rand_core::Error> {
+        let mut os_rng = OS_RNG.lock().expect("Poisoned lock.");
+        os_rng.try_fill_bytes(bytes)
     }
 }
 
@@ -135,7 +170,7 @@ thread_local! {
     static SERVO_THREAD_RNG: ServoThreadRng = ServoThreadRng { rng: Rc::new(RefCell::new(ServoRng::new())) };
 }
 
-impl Rng for ServoThreadRng {
+impl RngCore for ServoThreadRng {
     fn next_u32(&mut self) -> u32 {
         self.rng.borrow_mut().next_u32()
     }
@@ -148,12 +183,20 @@ impl Rng for ServoThreadRng {
     fn fill_bytes(&mut self, bytes: &mut [u8]) {
         self.rng.borrow_mut().fill_bytes(bytes)
     }
+
+    #[inline]
+    fn try_fill_bytes(&mut self, bytes: &mut [u8]) -> std::result::Result<(), rand_core::Error> {
+        (self.rng.borrow_mut()).try_fill_bytes(bytes)
+    }
 }
 
 // Generates a random value using the thread-local random number generator.
 // A drop-in replacement for rand::random.
 #[inline]
-pub fn random<T: Rand>() -> T {
+pub fn random<T>() -> T
+where
+    Standard: Distribution<T>,
+{
     thread_rng().gen()
 }
 

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -15,7 +15,7 @@ use js::jsapi::JSObject;
 use js::jsapi::Type;
 use js::rust::CustomAutoRooterGuard;
 use js::typedarray::ArrayBufferView;
-use servo_rand::{Rng, ServoRng};
+use servo_rand::{RngCore, ServoRng};
 use std::ptr::NonNull;
 
 unsafe_no_jsmanaged_fields!(ServoRng);

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -44,7 +44,6 @@ packages = [
   "nix", # https://github.com/servo/servo/issues/23189#issuecomment-487512605
   "parking_lot",
   "parking_lot_core",
-  "rand",
   "rand_core",
   "scopeguard",
   "unicase",


### PR DESCRIPTION
I changed the isaac random to always be the 32 bits one because the 64
bits version doesn't work with ReseedingRng as it requires the
generator's output to be u32 for some reasons.

The other main change is that the reseed method doesn't exist anymore
and now rand recreates a new generator when it needs to reseed so I had
to add a new method for when we don't want a generator to be reseeded.

Closes #23558

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23950)
<!-- Reviewable:end -->
