### PR TITLE
Pull in CRT runtime on VS 2019 as well

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -951,7 +951,7 @@ def package_msvc_dlls(servo_exe_dir, target, vcinstalldir, vs_version):
         "msvcp140.dll",
         "vcruntime140.dll",
     ]
-    if target_arch != "aarch64" and vs_version in ("14.0", "15.0"):
+    if target_arch != "aarch64" and vs_version in ("14.0", "15.0", "16.0"):
         msvc_deps += ["api-ms-win-crt-runtime-l1-1-0.dll"]
 
     # Check if it's Visual C++ Build Tools or Visual Studio 2015


### PR DESCRIPTION
Building for x64 UWP leads to the build system complaining about this DLL not being in the target/ folder.

I think these three VS versions are the only ones we support, perhaps we should remove this check entirely and unconditionally include this DLL?


r? @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24197)
<!-- Reviewable:end -->
