### PR TITLE
Update sparkle for GLES fix.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
  "raqote 0.6.2-alpha.0 (git+https://github.com/jrmuizel/raqote)",
  "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_config 0.0.1",
- "sparkle 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sparkle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender 0.60.0 (git+https://github.com/servo/webrender)",
  "webrender_api 0.60.0 (git+https://github.com/servo/webrender)",
  "webrender_traits 0.0.1",
@@ -429,7 +429,7 @@ dependencies = [
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo_config 0.0.1",
- "sparkle 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sparkle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "typetag 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "webrender_api 0.60.0 (git+https://github.com/servo/webrender)",
  "webvr_traits 0.0.1",
@@ -2587,7 +2587,7 @@ dependencies = [
  "servo_config 0.0.1",
  "servo_geometry 0.0.1",
  "servo_url 0.0.1",
- "sparkle 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sparkle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "webdriver_server 0.0.1",
@@ -3215,7 +3215,7 @@ dependencies = [
  "objc 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
- "sparkle 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sparkle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11 2.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3818,7 +3818,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ovr-mobile-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-webvr-api 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sparkle 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sparkle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3830,7 +3830,7 @@ dependencies = [
  "ipc-channel 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
- "sparkle 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sparkle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3959,7 +3959,7 @@ dependencies = [
  "servo_rand 0.0.1",
  "servo_url 0.0.1",
  "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "sparkle 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sparkle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "style 0.0.1",
  "style_traits 0.0.1",
  "swapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4638,7 +4638,7 @@ dependencies = [
 
 [[package]]
 name = "sparkle"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gl_generator 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5625,7 +5625,7 @@ dependencies = [
  "rust-webvr-api 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "script_traits 0.0.1",
  "servo_config 0.0.1",
- "sparkle 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sparkle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webvr_traits 0.0.1",
 ]
 
@@ -6228,7 +6228,7 @@ dependencies = [
 "checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
 "checksum smithay-client-toolkit 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2ccb8c57049b2a34d2cc2b203fa785020ba0129d31920ef0d317430adaf748fa"
 "checksum socket2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ff606e0486e88f5fc6cfeb3966e434fb409abbc7a3ab495238f70a1ca97f789d"
-"checksum sparkle 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c1e884e45eaf4690757766eb966b40309cd417a174b30d897e45d8e717875c7d"
+"checksum sparkle 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c5865f9c97493fa06817344e79fce24161e3ff74c9f45658f569ec0cdac5f20e"
 "checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum stb_truetype 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "48fa7d3136d8645909de1f7c7eb5416cc43057a75ace08fc39ae736bc9da8af1"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24206
- [x] These changes do not require tests because no GLES tests on CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24212)
<!-- Reviewable:end -->
