### PR TITLE
xmlhttprequest: Don't pass total value on timeout

### DIFF
--- a/tests/wpt/metadata/xhr/send-timeout-events.htm.ini
+++ b/tests/wpt/metadata/xhr/send-timeout-events.htm.ini
@@ -1,5 +1,0 @@
-[send-timeout-events.htm]
-  type: testharness
-  [XMLHttpRequest: The send() method: timeout is not 0 ]
-    expected: FAIL
-


### PR DESCRIPTION
fixes: #24286

Signed-off-by: Santosh Sivaraj <santosh@fossix.org>

<!-- Please describe your changes on the following line: -->

Progress event should not get total/partial load values on timeout. Fix to pass 0 in the error path.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #24286 

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___
