### PR TITLE
Pass argument by reference to CacheKey constructor

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -38,7 +38,7 @@ pub struct CacheKey {
 }
 
 impl CacheKey {
-    fn new(request: Request) -> CacheKey {
+    fn new(request: &Request) -> CacheKey {
         CacheKey {
             url: request.current_url(),
         }
@@ -575,7 +575,7 @@ impl HttpCache {
             // Only Get requests are cached, avoid a url based match for others.
             return None;
         }
-        let entry_key = CacheKey::new(request.clone());
+        let entry_key = CacheKey::new(&request);
         let resources = self
             .entries
             .get(&entry_key)?
@@ -672,7 +672,7 @@ impl HttpCache {
         if let ResponseBody::Done(ref completed_body) =
             *response.actual_response().body.lock().unwrap()
         {
-            let entry_key = CacheKey::new(request.clone());
+            let entry_key = CacheKey::new(&request);
             if let Some(cached_resources) = self.entries.get(&entry_key) {
                 // Ensure we only wake-up consumers of relevant resources,
                 // ie we don't want to wake-up 200 awaiting consumers with a 206.
@@ -709,7 +709,7 @@ impl HttpCache {
         done_chan: &mut DoneChannel,
     ) -> Option<Response> {
         assert_eq!(response.status.map(|s| s.0), Some(StatusCode::NOT_MODIFIED));
-        let entry_key = CacheKey::new(request.clone());
+        let entry_key = CacheKey::new(&request);
         if let Some(cached_resources) = self.entries.get_mut(&entry_key) {
             for cached_resource in cached_resources.iter_mut() {
                 // done_chan will have been set to Some(..) by http_network_fetch.
@@ -809,7 +809,7 @@ impl HttpCache {
             // responses to be stored is present in the response.
             return;
         };
-        let entry_key = CacheKey::new(request.clone());
+        let entry_key = CacheKey::new(&request);
         let metadata = match response.metadata() {
             Ok(FetchMetadata::Filtered {
                 filtered: _,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Argument now passed by reference, and clone() removed when calling
constructor.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #24353 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because @jdm said it only need to build

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24374)
<!-- Reviewable:end -->
