### PR TITLE
Issue 23009/separate angle and disable vsync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,6 +2673,7 @@ dependencies = [
 name = "libmlservo"
 version = "0.0.1"
 dependencies = [
+ "getopts",
  "libc",
  "libservo",
  "log",
@@ -4406,6 +4407,7 @@ dependencies = [
  "cc",
  "clipboard",
  "euclid",
+ "getopts",
  "gleam 0.6.18",
  "glutin",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,7 +2673,6 @@ dependencies = [
 name = "libmlservo"
 version = "0.0.1"
 dependencies = [
- "getopts",
  "libc",
  "libservo",
  "log",
@@ -4809,6 +4808,7 @@ name = "simpleservo"
 version = "0.0.1"
 dependencies = [
  "core-foundation",
+ "getopts",
  "gl_generator 0.11.0",
  "libc",
  "libloading",

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -32,10 +32,6 @@ pub struct Opts {
     /// The maximum size of each tile in pixels (`-s`).
     pub tile_size: usize,
 
-    /// The ratio of device pixels per px at the default scale. If unspecified, will use the
-    /// platform default setting.
-    pub device_pixels_per_px: Option<f32>,
-
     /// `None` to disable the time profiler or `Some` to enable it with:
     ///
     ///  - an interval in seconds to cause it to produce output on that interval.
@@ -524,7 +520,6 @@ pub fn default_opts() -> Opts {
         is_running_problem_test: false,
         url: None,
         tile_size: 512,
-        device_pixels_per_px: None,
         time_profiling: None,
         time_profiler_trace_path: None,
         mem_profiler_period: None,
@@ -587,7 +582,6 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
     opts.optflag("g", "gpu", "GPU painting");
     opts.optopt("o", "output", "Output file", "output.png");
     opts.optopt("s", "size", "Size of tiles", "512");
-    opts.optopt("", "device-pixel-ratio", "Device pixels per px", "");
     opts.optflagopt(
         "p",
         "profile",
@@ -792,15 +786,6 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         None => 512,
     };
 
-    let device_pixels_per_px = opt_match.opt_str("device-pixel-ratio").map(|dppx_str| {
-        dppx_str.parse().unwrap_or_else(|err| {
-            args_fail(&format!(
-                "Error parsing option: --device-pixel-ratio ({})",
-                err
-            ))
-        })
-    });
-
     // If only the flag is present, default to a 5 second period for both profilers
     let time_profiling = if opt_match.opt_present("p") {
         match opt_match.opt_str("p") {
@@ -951,7 +936,6 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         is_running_problem_test: is_running_problem_test,
         url: url_opt,
         tile_size: tile_size,
-        device_pixels_per_px: device_pixels_per_px,
         time_profiling: time_profiling,
         time_profiler_trace_path: opt_match.opt_str("profiler-trace-path"),
         mem_profiler_period: mem_profiler_period,

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -181,9 +181,6 @@ pub struct Opts {
     /// True to exit after the page load (`-x`).
     pub exit_after_load: bool,
 
-    /// Do not use native titlebar
-    pub no_native_titlebar: bool,
-
     /// True to show webrender profiling stats on screen.
     pub webrender_stats: bool,
 
@@ -200,9 +197,6 @@ pub struct Opts {
     /// useful when modifying the shaders, to ensure they all compile
     /// after each change is made.
     pub precache_shaders: bool,
-
-    /// True if WebRender should use multisample antialiasing.
-    pub use_msaa: bool,
 
     /// Directory for a default config directory
     pub config_dir: Option<PathBuf>,
@@ -225,9 +219,6 @@ pub struct Opts {
 
     /// Print Progressive Web Metrics to console.
     pub print_pwm: bool,
-
-    /// Only shutdown once all theads are finished.
-    pub clean_shutdown: bool,
 }
 
 fn print_usage(app: &str, opts: &Options) {
@@ -317,9 +308,6 @@ pub struct DebugOptions {
     /// Enable webrender instanced draw call batching.
     pub webrender_disable_batch: bool,
 
-    /// Use multisample antialiasing in WebRender.
-    pub use_msaa: bool,
-
     // don't skip any backtraces on panic
     pub full_backtraces: bool,
 
@@ -362,7 +350,6 @@ impl DebugOptions {
                 "wr-stats" => self.webrender_stats = true,
                 "wr-record" => self.webrender_record = true,
                 "wr-no-batch" => self.webrender_disable_batch = true,
-                "msaa" => self.use_msaa = true,
                 "full-backtraces" => self.full_backtraces = true,
                 "precache-shaders" => self.precache_shaders = true,
                 "signpost" => self.signpost = true,
@@ -453,7 +440,6 @@ fn print_debug_usage(app: &str) -> ! {
         "Load web fonts synchronously to avoid non-deterministic network-driven reflows",
     );
     print_option("wr-stats", "Show WebRender profiler on screen.");
-    print_option("msaa", "Use multisample antialiasing in WebRender.");
     print_option("full-backtraces", "Print full backtraces for all errors");
     print_option("wr-debug", "Display webrender tile borders.");
     print_option("wr-no-batch", "Disable webrender instanced batching.");
@@ -579,9 +565,7 @@ pub fn default_opts() -> Opts {
         style_sharing_stats: false,
         convert_mouse_to_touch: false,
         exit_after_load: false,
-        no_native_titlebar: false,
         webrender_stats: false,
-        use_msaa: false,
         config_dir: None,
         full_backtraces: false,
         is_printing_version: false,
@@ -593,7 +577,6 @@ pub fn default_opts() -> Opts {
         certificate_path: None,
         unminify_js: false,
         print_pwm: false,
-        clean_shutdown: false,
     }
 }
 
@@ -744,11 +727,6 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         "config-dir",
         "config directory following xdg spec on linux platform",
         "",
-    );
-    opts.optflag(
-        "",
-        "clean-shutdown",
-        "Do not shutdown until all threads have finished (macos only)",
     );
     opts.optflag("v", "version", "Display servo version information");
     opts.optflag("", "unminify-js", "Unminify Javascript");
@@ -964,9 +942,6 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         })
         .collect();
 
-    let do_not_use_native_titlebar =
-        opt_match.opt_present("b") || !(pref!(shell.native_titlebar.enabled));
-
     let enable_subpixel_text_antialiasing =
         !debug_options.disable_subpixel_aa && pref!(gfx.subpixel_text_antialiasing.enabled);
 
@@ -1017,9 +992,7 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         style_sharing_stats: debug_options.style_sharing_stats,
         convert_mouse_to_touch: debug_options.convert_mouse_to_touch,
         exit_after_load: opt_match.opt_present("x"),
-        no_native_titlebar: do_not_use_native_titlebar,
         webrender_stats: debug_options.webrender_stats,
-        use_msaa: debug_options.use_msaa,
         config_dir: opt_match.opt_str("config-dir").map(Into::into),
         full_backtraces: debug_options.full_backtraces,
         is_printing_version: is_printing_version,
@@ -1031,7 +1004,6 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         certificate_path: opt_match.opt_str("certificate-path"),
         unminify_js: opt_match.opt_present("unminify-js"),
         print_pwm: opt_match.opt_present("print-pwm"),
-        clean_shutdown: opt_match.opt_present("clean-shutdown"),
     };
 
     set_options(opts);

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -464,6 +464,10 @@ pub struct Constellation<Message, LTF, STF> {
 
     /// Mechanism to force the compositor to process events.
     event_loop_waker: Option<Box<dyn EventLoopWaker>>,
+
+    /// The ratio of device pixels per px at the default scale. If unspecified, will use the
+    /// platform default setting.
+    device_pixels_per_px: Option<f32>,
 }
 
 /// State needed to construct a constellation.
@@ -520,6 +524,10 @@ pub struct InitialConstellationState {
 
     /// Mechanism to force the compositor to process events.
     pub event_loop_waker: Option<Box<dyn EventLoopWaker>>,
+
+    /// The ratio of device pixels per px at the default scale. If unspecified, will use the
+    /// platform default setting.
+    pub device_pixels_per_px: Option<f32>,
 }
 
 /// Data needed for webdriver
@@ -837,6 +845,7 @@ where
                     glplayer_threads: state.glplayer_threads,
                     player_context: state.player_context,
                     event_loop_waker: state.event_loop_waker,
+                    device_pixels_per_px,
                 };
 
                 constellation.run();
@@ -1081,6 +1090,7 @@ where
             webxr_registry: self.webxr_registry.clone(),
             player_context: self.player_context.clone(),
             event_loop_waker: self.event_loop_waker.as_ref().map(|w| (*w).clone_box()),
+            device_pixels_per_px: self.device_pixels_per_px,
         });
 
         let pipeline = match result {

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -205,6 +205,10 @@ pub struct InitialPipelineState {
 
     /// Mechanism to force the compositor to process events.
     pub event_loop_waker: Option<Box<dyn EventLoopWaker>>,
+
+    /// The ratio of device pixels per px at the default scale. If unspecified, will use the
+    /// platform default setting.
+    pub device_pixels_per_px: Option<f32>,
 }
 
 pub struct NewPipeline {
@@ -312,6 +316,7 @@ impl Pipeline {
                     webvr_chan: state.webvr_chan,
                     webxr_registry: state.webxr_registry,
                     player_context: state.player_context,
+                    device_pixels_per_px: state.device_pixels_per_px,
                 };
 
                 // Spawn the child process.
@@ -518,6 +523,7 @@ pub struct UnprivilegedPipelineContent {
     webvr_chan: Option<IpcSender<WebVRMsg>>,
     webxr_registry: webxr_api::Registry,
     player_context: WindowGLContext,
+    device_pixels_per_px: Option<f32>,
 }
 
 impl UnprivilegedPipelineContent {
@@ -609,7 +615,7 @@ impl UnprivilegedPipelineContent {
             layout_thread_busy_flag.clone(),
             self.opts.load_webfonts_synchronously,
             self.opts.initial_window_size,
-            self.opts.device_pixels_per_px,
+            self.device_pixels_per_px,
             self.opts.dump_display_list,
             self.opts.dump_display_list_json,
             self.opts.dump_style_tree,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -306,7 +306,11 @@ impl<Window> Servo<Window>
 where
     Window: WindowMethods + 'static + ?Sized,
 {
-    pub fn new(mut embedder: Box<dyn EmbedderMethods>, window: Rc<Window>) -> Servo<Window> {
+    pub fn new(
+        mut embedder: Box<dyn EmbedderMethods>,
+        window: Rc<Window>,
+        device_pixels_per_px: Option<f32>,
+    ) -> Servo<Window> {
         // Global configuration options, parsed from the command line.
         let opts = opts::get();
 
@@ -551,6 +555,7 @@ where
             webvr_constellation_sender,
             glplayer_threads,
             event_loop_waker,
+            device_pixels_per_px,
         );
 
         // Send the constellation's swmanager sender to service worker manager thread
@@ -582,7 +587,7 @@ where
             opts.is_running_problem_test,
             opts.exit_after_load,
             opts.convert_mouse_to_touch,
-            opts.device_pixels_per_px,
+            device_pixels_per_px,
         );
 
         Servo {
@@ -870,6 +875,7 @@ fn create_constellation(
     webvr_constellation_sender: Option<Sender<Sender<ConstellationMsg>>>,
     glplayer_threads: Option<GLPlayerThreads>,
     event_loop_waker: Option<Box<dyn EventLoopWaker>>,
+    device_pixels_per_px: Option<f32>,
 ) -> (Sender<ConstellationMsg>, SWManagerSenders) {
     // Global configuration options, parsed from the command line.
     let opts = opts::get();
@@ -912,6 +918,7 @@ fn create_constellation(
         glplayer_threads,
         player_context,
         event_loop_waker,
+        device_pixels_per_px,
     };
     let (constellation_chan, from_swmanager_sender) = Constellation::<
         script_layout_interface::message::Msg,
@@ -920,7 +927,7 @@ fn create_constellation(
     >::start(
         initial_state,
         opts.initial_window_size,
-        opts.device_pixels_per_px,
+        device_pixels_per_px,
         opts.random_pipeline_closure_probability,
         opts.random_pipeline_closure_seed,
         opts.is_running_problem_test,

--- a/ports/glutin/Cargo.toml
+++ b/ports/glutin/Cargo.toml
@@ -49,6 +49,7 @@ vslatestinstalled = ["libservo/vslatestinstalled"]
 backtrace = "0.3"
 clipboard = "0.5"
 euclid = "0.20"
+getopts = "0.2.11"
 gleam = "0.6"
 glutin = "0.21.0"
 keyboard-types = "0.4.3"

--- a/ports/glutin/app.rs
+++ b/ports/glutin/app.rs
@@ -34,12 +34,18 @@ pub struct App {
 }
 
 impl App {
-    pub fn run(angle: bool, enable_vsync: bool, use_msaa: bool, no_native_titlebar: bool) {
+    pub fn run(
+        angle: bool,
+        enable_vsync: bool,
+        use_msaa: bool,
+        no_native_titlebar: bool,
+        device_pixels_per_px: Option<f32>,
+    ) {
         let events_loop = EventsLoop::new(opts::get().headless);
 
         // Implements window methods, used by compositor.
         let window = if opts::get().headless {
-            headless_window::Window::new(opts::get().initial_window_size)
+            headless_window::Window::new(opts::get().initial_window_size, device_pixels_per_px)
         } else {
             Rc::new(headed_window::Window::new(
                 opts::get().initial_window_size,
@@ -49,6 +55,7 @@ impl App {
                 enable_vsync,
                 use_msaa,
                 no_native_titlebar,
+                device_pixels_per_px,
             ))
         };
 
@@ -63,7 +70,7 @@ impl App {
         // Handle browser state.
         let browser = Browser::new(window.clone());
 
-        let mut servo = Servo::new(embedder, window.clone());
+        let mut servo = Servo::new(embedder, window.clone(), device_pixels_per_px);
         let browser_id = BrowserId::new();
         servo.handle_events(vec![WindowEvent::NewBrowser(get_default_url(), browser_id)]);
         servo.setup_logging();

--- a/ports/glutin/app.rs
+++ b/ports/glutin/app.rs
@@ -34,7 +34,7 @@ pub struct App {
 }
 
 impl App {
-    pub fn run(angle: bool, enable_vsync: bool) {
+    pub fn run(angle: bool, enable_vsync: bool, use_msaa: bool, no_native_titlebar: bool) {
         let events_loop = EventsLoop::new(opts::get().headless);
 
         // Implements window methods, used by compositor.
@@ -47,6 +47,8 @@ impl App {
                 events_loop.clone(),
                 angle,
                 enable_vsync,
+                use_msaa,
+                no_native_titlebar,
             ))
         };
 

--- a/ports/glutin/app.rs
+++ b/ports/glutin/app.rs
@@ -6,8 +6,8 @@
 
 use crate::browser::Browser;
 use crate::embedder::EmbedderCallbacks;
-use crate::window_trait::WindowPortsMethods;
 use crate::events_loop::EventsLoop;
+use crate::window_trait::WindowPortsMethods;
 use crate::{headed_window, headless_window};
 use glutin::WindowId;
 use servo::compositing::windowing::WindowEvent;
@@ -34,14 +34,20 @@ pub struct App {
 }
 
 impl App {
-    pub fn run() {
+    pub fn run(angle: bool, enable_vsync: bool) {
         let events_loop = EventsLoop::new(opts::get().headless);
 
         // Implements window methods, used by compositor.
         let window = if opts::get().headless {
             headless_window::Window::new(opts::get().initial_window_size)
         } else {
-            Rc::new(headed_window::Window::new(opts::get().initial_window_size, None, events_loop.clone()))
+            Rc::new(headed_window::Window::new(
+                opts::get().initial_window_size,
+                None,
+                events_loop.clone(),
+                angle,
+                enable_vsync,
+            ))
         };
 
         // Implements embedder methods, used by libservo and constellation.
@@ -49,6 +55,7 @@ impl App {
             window.clone(),
             events_loop.clone(),
             window.gl(),
+            angle,
         ));
 
         // Handle browser state.
@@ -110,7 +117,7 @@ impl App {
                             };
                             window.winit_event_to_servo_event(event);
                             return cont;
-                        }
+                        },
                     }
                 });
             },
@@ -121,7 +128,10 @@ impl App {
     fn run_loop(self) {
         loop {
             let animating = WINDOWS.with(|windows| {
-                windows.borrow().iter().any(|(_, window)| window.is_animating())
+                windows
+                    .borrow()
+                    .iter()
+                    .any(|(_, window)| window.is_animating())
             });
             if !animating || self.suspended.get() {
                 // If there's no animations running then we block on the window event loop.
@@ -219,8 +229,8 @@ pub fn register_window(window: Rc<dyn WindowPortsMethods>) {
     });
 }
 
-pub fn gl_version() -> glutin::GlRequest {
-    if opts::get().angle {
+pub fn gl_version(angle: bool) -> glutin::GlRequest {
+    if angle {
         glutin::GlRequest::Specific(glutin::Api::OpenGlEs, (3, 0))
     } else {
         glutin::GlRequest::GlThenGles {

--- a/ports/glutin/headed_window.rs
+++ b/ports/glutin/headed_window.rs
@@ -73,6 +73,8 @@ pub struct Window {
     xr_rotation: Cell<Rotation3D<f32, UnknownUnit, UnknownUnit>>,
     angle: bool,
     enable_vsync: bool,
+    use_msaa: bool,
+    no_native_titlebar: bool,
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -94,6 +96,8 @@ impl Window {
         events_loop: Rc<RefCell<EventsLoop>>,
         angle: bool,
         enable_vsync: bool,
+        use_msaa: bool,
+        no_native_titlebar: bool,
     ) -> Window {
         let opts = opts::get();
 
@@ -101,7 +105,7 @@ impl Window {
         // `load_end()`. This avoids an ugly flash of unstyled content (especially important since
         // unstyled content is white and chrome often has a transparent background). See issue
         // #9996.
-        let visible = opts.output_file.is_none() && !opts.no_native_titlebar;
+        let visible = opts.output_file.is_none() && !no_native_titlebar;
 
         let win_size: DeviceIntSize = (win_size.to_f32() * window_creation_scale_factor()).to_i32();
         let width = win_size.to_untyped().width;
@@ -109,8 +113,8 @@ impl Window {
 
         let mut window_builder = glutin::WindowBuilder::new()
             .with_title("Servo".to_string())
-            .with_decorations(!opts.no_native_titlebar)
-            .with_transparency(opts.no_native_titlebar)
+            .with_decorations(!no_native_titlebar)
+            .with_transparency(no_native_titlebar)
             .with_dimensions(LogicalSize::new(width as f64, height as f64))
             .with_visibility(visible)
             .with_multitouch();
@@ -121,7 +125,7 @@ impl Window {
             .with_gl(app::gl_version(angle))
             .with_vsync(enable_vsync);
 
-        if opts.use_msaa {
+        if use_msaa {
             context_builder = context_builder.with_multisampling(MULTISAMPLES)
         }
 
@@ -204,6 +208,8 @@ impl Window {
             xr_rotation: Cell::new(Rotation3D::identity()),
             angle,
             enable_vsync,
+            use_msaa,
+            no_native_titlebar,
         };
 
         window.present();
@@ -553,6 +559,8 @@ impl webxr::glwindow::GlWindow for Window {
             self.events_loop.clone(),
             self.angle,
             self.enable_vsync,
+            self.use_msaa,
+            self.no_native_titlebar,
         ));
         app::register_window(window.clone());
         Ok(window)

--- a/ports/glutin/headed_window.rs
+++ b/ports/glutin/headed_window.rs
@@ -71,6 +71,8 @@ pub struct Window {
     fullscreen: Cell<bool>,
     gl: Rc<dyn gl::Gl>,
     xr_rotation: Cell<Rotation3D<f32, UnknownUnit, UnknownUnit>>,
+    angle: bool,
+    enable_vsync: bool,
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -90,6 +92,8 @@ impl Window {
         win_size: Size2D<u32, DeviceIndependentPixel>,
         sharing: Option<&Window>,
         events_loop: Rc<RefCell<EventsLoop>>,
+        angle: bool,
+        enable_vsync: bool,
     ) -> Window {
         let opts = opts::get();
 
@@ -114,8 +118,8 @@ impl Window {
         window_builder = builder_with_platform_options(window_builder);
 
         let mut context_builder = glutin::ContextBuilder::new()
-            .with_gl(app::gl_version())
-            .with_vsync(opts.enable_vsync);
+            .with_gl(app::gl_version(angle))
+            .with_vsync(enable_vsync);
 
         if opts.use_msaa {
             context_builder = context_builder.with_multisampling(MULTISAMPLES)
@@ -198,6 +202,8 @@ impl Window {
             primary_monitor,
             screen_size,
             xr_rotation: Cell::new(Rotation3D::identity()),
+            angle,
+            enable_vsync,
         };
 
         window.present();
@@ -545,6 +551,8 @@ impl webxr::glwindow::GlWindow for Window {
             self.inner_size.get(),
             Some(self),
             self.events_loop.clone(),
+            self.angle,
+            self.enable_vsync,
         ));
         app::register_window(window.clone());
         Ok(window)

--- a/ports/glutin/headed_window.rs
+++ b/ports/glutin/headed_window.rs
@@ -75,6 +75,7 @@ pub struct Window {
     enable_vsync: bool,
     use_msaa: bool,
     no_native_titlebar: bool,
+    device_pixels_per_px: Option<f32>,
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -98,6 +99,7 @@ impl Window {
         enable_vsync: bool,
         use_msaa: bool,
         no_native_titlebar: bool,
+        device_pixels_per_px: Option<f32>,
     ) -> Window {
         let opts = opts::get();
 
@@ -210,6 +212,7 @@ impl Window {
             enable_vsync,
             use_msaa,
             no_native_titlebar,
+            device_pixels_per_px,
         };
 
         window.present();
@@ -329,7 +332,7 @@ impl Window {
     }
 
     fn servo_hidpi_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
-        match opts::get().device_pixels_per_px {
+        match self.device_pixels_per_px {
             Some(device_pixels_per_px) => Scale::new(device_pixels_per_px),
             _ => match opts::get().output_file {
                 Some(_) => Scale::new(1.0),
@@ -561,6 +564,7 @@ impl webxr::glwindow::GlWindow for Window {
             self.enable_vsync,
             self.use_msaa,
             self.no_native_titlebar,
+            self.device_pixels_per_px,
         ));
         app::register_window(window.clone());
         Ok(window)

--- a/ports/glutin/main2.rs
+++ b/ports/glutin/main2.rs
@@ -128,7 +128,7 @@ pub fn main() {
         process::exit(0);
     }
 
-    App::run();
+    App::run(opts::get().angle, opts::get().enable_vsync);
 
     platform::deinit()
 }

--- a/ports/glutin/main2.rs
+++ b/ports/glutin/main2.rs
@@ -96,6 +96,7 @@ pub fn main() {
     );
     opts.optflag("", "msaa", "Use multisample antialiasing in WebRender.");
     opts.optflag("b", "no-native-titlebar", "Do not use native titlebar");
+    opts.optopt("", "device-pixel-ratio", "Device pixels per px", "");
 
     let opts_matches;
     let content_process_token;
@@ -159,7 +160,14 @@ pub fn main() {
         opts_matches.opt_present("no-native-titlebar") || !(pref!(shell.native_titlebar.enabled));
     let enable_vsync = !opts_matches.opt_present("disable-vsync");
     let use_msaa = opts_matches.opt_present("msaa");
-    App::run(angle, enable_vsync, use_msaa, do_not_use_native_titlebar);
+    let device_pixels_per_px = opts_matches.opt_str("device-pixel-ratio").map(|dppx_str| {
+        dppx_str.parse().unwrap_or_else(|err| {
+            error!( "Error parsing option: --device-pixel-ratio ({})", err);
+            process::exit(1);
+        })
+    });
+
+    App::run(angle, enable_vsync, use_msaa, do_not_use_native_titlebar, device_pixels_per_px);
 
     platform::deinit(clean_shutdown)
 }

--- a/ports/glutin/platform/macos/mod.rs
+++ b/ports/glutin/platform/macos/mod.rs
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use servo::config::opts;
 use std::ptr;
 use std::thread;
 use std::time::Duration;
 
-pub fn deinit() {
+pub fn deinit(clean_shutdown: bool) {
     // An unfortunate hack to make sure the linker's dead code stripping doesn't strip our
     // `Info.plist`.
     unsafe {
@@ -21,7 +20,7 @@ pub fn deinit() {
             "{} threads are still running after shutdown (bad).",
             thread_count
         );
-        if opts::get().clean_shutdown {
+        if clean_shutdown {
             println!("Waiting until all threads have shutdown");
             loop {
                 let thread_count = unsafe { macos_count_running_threads() };

--- a/ports/libmlservo/Cargo.toml
+++ b/ports/libmlservo/Cargo.toml
@@ -25,7 +25,6 @@ simpleservo = { path = "../libsimpleservo/api", features = ["no_static_freetype"
 rust-webvr = { version = "0.16", features = ["magicleap"] }
 webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
 webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "magicleap"] }
-getopts = "0.2.11"
 libc = "0.2"
 log = "0.4"
 servo-egl = "0.2"

--- a/ports/libmlservo/Cargo.toml
+++ b/ports/libmlservo/Cargo.toml
@@ -25,6 +25,7 @@ simpleservo = { path = "../libsimpleservo/api", features = ["no_static_freetype"
 rust-webvr = { version = "0.16", features = ["magicleap"] }
 webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
 webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "magicleap"] }
+getopts = "0.2.11"
 libc = "0.2"
 log = "0.4"
 servo-egl = "0.2"

--- a/ports/libsimpleservo/api/Cargo.toml
+++ b/ports/libsimpleservo/api/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+getopts = "0.2.11"
 libservo = { path = "../../../components/servo" }
 log = "0.4"
 servo-media = { git = "https://github.com/servo/media" }

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -9,6 +9,7 @@ pub mod gl_glue;
 
 pub use servo::script_traits::MouseButton;
 
+use getopts::Options;
 use servo::compositing::windowing::{
     AnimationState, EmbedderCoordinates, EmbedderMethods, MouseWindowEvent, WindowEvent,
     WindowMethods,

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -205,7 +205,7 @@ pub fn init(
         gl: gl.clone(),
     });
 
-    let servo = Servo::new(embedder_callbacks, window_callbacks.clone());
+    let servo = Servo::new(embedder_callbacks, window_callbacks.clone(), None);
 
     SERVO.with(|s| {
         let mut servo_glue = ServoGlue {

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -171,7 +171,7 @@ pub fn init(
             gfx.subpixel_text_antialiasing.enabled,
             init_opts.enable_subpixel_text_antialiasing
         );
-        opts::from_cmdline_args(&args);
+        opts::from_cmdline_args(Options::new(), &args);
     }
 
     let embedder_url = init_opts.url.as_ref().and_then(|s| ServoUrl::parse(s).ok());


### PR DESCRIPTION
The `--angle` and `--disable-vsync` options were declared as global options, but only used in the Glutin embedding for desktop builds. Moving them to the Glutin embedding code makes them easier to update in the future.

I modified `opts::from_cmdline_args` to accept a `getopts::Options` (as prescribed in the issue) and augmented `opts::ArgumentParsingResult` to include an `opts::Matches` and `content-process` String when appropriate. I could use some feedback on this last bit. I could have changed the function to return `opts::Matches` and have the embedding code look for the presence of `content-process`, but I felt that the approach I went with was closer to the original design.

The other aspect I'm not sure about is moving `disable-vsync` from a global debug option to a plain embedder option. This changes the command line interface for glutin, which is maybe bad. However I wasn't sure whether it was worth preserving the original behavior given the complexity of injecting debug options into `opts::from_cmdline_args`.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes partially fix #23009 – there are 2 more options to deal with, but I'm not sure if we should handle them yet.
- [x] These changes do not require tests because this is a refactoring and I'm hoping that the existing tests cover these changes.

r? @jdm 