### PR TITLE
XMLHttpRequest.responseXML returns null when a network error occurs

### DIFF
--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1292,10 +1292,15 @@ impl XMLHttpRequest {
 
     // https://xhr.spec.whatwg.org/#document-response
     fn document_response(&self) -> Option<DomRoot<Document>> {
-        // Step 1
+        // Caching: if we have existing response xml, redirect it directly
         let response = self.response_xml.get();
         if response.is_some() {
             return self.response_xml.get();
+        }
+
+        // Step 1
+        if self.response_status.get().is_err() {
+            return None;
         }
 
         let mime_type = self.final_mime_type();

--- a/tests/wpt/metadata/xhr/abort-after-send.any.js.ini
+++ b/tests/wpt/metadata/xhr/abort-after-send.any.js.ini
@@ -1,6 +1,0 @@
-[abort-after-send.any.html]
-  [XMLHttpRequest: abort() after send()]
-    expected: FAIL
-
-
-[abort-after-send.any.worker.html]

--- a/tests/wpt/metadata/xhr/send-redirect-to-cors.htm.ini
+++ b/tests/wpt/metadata/xhr/send-redirect-to-cors.htm.ini
@@ -6,27 +6,6 @@
   [XMLHttpRequest: send() - Redirect to CORS-enabled resource (307 post with typed array)]
     expected: FAIL
 
-  [XMLHttpRequest: send() - Redirect to CORS-enabled resource (301 GET with explicit Content-Type)]
-    expected: FAIL
-
-  [XMLHttpRequest: send() - Redirect to CORS-enabled resource (301 POST with string and explicit Content-Type)]
-    expected: FAIL
-
-  [XMLHttpRequest: send() - Redirect to CORS-enabled resource (302 POST with string and explicit Content-Type)]
-    expected: FAIL
-
-  [XMLHttpRequest: send() - Redirect to CORS-enabled resource (307 POST with string and explicit Content-Type)]
-    expected: FAIL
-
-  [XMLHttpRequest: send() - Redirect to CORS-enabled resource (307 FOO with string and explicit Content-Type)]
-    expected: FAIL
-
-  [XMLHttpRequest: send() - Redirect to CORS-enabled resource (308 POST with string and explicit Content-Type)]
-    expected: FAIL
-
-  [XMLHttpRequest: send() - Redirect to CORS-enabled resource (308 FOO with string and explicit Content-Type)]
-    expected: FAIL
-
   [XMLHttpRequest: send() - Redirect to CORS-enabled resource (308 FOO with string and explicit Content-Type text/plain)]
     expected: FAIL
 

--- a/tests/wpt/metadata/xhr/xmlhttprequest-network-error-sync.htm.ini
+++ b/tests/wpt/metadata/xhr/xmlhttprequest-network-error-sync.htm.ini
@@ -1,5 +1,0 @@
-[xmlhttprequest-network-error-sync.htm]
-  type: testharness
-  [XMLHttpRequest: members during network errors (sync)]
-    expected: FAIL
-

--- a/tests/wpt/metadata/xhr/xmlhttprequest-network-error.htm.ini
+++ b/tests/wpt/metadata/xhr/xmlhttprequest-network-error.htm.ini
@@ -1,5 +1,0 @@
-[xmlhttprequest-network-error.htm]
-  type: testharness
-  [XMLHttpRequest: members during network errors]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24285 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because tests ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24342)
<!-- Reviewable:end -->
