### PR TITLE
Address upstream WPT test harness changes

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -18470,7 +18470,7 @@
    "testharness"
   ],
   "mozilla/animation-removed-node.html": [
-   "a2f9dfe284a22a6241290c86841172387dcdbeb6",
+   "d8845c873181c87cfde8bfdfbe31924ea6b73e59",
    "testharness"
   ],
   "mozilla/binding_keyword.html": [
@@ -18946,7 +18946,7 @@
    "testharness"
   ],
   "mozilla/inline-event-listener-panic.html": [
-   "2418893bc058666a018498dbf414faae2f22ffc5",
+   "acde98607ae4bfa19cf894ce7c81b2e6b7071e14",
    "testharness"
   ],
   "mozilla/inline_event_handler.html": [
@@ -18970,7 +18970,7 @@
    "testharness"
   ],
   "mozilla/interfaces.js": [
-   "786f6e12515ff71bc83f34e4ffa32e7e38b1cd26",
+   "c46c336f8a8a2db777f75d6236b1241c717a02dd",
    "support"
   ],
   "mozilla/interfaces.worker.js": [
@@ -19646,7 +19646,7 @@
    "testharness"
   ],
   "mozilla/window_requestAnimationFrame2.html": [
-   "237ef108c5ccaa842a165ee3a93df8fde1964b30",
+   "3227b28d5b249c683e8200cf70a6393181cec7f5",
    "testharness"
   ],
   "mozilla/window_resize_not_triggered_on_load.html": [

--- a/tests/wpt/mozilla/meta/mozilla/animation-removed-node.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/animation-removed-node.html.ini
@@ -1,6 +1,0 @@
-[animation-removed-node.html]
-  prefs: [css.animations.testing.enabled:true]
-  expected: ERROR
-  [animation-removed-node]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/inline-event-listener-panic.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/inline-event-listener-panic.html.ini
@@ -1,2 +1,0 @@
-[inline-event-listener-panic.html]
-  expected: ERROR

--- a/tests/wpt/mozilla/meta/mozilla/interfaces.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/interfaces.html.ini
@@ -1,4 +1,0 @@
-[interfaces.html]
-  [Interfaces exposed on the window]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/interfaces.worker.js.ini
+++ b/tests/wpt/mozilla/meta/mozilla/interfaces.worker.js.ini
@@ -1,4 +1,0 @@
-[interfaces.worker.html]
-  [interfaces]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/window_requestAnimationFrame2.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/window_requestAnimationFrame2.html.ini
@@ -1,6 +1,0 @@
-[window_requestAnimationFrame2.html]
-  type: testharness
-  expected: ERROR
-  [Test throwing an error inside requestAnimationFrame callback]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/tests/mozilla/animation-removed-node.html
+++ b/tests/wpt/mozilla/tests/mozilla/animation-removed-node.html
@@ -23,7 +23,7 @@ div.test { animation: boo 1s infinite; }
           // Verify that the previous animations are no longer considered active.
           assert_equals(window.runningAnimationCount, 0);
           t.done();
-        });
+        }));
       }));
     });
   }, "Animations are no longer active when a node can't be animated.");

--- a/tests/wpt/mozilla/tests/mozilla/inline-event-listener-panic.html
+++ b/tests/wpt/mozilla/tests/mozilla/inline-event-listener-panic.html
@@ -5,10 +5,11 @@
 <script src="/resources/testharnessreport.js"></script>
 <body>
 <script>
-var e = document.body;
-e.setAttribute("onclick", "console.log('x')");
-assert_not_equals(e.onclick, null);
-assert_not_equals(e.onclick, null);
-done();
+test(function() {
+  var e = document.body;
+  e.setAttribute("onclick", "console.log('x')");
+  assert_not_equals(e.onclick, null);
+  assert_not_equals(e.onclick, null);
+});
 </script>
 </body>

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.js
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.js
@@ -55,7 +55,7 @@ function test_interfaces(interfaceNamesInGlobalScope) {
     var sources = [
       ecmaGlobals,
       interfaceNamesInGlobalScope,
-      ["AssertionError", "EventWatcher"],
+      ["AssertionError", "EventWatcher", "PreconditionFailedError"],
     ];
 
     var interfaceMap = {};

--- a/tests/wpt/mozilla/tests/mozilla/window_requestAnimationFrame2.html
+++ b/tests/wpt/mozilla/tests/mozilla/window_requestAnimationFrame2.html
@@ -6,18 +6,19 @@
   </head>
   <body>
     <script>
-    var stepCalled = false;
-    function step() {
-        if (stepCalled) {
-          setTimeout(done, 0);
-        } else {
-          stepCalled = true;
-          window.requestAnimationFrame(step);
+      setup({allow_uncaught_exception: true});
+      async_test(function(t) {
+        var throwDidNotInterrupt = false;
+        function step() {
+          window.requestAnimationFrame(t.step_func(function() {
+            assert_true(throwDidNotInterrupt, "rAF should not throw errors");
+            t.done();
+          }));
+          throw new Error();
         }
-        throw new Error();
-    }
-    window.requestAnimationFrame(step);
-    assert_equals(true, true, "rAF should not throw errors");
+        window.requestAnimationFrame(step);
+        throwDidNotInterrupt = true;
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt/pull/19449 and https://github.com/web-platform-tests/wpt/pull/19993 caused some of our proprietary tests to silently start to fail. This addresses all of the breakage.