### PR TITLE
Add secure connection start

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -408,6 +408,17 @@ fn obtain_response(
         )
         .body(request_body.clone().into());
 
+    // TODO: We currently don't know when the handhhake before the connection is done
+    // so our best bet would be to set `secure_connection_start` here when we are currently
+    // fetching on a HTTPS url.
+    if url.scheme() == "https" {
+        context
+            .timing
+            .lock()
+            .unwrap()
+            .set_attribute(ResourceAttribute::SecureConnectionStart);
+    }
+
     let mut request = match request {
         Ok(request) => request,
         Err(e) => return Box::new(future::result(Err(NetworkError::from_http_error(&e)))),

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -466,6 +466,7 @@ pub struct ResourceFetchTiming {
     /// Number of redirects until final resource (currently limited to 20)
     pub redirect_count: u16,
     pub request_start: u64,
+    pub secure_connection_start: u64,
     pub response_start: u64,
     pub fetch_start: u64,
     pub response_end: u64,
@@ -496,6 +497,7 @@ pub enum ResourceAttribute {
     FetchStart,
     ConnectStart(u64),
     ConnectEnd(u64),
+    SecureConnectionStart,
     ResponseEnd,
 }
 
@@ -514,6 +516,7 @@ impl ResourceFetchTiming {
             timing_check_passed: true,
             domain_lookup_start: 0,
             redirect_count: 0,
+            secure_connection_start: 0,
             request_start: 0,
             response_start: 0,
             fetch_start: 0,
@@ -555,6 +558,9 @@ impl ResourceFetchTiming {
             ResourceAttribute::FetchStart => self.fetch_start = precise_time_ns(),
             ResourceAttribute::ConnectStart(val) => self.connect_start = val,
             ResourceAttribute::ConnectEnd(val) => self.connect_end = val,
+            ResourceAttribute::SecureConnectionStart => {
+                self.secure_connection_start = precise_time_ns()
+            },
             ResourceAttribute::ResponseEnd => self.response_end = precise_time_ns(),
         }
     }

--- a/components/script/dom/performanceresourcetiming.rs
+++ b/components/script/dom/performanceresourcetiming.rs
@@ -129,8 +129,7 @@ impl PerformanceResourceTiming {
             domain_lookup_end: 0.,
             connect_start: resource_timing.connect_start as f64,
             connect_end: resource_timing.connect_end as f64,
-            // TODO (#21271)
-            secure_connection_start: 0.,
+            secure_connection_start: resource_timing.secure_connection_start as f64,
             request_start: resource_timing.request_start as f64,
             response_start: resource_timing.response_start as f64,
             response_end: resource_timing.response_end as f64,


### PR DESCRIPTION
Implementing `secure_connection_start` as well as we can, this is related to #21268 

We are setting the value as well as we can since we don't have a way to know if we are currently using a secure transport or where the handshake before the connection is done as the spec says on the step 15 [https://w3c.github.io/resource-timing/#sec-process](https://w3c.github.io/resource-timing/#sec-process)

Regarding the Timing Allow Check, that's being done on another PR by another person which will take care of setting the rest of the values on `PerformaceResourceTiming` to Zero and prevent them to set them any other way.

I'm currently setting the `secure_connection_time` using `precise_time_ms()` as the `connection_start` and `connection_end` are set that way... but other attributes inside `PerformanceResourceTiming` are set using `precise_time

Another thing, the issue talks about setting `redirect_start` but I'm not really sure if it's related, if so I can look up into that too... I might have just read and thought it was all about secure connection start.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #21268 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/23990)
<!-- Reviewable:end -->
