### PR TITLE
Prefetch img, scripts and stylesheets during parsing

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -25,6 +25,7 @@ use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use net_traits::request::{Destination, RequestBuilder};
 use net_traits::response::{Response, ResponseInit};
 use net_traits::storage_thread::StorageThreadMsg;
+use net_traits::DiscardFetch;
 use net_traits::FetchTaskTarget;
 use net_traits::WebSocketNetworkEvent;
 use net_traits::{CookieSource, CoreResourceMsg, CoreResourceThread};
@@ -248,7 +249,7 @@ impl ResourceChannelManager {
                 ),
                 FetchChannels::Prefetch => {
                     self.resource_manager
-                        .fetch(req_init, None, (), http_state, None)
+                        .fetch(req_init, None, DiscardFetch, http_state, None)
                 },
             },
             CoreResourceMsg::DeleteCookies(request) => {

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -237,6 +237,18 @@ impl FetchTaskTarget for IpcSender<FetchResponseMsg> {
     }
 }
 
+impl FetchTaskTarget for () {
+    fn process_request_body(&mut self, _: &Request) {}
+
+    fn process_request_eof(&mut self, _: &Request) {}
+
+    fn process_response(&mut self, _: &Response) {}
+
+    fn process_response_chunk(&mut self, _: Vec<u8>) {}
+
+    fn process_response_eof(&mut self, _: &Response) {}
+}
+
 pub trait Action<Listener> {
     fn process(self, listener: &mut Listener);
 }
@@ -368,6 +380,9 @@ pub enum FetchChannels {
         event_sender: IpcSender<WebSocketNetworkEvent>,
         action_receiver: IpcReceiver<WebSocketDomAction>,
     },
+    /// If the fetch is just being done to populate the cache,
+    /// not because the data is needed now.
+    Prefetch,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -237,7 +237,12 @@ impl FetchTaskTarget for IpcSender<FetchResponseMsg> {
     }
 }
 
-impl FetchTaskTarget for () {
+/// A fetch task that discards all data it's sent,
+/// useful when speculatively prefetching data that we don't need right
+/// now, but might need in the future.
+pub struct DiscardFetch;
+
+impl FetchTaskTarget for DiscardFetch {
     fn process_request_body(&mut self, _: &Request) {}
 
     fn process_request_eof(&mut self, _: &Request) {}

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -80,7 +80,7 @@ use msg::constellation_msg::{
 use net_traits::filemanager_thread::RelativePos;
 use net_traits::image::base::{Image, ImageMetadata};
 use net_traits::image_cache::{ImageCache, PendingImageId};
-use net_traits::request::{Request, RequestBuilder};
+use net_traits::request::{Referrer, Request, RequestBuilder};
 use net_traits::response::HttpsState;
 use net_traits::response::{Response, ResponseBody};
 use net_traits::storage_thread::StorageType;
@@ -456,6 +456,7 @@ unsafe_no_jsmanaged_fields!(Request);
 unsafe_no_jsmanaged_fields!(RequestBuilder);
 unsafe_no_jsmanaged_fields!(StyleSharedRwLock);
 unsafe_no_jsmanaged_fields!(USVString);
+unsafe_no_jsmanaged_fields!(Referrer);
 unsafe_no_jsmanaged_fields!(ReferrerPolicy);
 unsafe_no_jsmanaged_fields!(Response);
 unsafe_no_jsmanaged_fields!(ResponseBody);

--- a/components/script/dom/servoparser/prefetch.rs
+++ b/components/script/dom/servoparser/prefetch.rs
@@ -1,0 +1,185 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::bindings::reflector::DomObject;
+use crate::dom::bindings::trace::JSTraceable;
+use crate::dom::document::Document;
+use crate::dom::htmlimageelement::image_fetch_request;
+use crate::dom::htmlscriptelement::script_fetch_request;
+use crate::stylesheet_loader::stylesheet_fetch_request;
+use html5ever::buffer_queue::BufferQueue;
+use html5ever::tokenizer::Tag;
+use html5ever::tokenizer::TagKind;
+use html5ever::tokenizer::Token;
+use html5ever::tokenizer::TokenSink;
+use html5ever::tokenizer::TokenSinkResult;
+use html5ever::tokenizer::Tokenizer as HtmlTokenizer;
+use html5ever::tokenizer::TokenizerResult;
+use html5ever::Attribute;
+use html5ever::LocalName;
+use js::jsapi::JSTracer;
+use msg::constellation_msg::PipelineId;
+use net_traits::request::CorsSettings;
+use net_traits::request::Referrer;
+use net_traits::CoreResourceMsg;
+use net_traits::FetchChannels;
+use net_traits::IpcSend;
+use net_traits::ReferrerPolicy;
+use net_traits::ResourceThreads;
+use servo_url::ImmutableOrigin;
+use servo_url::ServoUrl;
+
+#[derive(JSTraceable, MallocSizeOf)]
+#[must_root]
+pub struct Tokenizer {
+    #[ignore_malloc_size_of = "Defined in html5ever"]
+    inner: HtmlTokenizer<PrefetchSink>,
+}
+
+#[allow(unsafe_code)]
+unsafe impl JSTraceable for HtmlTokenizer<PrefetchSink> {
+    unsafe fn trace(&self, trc: *mut JSTracer) {
+        self.sink.trace(trc)
+    }
+}
+
+impl Tokenizer {
+    pub fn new(document: &Document) -> Self {
+        let sink = PrefetchSink {
+            origin: document.origin().immutable().clone(),
+            pipeline_id: document.global().pipeline_id(),
+            base: document.url(),
+            referrer: Referrer::ReferrerUrl(document.url()),
+            referrer_policy: document.get_referrer_policy(),
+            resource_threads: document.loader().resource_threads().clone(),
+            // Initially we set prefetching to false, and only set it
+            // true after the first script tag, since that is what will
+            // block the main parser.
+            prefetching: false,
+        };
+        let options = Default::default();
+        let inner = HtmlTokenizer::new(sink, options);
+        Tokenizer { inner }
+    }
+
+    pub fn feed(&mut self, input: &mut BufferQueue) -> TokenizerResult<()> {
+        self.inner.feed(input)
+    }
+}
+
+#[derive(JSTraceable)]
+struct PrefetchSink {
+    origin: ImmutableOrigin,
+    pipeline_id: PipelineId,
+    base: ServoUrl,
+    referrer: Referrer,
+    referrer_policy: Option<ReferrerPolicy>,
+    resource_threads: ResourceThreads,
+    prefetching: bool,
+}
+
+impl TokenSink for PrefetchSink {
+    type Handle = ();
+    fn process_token(&mut self, token: Token, _line_number: u64) -> TokenSinkResult<()> {
+        if let Token::TagToken(ref tag) = token {
+            match (tag.kind, &tag.name) {
+                (TagKind::StartTag, local_name!("script")) if self.prefetching => {
+                    if let Some(url) = self.get_url(tag, local_name!("src")) {
+                        debug!("Prefetch script {}", url);
+                        let cors_setting = self.get_cors_settings(tag, local_name!("crossorigin"));
+                        let integrity_metadata = self
+                            .get_attr(tag, local_name!("integrity"))
+                            .map(|attr| String::from(&attr.value))
+                            .unwrap_or_default();
+                        let request = script_fetch_request(
+                            url,
+                            cors_setting,
+                            self.origin.clone(),
+                            self.pipeline_id,
+                            self.referrer.clone(),
+                            self.referrer_policy,
+                            integrity_metadata,
+                        );
+                        let _ = self
+                            .resource_threads
+                            .send(CoreResourceMsg::Fetch(request, FetchChannels::Prefetch));
+                    }
+                    // Don't prefetch inside script
+                    self.prefetching = false;
+                },
+                (TagKind::StartTag, local_name!("img")) if self.prefetching => {
+                    if let Some(url) = self.get_url(tag, local_name!("src")) {
+                        debug!("Prefetch {} {}", tag.name, url);
+                        let request =
+                            image_fetch_request(url, self.origin.clone(), self.pipeline_id);
+                        let _ = self
+                            .resource_threads
+                            .send(CoreResourceMsg::Fetch(request, FetchChannels::Prefetch));
+                    }
+                },
+                (TagKind::StartTag, local_name!("link")) if self.prefetching => {
+                    if let Some(rel) = self.get_attr(tag, local_name!("rel")) {
+                        if rel.value.eq_ignore_ascii_case("stylesheet") {
+                            if let Some(url) = self.get_url(tag, local_name!("href")) {
+                                debug!("Prefetch {} {}", tag.name, url);
+                                let cors_setting =
+                                    self.get_cors_settings(tag, local_name!("crossorigin"));
+                                let integrity_metadata = self
+                                    .get_attr(tag, local_name!("integrity"))
+                                    .map(|attr| String::from(&attr.value))
+                                    .unwrap_or_default();
+                                let request = stylesheet_fetch_request(
+                                    url,
+                                    cors_setting,
+                                    self.origin.clone(),
+                                    self.pipeline_id,
+                                    self.referrer.clone(),
+                                    self.referrer_policy,
+                                    integrity_metadata,
+                                );
+                                let _ = self
+                                    .resource_threads
+                                    .send(CoreResourceMsg::Fetch(request, FetchChannels::Prefetch));
+                            }
+                        }
+                    }
+                },
+                (TagKind::EndTag, local_name!("script")) => {
+                    // After the first script tag, the main parser is blocked, so it's worth prefetching.
+                    self.prefetching = true;
+                },
+                (TagKind::StartTag, local_name!("base")) => {
+                    if let Some(url) = self.get_url(tag, local_name!("href")) {
+                        debug!("Setting base {}", url);
+                        self.base = url;
+                    }
+                },
+                _ => {},
+            }
+        }
+        TokenSinkResult::Continue
+    }
+}
+
+impl PrefetchSink {
+    fn get_attr<'a>(&'a self, tag: &'a Tag, name: LocalName) -> Option<&'a Attribute> {
+        tag.attrs.iter().find(|attr| attr.name.local == name)
+    }
+
+    fn get_url(&self, tag: &Tag, name: LocalName) -> Option<ServoUrl> {
+        self.get_attr(tag, name)
+            .and_then(|attr| ServoUrl::parse_with_base(Some(&self.base), &attr.value).ok())
+    }
+
+    fn get_cors_settings(&self, tag: &Tag, name: LocalName) -> Option<CorsSettings> {
+        let crossorigin = self.get_attr(tag, name)?;
+        if crossorigin.value.eq_ignore_ascii_case("anonymous") {
+            Some(CorsSettings::Anonymous)
+        } else if crossorigin.value.eq_ignore_ascii_case("use-credentials") {
+            Some(CorsSettings::UseCredentials)
+        } else {
+            None
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Eagerly tokenize html input, and scan for `script` and `img` tags which can be prefetched into the cache. This allows resources to be loaded concurrently, which would otherwise be loaded sequentially due to being blocked by script execution. On the cloth webgl demo, this takes the time-to-paint down from 732ms to 560ms.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #3847
- [x] These changes do not require tests because it's a perf improvement

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24148)
<!-- Reviewable:end -->
