### PR TITLE
webgl: Support vertex array objects on macOS.

### DIFF
--- a/components/canvas/gl_context.rs
+++ b/components/canvas/gl_context.rs
@@ -158,15 +158,16 @@ impl GLContextWrapper {
     pub fn apply_command(
         &self,
         cmd: WebGLCommand,
+        use_apple_vertex_array: bool,
         backtrace: WebGLCommandBacktrace,
         state: &mut GLState,
     ) {
         match *self {
             GLContextWrapper::Native(ref ctx) => {
-                WebGLImpl::apply(ctx, state, cmd, backtrace);
+                WebGLImpl::apply(ctx, state, use_apple_vertex_array, cmd, backtrace);
             },
             GLContextWrapper::OSMesa(ref ctx) => {
-                WebGLImpl::apply(ctx, state, cmd, backtrace);
+                WebGLImpl::apply(ctx, state, false, cmd, backtrace);
             },
         }
     }


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23960 and fix #12644

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24111)
<!-- Reviewable:end -->
