### PR TITLE
Update UWP ANGLE to a modern version

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -787,7 +787,7 @@ def angle_root(target, nuget_env):
     }
     angle_arch = arch[target.split('-')[0]]
     angle_default_path = path.join(os.getcwd(), "support", "hololens", "packages",
-                                   "ANGLE.WindowsStore.Servo.2.1.13", "bin", "UAP", angle_arch)
+                                   "ANGLE.WindowsStore.Servo.2.1.15", "bin", "UAP", angle_arch)
 
     # Nuget executable command
     nuget_app = path.join(os.getcwd(), "support", "hololens", "ServoApp.sln")

--- a/support/hololens/ServoApp/ServoApp.vcxproj
+++ b/support/hololens/ServoApp/ServoApp.vcxproj
@@ -947,8 +947,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\ANGLE.WindowsStore.Servo.2.1.13\build\native\ANGLE.WindowsStore.Servo.targets" Condition="Exists('..\packages\ANGLE.WindowsStore.Servo.2.1.13\build\native\ANGLE.WindowsStore.Servo.targets')" />
     <Import Project="..\packages\OpenXR.Loader.1.0.3\build\native\OpenXR.Loader.targets" Condition="Exists('..\packages\OpenXR.Loader.1.0.3\build\native\OpenXR.Loader.targets')" />
+    <Import Project="..\packages\ANGLE.WindowsStore.Servo.2.1.15\build\native\ANGLE.WindowsStore.Servo.targets" Condition="Exists('..\packages\ANGLE.WindowsStore.Servo.2.1.15\build\native\ANGLE.WindowsStore.Servo.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -956,8 +956,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.190620.2\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\ANGLE.WindowsStore.Servo.2.1.13\build\native\ANGLE.WindowsStore.Servo.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ANGLE.WindowsStore.Servo.2.1.13\build\native\ANGLE.WindowsStore.Servo.targets'))" />
     <Error Condition="!Exists('..\packages\OpenXR.Loader.1.0.3\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\OpenXR.Loader.1.0.3\build\native\OpenXR.Loader.props'))" />
     <Error Condition="!Exists('..\packages\OpenXR.Loader.1.0.3\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\OpenXR.Loader.1.0.3\build\native\OpenXR.Loader.targets'))" />
+    <Error Condition="!Exists('..\packages\ANGLE.WindowsStore.Servo.2.1.15\build\native\ANGLE.WindowsStore.Servo.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ANGLE.WindowsStore.Servo.2.1.15\build\native\ANGLE.WindowsStore.Servo.targets'))" />
   </Target>
 </Project>

--- a/support/hololens/ServoApp/ServoControl/OpenGLES.cpp
+++ b/support/hololens/ServoApp/ServoControl/OpenGLES.cpp
@@ -48,13 +48,10 @@ void OpenGLES::Initialize() {
       EGL_PLATFORM_ANGLE_TYPE_ANGLE,
       EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
 
-      // EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER is an optimization that
-      // can have large performance benefits on
-      // mobile devices. Its syntax is subject to change, though. Please update
-      // your Visual Studio templates if you
-      // experience compilation issues with it.
-      EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER,
-      EGL_TRUE,
+      // EGL_EXPERIMENTAL_PRESENT_PATH_ANGLE is an optimization that
+      // can have large performance benefits on mobile devices.
+      EGL_EXPERIMENTAL_PRESENT_PATH_ANGLE,
+      EGL_EXPERIMENTAL_PRESENT_PATH_FAST_ANGLE,
 
       // EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE is an option that
       // enables ANGLE to automatically call
@@ -79,8 +76,8 @@ void OpenGLES::Initialize() {
       9,
       EGL_PLATFORM_ANGLE_MAX_VERSION_MINOR_ANGLE,
       3,
-      EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER,
-      EGL_TRUE,
+      EGL_EXPERIMENTAL_PRESENT_PATH_ANGLE,
+      EGL_EXPERIMENTAL_PRESENT_PATH_FAST_ANGLE,
       EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE,
       EGL_TRUE,
       EGL_NONE,
@@ -93,9 +90,9 @@ void OpenGLES::Initialize() {
       EGL_PLATFORM_ANGLE_TYPE_ANGLE,
       EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
       EGL_PLATFORM_ANGLE_DEVICE_TYPE_ANGLE,
-      EGL_PLATFORM_ANGLE_DEVICE_TYPE_WARP_ANGLE,
-      EGL_ANGLE_DISPLAY_ALLOW_RENDER_TO_BACK_BUFFER,
-      EGL_TRUE,
+      EGL_PLATFORM_ANGLE_DEVICE_TYPE_D3D_WARP_ANGLE,
+      EGL_EXPERIMENTAL_PRESENT_PATH_ANGLE,
+      EGL_EXPERIMENTAL_PRESENT_PATH_FAST_ANGLE,
       EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE,
       EGL_TRUE,
       EGL_NONE,
@@ -194,8 +191,7 @@ void OpenGLES::Reset() {
 EGLSurface OpenGLES::CreateSurface(SwapChainPanel const &panel, float dpi) {
   EGLSurface surface = EGL_NO_SURFACE;
 
-  const EGLint surfaceAttributes[] = {EGL_ANGLE_SURFACE_RENDER_TO_BACK_BUFFER,
-                                      EGL_TRUE, EGL_NONE};
+  const EGLint surfaceAttributes[] = {EGL_NONE};
 
   PropertySet surfaceCreationProperties;
 

--- a/support/hololens/ServoApp/packages.config
+++ b/support/hololens/ServoApp/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ANGLE.WindowsStore.Servo" version="2.1.13" targetFramework="native" />
+  <package id="ANGLE.WindowsStore.Servo" version="2.1.15" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.190620.2" targetFramework="native" />
   <package id="OpenXR.Loader" version="1.0.3" targetFramework="native" />
 </packages>


### PR DESCRIPTION
The previous UWP ANGLE builds were made from https://github.com/servo/ms-angle/tree/servo-master which was based on an abandoned revision of ANGLE from >2 years ago. This is lacking some features that are necessary for https://github.com/servo/webxr/issues/46, so this is a new build produced from https://github.com/google/angle/ instead.

I've documented the process for releasing new ANGLE builds at https://github.com/servo/servo/wiki/Publishing-a-new-ANGLE-NuGet-version.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24199
- [x] These changes do not require tests because the windows testing situation is sad, and the UWP testing situation is sadder