### PR TITLE
Initial implementation of WebGLQueries

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1593,6 +1593,23 @@ impl WebGLImpl {
                 depth,
                 stencil,
             } => Self::initialize_framebuffer(ctx.gl(), state, color, depth, stencil),
+            WebGLCommand::BeginQuery(target, query_id) => {
+                ctx.gl().begin_query(target, query_id.get());
+            },
+            WebGLCommand::EndQuery(target) => {
+                ctx.gl().end_query(target);
+            },
+            WebGLCommand::DeleteQuery(query_id) => {
+                ctx.gl().delete_queries(&[query_id.get()]);
+            },
+            WebGLCommand::GenerateQuery(ref sender) => {
+                let id = ctx.gl().gen_queries(1)[0];
+                sender.send(unsafe { WebGLQueryId::new(id) }).unwrap()
+            },
+            WebGLCommand::GetQueryState(ref sender, query_id, pname) => {
+                let value = ctx.gl().get_query_object_uiv(query_id.get(), pname);
+                sender.send(value).unwrap()
+            },
         }
 
         // TODO: update test expectations in order to enable debug assertions

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -427,6 +427,11 @@ pub enum WebGLCommand {
         depth: bool,
         stencil: bool,
     },
+    BeginQuery(u32, WebGLQueryId),
+    DeleteQuery(WebGLQueryId),
+    EndQuery(u32),
+    GenerateQuery(WebGLSender<WebGLQueryId>),
+    GetQueryState(WebGLSender<u32>, WebGLQueryId, u32),
 }
 
 macro_rules! define_resource_id {
@@ -498,6 +503,7 @@ define_resource_id!(WebGLFramebufferId);
 define_resource_id!(WebGLRenderbufferId);
 define_resource_id!(WebGLTextureId);
 define_resource_id!(WebGLProgramId);
+define_resource_id!(WebGLQueryId);
 define_resource_id!(WebGLShaderId);
 define_resource_id!(WebGLVertexArrayId);
 

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -46,7 +46,7 @@ use canvas_traits::canvas::{
 };
 use canvas_traits::canvas::{CompositionOrBlending, LineCapStyle, LineJoinStyle, RepetitionStyle};
 use canvas_traits::webgl::{ActiveAttribInfo, ActiveUniformInfo, GlType, TexDataType, TexFormat};
-use canvas_traits::webgl::{GLFormats, GLLimits};
+use canvas_traits::webgl::{GLFormats, GLLimits, WebGLQueryId};
 use canvas_traits::webgl::{WebGLBufferId, WebGLChan, WebGLContextShareMode, WebGLError};
 use canvas_traits::webgl::{WebGLFramebufferId, WebGLMsgSender, WebGLPipeline, WebGLProgramId};
 use canvas_traits::webgl::{WebGLReceiver, WebGLRenderbufferId, WebGLSLVersion, WebGLSender};
@@ -477,6 +477,7 @@ unsafe_no_jsmanaged_fields!(WebGLFramebufferId);
 unsafe_no_jsmanaged_fields!(WebGLMsgSender);
 unsafe_no_jsmanaged_fields!(WebGLPipeline);
 unsafe_no_jsmanaged_fields!(WebGLProgramId);
+unsafe_no_jsmanaged_fields!(WebGLQueryId);
 unsafe_no_jsmanaged_fields!(WebGLRenderbufferId);
 unsafe_no_jsmanaged_fields!(WebGLShaderId);
 unsafe_no_jsmanaged_fields!(WebGLTextureId);

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -522,6 +522,7 @@ pub mod webglcontextevent;
 pub mod webglframebuffer;
 pub mod webglobject;
 pub mod webglprogram;
+pub mod webglquery;
 pub mod webglrenderbuffer;
 pub mod webglrenderingcontext;
 pub mod webglshader;

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding;
+use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants;
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextMethods;
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLContextAttributes;
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextMethods;
@@ -12,7 +13,7 @@ use crate::dom::bindings::codegen::UnionTypes::ImageDataOrHTMLImageElementOrHTML
 use crate::dom::bindings::codegen::UnionTypes::Int32ArrayOrLongSequence;
 use crate::dom::bindings::error::{ErrorResult, Fallible};
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
-use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom};
+use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::htmlcanvaselement::HTMLCanvasElement;
 use crate::dom::htmliframeelement::HTMLIFrameElement;
@@ -20,6 +21,7 @@ use crate::dom::webglactiveinfo::WebGLActiveInfo;
 use crate::dom::webglbuffer::WebGLBuffer;
 use crate::dom::webglframebuffer::WebGLFramebuffer;
 use crate::dom::webglprogram::WebGLProgram;
+use crate::dom::webglquery::WebGLQuery;
 use crate::dom::webglrenderbuffer::WebGLRenderbuffer;
 use crate::dom::webglrenderingcontext::{
     LayoutCanvasWebGLRenderingContextHelpers, WebGLRenderingContext,
@@ -31,11 +33,12 @@ use crate::dom::webgluniformlocation::WebGLUniformLocation;
 use crate::dom::window::Window;
 use crate::script_runtime::JSContext;
 /// https://www.khronos.org/registry/webgl/specs/latest/2.0/webgl.idl
+use canvas_traits::webgl::WebGLError::*;
 use canvas_traits::webgl::{GLContextAttributes, WebGLVersion};
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use js::jsapi::JSObject;
-use js::jsval::JSVal;
+use js::jsval::{BooleanValue, JSVal, NullValue, UInt32Value};
 use js::rust::CustomAutoRooterGuard;
 use js::typedarray::ArrayBufferView;
 use script_layout_interface::HTMLCanvasDataSource;
@@ -45,6 +48,8 @@ use std::ptr::NonNull;
 pub struct WebGL2RenderingContext {
     reflector_: Reflector,
     base: Dom<WebGLRenderingContext>,
+    occlusion_query: MutNullableDom<WebGLQuery>,
+    primitives_query: MutNullableDom<WebGLQuery>,
 }
 
 impl WebGL2RenderingContext {
@@ -58,6 +63,8 @@ impl WebGL2RenderingContext {
         Some(WebGL2RenderingContext {
             reflector_: Reflector::new(),
             base: Dom::from_ref(&*base),
+            occlusion_query: MutNullableDom::new(None),
+            primitives_query: MutNullableDom::new(None),
         })
     }
 
@@ -1043,6 +1050,152 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.9
     fn VertexAttribDivisor(&self, index: u32, divisor: u32) {
         self.base.vertex_attrib_divisor(index, divisor);
+    }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12
+    fn CreateQuery(&self) -> Option<DomRoot<WebGLQuery>> {
+        Some(WebGLQuery::new(&self.base))
+    }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    fn DeleteQuery(&self, query: Option<&WebGLQuery>) {
+        if let Some(query) = query {
+            handle_potential_webgl_error!(self.base, self.base.validate_ownership(query), return);
+
+            if let Some(query_target) = query.target() {
+                let slot = match query_target {
+                    constants::ANY_SAMPLES_PASSED |
+                    constants::ANY_SAMPLES_PASSED_CONSERVATIVE => {
+                        &self.occlusion_query
+                    },
+                    constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => {
+                        &self.primitives_query
+                    },
+                    _ => unreachable!(),
+                };
+                if let Some(stored_query) = slot.get() {
+                    if stored_query.target() == query.target() {
+                        slot.set(None);
+                    }
+                }
+            }
+
+            query.delete(false);
+        }
+    }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12
+    fn IsQuery(&self, query: Option<&WebGLQuery>) -> bool {
+        match query {
+            Some(query) => self.base.validate_ownership(query).is_ok() && query.is_valid(),
+            None => false,
+        }
+    }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    fn BeginQuery(&self, target: u32, query: &WebGLQuery) {
+        handle_potential_webgl_error!(self.base, self.base.validate_ownership(query), return);
+
+        let active_query = match target {
+            constants::ANY_SAMPLES_PASSED |
+            constants::ANY_SAMPLES_PASSED_CONSERVATIVE => {
+                &self.occlusion_query
+            },
+            constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => {
+                &self.primitives_query
+            },
+            _ => {
+                self.base.webgl_error(InvalidEnum);
+                return;
+            },
+        };
+        if active_query.get().is_some() {
+            self.base.webgl_error(InvalidOperation);
+            return;
+        }
+        let result = query.begin(&self.base, target);
+        match result {
+            Ok(_) => active_query.set(Some(query)),
+            Err(error) => self.base.webgl_error(error),
+        }
+    }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    fn EndQuery(&self, target: u32) {
+        let active_query = match target {
+            constants::ANY_SAMPLES_PASSED |
+            constants::ANY_SAMPLES_PASSED_CONSERVATIVE => {
+                self.occlusion_query.take()
+            },
+            constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => {
+                self.primitives_query.take()
+            },
+            _ => {
+                self.base.webgl_error(InvalidEnum);
+                return;
+            },
+        };
+        match active_query {
+            None => self.base.webgl_error(InvalidOperation),
+            Some(query) => {
+                let result = query.end(&self.base, target);
+                if let Err(error) = result {
+                    self.base.webgl_error(error);
+                }
+            },
+        }
+    }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    fn GetQuery(&self, target: u32, pname: u32) -> Option<DomRoot<WebGLQuery>> {
+        if pname != constants::CURRENT_QUERY {
+            self.base.webgl_error(InvalidEnum);
+            return None;
+        }
+        let active_query = match target {
+            constants::ANY_SAMPLES_PASSED |
+            constants::ANY_SAMPLES_PASSED_CONSERVATIVE => {
+                self.occlusion_query.get()
+            },
+            constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => {
+                self.primitives_query.get()
+            },
+            _ => {
+                self.base.webgl_error(InvalidEnum);
+                None
+            },
+        };
+        if let Some(query) = active_query.as_ref() {
+            if query.target() != Some(target) {
+                return None;
+            }
+        }
+        active_query
+    }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    fn GetQueryParameter(&self, _cx: JSContext, query: &WebGLQuery, pname: u32) -> JSVal {
+        handle_potential_webgl_error!(
+            self.base,
+            self.base.validate_ownership(query),
+            return NullValue()
+        );
+        match query.get_parameter(&self.base, pname) {
+            Ok(value) => match pname {
+                constants::QUERY_RESULT => UInt32Value(value),
+                constants::QUERY_RESULT_AVAILABLE => BooleanValue(value != 0),
+                _ => unreachable!(),
+            },
+            Err(error) => {
+                self.base.webgl_error(error);
+                NullValue()
+            },
+        }
     }
 }
 

--- a/components/script/dom/webglquery.rs
+++ b/components/script/dom/webglquery.rs
@@ -1,0 +1,194 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants;
+use crate::dom::bindings::codegen::Bindings::WebGLQueryBinding;
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::webglobject::WebGLObject;
+use crate::dom::webglrenderingcontext::WebGLRenderingContext;
+use crate::task_source::TaskSource;
+use canvas_traits::webgl::WebGLError::*;
+use canvas_traits::webgl::{webgl_channel, WebGLCommand, WebGLQueryId};
+use dom_struct::dom_struct;
+use std::cell::Cell;
+
+#[dom_struct]
+pub struct WebGLQuery {
+    webgl_object: WebGLObject,
+    gl_id: WebGLQueryId,
+    gl_target: Cell<Option<u32>>,
+    marked_for_deletion: Cell<bool>,
+    query_result_available: Cell<Option<u32>>,
+    query_result: Cell<u32>,
+}
+
+impl WebGLQuery {
+    fn new_inherited(context: &WebGLRenderingContext, id: WebGLQueryId) -> Self {
+        Self {
+            webgl_object: WebGLObject::new_inherited(context),
+            gl_id: id,
+            gl_target: Cell::new(None),
+            marked_for_deletion: Cell::new(false),
+            query_result_available: Cell::new(None),
+            query_result: Cell::new(0),
+        }
+    }
+
+    pub fn new(context: &WebGLRenderingContext) -> DomRoot<Self> {
+        let (sender, receiver) = webgl_channel().unwrap();
+        context.send_command(WebGLCommand::GenerateQuery(sender));
+        let id = receiver.recv().unwrap();
+
+        reflect_dom_object(
+            Box::new(Self::new_inherited(context, id)),
+            &*context.global(),
+            WebGLQueryBinding::Wrap,
+        )
+    }
+
+    pub fn begin(
+        &self,
+        context: &WebGLRenderingContext,
+        target: u32,
+    ) -> Result<(), canvas_traits::webgl::WebGLError> {
+        if self.marked_for_deletion.get() {
+            return Err(InvalidOperation);
+        }
+        if let Some(current_target) = self.gl_target.get() {
+            if current_target != target {
+                return Err(InvalidOperation);
+            }
+        }
+        match target {
+            constants::ANY_SAMPLES_PASSED |
+            constants::ANY_SAMPLES_PASSED_CONSERVATIVE |
+            constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => (),
+            _ => return Err(InvalidEnum),
+        }
+        self.gl_target.set(Some(target));
+
+        context.send_command(WebGLCommand::BeginQuery(target, self.gl_id));
+        Ok(())
+    }
+
+    pub fn end(
+        &self,
+        context: &WebGLRenderingContext,
+        target: u32,
+    ) -> Result<(), canvas_traits::webgl::WebGLError> {
+        if self.marked_for_deletion.get() {
+            return Err(InvalidOperation);
+        }
+        if let Some(current_target) = self.gl_target.get() {
+            if current_target != target {
+                return Err(InvalidOperation);
+            }
+        }
+        match target {
+            constants::ANY_SAMPLES_PASSED |
+            constants::ANY_SAMPLES_PASSED_CONSERVATIVE |
+            constants::TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN => (),
+            _ => return Err(InvalidEnum),
+        }
+        context.send_command(WebGLCommand::EndQuery(target));
+        Ok(())
+    }
+
+    pub fn delete(&self, fallible: bool) {
+        if !self.marked_for_deletion.get() {
+            self.marked_for_deletion.set(true);
+
+            let context = self.upcast::<WebGLObject>().context();
+            let command = WebGLCommand::DeleteQuery(self.gl_id);
+            if fallible {
+                context.send_command_ignored(command);
+            } else {
+                context.send_command(command);
+            }
+        }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        !self.marked_for_deletion.get() && self.target().is_some()
+    }
+
+    pub fn target(&self) -> Option<u32> {
+        self.gl_target.get()
+    }
+
+    fn update_results(&self, context: &WebGLRenderingContext) {
+        let (sender, receiver) = webgl_channel().unwrap();
+        context.send_command(WebGLCommand::GetQueryState(
+            sender,
+            self.gl_id,
+            constants::QUERY_RESULT_AVAILABLE,
+        ));
+        let is_available = receiver.recv().unwrap();
+        if is_available == 0 {
+            self.query_result_available.set(None);
+            return;
+        }
+
+        let (sender, receiver) = webgl_channel().unwrap();
+        context.send_command(WebGLCommand::GetQueryState(
+            sender,
+            self.gl_id,
+            constants::QUERY_RESULT,
+        ));
+
+        self.query_result.set(receiver.recv().unwrap());
+        self.query_result_available.set(Some(is_available));
+    }
+
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    pub fn get_parameter(
+        &self,
+        context: &WebGLRenderingContext,
+        pname: u32,
+    ) -> Result<u32, canvas_traits::webgl::WebGLError> {
+        if !self.is_valid() {
+            return Err(InvalidOperation);
+        }
+        match pname {
+            constants::QUERY_RESULT |
+            constants::QUERY_RESULT_AVAILABLE => {},
+            _ => return Err(InvalidEnum),
+        }
+
+        if self.query_result_available.get().is_none() {
+            self.query_result_available.set(Some(0));
+
+            let this = Trusted::new(self);
+            let context = Trusted::new(context);
+            let task = task!(request_query_state: move || {
+                let this = this.root();
+                let context = context.root();
+                this.update_results(&context);
+            });
+
+            let global = self.global();
+            global
+                .as_window()
+                .task_manager()
+                .dom_manipulation_task_source()
+                .queue(task, global.upcast())
+                .unwrap();
+        }
+
+        match pname {
+            constants::QUERY_RESULT => Ok(self.query_result.get()),
+            constants::QUERY_RESULT_AVAILABLE => Ok(self.query_result_available.get().unwrap()),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Drop for WebGLQuery {
+    fn drop(&mut self) {
+        self.delete(true);
+    }
+}

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -396,7 +396,7 @@ impl WebGLRenderingContext {
         }
     }
 
-    fn validate_ownership<T>(&self, object: &T) -> WebGLResult<()>
+    pub fn validate_ownership<T>(&self, object: &T) -> WebGLResult<()>
     where
         T: DerivedFrom<WebGLObject>,
     {

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -12,9 +12,6 @@ typedef long long GLint64;
 typedef unsigned long long GLuint64;
 
 
-// interface WebGLQuery : WebGLObject {
-// };
-
 // interface WebGLSampler : WebGLObject {
 // };
 
@@ -528,13 +525,13 @@ interface WebGL2RenderingContextBase
   // void clearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
 
   /* Query Objects */
-  /*WebGLQuery? createQuery();
+  WebGLQuery? createQuery();
   void deleteQuery(WebGLQuery? query);
-  [WebGLHandlesContextLoss] GLboolean isQuery(WebGLQuery? query);
+  /*[WebGLHandlesContextLoss]*/ GLboolean isQuery(WebGLQuery? query);
   void beginQuery(GLenum target, WebGLQuery query);
   void endQuery(GLenum target);
   WebGLQuery? getQuery(GLenum target, GLenum pname);
-  any getQueryParameter(WebGLQuery query, GLenum pname);*/
+  any getQueryParameter(WebGLQuery query, GLenum pname);
 
   /* Sampler Objects */
   /*WebGLSampler? createSampler();

--- a/components/script/dom/webidls/WebGLQuery.webidl
+++ b/components/script/dom/webidls/WebGLQuery.webidl
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//
+// WebGL IDL definitions scraped from the Khronos specification:
+// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.8
+//
+
+[Exposed=Window, Pref="dom.webgl2.enabled"]
+interface WebGLQuery : WebGLObject {
+};

--- a/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
@@ -1,259 +1,238 @@
 [methods-2.html]
-  [WebGL test #0: Property either does not exist or is not a function: isContextLost]
-    expected: FAIL
-
-  [WebGL test #1: Property either does not exist or is not a function: getBufferSubData]
-    expected: FAIL
-
-  [WebGL test #2: Property either does not exist or is not a function: copyBufferSubData]
-    expected: FAIL
-
-  [WebGL test #3: Property either does not exist or is not a function: blitFramebuffer]
-    expected: FAIL
-
-  [WebGL test #4: Property either does not exist or is not a function: framebufferTextureLayer]
-    expected: FAIL
-
-  [WebGL test #5: Property either does not exist or is not a function: getInternalformatParameter]
-    expected: FAIL
-
-  [WebGL test #6: Property either does not exist or is not a function: invalidateFramebuffer]
-    expected: FAIL
-
-  [WebGL test #7: Property either does not exist or is not a function: invalidateSubFramebuffer]
-    expected: FAIL
-
-  [WebGL test #8: Property either does not exist or is not a function: readBuffer]
-    expected: FAIL
-
-  [WebGL test #9: Property either does not exist or is not a function: renderbufferStorageMultisample]
-    expected: FAIL
-
-  [WebGL test #10: Property either does not exist or is not a function: texImage3D]
-    expected: FAIL
-
-  [WebGL test #11: Property either does not exist or is not a function: texStorage2D]
-    expected: FAIL
-
-  [WebGL test #12: Property either does not exist or is not a function: texStorage3D]
-    expected: FAIL
-
-  [WebGL test #13: Property either does not exist or is not a function: texSubImage3D]
-    expected: FAIL
-
-  [WebGL test #14: Property either does not exist or is not a function: copyTexSubImage3D]
-    expected: FAIL
-
-  [WebGL test #15: Property either does not exist or is not a function: compressedTexImage3D]
-    expected: FAIL
-
-  [WebGL test #16: Property either does not exist or is not a function: compressedTexSubImage3D]
-    expected: FAIL
-
-  [WebGL test #17: Property either does not exist or is not a function: getFragDataLocation]
-    expected: FAIL
-
-  [WebGL test #18: Property either does not exist or is not a function: uniform1ui]
-    expected: FAIL
-
-  [WebGL test #19: Property either does not exist or is not a function: uniform2ui]
-    expected: FAIL
-
-  [WebGL test #20: Property either does not exist or is not a function: uniform3ui]
-    expected: FAIL
-
-  [WebGL test #21: Property either does not exist or is not a function: uniform4ui]
-    expected: FAIL
-
-  [WebGL test #22: Property either does not exist or is not a function: uniform1uiv]
-    expected: FAIL
-
-  [WebGL test #23: Property either does not exist or is not a function: uniform2uiv]
-    expected: FAIL
-
-  [WebGL test #24: Property either does not exist or is not a function: uniform3uiv]
-    expected: FAIL
-
   [WebGL test #25: Property either does not exist or is not a function: uniform4uiv]
-    expected: FAIL
-
-  [WebGL test #26: Property either does not exist or is not a function: uniformMatrix2x3fv]
-    expected: FAIL
-
-  [WebGL test #27: Property either does not exist or is not a function: uniformMatrix3x2fv]
     expected: FAIL
 
   [WebGL test #28: Property either does not exist or is not a function: uniformMatrix2x4fv]
     expected: FAIL
 
-  [WebGL test #29: Property either does not exist or is not a function: uniformMatrix4x2fv]
+  [WebGL test #48: Property either does not exist or is not a function: samplerParameterf]
+    expected: FAIL
+
+  [WebGL test #1: Property either does not exist or is not a function: getBufferSubData]
+    expected: FAIL
+
+  [WebGL test #52: Property either does not exist or is not a function: deleteSync]
     expected: FAIL
 
   [WebGL test #30: Property either does not exist or is not a function: uniformMatrix3x4fv]
     expected: FAIL
 
-  [WebGL test #31: Property either does not exist or is not a function: uniformMatrix4x3fv]
+  [WebGL test #14: Property either does not exist or is not a function: copyTexSubImage3D]
     expected: FAIL
 
-  [WebGL test #32: Property either does not exist or is not a function: vertexAttribI4i]
+  [WebGL test #27: Property either does not exist or is not a function: uniformMatrix3x2fv]
+    expected: FAIL
+
+  [WebGL test #74: Property either does not exist or is not a function: uniformBlockBinding]
+    expected: FAIL
+
+  [WebGL test #59: Property either does not exist or is not a function: bindTransformFeedback]
+    expected: FAIL
+
+  [WebGL test #73: Property either does not exist or is not a function: getActiveUniformBlockName]
+    expected: FAIL
+
+  [WebGL test #72: Property either does not exist or is not a function: getActiveUniformBlockParameter]
+    expected: FAIL
+
+  [WebGL test #63: Property either does not exist or is not a function: getTransformFeedbackVarying]
+    expected: FAIL
+
+  [WebGL test #50: Property either does not exist or is not a function: fenceSync]
+    expected: FAIL
+
+  [WebGL test #3: Property either does not exist or is not a function: blitFramebuffer]
     expected: FAIL
 
   [WebGL test #33: Property either does not exist or is not a function: vertexAttribI4iv]
     expected: FAIL
 
-  [WebGL test #34: Property either does not exist or is not a function: vertexAttribI4ui]
+  [WebGL test #61: Property either does not exist or is not a function: endTransformFeedback]
     expected: FAIL
 
-  [WebGL test #35: Property either does not exist or is not a function: vertexAttribI4uiv]
+  [WebGL test #67: Property either does not exist or is not a function: bindBufferRange]
+    expected: FAIL
+
+  [WebGL test #69: Property either does not exist or is not a function: getUniformIndices]
+    expected: FAIL
+
+  [WebGL test #2: Property either does not exist or is not a function: copyBufferSubData]
+    expected: FAIL
+
+  [WebGL test #23: Property either does not exist or is not a function: uniform2uiv]
+    expected: FAIL
+
+  [WebGL test #31: Property either does not exist or is not a function: uniformMatrix4x3fv]
     expected: FAIL
 
   [WebGL test #36: Property either does not exist or is not a function: vertexAttribIPointer]
     expected: FAIL
 
-  [WebGL test #37: Property either does not exist or is not a function: drawRangeElements]
+  [WebGL test #54: Property either does not exist or is not a function: waitSync]
     expected: FAIL
 
-  [WebGL test #38: Property either does not exist or is not a function: drawBuffers]
+  [WebGL test #8: Property either does not exist or is not a function: readBuffer]
     expected: FAIL
 
-  [WebGL test #39: Property either does not exist or is not a function: clearBufferiv]
+  [WebGL test #35: Property either does not exist or is not a function: vertexAttribI4uiv]
     expected: FAIL
 
-  [WebGL test #40: Property either does not exist or is not a function: clearBufferuiv]
+  [WebGL test #5: Property either does not exist or is not a function: getInternalformatParameter]
+    expected: FAIL
+
+  [WebGL test #47: Property either does not exist or is not a function: samplerParameteri]
+    expected: FAIL
+
+  [WebGL test #53: Property either does not exist or is not a function: clientWaitSync]
+    expected: FAIL
+
+  [WebGL test #66: Property either does not exist or is not a function: bindBufferBase]
+    expected: FAIL
+
+  [WebGL test #56: Property either does not exist or is not a function: createTransformFeedback]
+    expected: FAIL
+
+  [WebGL test #32: Property either does not exist or is not a function: vertexAttribI4i]
+    expected: FAIL
+
+  [WebGL test #77: Property either does not exist or is not a function: isVertexArray]
+    expected: FAIL
+
+  [WebGL test #64: Property either does not exist or is not a function: pauseTransformFeedback]
     expected: FAIL
 
   [WebGL test #41: Property either does not exist or is not a function: clearBufferfv]
     expected: FAIL
 
+  [WebGL test #17: Property either does not exist or is not a function: getFragDataLocation]
+    expected: FAIL
+
+  [WebGL test #68: Property either does not exist or is not a function: getIndexedParameter]
+    expected: FAIL
+
+  [WebGL test #15: Property either does not exist or is not a function: compressedTexImage3D]
+    expected: FAIL
+
+  [WebGL test #43: Property either does not exist or is not a function: createSampler]
+    expected: FAIL
+
+  [WebGL test #34: Property either does not exist or is not a function: vertexAttribI4ui]
+    expected: FAIL
+
+  [WebGL test #55: Property either does not exist or is not a function: getSyncParameter]
+    expected: FAIL
+
+  [WebGL test #6: Property either does not exist or is not a function: invalidateFramebuffer]
+    expected: FAIL
+
+  [WebGL test #78: Property either does not exist or is not a function: bindVertexArray]
+    expected: FAIL
+
   [WebGL test #42: Property either does not exist or is not a function: clearBufferfi]
     expected: FAIL
 
-  [WebGL test #43: Property either does not exist or is not a function: createQuery]
+  [WebGL test #24: Property either does not exist or is not a function: uniform3uiv]
     expected: FAIL
 
-  [WebGL test #44: Property either does not exist or is not a function: deleteQuery]
+  [WebGL test #51: Property either does not exist or is not a function: isSync]
     expected: FAIL
 
-  [WebGL test #45: Property either does not exist or is not a function: isQuery]
+  [WebGL test #37: Property either does not exist or is not a function: drawRangeElements]
     expected: FAIL
 
-  [WebGL test #46: Property either does not exist or is not a function: beginQuery]
+  [WebGL test #39: Property either does not exist or is not a function: clearBufferiv]
     expected: FAIL
 
-  [WebGL test #47: Property either does not exist or is not a function: endQuery]
+  [WebGL test #46: Property either does not exist or is not a function: bindSampler]
     expected: FAIL
 
-  [WebGL test #48: Property either does not exist or is not a function: getQuery]
+  [WebGL test #16: Property either does not exist or is not a function: compressedTexSubImage3D]
     expected: FAIL
 
-  [WebGL test #49: Property either does not exist or is not a function: getQueryParameter]
+  [WebGL test #38: Property either does not exist or is not a function: drawBuffers]
     expected: FAIL
 
-  [WebGL test #50: Property either does not exist or is not a function: createSampler]
+  [WebGL test #60: Property either does not exist or is not a function: beginTransformFeedback]
     expected: FAIL
 
-  [WebGL test #51: Property either does not exist or is not a function: deleteSampler]
+  [WebGL test #0: Property either does not exist or is not a function: isContextLost]
     expected: FAIL
 
-  [WebGL test #52: Property either does not exist or is not a function: isSampler]
+  [WebGL test #9: Property either does not exist or is not a function: renderbufferStorageMultisample]
     expected: FAIL
 
-  [WebGL test #53: Property either does not exist or is not a function: bindSampler]
+  [WebGL test #18: Property either does not exist or is not a function: uniform1ui]
     expected: FAIL
 
-  [WebGL test #54: Property either does not exist or is not a function: samplerParameteri]
+  [WebGL test #7: Property either does not exist or is not a function: invalidateSubFramebuffer]
     expected: FAIL
 
-  [WebGL test #55: Property either does not exist or is not a function: samplerParameterf]
+  [WebGL test #40: Property either does not exist or is not a function: clearBufferuiv]
     expected: FAIL
 
-  [WebGL test #56: Property either does not exist or is not a function: getSamplerParameter]
+  [WebGL test #70: Property either does not exist or is not a function: getActiveUniforms]
     expected: FAIL
 
-  [WebGL test #57: Property either does not exist or is not a function: fenceSync]
+  [WebGL test #58: Property either does not exist or is not a function: isTransformFeedback]
     expected: FAIL
 
-  [WebGL test #58: Property either does not exist or is not a function: isSync]
+  [WebGL test #71: Property either does not exist or is not a function: getUniformBlockIndex]
     expected: FAIL
 
-  [WebGL test #59: Property either does not exist or is not a function: deleteSync]
+  [WebGL test #21: Property either does not exist or is not a function: uniform4ui]
     expected: FAIL
 
-  [WebGL test #60: Property either does not exist or is not a function: clientWaitSync]
+  [WebGL test #65: Property either does not exist or is not a function: resumeTransformFeedback]
     expected: FAIL
 
-  [WebGL test #61: Property either does not exist or is not a function: waitSync]
+  [WebGL test #11: Property either does not exist or is not a function: texStorage2D]
     expected: FAIL
 
-  [WebGL test #62: Property either does not exist or is not a function: getSyncParameter]
+  [WebGL test #19: Property either does not exist or is not a function: uniform2ui]
     expected: FAIL
 
-  [WebGL test #63: Property either does not exist or is not a function: createTransformFeedback]
+  [WebGL test #26: Property either does not exist or is not a function: uniformMatrix2x3fv]
     expected: FAIL
 
-  [WebGL test #64: Property either does not exist or is not a function: deleteTransformFeedback]
+  [WebGL test #76: Property either does not exist or is not a function: deleteVertexArray]
     expected: FAIL
 
-  [WebGL test #65: Property either does not exist or is not a function: isTransformFeedback]
+  [WebGL test #49: Property either does not exist or is not a function: getSamplerParameter]
     expected: FAIL
 
-  [WebGL test #66: Property either does not exist or is not a function: bindTransformFeedback]
+  [WebGL test #29: Property either does not exist or is not a function: uniformMatrix4x2fv]
     expected: FAIL
 
-  [WebGL test #67: Property either does not exist or is not a function: beginTransformFeedback]
+  [WebGL test #57: Property either does not exist or is not a function: deleteTransformFeedback]
     expected: FAIL
 
-  [WebGL test #68: Property either does not exist or is not a function: endTransformFeedback]
+  [WebGL test #20: Property either does not exist or is not a function: uniform3ui]
     expected: FAIL
 
-  [WebGL test #69: Property either does not exist or is not a function: transformFeedbackVaryings]
+  [WebGL test #22: Property either does not exist or is not a function: uniform1uiv]
     expected: FAIL
 
-  [WebGL test #70: Property either does not exist or is not a function: getTransformFeedbackVarying]
+  [WebGL test #4: Property either does not exist or is not a function: framebufferTextureLayer]
     expected: FAIL
 
-  [WebGL test #71: Property either does not exist or is not a function: pauseTransformFeedback]
+  [WebGL test #75: Property either does not exist or is not a function: createVertexArray]
     expected: FAIL
 
-  [WebGL test #72: Property either does not exist or is not a function: resumeTransformFeedback]
+  [WebGL test #44: Property either does not exist or is not a function: deleteSampler]
     expected: FAIL
 
-  [WebGL test #73: Property either does not exist or is not a function: bindBufferBase]
+  [WebGL test #12: Property either does not exist or is not a function: texStorage3D]
     expected: FAIL
 
-  [WebGL test #74: Property either does not exist or is not a function: bindBufferRange]
+  [WebGL test #10: Property either does not exist or is not a function: texImage3D]
     expected: FAIL
 
-  [WebGL test #75: Property either does not exist or is not a function: getIndexedParameter]
+  [WebGL test #45: Property either does not exist or is not a function: isSampler]
     expected: FAIL
 
-  [WebGL test #76: Property either does not exist or is not a function: getUniformIndices]
+  [WebGL test #62: Property either does not exist or is not a function: transformFeedbackVaryings]
     expected: FAIL
 
-  [WebGL test #77: Property either does not exist or is not a function: getActiveUniforms]
-    expected: FAIL
-
-  [WebGL test #78: Property either does not exist or is not a function: getUniformBlockIndex]
-    expected: FAIL
-
-  [WebGL test #79: Property either does not exist or is not a function: getActiveUniformBlockParameter]
-    expected: FAIL
-
-  [WebGL test #80: Property either does not exist or is not a function: getActiveUniformBlockName]
-    expected: FAIL
-
-  [WebGL test #81: Property either does not exist or is not a function: uniformBlockBinding]
-    expected: FAIL
-
-  [WebGL test #82: Property either does not exist or is not a function: createVertexArray]
-    expected: FAIL
-
-  [WebGL test #83: Property either does not exist or is not a function: deleteVertexArray]
-    expected: FAIL
-
-  [WebGL test #84: Property either does not exist or is not a function: isVertexArray]
-    expected: FAIL
-
-  [WebGL test #85: Property either does not exist or is not a function: bindVertexArray]
+  [WebGL test #13: Property either does not exist or is not a function: texSubImage3D]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/query/occlusion-query.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/query/occlusion-query.html.ini
@@ -1,2 +1,25 @@
 [occlusion-query.html]
-  expected: ERROR
+  [WebGL test #2: Occlusion query ANY_SAMPLES_PASSED_CONSERVATIVE returned an incorrect result 0 (expected 1)]
+    expected: FAIL
+
+  [WebGL test #16: Occlusion query ANY_SAMPLES_PASSED returned an incorrect result 0 (expected 1)]
+    expected: FAIL
+
+  [WebGL test #10: Occlusion query ANY_SAMPLES_PASSED_CONSERVATIVE returned an incorrect result 0 (expected 1)]
+    expected: FAIL
+
+  [WebGL test #4: Occlusion query ANY_SAMPLES_PASSED returned an incorrect result 0 (expected 1)]
+    expected: FAIL
+
+  [WebGL test #6: Occlusion query ANY_SAMPLES_PASSED_CONSERVATIVE returned an incorrect result 0 (expected 1)]
+    expected: FAIL
+
+  [WebGL test #14: Occlusion query ANY_SAMPLES_PASSED_CONSERVATIVE returned an incorrect result 0 (expected 1)]
+    expected: FAIL
+
+  [WebGL test #12: Occlusion query ANY_SAMPLES_PASSED returned an incorrect result 0 (expected 1)]
+    expected: FAIL
+
+  [WebGL test #8: Occlusion query ANY_SAMPLES_PASSED returned an incorrect result 0 (expected 1)]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/query/query.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/query/query.html.ini
@@ -1,5 +1,0 @@
-[query.html]
-  expected: ERROR
-  [WebGL test #4: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-


### PR DESCRIPTION
This patch adds initial support for WeGLQueries. Most related WebGL functions and objects ([1]) are implemented; what's still missing is:

- syncing the result of `getQueryParameter` with the event loop
- `EXT_disjoint_timer_query_webgl2` support

[1]: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.12

<!-- Please describe your changes on the following line: -->
cc @jdm @zakorgy 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24178)
<!-- Reviewable:end -->
