### PR TITLE
Isolate UWP builds from external gstreamers

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -298,6 +298,10 @@ class MachCommands(CommandBase):
             env["GSTREAMER_1_0_ROOT_" + arch['gst']] = path.join(
                 self.msvc_package_dir("gstreamer-uwp"), arch['gst_root']
             )
+            env["PKG_CONFIG_PATH"] = path.join(
+                self.msvc_package_dir("gstreamer-uwp"), arch['gst_root'],
+                "lib", "pkgconfig"
+            )
 
         # Ensure that GStreamer libraries are accessible when linking.
         if 'windows' in target_triple:

--- a/python/servo/packages.py
+++ b/python/servo/packages.py
@@ -9,6 +9,6 @@ WINDOWS_MSVC = {
     "ninja": "1.7.1",
     "nuget": "08-08-2019",
     "openssl": "111.3.0+1.1.1c-vs2017",
-    "gstreamer-uwp": "1.16.0.4",
+    "gstreamer-uwp": "1.16.0.5",
     "openxr-loader-uwp": "1.0",
 }


### PR DESCRIPTION
Fixes https://github.com/servo/servo/issues/24327

This further seals the UWP build from the non-cross regular environment and makes pkg-config look at the UWP package.

This makes sure external gstreamer stuff doesn't sneak in. We already kinda do this by setting the LIB environment variable, but PKG_CONFIG_PATH also sneaks in and causes problems. Thing is, it turns out that the pkgconfig in gstreamer-uwp isn't enough for a full servo build, since we don't package gstreamer-webrtc, and the gstreamer-webrtc crate requires it to be around, even if we won't end up loading the library at runtime. Stuff has succeeded so far because people have gstreamer installations whose PKG_CONFIG_PATH is pulled in, despite us using a different set of DLLs, which somehow works but sometimes doesn't (I still don't know why).

I've added a fake gstreamer-webrtc-1.0.pc file to both targets in the gstreamer-uwp package with the following contents. It doesn't do anything the other pc files don't, so it doesn't end up pulling in additional libraries, it just exists to convince pkgconfig that we *have* this library (even though we don't), so that the build may succeed (we'll fail at runtime when we try to open WebRTC connections, but those are disabled anyway).

<details>

```pkgconfig

prefix=c:/gstreamer/1.0/arm64.uwp-release
exec_prefix=${prefix}
libdir=${prefix}/lib
includedir=${prefix}/include/gstreamer-1.0
datarootdir=${prefix}/share
datadir=${datarootdir}
girdir=${datadir}/gir-1.0
typelibdir=${libdir}/girepository-1.0

Name: Fake GStreamer WebRTC library
Description: Hacky stand-in for gstreamer-webrtc, does nothing but stops the Rust gstreamer-webrtc crate from failing during build
Requires: gstreamer-1.0 gstreamer-base-1.0
Version: 1.16.0
Libs: -L${libdir}
Cflags: -I${includedir}

```
</details>

r? @jdm

Perhaps don't merge yet, I can't test this until tomorrow (and ideally would like to test this from scratch tomorrow evening)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24343)
<!-- Reviewable:end -->
