### PR TITLE
implement PerformanceResourceTiming duration

### DIFF
--- a/components/script/dom/performanceresourcetiming.rs
+++ b/components/script/dom/performanceresourcetiming.rs
@@ -55,7 +55,6 @@ pub struct PerformanceResourceTiming {
     decoded_body_size: u64, //size in octets
 }
 
-// TODO(#21255): duration
 // TODO(#21269): next_hop
 // TODO(#21264): worker_start
 // TODO(#21258): fetch_start
@@ -115,7 +114,7 @@ impl PerformanceResourceTiming {
                 DOMString::from(url.into_string()),
                 DOMString::from("resource"),
                 resource_timing.start_time as f64,
-                0.,
+                resource_timing.response_end as f64 - resource_timing.start_time as f64,
             ),
             initiator_type: initiator_type,
             next_hop: next_hop,

--- a/tests/wpt/metadata/resource-timing/test_resource_timing.html.ini
+++ b/tests/wpt/metadata/resource-timing/test_resource_timing.html.ini
@@ -15,9 +15,6 @@
   [PerformanceEntry has correct protocol attribute (iframe)]
     expected: FAIL
 
-  [PerformanceEntry has correct name, initiatorType, startTime, and duration (img)]
-    expected: FAIL
-
   [PerformanceEntry has correct order of timing attributes (img)]
     expected: FAIL
 

--- a/tests/wpt/metadata/resource-timing/test_resource_timing.https.html.ini
+++ b/tests/wpt/metadata/resource-timing/test_resource_timing.https.html.ini
@@ -66,9 +66,6 @@
   [PerformanceEntry has correct protocol attribute (script)]
     expected: FAIL
 
-  [PerformanceEntry has correct name, initiatorType, startTime, and duration (img)]
-    expected: FAIL
-
   [PerformanceEntry has correct name, initiatorType, startTime, and duration (link)]
     expected: NOTRUN
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Implements #21255

I wanted to give this a shot, but I'm not sure this is the appropriate implementation. In particular, I'm not sure if adding duration to the webidl interface is correct, because that doesn't seem to align with the web version (linked above the interface)? 

Also, I'd like to write a test for this method, but I'm not sure where that test should go.

My apologies if this is way off target.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21255 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
