### PR TITLE
Fix HTTP cache revalidation bugs

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -767,10 +767,12 @@ impl HttpCache {
                 constructed_response.referrer_policy = request.referrer_policy.clone();
                 constructed_response.raw_status = cached_resource.data.raw_status.clone();
                 constructed_response.url_list = cached_resource.data.url_list.clone();
+                {
+                    let mut stored_headers = cached_resource.data.metadata.headers.lock().unwrap();
+                    stored_headers.extend(response.headers);
+                    constructed_response.headers = stored_headers.clone();
+                }
                 cached_resource.data.expires = get_response_expiry(&constructed_response);
-                let mut stored_headers = cached_resource.data.metadata.headers.lock().unwrap();
-                stored_headers.extend(response.headers);
-                constructed_response.headers = stored_headers.clone();
                 return Some(constructed_response);
             }
         }

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -223,7 +223,8 @@ fn get_response_expiry(response: &Response) -> Duration {
             // If the response has a Last-Modified header field,
             // caches are encouraged to use a heuristic expiration value
             // that is no more than some fraction of the interval since that time.
-            response.headers.typed_get::<LastModified>() {
+            response.headers.typed_get::<LastModified>()
+        {
             let current = time::now().to_timespec();
             let last_modified: SystemTime = last_modified.into();
             let last_modified = last_modified.duration_since(SystemTime::UNIX_EPOCH).unwrap();


### PR DESCRIPTION
This fixes two cache related issues:
* old cached content could be viewed as a result of revalidating a newer cached response
* the expiry of a cached response refreshed through a revalidation could be calculated without any of the original response's headers

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24385
- [ ] There are tests for these changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24388)
<!-- Reviewable:end -->
