### PR TITLE
Various XR fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5927,7 +5927,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#ec49fdd1c1a7e45a2dfde2f4a7f07e9581f386ef"
+source = "git+https://github.com/servo/webxr#61344bc5d92bc218458063baa7bc5d2d388aa7f5"
 dependencies = [
  "bindgen",
  "euclid",
@@ -5945,7 +5945,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#ec49fdd1c1a7e45a2dfde2f4a7f07e9581f386ef"
+source = "git+https://github.com/servo/webxr#61344bc5d92bc218458063baa7bc5d2d388aa7f5"
 dependencies = [
  "euclid",
  "gleam 0.6.18",

--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -123,6 +123,7 @@ transitionend
 unhandledrejection
 unload
 url
+visibilitychange
 volumechange
 waiting
 webglcontextcreationerror

--- a/components/script/dom/webidls/XRSession.webidl
+++ b/components/script/dom/webidls/XRSession.webidl
@@ -10,6 +10,12 @@ enum XREnvironmentBlendMode {
   "alpha-blend",
 };
 
+enum XRVisibilityState {
+  "visible",
+  "visible-blurred",
+  "hidden",
+};
+
 callback XRFrameRequestCallback = void (DOMHighResTimeStamp time, XRFrame frame);
 
 [SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]
@@ -17,7 +23,7 @@ interface XRSession : EventTarget {
   // // Attributes
   readonly attribute XREnvironmentBlendMode environmentBlendMode;
 
-  // readonly attribute XRVisibilityState visibilityState;
+  readonly attribute XRVisibilityState visibilityState;
   [SameObject] readonly attribute XRRenderState renderState;
   [SameObject] readonly attribute XRInputSourceArray inputSources;
 

--- a/components/script/dom/webidls/XRSession.webidl
+++ b/components/script/dom/webidls/XRSession.webidl
@@ -42,5 +42,5 @@ interface XRSession : EventTarget {
   // attribute EventHandler oninputsourceschange;
   attribute EventHandler onselectstart;
   attribute EventHandler onselectend;
-  // attribute EventHandler onvisibilitychange;
+  attribute EventHandler onvisibilitychange;
 };

--- a/components/script/dom/webidls/XRSession.webidl
+++ b/components/script/dom/webidls/XRSession.webidl
@@ -15,7 +15,6 @@ callback XRFrameRequestCallback = void (DOMHighResTimeStamp time, XRFrame frame)
 [SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]
 interface XRSession : EventTarget {
   // // Attributes
-  readonly attribute XRSessionMode mode;
   readonly attribute XREnvironmentBlendMode environmentBlendMode;
 
   // readonly attribute XRVisibilityState visibilityState;

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -49,7 +49,7 @@ use profile_traits::ipc;
 use std::cell::Cell;
 use std::mem;
 use std::rc::Rc;
-use webxr_api::{self, EnvironmentBlendMode, Event as XREvent, Frame, SelectEvent, Session};
+use webxr_api::{self, EnvironmentBlendMode, Event as XREvent, Frame, SelectEvent, Session, Visibility};
 
 #[dom_struct]
 pub struct XRSession {
@@ -213,6 +213,22 @@ impl XRSession {
                     }
                     frame.set_active(false);
                 }
+            },
+            XREvent::VisibilityChange(v) => {
+                let v = match v {
+                    Visibility::Visible => XRVisibilityState::Visible,
+                    Visibility::VisibleBlurred => XRVisibilityState::Visible_blurred,
+                    Visibility::Hidden => XRVisibilityState::Hidden,
+                };
+                self.visibility_state.set(v);
+                let event = XRSessionEvent::new(
+                    &self.global(),
+                    atom!("visibilitychange"),
+                    false,
+                    false,
+                    self,
+                );
+                event.upcast::<Event>().fire(self.upcast());
             },
             _ => (), // XXXManishearth TBD
         }

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -49,7 +49,9 @@ use profile_traits::ipc;
 use std::cell::Cell;
 use std::mem;
 use std::rc::Rc;
-use webxr_api::{self, EnvironmentBlendMode, Event as XREvent, Frame, SelectEvent, Session, Visibility};
+use webxr_api::{
+    self, EnvironmentBlendMode, Event as XREvent, Frame, SelectEvent, Session, Visibility,
+};
 
 #[dom_struct]
 pub struct XRSession {
@@ -312,6 +314,13 @@ impl XRSessionMethods for XRSession {
 
     /// https://immersive-web.github.io/webxr/#eventdef-xrsession-selectend
     event_handler!(selectend, GetOnselectend, SetOnselectend);
+
+    /// https://immersive-web.github.io/webxr/#eventdef-xrsession-visibilitychange
+    event_handler!(
+        visibilitychange,
+        GetOnvisibilitychange,
+        SetOnvisibilitychange
+    );
 
     // https://immersive-web.github.io/webxr/#dom-xrsession-renderstate
     fn RenderState(&self) -> DomRoot<XRRenderState> {

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -9,7 +9,6 @@ use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorBinding:
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextConstants as constants;
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowBinding::WindowMethods;
-use crate::dom::bindings::codegen::Bindings::XRBinding::XRSessionMode;
 use crate::dom::bindings::codegen::Bindings::XRReferenceSpaceBinding::XRReferenceSpaceType;
 use crate::dom::bindings::codegen::Bindings::XRRenderStateBinding::XRRenderStateInit;
 use crate::dom::bindings::codegen::Bindings::XRRenderStateBinding::XRRenderStateMethods;
@@ -295,11 +294,6 @@ impl XRSessionMethods for XRSession {
 
     /// https://immersive-web.github.io/webxr/#eventdef-xrsession-selectend
     event_handler!(selectend, GetOnselectend, SetOnselectend);
-
-    /// https://immersive-web.github.io/webxr/#dom-xrsession-mode
-    fn Mode(&self) -> XRSessionMode {
-        XRSessionMode::Immersive_vr
-    }
 
     // https://immersive-web.github.io/webxr/#dom-xrsession-renderstate
     fn RenderState(&self) -> DomRoot<XRRenderState> {

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -16,6 +16,7 @@ use crate::dom::bindings::codegen::Bindings::XRSessionBinding;
 use crate::dom::bindings::codegen::Bindings::XRSessionBinding::XREnvironmentBlendMode;
 use crate::dom::bindings::codegen::Bindings::XRSessionBinding::XRFrameRequestCallback;
 use crate::dom::bindings::codegen::Bindings::XRSessionBinding::XRSessionMethods;
+use crate::dom::bindings::codegen::Bindings::XRSessionBinding::XRVisibilityState;
 use crate::dom::bindings::codegen::Bindings::XRWebGLLayerBinding::XRWebGLLayerMethods;
 use crate::dom::bindings::error::{Error, ErrorResult};
 use crate::dom::bindings::inheritance::Castable;
@@ -55,6 +56,7 @@ pub struct XRSession {
     eventtarget: EventTarget,
     base_layer: MutNullableDom<XRWebGLLayer>,
     blend_mode: XREnvironmentBlendMode,
+    visibility_state: Cell<XRVisibilityState>,
     viewer_space: MutNullableDom<XRSpace>,
     #[ignore_malloc_size_of = "defined in webxr"]
     session: DomRefCell<Session>,
@@ -85,6 +87,7 @@ impl XRSession {
             eventtarget: EventTarget::new_inherited(),
             base_layer: Default::default(),
             blend_mode: session.environment_blend_mode().into(),
+            visibility_state: Cell::new(XRVisibilityState::Visible),
             viewer_space: Default::default(),
             session: DomRefCell::new(session),
             frame_requested: Cell::new(false),
@@ -403,6 +406,11 @@ impl XRSessionMethods for XRSession {
     /// https://immersive-web.github.io/webxr/#dom-xrsession-environmentblendmode
     fn EnvironmentBlendMode(&self) -> XREnvironmentBlendMode {
         self.blend_mode
+    }
+
+    /// https://immersive-web.github.io/webxr/#dom-xrsession-visibilitystate
+    fn VisibilityState(&self) -> XRVisibilityState {
+        self.visibility_state.get()
     }
 
     /// https://immersive-web.github.io/webxr/#dom-xrsession-requestreferencespace

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -48,7 +48,7 @@ use profile_traits::ipc;
 use std::cell::Cell;
 use std::mem;
 use std::rc::Rc;
-use webxr_api::{self, Event as XREvent, Frame, SelectEvent, Session};
+use webxr_api::{self, EnvironmentBlendMode, Event as XREvent, Frame, SelectEvent, Session};
 
 #[dom_struct]
 pub struct XRSession {
@@ -84,8 +84,7 @@ impl XRSession {
         XRSession {
             eventtarget: EventTarget::new_inherited(),
             base_layer: Default::default(),
-            // we don't yet support any AR devices
-            blend_mode: XREnvironmentBlendMode::Opaque,
+            blend_mode: session.environment_blend_mode().into(),
             viewer_space: Default::default(),
             session: DomRefCell::new(session),
             frame_requested: Cell::new(false),
@@ -462,4 +461,14 @@ pub fn cast_transform<T, U, V, W>(
     transform: RigidTransform3D<f32, T, U>,
 ) -> RigidTransform3D<f32, V, W> {
     unsafe { mem::transmute(transform) }
+}
+
+impl From<EnvironmentBlendMode> for XREnvironmentBlendMode {
+    fn from(x: EnvironmentBlendMode) -> Self {
+        match x {
+            EnvironmentBlendMode::Opaque => XREnvironmentBlendMode::Opaque,
+            EnvironmentBlendMode::AlphaBlend => XREnvironmentBlendMode::Alpha_blend,
+            EnvironmentBlendMode::Additive => XREnvironmentBlendMode::Additive,
+        }
+    }
 }

--- a/tests/wpt/metadata/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/metadata/webxr/idlharness.https.window.js.ini
@@ -143,9 +143,6 @@
   [XRBoundedReferenceSpace interface object name]
     expected: FAIL
 
-  [XRSession interface: attribute visibilityState]
-    expected: FAIL
-
   [XRWebGLLayer interface: attribute ignoreDepthValues]
     expected: FAIL
 

--- a/tests/wpt/metadata/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/metadata/webxr/idlharness.https.window.js.ini
@@ -14,9 +14,6 @@
   [XR interface: calling supportsSession(XRSessionMode) on navigator.xr with too few arguments must throw TypeError]
     expected: FAIL
 
-  [XRSession interface: attribute onvisibilitychange]
-    expected: FAIL
-
   [XRInputSourcesChangeEvent interface object length]
     expected: FAIL
 


### PR DESCRIPTION
Mostly making sure we expose the correct things on the XRSession interface.

No backend currently supports visibility state changes, and it's tricky to do this for Hololens because currently we must pump the event loop to notice these events, and only rAF pumps the event loop right now, which means that applications which choose to stop running rAF when blurred will have a problem.


r? @jdm