### PR TITLE
Add simple implementation of content-security-policy on network requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,6 +737,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "content-security-policy"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30ee9967a875968e66f6690e299f06781ed109cb82d10e0d60a126a38d61947"
+dependencies = [
+ "bitflags",
+ "lazy_static",
+ "percent-encoding",
+ "regex",
+ "serde",
+ "url",
+]
+
+[[package]]
 name = "cookie"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,6 +2849,7 @@ name = "malloc_size_of"
 version = "0.0.1"
 dependencies = [
  "app_units",
+ "content-security-policy",
  "crossbeam-channel",
  "cssparser",
  "euclid",
@@ -3156,6 +3171,7 @@ dependencies = [
  "base64",
  "brotli",
  "bytes",
+ "content-security-policy",
  "cookie",
  "crossbeam-channel",
  "devtools_traits",
@@ -3215,6 +3231,7 @@ dependencies = [
 name = "net_traits"
 version = "0.0.1"
 dependencies = [
+ "content-security-policy",
  "cookie",
  "embedder_traits",
  "headers",
@@ -4122,6 +4139,7 @@ dependencies = [
  "canvas_traits",
  "caseless",
  "chrono",
+ "content-security-policy",
  "cookie",
  "crossbeam-channel",
  "cssparser",

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -21,10 +21,12 @@ servo = [
     "url",
     "webrender_api",
     "xml5ever",
+    "content-security-policy",
 ]
 
 [dependencies]
 app_units = "0.7"
+content-security-policy = {version = "0.3.0", features = ["serde"], optional = true}
 crossbeam-channel = { version = "0.3", optional = true }
 cssparser = "0.25"
 euclid = "0.20"

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -48,6 +48,8 @@
 
 extern crate app_units;
 #[cfg(feature = "servo")]
+extern crate content_security_policy;
+#[cfg(feature = "servo")]
 extern crate crossbeam_channel;
 extern crate cssparser;
 extern crate euclid;
@@ -79,6 +81,8 @@ extern crate webrender_api;
 #[cfg(feature = "servo")]
 extern crate xml5ever;
 
+#[cfg(feature = "servo")]
+use content_security_policy as csp;
 #[cfg(feature = "servo")]
 use serde_bytes::ByteBuf;
 use std::hash::{BuildHasher, Hash};
@@ -832,6 +836,8 @@ malloc_size_of_is_0!(Range<f32>, Range<f64>);
 malloc_size_of_is_0!(app_units::Au);
 
 malloc_size_of_is_0!(cssparser::RGBA, cssparser::TokenSerializationType);
+
+malloc_size_of_is_0!(csp::Destination);
 
 #[cfg(feature = "url")]
 impl MallocSizeOf for url::Host {

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 base64 = "0.10.1"
 brotli = "3"
 bytes = "0.4"
+content-security-policy = {version = "0.3.0", features = ["serde"]}
 cookie_rs = {package = "cookie", version = "0.11"}
 crossbeam-channel = "0.3"
 devtools_traits = {path = "../devtools_traits"}

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -8,6 +8,7 @@ use crate::filemanager_thread::{fetch_file_in_chunks, FileManager, FILE_CHUNK_SI
 use crate::http_loader::{determine_request_referrer, http_fetch, HttpState};
 use crate::http_loader::{set_default_accept, set_default_accept_language};
 use crate::subresource_integrity::is_response_integrity_valid;
+use content_security_policy as csp;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use devtools_traits::DevtoolsControlMsg;
 use headers::{AccessControlExposeHeaders, ContentType, HeaderMapExt, Range};
@@ -138,6 +139,30 @@ pub fn fetch_with_cors_cache(
     main_fetch(request, cache, false, false, target, &mut None, &context);
 }
 
+/// https://www.w3.org/TR/CSP/#should-block-request
+pub fn should_request_be_blocked_by_csp(request: &Request) -> csp::CheckResult {
+    let origin = match &request.origin {
+        Origin::Client => return csp::CheckResult::Allowed,
+        Origin::Origin(origin) => origin,
+    };
+    let csp_request = csp::Request {
+        url: request.url().into_url(),
+        origin: origin.clone().into_url_origin(),
+        redirect_count: request.redirect_count,
+        destination: request.destination,
+        initiator: csp::Initiator::None,
+        nonce: String::new(),
+        integrity_metadata: request.integrity_metadata.clone(),
+        parser_metadata: csp::ParserMetadata::None,
+    };
+    // TODO: Instead of ignoring violations, report them.
+    request
+        .csp_list
+        .as_ref()
+        .map(|c| c.should_request_be_blocked(&csp_request).0)
+        .unwrap_or(csp::CheckResult::Allowed)
+}
+
 /// [Main fetch](https://fetch.spec.whatwg.org/#concept-main-fetch)
 pub fn main_fetch(
     request: &mut Request,
@@ -163,8 +188,18 @@ pub fn main_fetch(
         }
     }
 
+    // Step 2.2.
+    // TODO: Report violations.
+
+    // Step 2.4.
+    if should_request_be_blocked_by_csp(request) == csp::CheckResult::Blocked {
+        response = Some(Response::network_error(NetworkError::Internal(
+            "Blocked by Content-Security-Policy".into(),
+        )))
+    }
+
     // Step 3.
-    // TODO: handle content security policy violations.
+    // TODO: handle request abort.
 
     // Step 4.
     // TODO: handle upgrade to a potentially secure URL.

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -13,6 +13,7 @@ test = false
 doctest = false
 
 [dependencies]
+content-security-policy = {version = "0.3.0", features = ["serde"]}
 cookie = "0.11"
 embedder_traits = { path = "../embedder_traits" }
 headers = "0.2"

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -4,6 +4,7 @@
 
 use crate::ReferrerPolicy;
 use crate::ResourceTimingType;
+use content_security_policy::{self as csp, CspList};
 use http::HeaderMap;
 use hyper::Method;
 use msg::constellation_msg::PipelineId;
@@ -20,37 +21,7 @@ pub enum Initiator {
 }
 
 /// A request [destination](https://fetch.spec.whatwg.org/#concept-request-destination)
-#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
-pub enum Destination {
-    None,
-    Audio,
-    Document,
-    Embed,
-    Font,
-    Image,
-    Manifest,
-    Object,
-    Report,
-    Script,
-    ServiceWorker,
-    SharedWorker,
-    Style,
-    Track,
-    Video,
-    Worker,
-    Xslt,
-}
-
-impl Destination {
-    /// https://fetch.spec.whatwg.org/#request-destination-script-like
-    #[inline]
-    pub fn is_script_like(&self) -> bool {
-        *self == Destination::Script ||
-            *self == Destination::ServiceWorker ||
-            *self == Destination::SharedWorker ||
-            *self == Destination::Worker
-    }
-}
+pub use csp::Destination;
 
 /// A request [origin](https://fetch.spec.whatwg.org/#concept-request-origin)
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
@@ -175,6 +146,11 @@ pub struct RequestBuilder {
     pub pipeline_id: Option<PipelineId>,
     pub redirect_mode: RedirectMode,
     pub integrity_metadata: String,
+    // This is nominally a part of the client's global object.
+    // It is copied here to avoid having to reach across the thread
+    // boundary every time a redirect occurs.
+    #[ignore_malloc_size_of = "Defined in rust-content-security-policy"]
+    pub csp_list: Option<CspList>,
     // to keep track of redirects
     pub url_list: Vec<ServoUrl>,
     pub parser_metadata: ParserMetadata,
@@ -206,6 +182,7 @@ impl RequestBuilder {
             url_list: vec![],
             parser_metadata: ParserMetadata::Default,
             initiator: Initiator::None,
+            csp_list: None,
         }
     }
 
@@ -329,6 +306,7 @@ impl RequestBuilder {
         request.url_list = url_list;
         request.integrity_metadata = self.integrity_metadata;
         request.parser_metadata = self.parser_metadata;
+        request.csp_list = self.csp_list;
         request
     }
 }
@@ -396,6 +374,11 @@ pub struct Request {
     pub response_tainting: ResponseTainting,
     /// <https://fetch.spec.whatwg.org/#concept-request-parser-metadata>
     pub parser_metadata: ParserMetadata,
+    // This is nominally a part of the client's global object.
+    // It is copied here to avoid having to reach across the thread
+    // boundary every time a redirect occurs.
+    #[ignore_malloc_size_of = "Defined in rust-content-security-policy"]
+    pub csp_list: Option<CspList>,
 }
 
 impl Request {
@@ -428,6 +411,7 @@ impl Request {
             parser_metadata: ParserMetadata::Default,
             redirect_count: 0,
             response_tainting: ResponseTainting::Basic,
+            csp_list: None,
         }
     }
 

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -38,6 +38,7 @@ bitflags = "1.0"
 bluetooth_traits = {path = "../bluetooth_traits"}
 canvas_traits = {path = "../canvas_traits"}
 caseless = "0.2"
+content-security-policy = {version = "0.3.0", features = ["serde"]}
 cookie = "0.11"
 chrono = "0.4"
 crossbeam-channel = "0.3"

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -54,6 +54,7 @@ use canvas_traits::webgl::{
 use canvas_traits::webgl::{WebGLFramebufferId, WebGLMsgSender, WebGLPipeline, WebGLProgramId};
 use canvas_traits::webgl::{WebGLReceiver, WebGLRenderbufferId, WebGLSLVersion, WebGLSender};
 use canvas_traits::webgl::{WebGLShaderId, WebGLSyncId, WebGLTextureId, WebGLVersion};
+use content_security_policy::CspList;
 use crossbeam_channel::{Receiver, Sender};
 use cssparser::RGBA;
 use devtools_traits::{CSSError, TimelineMarkerType, WorkerId};
@@ -169,6 +170,8 @@ unsafe_no_jsmanaged_fields!(TexDataType, TexFormat);
 unsafe_no_jsmanaged_fields!(*mut JobQueue);
 
 unsafe_no_jsmanaged_fields!(Cow<'static, str>);
+
+unsafe_no_jsmanaged_fields!(CspList);
 
 /// Trace a `JSVal`.
 pub fn trace_jsval(tracer: *mut JSTracer, description: &str, val: &Heap<JSVal>) {

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -38,6 +38,7 @@ use crate::task_source::websocket::WebsocketTaskSource;
 use crate::task_source::TaskSourceName;
 use crate::timers::{IsInterval, OneshotTimerCallback, OneshotTimerHandle};
 use crate::timers::{OneshotTimers, TimerCallback};
+use content_security_policy::CspList;
 use devtools_traits::{ScriptToDevtoolsControlMsg, WorkerId};
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
@@ -811,6 +812,15 @@ impl GlobalScope {
 
     pub fn get_user_agent(&self) -> Cow<'static, str> {
         self.user_agent.clone()
+    }
+
+    /// https://www.w3.org/TR/CSP/#get-csp-of-object
+    pub fn get_csp_list(&self) -> Option<CspList> {
+        if let Some(window) = self.downcast::<Window>() {
+            return window.Document().get_csp_list().map(|c| c.clone());
+        }
+        // TODO: Worker and Worklet global scopes.
+        None
     }
 }
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -27,6 +27,7 @@ use crate::dom::performanceresourcetiming::InitiatorType;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::fetch::create_a_potential_CORS_request;
 use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingListener};
+use content_security_policy as csp;
 use dom_struct::dom_struct;
 use encoding_rs::Encoding;
 use html5ever::{LocalName, Prefix};
@@ -428,7 +429,16 @@ impl HTMLScriptElement {
 
         // TODO: Step 12: nomodule content attribute
 
-        // TODO(#4577): Step 13: CSP.
+        // Step 13.
+        if !element.has_attribute(&local_name!("src")) &&
+            doc.should_elements_inline_type_behavior_be_blocked(
+                &element,
+                csp::InlineCheckType::Script,
+                &text,
+            ) == csp::CheckResult::Blocked
+        {
+            return;
+        }
 
         // Step 14.
         let for_attribute = element.get_attribute(&ns!(), &local_name!("for"));

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -755,7 +755,9 @@ impl Into<RequestDestination> for NetTraitsRequestDestination {
             NetTraitsRequestDestination::Object => RequestDestination::Object,
             NetTraitsRequestDestination::Report => RequestDestination::Report,
             NetTraitsRequestDestination::Script => RequestDestination::Script,
-            NetTraitsRequestDestination::ServiceWorker => {
+            NetTraitsRequestDestination::ServiceWorker |
+            NetTraitsRequestDestination::AudioWorklet |
+            NetTraitsRequestDestination::PaintWorklet => {
                 panic!("ServiceWorker request destination should not be exposed to DOM")
             },
             NetTraitsRequestDestination::SharedWorker => RequestDestination::Sharedworker,

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -127,6 +127,7 @@ fn request_init_from_request(request: NetTraitsRequest) -> RequestBuilder {
         url_list: vec![],
         parser_metadata: request.parser_metadata,
         initiator: request.initiator,
+        csp_list: None,
     }
 }
 
@@ -155,6 +156,7 @@ pub fn Fetch(
     let timing_type = request.timing_type();
 
     let mut request_init = request_init_from_request(request);
+    request_init.csp_list = global.get_csp_list().clone();
 
     // Step 3
     if global.downcast::<ServiceWorkerGlobalScope>().is_some() {

--- a/tests/wpt/metadata/fetch/api/policies/csp-blocked.html.ini
+++ b/tests/wpt/metadata/fetch/api/policies/csp-blocked.html.ini
@@ -1,5 +1,0 @@
-[csp-blocked.html]
-  type: testharness
-  [Fetch is blocked by CSP, got a TypeError]
-    expected: FAIL
-


### PR DESCRIPTION
This needs a lot more hooks before it'll actually be a good implementation, but for a start it can help get some feedback on if this is the right way to go about it.

Part of servo/servo#4577 but we should probably track the rest of the implementation somewhere.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes (before merging, this PR should fix at least some of the WPT tests for CSP)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24315)
<!-- Reviewable:end -->
