### PR TITLE
Set response mime_type based on Content-Type

### DIFF
--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -403,6 +403,7 @@ impl Response {
             Some(hyper_headers) => hyper_headers.into_inner(),
             None => HyperHeaders::new(),
         });
+        *self.mime_type.borrow_mut() = self.Headers().extract_mime_type();
     }
 
     pub fn set_raw_status(&self, status: Option<(u16, Vec<u8>)>) {

--- a/tests/wpt/metadata/fetch/api/response/response-consume.html.ini
+++ b/tests/wpt/metadata/fetch/api/response/response-consume.html.ini
@@ -67,9 +67,6 @@
   [Consume response's body: from stream without correct urlencoded type to formData (error case)]
     expected: FAIL
 
-  [Consume response's body: from fetch to blob]
-    expected: FAIL
-
   [Consume response's body: from multipart form data blob to formData]
     expected: FAIL
 

--- a/tests/wpt/metadata/fetch/corb/script-html-via-cross-origin-blob-url.sub.html.ini
+++ b/tests/wpt/metadata/fetch/corb/script-html-via-cross-origin-blob-url.sub.html.ini
@@ -1,6 +1,5 @@
 [script-html-via-cross-origin-blob-url.sub.html]
-  [Untitled]
-    expected: FAIL
+  expected: ERROR
 
   [script-html-via-cross-origin-blob-url]
     expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Set the response's `mime_type` based on its `Content-Type` header whenever `Response::set_headers` is called. This ensures that `mime_type` is always consistent with `Content-Type`. The other reason for going with this approach is it relies on `extract_mime_type`: https://github.com/servo/servo/blob/afbcbf75eaa63ff0eec8fd3858e9155eb8dbadaa/components/script/dom/headers.rs#L260-L261

Besides the consistency argument, I also expect that we'll update the `extract_mime_type` method to conform with its specification.

Another option I explored was adding a `set_mime_type` member to `Response` and calling that with the mime type from `Metadata::content_type` in `FetchResponseListener::process_response`. I decided against this since it expanded the interface of `Response` and didn't have the same benefits of the first option. 

Fixes #24628.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24628.

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
