### PR TITLE
Do not assume UWP and Servo agree on URL validity

### DIFF
--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -152,6 +152,12 @@ pub fn servo_version() -> String {
     servo::config::servo_version()
 }
 
+/// Test if a url is valid.
+pub fn is_uri_valid(url: &str) -> bool {
+    info!("load_uri: {}", url);
+    ServoUrl::parse(url).is_ok()
+}
+
 /// Initialize Servo. At that point, we need a valid GL context.
 /// In the future, this will be done in multiple steps.
 pub fn init(

--- a/support/hololens/ServoApp/BrowserPage.cpp
+++ b/support/hololens/ServoApp/BrowserPage.cpp
@@ -116,7 +116,7 @@ void BrowserPage::OnURLEdited(IInspectable const &,
     servoControl().Focus(FocusState::Programmatic);
     auto input = urlTextbox().Text();
     auto uri = servoControl().LoadURIOrSearch(input);
-    urlTextbox().Text(uri.ToString());
+    urlTextbox().Text(uri);
   }
 }
 

--- a/support/hololens/ServoApp/ServoControl/Servo.h
+++ b/support/hololens/ServoApp/ServoControl/Servo.h
@@ -66,7 +66,10 @@ public:
 
   void Reload() { capi::reload(); }
   void Stop() { capi::stop(); }
-  void LoadUri(hstring uri) { capi::load_uri(*hstring2char(uri)); }
+  bool LoadUri(hstring uri) { return capi::load_uri(*hstring2char(uri)); }
+  bool IsUriValid(hstring uri) {
+    return capi::is_uri_valid(*hstring2char(uri));
+  }
   void Scroll(float dx, float dy, float x, float y) {
     capi::scroll((int32_t)dx, (int32_t)dy, (int32_t)x, (int32_t)y);
   }

--- a/support/hololens/ServoApp/ServoControl/ServoControl.h
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.h
@@ -14,7 +14,7 @@ struct ServoControl : ServoControlT<ServoControl>, public servo::ServoDelegate {
   void Reload();
   void Stop();
   void Shutdown();
-  Windows::Foundation::Uri LoadURIOrSearch(hstring);
+  hstring LoadURIOrSearch(hstring);
 
   void OnLoaded(IInspectable const &,
                 Windows::UI::Xaml::RoutedEventArgs const &);
@@ -110,14 +110,6 @@ private:
   void StopRenderLoop();
   void Loop();
 
-  std::optional<Windows::Foundation::Uri> TryParseURI(hstring input) {
-    try {
-      return Windows::Foundation::Uri(input);
-    } catch (hresult_invalid_argument const &) {
-      return {};
-    }
-  }
-
   void OnSurfaceTapped(IInspectable const &,
                        Windows::UI::Xaml::Input::TappedRoutedEventArgs const &);
 
@@ -146,6 +138,8 @@ private:
 
   template <typename Callable> void RunOnUIThread(Callable);
   void RunOnGLThread(std::function<void()>);
+
+  void TryLoadUri(hstring);
 
   std::unique_ptr<servo::Servo> mServo;
   EGLSurface mRenderSurface{EGL_NO_SURFACE};

--- a/support/hololens/ServoApp/ServoControl/ServoControl.idl
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.idl
@@ -9,7 +9,7 @@ namespace ServoApp {
       void GoForward();
       void Reload();
       void Stop();
-      Windows.Foundation.Uri LoadURIOrSearch(String url);
+      String LoadURIOrSearch(String url);
       void SetTransientMode(Boolean transient);
       void SetArgs(String args);
       void Shutdown();


### PR DESCRIPTION
This should address #24589.

Note: to check that a URL is valid, we try to parse the url and if an exception is raised, we assume the url is not valid. Even though we catch the exception, Visual Studio might "force" the crash + break here: https://github.com/servo/servo/compare/master...paulrouget:url?expand=1#diff-4e059561062fe024a35522f60f7f14c1R116 - I'm not sure why. In VS, in the Exception Setting, we need to uncheck the Break When Thrown option to avoid that crash. It only happens for few urls and I'm unclear why.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24589 (GitHub issue number if applicable)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
