### PR TITLE
Remove obsolete macOS build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,20 +66,6 @@ pip install virtualenv
 ``` sh
 sudo port install python27 py27-virtualenv cmake yasm llvm
 ```
-##### On macOS >= 10.11 (El Capitan), you also have to install OpenSSL
-
-``` sh
-brew install openssl
-
-export OPENSSL_INCLUDE_DIR="$(brew --prefix openssl)/include"
-export OPENSSL_LIB_DIR="$(brew --prefix openssl)/lib"
-
-./mach build ...
-```
-
-##### Note: Please make sure the required `PKG_CONFIG_PATH` environment variable is set the same as the one provided from `brew info libffi` ([Check this comment for more details](https://github.com/servo/servo/issues/23015#issuecomment-475050175)).
-
-If you've already partially compiled servo but forgot to do this step, run `./mach clean`, set the shell variables, and recompile.
 
 #### On Debian-based Linuxes
 

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -601,12 +601,7 @@ def macos_wpt():
     build_task = macos_release_build()
     def macos_run_task(name):
         task = macos_task(name).with_python2()
-        return (
-            with_homebrew(task, ["etc/taskcluster/macos/Brewfile-gstreamer"])
-            .with_script("""
-                export PKG_CONFIG_PATH="$(brew --prefix libffi)/lib/pkgconfig/"
-            """)
-        )
+        return with_homebrew(task, ["etc/taskcluster/macos/Brewfile-gstreamer"])
     wpt_chunks("macOS x64", macos_run_task, build_task, repo_dir="repo",
                total_chunks=6, processes=4)
 


### PR DESCRIPTION
openssl is already installed through the Brewfile, and libffi needs no
environment variable anymore now that glib was fixed.

https://github.com/Homebrew/homebrew-core/pull/44446

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24279)
<!-- Reviewable:end -->
