### PR TITLE
Remove use of packed_simd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,6 @@ dependencies = [
  "malloc_size_of 0.0.1",
  "net_traits 0.0.1",
  "ordered-float 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "packed_simd 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "range 0.0.1",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "servo-fontconfig 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3300,14 +3299,6 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "packed_simd"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6147,7 +6138,6 @@ dependencies = [
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 "checksum ovr-mobile-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a69b517feac6fc640f0679625defa0998bbcb32871a6901e63063c2abf9c4cbe"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-"checksum packed_simd 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "25d36de864f7218ec5633572a800109bbe5a1cc8d9d95a967f3daf93ea7e6ddc"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum paste 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4a4a1c555c6505821f9d58b8779d0f630a6b7e4e1be24ba718610acf01fa79"

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -28,7 +28,6 @@ log = "0.4"
 malloc_size_of = { path = "../malloc_size_of" }
 net_traits = {path = "../net_traits"}
 ordered-float = "1.0"
-packed_simd = "0.3"
 range = {path = "../range"}
 serde = "1.0"
 servo_arc = {path = "../servo_arc"}

--- a/components/gfx/text/glyph.rs
+++ b/components/gfx/text/glyph.rs
@@ -4,8 +4,6 @@
 
 use app_units::Au;
 use euclid::default::Point2D;
-#[cfg(any(target_feature = "sse2", target_feature = "neon"))]
-use packed_simd::u32x4;
 use range::{self, EachIndex, Range, RangeIndex};
 use std::cmp::{Ordering, PartialOrd};
 use std::vec::Vec;
@@ -72,8 +70,6 @@ pub type GlyphId = u32;
 // TODO: make this more type-safe.
 
 const FLAG_CHAR_IS_SPACE: u32 = 0x40000000;
-#[cfg(any(target_feature = "sse2", target_feature = "neon"))]
-const FLAG_CHAR_IS_SPACE_SHIFT: u32 = 30;
 const FLAG_IS_SIMPLE_GLYPH: u32 = 0x80000000;
 
 // glyph advance; in Au's.
@@ -600,12 +596,12 @@ impl<'a> GlyphStore {
         } else if !self.has_detailed_glyphs {
             self.advance_for_byte_range_simple_glyphs(range, extra_word_spacing)
         } else {
-            self.advance_for_byte_range_slow_path(range, extra_word_spacing)
+            self.advance_for_byte_range_simple_glyphs(range, extra_word_spacing)
         }
     }
 
     #[inline]
-    pub fn advance_for_byte_range_slow_path(
+    pub fn advance_for_byte_range_simple_glyphs(
         &self,
         range: &Range<ByteIndex>,
         extra_word_spacing: Au,
@@ -618,73 +614,6 @@ impl<'a> GlyphStore {
                     advance + glyph.advance()
                 }
             })
-    }
-
-    #[inline]
-    #[cfg(any(target_feature = "sse2", target_feature = "neon"))]
-    fn advance_for_byte_range_simple_glyphs(
-        &self,
-        range: &Range<ByteIndex>,
-        extra_word_spacing: Au,
-    ) -> Au {
-        let advance_mask = u32x4::splat(GLYPH_ADVANCE_MASK);
-        let space_flag_mask = u32x4::splat(FLAG_CHAR_IS_SPACE);
-        let mut simd_advance = u32x4::splat(0);
-        let mut simd_spaces = u32x4::splat(0);
-        let begin = range.begin().to_usize();
-        let len = range.length().to_usize();
-        let num_simd_iterations = len / 4;
-        let leftover_entries = range.end().to_usize() - (len - num_simd_iterations * 4);
-        let buf = self.transmute_entry_buffer_to_u32_buffer();
-
-        for i in 0..num_simd_iterations {
-            let offset = begin + i * 4;
-            let v = u32x4::from_slice_unaligned(&buf[offset..]);
-            let advance = (v & advance_mask) >> GLYPH_ADVANCE_SHIFT;
-            let spaces = (v & space_flag_mask) >> FLAG_CHAR_IS_SPACE_SHIFT;
-            simd_advance = simd_advance + advance;
-            simd_spaces = simd_spaces + spaces;
-        }
-
-        let advance = (simd_advance.extract(0) +
-            simd_advance.extract(1) +
-            simd_advance.extract(2) +
-            simd_advance.extract(3)) as i32;
-        let spaces = (simd_spaces.extract(0) +
-            simd_spaces.extract(1) +
-            simd_spaces.extract(2) +
-            simd_spaces.extract(3)) as i32;
-        let mut leftover_advance = Au(0);
-        let mut leftover_spaces = 0;
-        for i in leftover_entries..range.end().to_usize() {
-            leftover_advance = leftover_advance + self.entry_buffer[i].advance();
-            if self.entry_buffer[i].char_is_space() {
-                leftover_spaces += 1;
-            }
-        }
-        Au::new(advance) + leftover_advance + extra_word_spacing * (spaces + leftover_spaces)
-    }
-
-    /// When SIMD isn't available, fallback to the slow path.
-    #[inline]
-    #[cfg(not(any(target_feature = "sse2", target_feature = "neon")))]
-    fn advance_for_byte_range_simple_glyphs(
-        &self,
-        range: &Range<ByteIndex>,
-        extra_word_spacing: Au,
-    ) -> Au {
-        self.advance_for_byte_range_slow_path(range, extra_word_spacing)
-    }
-
-    /// Used for SIMD.
-    #[inline]
-    #[cfg(any(target_feature = "sse2", target_feature = "neon"))]
-    #[allow(unsafe_code)]
-    fn transmute_entry_buffer_to_u32_buffer(&self) -> &[u32] {
-        // Statically assert identical sizes
-        let _ = mem::transmute::<GlyphEntry, u32>;
-
-        unsafe { mem::transmute::<&[GlyphEntry], &[u32]>(self.entry_buffer.as_slice()) }
     }
 
     pub fn char_is_space(&self, i: ByteIndex) -> bool {


### PR DESCRIPTION
This crate takes about 40 seconds to build of a fast desktop, and was used in exactly one place. Additionally, that use was previously accidentally disabled (a553964123d9e65fc483e608864d880ba1909300) and we only noticed more than a year later when the build broke (d1efad676301798756c36990de8aa2784dab91db).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24304)
<!-- Reviewable:end -->
