### PR TITLE
Use EGL context and display parameters when initializing magicleap servo

### DIFF
--- a/ports/libmlservo/src/lib.rs
+++ b/ports/libmlservo/src/lib.rs
@@ -173,8 +173,8 @@ pub unsafe extern "C" fn init_servo(
         vr_init,
         xr_discovery,
         coordinates,
-        gl_context_pointer: Some(gl.gl_context),
-        native_display_pointer: Some(gl.display),
+        gl_context_pointer: Some(ctxt),
+        native_display_pointer: Some(disp),
     };
     let wakeup = Box::new(EventLoopWakerInstance);
     let shut_down_complete = Rc::new(Cell::new(false));


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Initialize magicleap servo using the provided EGL context and display, not the current ones. (This was causing problems for gstreamer getting the wrong display id).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's embedding initialization

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24235)
<!-- Reviewable:end -->
