### PR TITLE
Clean up gating and order of getting display/glcontext from glutin

### DIFF
--- a/ports/glutin/context.rs
+++ b/ports/glutin/context.rs
@@ -85,13 +85,7 @@ impl GlContext {
     pub fn raw_context(&self) -> RawContext {
         match self {
             GlContext::Current(c) => {
-                #[cfg(any(
-                    target_os = "linux",
-                    target_os = "dragonfly",
-                    target_os = "freebsd",
-                    target_os = "netbsd",
-                    target_os = "openbsd",
-                ))]
+                #[cfg(target_os = "linux")]
                 {
                     use glutin::os::unix::RawHandle;
 
@@ -114,23 +108,14 @@ impl GlContext {
                     }
                 }
 
-                #[cfg(target_os = "android")]
-                {
-                    let raw_handle = unsafe { c.raw_handle() };
-                    return RawContext::Egl(raw_handle as usize);
-                }
-
+                // @TODO(victor): https://github.com/rust-windowing/glutin/pull/1221
+                //                https://github.com/servo/media/pull/315
                 #[cfg(target_os = "macos")]
-                return unimplemented!(); // @TODO(victor): RawContext::Cocoa in servo-media
+                return unimplemented!();
 
                 #[cfg(not(any(
                     target_os = "linux",
-                    target_os = "dragonfly",
-                    target_os = "freebsd",
-                    target_os = "netbsd",
-                    target_os = "openbsd",
                     target_os = "windows",
-                    target_os = "android",
                     target_os = "macos",
                 )))]
                 unimplemented!()


### PR DESCRIPTION
This patch simply simplify the OS gating for getting display and gl
context from glutin since it is only used for a linux, mac and not
UWP-based windows.

Also, in linux tries to fetch the wayland display and don't rely
on EGLDisplay because it might bring problems in servo/media.
Nonetheless it is required to compile render-unix in servo-media
with feature 'gl-wayland'

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because no functional changes, just clean ups

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24310)
<!-- Reviewable:end -->
