### PR TITLE
Support grip spaces in WebXR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5927,7 +5927,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#a7e8cae09a5fc3cd3434e644b6e9e2b7697b438c"
+source = "git+https://github.com/servo/webxr#ec49fdd1c1a7e45a2dfde2f4a7f07e9581f386ef"
 dependencies = [
  "bindgen",
  "euclid",
@@ -5945,7 +5945,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#a7e8cae09a5fc3cd3434e644b6e9e2b7697b438c"
+source = "git+https://github.com/servo/webxr#ec49fdd1c1a7e45a2dfde2f4a7f07e9581f386ef"
 dependencies = [
  "euclid",
  "gleam 0.6.18",

--- a/components/script/dom/webidls/XRInputSource.webidl
+++ b/components/script/dom/webidls/XRInputSource.webidl
@@ -21,6 +21,6 @@ interface XRInputSource {
   readonly attribute XRHandedness handedness;
   // [SameObject] readonly attribute XRTargetRayMode targetRayMode;
   [SameObject] readonly attribute XRSpace targetRaySpace;
-  // [SameObject] readonly attribute XRSpace? gripSpace;
+  [SameObject] readonly attribute XRSpace? gripSpace;
   // [SameObject] readonly attribute Gamepad? gamepad;
 };

--- a/tests/wpt/metadata/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/metadata/webxr/idlharness.https.window.js.ini
@@ -125,9 +125,6 @@
   [XRRay interface: existence and properties of interface prototype object]
     expected: FAIL
 
-  [XRInputSource interface: attribute gripSpace]
-    expected: FAIL
-
   [XRReferenceSpaceEvent interface: existence and properties of interface prototype object's "constructor" property]
     expected: FAIL
 


### PR DESCRIPTION
Requires https://github.com/servo/webxr/pull/67

Uses the support added in https://github.com/servo/webxr/pull/67 to expose an optional grip space.


The per-frame click added there can't yet be consumed because we need to hook up gamepads (see https://github.com/servo/servo/issues/24389)


r? @asajeffrey @jdm

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24390)
<!-- Reviewable:end -->
