### PR TITLE
Adding a check for "Linux Mint" with a space

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -348,7 +348,7 @@ def get_linux_distribution():
     distrib = six.ensure_str(distrib)
     version = six.ensure_str(version)
 
-    if distrib == 'LinuxMint':
+    if distrib == 'LinuxMint' or distrib == 'Linux Mint':
         if '.' in version:
             major, _ = version.split('.', 1)
         else:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
While trying to run `./mach bootstrap` on Linux Mint I encountered the following error:
```
$ ./mach bootstrap
Traceback (most recent call last):
  File "./mach", line 103, in <module>
    main(sys.argv)
  File "./mach", line 31, in main
    sys.exit(mach_bootstrap.bootstrap_command_only(topdir))
  File "/home/gmartin/servo/python/mach_bootstrap.py", line 234, in bootstrap_command_only
    bootstrap(context, force)
  File "/home/gmartin/servo/python/servo/bootstrap.py", line 403, in bootstrap
    distrib, version = get_linux_distribution()
  File "/home/gmartin/servo/python/servo/bootstrap.py", line 391, in get_linux_distribution
    raise Exception('mach bootstrap does not support %s, please file a bug' % distrib)
Exception: mach bootstrap does not support Linux Mint, please file a bug
```

The solution is to add another check for Linux Mint which included a space in the distro name.

Question: Is it generally a requirement to open an issue if I also have the fix ready to go (as is the case here)?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [X] These changes do not require tests because I couldn't find any existing unit tests for [python/servo/bootstrap.py](python/servo/bootstrap.py)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
