### PR TITLE
Performance interface's timing member as an attribute change

### DIFF
--- a/components/script/dom/webidls/Performance.webidl
+++ b/components/script/dom/webidls/Performance.webidl
@@ -47,7 +47,7 @@ partial interface Performance {
 // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/NavigationTiming/Overview.html#performance-timing-attribute
 [Exposed=(Window)]
 partial interface Performance {
-  PerformanceNavigationTiming timing();
+  readonly attribute PerformanceNavigationTiming timing;
 };
 // https://w3c.github.io/navigation-timing/#extensions-to-the-performance-interface
 partial interface Performance {


### PR DESCRIPTION
In this patch we change the Performance Interface's `timing` member to be an attribute as the spec requires: https://w3c.github.io/navigation-timing/#extensions-to-the-performance-interface

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23330

---

- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___
