### PR TITLE
Properly set event.buttons value on mousemove

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -779,11 +779,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
         let results = self.hit_test_at_point(cursor);
         if let Some(item) = results.items.first() {
             let node_address = Some(UntrustedNodeAddress(item.tag.0 as *const c_void));
-            let event = MouseMoveEvent(
-                Some(item.point_in_viewport.to_untyped()),
-                node_address,
-                MouseButton::Left as u16,
-            );
+            let event = MouseMoveEvent(Some(item.point_in_viewport.to_untyped()), node_address, 0);
             let pipeline_id = PipelineId::from_webrender(item.pipeline);
             let msg = ConstellationMsg::ForwardEvent(pipeline_id, event);
             if let Err(e) = self.constellation_chan.send(msg) {

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2286,6 +2286,10 @@ where
             _ => event,
         };
 
+        if let MouseButtonEvent(MouseEventType::Click, ..) = event {
+            self.pressed_mouse_buttons = 0;
+        }
+
         let msg = ConstellationControlMsg::SendEvent(destination_pipeline_id, event);
         let result = match self.pipelines.get(&destination_pipeline_id) {
             None => {

--- a/support/hololens/ServoApp/ServoControl/ServoControl.cpp
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.cpp
@@ -159,6 +159,7 @@ void ServoControl::OnSurfacePointerMoved(
     auto point = e.GetCurrentPoint(Panel());
     auto x = point.Position().X * mDPI;
     auto y = point.Position().Y * mDPI;
+    e.Handled(true);
     RunOnGLThread([=] { mServo->MouseMove(x, y); });
   }
 }


### PR DESCRIPTION
A regular mousemove doesn't have any pressed button. And we were not resetting the pressed buttons after a click. That was messing up some jquery polyfil.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24596 (GitHub issue number if applicable)