### PR TITLE
Synchronize WebGL layer creation with underlying GL APIs

### DIFF
--- a/components/script/dom/xrwebgllayer.rs
+++ b/components/script/dom/xrwebgllayer.rs
@@ -192,6 +192,9 @@ impl XRWebGLLayer {
             return Err(Error::Operation);
         }
 
+        // Ensure that we finish setting up this layer before continuing.
+        context.Finish();
+
         // Step 10. "Return layer."
         Ok(XRWebGLLayer::new(
             &global.global(),


### PR DESCRIPTION
I believe the underlying cause of #24373 is that the XR callbacks can end up executing before the XR WebGL layer setup has occurred. This was observed in the following symptom:
* a DOM exception would be thrown from inside the renderVR function, which is only called from XR's requestAnimationFrame callback
* following this, the webgl thread would panic with a GL error when executing the GL operations invoked from XRWebGLLayer::Constructor

This indicates that _somehow_ the XR rAF callback that raised an exception would have been operating on GL state that was not actually the state intended.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/24408)
<!-- Reviewable:end -->
