### PR TITLE
macos: Remove font size attribute from font descriptor.

### DIFF
--- a/components/gfx/platform/macos/font_template.rs
+++ b/components/gfx/platform/macos/font_template.rs
@@ -108,10 +108,6 @@ impl FontTemplateData {
                                 CFString::new("NSFontNameAttribute"),
                                 CFString::new(&*self.identifier).as_CFType(),
                             ),
-                            (
-                                CFString::new("NSFontSizeAttribute"),
-                                CFNumber::from(clamped_pt_size).as_CFType(),
-                            ),
                         ]);
 
                     let descriptor = font_descriptor::new_from_attributes(&attributes);

--- a/components/gfx/platform/macos/font_template.rs
+++ b/components/gfx/platform/macos/font_template.rs
@@ -6,7 +6,6 @@ use app_units::Au;
 use core_foundation::array::CFArray;
 use core_foundation::base::{CFType, TCFType};
 use core_foundation::dictionary::CFDictionary;
-use core_foundation::number::CFNumber;
 use core_foundation::string::CFString;
 use core_graphics::data_provider::CGDataProvider;
 use core_graphics::font::CGFont;
@@ -103,12 +102,10 @@ impl FontTemplateData {
                     // that one.
 
                     let attributes: CFDictionary<CFString, CFType> =
-                        CFDictionary::from_CFType_pairs(&[
-                            (
-                                CFString::new("NSFontNameAttribute"),
-                                CFString::new(&*self.identifier).as_CFType(),
-                            ),
-                        ]);
+                        CFDictionary::from_CFType_pairs(&[(
+                            CFString::new("NSFontNameAttribute"),
+                            CFString::new(&*self.identifier).as_CFType(),
+                        )]);
 
                     let descriptor = font_descriptor::new_from_attributes(&attributes);
                     let descriptors = CFArray::from_CFTypes(&[descriptor]);


### PR DESCRIPTION
This attribute isn't present in font-kit, and maybe this will help with #23290?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24387)
<!-- Reviewable:end -->
