### PR TITLE
Fix build error when using the 'webgl_backtrace' feature

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1118,10 +1118,10 @@ pub fn capture_webgl_backtrace<T: DomObject>(_: &T) -> WebGLCommandBacktrace {
 pub fn capture_webgl_backtrace<T: DomObject>(obj: &T) -> WebGLCommandBacktrace {
     let bt = Backtrace::new();
     unsafe {
-        capture_stack!(in(obj.global().get_cx()) let stack);
+        capture_stack!(in(*obj.global().get_cx()) let stack);
         WebGLCommandBacktrace {
             backtrace: format!("{:?}", bt),
-            js_backtrace: stack.and_then(|s| s.as_string(None)),
+            js_backtrace: stack.and_then(|s| s.as_string(None, js::jsapi::StackFormat::Default)),
         }
     }
 }


### PR DESCRIPTION
This patch fixes a build error that happens when building with `--features webgl_backtrace`.

However, while working on this I've noticed that calling `Backtrace::new()` instantly causes a segmentation fault. This didn't happen with the example code of [the package](https://crates.io/crates/backtrace) though, so I wasn't sure where to report this (maybe related: [backtrace-rs/#150](https://github.com/rust-lang/backtrace-rs/issues/150), [backtrace-rs/#189](https://github.com/rust-lang/backtrace-rs/issues/189)).

cc @alexcrichton @jdm 

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___
- [x] These changes fix an issue that happens with a compile time feature not tested by the CI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23966)
<!-- Reviewable:end -->
