### PR TITLE
Package both Servo2D and Servo3D in one magicleap mpk

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -57,8 +57,7 @@ PACKAGES = {
         'target/release/brew/servo.tar.gz',
     ],
     'magicleap': [
-        'target/magicleap/aarch64-linux-android/release/Servo2D.mpk',
-        'target/magicleap/aarch64-linux-android/release/Servo3D.mpk',
+        'target/magicleap/aarch64-linux-android/release/Servo.mpk',
     ],
     'maven': [
         'target/android/gradle/servoview/maven/org/mozilla/servoview/servoview-armv7/',
@@ -237,8 +236,7 @@ class PackageCommands(CommandBase):
 
             mabu = path.join(env.get("MAGICLEAP_SDK"), "mabu")
             packages = [
-                "./support/magicleap/Servo3D/Servo3D.package",
-                "./support/magicleap/Servo2D/Servo2D.package",
+                "./support/magicleap/Servo.package",
             ]
             if dev:
                 build_type = "lumin_debug"
@@ -249,6 +247,7 @@ class PackageCommands(CommandBase):
                     mabu,
                     "-o", target_dir,
                     "-t", build_type,
+                    "-r",
                     "GSTREAMER_DIR=" + env["GSTREAMER_DIR"],
                     package
                 ]

--- a/support/magicleap/Servo.package
+++ b/support/magicleap/Servo.package
@@ -1,11 +1,6 @@
-USES = \
-    scenes \
-    pipeline/cache/AssetManifest
-
-DATAS = \
-    fonts.xml : etc/fonts.xml
-
-REFS = Servo2D
+REFS = \
+    Servo2D/Servo2D \
+    Servo3D/Servo3D
 
 # Servo SEGVs if we don't set the debuggable flag in the mpk's taildata
 # https://github.com/servo/servo/issues/22188

--- a/support/magicleap/Servo2D/Servo2D.mabu
+++ b/support/magicleap/Servo2D/Servo2D.mabu
@@ -23,6 +23,7 @@ LDFLAGS.device = \
     -L$(MLSDK)/lumin/stl/libc++/lib
 
 DATAS = \
+    fonts.xml : etc/fonts.xml \
     $(GSTREAMER_DIR)/system/lib64/*.so : bin/ \
     $(GSTREAMER_DIR)/system/lib64/gstreamer-1.0/*.so : bin/
 
@@ -51,4 +52,6 @@ CXXFLAGS = \
 
 USES = \
     lumin_runtime \
+    scenes \
+    pipeline/cache/AssetManifest \
     code/srcs

--- a/support/magicleap/Servo3D/Servo3D.package
+++ b/support/magicleap/Servo3D/Servo3D.package
@@ -1,8 +1,0 @@
-REFS = Servo3D
-
-DATAS = \
-    fonts.xml : etc/fonts.xml
-
-# Servo SEGVs if we don't set the debuggable flag in the mpk's taildata
-# https://github.com/servo/servo/issues/22188
-OPTIONS=package/debuggable/on

--- a/support/magicleap/manifest.xml
+++ b/support/magicleap/manifest.xml
@@ -1,0 +1,31 @@
+<manifest
+  xmlns:ml="magicleap"
+  ml:package="com.mozilla.servo"
+  ml:version_code="1"
+  ml:version_name="1.0">
+  <application
+    ml:visible_name="Servo"
+    ml:sdk_version="1.0">
+    <component
+      ml:name=".servo2d.universe"
+      ml:visible_name="Servo2D"
+      ml:binary_name="bin/Servo2D"
+      ml:type="Universe">
+      <icon
+        ml:model_folder="Icon/Model/"
+        ml:portal_folder="Icon/Portal/" />
+    </component>
+    <component
+      ml:name=".servo3d.fullscreen"
+      ml:visible_name="Servo3D"
+      ml:binary_name="bin/Servo3D"
+      ml:type="Fullscreen">
+      <icon
+        ml:model_folder="Icon/Model/"
+        ml:portal_folder="Icon/Portal/" />
+    </component>
+    <uses-privilege ml:name="ControllerPose"/>
+    <uses-privilege ml:name="Internet"/>
+    <uses-privilege ml:name="LowLatencyLightwear"/>
+  </application>
+</manifest>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Put both magicleap apps in one mpk archive.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes do not require tests because we don't test native packaging

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23976)
<!-- Reviewable:end -->
