### PR TITLE
Extend nightly WPT update timeout by an hour.

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -558,7 +558,7 @@ def update_wpt():
         .with_features("taskclusterProxy")
         .with_scopes("secrets:get:project/servo/wpt-sync")
         .with_index_and_artifacts_expire_in(log_artifacts_expire_in)
-        .with_max_run_time_minutes(5 * 60)
+        .with_max_run_time_minutes(6 * 60)
     )
     return (
         with_homebrew(update_task, [


### PR DESCRIPTION
Jobs have been timing out more than usual recently, and on machines that don't have any clear resource hogging going on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24268)
<!-- Reviewable:end -->
