### PR TITLE
derive_common: Fix example in documentation

### DIFF
--- a/components/derive_common/cg.rs
+++ b/components/derive_common/cg.rs
@@ -26,7 +26,9 @@ use synstructure::{self, BindStyle, BindingInfo, VariantAst, VariantInfo};
 ///
 /// For example:
 ///
+/// ```ignore
 ///     <T as ToComputedValue>::ComputedValue: Zero,
+/// ```
 ///
 /// This needs to run before adding other bounds to the type parameters.
 pub fn propagate_clauses_to_output_type(


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The docstring for `propagate_clauses_to_output_type` has an indented chunk which is getting picked up as a doc-test.  It's not meant to compile, so just mark it as ignored.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
