### PR TITLE
Account for pending request state in <img>.complete

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -921,6 +921,12 @@ impl HTMLImageElement {
         let src = elem.get_url_attribute(&local_name!("src"));
         let base_url = document.base_url();
 
+        {
+            if let Some(ref mut pending_request) = *self.pending_request.borrow_mut() {
+                pending_request.state = State::Unavailable;
+            }
+        }
+
         if !document.is_active() {
             // Step 1 (if the document is inactive)
             // TODO: use GlobalScope::enqueue_microtask,

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -922,8 +922,10 @@ impl HTMLImageElement {
         let base_url = document.base_url();
 
         {
-            if let Some(ref mut pending_request) = *self.pending_request.borrow_mut() {
-                pending_request.state = State::Unavailable;
+            // Reset pending_request to ensure a consistent `<img>.complete` state.
+            let mut pending_opt = self.pending_request.borrow_mut();
+            if pending_opt.is_none() {
+                *pending_opt = Some(ImageRequest::new());
             }
         }
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -66,13 +66,12 @@ use servo_url::origin::ImmutableOrigin;
 use servo_url::origin::MutableOrigin;
 use servo_url::ServoUrl;
 use std::cell::Cell;
-use std::char;
 use std::collections::HashSet;
 use std::default::Default;
 use std::i32;
-use std::mem;
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex};
+use std::{char, mem};
 use style::attr::{
     parse_double, parse_length, parse_unsigned_integer, AttrValue, LengthOrPercentageOrAuto,
 };
@@ -484,8 +483,7 @@ impl HTMLImageElement {
                 pending_request.metadata = Some(meta);
             },
             ImageResponse::None => {
-                let mut pending_opt = self.pending_request.borrow_mut();
-                *pending_opt = None;
+                *self.pending_request.borrow_mut() = None;
             },
         };
     }
@@ -871,8 +869,7 @@ impl HTMLImageElement {
                         // non-active-document.html tests.
                         this.abort_request(State::Broken, ImageRequestPhase::Current);
                         this.abort_request(State::Broken, ImageRequestPhase::Pending);
-                        let mut pending_opt = this.pending_request.borrow_mut();
-                        *pending_opt = None;
+                        *this.pending_request.borrow_mut() = None;
                     }),
                     window.upcast(),
                 );
@@ -885,7 +882,7 @@ impl HTMLImageElement {
         let parsed_url = base_url.join(&src.0);
         match parsed_url {
             Ok(url) => {
-                // Step 13-17
+                // Step 12-17
                 self.prepare_image_request(&url, &src, pixel_density);
             },
             Err(_) => {
@@ -909,8 +906,7 @@ impl HTMLImageElement {
                         // non-active-document.html tests.
                         this.abort_request(State::Broken, ImageRequestPhase::Current);
                         this.abort_request(State::Broken, ImageRequestPhase::Pending);
-                        let mut pending_opt = this.pending_request.borrow_mut();
-                        *pending_opt = None;
+                        *this.pending_request.borrow_mut() = None;
                     }),
                     window.upcast(),
                 );
@@ -974,8 +970,7 @@ impl HTMLImageElement {
                     // Step 6.3.2 abort requests
                     self.abort_request(State::CompletelyAvailable, ImageRequestPhase::Current);
                     self.abort_request(State::Unavailable, ImageRequestPhase::Pending);
-                    let mut pending_opt = self.pending_request.borrow_mut();
-                    *pending_opt = None;
+                    *self.pending_request.borrow_mut() = None;
                     let mut current_request = self.current_request.borrow_mut();
                     current_request.final_url = Some(url);
                     current_request.image = Some(image.clone());
@@ -1185,8 +1180,7 @@ impl HTMLImageElement {
                 let relevant_mutation = this.generation.get() != generation;
                 // Step 15.1
                 if relevant_mutation {
-                    let mut pending_opt = this.pending_request.borrow_mut();
-                    *pending_opt = None;
+                    *this.pending_request.borrow_mut() = None;
                     return;
                 }
                 // Step 15.2

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -66,12 +66,12 @@ use servo_url::origin::ImmutableOrigin;
 use servo_url::origin::MutableOrigin;
 use servo_url::ServoUrl;
 use std::cell::Cell;
+use std::char;
 use std::collections::HashSet;
 use std::default::Default;
 use std::i32;
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex};
-use std::{char, mem};
 use style::attr::{
     parse_double, parse_length, parse_unsigned_integer, AttrValue, LengthOrPercentageOrAuto,
 };
@@ -384,12 +384,11 @@ impl HTMLImageElement {
 
     /// https://html.spec.whatwg.org/multipage/#upgrade-the-pending-request-to-the-current-request
     fn upgrade_pending_to_current(&self) {
-        let mut pending_opt = self.pending_request.borrow_mut();
-        mem::swap(
-            &mut self.current_request.borrow_mut().deref_mut(),
-            &mut pending_opt.get_or_insert(ImageRequest::new()),
-        );
-        *pending_opt = None;
+        *self.current_request.borrow_mut() = self
+            .pending_request
+            .borrow_mut()
+            .take()
+            .expect("no pending request");
         self.image_request.set(ImageRequestPhase::Current);
     }
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -776,18 +776,18 @@ impl HTMLImageElement {
         request.blocker = Some(LoadBlocker::new(&*document, LoadType::Image(url.clone())));
     }
 
-    /// Step 13-17 of html.spec.whatwg.org/multipage/#update-the-image-data
+    /// Step 12-17 of html.spec.whatwg.org/multipage/#update-the-image-data
     fn prepare_image_request(&self, url: &ServoUrl, src: &USVString, selected_pixel_density: f64) {
         match self.image_request.get() {
             ImageRequestPhase::Pending => {
-                self.pending_request.borrow().as_ref().map(|request| {
-                    // Step 12
-                    if let Some(pending_url) = request.parsed_url.clone() {
+                // Step 12
+                if let Some(pending_request) = self.pending_request.borrow().as_ref() {
+                    if let Some(pending_url) = pending_request.parsed_url.clone() {
                         if pending_url == *url {
                             return;
                         }
                     }
-                });
+                }
             },
             ImageRequestPhase::Current => {
                 let mut current_request = self.current_request.borrow_mut();


### PR DESCRIPTION
Per spec update, if the \<img\> current request is completely available or broken, `complete` is only `true` if the \<img\>'s pending request is also unavailable.

> The IDL attribute complete must return true if any of the following conditions is true:
       * Both the src attribute and the srcset attribute are omitted.
       * The srcset attribute is omitted and the src attribute's value is the empty string. 
       * **The img element's current request's state is completely available and its pending request is null.**
       * **The img element's current request's state is broken and its pending request is null.** 

Spec diff: https://whatpr.org/html/4934/1ab7c86...02772ea/embedded-content.html#the-img-element

#24450

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24450.
- [x] These changes do not require tests because they _should_ be covered by the automatically synced WPT associated with the spec update at https://github.com/whatwg/html/pull/4934.  

However, the [test updated with the spec change](https://github.com/servo/servo/blob/master/tests/wpt/web-platform-tests/html/semantics/embedded-content/the-img-element/img.complete.html) passes before and after this PR.  Should another test be added?

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
