### PR TITLE
Revert "Upload uncompressed Docker images"

### DIFF
--- a/etc/taskcluster/decisionlib.py
+++ b/etc/taskcluster/decisionlib.py
@@ -766,24 +766,24 @@ class DockerWorkerTask(UnixTaskMixin, Task):
             .with_index_and_artifacts_expire_in(CONFIG.docker_images_expire_in)
             .with_features("dind")
             .with_env(DOCKERFILE=dockerfile_contents)
-            .with_artifacts("/image.tar")
+            .with_artifacts("/image.tar.lz4")
             .with_script("""
                 echo "$DOCKERFILE" | docker build -t taskcluster-built -
-                docker save taskcluster-built > /image.tar
+                docker save taskcluster-built | lz4 > /image.tar.lz4
             """)
             .with_docker_image(
                 # https://github.com/servo/taskcluster-bootstrap-docker-images#image-builder
                 "servobrowser/taskcluster-bootstrap:image-builder@sha256:" \
                 "0a7d012ce444d62ffb9e7f06f0c52fedc24b68c2060711b313263367f7272d9d"
             )
-            .find_or_create("docker-image-uncompressed." + digest)
+            .find_or_create("docker-image." + digest)
         )
 
         return self \
         .with_dependencies(image_build_task) \
         .with_docker_image({
             "type": "task-image",
-            "path": "public/image.tar",
+            "path": "public/image.tar.lz4",
             "taskId": image_build_task,
         })
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1593543 is fixed.

This reverts commit 5abb013dfdacaf9b7029b4c07dcb93c016e378b8.