### PR TITLE
Skip timing out test directories for unimplemented features

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -91,6 +91,14 @@ skip: true
     skip: true
   [semantics]
     skip: false
+    [document-metadata]
+      skip: false
+      [the-meta-element]
+        skip: false
+        [pragma-directives]
+          skip: false
+          [attr-meta-http-equiv-refresh]
+            skip: true
     [embedded-content]
       skip: false
       [media-elements]

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -87,6 +87,16 @@ skip: true
   skip: false
   [semantics]
     skip: false
+    [embedded-content]
+      skip: false
+      [media-elements]
+        skip: false
+        [track]
+          skip: false
+          [track-element]
+            skip: false
+            [cors]
+              skip: true
     [scripting-1]
       skip: false
       [the-script-element]

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -111,6 +111,14 @@ skip: true
   skip: false
 [referrer-policy]
   skip: false
+  [gen]
+    skip: false
+    [srcdoc-inherit.http-rp]
+      skip: true
+    [srcdoc-inherit.meta]
+      skip: true
+    [srcdoc.meta]
+      skip: true
 [resource-timing]
   skip: false
 [subresource-integrity]

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -173,5 +173,7 @@ skip: true
   skip: false
 [workers]
   skip: false
+  [modules]
+    skip: true
 [xhr]
   skip: false

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -85,6 +85,10 @@ skip: true
   skip: false
 [html]
   skip: false
+  [cross-origin-embedder-policy]
+    skip: true
+  [cross-origin-opener-policy]
+    skip: true
   [semantics]
     skip: false
     [embedded-content]

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -113,6 +113,8 @@ skip: true
       skip: false
       [the-script-element]
         skip: false
+        [json-module]
+          skip: true
         [module]
           skip: true
 [js]


### PR DESCRIPTION
Based on an analysis of the logs of a recent WPT test run on CI, these are some of the biggest offenders for timing out tests and we get no value from continuing to run them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24216)
<!-- Reviewable:end -->
