### PR TITLE
UWP: More mouse events

### DIFF
--- a/ports/libmlservo/src/lib.rs
+++ b/ports/libmlservo/src/lib.rs
@@ -240,7 +240,7 @@ pub unsafe extern "C" fn move_servo(servo: *mut ServoInstance, x: f32, y: f32) {
         match servo.scroll_state {
             ScrollState::TriggerUp => {
                 servo.scroll_state = ScrollState::TriggerUp;
-                let _ = call(|s| s.move_mouse(x, y));
+                let _ = call(|s| s.mouse_move(x, y));
             },
             ScrollState::TriggerDown(start)
                 if (start - point).square_length() < DRAG_CUTOFF_SQUARED =>
@@ -249,14 +249,14 @@ pub unsafe extern "C" fn move_servo(servo: *mut ServoInstance, x: f32, y: f32) {
             }
             ScrollState::TriggerDown(start) => {
                 servo.scroll_state = ScrollState::TriggerDragging(start, point);
-                let _ = call(|s| s.move_mouse(x, y));
+                let _ = call(|s| s.mouse_move(x, y));
                 let delta = (point - start) * servo.scroll_scale;
                 let start = start.to_i32();
                 let _ = call(|s| s.scroll_start(delta.x, delta.y, start.x, start.y));
             },
             ScrollState::TriggerDragging(start, prev) => {
                 servo.scroll_state = ScrollState::TriggerDragging(start, point);
-                let _ = call(|s| s.move_mouse(x, y));
+                let _ = call(|s| s.mouse_move(x, y));
                 let delta = (point - prev) * servo.scroll_scale;
                 let start = start.to_i32();
                 let _ = call(|s| s.scroll(delta.x, delta.y, start.x, start.y));
@@ -279,7 +279,7 @@ pub unsafe extern "C" fn trigger_servo(servo: *mut ServoInstance, x: f32, y: f32
                 servo.scroll_state = ScrollState::TriggerUp;
                 let _ = call(|s| s.mouse_up(start.x, start.y, MouseButton::Left));
                 let _ = call(|s| s.click(start.x as f32, start.y as f32));
-                let _ = call(|s| s.move_mouse(start.x, start.y));
+                let _ = call(|s| s.mouse_move(start.x, start.y));
             },
             ScrollState::TriggerDragging(start, prev) if !down => {
                 servo.scroll_state = ScrollState::TriggerUp;

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -397,7 +397,7 @@ impl ServoGlue {
     }
 
     /// Register a mouse movement.
-    pub fn move_mouse(&mut self, x: f32, y: f32) -> Result<(), &'static str> {
+    pub fn mouse_move(&mut self, x: f32, y: f32) -> Result<(), &'static str> {
         let point = Point2D::new(x, y);
         let event = WindowEvent::MouseWindowMoveEventClass(point);
         self.process_event(event)

--- a/ports/libsimpleservo/capi/src/lib.rs
+++ b/ports/libsimpleservo/capi/src/lib.rs
@@ -560,6 +560,14 @@ pub extern "C" fn pinchzoom_end(factor: f32, x: i32, y: i32) {
 }
 
 #[no_mangle]
+pub extern "C" fn mouse_move(x: f32, y: f32) {
+    catch_any_panic(|| {
+        debug!("mouse_move");
+        call(|s| s.mouse_move(x, y));
+    });
+}
+
+#[no_mangle]
 pub extern "C" fn mouse_down(x: f32, y: f32, button: CMouseButton) {
     catch_any_panic(|| {
         debug!("mouse_down");

--- a/support/hololens/ServoApp/ServoControl/Servo.h
+++ b/support/hololens/ServoApp/ServoControl/Servo.h
@@ -62,6 +62,9 @@ public:
   void MouseUp(float x, float y, capi::CMouseButton b) {
     capi::mouse_up(x, y, b);
   }
+  void MouseMove(float x, float y) {
+    capi::mouse_move(x, y);
+  }
 
   void Reload() { capi::reload(); }
   void Stop() { capi::stop(); }

--- a/support/hololens/ServoApp/ServoControl/ServoControl.h
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.h
@@ -125,6 +125,18 @@ private:
   void OnSurfacePointerPressed(IInspectable const &,
                        Windows::UI::Xaml::Input::PointerRoutedEventArgs const &);
 
+  void OnSurfacePointerCanceled(
+      IInspectable const &,
+      Windows::UI::Xaml::Input::PointerRoutedEventArgs const &);
+
+  void OnSurfacePointerMoved(
+      IInspectable const &,
+      Windows::UI::Xaml::Input::PointerRoutedEventArgs const &);
+
+  void OnSurfaceWheelChanged(
+      IInspectable const &,
+      Windows::UI::Xaml::Input::PointerRoutedEventArgs const &);
+
   void OnSurfaceManipulationDelta(
       IInspectable const &,
       Windows::UI::Xaml::Input::ManipulationDeltaRoutedEventArgs const &);


### PR DESCRIPTION
Support more UWP Desktop events (mouse wheel, mouse move, etc).

This introduces a new issue, where the basic bbjs demo requires double click to select a color (unrelated to #24530 I believe). Filed #24596.

Next step is to properly fire touch events in HoloLens and only mouse events on Desktop (see #24587).