### PR TITLE
Update to UWP compatible OpenSSL build.

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -234,7 +234,7 @@ class MachCommands(CommandBase):
                 check_call(["rustup" + BIN_SUFFIX, "target", "add",
                             "--toolchain", self.toolchain(), target])
 
-        env = self.build_env(target=target, is_build=True)
+        env = self.build_env(target=target, is_build=True, uwp=uwp)
         self.ensure_bootstrapped(target=target)
         self.ensure_clobbered()
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -614,7 +614,7 @@ install them, let us know by filing a bug!")
             'vcdir': vcinstalldir,
         }
 
-    def build_env(self, hosts_file_path=None, target=None, is_build=False, test_unit=False):
+    def build_env(self, hosts_file_path=None, target=None, is_build=False, test_unit=False, uwp=False):
         """Return an extended environment dictionary."""
         env = os.environ.copy()
         if sys.platform == "win32" and type(env['PATH']) == unicode:
@@ -639,6 +639,9 @@ install them, let us know by filing a bug!")
                 "i686": "x86-windows",
                 "aarch64": "arm64-windows",
             }
+            target_arch = vcpkg_arch[arch]
+            if uwp:
+                target_arch += "-uwp"
             openssl_base_dir = path.join(self.msvc_package_dir("openssl"), vcpkg_arch[arch])
 
             # Link openssl

--- a/python/servo/packages.py
+++ b/python/servo/packages.py
@@ -8,7 +8,7 @@ WINDOWS_MSVC = {
     "moztools": "3.2",
     "ninja": "1.7.1",
     "nuget": "08-08-2019",
-    "openssl": "111.3.0+1.1.1c-vs2017",
+    "openssl": "111.3.0+1.1.1c-vs2017-2019-09-18",
     "gstreamer-uwp": "1.16.0.5",
     "openxr-loader-uwp": "1.0",
 }


### PR DESCRIPTION
This uses OpenSSL binaries built from https://github.com/servo/openssl-windows-build which yield no more WACK violations.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24138
- [x] These changes do not require tests because no CI for WACK or windows yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24257)
<!-- Reviewable:end -->
