### PR TITLE
Call gstreamer_root with top_dir string, not func.

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -571,7 +571,7 @@ class CommandBase(object):
             # We don't build gstreamer for non-x86_64 / android yet
             return False
         if sys.platform == "linux2" or is_windows():
-            if path.isdir(gstreamer_root(effective_target, env, self.get_top_dir)):
+            if path.isdir(gstreamer_root(effective_target, env, self.get_top_dir())):
                 return True
             else:
                 raise Exception("Your system's gstreamer libraries are out of date \
@@ -586,7 +586,7 @@ install them, let us know by filing a bug!")
         """Some commands, like test-wpt, don't use a full build env,
            but may still need dynamic search paths. This command sets that up"""
         if not android and self.needs_gstreamer_env(None, os.environ):
-            gstpath = gstreamer_root(host_triple(), os.environ, self.get_top_dir)
+            gstpath = gstreamer_root(host_triple(), os.environ, self.get_top_dir())
             if gstpath is None:
                 return
             os.environ["LD_LIBRARY_PATH"] = path.join(gstpath, "lib")


### PR DESCRIPTION
Commit 72e28dffcdf560543d312abc0ec4ff76b7c7dfaf introduced a build regression on Linux when resolving the in-tree gstreamer libs.

The error:

```
$ ./mach build --release
...
The details of the failure are as follows:

AttributeError: 'function' object has no attribute 'endswith'

  File "/data/joelm/personal/UTA/dissertation/servo/servo-master.git/python/servo/build_commands.py", line 237, in build
    env = self.build_env(target=target, is_build=True)
  File "/data/joelm/personal/UTA/dissertation/servo/servo-master.git/python/servo/command_base.py", line 646, in build_env
    if self.needs_gstreamer_env(target or host_triple(), env):
  File "/data/joelm/personal/UTA/dissertation/servo/servo-master.git/python/servo/command_base.py", line 574, in needs_gstreamer_env
    if path.isdir(gstreamer_root(effective_target, env, self.get_top_dir)):
  File "/data/joelm/personal/UTA/dissertation/servo/servo-master.git/python/servo/command_base.py", line 257, in gstreamer_root
    return path.join(topdir, "support", "linux", "gstreamer", "gst")
  File "/usr/lib/python2.7/posixpath.py", line 70, in join
    elif path == '' or path.endswith('/'):
```

The problem is that get_top_dir is being passed as a function to
gstreamer_root in a couple of places instead of being invoked first.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because: it is early in a build script and outside the scope of tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24099)
<!-- Reviewable:end -->
