### PR TITLE
Enable video frames as OES textures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4183,7 +4183,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#131007e6897a15d57ff5080749ae523e04a0dee0"
+source = "git+https://github.com/servo/media#6e864ed1b3c39e26fa39faad2ab99ef79d83b64d"
 dependencies = [
  "servo-media-audio 0.1.0 (git+https://github.com/servo/media)",
  "servo-media-player 0.1.0 (git+https://github.com/servo/media)",
@@ -4195,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#131007e6897a15d57ff5080749ae523e04a0dee0"
+source = "git+https://github.com/servo/media#6e864ed1b3c39e26fa39faad2ab99ef79d83b64d"
 dependencies = [
  "boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-slice-cast 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4212,7 +4212,7 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#131007e6897a15d57ff5080749ae523e04a0dee0"
+source = "git+https://github.com/servo/media#6e864ed1b3c39e26fa39faad2ab99ef79d83b64d"
 dependencies = [
  "boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipc-channel 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4227,7 +4227,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#131007e6897a15d57ff5080749ae523e04a0dee0"
+source = "git+https://github.com/servo/media#6e864ed1b3c39e26fa39faad2ab99ef79d83b64d"
 dependencies = [
  "boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-slice-cast 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4262,7 +4262,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#131007e6897a15d57ff5080749ae523e04a0dee0"
+source = "git+https://github.com/servo/media#6e864ed1b3c39e26fa39faad2ab99ef79d83b64d"
 dependencies = [
  "gstreamer 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-video 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4272,7 +4272,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#131007e6897a15d57ff5080749ae523e04a0dee0"
+source = "git+https://github.com/servo/media#6e864ed1b3c39e26fa39faad2ab99ef79d83b64d"
 dependencies = [
  "glib 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#131007e6897a15d57ff5080749ae523e04a0dee0"
+source = "git+https://github.com/servo/media#6e864ed1b3c39e26fa39faad2ab99ef79d83b64d"
 dependencies = [
  "ipc-channel 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4297,7 +4297,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#131007e6897a15d57ff5080749ae523e04a0dee0"
+source = "git+https://github.com/servo/media#6e864ed1b3c39e26fa39faad2ab99ef79d83b64d"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4306,12 +4306,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#131007e6897a15d57ff5080749ae523e04a0dee0"
+source = "git+https://github.com/servo/media#6e864ed1b3c39e26fa39faad2ab99ef79d83b64d"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#131007e6897a15d57ff5080749ae523e04a0dee0"
+source = "git+https://github.com/servo/media#6e864ed1b3c39e26fa39faad2ab99ef79d83b64d"
 dependencies = [
  "boxfnonce 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4410,7 +4410,7 @@ dependencies = [
 [[package]]
 name = "servo_media_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#131007e6897a15d57ff5080749ae523e04a0dee0"
+source = "git+https://github.com/servo/media#6e864ed1b3c39e26fa39faad2ab99ef79d83b64d"
 dependencies = [
  "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -214,13 +214,19 @@ impl FrameRenderer for MediaFrameRenderer {
                 *height = frame.get_height();
 
                 let image_data = if frame.is_gl_texture() && self.player_id.is_some() {
+                    let texture_target = if frame.is_external_oes() {
+                        TextureTarget::External
+                    } else {
+                        TextureTarget::Default
+                    };
+
                     self.current_frame_holder
                         .get_or_insert_with(|| FrameHolder::new(frame.clone()))
                         .set(frame);
                     ImageData::External(ExternalImageData {
                         id: ExternalImageId(self.player_id.unwrap()),
                         channel_index: 0,
-                        image_type: ExternalImageType::TextureHandle(TextureTarget::Default),
+                        image_type: ExternalImageType::TextureHandle(texture_target),
                     })
                 } else {
                     ImageData::Raw(frame.get_data())
@@ -232,11 +238,17 @@ impl FrameRenderer for MediaFrameRenderer {
                 self.current_frame = Some((image_key, frame.get_width(), frame.get_height()));
 
                 let image_data = if frame.is_gl_texture() && self.player_id.is_some() {
+                    let texture_target = if frame.is_external_oes() {
+                        TextureTarget::External
+                    } else {
+                        TextureTarget::Default
+                    };
+
                     self.current_frame_holder = Some(FrameHolder::new(frame));
                     ImageData::External(ExternalImageData {
                         id: ExternalImageId(self.player_id.unwrap()),
                         channel_index: 0,
-                        image_type: ExternalImageType::TextureHandle(TextureTarget::Default),
+                        image_type: ExternalImageType::TextureHandle(texture_target),
                     })
                 } else {
                     ImageData::Raw(frame.get_data())


### PR DESCRIPTION
This patch parametrizes WR to handle OES textures if the incoming
frame wraps one.

It requires the update of servo-media package and the according
WR parametrization.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it requires an specific android hardware with certain video decoders

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24174)
<!-- Reviewable:end -->
