### PR TITLE
Initial implementation of WebGLSync

### DIFF
--- a/components/canvas/gl_context.rs
+++ b/components/canvas/gl_context.rs
@@ -238,6 +238,7 @@ fn map_limits(limits: RawGLLimits) -> GLLimits {
         max_varying_vectors: limits.max_varying_vectors,
         max_vertex_texture_image_units: limits.max_vertex_texture_image_units,
         max_vertex_uniform_vectors: limits.max_vertex_uniform_vectors,
+        max_client_wait_timeout_webgl: std::time::Duration::new(1, 0),
     }
 }
 

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1360,6 +1360,33 @@ impl WebGLImpl {
                 }
                 sender.send(value[0] != 0).unwrap()
             },
+            WebGLCommand::FenceSync(ref sender) => {
+                let value = ctx.gl().fence_sync(gl::SYNC_GPU_COMMANDS_COMPLETE, 0);
+                sender
+                    .send(unsafe { WebGLSyncId::new(value as u64) })
+                    .unwrap();
+            },
+            WebGLCommand::IsSync(sync_id, ref sender) => {
+                let value = ctx.gl().is_sync(sync_id.get() as *const _);
+                sender.send(value).unwrap();
+            },
+            WebGLCommand::ClientWaitSync(sync_id, flags, timeout, ref sender) => {
+                let value =
+                    ctx.gl()
+                        .client_wait_sync(sync_id.get() as *const _, flags, timeout as u64);
+                sender.send(value).unwrap();
+            },
+            WebGLCommand::WaitSync(sync_id, flags, timeout) => {
+                ctx.gl()
+                    .wait_sync(sync_id.get() as *const _, flags, timeout as u64);
+            },
+            WebGLCommand::GetSyncParameter(sync_id, param, ref sender) => {
+                let value = ctx.gl().get_sync_iv(sync_id.get() as *const _, param);
+                sender.send(value[0] as u32).unwrap();
+            },
+            WebGLCommand::DeleteSync(sync_id) => {
+                ctx.gl().delete_sync(sync_id.get() as *const _);
+            },
             WebGLCommand::GetParameterBool4(param, ref sender) => {
                 let mut value = [0; 4];
                 unsafe {

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -9,7 +9,7 @@ use sparkle::gl;
 use sparkle::gl::Gl;
 use std::borrow::Cow;
 use std::fmt;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroU64};
 use std::ops::Deref;
 use webrender_api::{DocumentId, ImageKey, PipelineId};
 use webvr_traits::WebVRPoseInformation;
@@ -280,6 +280,12 @@ pub enum WebGLCommand {
     StencilMaskSeparate(u32, u32),
     StencilOp(u32, u32, u32),
     StencilOpSeparate(u32, u32, u32, u32),
+    FenceSync(WebGLSender<WebGLSyncId>),
+    IsSync(WebGLSyncId, WebGLSender<bool>),
+    ClientWaitSync(WebGLSyncId, u32, u64, WebGLSender<u32>),
+    WaitSync(WebGLSyncId, u32, i64),
+    GetSyncParameter(WebGLSyncId, u32, WebGLSender<u32>),
+    DeleteSync(WebGLSyncId),
     Hint(u32, u32),
     LineWidth(f32),
     PixelStorei(u32, i32),
@@ -434,20 +440,29 @@ pub enum WebGLCommand {
     GetQueryState(WebGLSender<u32>, WebGLQueryId, u32),
 }
 
+macro_rules! nonzero_type {
+    (u32) => {
+        NonZeroU32
+    };
+    (u64) => {
+        NonZeroU64
+    };
+}
+
 macro_rules! define_resource_id {
-    ($name:ident) => {
+    ($name:ident, $type:tt) => {
         #[derive(Clone, Copy, Eq, Hash, PartialEq)]
-        pub struct $name(NonZeroU32);
+        pub struct $name(nonzero_type!($type));
 
         impl $name {
             #[allow(unsafe_code)]
             #[inline]
-            pub unsafe fn new(id: u32) -> Self {
-                $name(NonZeroU32::new_unchecked(id))
+            pub unsafe fn new(id: $type) -> Self {
+                $name(<nonzero_type!($type)>::new_unchecked(id))
             }
 
             #[inline]
-            pub fn get(self) -> u32 {
+            pub fn get(self) -> $type {
                 self.0.get()
             }
         }
@@ -458,7 +473,7 @@ macro_rules! define_resource_id {
             where
                 D: ::serde::Deserializer<'de>,
             {
-                let id = u32::deserialize(deserializer)?;
+                let id = <$type>::deserialize(deserializer)?;
                 if id == 0 {
                     Err(::serde::de::Error::custom("expected a non-zero value"))
                 } else {
@@ -498,14 +513,15 @@ macro_rules! define_resource_id {
     };
 }
 
-define_resource_id!(WebGLBufferId);
-define_resource_id!(WebGLFramebufferId);
-define_resource_id!(WebGLRenderbufferId);
-define_resource_id!(WebGLTextureId);
-define_resource_id!(WebGLProgramId);
-define_resource_id!(WebGLQueryId);
-define_resource_id!(WebGLShaderId);
-define_resource_id!(WebGLVertexArrayId);
+define_resource_id!(WebGLBufferId, u32);
+define_resource_id!(WebGLFramebufferId, u32);
+define_resource_id!(WebGLRenderbufferId, u32);
+define_resource_id!(WebGLTextureId, u32);
+define_resource_id!(WebGLProgramId, u32);
+define_resource_id!(WebGLQueryId, u32);
+define_resource_id!(WebGLShaderId, u32);
+define_resource_id!(WebGLSyncId, u64);
+define_resource_id!(WebGLVertexArrayId, u32);
 
 #[derive(
     Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, Ord, PartialEq, PartialOrd, Serialize,
@@ -893,6 +909,7 @@ pub struct GLLimits {
     pub max_varying_vectors: u32,
     pub max_vertex_texture_image_units: u32,
     pub max_vertex_uniform_vectors: u32,
+    pub max_client_wait_timeout_webgl: std::time::Duration,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, Serialize)]

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -45,12 +45,13 @@ use canvas_traits::canvas::{
     CanvasGradientStop, CanvasId, LinearGradientStyle, RadialGradientStyle,
 };
 use canvas_traits::canvas::{CompositionOrBlending, LineCapStyle, LineJoinStyle, RepetitionStyle};
+use canvas_traits::webgl::WebGLVertexArrayId;
 use canvas_traits::webgl::{ActiveAttribInfo, ActiveUniformInfo, GlType, TexDataType, TexFormat};
 use canvas_traits::webgl::{GLFormats, GLLimits, WebGLQueryId};
 use canvas_traits::webgl::{WebGLBufferId, WebGLChan, WebGLContextShareMode, WebGLError};
 use canvas_traits::webgl::{WebGLFramebufferId, WebGLMsgSender, WebGLPipeline, WebGLProgramId};
 use canvas_traits::webgl::{WebGLReceiver, WebGLRenderbufferId, WebGLSLVersion, WebGLSender};
-use canvas_traits::webgl::{WebGLShaderId, WebGLTextureId, WebGLVersion, WebGLVertexArrayId};
+use canvas_traits::webgl::{WebGLShaderId, WebGLSyncId, WebGLTextureId, WebGLVersion};
 use crossbeam_channel::{Receiver, Sender};
 use cssparser::RGBA;
 use devtools_traits::{CSSError, TimelineMarkerType, WorkerId};
@@ -480,6 +481,7 @@ unsafe_no_jsmanaged_fields!(WebGLProgramId);
 unsafe_no_jsmanaged_fields!(WebGLQueryId);
 unsafe_no_jsmanaged_fields!(WebGLRenderbufferId);
 unsafe_no_jsmanaged_fields!(WebGLShaderId);
+unsafe_no_jsmanaged_fields!(WebGLSyncId);
 unsafe_no_jsmanaged_fields!(WebGLTextureId);
 unsafe_no_jsmanaged_fields!(WebGLVertexArrayId);
 unsafe_no_jsmanaged_fields!(WebGLVersion);

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -527,6 +527,7 @@ pub mod webglrenderbuffer;
 pub mod webglrenderingcontext;
 pub mod webglshader;
 pub mod webglshaderprecisionformat;
+pub mod webglsync;
 pub mod webgltexture;
 pub mod webgluniformlocation;
 pub mod webglvertexarrayobjectoes;

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -28,17 +28,18 @@ use crate::dom::webglrenderingcontext::{
 };
 use crate::dom::webglshader::WebGLShader;
 use crate::dom::webglshaderprecisionformat::WebGLShaderPrecisionFormat;
+use crate::dom::webglsync::WebGLSync;
 use crate::dom::webgltexture::WebGLTexture;
 use crate::dom::webgluniformlocation::WebGLUniformLocation;
 use crate::dom::window::Window;
 use crate::script_runtime::JSContext;
-/// https://www.khronos.org/registry/webgl/specs/latest/2.0/webgl.idl
 use canvas_traits::webgl::WebGLError::*;
-use canvas_traits::webgl::{GLContextAttributes, WebGLVersion};
+/// https://www.khronos.org/registry/webgl/specs/latest/2.0/webgl.idl
+use canvas_traits::webgl::{webgl_channel, GLContextAttributes, WebGLCommand, WebGLVersion};
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use js::jsapi::JSObject;
-use js::jsval::{BooleanValue, JSVal, NullValue, UInt32Value};
+use js::jsval::{BooleanValue, Int32Value, JSVal, NullValue, UInt32Value};
 use js::rust::CustomAutoRooterGuard;
 use js::typedarray::ArrayBufferView;
 use script_layout_interface::HTMLCanvasDataSource;
@@ -125,7 +126,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     #[allow(unsafe_code)]
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
     fn GetParameter(&self, cx: JSContext, parameter: u32) -> JSVal {
-        self.base.GetParameter(cx, parameter)
+        match parameter {
+            constants::MAX_CLIENT_WAIT_TIMEOUT_WEBGL => {
+                Int32Value(self.base.limits().max_client_wait_timeout_webgl.as_nanos() as i32)
+            },
+            _ => self.base.GetParameter(cx, parameter),
+        }
     }
 
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
@@ -1195,6 +1201,124 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
                 self.base.webgl_error(error);
                 NullValue()
             },
+        }
+    }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14
+    fn FenceSync(&self, condition: u32, flags: u32) -> Option<DomRoot<WebGLSync>> {
+        if flags != 0 {
+            self.base.webgl_error(InvalidValue);
+            return None;
+        }
+        if condition != constants::SYNC_GPU_COMMANDS_COMPLETE {
+            self.base.webgl_error(InvalidEnum);
+            return None;
+        }
+
+        Some(WebGLSync::new(&self.base))
+    }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14
+    fn IsSync(&self, sync: Option<&WebGLSync>) -> bool {
+        match sync {
+            Some(sync) => {
+                if !sync.is_valid() {
+                    return false;
+                }
+                handle_potential_webgl_error!(
+                    self.base,
+                    self.base.validate_ownership(sync),
+                    return false
+                );
+                let (sender, receiver) = webgl_channel().unwrap();
+                self.base
+                    .send_command(WebGLCommand::IsSync(sync.id(), sender));
+                receiver.recv().unwrap()
+            },
+            None => false,
+        }
+    }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14
+    fn ClientWaitSync(&self, sync: &WebGLSync, flags: u32, timeout: u64) -> u32 {
+        if !sync.is_valid() {
+            self.base.webgl_error(InvalidOperation);
+            return constants::WAIT_FAILED;
+        }
+        handle_potential_webgl_error!(
+            self.base,
+            self.base.validate_ownership(sync),
+            return constants::WAIT_FAILED
+        );
+        if flags != 0 && flags != constants::SYNC_FLUSH_COMMANDS_BIT {
+            self.base.webgl_error(InvalidValue);
+            return constants::WAIT_FAILED;
+        }
+        if timeout > self.base.limits().max_client_wait_timeout_webgl.as_nanos() as u64 {
+            self.base.webgl_error(InvalidOperation);
+            return constants::WAIT_FAILED;
+        }
+
+        match sync.client_wait_sync(&self.base, flags, timeout) {
+            Some(status) => status,
+            None => constants::WAIT_FAILED,
+        }
+    }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14
+    fn WaitSync(&self, sync: &WebGLSync, flags: u32, timeout: i64) {
+        if !sync.is_valid() {
+            self.base.webgl_error(InvalidOperation);
+            return;
+        }
+        handle_potential_webgl_error!(self.base, self.base.validate_ownership(sync), return);
+        if flags != 0 {
+            self.base.webgl_error(InvalidValue);
+            return;
+        }
+        if timeout != constants::TIMEOUT_IGNORED {
+            self.base.webgl_error(InvalidValue);
+            return;
+        }
+
+        self.base
+            .send_command(WebGLCommand::WaitSync(sync.id(), flags, timeout));
+    }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14
+    fn GetSyncParameter(&self, _cx: JSContext, sync: &WebGLSync, pname: u32) -> JSVal {
+        if !sync.is_valid() {
+            self.base.webgl_error(InvalidOperation);
+            return NullValue();
+        }
+        handle_potential_webgl_error!(
+            self.base,
+            self.base.validate_ownership(sync),
+            return NullValue()
+        );
+        match pname {
+            constants::OBJECT_TYPE | constants::SYNC_CONDITION | constants::SYNC_FLAGS => {
+                let (sender, receiver) = webgl_channel().unwrap();
+                self.base
+                    .send_command(WebGLCommand::GetSyncParameter(sync.id(), pname, sender));
+                UInt32Value(receiver.recv().unwrap())
+            },
+            constants::SYNC_STATUS => match sync.get_sync_status(pname, &self.base) {
+                Some(status) => UInt32Value(status),
+                None => UInt32Value(constants::UNSIGNALED),
+            },
+            _ => {
+                self.base.webgl_error(InvalidEnum);
+                NullValue()
+            },
+        }
+    }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14
+    fn DeleteSync(&self, sync: Option<&WebGLSync>) {
+        if let Some(sync) = sync {
+            handle_potential_webgl_error!(self.base, self.base.validate_ownership(sync), return);
+            sync.delete(false);
         }
     }
 }

--- a/components/script/dom/webglsync.rs
+++ b/components/script/dom/webglsync.rs
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants;
+use crate::dom::bindings::codegen::Bindings::WebGLSyncBinding;
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::webglobject::WebGLObject;
+use crate::dom::webglrenderingcontext::WebGLRenderingContext;
+use crate::task_source::TaskSource;
+use canvas_traits::webgl::{webgl_channel, WebGLCommand, WebGLSyncId};
+use dom_struct::dom_struct;
+use std::cell::Cell;
+
+#[dom_struct]
+pub struct WebGLSync {
+    webgl_object: WebGLObject,
+    sync_id: WebGLSyncId,
+    marked_for_deletion: Cell<bool>,
+    client_wait_status: Cell<Option<u32>>,
+    sync_status: Cell<Option<u32>>,
+}
+
+impl WebGLSync {
+    fn new_inherited(context: &WebGLRenderingContext, sync_id: WebGLSyncId) -> Self {
+        Self {
+            webgl_object: WebGLObject::new_inherited(context),
+            sync_id,
+            marked_for_deletion: Cell::new(false),
+            client_wait_status: Cell::new(None),
+            sync_status: Cell::new(None),
+        }
+    }
+
+    pub fn new(context: &WebGLRenderingContext) -> DomRoot<Self> {
+        let (sender, receiver) = webgl_channel().unwrap();
+        context.send_command(WebGLCommand::FenceSync(sender));
+        let sync_id = receiver.recv().unwrap();
+
+        reflect_dom_object(
+            Box::new(WebGLSync::new_inherited(context, sync_id)),
+            &*context.global(),
+            WebGLSyncBinding::Wrap,
+        )
+    }
+}
+
+impl WebGLSync {
+    pub fn client_wait_sync(
+        &self,
+        context: &WebGLRenderingContext,
+        flags: u32,
+        timeout: u64,
+    ) -> Option<u32> {
+        match self.client_wait_status.get() {
+            Some(constants::TIMEOUT_EXPIRED) | Some(constants::WAIT_FAILED) | None => {
+                let global = self.global();
+                let this = Trusted::new(self);
+                let context = Trusted::new(context);
+                let task = task!(request_client_wait_status: move || {
+                    let this = this.root();
+                    let context = context.root();
+                    let (sender, receiver) = webgl_channel().unwrap();
+                    context.send_command(WebGLCommand::ClientWaitSync(
+                        this.sync_id,
+                        flags,
+                        timeout,
+                        sender,
+                    ));
+                    this.client_wait_status.set(Some(receiver.recv().unwrap()));
+                });
+                global
+                    .as_window()
+                    .task_manager()
+                    .dom_manipulation_task_source()
+                    .queue(task, global.upcast())
+                    .unwrap();
+            },
+            _ => {},
+        }
+        self.client_wait_status.get()
+    }
+
+    pub fn delete(&self, fallible: bool) {
+        if self.is_valid() {
+            self.marked_for_deletion.set(true);
+            let context = self.upcast::<WebGLObject>().context();
+            let cmd = WebGLCommand::DeleteSync(self.sync_id);
+            if fallible {
+                context.send_command_ignored(cmd);
+            } else {
+                context.send_command(cmd);
+            }
+        }
+    }
+
+    pub fn get_sync_status(&self, pname: u32, context: &WebGLRenderingContext) -> Option<u32> {
+        match self.sync_status.get() {
+            Some(constants::UNSIGNALED) | None => {
+                let global = self.global();
+                let this = Trusted::new(self);
+                let context = Trusted::new(context);
+                let task = task!(request_sync_status: move || {
+                    let this = this.root();
+                    let context = context.root();
+                    let (sender, receiver) = webgl_channel().unwrap();
+                    context.send_command(WebGLCommand::GetSyncParameter(this.sync_id, pname, sender));
+                    this.sync_status.set(Some(receiver.recv().unwrap()));
+                });
+                global
+                    .as_window()
+                    .task_manager()
+                    .dom_manipulation_task_source()
+                    .queue(task, global.upcast())
+                    .unwrap();
+            },
+            _ => {},
+        }
+        self.sync_status.get()
+    }
+
+    pub fn is_valid(&self) -> bool {
+        !self.marked_for_deletion.get()
+    }
+
+    pub fn id(&self) -> WebGLSyncId {
+        self.sync_id
+    }
+}
+
+impl Drop for WebGLSync {
+    fn drop(&mut self) {
+        self.delete(true);
+    }
+}

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -15,9 +15,6 @@ typedef unsigned long long GLuint64;
 // interface WebGLSampler : WebGLObject {
 // };
 
-// interface WebGLSync : WebGLObject {
-// };
-
 // interface WebGLTransformFeedback : WebGLObject {
 // };
 
@@ -542,12 +539,12 @@ interface mixin WebGL2RenderingContextBase
   any getSamplerParameter(WebGLSampler sampler, GLenum pname);*/
 
   /* Sync objects */
-  /*WebGLSync? fenceSync(GLenum condition, GLbitfield flags);
+  WebGLSync? fenceSync(GLenum condition, GLbitfield flags);
   [WebGLHandlesContextLoss] GLboolean isSync(WebGLSync? sync);
   void deleteSync(WebGLSync? sync);
   GLenum clientWaitSync(WebGLSync sync, GLbitfield flags, GLuint64 timeout);
   void waitSync(WebGLSync sync, GLbitfield flags, GLint64 timeout);
-  any getSyncParameter(WebGLSync sync, GLenum pname);*/
+  any getSyncParameter(WebGLSync sync, GLenum pname);
 
   /* Transform Feedback */
   /*WebGLTransformFeedback? createTransformFeedback();

--- a/components/script/dom/webidls/WebGLSync.webidl
+++ b/components/script/dom/webidls/WebGLSync.webidl
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//
+// WebGL IDL definitions scraped from the Khronos specification:
+// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14
+//
+
+[Pref="dom.webgl2.enabled"]
+interface WebGLSync : WebGLObject {
+};

--- a/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
@@ -2,6 +2,9 @@
   [WebGL test #25: Property either does not exist or is not a function: uniform4uiv]
     expected: FAIL
 
+  [WebGL test #72: Property either does not exist or is not a function: bindVertexArray]
+    expected: FAIL
+
   [WebGL test #28: Property either does not exist or is not a function: uniformMatrix2x4fv]
     expected: FAIL
 
@@ -9,9 +12,6 @@
     expected: FAIL
 
   [WebGL test #1: Property either does not exist or is not a function: getBufferSubData]
-    expected: FAIL
-
-  [WebGL test #52: Property either does not exist or is not a function: deleteSync]
     expected: FAIL
 
   [WebGL test #30: Property either does not exist or is not a function: uniformMatrix3x4fv]
@@ -23,22 +23,16 @@
   [WebGL test #27: Property either does not exist or is not a function: uniformMatrix3x2fv]
     expected: FAIL
 
-  [WebGL test #74: Property either does not exist or is not a function: uniformBlockBinding]
+  [WebGL test #60: Property either does not exist or is not a function: bindBufferBase]
     expected: FAIL
 
-  [WebGL test #59: Property either does not exist or is not a function: bindTransformFeedback]
+  [WebGL test #63: Property either does not exist or is not a function: getUniformIndices]
     expected: FAIL
 
-  [WebGL test #73: Property either does not exist or is not a function: getActiveUniformBlockName]
+  [WebGL test #57: Property either does not exist or is not a function: getTransformFeedbackVarying]
     expected: FAIL
 
-  [WebGL test #72: Property either does not exist or is not a function: getActiveUniformBlockParameter]
-    expected: FAIL
-
-  [WebGL test #63: Property either does not exist or is not a function: getTransformFeedbackVarying]
-    expected: FAIL
-
-  [WebGL test #50: Property either does not exist or is not a function: fenceSync]
+  [WebGL test #64: Property either does not exist or is not a function: getActiveUniforms]
     expected: FAIL
 
   [WebGL test #3: Property either does not exist or is not a function: blitFramebuffer]
@@ -47,13 +41,13 @@
   [WebGL test #33: Property either does not exist or is not a function: vertexAttribI4iv]
     expected: FAIL
 
-  [WebGL test #61: Property either does not exist or is not a function: endTransformFeedback]
+  [WebGL test #58: Property either does not exist or is not a function: pauseTransformFeedback]
     expected: FAIL
 
-  [WebGL test #67: Property either does not exist or is not a function: bindBufferRange]
+  [WebGL test #62: Property either does not exist or is not a function: getIndexedParameter]
     expected: FAIL
 
-  [WebGL test #69: Property either does not exist or is not a function: getUniformIndices]
+  [WebGL test #56: Property either does not exist or is not a function: transformFeedbackVaryings]
     expected: FAIL
 
   [WebGL test #2: Property either does not exist or is not a function: copyBufferSubData]
@@ -68,7 +62,7 @@
   [WebGL test #36: Property either does not exist or is not a function: vertexAttribIPointer]
     expected: FAIL
 
-  [WebGL test #54: Property either does not exist or is not a function: waitSync]
+  [WebGL test #54: Property either does not exist or is not a function: beginTransformFeedback]
     expected: FAIL
 
   [WebGL test #8: Property either does not exist or is not a function: readBuffer]
@@ -83,31 +77,25 @@
   [WebGL test #47: Property either does not exist or is not a function: samplerParameteri]
     expected: FAIL
 
-  [WebGL test #53: Property either does not exist or is not a function: clientWaitSync]
-    expected: FAIL
-
-  [WebGL test #66: Property either does not exist or is not a function: bindBufferBase]
-    expected: FAIL
-
-  [WebGL test #56: Property either does not exist or is not a function: createTransformFeedback]
-    expected: FAIL
-
   [WebGL test #32: Property either does not exist or is not a function: vertexAttribI4i]
     expected: FAIL
 
-  [WebGL test #77: Property either does not exist or is not a function: isVertexArray]
+  [WebGL test #68: Property either does not exist or is not a function: uniformBlockBinding]
     expected: FAIL
 
-  [WebGL test #64: Property either does not exist or is not a function: pauseTransformFeedback]
+  [WebGL test #55: Property either does not exist or is not a function: endTransformFeedback]
+    expected: FAIL
+
+  [WebGL test #69: Property either does not exist or is not a function: createVertexArray]
+    expected: FAIL
+
+  [WebGL test #70: Property either does not exist or is not a function: deleteVertexArray]
     expected: FAIL
 
   [WebGL test #41: Property either does not exist or is not a function: clearBufferfv]
     expected: FAIL
 
   [WebGL test #17: Property either does not exist or is not a function: getFragDataLocation]
-    expected: FAIL
-
-  [WebGL test #68: Property either does not exist or is not a function: getIndexedParameter]
     expected: FAIL
 
   [WebGL test #15: Property either does not exist or is not a function: compressedTexImage3D]
@@ -119,13 +107,13 @@
   [WebGL test #34: Property either does not exist or is not a function: vertexAttribI4ui]
     expected: FAIL
 
-  [WebGL test #55: Property either does not exist or is not a function: getSyncParameter]
+  [WebGL test #51: Property either does not exist or is not a function: deleteTransformFeedback]
     expected: FAIL
 
   [WebGL test #6: Property either does not exist or is not a function: invalidateFramebuffer]
     expected: FAIL
 
-  [WebGL test #78: Property either does not exist or is not a function: bindVertexArray]
+  [WebGL test #61: Property either does not exist or is not a function: bindBufferRange]
     expected: FAIL
 
   [WebGL test #42: Property either does not exist or is not a function: clearBufferfi]
@@ -134,13 +122,16 @@
   [WebGL test #24: Property either does not exist or is not a function: uniform3uiv]
     expected: FAIL
 
-  [WebGL test #51: Property either does not exist or is not a function: isSync]
-    expected: FAIL
-
   [WebGL test #37: Property either does not exist or is not a function: drawRangeElements]
     expected: FAIL
 
   [WebGL test #39: Property either does not exist or is not a function: clearBufferiv]
+    expected: FAIL
+
+  [WebGL test #71: Property either does not exist or is not a function: isVertexArray]
+    expected: FAIL
+
+  [WebGL test #52: Property either does not exist or is not a function: isTransformFeedback]
     expected: FAIL
 
   [WebGL test #46: Property either does not exist or is not a function: bindSampler]
@@ -150,9 +141,6 @@
     expected: FAIL
 
   [WebGL test #38: Property either does not exist or is not a function: drawBuffers]
-    expected: FAIL
-
-  [WebGL test #60: Property either does not exist or is not a function: beginTransformFeedback]
     expected: FAIL
 
   [WebGL test #0: Property either does not exist or is not a function: isContextLost]
@@ -170,22 +158,22 @@
   [WebGL test #40: Property either does not exist or is not a function: clearBufferuiv]
     expected: FAIL
 
-  [WebGL test #70: Property either does not exist or is not a function: getActiveUniforms]
+  [WebGL test #66: Property either does not exist or is not a function: getActiveUniformBlockParameter]
     expected: FAIL
 
-  [WebGL test #58: Property either does not exist or is not a function: isTransformFeedback]
-    expected: FAIL
-
-  [WebGL test #71: Property either does not exist or is not a function: getUniformBlockIndex]
+  [WebGL test #53: Property either does not exist or is not a function: bindTransformFeedback]
     expected: FAIL
 
   [WebGL test #21: Property either does not exist or is not a function: uniform4ui]
     expected: FAIL
 
-  [WebGL test #65: Property either does not exist or is not a function: resumeTransformFeedback]
+  [WebGL test #50: Property either does not exist or is not a function: createTransformFeedback]
     expected: FAIL
 
   [WebGL test #11: Property either does not exist or is not a function: texStorage2D]
+    expected: FAIL
+
+  [WebGL test #59: Property either does not exist or is not a function: resumeTransformFeedback]
     expected: FAIL
 
   [WebGL test #19: Property either does not exist or is not a function: uniform2ui]
@@ -194,7 +182,7 @@
   [WebGL test #26: Property either does not exist or is not a function: uniformMatrix2x3fv]
     expected: FAIL
 
-  [WebGL test #76: Property either does not exist or is not a function: deleteVertexArray]
+  [WebGL test #67: Property either does not exist or is not a function: getActiveUniformBlockName]
     expected: FAIL
 
   [WebGL test #49: Property either does not exist or is not a function: getSamplerParameter]
@@ -203,7 +191,7 @@
   [WebGL test #29: Property either does not exist or is not a function: uniformMatrix4x2fv]
     expected: FAIL
 
-  [WebGL test #57: Property either does not exist or is not a function: deleteTransformFeedback]
+  [WebGL test #65: Property either does not exist or is not a function: getUniformBlockIndex]
     expected: FAIL
 
   [WebGL test #20: Property either does not exist or is not a function: uniform3ui]
@@ -213,9 +201,6 @@
     expected: FAIL
 
   [WebGL test #4: Property either does not exist or is not a function: framebufferTextureLayer]
-    expected: FAIL
-
-  [WebGL test #75: Property either does not exist or is not a function: createVertexArray]
     expected: FAIL
 
   [WebGL test #44: Property either does not exist or is not a function: deleteSampler]
@@ -228,9 +213,6 @@
     expected: FAIL
 
   [WebGL test #45: Property either does not exist or is not a function: isSampler]
-    expected: FAIL
-
-  [WebGL test #62: Property either does not exist or is not a function: transformFeedbackVaryings]
     expected: FAIL
 
   [WebGL test #13: Property either does not exist or is not a function: texSubImage3D]

--- a/tests/wpt/webgl/meta/conformance2/sync/sync-webgl-specific.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/sync/sync-webgl-specific.html.ini
@@ -1,5 +1,0 @@
-[sync-webgl-specific.html]
-  expected: ERROR
-  [WebGL test #3: gl.getError() should be 0. Was 1280.]
-    expected: FAIL
-


### PR DESCRIPTION
This patch adds initial support for [WebGLSync](https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.14).

Note:
There is no test for the isSync, deleteSync and waitSync functions in the `conformance2/sync/sync-webgl-specific.html`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24250)
<!-- Reviewable:end -->
