### PR TITLE
Add missing package dependency for Arch Linux in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ sudo zypper install libX11-devel libexpat-devel libbz2-devel Mesa-libEGL-devel M
 
 ``` sh
 sudo pacman -S --needed base-devel git python2 python2-virtualenv python2-pip mesa cmake bzip2 libxmu glu \
-    pkg-config ttf-fira-sans harfbuzz ccache clang autoconf2.13 gstreamer gstreamer-vaapi
+    pkg-config ttf-fira-sans harfbuzz ccache llvm clang autoconf2.13 gstreamer gstreamer-vaapi
 ```
 #### On Gentoo Linux
 


### PR DESCRIPTION
Without LLVM installed you get: "Error: Can't find llvm-objdump" when
running ./mach build --dev. LLVM is not installed automatically because it's not a dependency for any of the other dependencies.

Signed-off-by: Jakob Sinclair <sinclair.jakob@mailbox.org>

<!-- Please describe your changes on the following line: -->


---
- [X] These changes do not require tests because only the README.md file was updated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24361)
<!-- Reviewable:end -->
