### PR TITLE
Limit the referer header's value length to 4096

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -195,13 +195,15 @@ fn strict_origin_when_cross_origin(referrer_url: ServoUrl, url: ServoUrl) -> Opt
 
 /// <https://w3c.github.io/webappsec-referrer-policy/#strip-url>
 fn strip_url(mut referrer_url: ServoUrl, origin_only: bool) -> Option<ServoUrl> {
+    const MAX_REFERRER_URL_LENGTH: usize = 4096;
     if referrer_url.scheme() == "https" || referrer_url.scheme() == "http" {
         {
             let referrer = referrer_url.as_mut_url();
             referrer.set_username("").unwrap();
             referrer.set_password(None).unwrap();
             referrer.set_fragment(None);
-            if origin_only {
+            // Limit `referer` header's value to 4k <https://github.com/w3c/webappsec-referrer-policy/pull/122>
+            if origin_only || referrer.as_str().len() > MAX_REFERRER_URL_LENGTH {
                 referrer.set_path("");
                 referrer.set_query(None);
             }

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -27,11 +27,12 @@ use hyper::{Request as HyperRequest, Response as HyperResponse};
 use msg::constellation_msg::TEST_PIPELINE_ID;
 use net::cookie::Cookie;
 use net::cookie_storage::CookieStorage;
+use net::http_loader::determine_request_referrer;
 use net::resource_thread::AuthCacheEntry;
 use net::test::replace_host_table;
 use net_traits::request::{CredentialsMode, Destination, RequestBuilder, RequestMode};
 use net_traits::response::ResponseBody;
-use net_traits::{CookieSource, NetworkError};
+use net_traits::{CookieSource, NetworkError, ReferrerPolicy};
 use servo_url::{ImmutableOrigin, ServoUrl};
 use std::collections::HashMap;
 use std::io::Write;
@@ -1420,4 +1421,48 @@ fn test_origin_set() {
         .is_success());
 
     let _ = server.close();
+}
+
+#[test]
+fn test_determine_request_referrer_shorter_than_4k() {
+    let mut headers = HeaderMap::new();
+
+    let referrer_source =
+        ServoUrl::parse("http://username:password@example.com/such/short/referer?query#fragment")
+            .unwrap();
+
+    let current_url = ServoUrl::parse("http://example.com/current/url").unwrap();
+
+    let referer = determine_request_referrer(
+        &mut headers,
+        ReferrerPolicy::UnsafeUrl,
+        referrer_source,
+        current_url,
+    );
+
+    assert_eq!(
+        referer.unwrap().as_str(),
+        "http://example.com/such/short/referer?query"
+    );
+}
+
+#[test]
+fn test_determine_request_referrer_longer_than_4k() {
+    let long_url_str = format!(
+        "http://username:password@example.com/such/{}/referer?query#fragment",
+        "long".repeat(1024)
+    );
+
+    let mut headers = HeaderMap::new();
+    let referrer_source = ServoUrl::parse(&long_url_str).unwrap();
+    let current_url = ServoUrl::parse("http://example.com/current/url").unwrap();
+
+    let referer = determine_request_referrer(
+        &mut headers,
+        ReferrerPolicy::UnsafeUrl,
+        referrer_source,
+        current_url,
+    );
+
+    assert_eq!(referer.unwrap().as_str(), "http://example.com/");
 }

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/cross-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/cross-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/cross-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/cross-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/cross-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/cross-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/cross-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/cross-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/cross-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/cross-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/cross-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/cross-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/same-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/same-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/same-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/same-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/same-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/same-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/same-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/script-tag/same-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/cross-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/cross-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/cross-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/cross-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/cross-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/cross-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/cross-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/cross-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/cross-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/cross-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/cross-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/cross-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/same-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/same-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/same-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/same-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/same-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/same-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/same-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/no-referrer-when-downgrade/xhr/same-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/origin-when-cross-origin/script-tag/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/origin-when-cross-origin/script-tag/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/origin-when-cross-origin/script-tag/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/origin-when-cross-origin/script-tag/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/origin-when-cross-origin/xhr/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/origin-when-cross-origin/xhr/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/origin-when-cross-origin/xhr/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/origin-when-cross-origin/xhr/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/same-origin/script-tag/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/same-origin/script-tag/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/same-origin/script-tag/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/same-origin/script-tag/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/same-origin/xhr/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/same-origin/xhr/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/same-origin/xhr/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/same-origin/xhr/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/strict-origin-when-cross-origin/script-tag/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/strict-origin-when-cross-origin/script-tag/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/strict-origin-when-cross-origin/script-tag/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/strict-origin-when-cross-origin/script-tag/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/strict-origin-when-cross-origin/xhr/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/strict-origin-when-cross-origin/xhr/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/strict-origin-when-cross-origin/xhr/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/strict-origin-when-cross-origin/xhr/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/cross-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/cross-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/cross-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/cross-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/cross-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/cross-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/cross-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/cross-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/cross-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/cross-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/cross-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/cross-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/same-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/same-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/same-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/same-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/same-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/same-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/same-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/script-tag/same-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/cross-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/cross-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/cross-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/cross-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/cross-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/cross-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/cross-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/cross-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/cross-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/cross-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/cross-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/cross-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/same-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/same-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/same-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/same-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/same-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/same-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/same-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unsafe-url/xhr/same-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/cross-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/cross-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/cross-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/cross-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/cross-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/cross-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/cross-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/cross-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/cross-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/cross-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/cross-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/cross-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/same-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/same-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/same-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/same-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/same-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/same-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/same-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/script-tag/same-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/cross-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/cross-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/cross-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/cross-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/cross-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/cross-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/cross-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/cross-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/cross-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/cross-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/cross-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/cross-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/same-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/same-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/same-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/same-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/same-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/same-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/same-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.http-rp/unset/xhr/same-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/cross-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/cross-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/cross-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/cross-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/cross-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/cross-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/cross-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/cross-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/cross-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/cross-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/cross-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/cross-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/same-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/same-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/same-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/same-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/same-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/same-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/same-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/script-tag/same-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/cross-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/cross-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/cross-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/cross-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/cross-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/cross-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/cross-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/cross-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/cross-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/cross-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/cross-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/cross-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/same-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/same-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/same-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/same-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/same-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/same-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/same-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/no-referrer-when-downgrade/xhr/same-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/origin-when-cross-origin/script-tag/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/origin-when-cross-origin/script-tag/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/origin-when-cross-origin/script-tag/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/origin-when-cross-origin/script-tag/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/origin-when-cross-origin/xhr/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/origin-when-cross-origin/xhr/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/origin-when-cross-origin/xhr/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/origin-when-cross-origin/xhr/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/same-origin/script-tag/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/same-origin/script-tag/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/same-origin/script-tag/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/same-origin/script-tag/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/same-origin/xhr/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/same-origin/xhr/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/same-origin/xhr/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/same-origin/xhr/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/strict-origin-when-cross-origin/script-tag/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/strict-origin-when-cross-origin/script-tag/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/strict-origin-when-cross-origin/script-tag/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/strict-origin-when-cross-origin/script-tag/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/strict-origin-when-cross-origin/xhr/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/strict-origin-when-cross-origin/xhr/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/strict-origin-when-cross-origin/xhr/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/strict-origin-when-cross-origin/xhr/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/cross-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/cross-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/cross-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/cross-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/cross-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/cross-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/cross-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/cross-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/cross-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/cross-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/cross-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/cross-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/same-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/same-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/same-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/same-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/same-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/same-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/same-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/script-tag/same-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/cross-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/cross-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/cross-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/cross-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/cross-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/cross-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/cross-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/cross-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/cross-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/cross-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/cross-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/cross-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/same-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/same-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/same-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/same-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/same-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/same-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/same-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unsafe-url/xhr/same-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/cross-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/cross-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/cross-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/cross-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/cross-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/cross-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/cross-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/cross-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/cross-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/cross-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/cross-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/cross-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/same-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/same-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/same-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/same-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/same-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/same-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/same-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/script-tag/same-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/cross-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/cross-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/cross-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/cross-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/cross-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/cross-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/cross-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/cross-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/cross-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/cross-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/cross-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/cross-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[cross-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/same-http.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/same-http.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/same-http.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/same-http.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/same-http.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/same-http.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-http.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/same-https.keep-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/same-https.keep-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.keep-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/same-https.no-redirect.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/same-https.no-redirect.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.no-redirect.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/same-https.swap-origin.http.html.ini
+++ b/tests/wpt/metadata/referrer-policy/gen/top.meta/unset/xhr/same-https.swap-origin.http.html.ini
@@ -1,4 +1,0 @@
-[same-https.swap-origin.http.html]
-  [`Referer` header with length > 4k is stripped to an origin.]
-    expected: FAIL
-


### PR DESCRIPTION
If the referer header's value is a URL with a length of more than 4k, strip it down to an origin.
This change reflects [w3c/webappsec-referrer-policy#122](https://github.com/w3c/webappsec-referrer-policy/pull/122)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #24515
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
