### PR TITLE
fix getimagedata returns empty pixels

### DIFF
--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -33,6 +33,8 @@ pub struct OffscreenCanvasRenderingContext2D {
     canvas: Option<Dom<OffscreenCanvas>>,
     canvas_state: DomRefCell<CanvasState>,
     htmlcanvas: Option<Dom<HTMLCanvasElement>>,
+    width: u32,
+    height: u32,
 }
 
 impl OffscreenCanvasRenderingContext2D {
@@ -50,6 +52,8 @@ impl OffscreenCanvasRenderingContext2D {
                 global,
                 Size2D::new(size.width as u64, size.height as u64),
             )),
+            width: size.width as u32,
+            height: size.height as u32,
         }
     }
 
@@ -307,7 +311,7 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-getimagedata
     fn GetImageData(&self, sx: i32, sy: i32, sw: i32, sh: i32) -> Fallible<DomRoot<ImageData>> {
         self.canvas_state.borrow().GetImageData(
-            self.htmlcanvas.as_ref().map(|c| &**c),
+            Size2D::new(self.width, self.height),
             &self.global(),
             sx,
             sy,
@@ -319,7 +323,7 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata
     fn PutImageData(&self, imagedata: &ImageData, dx: i32, dy: i32) {
         self.canvas_state.borrow().PutImageData(
-            self.htmlcanvas.as_ref().map(|c| &**c),
+            Size2D::new(self.width, self.height),
             imagedata,
             dx,
             dy,
@@ -339,7 +343,7 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
         dirty_height: i32,
     ) {
         self.canvas_state.borrow().PutImageData_(
-            self.htmlcanvas.as_ref().map(|c| &**c),
+            Size2D::new(self.width, self.height),
             imagedata,
             dx,
             dy,

--- a/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.fill.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.fill.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.interpolate.zerosize.fill.html]
-  [OffscreenCanvas test: 2d.gradient.interpolate.zerosize.fill]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.fill.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.fill.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.gradient.interpolate.zerosize.fill.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.fillRect.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.fillRect.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.interpolate.zerosize.fillRect.html]
-  [OffscreenCanvas test: 2d.gradient.interpolate.zerosize.fillRect]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.fillRect.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.fillRect.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.gradient.interpolate.zerosize.fillRect.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.stroke.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.stroke.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.interpolate.zerosize.stroke.html]
-  [OffscreenCanvas test: 2d.gradient.interpolate.zerosize.stroke]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.stroke.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.stroke.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.gradient.interpolate.zerosize.stroke.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.strokeRect.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.strokeRect.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.interpolate.zerosize.strokeRect.html]
-  [OffscreenCanvas test: 2d.gradient.interpolate.zerosize.strokeRect]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.strokeRect.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/fill-and-stroke-styles/2d.gradient.interpolate.zerosize.strokeRect.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.gradient.interpolate.zerosize.strokeRect.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/filter/offscreencanvas.filter.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/filter/offscreencanvas.filter.html.ini
@@ -1,4 +1,0 @@
-[offscreencanvas.filter.html]
-  [none]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cap.closed.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cap.closed.html.ini
@@ -1,4 +1,0 @@
-[2d.line.cap.closed.html]
-  [Line caps are not drawn at the corners of an unclosed rectangle]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cap.closed.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cap.closed.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.line.cap.closed.worker.html]
-  [Line caps are not drawn at the corners of an unclosed rectangle]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cap.open.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cap.open.html.ini
@@ -1,4 +1,0 @@
-[2d.line.cap.open.html]
-  [Line caps are drawn at the corners of an unclosed rectangle]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cap.open.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cap.open.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.line.cap.open.worker.html]
-  [Line caps are drawn at the corners of an unclosed rectangle]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cross.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cross.html.ini
@@ -1,4 +1,0 @@
-[2d.line.cross.html]
-  [OffscreenCanvas test: 2d.line.cross]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cross.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cross.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.line.cross.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.join.closed.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.join.closed.html.ini
@@ -1,4 +1,0 @@
-[2d.line.join.closed.html]
-  [Line joins are drawn at the corner of a closed rectangle]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.join.closed.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.join.closed.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.line.join.closed.worker.html]
-  [Line joins are drawn at the corner of a closed rectangle]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.join.open.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.join.open.html.ini
@@ -1,4 +1,0 @@
-[2d.line.join.open.html]
-  [Line joins are not drawn at the corner of an unclosed rectangle]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.join.open.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.join.open.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.line.join.open.worker.html]
-  [Line joins are not drawn at the corner of an unclosed rectangle]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.join.parallel.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.join.parallel.html.ini
@@ -1,4 +1,0 @@
-[2d.line.join.parallel.html]
-  [Line joins are drawn at 180-degree joins]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.join.parallel.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.join.parallel.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.line.join.parallel.worker.html]
-  [Line joins are drawn at 180-degree joins]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.acute.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.acute.html.ini
@@ -1,4 +1,0 @@
-[2d.line.miter.acute.html]
-  [Miter joins are drawn correctly with acute angles]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.acute.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.acute.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.line.miter.acute.worker.html]
-  [Miter joins are drawn correctly with acute angles]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.exceeded.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.exceeded.html.ini
@@ -1,4 +1,0 @@
-[2d.line.miter.exceeded.html]
-  [Miter joins are not drawn when the miter limit is exceeded]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.exceeded.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.exceeded.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.line.miter.exceeded.worker.html]
-  [Miter joins are not drawn when the miter limit is exceeded]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.lineedge.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.lineedge.html.ini
@@ -1,4 +1,0 @@
-[2d.line.miter.lineedge.html]
-  [Miter joins are not drawn when the miter limit is exceeded at the corners of a zero-height rectangle]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.lineedge.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.lineedge.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.line.miter.lineedge.worker.html]
-  [Miter joins are not drawn when the miter limit is exceeded at the corners of a zero-height rectangle]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.obtuse.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.obtuse.html.ini
@@ -1,4 +1,0 @@
-[2d.line.miter.obtuse.html]
-  [Miter joins are drawn correctly with obtuse angles]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.obtuse.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.obtuse.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.line.miter.obtuse.worker.html]
-  [Miter joins are drawn correctly with obtuse angles]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.rightangle.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.rightangle.html.ini
@@ -1,4 +1,0 @@
-[2d.line.miter.rightangle.html]
-  [Miter joins are not drawn when the miter limit is exceeded, on exact right angles]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.rightangle.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.rightangle.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.line.miter.rightangle.worker.html]
-  [Miter joins are not drawn when the miter limit is exceeded, on exact right angles]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.within.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.within.html.ini
@@ -1,4 +1,0 @@
-[2d.line.miter.within.html]
-  [Miter joins are drawn when the miter limit is not quite exceeded]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.within.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.miter.within.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.line.miter.within.worker.html]
-  [Miter joins are drawn when the miter limit is not quite exceeded]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.union.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.union.html.ini
@@ -1,4 +1,0 @@
-[2d.line.union.html]
-  [OffscreenCanvas test: 2d.line.union]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.union.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.union.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.line.union.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.clamp.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.clamp.html.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.clamp.html]
-  [getImageData() clamps colours to the range [0, 255\]]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.clamp.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.clamp.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.clamp.worker.html]
-  [getImageData() clamps colours to the range [0, 255\]]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.nonpremul.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.nonpremul.html.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.nonpremul.html]
-  [getImageData() returns non-premultiplied colours]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.nonpremul.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.nonpremul.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.nonpremul.worker.html]
-  [getImageData() returns non-premultiplied colours]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.alpha.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.alpha.html.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.order.alpha.html]
-  [getImageData() returns A in the fourth component]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.alpha.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.alpha.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.order.alpha.worker.html]
-  [getImageData() returns A in the fourth component]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.cols.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.cols.html.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.order.cols.html]
-  [getImageData() returns leftmost columns first]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.cols.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.cols.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.order.cols.worker.html]
-  [getImageData() returns leftmost columns first]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.rgb.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.rgb.html.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.order.rgb.html]
-  [getImageData() returns R then G then B]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.rgb.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.rgb.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.order.rgb.worker.html]
-  [getImageData() returns R then G then B]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.rows.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.rows.html.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.order.rows.html]
-  [getImageData() returns topmost rows first]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.rows.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.order.rows.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.order.rows.worker.html]
-  [getImageData() returns topmost rows first]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.range.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.range.html.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.range.html]
-  [getImageData() returns values in the range [0, 255\]]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.range.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.get.range.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.imageData.get.range.worker.html]
-  [getImageData() returns values in the range [0, 255\]]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.put.unchanged.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.put.unchanged.html.ini
@@ -1,0 +1,4 @@
+[2d.imageData.put.unchanged.html]
+  [putImageData(getImageData(...), ...) has no effect]
+    expected: FAIL
+

--- a/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.put.unchanged.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.put.unchanged.worker.js.ini
@@ -1,0 +1,4 @@
+[2d.imageData.put.unchanged.worker.html]
+  [putImageData(getImageData(...), ...) has no effect]
+    expected: FAIL
+

--- a/tests/wpt/metadata/offscreen-canvas/the-offscreen-canvas/initial.reset.path.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/the-offscreen-canvas/initial.reset.path.html.ini
@@ -1,0 +1,4 @@
+[initial.reset.path.html]
+  [Resetting the canvas state resets the current path]
+    expected: FAIL
+

--- a/tests/wpt/metadata/offscreen-canvas/the-offscreen-canvas/initial.reset.path.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/the-offscreen-canvas/initial.reset.path.worker.js.ini
@@ -1,0 +1,4 @@
+[initial.reset.path.worker.html]
+  [Resetting the canvas state resets the current path]
+    expected: FAIL
+

--- a/tests/wpt/metadata/offscreen-canvas/the-offscreen-canvas/offscreencanvas.getcontext.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/the-offscreen-canvas/offscreencanvas.getcontext.html.ini
@@ -5,9 +5,6 @@
   [Test that webglcontext.canvas should return the original OffscreenCanvas]
     expected: FAIL
 
-  [Test that OffscreenCanvasRenderingContext2D with alpha enabled preserves the alpha]
-    expected: FAIL
-
   [Test that getContext with un-supported string throws a TypeError.]
     expected: FAIL
 
@@ -15,9 +12,6 @@
     expected: FAIL
 
   [Test that getContext twice with different context type returns null the second time]
-    expected: FAIL
-
-  [Test that 'alpha' context creation attribute is true by default]
     expected: FAIL
 
   [Test that 2dcontext.canvas should return the original OffscreenCanvas]

--- a/tests/wpt/metadata/offscreen-canvas/the-offscreen-canvas/offscreencanvas.getcontext.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/the-offscreen-canvas/offscreencanvas.getcontext.worker.js.ini
@@ -5,9 +5,6 @@
   [Test that webglcontext.canvas should return the original OffscreenCanvas]
     expected: FAIL
 
-  [Test that OffscreenCanvasRenderingContext2D with alpha enabled preserves the alpha]
-    expected: FAIL
-
   [Test that getContext with un-supported string throws a TypeError.]
     expected: FAIL
 
@@ -15,9 +12,6 @@
     expected: FAIL
 
   [Test that getContext twice with different context type returns null the second time]
-    expected: FAIL
-
-  [Test that 'alpha' context creation attribute is true by default]
     expected: FAIL
 
   [Test that 2dcontext.canvas should return the original OffscreenCanvas]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
GetImageData for OffscreenCanvas without an associated canvas element returned blank pixels. To solve this, we now pass a `Size2D` instead of a canvas to relevant functions.

I don't quite know if it's ok that `OffscreenCanvasRenderingContext2D` now have a `width` and `height`, but I found no other reasonable solution to this.

There are some tests that previously were marked as `PASS` that are now failing. It seems that they were passing for the wrong reason.
These are:
> tests/wpt/metadata/offscreen-canvas/pixel-manipulation/2d.imageData.put.unchanged.html.ini
> tests/wpt/metadata/offscreen-canvas/pixel-manipulatio/2d.imageData.put.unchanged.worker.js.ini
> tests/wpt/metadata/offscreen-canvas/the-offscreen-canvas/initial.reset.path.html.ini
> tests/wpt/metadata/offscreen-canvas/the-offscreen-canvas/initial.reset.path.worker.js.ini
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24271 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
