### PR TITLE
ISSUE-23995: lazily generate UniqueIds for Nodes

### DIFF
--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -7,6 +7,7 @@ use crate::dom::customelementregistry::{
     CustomElementDefinition, CustomElementReaction, CustomElementState,
 };
 use crate::dom::mutationobserver::RegisteredObserver;
+use crate::dom::node::UniqueId;
 use crate::dom::shadowroot::ShadowRoot;
 use std::rc::Rc;
 
@@ -22,6 +23,8 @@ pub struct NodeRareData {
     pub containing_shadow_root: Option<Dom<ShadowRoot>>,
     /// Registered observers for this node.
     pub mutation_observers: Vec<RegisteredObserver>,
+    /// Lazily-generated Unique Id for this node.
+    pub unique_id: Option<UniqueId>,
 }
 
 #[derive(Default, JSTraceable, MallocSizeOf)]

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -30,10 +30,10 @@ macro_rules! sizeof_checker (
 
 // Update the sizes here
 sizeof_checker!(size_event_target, EventTarget, 56);
-sizeof_checker!(size_node, Node, 184);
-sizeof_checker!(size_element, Element, 392);
-sizeof_checker!(size_htmlelement, HTMLElement, 408);
-sizeof_checker!(size_div, HTMLDivElement, 408);
-sizeof_checker!(size_span, HTMLSpanElement, 408);
-sizeof_checker!(size_text, Text, 216);
-sizeof_checker!(size_characterdata, CharacterData, 216);
+sizeof_checker!(size_node, Node, 176);
+sizeof_checker!(size_element, Element, 384);
+sizeof_checker!(size_htmlelement, HTMLElement, 400);
+sizeof_checker!(size_div, HTMLDivElement, 400);
+sizeof_checker!(size_span, HTMLSpanElement, 400);
+sizeof_checker!(size_text, Text, 208);
+sizeof_checker!(size_characterdata, CharacterData, 208);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Updated `Node` so that its `unique_id` is only generated when `unique_id()` is called. This getter now also has assumed the responsibility for saving the `id` to the global hashset on `ScriptThread`. 

Felt like I was fighting the borrow-checker a little bit on this one. Definitely a good learning experience for me, but the result strikes me as a little messy? 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23995 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24217)
<!-- Reviewable:end -->
