### PR TITLE
Require FormDataEventInit dictionary

### DIFF
--- a/components/script/dom/formdataevent.rs
+++ b/components/script/dom/formdataevent.rs
@@ -5,7 +5,7 @@
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventMethods;
 use crate::dom::bindings::codegen::Bindings::FormDataEventBinding;
 use crate::dom::bindings::codegen::Bindings::FormDataEventBinding::FormDataEventMethods;
-use crate::dom::bindings::error::{Error, Fallible};
+use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -56,21 +56,12 @@ impl FormDataEvent {
         let bubbles = EventBubbles::from(init.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.cancelable);
 
-        let form_data = match init.formData {
-            Some(ref form_data) => form_data.clone(),
-            None => {
-                return Err(Error::Type(
-                    "required member formData is undefined".to_string(),
-                ));
-            },
-        };
-
         let event = FormDataEvent::new(
             &window.global(),
             Atom::from(type_),
             bubbles,
             cancelable,
-            &*form_data,
+            &*init.formData.clone(),
         );
 
         Ok(event)

--- a/components/script/dom/webidls/FormDataEvent.webidl
+++ b/components/script/dom/webidls/FormDataEvent.webidl
@@ -5,10 +5,10 @@
 // https://html.spec.whatwg.org/multipage/#the-formdataevent-interface
 [Exposed=Window]
 interface FormDataEvent : Event {
-  [Throws] constructor(DOMString type, optional FormDataEventInit eventInitDict = {});
+  [Throws] constructor(DOMString type, FormDataEventInit eventInitDict);
   readonly attribute FormData formData;
 };
 
 dictionary FormDataEventInit : EventInit {
-  /*required*/ FormData formData;
+  required FormData formData;
 };

--- a/tests/wpt/metadata/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/metadata/html/dom/idlharness.https.html.ini
@@ -1409,9 +1409,6 @@
   [SubmitEvent interface: existence and properties of interface prototype object's "constructor" property]
     expected: FAIL
 
-  [FormDataEvent interface object length]
-    expected: FAIL
-
 
 [idlharness.https.html?include=(Document|Window)]
   [Document interface: documentWithHandlers must inherit property "queryCommandEnabled(DOMString)" with the proper type]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Should probably wait until https://github.com/whatwg/html/issues/5064 be fixed.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix __ (#22670 mentions `FormDataEvent` but the codegen itself still has a problem, in e.g. `PromiseRejectionEventInit`)

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
