### PR TITLE
FileReader.read sets `result` to null before performing read operation

### DIFF
--- a/tests/wpt/metadata/FileAPI/reading-data-section/filereader_result.html.ini
+++ b/tests/wpt/metadata/FileAPI/reading-data-section/filereader_result.html.ini
@@ -2,27 +2,8 @@
   [result is null during "loadstart" event for readAsBinaryString]
     expected: FAIL
 
-  [result is null during "loadstart" event for readAsDataURL]
-    expected: FAIL
-
-  [result is null during "progress" event for readAsArrayBuffer]
-    expected: FAIL
-
   [result is null during "progress" event for readAsBinaryString]
-    expected: FAIL
-
-  [result is null during "loadstart" event for readAsArrayBuffer]
     expected: FAIL
 
   [readAsBinaryString]
     expected: FAIL
-
-  [result is null during "progress" event for readAsDataURL]
-    expected: FAIL
-
-  [result is null during "loadstart" event for readAsText]
-    expected: FAIL
-
-  [result is null during "progress" event for readAsText]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
As described in the spec, FileReader.read now sets its `result` to null after the FileReader's ready state is changed to "loading".
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #24288 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24329)
<!-- Reviewable:end -->
