### PR TITLE
Update the maximum version of Ubuntu suppported to 19.10

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -379,7 +379,7 @@ def get_linux_distribution():
             raise Exception('unsupported version of %s: %s' % (distrib, version))
         distrib, version = 'Ubuntu', base_version
     elif distrib.lower() == 'ubuntu':
-        if version > '19.04':
+        if version > '19.10':
             raise Exception('unsupported version of %s: %s' % (distrib, version))
     # Fixme: we should allow checked/supported versions only
     elif distrib.lower() not in [


### PR DESCRIPTION
Update bootstrap.py to allow it to run on Ubuntu 19.10


---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23881

- [ ] There are tests for these changes OR
- [X] These changes do not require tests because there are no tests for bootstrap.py
