### PR TITLE
Glutin new window shares gl bindings

### DIFF
--- a/ports/glutin/context.rs
+++ b/ports/glutin/context.rs
@@ -35,6 +35,13 @@ impl GlContext {
         *self = match std::mem::replace(self, GlContext::None) {
             GlContext::Current(c) => {
                 warn!("Making an already current context current");
+                // Servo thinks that that this window is current,
+                // but it might be wrong, since other code may have
+                // changed the current GL context. Just to be on
+                // the safe side, we make it current anyway.
+                let c = unsafe {
+                    c.make_current().expect("Couldn't make window current")
+                };
                 GlContext::Current(c)
             },
             GlContext::NotCurrent(c) => {

--- a/ports/glutin/headed_window.rs
+++ b/ports/glutin/headed_window.rs
@@ -134,6 +134,7 @@ impl Window {
         }
 
         let context = unsafe {
+            debug!("Making window {:?} current", context.window().id());
             context.make_current().expect("Couldn't make window current")
         };
 
@@ -173,6 +174,7 @@ impl Window {
 
         context.make_not_current();
 
+        debug!("Created window {:?}", context.window().id());
         let window = Window {
             gl_context: RefCell::new(context),
             events_loop,
@@ -480,10 +482,12 @@ impl WindowPortsMethods for Window {
 
 impl webxr::glwindow::GlWindow for Window {
     fn make_current(&mut self) {
+        debug!("Making window {:?} current", self.gl_context.borrow().window().id());
         self.gl_context.get_mut().make_current();
     }
 
     fn swap_buffers(&mut self) {
+        debug!("Swapping buffers on window {:?}", self.gl_context.borrow().window().id());
         self.gl_context.get_mut().swap_buffers();
         self.gl_context.get_mut().make_not_current();
     }

--- a/ports/glutin/headed_window.rs
+++ b/ports/glutin/headed_window.rs
@@ -133,6 +133,11 @@ impl Window {
             context.window().set_window_icon(Some(load_icon(icon_bytes)));
         }
 
+        if let Some(sharing) = sharing {
+            debug!("Making window {:?} not current", sharing.gl_context.borrow().window().id());
+            sharing.gl_context.borrow_mut().make_not_current();
+        }
+
         let context = unsafe {
             debug!("Making window {:?} current", context.window().id());
             context.make_current().expect("Couldn't make window current")


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

At the moment when the glutin port creates a new window which shares GL objects, it creates new GL bindings rather than sharting the existing ones. This PR fixes that.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's an efficiency improvement

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24253)
<!-- Reviewable:end -->
