### PR TITLE
Print an error if Glutin port needs to manage a new tab

### DIFF
--- a/ports/glutin/browser.rs
+++ b/ports/glutin/browser.rs
@@ -346,6 +346,8 @@ where
                     self.browsers.push(new_browser_id);
                     if self.browser_id.is_none() {
                         self.browser_id = Some(new_browser_id);
+                    } else {
+                        error!("Multiple top level browsing contexts not supported yet.");
                     }
                     self.event_queue
                         .push(WindowEvent::SelectBrowser(new_browser_id));


### PR DESCRIPTION
When a tab needs to be created because the user clicks on a link with a `target=…` attribute, the Glutin port just ignores it, creating weird behaviors.

We should at least print an error.