### PR TITLE
Switch to chromeless mode when app opens from a servo:// link

### DIFF
--- a/support/hololens/ServoApp/App.cpp
+++ b/support/hololens/ServoApp/App.cpp
@@ -71,7 +71,8 @@ void App::OnActivated(IActivatedEventArgs const &args) {
     Frame rootFrame{nullptr};
 
     auto content = Window::Current().Content();
-    if (content == nullptr) {
+    bool isRunning = content != nullptr;
+    if (!isRunning) {
       rootFrame = Frame();
       rootFrame.Navigate(xaml_typename<ServoApp::BrowserPage>());
       Window::Current().Content(rootFrame);
@@ -81,6 +82,9 @@ void App::OnActivated(IActivatedEventArgs const &args) {
     }
     auto page = rootFrame.Content().try_as<BrowserPage>();
     page->LoadServoURI(protocolActivatedEventArgs.Uri());
+    // If Servo was opened as a result of clicking on a servo:// URL,
+    // we activate transient mode.
+    page->SetTransientMode(!isRunning);
   }
 }
 

--- a/support/hololens/ServoApp/BrowserPage.cpp
+++ b/support/hololens/ServoApp/BrowserPage.cpp
@@ -55,6 +55,12 @@ void BrowserPage::LoadServoURI(Uri uri) {
   servoControl().LoadURIOrSearch(raw2);
 }
 
+void BrowserPage::SetTransientMode(bool transient) {
+  servoControl().SetTransientMode(transient);
+  navigationBar().Visibility(transient ? Visibility::Collapsed
+                                       : Visibility::Visible);
+}
+
 void BrowserPage::Shutdown() { servoControl().Shutdown(); }
 
 /**** USER INTERACTIONS WITH UI ****/

--- a/support/hololens/ServoApp/BrowserPage.h
+++ b/support/hololens/ServoApp/BrowserPage.h
@@ -28,6 +28,7 @@ public:
                    Windows::UI::Xaml::Input::KeyRoutedEventArgs const &);
   void Shutdown();
   void LoadServoURI(Windows::Foundation::Uri uri);
+  void SetTransientMode(bool);
 
 private:
   void BindServoEvents();

--- a/support/hololens/ServoApp/ServoControl/ServoControl.cpp
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.cpp
@@ -8,6 +8,7 @@ using namespace winrt::Windows::Graphics::Display;
 using namespace winrt::Windows::UI::Xaml;
 using namespace winrt::Windows::UI::Core;
 using namespace winrt::Windows::Foundation;
+using namespace winrt::Windows::System;
 using namespace concurrency;
 using namespace winrt::servo;
 
@@ -270,7 +271,14 @@ void ServoControl::WakeUp() {
   RunOnGLThread([=] {});
 }
 
-bool ServoControl::OnServoAllowNavigation(hstring) { return true; }
+bool ServoControl::OnServoAllowNavigation(hstring uri) {
+  if (mTransient) {
+    RunOnUIThread([=] {
+      Launcher::LaunchUriAsync(Uri{uri});
+    });
+  }
+  return !mTransient;
+}
 
 void ServoControl::OnServoAnimatingChanged(bool animating) {
   EnterCriticalSection(&mGLLock);

--- a/support/hololens/ServoApp/ServoControl/ServoControl.h
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.h
@@ -69,6 +69,8 @@ struct ServoControl : ServoControlT<ServoControl>, public servo::ServoDelegate {
     mOnCaptureGesturesEndedEvent.remove(token);
   }
 
+  void SetTransientMode(bool transient) { mTransient = transient; }
+
   virtual void WakeUp();
   virtual void OnServoLoadStarted();
   virtual void OnServoLoadEnded();
@@ -94,6 +96,7 @@ private:
 
   float mDPI = 1;
   hstring mInitialURL = L"https://servo.org";
+  bool mTransient = false;
 
   Windows::UI::Xaml::Controls::SwapChainPanel ServoControl::Panel();
   void CreateRenderSurface();

--- a/support/hololens/ServoApp/ServoControl/ServoControl.idl
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.idl
@@ -10,6 +10,7 @@ namespace ServoApp {
       void Reload();
       void Stop();
       Windows.Foundation.Uri LoadURIOrSearch(String url);
+      void SetTransientMode(Boolean transient);
       void Shutdown();
       event EventDelegate OnLoadStarted;
       event EventDelegate OnLoadEnded;

--- a/support/hololens/ServoApp/pch.h
+++ b/support/hololens/ServoApp/pch.h
@@ -39,6 +39,7 @@
 #include <winrt/Windows.Perception.Spatial.h>
 #include <winrt/Windows.Storage.h>
 #include <winrt/Windows.Storage.Streams.h>
+#include <winrt/windows.system.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Input.Spatial.h>
 #include <winrt/Windows.UI.Popups.h>


### PR DESCRIPTION
Fix #24077

There's an issue where, in chromeless mode, when clicking a link in Servo, Edge opens the link (as expected) but not in a new tab, in a new window.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24095)
<!-- Reviewable:end -->
