### PR TITLE
Allow playing video/webm on Windows

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -166,6 +166,7 @@ mod media_platform {
         ];
 
         let non_uwp_plugins = [
+            "gstmatroska.dll",
             "gstnice.dll",
             "gstogg.dll",
             "gstopengl.dll",

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -892,6 +892,7 @@ def package_gstreamer_dlls(env, servo_exe_dir, target, uwp):
 
     if not uwp:
         gst_dlls += [
+            "gstmatroska.dll",
             "gstnice.dll",
             "gstogg.dll",
             "gstopengl.dll",


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

This makes video/webm play on non-UWP Windows. I couldn't find the equivalent gstmatroska.dll on our GStreamer binaries for UWP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24280)
<!-- Reviewable:end -->
