### PR TITLE
Run non-macOS tasks on Community-TC for push events

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -24,10 +24,6 @@ def main(task_for):
     magicleap_nightly = lambda: None
 
     if task_for == "github-push":
-        if not CONFIG.legacy_tc_deployment:  # pragma: no cover
-            # Do nothing (other than the decision task itsef) on community-tc by default for now
-            return
-
         # FIXME https://github.com/servo/servo/issues/22187
         # In-emulator testing is disabled for now. (Instead we only compile.)
         # This local variable shadows the module-level function of the same name.
@@ -75,6 +71,25 @@ def main(task_for):
                 android_x86_wpt
             ],
         }
+        if not CONFIG.legacy_tc_deployment:  # pragma: no cover
+            by_branch_name = {
+                "auto": [
+                    # Everything not running on macOS,
+                    # which only has one worker on Community-TC for now
+                    linux_tidy_unit_docs,
+                    windows_unit,
+                    windows_arm64,
+                    windows_uwp_x64,
+                    android_arm32_dev,
+                    android_arm32_release,
+                    android_x86_wpt,
+                    linux_wpt,
+                    linux_release,
+                ],
+                "master": [
+                    upload_docs,
+                ],
+            }
         for function in by_branch_name.get(branch, []):
             function()
 
@@ -472,7 +487,7 @@ def windows_unit(worker_type=None, cached=True):
     if cached:
         return task.find_or_create("build.windows_x64_dev." + CONFIG.task_id())
     else:
-        return task.create()
+        return task.create() 
 
 
 def windows_release():

--- a/etc/taskcluster/mock.py
+++ b/etc/taskcluster/mock.py
@@ -46,6 +46,7 @@ os.environ.update(**{k: k for k in "TASK_ID TASK_OWNER TASK_SOURCE GIT_URL GIT_S
 os.environ["GIT_REF"] = "refs/heads/auto"
 os.environ["TASKCLUSTER_ROOT_URL"] = "https://taskcluster.net"
 os.environ["TASKCLUSTER_PROXY_URL"] = "http://taskcluster"
+os.environ["NEW_AMI_WORKER_TYPE"] = "-"
 import decision_task
 
 print("\n# Push:")
@@ -63,6 +64,9 @@ decision_task.main("github-push")
 
 print("\n# Daily:")
 decision_task.main("daily")
+
+print("\n# Try AMI:")
+decision_task.main("try-windows-ami")
 
 print("\n# PR:")
 decision_task.main("github-pull-request")


### PR DESCRIPTION
These tasks will run on *both* TC deployments, and with https://github.com/servo/saltfs/pull/983 PRs will not land if *either* deployment has any failure. Note that this does not include WPT, so intermittents should not be an issue.