### PR TITLE
Use an already-installed Homebrew at /usr/local

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -876,7 +876,7 @@ def windows_build_task(name, package=True, arch="x86_64"):
 
 def with_homebrew(task, brewfiles):
     for brewfile in brewfiles:
-        task.with_script("time brew bundle install --no-upgrade --file=" + brewfile)
+        task.with_script("time brew bundle install --verbose --no-upgrade --file=" + brewfile)
     return task
 
 

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -883,8 +883,9 @@ def with_homebrew(task, brewfiles):
 def macos_build_task(name):
     build_task = (
         macos_task(name)
-        # Allow long runtime in case the cache expired for all those Homebrew dependencies
-        .with_max_run_time_minutes(60 * 4)
+        # Stray processes eating CPU can slow things down:
+        # https://github.com/servo/servo/issues/24735
+        .with_max_run_time_minutes(60 * 2)
         .with_env(**build_env, **unix_build_env, **macos_build_env)
         .with_repo()
         .with_python2()

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -595,7 +595,7 @@ def update_wpt():
             "etc/taskcluster/macos/Brewfile-gstreamer",
         ])
         # Pushing the new changes to the git remote requires a full repo clone.
-        .with_repo(shallow=False)
+        .with_repo(shallow=False, alternate_object_dir="/var/cache/servo.git/objects")
         .with_curl_artifact_script(build_task, "target.tar.gz")
         .with_script("""
             export PKG_CONFIG_PATH="$(brew --prefix libffi)/lib/pkgconfig/"
@@ -631,19 +631,26 @@ def macos_wpt():
     def macos_run_task(name):
         task = macos_task(name).with_python2()
         return with_homebrew(task, ["etc/taskcluster/macos/Brewfile-gstreamer"])
-    wpt_chunks("macOS x64", macos_run_task, build_task, repo_dir="repo",
-               total_chunks=6, processes=4)
+    wpt_chunks(
+        "macOS x64",
+        macos_run_task,
+        build_task,
+        repo_dir="repo",
+        repo_kwargs=dict(alternate_object_dir="/var/cache/servo.git/objects"),
+        total_chunks=6,
+        processes=4,
+    )
 
 
 def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
-               repo_dir, chunks="all"):
+               repo_dir, chunks="all", repo_kwargs={}):
     if chunks == "all":
         chunks = [n + 1 for n in range(total_chunks)]
     for this_chunk in chunks:
         task = (
             make_chunk_task("WPT chunk %s / %s" % (this_chunk, total_chunks))
             .with_treeherder(platform, "WPT-%s" % this_chunk)
-            .with_repo()
+            .with_repo(**repo_kwargs)
             .with_curl_artifact_script(build_task, "target.tar.gz")
             .with_script("tar -xzf target.tar.gz")
             .with_index_and_artifacts_expire_in(log_artifacts_expire_in)
@@ -887,7 +894,7 @@ def macos_build_task(name):
         # https://github.com/servo/servo/issues/24735
         .with_max_run_time_minutes(60 * 2)
         .with_env(**build_env, **unix_build_env, **macos_build_env)
-        .with_repo()
+        .with_repo(alternate_object_dir="/var/cache/servo.git/objects")
         .with_python2()
         .with_rustup()
         # Since macOS workers are long-lived and ~/.rustup kept across tasks:

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -89,7 +89,8 @@ def main(task_for):
 
     elif task_for == "try-windows-ami":
         CONFIG.git_sha_is_current_head()
-        windows_unit(os.environ["NEW_AMI_WORKER_TYPE"], cached=False)
+        CONFIG.windows_worker_type = os.environ["NEW_AMI_WORKER_TYPE"]
+        windows_unit(cached=False)
 
     # https://tools.taskcluster.net/hooks/project-servo/daily
     elif task_for == "daily":
@@ -457,9 +458,9 @@ def uwp_nightly():
     )
 
 
-def windows_unit(worker_type=None, cached=True):
+def windows_unit(cached=True):
     task = (
-        windows_build_task("Dev build + unit tests", worker_type=worker_type)
+        windows_build_task("Dev build + unit tests")
         .with_treeherder("Windows x64", "Unit")
         .with_script(
             # Not necessary as this would be done at the start of `build`,
@@ -757,12 +758,10 @@ def linux_task(name):
     )
 
 
-def windows_task(name, worker_type=None):
-    if worker_type is None:
-        worker_type = "win2016"
+def windows_task(name):
     return (
         decisionlib.WindowsGenericWorkerTask(name)
-        .with_worker_type(worker_type)
+        .with_worker_type(CONFIG.windows_worker_type)
         .with_treeherder_required()
     )
 
@@ -771,7 +770,7 @@ def macos_task(name):
     return (
         decisionlib.MacOsGenericWorkerTask(name)
         .with_provisioner_id("proj-servo")
-        .with_worker_type("macos")
+        .with_worker_type(CONFIG.macos_worker_type)
         .with_treeherder_required()
     )
 
@@ -814,7 +813,7 @@ def android_build_task(name):
     )
 
 
-def windows_build_task(name, package=True, arch="x86_64", worker_type=None):
+def windows_build_task(name, package=True, arch="x86_64"):
     hashes = {
         "devel": {
             "x86_64": "c136cbfb0330041d52fe6ec4e3e468563176333c857f6ed71191ebc37fc9d605",
@@ -828,7 +827,7 @@ def windows_build_task(name, package=True, arch="x86_64", worker_type=None):
     }
     version = "1.16.0"
     task = (
-        windows_task(name, worker_type=worker_type)
+        windows_task(name)
         .with_max_run_time_minutes(90)
         .with_env(
             **build_env,
@@ -992,6 +991,8 @@ CONFIG.index_prefix = "project.servo"
 CONFIG.default_provisioner_id = "proj-servo"
 CONFIG.docker_image_build_worker_type = "docker"
 
+CONFIG.windows_worker_type = "win2016"
+CONFIG.macos_worker_type = "macos"
 
 if __name__ == "__main__":  # pragma: no cover
     main(task_for=os.environ["TASK_FOR"])

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -909,6 +909,7 @@ def macos_build_task(name):
             export OPENSSL_INCLUDE_DIR="$(brew --prefix openssl)/include"
             export OPENSSL_LIB_DIR="$(brew --prefix openssl)/lib"
             export PKG_CONFIG_PATH="$(brew --prefix libffi)/lib/pkgconfig/"
+            export PKG_CONFIG_PATH="$(brew --prefix zlib)/lib/pkgconfig/:$PKG_CONFIG_PATH"
         """)
 
         .with_directory_mount(

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -876,17 +876,9 @@ def windows_build_task(name, package=True, arch="x86_64", worker_type=None):
 
 
 def with_homebrew(task, brewfiles):
-        task = task.with_script("""
-            mkdir -p "$HOME/homebrew"
-            export PATH="$HOME/homebrew/bin:$PATH"
-            which brew || curl -L https://github.com/Homebrew/brew/tarball/master \
-                | tar xz --strip 1 -C "$HOME/homebrew"
-        """)
-        for brewfile in brewfiles:
-            task = task.with_script("""
-                time brew bundle install --no-upgrade --file={brewfile}
-            """.format(brewfile=brewfile))
-        return task
+    for brewfile in brewfiles:
+        task.with_script("time brew bundle install --no-upgrade --file=" + brewfile)
+    return task
 
 
 def macos_build_task(name):

--- a/etc/taskcluster/decisionlib.py
+++ b/etc/taskcluster/decisionlib.py
@@ -475,7 +475,7 @@ class WindowsGenericWorkerTask(GenericWorkerTask):
                 type .git\\info\\sparse-checkout
             """
         git += """
-            git fetch {depth} %GIT_URL% %GIT_REF%
+            git fetch --no-tags {depth} %GIT_URL% %GIT_REF%
             git reset --hard %GIT_SHA%
         """.format(depth="--depth 30" if shallow else "")
         return self \
@@ -597,7 +597,7 @@ class UnixTaskMixin(Task):
         .with_early_script("""
             git init repo
             cd repo
-            time git fetch {depth} "$GIT_URL" "$GIT_REF"
+            time git fetch --no-tags {depth} "$GIT_URL" "$GIT_REF"
             time git reset --hard "$GIT_SHA"
         """.format(depth="--depth 30" if shallow else ""))
 

--- a/etc/taskcluster/decisionlib.py
+++ b/etc/taskcluster/decisionlib.py
@@ -477,7 +477,7 @@ class WindowsGenericWorkerTask(GenericWorkerTask):
         git += """
             git fetch {depth} %GIT_URL% %GIT_REF%
             git reset --hard %GIT_SHA%
-        """.format(depth="--depth 100" if shallow else "")
+        """.format(depth="--depth 30" if shallow else "")
         return self \
         .with_git() \
         .with_script(git) \
@@ -599,7 +599,7 @@ class UnixTaskMixin(Task):
             cd repo
             time git fetch {depth} "$GIT_URL" "$GIT_REF"
             time git reset --hard "$GIT_SHA"
-        """.format(depth="--depth 100" if shallow else ""))
+        """.format(depth="--depth 30" if shallow else ""))
 
     def with_curl_script(self, url, file_path):
         self.curl_scripts_count += 1

--- a/etc/taskcluster/decisionlib.py
+++ b/etc/taskcluster/decisionlib.py
@@ -597,8 +597,8 @@ class UnixTaskMixin(Task):
         .with_early_script("""
             git init repo
             cd repo
-            git fetch {depth} "$GIT_URL" "$GIT_REF"
-            git reset --hard "$GIT_SHA"
+            time git fetch {depth} "$GIT_URL" "$GIT_REF"
+            time git reset --hard "$GIT_SHA"
         """.format(depth="--depth 100" if shallow else ""))
 
     def with_curl_script(self, url, file_path):

--- a/etc/taskcluster/macos/Brewfile
+++ b/etc/taskcluster/macos/Brewfile
@@ -5,6 +5,7 @@ brew "openssl"
 brew "pkg-config"
 brew "llvm"
 brew "yasm"
+brew "zlib"
 
 # For sccache
 brew "openssl@1.1"

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -627,6 +627,9 @@ class MachCommands(CommandBase):
                     '-C', env["GSTREAMER_DIR"],
                 ])
 
+        # https://internals.rust-lang.org/t/exploring-crate-graph-build-times-with-cargo-build-ztimings/10975
+        opts += ["-Ztimings=info"]
+
         if very_verbose:
             print (["Calling", "cargo", "build"] + opts)
             for key in env:


### PR DESCRIPTION
This requires https://github.com/servo/taskcluster-config/pull/4 to be deployed.

Having the standard location helps `pkg-config` (CC https://github.com/servo/servo/pull/24688), and allows installing pre-compiled pakcages (which is much faster than compiling from source).