### PR TITLE
Use updated gstreamer binaries for UWP.

### DIFF
--- a/python/servo/packages.py
+++ b/python/servo/packages.py
@@ -9,6 +9,6 @@ WINDOWS_MSVC = {
     "ninja": "1.7.1",
     "nuget": "08-08-2019",
     "openssl": "111.3.0+1.1.1c-vs2017",
-    "gstreamer-uwp": "1.16.0.3",
+    "gstreamer-uwp": "1.16.0.4",
     "openxr-loader-uwp": "1.0",
 }


### PR DESCRIPTION
This removes a bunch of WACK errors.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because no tests on windows

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24183)
<!-- Reviewable:end -->
