### PR TITLE
[WIP] Use more recent harfbuzz.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,8 +2051,7 @@ checksum = "63d68db75012a85555434ee079e7e6337931f87a087ab2988becbadf64673a7f"
 [[package]]
 name = "harfbuzz-sys"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1042ab0b3e7bc1ff64f7f5935778b644ff2194a1cae5ec52167127d3fd23961"
+source = "git+https://github.com/servo/rust-harfbuzz#10544029a92f0ffab42fbf77ec8e17af134b699d"
 dependencies = [
  "cmake",
  "core-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ opt-level = 3
 mio = { git = "https://github.com/servo/mio.git", branch = "servo" }
 # https://github.com/retep998/winapi-rs/pull/816
 winapi = { git = "https://github.com/servo/winapi-rs", branch = "patch-1" }
+harfbuzz-sys = { git = " https://github.com/servo/rust-harfbuzz" }


### PR DESCRIPTION
There hasn't been a new published version of harfbuzz-sys since April, but we've kept merging upgrades to git. Let's see if this improves #24611 at all.