### PR TITLE
don't send progress event for empty blob

### DIFF
--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -494,8 +494,10 @@ fn perform_annotated_read_operation(
     let task = FileReadingTask::ProcessRead(filereader.clone(), gen_id);
     task_source.queue_with_canceller(task, &canceller).unwrap();
 
-    let task = FileReadingTask::ProcessReadData(filereader.clone(), gen_id);
-    task_source.queue_with_canceller(task, &canceller).unwrap();
+    if !blob_contents.is_empty() {
+        let task = FileReadingTask::ProcessReadData(filereader.clone(), gen_id);
+        task_source.queue_with_canceller(task, &canceller).unwrap();
+    }
 
     let task = FileReadingTask::ProcessReadEOF(filereader, gen_id, data, blob_contents);
     task_source.queue_with_canceller(task, &canceller).unwrap();

--- a/tests/wpt/metadata/FileAPI/reading-data-section/filereader_events.any.js.ini
+++ b/tests/wpt/metadata/FileAPI/reading-data-section/filereader_events.any.js.ini
@@ -1,9 +1,0 @@
-[filereader_events.any.html]
-  [events are dispatched in the correct order for an empty blob]
-    expected: FAIL
-
-
-[filereader_events.any.worker.html]
-  [events are dispatched in the correct order for an empty blob]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #24289 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24312)
<!-- Reviewable:end -->
