### PR TITLE
Implement as much of opaque framebuffers as we can without surfman

### DIFF
--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -243,7 +243,7 @@ pub enum WebGLCommand {
     CopyTexImage2D(u32, i32, u32, i32, i32, i32, i32, i32),
     CopyTexSubImage2D(u32, i32, i32, i32, i32, i32, i32, i32),
     CreateBuffer(WebGLSender<Option<WebGLBufferId>>),
-    CreateFramebuffer(WebGLSender<Option<WebGLFramebufferId>>),
+    CreateFramebuffer(WebGLSender<Option<WebGLTransparentFramebufferId>>),
     CreateRenderbuffer(WebGLSender<Option<WebGLRenderbufferId>>),
     CreateTexture(WebGLSender<Option<WebGLTextureId>>),
     CreateProgram(WebGLSender<Option<WebGLProgramId>>),
@@ -494,9 +494,9 @@ macro_rules! define_resource_id {
 }
 
 define_resource_id!(WebGLBufferId);
-define_resource_id!(WebGLFramebufferId);
 define_resource_id!(WebGLRenderbufferId);
 define_resource_id!(WebGLTextureId);
+define_resource_id!(WebGLTransparentFramebufferId);
 define_resource_id!(WebGLProgramId);
 define_resource_id!(WebGLShaderId);
 define_resource_id!(WebGLVertexArrayId);
@@ -514,6 +514,16 @@ pub enum WebGLError {
     InvalidValue,
     OutOfMemory,
     ContextLost,
+}
+
+// TODO: once surfman arrives, make this a swap chain id
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
+pub enum WebGLOpaqueFramebufferId {}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
+pub enum WebGLFramebufferId {
+    Transparent(WebGLTransparentFramebufferId),
+    Opaque(WebGLOpaqueFramebufferId),
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -48,7 +48,10 @@ use canvas_traits::canvas::{CompositionOrBlending, LineCapStyle, LineJoinStyle, 
 use canvas_traits::webgl::{ActiveAttribInfo, ActiveUniformInfo, GlType, TexDataType, TexFormat};
 use canvas_traits::webgl::{GLFormats, GLLimits};
 use canvas_traits::webgl::{WebGLBufferId, WebGLChan, WebGLContextShareMode, WebGLError};
-use canvas_traits::webgl::{WebGLFramebufferId, WebGLMsgSender, WebGLPipeline, WebGLProgramId};
+use canvas_traits::webgl::{
+    WebGLFramebufferId, WebGLOpaqueFramebufferId, WebGLTransparentFramebufferId,
+};
+use canvas_traits::webgl::{WebGLMsgSender, WebGLPipeline, WebGLProgramId};
 use canvas_traits::webgl::{WebGLReceiver, WebGLRenderbufferId, WebGLSLVersion, WebGLSender};
 use canvas_traits::webgl::{WebGLShaderId, WebGLTextureId, WebGLVersion, WebGLVertexArrayId};
 use crossbeam_channel::{Receiver, Sender};
@@ -474,6 +477,8 @@ unsafe_no_jsmanaged_fields!(WebGLBufferId);
 unsafe_no_jsmanaged_fields!(WebGLChan);
 unsafe_no_jsmanaged_fields!(WebGLContextShareMode);
 unsafe_no_jsmanaged_fields!(WebGLFramebufferId);
+unsafe_no_jsmanaged_fields!(WebGLOpaqueFramebufferId);
+unsafe_no_jsmanaged_fields!(WebGLTransparentFramebufferId);
 unsafe_no_jsmanaged_fields!(WebGLMsgSender);
 unsafe_no_jsmanaged_fields!(WebGLPipeline);
 unsafe_no_jsmanaged_fields!(WebGLProgramId);

--- a/components/script/dom/webglrenderbuffer.rs
+++ b/components/script/dom/webglrenderbuffer.rs
@@ -106,7 +106,7 @@ impl WebGLRenderbuffer {
             let currently_bound_framebuffer =
                 self.upcast::<WebGLObject>().context().bound_framebuffer();
             if let Some(fb) = currently_bound_framebuffer {
-                fb.detach_renderbuffer(self);
+                let _ = fb.detach_renderbuffer(self);
             }
 
             let context = self.upcast::<WebGLObject>().context();

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -210,7 +210,7 @@ impl WebGLTexture {
             let currently_bound_framebuffer =
                 self.upcast::<WebGLObject>().context().bound_framebuffer();
             if let Some(fb) = currently_bound_framebuffer {
-                fb.detach_texture(self);
+                let _ = fb.detach_texture(self);
             }
 
             let cmd = WebGLCommand::DeleteTexture(self.id);

--- a/components/script/dom/xrwebgllayer.rs
+++ b/components/script/dom/xrwebgllayer.rs
@@ -98,7 +98,8 @@ impl XRWebGLLayer {
 
         // Step 9.2. "Initialize layer’s framebuffer to a new opaque framebuffer created with
         // context and layerInit’s depth, stencil, and alpha values."
-        let framebuffer = context.CreateFramebuffer().ok_or(Error::Operation)?;
+        // TODO: make this an opaque framebuffer
+        let framebuffer = WebGLFramebuffer::maybe_new(context).ok_or(Error::Operation)?;
 
         // Step 9.3. "Allocate and initialize resources compatible with session’s XR device,
         // including GPU accessible memory buffers, as required to support the compositing of layer."
@@ -173,6 +174,8 @@ impl XRWebGLLayer {
         context.BindTexture(constants::TEXTURE_2D, old_texture.as_ref().map(|t| &**t));
         context.BindFramebuffer(constants::FRAMEBUFFER, old_fbo.as_ref().map(|f| &**f));
         context.BindRenderbuffer(constants::RENDERBUFFER, old_rbo.as_ref().map(|f| &**f));
+
+        framebuffer.set_xr_session(session);
 
         // Step 9.4: "If layer’s resources were unable to be created for any reason,
         // throw an OperationError and abort these steps."

--- a/tests/wpt/metadata/webxr/xrWebGLLayer_framebuffer_draw.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrWebGLLayer_framebuffer_draw.https.html.ini
@@ -1,4 +1,0 @@
-[xrWebGLLayer_framebuffer_draw.https.html]
-  [Ensure a WebGL layer's framebuffer can only be drawn to inside a XR frame]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webxr/xrWebGLLayer_opaque_framebuffer.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrWebGLLayer_opaque_framebuffer.https.html.ini
@@ -1,7 +1,4 @@
 [xrWebGLLayer_opaque_framebuffer.https.html]
-  [Ensure that the framebuffer given by the WebGL layer is opaque for immersive]
-    expected: FAIL
-
   [Ensure that the framebuffer given by the WebGL layer is opaque for non-immersive]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This PR implements as much of opaque framebuffers as we can without surfman. Once surfman lands, opaque framebuffers can be backed by surfman swap chains rather than shared textures.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24326)
<!-- Reviewable:end -->
