### PR TITLE
response: remove text from default statusCode

### DIFF
--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -58,7 +58,7 @@ impl Response {
             mime_type: DomRefCell::new("".to_string().into_bytes()),
             body_used: Cell::new(false),
             status: DomRefCell::new(Some(StatusCode::OK)),
-            raw_status: DomRefCell::new(Some((200, b"OK".to_vec()))),
+            raw_status: DomRefCell::new(Some((200, b"".to_vec()))),
             response_type: DomRefCell::new(DOMResponseType::Default),
             url: DomRefCell::new(None),
             url_list: DomRefCell::new(vec![]),
@@ -313,7 +313,7 @@ impl ResponseMethods for Response {
     fn StatusText(&self) -> ByteString {
         match *self.raw_status.borrow() {
             Some((_, ref st)) => ByteString::new(st.clone()),
-            None => ByteString::new(b"OK".to_vec()),
+            None => ByteString::new(b"".to_vec()),
         }
     }
 


### PR DESCRIPTION
According to the [specification](https://fetch.spec.whatwg.org/#concept-response-status-message) the text of the default statusCode text should be empty.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24371 

<!-- Either: -->
- [x] These changes do not require tests because it is a simple string change that having tests would just be useless

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24378)
<!-- Reviewable:end -->
