### PR TITLE
Launch UWP app from command line

### DIFF
--- a/support/hololens/ServoApp/App.cpp
+++ b/support/hololens/ServoApp/App.cpp
@@ -31,7 +31,9 @@ App::App() {
 #endif
 }
 
-void App::OnLaunched(LaunchActivatedEventArgs const &e) {
+void App::createRootFrame(
+    bool prelaunchActivated,
+    winrt::Windows::Foundation::IInspectable const &args) {
   Frame rootFrame{nullptr};
   auto content = Window::Current().Content();
   if (content) {
@@ -43,26 +45,33 @@ void App::OnLaunched(LaunchActivatedEventArgs const &e) {
 
     rootFrame.NavigationFailed({this, &App::OnNavigationFailed});
 
-    if (e.PrelaunchActivated() == false) {
+    if (prelaunchActivated == false) {
       if (rootFrame.Content() == nullptr) {
-        rootFrame.Navigate(xaml_typename<ServoApp::BrowserPage>(),
-                           box_value(e.Arguments()));
+        rootFrame.Navigate(xaml_typename<ServoApp::BrowserPage>(), args);
       }
       Window::Current().Content(rootFrame);
       Window::Current().Activate();
     }
   } else {
-    if (e.PrelaunchActivated() == false) {
+    if (prelaunchActivated == false) {
       if (rootFrame.Content() == nullptr) {
-        rootFrame.Navigate(xaml_typename<ServoApp::BrowserPage>(),
-                           box_value(e.Arguments()));
+        rootFrame.Navigate(xaml_typename<ServoApp::BrowserPage>(), args);
       }
       Window::Current().Activate();
     }
   }
 }
 
+void App::OnLaunched(LaunchActivatedEventArgs const &e) {
+  this->createRootFrame(e.PrelaunchActivated(), box_value(e.Arguments()));
+}
+
 void App::OnActivated(IActivatedEventArgs const &args) {
+  if (args.Kind() == Windows::ApplicationModel::Activation::ActivationKind::
+                         CommandLineLaunch) {
+    return this->createRootFrame(false, nullptr);
+  }
+
   if (args.Kind() ==
       Windows::ApplicationModel::Activation::ActivationKind::Protocol) {
     auto protocolActivatedEventArgs{args.as<

--- a/support/hololens/ServoApp/App.h
+++ b/support/hololens/ServoApp/App.h
@@ -9,12 +9,12 @@ namespace winrt::ServoApp::implementation {
 struct App : AppT<App> {
   App();
 
-  void createRootFrame(bool prelaunchActivated,
-                       winrt::Windows::Foundation::IInspectable const &args);
+  void createRootFrame(winrt::Windows::UI::Xaml::Controls::Frame &, bool,
+                       winrt::Windows::Foundation::IInspectable const &);
   void OnLaunched(
       Windows::ApplicationModel::Activation::LaunchActivatedEventArgs const &);
   void App::OnActivated(
-      Windows::ApplicationModel::Activation::IActivatedEventArgs const &args);
+      Windows::ApplicationModel::Activation::IActivatedEventArgs const &);
   void OnSuspending(IInspectable const &,
                     Windows::ApplicationModel::SuspendingEventArgs const &);
   void OnNavigationFailed(

--- a/support/hololens/ServoApp/App.h
+++ b/support/hololens/ServoApp/App.h
@@ -9,6 +9,8 @@ namespace winrt::ServoApp::implementation {
 struct App : AppT<App> {
   App();
 
+  void createRootFrame(bool prelaunchActivated,
+                       winrt::Windows::Foundation::IInspectable const &args);
   void OnLaunched(
       Windows::ApplicationModel::Activation::LaunchActivatedEventArgs const &);
   void App::OnActivated(

--- a/support/hololens/ServoApp/BrowserPage.cpp
+++ b/support/hololens/ServoApp/BrowserPage.cpp
@@ -67,6 +67,8 @@ void BrowserPage::SetTransientMode(bool transient) {
                                        : Visibility::Visible);
 }
 
+void BrowserPage::SetArgs(hstring args) { servoControl().SetArgs(args); }
+
 void BrowserPage::Shutdown() { servoControl().Shutdown(); }
 
 /**** USER INTERACTIONS WITH UI ****/

--- a/support/hololens/ServoApp/BrowserPage.h
+++ b/support/hololens/ServoApp/BrowserPage.h
@@ -29,6 +29,7 @@ public:
   void Shutdown();
   void LoadServoURI(Windows::Foundation::Uri uri);
   void SetTransientMode(bool);
+  void SetArgs(hstring);
 
 private:
   void BindServoEvents();

--- a/support/hololens/ServoApp/Package.appxmanifest
+++ b/support/hololens/ServoApp/Package.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" IgnorableNamespaces="uap mp uap5">
   <Identity Name="1d265729-8836-4bd3-9992-4cb111d1068b" Publisher="CN=Allizom" Version="1.0.0.0" />
   <mp:PhoneIdentity PhoneProductId="1d265729-8836-4bd3-9992-4cb111d1068b" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -32,6 +32,14 @@
             <uap:DisplayName>Firefox Reality URL</uap:DisplayName>
           </uap:Protocol>
         </uap:Extension>
+        <uap5:Extension
+          Category="windows.appExecutionAlias"
+          Executable="ServoApp.exe"
+          EntryPoint="ServoApp.App">
+          <uap5:AppExecutionAlias>
+            <uap5:ExecutionAlias Alias="Servo.exe" />
+          </uap5:AppExecutionAlias>
+        </uap5:Extension>
       </Extensions>
     </Application>
   </Applications>

--- a/support/hololens/ServoApp/ServoControl/Servo.cpp
+++ b/support/hololens/ServoApp/ServoControl/Servo.cpp
@@ -61,7 +61,8 @@ Servo::Servo(hstring url, hstring args, GLsizei width, GLsizei height, float dpi
     : mWindowHeight(height), mWindowWidth(width), mDelegate(aDelegate) {
 
   capi::CInitOptions o;
-  o.args = *hstring2char(args);
+  hstring defaultPrefs = L" --pref dom.webxr.enabled";
+  o.args = *hstring2char(args + defaultPrefs);
   o.url = *hstring2char(url);
   o.width = mWindowWidth;
   o.height = mWindowHeight;

--- a/support/hololens/ServoApp/ServoControl/Servo.cpp
+++ b/support/hololens/ServoApp/ServoControl/Servo.cpp
@@ -56,12 +56,12 @@ const char* get_clipboard_contents() {
   return nullptr;
 }
 
-Servo::Servo(hstring url, GLsizei width, GLsizei height, float dpi,
+Servo::Servo(hstring url, hstring args, GLsizei width, GLsizei height, float dpi,
              ServoDelegate &aDelegate)
     : mWindowHeight(height), mWindowWidth(width), mDelegate(aDelegate) {
 
   capi::CInitOptions o;
-  o.args = "--pref dom.webxr.enabled";
+  o.args = *hstring2char(args);
   o.url = *hstring2char(url);
   o.width = mWindowWidth;
   o.height = mWindowHeight;

--- a/support/hololens/ServoApp/ServoControl/Servo.h
+++ b/support/hololens/ServoApp/ServoControl/Servo.h
@@ -43,7 +43,7 @@ protected:
 
 class Servo {
 public:
-  Servo(hstring, GLsizei, GLsizei, float, ServoDelegate &);
+  Servo(hstring, hstring, GLsizei, GLsizei, float, ServoDelegate &);
   ~Servo();
   ServoDelegate &Delegate() { return mDelegate; }
 

--- a/support/hololens/ServoApp/ServoControl/ServoControl.cpp
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.cpp
@@ -40,20 +40,19 @@ void ServoControl::OnLoaded(IInspectable const &, RoutedEventArgs const &) {
       std::bind(&ServoControl::OnSurfaceClicked, this, _1, _2));
   panel.ManipulationStarted(
       [=](IInspectable const &,
-         Input::ManipulationStartedRoutedEventArgs const &e) {
+          Input::ManipulationStartedRoutedEventArgs const &e) {
         mOnCaptureGesturesStartedEvent();
         e.Handled(true);
       });
   panel.ManipulationCompleted(
       [=](IInspectable const &,
-         Input::ManipulationCompletedRoutedEventArgs const &e) {
+          Input::ManipulationCompletedRoutedEventArgs const &e) {
         mOnCaptureGesturesEndedEvent();
         e.Handled(true);
       });
   panel.ManipulationDelta(
       std::bind(&ServoControl::OnSurfaceManipulationDelta, this, _1, _2));
-  Panel().SizeChanged(
-      std::bind(&ServoControl::OnSurfaceResized, this, _1, _2));
+  Panel().SizeChanged(std::bind(&ServoControl::OnSurfaceResized, this, _1, _2));
   InitializeConditionVariable(&mGLCondVar);
   InitializeCriticalSection(&mGLLock);
   CreateRenderSurface();
@@ -166,7 +165,8 @@ void ServoControl::Loop() {
   if (mServo == nullptr) {
     log("Entering loop");
     ServoDelegate *sd = static_cast<ServoDelegate *>(this);
-    mServo = std::make_unique<Servo>(mInitialURL, panelWidth, panelHeight, mDPI, *sd);
+    mServo = std::make_unique<Servo>(mInitialURL, mArgs, panelWidth, panelHeight, mDPI,
+                                     *sd);
   } else {
     // FIXME: this will fail since create_task didn't pick the thread
     // where Servo was running initially.
@@ -273,9 +273,7 @@ void ServoControl::WakeUp() {
 
 bool ServoControl::OnServoAllowNavigation(hstring uri) {
   if (mTransient) {
-    RunOnUIThread([=] {
-      Launcher::LaunchUriAsync(Uri{uri});
-    });
+    RunOnUIThread([=] { Launcher::LaunchUriAsync(Uri{uri}); });
   }
   return !mTransient;
 }
@@ -288,7 +286,8 @@ void ServoControl::OnServoAnimatingChanged(bool animating) {
 }
 
 void ServoControl::OnServoIMEStateChanged(bool aShow) {
-  // FIXME: https://docs.microsoft.com/en-us/windows/win32/winauto/uiauto-implementingtextandtextrange
+  // FIXME:
+  // https://docs.microsoft.com/en-us/windows/win32/winauto/uiauto-implementingtextandtextrange
 }
 
 template <typename Callable> void ServoControl::RunOnUIThread(Callable cb) {

--- a/support/hololens/ServoApp/ServoControl/ServoControl.h
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.h
@@ -72,6 +72,8 @@ struct ServoControl : ServoControlT<ServoControl>, public servo::ServoDelegate {
 
   void SetTransientMode(bool transient) { mTransient = transient; }
 
+  void SetArgs(hstring args) { mArgs = args; }
+
   virtual void WakeUp();
   virtual void OnServoLoadStarted();
   virtual void OnServoLoadEnded();
@@ -139,6 +141,7 @@ private:
   CRITICAL_SECTION mGLLock;
   CONDITION_VARIABLE mGLCondVar;
   std::unique_ptr<Concurrency::task<void>> mLoopTask;
+  hstring mArgs;
 };
 } // namespace winrt::ServoApp::implementation
 

--- a/support/hololens/ServoApp/ServoControl/ServoControl.idl
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.idl
@@ -11,6 +11,7 @@ namespace ServoApp {
       void Stop();
       Windows.Foundation.Uri LoadURIOrSearch(String url);
       void SetTransientMode(Boolean transient);
+      void SetArgs(String args);
       void Shutdown();
       event EventDelegate OnLoadStarted;
       event EventDelegate OnLoadEnded;


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

This PR makes it possible to launch the UWP app from the command line by executing (on any path) the `Servo` command. It requires building and launching Servo once on VS, so the command alias is properly registered.

It also allows passing command line arguments. So we can do for example `Servo --pref dom.webxr.enabled`.

Debugging is also possible when launching the app from the command line. It requires setting the `Launch Application` option (right click on `ServoApp (Universal Windows`) on the Solution Explorer view -> Properties ->  Configuration Properties -> Debugging) to `No`.