### PR TITLE
Fix extension querying when using WebGL2

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1721,8 +1721,19 @@ impl WebGLImpl {
         chan.send(result).unwrap();
     }
 
+    #[allow(unsafe_code)]
     fn get_extensions(gl: &dyn gl::Gl, chan: &WebGLSender<String>) {
-        chan.send(gl.get_string(gl::EXTENSIONS)).unwrap();
+        let mut ext_count = [0];
+        unsafe {
+            gl.get_integer_v(gl::NUM_EXTENSIONS, &mut ext_count);
+        }
+        let ext_count = ext_count[0] as usize;
+        let mut extensions = Vec::with_capacity(ext_count);
+        for idx in 0..ext_count {
+            extensions.push(gl.get_string_i(gl::EXTENSIONS, idx as u32))
+        }
+        let extensions = extensions.join(" ");
+        chan.send(extensions).unwrap();
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6


### PR DESCRIPTION
This patch fixes a crash caused by using a deprecated GL call. Starting with OpenGL 3 (used by WebGL2), the glGetString(GL_EXTENSIONS) call is deprecated, and some drivers produce GL_INVALID_ENUM error. Querying can be done by checking the number of extensions first, then getting the extensions one by one.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests (I think) because it depends on the video driver

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24055)
<!-- Reviewable:end -->
