### PR TITLE
Download platform-tools even for non-emulator builds

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -145,6 +145,7 @@ class MachCommands(CommandBase):
             ]
         if build:
             components += [
+                "platform-tools",
                 "platforms;android-18",
             ]
 


### PR DESCRIPTION
`mach install --android` fails because adb is missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24063)
<!-- Reviewable:end -->
