### PR TITLE
Fix GL panic with updated ANGLE

### DIFF
--- a/components/script/dom/webgl_extensions/ext/oestexturefloat.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturefloat.rs
@@ -49,21 +49,15 @@ impl WebGLExtension for OESTextureFloat {
 
     fn enable(ext: &WebGLExtensions) {
         ext.enable_tex_type(webgl::FLOAT);
-        if !ext.supports_gl_extension("GL_OES_texture_float") {
-            ext.add_effective_tex_internal_format(webgl::RGBA, webgl::FLOAT, gl::RGBA32F);
-            ext.add_effective_tex_internal_format(webgl::RGB, webgl::FLOAT, gl::RGB32F);
-            ext.add_effective_tex_internal_format(
-                webgl::LUMINANCE,
-                webgl::FLOAT,
-                gl::LUMINANCE32F_ARB,
-            );
-            ext.add_effective_tex_internal_format(webgl::ALPHA, webgl::FLOAT, gl::ALPHA32F_ARB);
-            ext.add_effective_tex_internal_format(
-                webgl::LUMINANCE_ALPHA,
-                webgl::FLOAT,
-                gl::LUMINANCE_ALPHA32F_ARB,
-            );
-        }
+        ext.add_effective_tex_internal_format(webgl::RGBA, webgl::FLOAT, gl::RGBA32F);
+        ext.add_effective_tex_internal_format(webgl::RGB, webgl::FLOAT, gl::RGB32F);
+        ext.add_effective_tex_internal_format(webgl::LUMINANCE, webgl::FLOAT, gl::LUMINANCE32F_ARB);
+        ext.add_effective_tex_internal_format(webgl::ALPHA, webgl::FLOAT, gl::ALPHA32F_ARB);
+        ext.add_effective_tex_internal_format(
+            webgl::LUMINANCE_ALPHA,
+            webgl::FLOAT,
+            gl::LUMINANCE_ALPHA32F_ARB,
+        );
     }
 
     fn name() -> &'static str {

--- a/components/script/dom/webgl_extensions/ext/oestexturehalffloat.rs
+++ b/components/script/dom/webgl_extensions/ext/oestexturehalffloat.rs
@@ -53,17 +53,15 @@ impl WebGLExtension for OESTextureHalfFloat {
     fn enable(ext: &WebGLExtensions) {
         let hf = OESTextureHalfFloatConstants::HALF_FLOAT_OES;
         ext.enable_tex_type(hf);
-        if !ext.supports_gl_extension("GL_OES_texture_half_float") {
-            ext.add_effective_tex_internal_format(webgl::RGBA, hf, gl::RGBA16F);
-            ext.add_effective_tex_internal_format(webgl::RGB, hf, gl::RGB16F);
-            ext.add_effective_tex_internal_format(webgl::LUMINANCE, hf, gl::LUMINANCE16F_ARB);
-            ext.add_effective_tex_internal_format(webgl::ALPHA, hf, gl::ALPHA16F_ARB);
-            ext.add_effective_tex_internal_format(
-                webgl::LUMINANCE_ALPHA,
-                hf,
-                gl::LUMINANCE_ALPHA16F_ARB,
-            );
-        }
+        ext.add_effective_tex_internal_format(webgl::RGBA, hf, gl::RGBA16F);
+        ext.add_effective_tex_internal_format(webgl::RGB, hf, gl::RGB16F);
+        ext.add_effective_tex_internal_format(webgl::LUMINANCE, hf, gl::LUMINANCE16F_ARB);
+        ext.add_effective_tex_internal_format(webgl::ALPHA, hf, gl::ALPHA16F_ARB);
+        ext.add_effective_tex_internal_format(
+            webgl::LUMINANCE_ALPHA,
+            hf,
+            gl::LUMINANCE_ALPHA16F_ARB,
+        );
     }
 
     fn name() -> &'static str {


### PR DESCRIPTION
Our OES_texture_float extension implementation relied on the GL implementation to convert from unsized formats like RGBA when using the FLOAT/HALF_FLOAT type to an internal sized format that was acceptable. ANGLE no longer appears to do that since #24542, so we should enable the format conversion unconditionally.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24578
- [x] There are tests for these changes