### PR TITLE
Make inline elements work in fullscreen mode

### DIFF
--- a/components/layout/construct.rs
+++ b/components/layout/construct.rs
@@ -1878,7 +1878,9 @@ where
             // Inline items that are absolutely-positioned contribute inline fragment construction
             // results with a hypothetical fragment.
             (Display::Inline, _, Position::Absolute) |
-            (Display::InlineBlock, _, Position::Absolute) => {
+            (Display::Inline, _, Position::Fixed) |
+            (Display::InlineBlock, _, Position::Absolute) |
+            (Display::InlineBlock, _, Position::Fixed) => {
                 let construction_result =
                     self.build_fragment_for_absolutely_positioned_inline(node);
                 self.set_flow_construction_result(node, construction_result)

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -1,5 +1,11 @@
 {
  "items": {
+  "conformancechecker": {
+   "css/blockify_inline_element.html": []
+  },
+  "manual": {
+   "css/blockify_inline_element.html": []
+  },
   "reftest": {
    "css/abs-overflow-stackingcontext.html": [
     [
@@ -773,6 +779,18 @@
      [
       [
        "/_mozilla/css/block_replaced_content_ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
+   "css/blockify_inline_element.html": [
+    [
+     "css/blockify_inline_element.html",
+     [
+      [
+       "/_mozilla/css/blockify_inline_element_ref.html",
        "=="
       ]
      ],
@@ -7640,6 +7658,9 @@
     ]
    ]
   },
+  "stub": {
+   "css/blockify_inline_element.html": []
+  },
   "support": {
    ".gitignore": [
     []
@@ -7864,6 +7885,10 @@
     []
    ],
    "css/block_replaced_content_ref.html": [
+    []
+   ],
+   "css/blockify_inline_element.html": [],
+   "css/blockify_inline_element_ref.html": [
     []
    ],
    "css/blur_ref.html": [
@@ -11096,6 +11121,7 @@
      {}
     ]
    ],
+   "css/blockify_inline_element.html": [],
    "css/bug_1345483.html": [
     [
      "css/bug_1345483.html",
@@ -12515,6 +12541,12 @@
      {}
     ]
    ]
+  },
+  "visual": {
+   "css/blockify_inline_element.html": []
+  },
+  "wdspec": {
+   "css/blockify_inline_element.html": []
   }
  },
  "paths": {
@@ -13940,6 +13972,14 @@
   ],
   "css/block_replaced_content_ref.html": [
    "4d48d763eb784170f680276541d864681a05962b",
+   "support"
+  ],
+  "css/blockify_inline_element.html": [
+   "7f9da081c8e246c7d72a85ecfd129a5ddc56e07a",
+   "reftest"
+  ],
+  "css/blockify_inline_element_ref.html": [
+   "ad88ac2f3f7e4b56a3781e61655dc580806fc4cd",
    "support"
   ],
   "css/blur_a.html": [

--- a/tests/wpt/mozilla/tests/css/blockify_inline_element.html
+++ b/tests/wpt/mozilla/tests/css/blockify_inline_element.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Blockify inline/inline-block elements</title>
+<link rel="match" href="blockify_inline_element_ref.html">
+<style>
+  span {
+    width: 50px;
+    height: 50px;
+    position: fixed;
+   }
+  .blue {
+    display: inline;
+    top: 0;
+    left: 0;
+    background: blue;
+  }
+  .red {
+    display: inline-block;
+    top: 50;
+    left: 0;
+    background: red;
+  }
+</style>
+<span class="blue"></span>
+<div><span class="red"></span></div>

--- a/tests/wpt/mozilla/tests/css/blockify_inline_element_ref.html
+++ b/tests/wpt/mozilla/tests/css/blockify_inline_element_ref.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Blockify inline/inline-block element</title>
+<style>
+  span {
+    display: block;
+    position: fixed;
+    width: 50px;
+    height: 50px;
+   }
+  .blue {
+    top: 0;
+    left: 0;
+    background: blue;
+  }
+  .red {
+    top: 50;
+    left: 0;
+    background: red;
+  }
+</style>
+<span class="blue"></span>
+<span class="red"></span>


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22358

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24034)
<!-- Reviewable:end -->
