### PR TITLE
Add CRLF to encoded multipart form data

### DIFF
--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1366,7 +1366,7 @@ pub fn encode_multipart_form_data(
         }
     }
 
-    let mut boundary_bytes = format!("\r\n--{}--", boundary).into_bytes();
+    let mut boundary_bytes = format!("\r\n--{}--\r\n", boundary).into_bytes();
     result.append(&mut boundary_bytes);
 
     result

--- a/tests/wpt/metadata/fetch/api/response/response-consume.html.ini
+++ b/tests/wpt/metadata/fetch/api/response/response-consume.html.ini
@@ -34,15 +34,6 @@
   [Consume response's body: from FormData to formData]
     expected: FAIL
 
-  [Consume response's body: from FormData to blob]
-    expected: FAIL
-
-  [Consume response's body: from FormData to text]
-    expected: FAIL
-
-  [Consume response's body: from FormData to arrayBuffer]
-    expected: FAIL
-
   [Consume response's body: from stream to blob]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -18442,7 +18442,7 @@
    "testharness"
   ],
   "mozilla/FileAPI/resource/file-submission.py": [
-   "24d5129eb8d38c9415622c78ed401ae344273ce1",
+   "79e72fb99a95c186e4916b40627ee762d694b8ea",
    "support"
   ],
   "mozilla/FileAPI/resource/upload.txt": [

--- a/tests/wpt/mozilla/tests/mozilla/FileAPI/resource/file-submission.py
+++ b/tests/wpt/mozilla/tests/mozilla/FileAPI/resource/file-submission.py
@@ -21,7 +21,7 @@ def main(request, response):
     boundary = content_type[1].strip("boundary=")
 
     body = "--" + boundary + "\r\nContent-Disposition: form-data; name=\"file-input\"; filename=\"upload.txt\""
-    body += "\r\n" + "content-type: text/plain\r\n\r\nHello\r\n--" + boundary + "--"
+    body += "\r\n" + "content-type: text/plain\r\n\r\nHello\r\n--" + boundary + "--\r\n"
 
     if body != request.body:
         return fail("request body doesn't match: " + body + "+++++++" + request.body)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Some (3) WPT tests were failing because they expected the body for a multipart form data response to end with a CRLF. So I updated encode_multipart_form_data to add the missing terminator.

Looking at the corresponding spec (https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#multipart%2Fform-data-encoding-algorithm) and RFC (https://tools.ietf.org/html/rfc7578), I couldn't find anything mentioned about this detail.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
