### PR TITLE
Properly set MouseEvent buttons property

### DIFF
--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -137,7 +137,7 @@ impl MouseEvent {
             init.parent.shiftKey,
             init.parent.metaKey,
             init.button,
-            0,
+            init.buttons,
             init.relatedTarget.as_deref(),
             None,
         );

--- a/tests/wpt/metadata/dom/events/Event-subclasses-constructors.html.ini
+++ b/tests/wpt/metadata/dom/events/Event-subclasses-constructors.html.ini
@@ -1,8 +1,5 @@
 [Event-subclasses-constructors.html]
   type: testharness
-  [MouseEvent constructor (argument with non-default values)]
-    expected: FAIL
-
   [WheelEvent constructor (argument with non-default values)]
     expected: FAIL
 


### PR DESCRIPTION
Properly set MouseEvent buttons property. Same behavior as Chrome and Firefox.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24363 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
