### PR TITLE
Switch rust compiler before installing rustup components.

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -269,8 +269,8 @@ def with_rust_nightly():
     return (
         linux_build_task("with Rust Nightly", build_env=modified_build_env)
         .with_treeherder("Linux x64", "RustNightly")
+        .with_early_script('echo "nightly" > rust-toolchain')
         .with_script("""
-            echo "nightly" > rust-toolchain
             ./mach build --dev
             ./mach test-unit
         """)


### PR DESCRIPTION
This should address the issue with nightly builds where we install the rustc-dev component for the current Rust compiler and then switch to the nightly toolchain and try to build.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24579
- [x] There are tests for these changes