### PR TITLE
In mach, add arguments to bare uses of is_windows

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -240,7 +240,7 @@ def set_osmesa_env(bin_path, env):
 
 
 def gstreamer_root(target, env, topdir=None):
-    if is_windows:
+    if is_windows():
         arch = {
             "x86_64": "X86_64",
             "x86": "X86",
@@ -570,7 +570,7 @@ class CommandBase(object):
         if "x86_64" not in effective_target or "android" in effective_target:
             # We don't build gstreamer for non-x86_64 / android yet
             return False
-        if sys.platform == "linux2" or is_windows:
+        if sys.platform == "linux2" or is_windows():
             if path.isdir(gstreamer_root(effective_target, env, self.get_top_dir)):
                 return True
             else:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Replace bare uses of `is_windows` by `is_windows()` in mach.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because we don't test infra

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24041)
<!-- Reviewable:end -->
