### PR TITLE
Move malloc_size_of_derive back into the Servo repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ dependencies = [
  "ipc-channel",
  "lazy_static",
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "pixels",
  "serde",
  "serde_bytes",
@@ -1058,7 +1058,7 @@ dependencies = [
  "http",
  "ipc-channel",
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "msg",
  "serde",
  "servo_url",
@@ -1515,7 +1515,7 @@ name = "gfx_traits"
 version = "0.0.1"
 dependencies = [
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "range",
  "serde",
 ]
@@ -2838,6 +2838,15 @@ dependencies = [
 [[package]]
 name = "malloc_size_of_derive"
 version = "0.1.0"
+dependencies = [
+ "proc-macro2 0.4.26",
+ "syn 0.15.39",
+ "synstructure 0.10.1",
+]
+
+[[package]]
+name = "malloc_size_of_derive"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35adee9ed962cf7d07d62cb58bc45029f3227f5b5b86246caa8632f06c187bc3"
 dependencies = [
@@ -2926,7 +2935,7 @@ dependencies = [
  "ipc-channel",
  "log",
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "msg",
  "profile_traits",
  "script_traits",
@@ -3114,7 +3123,7 @@ dependencies = [
  "ipc-channel",
  "lazy_static",
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "parking_lot",
  "serde",
  "size_of_test",
@@ -3151,7 +3160,7 @@ dependencies = [
  "libflate",
  "log",
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "matches",
  "mime",
  "mime_guess",
@@ -3204,7 +3213,7 @@ dependencies = [
  "lazy_static",
  "log",
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "mime",
  "msg",
  "num-traits",
@@ -3597,7 +3606,7 @@ version = "0.0.1"
 dependencies = [
  "euclid",
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "serde",
 ]
 
@@ -3857,7 +3866,7 @@ name = "range"
 version = "0.0.1"
 dependencies = [
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "num-traits",
  "serde",
 ]
@@ -4127,7 +4136,7 @@ dependencies = [
  "libc",
  "log",
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "media",
  "metrics",
  "mime",
@@ -4195,7 +4204,7 @@ dependencies = [
  "ipc-channel",
  "libc",
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "metrics",
  "msg",
  "net_traits",
@@ -4250,7 +4259,7 @@ dependencies = [
  "keyboard-types",
  "libc",
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "media",
  "msg",
  "net_traits",
@@ -4659,7 +4668,7 @@ dependencies = [
  "app_units",
  "euclid",
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "webrender_api",
 ]
 
@@ -4698,7 +4707,7 @@ name = "servo_url"
 version = "0.0.1"
 dependencies = [
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "serde",
  "servo_rand",
  "to_shmem",
@@ -4969,7 +4978,7 @@ dependencies = [
  "lazy_static",
  "log",
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "matches",
  "new_debug_unreachable",
  "num-derive",
@@ -5048,7 +5057,7 @@ dependencies = [
  "euclid",
  "lazy_static",
  "malloc_size_of",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0",
  "selectors",
  "serde",
  "servo_arc",
@@ -5839,7 +5848,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits",
  "plane-split",
  "rayon",
@@ -5870,7 +5879,7 @@ dependencies = [
  "derive_more",
  "euclid",
  "ipc-channel",
- "malloc_size_of_derive",
+ "malloc_size_of_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "peek-poke",
  "serde",
  "serde_bytes",

--- a/components/canvas_traits/Cargo.toml
+++ b/components/canvas_traits/Cargo.toml
@@ -19,7 +19,7 @@ euclid = "0.20"
 ipc-channel = "0.12"
 lazy_static = "1"
 malloc_size_of = { path = "../malloc_size_of" }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 pixels = {path = "../pixels"}
 serde = "1.0"
 serde_bytes = "0.10"

--- a/components/devtools_traits/Cargo.toml
+++ b/components/devtools_traits/Cargo.toml
@@ -15,7 +15,7 @@ bitflags = "1.0"
 http = "0.1"
 ipc-channel = "0.12"
 malloc_size_of = { path = "../malloc_size_of" }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 msg = {path = "../msg"}
 serde = "1.0"
 servo_url = {path = "../url"}

--- a/components/geometry/Cargo.toml
+++ b/components/geometry/Cargo.toml
@@ -14,5 +14,5 @@ path = "lib.rs"
 app_units = "0.7"
 euclid = "0.20"
 malloc_size_of = { path = "../malloc_size_of" }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 webrender_api = { git = "https://github.com/servo/webrender" }

--- a/components/gfx_traits/Cargo.toml
+++ b/components/gfx_traits/Cargo.toml
@@ -12,6 +12,6 @@ path = "lib.rs"
 
 [dependencies]
 malloc_size_of = { path = "../malloc_size_of" }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 range = {path = "../range"}
 serde = "1.0"

--- a/components/malloc_size_of_derive/Cargo.toml
+++ b/components/malloc_size_of_derive/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "malloc_size_of_derive"
+version = "0.1.0"
+authors = ["The Servo Project Developers"]
+license = "MIT/Apache-2.0"
+description = "Crate for Firefox memory reporting, not intended for external use"
+publish = false
+
+[lib]
+path = "lib.rs"
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "0.4"
+syn = { version = "0.15", features = ["full"] }
+synstructure = "0.10"

--- a/components/malloc_size_of_derive/LICENSE-APACHE
+++ b/components/malloc_size_of_derive/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/components/malloc_size_of_derive/LICENSE-MIT
+++ b/components/malloc_size_of_derive/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/components/malloc_size_of_derive/lib.rs
+++ b/components/malloc_size_of_derive/lib.rs
@@ -1,0 +1,125 @@
+// Copyright 2016-2017 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A crate for deriving the MallocSizeOf trait.
+
+extern crate proc_macro2;
+#[macro_use]
+extern crate syn;
+#[macro_use]
+extern crate synstructure;
+
+#[cfg(not(test))]
+decl_derive!([MallocSizeOf, attributes(ignore_malloc_size_of)] => malloc_size_of_derive);
+
+fn malloc_size_of_derive(s: synstructure::Structure) -> proc_macro2::TokenStream {
+    let match_body = s.each(|binding| {
+        let ignore = binding
+            .ast()
+            .attrs
+            .iter()
+            .any(|attr| match attr.interpret_meta().unwrap() {
+                syn::Meta::Word(ref ident) | syn::Meta::List(syn::MetaList { ref ident, .. })
+                    if ident == "ignore_malloc_size_of" =>
+                {
+                    panic!(
+                        "#[ignore_malloc_size_of] should have an explanation, \
+                         e.g. #[ignore_malloc_size_of = \"because reasons\"]"
+                    );
+                }
+                syn::Meta::NameValue(syn::MetaNameValue { ref ident, .. })
+                    if ident == "ignore_malloc_size_of" =>
+                {
+                    true
+                },
+                _ => false,
+            });
+        if ignore {
+            None
+        } else if let syn::Type::Array(..) = binding.ast().ty {
+            Some(quote! {
+                for item in #binding.iter() {
+                    sum += ::malloc_size_of::MallocSizeOf::size_of(item, ops);
+                }
+            })
+        } else {
+            Some(quote! {
+                sum += ::malloc_size_of::MallocSizeOf::size_of(#binding, ops);
+            })
+        }
+    });
+
+    let ast = s.ast();
+    let name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    let mut where_clause = where_clause.unwrap_or(&parse_quote!(where)).clone();
+    for param in ast.generics.type_params() {
+        let ident = &param.ident;
+        where_clause
+            .predicates
+            .push(parse_quote!(#ident: ::malloc_size_of::MallocSizeOf));
+    }
+
+    let tokens = quote! {
+        impl #impl_generics ::malloc_size_of::MallocSizeOf for #name #ty_generics #where_clause {
+            #[inline]
+            #[allow(unused_variables, unused_mut, unreachable_code)]
+            fn size_of(&self, ops: &mut ::malloc_size_of::MallocSizeOfOps) -> usize {
+                let mut sum = 0;
+                match *self {
+                    #match_body
+                }
+                sum
+            }
+        }
+    };
+
+    tokens
+}
+
+#[test]
+fn test_struct() {
+    let source = syn::parse_str(
+        "struct Foo<T> { bar: Bar, baz: T, #[ignore_malloc_size_of = \"\"] z: Arc<T> }",
+    )
+    .unwrap();
+    let source = synstructure::Structure::new(&source);
+
+    let expanded = malloc_size_of_derive(source).to_string();
+    let mut no_space = expanded.replace(" ", "");
+    macro_rules! match_count {
+        ($e: expr, $count: expr) => {
+            assert_eq!(
+                no_space.matches(&$e.replace(" ", "")).count(),
+                $count,
+                "counting occurences of {:?} in {:?} (whitespace-insensitive)",
+                $e,
+                expanded
+            )
+        };
+    }
+    match_count!("struct", 0);
+    match_count!("ignore_malloc_size_of", 0);
+    match_count!("impl<T> ::malloc_size_of::MallocSizeOf for Foo<T> where T: ::malloc_size_of::MallocSizeOf {", 1);
+    match_count!("sum += ::malloc_size_of::MallocSizeOf::size_of(", 2);
+
+    let source = syn::parse_str("struct Bar([Baz; 3]);").unwrap();
+    let source = synstructure::Structure::new(&source);
+    let expanded = malloc_size_of_derive(source).to_string();
+    no_space = expanded.replace(" ", "");
+    match_count!("for item in", 1);
+}
+
+#[should_panic(expected = "should have an explanation")]
+#[test]
+fn test_no_reason() {
+    let input = syn::parse_str("struct A { #[ignore_malloc_size_of] b: C }").unwrap();
+    malloc_size_of_derive(synstructure::Structure::new(&input));
+}

--- a/components/metrics/Cargo.toml
+++ b/components/metrics/Cargo.toml
@@ -15,7 +15,7 @@ gfx_traits = {path = "../gfx_traits"}
 ipc-channel = "0.12"
 log = "0.4"
 malloc_size_of = { path = "../malloc_size_of" }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 msg = {path = "../msg"}
 profile_traits = {path = "../profile_traits"}
 script_traits = {path = "../script_traits"}

--- a/components/msg/Cargo.toml
+++ b/components/msg/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 lazy_static = "1"
 ipc-channel = "0.12"
 malloc_size_of = { path = "../malloc_size_of" }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 parking_lot = "0.9"
 serde = "1.0.60"
 webrender_api = {git = "https://github.com/servo/webrender", features = ["ipc"]}

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -34,7 +34,7 @@ lazy_static = "1"
 libflate = "0.1"
 log = "0.4"
 malloc_size_of = { path = "../malloc_size_of" }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 matches = "0.1"
 mime = "0.3"
 mime_guess = "2.0.0-alpha.6"

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -24,7 +24,7 @@ ipc-channel = "0.12"
 lazy_static = "1"
 log = "0.4"
 malloc_size_of = { path = "../malloc_size_of" }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 mime = "0.3"
 msg = {path = "../msg"}
 num-traits = "0.2"

--- a/components/pixels/Cargo.toml
+++ b/components/pixels/Cargo.toml
@@ -13,5 +13,5 @@ path = "lib.rs"
 [dependencies]
 euclid = "0.20"
 malloc_size_of = {path = "../malloc_size_of"}
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 serde = {version = "1", features = ["derive"]}

--- a/components/range/Cargo.toml
+++ b/components/range/Cargo.toml
@@ -13,6 +13,6 @@ path = "lib.rs"
 
 [dependencies]
 malloc_size_of = { path = "../malloc_size_of" }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 num-traits = "0.2"
 serde = "1.0"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -67,7 +67,7 @@ lazy_static = "1"
 libc = "0.2"
 log = "0.4"
 malloc_size_of = { path = "../malloc_size_of" }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 media = {path = "../media"}
 metrics = {path = "../metrics"}
 mitochondria = "1.1.2"

--- a/components/script_layout_interface/Cargo.toml
+++ b/components/script_layout_interface/Cargo.toml
@@ -21,7 +21,7 @@ html5ever = "0.24"
 ipc-channel = "0.12"
 libc = "0.2"
 malloc_size_of = { path = "../malloc_size_of" }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 metrics = {path = "../metrics"}
 msg = {path = "../msg"}
 net_traits = {path = "../net_traits"}

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -26,7 +26,7 @@ ipc-channel = "0.12"
 keyboard-types = "0.4.3"
 libc = "0.2"
 malloc_size_of = { path = "../malloc_size_of" }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 media = {path = "../media"}
 msg = {path = "../msg"}
 net_traits = {path = "../net_traits"}

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -48,7 +48,7 @@ itoa = "0.4"
 lazy_static = "1"
 log = { version = "0.4", features = ["std"] }
 malloc_size_of = { path = "../malloc_size_of" }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 matches = "0.1"
 num_cpus = {version = "1.1.0"}
 num-integer = "0.1"

--- a/components/style_traits/Cargo.toml
+++ b/components/style_traits/Cargo.toml
@@ -20,7 +20,7 @@ bitflags = "1.0"
 euclid = "0.20"
 lazy_static = "1"
 malloc_size_of = { path = "../malloc_size_of" }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 selectors = { path = "../selectors" }
 serde = {version = "1.0", optional = true}
 webrender_api = {git = "https://github.com/servo/webrender", optional = true}

--- a/components/url/Cargo.toml
+++ b/components/url/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 
 [dependencies]
 malloc_size_of = { path = "../malloc_size_of", features = ["servo"] }
-malloc_size_of_derive = "0.1"
+malloc_size_of_derive = { path = "../malloc_size_of_derive" }
 to_shmem = { path = "../to_shmem" }
 serde = {version = "1.0", features = ["derive"]}
 servo_rand = {path = "../rand"}


### PR DESCRIPTION
Per issue #24419, the `MallocSizeOf` trait is not available on crates.io, so the derive shouldn't be either.  Move this derive back into the Servo repository.

Derive taken from: https://github.com/bholley/malloc_size_of_derive

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes fix #24419

<!-- Either: -->
- [x] These changes do not require tests because they are simply the movement of this derive back into the Servo repository.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
