### PR TITLE
Correct inverted logic for available image checks.

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -927,10 +927,7 @@ impl HTMLImageElement {
         *self.last_selected_source.borrow_mut() = selected_source.clone();
 
         // Step 6, check the list of available images
-        if !selected_source
-            .as_ref()
-            .map_or(false, |source| source.is_empty())
-        {
+        if let Some(src) = selected_source {
             if let Ok(img_url) = base_url.join(&src) {
                 let image_cache = window.image_cache();
                 let response = image_cache.find_image_or_metadata(


### PR DESCRIPTION
From https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data:
Step 3 says to initialize selected source to null.
Step 4 says to set the selected source to the image element's src value if it's not using responsive images and it has a non-empty src value.
Step 6 performs some steps if selected source is not null.

The existing code tried to do the step 6 check in a roundabout way which caused us to always check for an available image when using responsive images, which is incorrect. The new code is easier to read and matches the specification text.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's not worth writing a test to verify that an image cache check that would always fail does not happen.