### PR TITLE
Remove use of on_unimplemented

### DIFF
--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -63,7 +63,7 @@ pub enum WebGLMsg {
         WebGLVersion,
         Size2D<u32>,
         GLContextAttributes,
-        WebGLSender<Result<(WebGLCreateContextResult), String>>,
+        WebGLSender<Result<WebGLCreateContextResult, String>>,
     ),
     /// Resizes a WebGLContext.
     ResizeContext(WebGLContextId, Size2D<u32>, WebGLSender<Result<(), String>>),

--- a/components/constellation/network_listener.rs
+++ b/components/constellation/network_listener.rs
@@ -90,7 +90,7 @@ impl NetworkListener {
         }
     }
 
-    fn check_redirect(&mut self, message: Result<(FetchMetadata), NetworkError>) {
+    fn check_redirect(&mut self, message: Result<FetchMetadata, NetworkError>) {
         match message {
             Ok(res_metadata) => {
                 let metadata = match res_metadata {

--- a/components/geometry/lib.rs
+++ b/components/geometry/lib.rs
@@ -38,11 +38,11 @@ pub enum DeviceIndependentPixel {}
 // See https://bugzilla.mozilla.org/show_bug.cgi?id=177805 for more info.
 
 pub trait MaxRect {
-    #[inline(always)]
     fn max_rect() -> Self;
 }
 
 impl MaxRect for Rect<Au> {
+    #[inline]
     fn max_rect() -> Rect<Au> {
         Rect::new(
             Point2D::new(MIN_AU / 2, MIN_AU / 2),
@@ -52,6 +52,7 @@ impl MaxRect for Rect<Au> {
 }
 
 impl MaxRect for LayoutRect {
+    #[inline]
     fn max_rect() -> LayoutRect {
         LayoutRect::new(
             LayoutPoint::new(f32::MIN / 2.0, f32::MIN / 2.0),

--- a/components/hashglobe/src/hash_map.rs
+++ b/components/hashglobe/src/hash_map.rs
@@ -1702,7 +1702,7 @@ impl<'a, K, V> Iterator for Keys<'a, K, V> {
     type Item = &'a K;
 
     #[inline]
-    fn next(&mut self) -> Option<(&'a K)> {
+    fn next(&mut self) -> Option<&'a K> {
         self.inner.next().map(|(k, _)| k)
     }
     #[inline]
@@ -1721,7 +1721,7 @@ impl<'a, K, V> Iterator for Values<'a, K, V> {
     type Item = &'a V;
 
     #[inline]
-    fn next(&mut self) -> Option<(&'a V)> {
+    fn next(&mut self) -> Option<&'a V> {
         self.inner.next().map(|(_, v)| v)
     }
     #[inline]
@@ -1739,7 +1739,7 @@ impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
     type Item = &'a mut V;
 
     #[inline]
-    fn next(&mut self) -> Option<(&'a mut V)> {
+    fn next(&mut self) -> Option<&'a mut V> {
         self.inner.next().map(|(_, v)| v)
     }
     #[inline]

--- a/components/script/dom/bindings/conversions.rs
+++ b/components/script/dom/bindings/conversions.rs
@@ -74,7 +74,6 @@ pub trait IDLInterface {
 }
 
 /// A trait to mark an IDL interface as deriving from another one.
-#[rustc_on_unimplemented(message = "The IDL interface `{Self}` is not derived from `{T}`.")]
 pub trait DerivedFrom<T: Castable>: Castable {}
 
 impl<T: Float + ToJSValConvertible> ToJSValConvertible for Finite<T> {

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -6,7 +6,6 @@
 #![feature(core_intrinsics)]
 #![feature(drain_filter)]
 #![feature(inner_deref)]
-#![feature(on_unimplemented)]
 #![feature(plugin)]
 #![deny(unsafe_code)]
 #![allow(non_snake_case)]

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -221,7 +221,6 @@ pub trait ThreadSafeLayoutNode:
     fn children(&self) -> LayoutIterator<Self::ChildrenIterator>;
 
     /// Returns a ThreadSafeLayoutElement if this is an element, None otherwise.
-    #[inline]
     fn as_element(&self) -> Option<Self::ConcreteThreadSafeLayoutElement>;
 
     #[inline]
@@ -348,14 +347,12 @@ pub trait ThreadSafeLayoutElement:
     /// lazily_compute_pseudo_element_style, which operates on TElement.
     unsafe fn unsafe_get(self) -> Self::ConcreteElement;
 
-    #[inline]
     fn get_attr(&self, namespace: &Namespace, name: &LocalName) -> Option<&str>;
 
     fn get_attr_enum(&self, namespace: &Namespace, name: &LocalName) -> Option<&AttrValue>;
 
     fn style_data(&self) -> AtomicRef<ElementData>;
 
-    #[inline]
     fn get_pseudo_element_type(&self) -> PseudoElementType;
 
     #[inline]

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -239,9 +239,9 @@ pub enum ScriptMsg {
     /// Get Window Informations size and position
     GetClientWindow(IpcSender<(DeviceIntSize, DeviceIntPoint)>),
     /// Get the screen size (pixel)
-    GetScreenSize(IpcSender<(DeviceIntSize)>),
+    GetScreenSize(IpcSender<DeviceIntSize>),
     /// Get the available screen size (pixel)
-    GetScreenAvailSize(IpcSender<(DeviceIntSize)>),
+    GetScreenAvailSize(IpcSender<DeviceIntSize>),
 }
 
 impl fmt::Debug for ScriptMsg {

--- a/components/style/values/animated/font.rs
+++ b/components/style/values/animated/font.rs
@@ -48,7 +48,7 @@ type ComputedVariationValue = VariationValue<Number>;
 
 // FIXME: Could do a rename, this is only used for font variations.
 struct FontSettingTagIterState<'a> {
-    tags: Vec<(&'a ComputedVariationValue)>,
+    tags: Vec<&'a ComputedVariationValue>,
     index: usize,
     prev_tag: FontTag,
 }

--- a/components/style/values/computed/mod.rs
+++ b/components/style/values/computed/mod.rs
@@ -302,10 +302,8 @@ pub trait ToComputedValue {
 
     /// Convert a specified value to a computed value, using itself and the data
     /// inside the `Context`.
-    #[inline]
     fn to_computed_value(&self, context: &Context) -> Self::ComputedValue;
 
-    #[inline]
     /// Convert a computed value to specified value form.
     ///
     /// This will be used for recascading during animation.


### PR DESCRIPTION
It errors in today’s Nightly:

```rust
error[E0557]: feature has been removed
 --> components/script/lib.rs:9:12
  |
9 | #![feature(on_unimplemented)]
  |            ^^^^^^^^^^^^^^^^ feature has been removed

error[E0658]: this is an internal attribute that will never be stable
  --> components/script/dom/bindings/conversions.rs:77:1
   |
77 | #[rustc_on_unimplemented(message = "The IDL interface `{Self}` is not derived from `{T}`.")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable

error: aborting due to 2 previous errors
```
