### PR TITLE
Work around crash on Windows when returning JS::Value by value.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.12.0"
-source = "git+https://github.com/servo/rust-mozjs#ab48ca77aec7fc656b7d1fd36bc33e7bc1036a17"
+source = "git+https://github.com/servo/rust-mozjs#92136c0b9a1efba2eb18b4400669278705816027"
 dependencies = [
  "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -37,8 +37,9 @@ use js::jsapi::{
 };
 use js::jsapi::{JSObject, PromiseRejectionHandlingState, SetPreserveWrapperCallback};
 use js::jsapi::{SetJobQueue, SetProcessBuildIdOp, SetPromiseRejectionTrackerCallback};
+use js::jsval::UndefinedValue;
 use js::panic::wrap_panic;
-use js::rust::wrappers::{GetPromiseIsHandled, GetPromiseResult};
+use js::rust::wrappers::{GetPromiseIsHandled, JS_GetPromiseResult};
 use js::rust::Handle;
 use js::rust::IntoHandle;
 use js::rust::JSEngine;
@@ -251,7 +252,8 @@ unsafe extern "C" fn promise_rejection_tracker(
                         let cx = target.global().get_cx();
                         let root_promise = trusted_promise.root();
 
-                        rooted!(in(*cx) let reason = GetPromiseResult(root_promise.reflector().get_jsobject()));
+                        rooted!(in(*cx) let mut reason = UndefinedValue());
+                        JS_GetPromiseResult(root_promise.reflector().get_jsobject(), reason.handle_mut());
 
                         let event = PromiseRejectionEvent::new(
                             &target.global(),
@@ -314,7 +316,8 @@ pub fn notify_about_rejected_promises(global: &GlobalScope) {
                         }
 
                         // Step 4-2.
-                        rooted!(in(*cx) let reason = GetPromiseResult(promise.reflector().get_jsobject()));
+                        rooted!(in(*cx) let mut reason = UndefinedValue());
+                        JS_GetPromiseResult(promise.reflector().get_jsobject(), reason.handle_mut());
 
                         let event = PromiseRejectionEvent::new(
                             &target.global(),


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24061
- [x] These changes do not require tests because no tests on Windows, sadly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24120)
<!-- Reviewable:end -->
