### PR TITLE
Enable webxr for the UWP port.

### DIFF
--- a/support/hololens/ServoApp/Servo.cpp
+++ b/support/hololens/ServoApp/Servo.cpp
@@ -32,7 +32,7 @@ Servo::Servo(GLsizei width, GLsizei height, ServoDelegate &aDelegate)
     : mWindowHeight(height), mWindowWidth(width), mDelegate(aDelegate) {
 
   capi::CInitOptions o;
-  o.args = NULL;
+  o.args = "--pref dom.webxr.enabled";
   o.url = "https://servo.org";
   o.width = mWindowWidth;
   o.height = mWindowHeight;


### PR DESCRIPTION
This avoids a common papercut for the UWP port while our webxr support is still in progress.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23978)
<!-- Reviewable:end -->
