### PR TITLE
Remove unused checking in GetResponseXML

### DIFF
--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -935,12 +935,6 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
 
     // https://xhr.spec.whatwg.org/#the-responsexml-attribute
     fn GetResponseXML(&self) -> Fallible<Option<DomRoot<Document>>> {
-        // TODO(#2823): Until [Exposed] is implemented, this attribute needs to return null
-        //              explicitly in the worker scope.
-        if self.global().is::<WorkerGlobalScope>() {
-            return Ok(None);
-        }
-
         match self.response_type.get() {
             XMLHttpRequestResponseType::_empty | XMLHttpRequestResponseType::Document => {
                 // Step 3


### PR DESCRIPTION
We've supported [Exposed] so no need to check the global scope type!

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it just removes an unused checking. Also, those tests marked as `PASS` in #10573 should still pass.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24300)
<!-- Reviewable:end -->
