### PR TITLE
Use unfiltered response body when replicating body of cached responses.

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -669,7 +669,9 @@ impl HttpCache {
 
     /// Updating consumers who received a response constructed with a ResponseBody::Receiving.
     pub fn update_awaiting_consumers(&mut self, request: &Request, response: &Response) {
-        if let ResponseBody::Done(ref completed_body) = *response.actual_response().body.lock().unwrap() {
+        if let ResponseBody::Done(ref completed_body) =
+            *response.actual_response().body.lock().unwrap()
+        {
             let entry_key = CacheKey::new(request.clone());
             if let Some(cached_resources) = self.entries.get(&entry_key) {
                 // Ensure we only wake-up consumers of relevant resources,

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -669,7 +669,7 @@ impl HttpCache {
 
     /// Updating consumers who received a response constructed with a ResponseBody::Receiving.
     pub fn update_awaiting_consumers(&mut self, request: &Request, response: &Response) {
-        if let ResponseBody::Done(ref completed_body) = *response.body.lock().unwrap() {
+        if let ResponseBody::Done(ref completed_body) = *response.actual_response().body.lock().unwrap() {
             let entry_key = CacheKey::new(request.clone());
             if let Some(cached_resources) = self.entries.get(&entry_key) {
                 // Ensure we only wake-up consumers of relevant resources,


### PR DESCRIPTION
The amount of time it took me to track this down makes me wonder if there would be a better way of representing response bodies and filtered responses.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24350
- [ ] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24356)
<!-- Reviewable:end -->
