### PR TITLE
Add start_time to resource timing.

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -21,8 +21,8 @@ use net_traits::filemanager_thread::RelativePos;
 use net_traits::request::{CredentialsMode, Destination, Referrer, Request, RequestMode};
 use net_traits::request::{Origin, ResponseTainting, Window};
 use net_traits::response::{Response, ResponseBody, ResponseType};
-use net_traits::ResourceAttribute;
 use net_traits::{FetchTaskTarget, NetworkError, ReferrerPolicy, ResourceFetchTiming};
+use net_traits::{ResourceAttribute, ResourceTimeValue};
 use servo_arc::Arc as ServoArc;
 use servo_url::ServoUrl;
 use std::borrow::Cow;
@@ -89,12 +89,19 @@ pub type DoneChannel = Option<(Sender<Data>, Receiver<Data>)>;
 
 /// [Fetch](https://fetch.spec.whatwg.org#concept-fetch)
 pub fn fetch(request: &mut Request, target: Target, context: &FetchContext) {
-    // Step 7 of https://w3c.github.io/resource-timing/#processing-model
+    // Steps 7,4 of https://w3c.github.io/resource-timing/#processing-model
+    // rev order okay since spec says they're equal - https://w3c.github.io/resource-timing/#dfn-starttime
     context
         .timing
         .lock()
         .unwrap()
         .set_attribute(ResourceAttribute::FetchStart);
+    context
+        .timing
+        .lock()
+        .unwrap()
+        .set_attribute(ResourceAttribute::StartTime(ResourceTimeValue::FetchStart));
+
     fetch_with_cors_cache(request, &mut CorsCache::new(), target, context);
 }
 

--- a/components/net_traits/tests/lib.rs
+++ b/components/net_traits/tests/lib.rs
@@ -185,10 +185,7 @@ fn test_not_set_start_time_to_redirect_start_if_zero_no_tao() {
 fn test_set_start_time() {
     let mut resource_timing: ResourceFetchTiming =
         ResourceFetchTiming::new(ResourceTimingType::Resource);
-    assert_eq!(
-        resource_timing.start_time, 0,
-        "initial `start_time` should be zero"
-    );
+    assert_eq!(resource_timing.start_time, 0, "`start_time` should be zero");
 
     // verify setting `start_time` to current time succeeds
     resource_timing.set_attribute(ResourceAttribute::StartTime(ResourceTimeValue::Now));
@@ -198,7 +195,7 @@ fn test_set_start_time() {
 fn test_reset_start_time() {
     let mut resource_timing: ResourceFetchTiming =
         ResourceFetchTiming::new(ResourceTimingType::Resource);
-    assert_eq!(resource_timing.start_time, 0, "initial `start_time` = 0");
+    assert_eq!(resource_timing.start_time, 0, "`start_time` should be zero");
 
     resource_timing.start_time = 1;
     assert!(

--- a/components/net_traits/tests/lib.rs
+++ b/components/net_traits/tests/lib.rs
@@ -1,0 +1,215 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use net_traits::{ResourceAttribute, ResourceFetchTiming, ResourceTimeValue, ResourceTimingType};
+
+#[test]
+fn test_set_start_time_to_fetch_start_if_nonzero_tao() {
+    let mut resource_timing: ResourceFetchTiming =
+        ResourceFetchTiming::new(ResourceTimingType::Resource);
+    resource_timing.fetch_start = 1;
+    assert_eq!(resource_timing.start_time, 0, "`start_time` should be zero");
+    assert!(
+        resource_timing.fetch_start > 0,
+        "`fetch_start` should have a positive value"
+    );
+
+    // verify that setting `start_time` to `fetch_start` succeeds
+    resource_timing.set_attribute(ResourceAttribute::StartTime(ResourceTimeValue::FetchStart));
+    assert_eq!(
+        resource_timing.start_time, resource_timing.fetch_start,
+        "`start_time` should equal `fetch_start`"
+    );
+}
+
+#[test]
+fn test_set_start_time_to_fetch_start_if_zero_tao() {
+    let mut resource_timing: ResourceFetchTiming =
+        ResourceFetchTiming::new(ResourceTimingType::Resource);
+    resource_timing.start_time = 1;
+    assert!(
+        resource_timing.start_time > 0,
+        "`start_time` should have a positive value"
+    );
+    assert_eq!(
+        resource_timing.fetch_start, 0,
+        "`fetch_start` should be zero"
+    );
+
+    // verify that setting `start_time` to `fetch_start` succeeds even when `fetch_start` == zero
+    resource_timing.set_attribute(ResourceAttribute::StartTime(ResourceTimeValue::FetchStart));
+    assert_eq!(
+        resource_timing.start_time, resource_timing.fetch_start,
+        "`start_time` should equal `fetch_start`"
+    );
+}
+
+#[test]
+fn test_set_start_time_to_fetch_start_if_nonzero_no_tao() {
+    let mut resource_timing: ResourceFetchTiming =
+        ResourceFetchTiming::new(ResourceTimingType::Resource);
+    resource_timing.mark_timing_check_failed();
+    resource_timing.fetch_start = 1;
+    assert_eq!(resource_timing.start_time, 0, "`start_time` should be zero");
+    assert!(
+        resource_timing.fetch_start > 0,
+        "`fetch_start` should have a positive value"
+    );
+
+    // verify that setting `start_time` to `fetch_start` succeeds even when TAO check failed
+    resource_timing.set_attribute(ResourceAttribute::StartTime(ResourceTimeValue::FetchStart));
+    assert_eq!(
+        resource_timing.start_time, resource_timing.fetch_start,
+        "`start_time` should equal `fetch_start`"
+    );
+}
+
+#[test]
+fn test_set_start_time_to_fetch_start_if_zero_no_tao() {
+    let mut resource_timing: ResourceFetchTiming =
+        ResourceFetchTiming::new(ResourceTimingType::Resource);
+    resource_timing.mark_timing_check_failed();
+    resource_timing.start_time = 1;
+    assert!(
+        resource_timing.start_time > 0,
+        "`start_time` should have a positive value"
+    );
+    assert_eq!(
+        resource_timing.fetch_start, 0,
+        "`fetch_start` should be zero"
+    );
+
+    // verify that setting `start_time` to `fetch_start` succeeds even when `fetch_start`==0 and no TAO
+    resource_timing.set_attribute(ResourceAttribute::StartTime(ResourceTimeValue::FetchStart));
+    assert_eq!(
+        resource_timing.start_time, resource_timing.fetch_start,
+        "`start_time` should equal `fetch_start`"
+    );
+}
+
+#[test]
+fn test_set_start_time_to_redirect_start_if_nonzero_tao() {
+    let mut resource_timing: ResourceFetchTiming =
+        ResourceFetchTiming::new(ResourceTimingType::Resource);
+    resource_timing.redirect_start = 1;
+    assert_eq!(resource_timing.start_time, 0, "`start_time` should be zero");
+    assert!(
+        resource_timing.redirect_start > 0,
+        "`redirect_start` should have a positive value"
+    );
+
+    // verify that setting `start_time` to `redirect_start` succeeds for nonzero `redirect_start`, TAO pass
+    resource_timing.set_attribute(ResourceAttribute::StartTime(
+        ResourceTimeValue::RedirectStart,
+    ));
+    assert_eq!(
+        resource_timing.start_time, resource_timing.redirect_start,
+        "`start_time` should equal `redirect_start`"
+    );
+}
+
+#[test]
+fn test_not_set_start_time_to_redirect_start_if_zero_tao() {
+    let mut resource_timing: ResourceFetchTiming =
+        ResourceFetchTiming::new(ResourceTimingType::Resource);
+    resource_timing.start_time = 1;
+    assert!(
+        resource_timing.start_time > 0,
+        "`start_time` should have a positive value"
+    );
+    assert_eq!(
+        resource_timing.redirect_start, 0,
+        "`redirect_start` should be zero"
+    );
+
+    // verify that setting `start_time` to `redirect_start` fails if `redirect_start` == 0
+    resource_timing.set_attribute(ResourceAttribute::StartTime(
+        ResourceTimeValue::RedirectStart,
+    ));
+    assert_ne!(
+        resource_timing.start_time, resource_timing.redirect_start,
+        "`start_time` should *not* equal `redirect_start`"
+    );
+}
+
+#[test]
+fn test_not_set_start_time_to_redirect_start_if_nonzero_no_tao() {
+    let mut resource_timing: ResourceFetchTiming =
+        ResourceFetchTiming::new(ResourceTimingType::Resource);
+    resource_timing.mark_timing_check_failed();
+    // Note: properly-behaved redirect_start should never be nonzero once TAO check has failed
+    resource_timing.redirect_start = 1;
+    assert_eq!(resource_timing.start_time, 0, "`start_time` should be zero");
+    assert!(
+        resource_timing.redirect_start > 0,
+        "`redirect_start` should have a positive value"
+    );
+
+    // verify that setting `start_time` to `redirect_start` fails if TAO check fails
+    resource_timing.set_attribute(ResourceAttribute::StartTime(
+        ResourceTimeValue::RedirectStart,
+    ));
+    assert_ne!(
+        resource_timing.start_time, resource_timing.redirect_start,
+        "`start_time` should *not* equal `redirect_start`"
+    );
+}
+
+#[test]
+fn test_not_set_start_time_to_redirect_start_if_zero_no_tao() {
+    let mut resource_timing: ResourceFetchTiming =
+        ResourceFetchTiming::new(ResourceTimingType::Resource);
+    resource_timing.mark_timing_check_failed();
+    resource_timing.start_time = 1;
+    assert!(
+        resource_timing.start_time > 0,
+        "`start_time` should have a positive value"
+    );
+    assert_eq!(
+        resource_timing.redirect_start, 0,
+        "`redirect_start` should be zero"
+    );
+
+    // verify that setting `start_time` to `redirect_start` fails if `redirect_start`==0 and no TAO
+    resource_timing.set_attribute(ResourceAttribute::StartTime(
+        ResourceTimeValue::RedirectStart,
+    ));
+    assert_ne!(
+        resource_timing.start_time, resource_timing.redirect_start,
+        "`start_time` should *not* equal `redirect_start`"
+    );
+}
+
+#[test]
+fn test_set_start_time() {
+    let mut resource_timing: ResourceFetchTiming =
+        ResourceFetchTiming::new(ResourceTimingType::Resource);
+    assert_eq!(
+        resource_timing.start_time, 0,
+        "initial `start_time` should be zero"
+    );
+
+    // verify setting `start_time` to current time succeeds
+    resource_timing.set_attribute(ResourceAttribute::StartTime(ResourceTimeValue::Now));
+    assert!(resource_timing.start_time > 0, "failed to set `start_time`");
+}
+#[test]
+fn test_reset_start_time() {
+    let mut resource_timing: ResourceFetchTiming =
+        ResourceFetchTiming::new(ResourceTimingType::Resource);
+    assert_eq!(resource_timing.start_time, 0, "initial `start_time` = 0");
+
+    resource_timing.start_time = 1;
+    assert!(
+        resource_timing.start_time > 0,
+        "`start_time` should have a positive value"
+    );
+
+    // verify resetting `start_time` (to zero) succeeds
+    resource_timing.set_attribute(ResourceAttribute::StartTime(ResourceTimeValue::Zero));
+    assert_eq!(
+        resource_timing.start_time, 0,
+        "failed to reset `start_time`"
+    );
+}

--- a/components/script/dom/performanceresourcetiming.rs
+++ b/components/script/dom/performanceresourcetiming.rs
@@ -55,7 +55,6 @@ pub struct PerformanceResourceTiming {
     decoded_body_size: u64, //size in octets
 }
 
-// TODO(#21254): startTime
 // TODO(#21255): duration
 // TODO(#21269): next_hop
 // TODO(#21264): worker_start
@@ -115,7 +114,7 @@ impl PerformanceResourceTiming {
             entry: PerformanceEntry::new_inherited(
                 DOMString::from(url.into_string()),
                 DOMString::from("resource"),
-                0.,
+                resource_timing.start_time as f64,
                 0.,
             ),
             initiator_type: initiator_type,

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -19634,7 +19634,7 @@
    "testharness"
   ],
   "mozilla/window_performance.html": [
-   "690870b7080e179481ca0255f7c30337e8b6636a",
+   "302073e8041763102d678326509d7ef0a1fb5c79",
    "testharness"
   ],
   "mozilla/window_performance_topLevelDomComplete.html": [

--- a/tests/wpt/mozilla/meta/mozilla/window_performance.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/window_performance.html.ini
@@ -1,4 +1,0 @@
-[window_performance.html]
-  [window_performance]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/tests/mozilla/window_performance.html
+++ b/tests/wpt/mozilla/tests/mozilla/window_performance.html
@@ -16,8 +16,13 @@ test(function() {
   assert_not_equals(entries.length, 0);
   assert_true(entries[0] instanceof PerformanceNavigationTiming);
 
-  // TODO(#21254) navigationTiming/startTime is not fully implemented yet, so this assertion will fail
-  assert_greater_than(entries[0].startTime, 0);
+  /* PerformanceResourceTiming */
+  var resourceEntries = window.performance.getEntriesByType("resource");
+  assert_not_equals(resourceEntries.length, 0);
+  assert_true(resourceEntries[0] instanceof PerformanceResourceTiming);
+  // no redirects => 0 < startTime == fetchStart
+  assert_greater_than(resourceEntries[0].startTime, 0);
+  assert_equals(resourceEntries[0].startTime, resourceEntries[0].fetchStart);
 
   var last = window.performance.now();
   assert_greater_than(last, 0);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`start_time` property added to `ResourceFetchTiming`, which enables the setting of `start_time` in the `PerformanceEntry` member of `PerformanceResourceTiming`.

Following the specification at https://w3c.github.io/resource-timing/#dfn-starttime, `start_time` is set to the value of `redirect_start` if redirection occurs and the timing allow check passes. Otherwise it has the same value as `fetch_start`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21254

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
