### PR TITLE
Remove usage of opts::get() from style.

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -310,6 +310,15 @@ where
         // Global configuration options, parsed from the command line.
         let opts = opts::get();
 
+        use std::sync::atomic::Ordering;
+
+        style::context::DEFAULT_DISABLE_STYLE_SHARING_CACHE
+            .store(opts.disable_share_style_cache, Ordering::Relaxed);
+        style::context::DEFAULT_DUMP_STYLE_STATISTICS
+            .store(opts.style_sharing_stats, Ordering::Relaxed);
+        style::traversal::IS_SERVO_NONINCREMENTAL_LAYOUT
+            .store(opts.nonincremental_layout, Ordering::Relaxed);
+
         if !opts.multiprocess {
             media_platform::init();
         }

--- a/components/style/context.rs
+++ b/components/style/context.rs
@@ -103,14 +103,29 @@ fn get_env_usize(name: &str) -> Option<usize> {
     })
 }
 
+/// A global variable holding the state of
+/// `StyleSystemOptions::default().disable_style_sharing_cache`.
+/// See [#22854](https://github.com/servo/servo/issues/22854).
+#[cfg(feature = "servo")]
+pub static DEFAULT_DISABLE_STYLE_SHARING_CACHE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// A global variable holding the state of
+/// `StyleSystemOptions::default().dump_style_statistics`.
+/// See [#22854](https://github.com/servo/servo/issues/22854).
+#[cfg(feature = "servo")]
+pub static DEFAULT_DUMP_STYLE_STATISTICS: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 impl Default for StyleSystemOptions {
     #[cfg(feature = "servo")]
     fn default() -> Self {
-        use servo_config::opts;
+        use std::sync::atomic::Ordering;
 
         StyleSystemOptions {
-            disable_style_sharing_cache: opts::get().disable_share_style_cache,
-            dump_style_statistics: opts::get().style_sharing_stats,
+            disable_style_sharing_cache: DEFAULT_DISABLE_STYLE_SHARING_CACHE
+                .load(Ordering::Relaxed),
+            dump_style_statistics: DEFAULT_DUMP_STYLE_STATISTICS.load(Ordering::Relaxed),
             style_statistics_threshold: DEFAULT_STATISTICS_THRESHOLD,
         }
     }

--- a/components/style/traversal.rs
+++ b/components/style/traversal.rs
@@ -45,12 +45,19 @@ impl<E: TElement> PreTraverseToken<E> {
     }
 }
 
+/// A global variable holding the state of
+/// `is_servo_nonincremental_layout()`.
+/// See [#22854](https://github.com/servo/servo/issues/22854).
+#[cfg(feature = "servo")]
+pub static IS_SERVO_NONINCREMENTAL_LAYOUT: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 #[cfg(feature = "servo")]
 #[inline]
 fn is_servo_nonincremental_layout() -> bool {
-    use servo_config::opts;
+    use std::sync::atomic::Ordering;
 
-    opts::get().nonincremental_layout
+    IS_SERVO_NONINCREMENTAL_LAYOUT.load(Ordering::Relaxed)
 }
 
 #[cfg(not(feature = "servo"))]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Use `AtomicBool`s to create a global storage for a couple of settings used by an implementation of `Default`, suggested in https://github.com/servo/servo/issues/22854#issuecomment-540955207.

I do have one main question: I'm currently setting these statics in `Servo::new()`, would there be a better place to put this? Same goes with making these `pub`, is there a better way to go about this?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
  - Seems to be failing in script for unknown/unrelated reasons, experiencing SIGKILL on two different machines. (May be an issue with the latest commit?) Still works fine on CI though.
- [X] `./mach test-tidy` does not report any errors
- [X] These changes help with #22854

These changes do not require tests because these are cleanup changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
