### PR TITLE
Use correct OpenSSL arch in UWP builds.

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -642,7 +642,7 @@ install them, let us know by filing a bug!")
             target_arch = vcpkg_arch[arch]
             if uwp:
                 target_arch += "-uwp"
-            openssl_base_dir = path.join(self.msvc_package_dir("openssl"), vcpkg_arch[arch])
+            openssl_base_dir = path.join(self.msvc_package_dir("openssl"), target_arch)
 
             # Link openssl
             env["OPENSSL_INCLUDE_DIR"] = path.join(openssl_base_dir, "include")


### PR DESCRIPTION
This is a followup from #24257. I forgot to run the UWP WACK tests after making my changes, or I would have noticed that the wrong DLLs were being selected for UWP builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24352)
<!-- Reviewable:end -->
