### PR TITLE
Return false from CanvasState::is_point_in_path for NaN/infinite values

### DIFF
--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -1241,6 +1241,10 @@ impl CanvasState {
         y: f64,
         fill_rule: CanvasFillRule,
     ) -> bool {
+        if !(x.is_finite() && y.is_finite()) {
+            return false;
+        }
+
         let fill_rule = match fill_rule {
             CanvasFillRule::Nonzero => FillRule::Nonzero,
             CanvasFillRule::Evenodd => FillRule::Evenodd,


### PR DESCRIPTION
Servo doesn't pass WPT test `/2dcontext/path-objects/2d.path.isPointInPath.nonfinite.html` when built with raqote (see [here](https://github.com/servo/servo/pull/24470#issuecomment-546009000)).
This change adds a missing check for NaN/infinite values in `CanvasState::is_point_in_path` and fixes this.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #24540
- [X] These changes do not require tests because WPT tests cover it
