### PR TITLE
Cache crossorigin test

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -297,6 +297,7 @@ fn create_cached_response(
     cached_headers: &HeaderMap,
     done_chan: &mut DoneChannel,
 ) -> CachedResponse {
+    debug!("creating a cached response for {:?}", request.url());
     let resource_timing = ResourceFetchTiming::new(request.timing_type());
     let mut response = Response::new(
         cached_resource.data.metadata.data.final_url.clone(),
@@ -305,6 +306,7 @@ fn create_cached_response(
     response.headers = cached_headers.clone();
     response.body = cached_resource.body.clone();
     if let ResponseBody::Receiving(_) = *cached_resource.body.lock().unwrap() {
+        debug!("existing body is in progress");
         let (done_sender, done_receiver) = unbounded();
         *done_chan = Some((done_sender.clone(), done_receiver));
         cached_resource
@@ -571,8 +573,10 @@ impl HttpCache {
         done_chan: &mut DoneChannel,
     ) -> Option<CachedResponse> {
         // TODO: generate warning headers as appropriate <https://tools.ietf.org/html/rfc7234#section-5.5>
+        debug!("trying to construct cache response for {:?}", request.url());
         if request.method != Method::GET {
             // Only Get requests are cached, avoid a url based match for others.
+            debug!("non-GET method, not caching");
             return None;
         }
         let entry_key = CacheKey::new(request.clone());
@@ -588,6 +592,7 @@ impl HttpCache {
             let original_request_headers = cached_resource.request_headers.lock().unwrap();
             if let Some(vary_value) = cached_headers.typed_get::<Vary>() {
                 if vary_value.is_any() {
+                    debug!("vary value is any, not caching");
                     can_be_constructed = false
                 } else {
                     // For every header name found in the Vary header of the stored response.
@@ -602,6 +607,7 @@ impl HttpCache {
                                     // Check that the value of the nominated header field,
                                     // in the original request, matches the value in the current request.
                                     if original_header_data != header_data {
+                                        debug!("headers don't match, not caching");
                                         can_be_constructed = false;
                                         break;
                                     }
@@ -613,6 +619,9 @@ impl HttpCache {
                                 // were also absent in the original request.
                                 can_be_constructed =
                                     original_request_headers.get(vary_val).is_none();
+                                if !can_be_constructed {
+                                    debug!("vary header present, not caching");
+                                }
                             },
                         }
                         if !can_be_constructed {
@@ -663,6 +672,7 @@ impl HttpCache {
                 return Some(cached_response);
             }
         }
+        debug!("couldn't find an appropriate response, not caching");
         // The cache wasn't able to construct anything.
         None
     }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11353,6 +11353,12 @@
      {}
     ]
    ],
+   "mozilla/cache_crossorigin_response.sub.html": [
+    [
+     "mozilla/cache_crossorigin_response.sub.html",
+     {}
+    ]
+   ],
    "mozilla/calc.html": [
     [
      "mozilla/calc.html",
@@ -18477,6 +18483,10 @@
   ],
   "mozilla/body_listener.html": [
    "13a1a0fdc15ac05458ebf2c1fd75d501a6de92e3",
+   "testharness"
+  ],
+  "mozilla/cache_crossorigin_response.sub.html": [
+   "266995f30afa3e9b3472e4cc43be6493c562aef6",
    "testharness"
   ],
   "mozilla/calc.html": [

--- a/tests/wpt/mozilla/tests/mozilla/cache_crossorigin_response.sub.html
+++ b/tests/wpt/mozilla/tests/mozilla/cache_crossorigin_response.sub.html
@@ -1,0 +1,31 @@
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  let t = async_test("Cached cross-origin response doesn't hang");
+
+  onload = t.step_func(function() {
+      let complete = 0;
+      function check() {
+          complete++;
+          if (complete == 2) {
+              t.done();
+          }
+      }
+
+      const url = "http://{{hosts[][www]]}}:{{ports[http][0]}}/html/semantics/scripting-1/the-script-element/is-script-goal.js?pipe=trickle(d5)|header(Cache-Control,max-age=3600)|header(Pragma,)|header(Expires,36000)";
+
+      function loadScript() {
+          let script = document.createElement('script');
+          document.body.appendChild(script);
+          script.src = url;
+          script.onerror = t.unreached_func();
+          script.onload = t.step_func(check);
+      }
+      // Kick off a load so there's a cache entry with an in progress response.
+      loadScript();
+
+      // Kick off a second load after a slight delay which should end up waiting until
+      // the first load is complete before sharing the existing cached response.
+      t.step_timeout(loadScript, 0);
+  });
+</script>


### PR DESCRIPTION
This adds a test for #24356 to ensure that we don't regress our cache behaviour.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24370)
<!-- Reviewable:end -->
