### PR TITLE
Only updated history once

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3995,7 +3995,6 @@ where
                     new_context_info.is_visible,
                 );
                 self.update_activity(change.new_pipeline_id);
-                self.notify_history_changed(change.top_level_browsing_context_id);
             },
             Some(old_pipeline_id) => {
                 if let Some(pipeline) = self.pipelines.get(&old_pipeline_id) {
@@ -4087,8 +4086,6 @@ where
                         );
                     }
                 }
-
-                self.notify_history_changed(change.top_level_browsing_context_id);
             },
         }
 


### PR DESCRIPTION
We get the `HistoryChanged` event twice in many situations. This should fix it.

@cbrewster do these change make sense?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24633 (GitHub issue number if applicable)



<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
