### PR TITLE
UIEvent does not properly initialize its view attribute 

### DIFF
--- a/components/script/dom/compositionevent.rs
+++ b/components/script/dom/compositionevent.rs
@@ -8,7 +8,7 @@ use crate::dom::bindings::codegen::Bindings::CompositionEventBinding::{
 use crate::dom::bindings::codegen::Bindings::UIEventBinding::UIEventBinding::UIEventMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::reflect_dom_object;
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
@@ -32,7 +32,7 @@ impl CompositionEvent {
     ) -> DomRoot<CompositionEvent> {
         let ev = reflect_dom_object(
             Box::new(CompositionEvent {
-                uievent: UIEvent::new_inherited(),
+                uievent: UIEvent::new_inherited(MutNullableDom::new(Some(window))),
                 data: data,
             }),
             window,

--- a/components/script/dom/compositionevent.rs
+++ b/components/script/dom/compositionevent.rs
@@ -8,7 +8,7 @@ use crate::dom::bindings::codegen::Bindings::CompositionEventBinding::{
 use crate::dom::bindings::codegen::Bindings::UIEventBinding::UIEventBinding::UIEventMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::reflect_dom_object;
-use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
@@ -32,7 +32,7 @@ impl CompositionEvent {
     ) -> DomRoot<CompositionEvent> {
         let ev = reflect_dom_object(
             Box::new(CompositionEvent {
-                uievent: UIEvent::new_inherited(MutNullableDom::new(Some(window))),
+                uievent: UIEvent::new_inherited(window),
                 data: data,
             }),
             window,

--- a/components/script/dom/focusevent.rs
+++ b/components/script/dom/focusevent.rs
@@ -24,16 +24,16 @@ pub struct FocusEvent {
 }
 
 impl FocusEvent {
-    fn new_inherited() -> FocusEvent {
+    fn new_inherited(window: &Window) -> FocusEvent {
         FocusEvent {
-            uievent: UIEvent::new_inherited(),
+            uievent: UIEvent::new_inherited(MutNullableDom::new(Some(window))),
             related_target: Default::default(),
         }
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<FocusEvent> {
         reflect_dom_object(
-            Box::new(FocusEvent::new_inherited()),
+            Box::new(FocusEvent::new_inherited(window)),
             window,
             FocusEventBinding::Wrap,
         )

--- a/components/script/dom/focusevent.rs
+++ b/components/script/dom/focusevent.rs
@@ -26,7 +26,7 @@ pub struct FocusEvent {
 impl FocusEvent {
     fn new_inherited(window: &Window) -> FocusEvent {
         FocusEvent {
-            uievent: UIEvent::new_inherited(MutNullableDom::new(Some(window))),
+            uievent: UIEvent::new_inherited(window),
             related_target: Default::default(),
         }
     }

--- a/components/script/dom/inputevent.rs
+++ b/components/script/dom/inputevent.rs
@@ -6,7 +6,7 @@ use crate::dom::bindings::codegen::Bindings::InputEventBinding::{self, InputEven
 use crate::dom::bindings::codegen::Bindings::UIEventBinding::UIEventBinding::UIEventMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::reflect_dom_object;
-use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
@@ -32,7 +32,7 @@ impl InputEvent {
     ) -> DomRoot<InputEvent> {
         let ev = reflect_dom_object(
             Box::new(InputEvent {
-                uievent: UIEvent::new_inherited(MutNullableDom::new(Some(window))),
+                uievent: UIEvent::new_inherited(window),
                 data: data,
                 is_composing: is_composing,
             }),

--- a/components/script/dom/inputevent.rs
+++ b/components/script/dom/inputevent.rs
@@ -6,7 +6,7 @@ use crate::dom::bindings::codegen::Bindings::InputEventBinding::{self, InputEven
 use crate::dom::bindings::codegen::Bindings::UIEventBinding::UIEventBinding::UIEventMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::reflect_dom_object;
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
@@ -32,7 +32,7 @@ impl InputEvent {
     ) -> DomRoot<InputEvent> {
         let ev = reflect_dom_object(
             Box::new(InputEvent {
-                uievent: UIEvent::new_inherited(),
+                uievent: UIEvent::new_inherited(MutNullableDom::new(Some(window))),
                 data: data,
                 is_composing: is_composing,
             }),

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -9,7 +9,7 @@ use crate::dom::bindings::codegen::Bindings::UIEventBinding::UIEventMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object;
-use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::uievent::UIEvent;
@@ -38,7 +38,7 @@ pub struct KeyboardEvent {
 impl KeyboardEvent {
     fn new_inherited(window: &Window) -> KeyboardEvent {
         KeyboardEvent {
-            uievent: UIEvent::new_inherited(MutNullableDom::new(Some(window))),
+            uievent: UIEvent::new_inherited(window),
             key: DomRefCell::new(DOMString::new()),
             typed_key: DomRefCell::new(Key::Unidentified),
             code: DomRefCell::new(DOMString::new()),

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -9,7 +9,7 @@ use crate::dom::bindings::codegen::Bindings::UIEventBinding::UIEventMethods;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object;
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::Event;
 use crate::dom::uievent::UIEvent;
@@ -36,9 +36,9 @@ pub struct KeyboardEvent {
 }
 
 impl KeyboardEvent {
-    fn new_inherited() -> KeyboardEvent {
+    fn new_inherited(window: &Window) -> KeyboardEvent {
         KeyboardEvent {
-            uievent: UIEvent::new_inherited(),
+            uievent: UIEvent::new_inherited(MutNullableDom::new(Some(window))),
             key: DomRefCell::new(DOMString::new()),
             typed_key: DomRefCell::new(Key::Unidentified),
             code: DomRefCell::new(DOMString::new()),
@@ -53,7 +53,7 @@ impl KeyboardEvent {
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<KeyboardEvent> {
         reflect_dom_object(
-            Box::new(KeyboardEvent::new_inherited()),
+            Box::new(KeyboardEvent::new_inherited(window)),
             window,
             KeyboardEventBinding::Wrap,
         )

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -38,9 +38,9 @@ pub struct MouseEvent {
 }
 
 impl MouseEvent {
-    pub fn new_inherited() -> MouseEvent {
+    pub fn new_inherited(window: &Window) -> MouseEvent {
         MouseEvent {
-            uievent: UIEvent::new_inherited(),
+            uievent: UIEvent::new_inherited(MutNullableDom::new(Some(window))),
             screen_x: Cell::new(0),
             screen_y: Cell::new(0),
             client_x: Cell::new(0),
@@ -58,7 +58,7 @@ impl MouseEvent {
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<MouseEvent> {
         reflect_dom_object(
-            Box::new(MouseEvent::new_inherited()),
+            Box::new(MouseEvent::new_inherited(window)),
             window,
             MouseEventBinding::Wrap,
         )

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -40,7 +40,7 @@ pub struct MouseEvent {
 impl MouseEvent {
     pub fn new_inherited(window: &Window) -> MouseEvent {
         MouseEvent {
-            uievent: UIEvent::new_inherited(MutNullableDom::new(Some(window))),
+            uievent: UIEvent::new_inherited(window),
             screen_x: Cell::new(0),
             screen_y: Cell::new(0),
             client_x: Cell::new(0),

--- a/components/script/dom/touchevent.rs
+++ b/components/script/dom/touchevent.rs
@@ -7,7 +7,7 @@ use crate::dom::bindings::codegen::Bindings::TouchEventBinding::TouchEventMethod
 use crate::dom::bindings::codegen::Bindings::UIEventBinding::UIEventMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object;
-use crate::dom::bindings::root::{DomRoot, MutDom, MutNullableDom};
+use crate::dom::bindings::root::{DomRoot, MutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{EventBubbles, EventCancelable};
 use crate::dom::touchlist::TouchList;
@@ -36,7 +36,7 @@ impl TouchEvent {
         target_touches: &TouchList,
     ) -> TouchEvent {
         TouchEvent {
-            uievent: UIEvent::new_inherited(MutNullableDom::new(Some(window))),
+            uievent: UIEvent::new_inherited(window),
             touches: MutDom::new(touches),
             target_touches: MutDom::new(target_touches),
             changed_touches: MutDom::new(changed_touches),

--- a/components/script/dom/touchevent.rs
+++ b/components/script/dom/touchevent.rs
@@ -7,7 +7,7 @@ use crate::dom::bindings::codegen::Bindings::TouchEventBinding::TouchEventMethod
 use crate::dom::bindings::codegen::Bindings::UIEventBinding::UIEventMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object;
-use crate::dom::bindings::root::{DomRoot, MutDom};
+use crate::dom::bindings::root::{DomRoot, MutDom, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{EventBubbles, EventCancelable};
 use crate::dom::touchlist::TouchList;
@@ -30,12 +30,13 @@ pub struct TouchEvent {
 
 impl TouchEvent {
     fn new_inherited(
+        window: &Window,
         touches: &TouchList,
         changed_touches: &TouchList,
         target_touches: &TouchList,
     ) -> TouchEvent {
         TouchEvent {
-            uievent: UIEvent::new_inherited(),
+            uievent: UIEvent::new_inherited(MutNullableDom::new(Some(window))),
             touches: MutDom::new(touches),
             target_touches: MutDom::new(target_touches),
             changed_touches: MutDom::new(changed_touches),
@@ -54,6 +55,7 @@ impl TouchEvent {
     ) -> DomRoot<TouchEvent> {
         reflect_dom_object(
             Box::new(TouchEvent::new_inherited(
+                window,
                 touches,
                 changed_touches,
                 target_touches,

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -26,17 +26,17 @@ pub struct UIEvent {
 }
 
 impl UIEvent {
-    pub fn new_inherited() -> UIEvent {
+    pub fn new_inherited(view: MutNullableDom<dom::window::Window>) -> UIEvent {
         UIEvent {
             event: Event::new_inherited(),
-            view: Default::default(),
+            view: view,
             detail: Cell::new(0),
         }
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<UIEvent> {
         reflect_dom_object(
-            Box::new(UIEvent::new_inherited()),
+            Box::new(UIEvent::new_inherited(MutNullableDom::new(Some(window)))),
             window,
             UIEventBinding::Wrap,
         )

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -26,7 +26,7 @@ pub struct UIEvent {
 }
 
 impl UIEvent {
-    pub fn new_inherited(view: MutNullableDom<dom::window::Window>) -> UIEvent {
+    pub fn new_inherited(view: MutNullableDom<Window>) -> UIEvent {
         UIEvent {
             event: Event::new_inherited(),
             view: view,

--- a/components/script/dom/uievent.rs
+++ b/components/script/dom/uievent.rs
@@ -15,7 +15,6 @@ use crate::dom::window::Window;
 use dom_struct::dom_struct;
 use servo_atoms::Atom;
 use std::cell::Cell;
-use std::default::Default;
 
 // https://w3c.github.io/uievents/#interface-uievent
 #[dom_struct]
@@ -26,17 +25,17 @@ pub struct UIEvent {
 }
 
 impl UIEvent {
-    pub fn new_inherited(view: MutNullableDom<Window>) -> UIEvent {
+    pub fn new_inherited(window: &Window) -> UIEvent {
         UIEvent {
             event: Event::new_inherited(),
-            view: view,
+            view: MutNullableDom::new(Some(window)),
             detail: Cell::new(0),
         }
     }
 
     pub fn new_uninitialized(window: &Window) -> DomRoot<UIEvent> {
         reflect_dom_object(
-            Box::new(UIEvent::new_inherited(MutNullableDom::new(Some(window)))),
+            Box::new(UIEvent::new_inherited(window)),
             window,
             UIEventBinding::Wrap,
         )

--- a/components/script/dom/wheelevent.rs
+++ b/components/script/dom/wheelevent.rs
@@ -27,9 +27,9 @@ pub struct WheelEvent {
 }
 
 impl WheelEvent {
-    fn new_inherited() -> WheelEvent {
+    fn new_inherited(window: &Window) -> WheelEvent {
         WheelEvent {
-            mouseevent: MouseEvent::new_inherited(),
+            mouseevent: MouseEvent::new_inherited(window),
             delta_x: Cell::new(Finite::wrap(0.0)),
             delta_y: Cell::new(Finite::wrap(0.0)),
             delta_z: Cell::new(Finite::wrap(0.0)),
@@ -39,7 +39,7 @@ impl WheelEvent {
 
     pub fn new_unintialized(window: &Window) -> DomRoot<WheelEvent> {
         reflect_dom_object(
-            Box::new(WheelEvent::new_inherited()),
+            Box::new(WheelEvent::new_inherited(window)),
             window,
             WheelEventBinding::Wrap,
         )


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
* `uievent.rs` initializes view for events
```
    pub fn new_inherited(window: &Window) -> UIEvent {
        UIEvent {
            event: Event::new_inherited(),
            view: MutNullableDom::new(Some(window)),
            detail: Cell::new(0),
        }
    }
```

* `compositionevent.rs`
* `focusevent.rs`
* `inputevent.rs`
* `keyboardevent.rs`
* `mouseevent.rs`
* `touchevent.rs`
* `uievent.rs`
new function signatures for events handlers to accomodate changes in `uievent.rs`

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #24463 

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
