### PR TITLE
Fix python precedence issue.

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -381,7 +381,7 @@ def appx_artifact(debug, platforms):
         'hololens',
         'AppPackages',
         'ServoApp',
-        'ServoApp_1.0.0.0_%sTest' % 'Debug_' if debug else '',
+        'ServoApp_1.0.0.0_%sTest' % ('Debug_' if debug else ''),
         'ServoApp_1.0.0.0_%s%s.appxbundle' % (
             '_'.join(platforms), '_Debug' if debug else ''
         ),


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24228
- [x] These changes do not require tests because nightly builds are tricky to trigger manually

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24229)
<!-- Reviewable:end -->
