### PR TITLE
Added support in CInitOptions to pass logging/filter modules to VSLog…

### DIFF
--- a/ports/libsimpleservo/capi/Cargo.toml
+++ b/ports/libsimpleservo/capi/Cargo.toml
@@ -15,8 +15,8 @@ bench = false
 [dependencies]
 simpleservo = { path = "../api" }
 log = "0.4"
-env_logger = "0.6"
 lazy_static = "1"
+env_logger = "0.6"
 backtrace = "0.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/ports/libsimpleservo/capi/src/vslogger.rs
+++ b/ports/libsimpleservo/capi/src/vslogger.rs
@@ -3,6 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use log::{self, Level, Metadata, Record};
+use std::sync::{Arc, Mutex};
+
+lazy_static! {
+    pub static ref LOG_MODULE_FILTERS: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(vec![]));
+}
 
 extern "C" {
     fn OutputDebugStringA(s: *const u8);
@@ -12,7 +17,10 @@ pub struct VSLogger;
 
 impl log::Log for VSLogger {
     fn enabled(&self, metadata: &Metadata) -> bool {
-        metadata.level() <= Level::Warn
+        let modules = LOG_MODULE_FILTERS.lock().unwrap();
+        let is_module_enabled =
+            modules.contains(&String::from(metadata.target())) || modules.is_empty();
+        return metadata.level() <= Level::Warn && is_module_enabled;
     }
 
     fn log(&self, record: &Record) {

--- a/support/hololens/ServoApp/ServoControl/Servo.cpp
+++ b/support/hololens/ServoApp/ServoControl/Servo.cpp
@@ -69,6 +69,28 @@ Servo::Servo(hstring url, GLsizei width, GLsizei height, float dpi,
   o.enable_subpixel_text_antialiasing = false;
   o.vr_pointer = NULL;
 
+  // 7 filter modules.
+  /* Sample list of servo modules to filter.
+  static char *pfilters[] = {
+	  "servo",
+	  "simpleservo", 
+	  "simpleservo::jniapi",
+	  "simpleservo::gl_glue::egl",
+	  // Show JS errors by default.
+	  "script::dom::bindings::error",
+	  // Show GL errors by default.
+	  "canvas::webgl_thread",
+	  "compositing::compositor",
+	  "constellation::constellation",
+  };
+  */
+
+  // Example Call when *pfilters[] is used:
+  // o.vslogger_mod_list = pfilters; // servo log modules
+  // o.vslogger_mod_size = sizeof(pfilters) / sizeof(pfilters[0]) -1; // Important: Number of modules in pfilters
+  o.vslogger_mod_list = NULL;
+  o.vslogger_mod_size = 0;
+
   sServo = this; // FIXME;
 
   capi::CHostCallbacks c;


### PR DESCRIPTION
…ger.

<!-- Please describe your changes on the following line: -->
Preliminary implementation of #23754.  Added support in CInitOptions to take a **pmoduleList (array of string modules) and the size of the array string.  Added logic to covert the **pmoduleList in HoloLens to a Vec<String>.

Pending: implement how the passed in list of modules are used for filtering.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23754__ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24107)
<!-- Reviewable:end -->
