### PR TITLE
Make tidy report when a rand exception is no longer needed

### DIFF
--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -65,7 +65,7 @@ COMMENTS = ["// ", "# ", " *", "/* "]
 
 # File patterns to include in the non-WPT tidy check.
 FILE_PATTERNS_TO_CHECK = ["*.rs", "*.rc", "*.cpp", "*.c",
-                          "*.h", "Cargo.lock", "*.py", "*.sh",
+                          "*.h", "*.py", "*.sh",
                           "*.toml", "*.webidl", "*.json", "*.html",
                           "*.yml"]
 
@@ -193,6 +193,9 @@ def filter_file(file_name):
 def filter_files(start_dir, only_changed_files, progress):
     file_iter = FileList(start_dir, only_changed_files=only_changed_files,
                          exclude_dirs=config["ignore"]["directories"], progress=progress)
+    # always yield Cargo.lock so that the correctness of transitive dependacies is checked
+    yield "./Cargo.lock"
+
     for file_name in file_iter:
         base_name = os.path.basename(file_name)
         if not any(fnmatch.fnmatch(base_name, pattern) for pattern in FILE_PATTERNS_TO_CHECK):

--- a/python/tidy/servo_tidy_tests/blocked_package.lock
+++ b/python/tidy/servo_tidy_tests/blocked_package.lock
@@ -1,0 +1,26 @@
+[root]
+name = "servo"
+version = "0.0.1"
+
+[[package]]
+name = "test_blocked"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+    "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "test_exception"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+    "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "test_unneeded_exception"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+]

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -229,6 +229,25 @@ class CheckTidiness(unittest.TestCase):
 
         self.assertNoMoreErrors(errors)
 
+    def test_lock_exceptions(self):
+        tidy.config["blocked-packages"]["rand"] = ["test_exception", "test_unneeded_exception"]
+        errors = tidy.collect_errors_for_files(iterFile('blocked_package.lock'), [tidy.check_lock], [], print_text=False)
+
+        msg = (
+            "Package test_blocked 0.0.2 depends on blocked package rand."
+        )
+
+        msg2 = (
+            "Package test_unneeded_exception is not required to be an exception of blocked package rand."
+        )
+
+        self.assertEqual(msg, errors.next()[2])
+        self.assertEqual(msg2, errors.next()[2])
+        self.assertNoMoreErrors(errors)
+
+        # needed to not raise errors in other test cases
+        tidy.config["blocked-packages"]["rand"] = []
+
     def test_lint_runner(self):
         test_path = base_path + 'lints/'
         runner = tidy.LintRunner(only_changed_files=False, progress=False)


### PR DESCRIPTION
Make test-tidy always check Cargo.lock and make tidy report when a rand exception is not needed
---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #24152  (GitHub issue number if applicable)

- [X] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24264)
<!-- Reviewable:end -->
