### PR TITLE
Change setBody to be less strict when getting the immediate child

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3996,7 +3996,7 @@ impl DocumentMethods for Document {
             return Ok(());
         }
 
-        match (self.get_html_element(), &old_body) {
+        match (self.GetDocumentElement(), &old_body) {
             // Step 3.
             (Some(ref root), &Some(ref child)) => {
                 let root = root.upcast::<Node>();

--- a/tests/wpt/metadata/html/dom/documents/dom-tree-accessors/Document.body.html.ini
+++ b/tests/wpt/metadata/html/dom/documents/dom-tree-accessors/Document.body.html.ini
@@ -1,4 +1,0 @@
-[Document.body.html]
-  [Setting document.body to a new body element when the root element is a test element.]
-    expected: FAIL
-


### PR DESCRIPTION
Step four of the dom document body calls for throwing an exception
if no document element was found. The current setBody implementation
was looking for a document element that is also an html element. It
has been updated to use GetDocumentElement which returns any document
element.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #24291 

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24316)
<!-- Reviewable:end -->
