### PR TITLE
mach bootstrap - activate virtual env

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -224,6 +224,14 @@ class DummyContext(object):
 
 
 def bootstrap_command_only(topdir):
+    # See if we're inside a Firefox checkout.
+    parentdir = os.path.normpath(os.path.join(topdir, '..'))
+    is_firefox = os.path.isfile(os.path.join(parentdir,
+                                             'build/mach_bootstrap.py'))
+    # we should activate the venv before importing servo.boostrap
+    # because the module requires non-standard python packages
+    _activate_virtualenv(topdir, is_firefox)
+
     from servo.bootstrap import bootstrap
 
     context = DummyContext()

--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -223,14 +223,17 @@ class DummyContext(object):
     pass
 
 
-def bootstrap_command_only(topdir):
-    # See if we're inside a Firefox checkout.
+def is_firefox_checkout(topdir):
     parentdir = os.path.normpath(os.path.join(topdir, '..'))
     is_firefox = os.path.isfile(os.path.join(parentdir,
                                              'build/mach_bootstrap.py'))
+    return is_firefox
+
+
+def bootstrap_command_only(topdir):
     # we should activate the venv before importing servo.boostrap
     # because the module requires non-standard python packages
-    _activate_virtualenv(topdir, is_firefox)
+    _activate_virtualenv(topdir, is_firefox_checkout(topdir))
 
     from servo.bootstrap import bootstrap
 
@@ -273,10 +276,7 @@ def bootstrap(topdir):
         print('You are running Python', platform.python_version())
         sys.exit(1)
 
-    # See if we're inside a Firefox checkout.
-    parentdir = os.path.normpath(os.path.join(topdir, '..'))
-    is_firefox = os.path.isfile(os.path.join(parentdir,
-                                             'build/mach_bootstrap.py'))
+    is_firefox = is_firefox_checkout(topdir)
 
     _activate_virtualenv(topdir, is_firefox)
 


### PR DESCRIPTION
This modifies the `./mach bootstrap` script to activate the python virtual environment, fixing issues on systems that don't have `six` and `distro` pre-installed. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24561 (also relevant to #24541)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they are in the `./mach bootstrap` script - although this may be something that could be checked in CI - Is there any interest in setting this up? 