### PR TITLE
Fallback to old extensions API if NUM_EXTENSIONS errors

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1727,6 +1727,11 @@ impl WebGLImpl {
         unsafe {
             gl.get_integer_v(gl::NUM_EXTENSIONS, &mut ext_count);
         }
+        // Fall back to the depricated extensions API if that fails
+        if gl.get_error() != gl::NO_ERROR {
+            chan.send(gl.get_string(gl::EXTENSIONS)).unwrap();
+            return;
+        }
         let ext_count = ext_count[0] as usize;
         let mut extensions = Vec::with_capacity(ext_count);
         for idx in 0..ext_count {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Fixes a panic querying extensions in WebGL 1.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21993
- [x] These changes do not require tests because it fixes a panic

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24128)
<!-- Reviewable:end -->
