### PR TITLE
Fix keypress trigger condition

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1435,7 +1435,8 @@ impl Document {
 
         // https://w3c.github.io/uievents/#keys-cancelable-keys
         if keyboard_event.state == KeyState::Down &&
-            keyboard_event.key.legacy_charcode() != 0 &&
+            is_character_value_key(&(keyboard_event.key)) &&
+            !keyboard_event.is_composing &&
             cancel_state != EventDefault::Prevented
         {
             // https://w3c.github.io/uievents/#keypress-event-order
@@ -2502,6 +2503,13 @@ impl Document {
             .send(WebGLMsg::SwapBuffers(dirty_context_ids, sender))
             .unwrap();
         receiver.recv().unwrap();
+    }
+}
+
+fn is_character_value_key(key: &Key) -> bool {
+    match key {
+        Key::Character(_) | Key::Enter => true,
+        _ => false,
     }
 }
 


### PR DESCRIPTION
Fix #22346

keypress event should be triggered for keys representing character
values. So, we should trigger this event for enter key.
This event should not trigger for IME inputs.

TODO:
- It seems we don't handle composition events correctly. To implement this keypress condition correctly, we should fix that first. In my current implementation, onkeypress event will be trigger when the user press Enter key to send inputs in IME (onCompotionEnd).
- I don't update any tests, and I couldn't find any tests related to this change in WPT. It might be better to add some tests for it, but I don't know what is the appropriate way.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
