### PR TITLE
Implement timer-task-source, time-out service worker

### DIFF
--- a/components/script/dom/abstractworkerglobalscope.rs
+++ b/components/script/dom/abstractworkerglobalscope.rs
@@ -81,32 +81,27 @@ impl ScriptPort for Receiver<DedicatedWorkerScriptMsg> {
 }
 
 pub trait WorkerEventLoopMethods {
-    type TimerMsg: Send;
     type WorkerMsg: QueuedTaskConversion + Send;
     type Event;
-    fn timer_event_port(&self) -> &Receiver<Self::TimerMsg>;
     fn task_queue(&self) -> &TaskQueue<Self::WorkerMsg>;
     fn handle_event(&self, event: Self::Event);
     fn handle_worker_post_event(&self, worker: &TrustedWorkerAddress) -> Option<AutoWorkerReset>;
     fn from_worker_msg(&self, msg: Self::WorkerMsg) -> Self::Event;
-    fn from_timer_msg(&self, msg: Self::TimerMsg) -> Self::Event;
     fn from_devtools_msg(&self, msg: DevtoolScriptControlMsg) -> Self::Event;
 }
 
 // https://html.spec.whatwg.org/multipage/#worker-event-loop
-pub fn run_worker_event_loop<T, TimerMsg, WorkerMsg, Event>(
+pub fn run_worker_event_loop<T, WorkerMsg, Event>(
     worker_scope: &T,
     worker: Option<&TrustedWorkerAddress>,
 ) where
-    TimerMsg: Send,
     WorkerMsg: QueuedTaskConversion + Send,
-    T: WorkerEventLoopMethods<TimerMsg = TimerMsg, WorkerMsg = WorkerMsg, Event = Event>
+    T: WorkerEventLoopMethods<WorkerMsg = WorkerMsg, Event = Event>
         + DerivedFrom<WorkerGlobalScope>
         + DerivedFrom<GlobalScope>
         + DomObject,
 {
     let scope = worker_scope.upcast::<WorkerGlobalScope>();
-    let timer_event_port = worker_scope.timer_event_port();
     let devtools_port = match scope.from_devtools_sender() {
         Some(_) => Some(scope.from_devtools_receiver()),
         None => None,
@@ -117,7 +112,6 @@ pub fn run_worker_event_loop<T, TimerMsg, WorkerMsg, Event>(
             task_queue.take_tasks(msg.unwrap());
             worker_scope.from_worker_msg(task_queue.recv().unwrap())
         },
-        recv(timer_event_port) -> msg => worker_scope.from_timer_msg(msg.unwrap()),
         recv(devtools_port.unwrap_or(&crossbeam_channel::never())) -> msg =>
             worker_scope.from_devtools_msg(msg.unwrap()),
     };
@@ -132,13 +126,10 @@ pub fn run_worker_event_loop<T, TimerMsg, WorkerMsg, Event>(
         // Batch all events that are ready.
         // The task queue will throttle non-priority tasks if necessary.
         match task_queue.try_recv() {
-            Err(_) => match timer_event_port.try_recv() {
-                Err(_) => match devtools_port.map(|port| port.try_recv()) {
-                    None => {},
-                    Some(Err(_)) => break,
-                    Some(Ok(ev)) => sequential.push(worker_scope.from_devtools_msg(ev)),
-                },
-                Ok(ev) => sequential.push(worker_scope.from_timer_msg(ev)),
+            Err(_) => match devtools_port.map(|port| port.try_recv()) {
+                None => {},
+                Some(Err(_)) => break,
+                Some(Ok(ev)) => sequential.push(worker_scope.from_devtools_msg(ev)),
             },
             Ok(ev) => sequential.push(worker_scope.from_worker_msg(ev)),
         }

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -15,7 +15,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::windowproxy::WindowProxy;
 use crate::script_runtime::JSContext;
 use dom_struct::dom_struct;
-use ipc_channel::ipc;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue};
@@ -48,8 +47,6 @@ impl DissimilarOriginWindow {
     #[allow(unsafe_code)]
     pub fn new(global_to_clone_from: &GlobalScope, window_proxy: &WindowProxy) -> DomRoot<Self> {
         let cx = global_to_clone_from.get_cx();
-        // Any timer events fired on this window are ignored.
-        let (timer_event_chan, _) = ipc::channel().unwrap();
         let win = Box::new(Self {
             globalscope: GlobalScope::new_inherited(
                 PipelineId::new(),
@@ -59,7 +56,6 @@ impl DissimilarOriginWindow {
                 global_to_clone_from.script_to_constellation_chan().clone(),
                 global_to_clone_from.scheduler_chan().clone(),
                 global_to_clone_from.resource_threads().clone(),
-                timer_event_chan,
                 global_to_clone_from.origin().clone(),
                 // FIXME(nox): The microtask queue is probably not important
                 // here, but this whole DOM interface is a hack anyway.

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -106,8 +106,7 @@ use script_layout_interface::{PendingImageState, TrustedNodeAddress};
 use script_traits::webdriver_msg::{WebDriverJSError, WebDriverJSResult};
 use script_traits::{ConstellationControlMsg, DocumentState, HistoryEntryReplacement, LoadData};
 use script_traits::{
-    ScriptMsg, ScriptToConstellationChan, ScrollState, StructuredSerializedData, TimerEvent,
-    TimerEventId,
+    ScriptMsg, ScriptToConstellationChan, ScrollState, StructuredSerializedData, TimerEventId,
 };
 use script_traits::{TimerSchedulerMsg, WindowSizeData, WindowSizeType};
 use selectors::attr::CaseSensitivity;
@@ -2186,7 +2185,6 @@ impl Window {
         constellation_chan: ScriptToConstellationChan,
         control_chan: IpcSender<ConstellationControlMsg>,
         scheduler_chan: IpcSender<TimerSchedulerMsg>,
-        timer_event_chan: IpcSender<TimerEvent>,
         layout_chan: Sender<Msg>,
         pipelineid: PipelineId,
         parent_info: Option<PipelineId>,
@@ -2229,7 +2227,6 @@ impl Window {
                 constellation_chan,
                 scheduler_chan,
                 resource_threads,
-                timer_event_chan,
                 origin,
                 microtask_queue,
                 is_headless,

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -15,7 +15,6 @@ use crate::script_thread::MainThreadScriptMsg;
 use crossbeam_channel::Sender;
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use dom_struct::dom_struct;
-use ipc_channel::ipc;
 use ipc_channel::ipc::IpcSender;
 use js::jsval::UndefinedValue;
 use js::rust::Runtime;
@@ -55,8 +54,6 @@ impl WorkletGlobalScope {
         executor: WorkletExecutor,
         init: &WorkletGlobalScopeInit,
     ) -> Self {
-        // Any timer events fired on this global are ignored.
-        let (timer_event_chan, _) = ipc::channel().unwrap();
         let script_to_constellation_chan = ScriptToConstellationChan {
             sender: init.to_constellation_sender.clone(),
             pipeline_id,
@@ -70,7 +67,6 @@ impl WorkletGlobalScope {
                 script_to_constellation_chan,
                 init.scheduler_chan.clone(),
                 init.resource_threads.clone(),
-                timer_event_chan,
                 MutableOrigin::new(ImmutableOrigin::new_opaque()),
                 Default::default(),
                 init.is_headless,

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -12,6 +12,7 @@ use crate::task_source::networking::NetworkingTaskSource;
 use crate::task_source::performance_timeline::PerformanceTimelineTaskSource;
 use crate::task_source::port_message::PortMessageQueue;
 use crate::task_source::remote_event::RemoteEventTaskSource;
+use crate::task_source::timer::TimerTaskSource;
 use crate::task_source::user_interaction::UserInteractionTaskSource;
 use crate::task_source::websocket::WebsocketTaskSource;
 use crate::task_source::TaskSourceName;
@@ -54,6 +55,8 @@ pub struct TaskManager {
     #[ignore_malloc_size_of = "task sources are hard"]
     remote_event_task_source: RemoteEventTaskSource,
     #[ignore_malloc_size_of = "task sources are hard"]
+    timer_task_source: TimerTaskSource,
+    #[ignore_malloc_size_of = "task sources are hard"]
     websocket_task_source: WebsocketTaskSource,
 }
 
@@ -68,6 +71,7 @@ impl TaskManager {
         port_message_queue: PortMessageQueue,
         user_interaction_task_source: UserInteractionTaskSource,
         remote_event_task_source: RemoteEventTaskSource,
+        timer_task_source: TimerTaskSource,
         websocket_task_source: WebsocketTaskSource,
     ) -> Self {
         TaskManager {
@@ -80,6 +84,7 @@ impl TaskManager {
             port_message_queue,
             user_interaction_task_source,
             remote_event_task_source,
+            timer_task_source,
             websocket_task_source,
             task_cancellers: Default::default(),
         }
@@ -155,6 +160,14 @@ impl TaskManager {
         remote_event_task_source,
         RemoteEventTaskSource,
         RemoteEvent
+    );
+
+    task_source_functions!(
+        self,
+        timer_task_source_with_canceller,
+        timer_task_source,
+        TimerTaskSource,
+        Timer
     );
 
     task_source_functions!(

--- a/components/script/task_source/mod.rs
+++ b/components/script/task_source/mod.rs
@@ -10,6 +10,7 @@ pub mod networking;
 pub mod performance_timeline;
 pub mod port_message;
 pub mod remote_event;
+pub mod timer;
 pub mod user_interaction;
 pub mod websocket;
 
@@ -34,6 +35,7 @@ pub enum TaskSourceName {
     RemoteEvent,
     MediaElement,
     Websocket,
+    Timer,
 }
 
 impl TaskSourceName {

--- a/components/script/task_source/timer.rs
+++ b/components/script/task_source/timer.rs
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::script_runtime::{CommonScriptMsg, ScriptChan, ScriptThreadEventCategory};
+use crate::task::{TaskCanceller, TaskOnce};
+use crate::task_source::{TaskSource, TaskSourceName};
+use msg::constellation_msg::PipelineId;
+use std::fmt;
+
+#[derive(JSTraceable)]
+/// https://html.spec.whatwg.org/multipage/#timer-task-source
+pub struct TimerTaskSource(pub Box<dyn ScriptChan + Send + 'static>, pub PipelineId);
+
+impl Clone for TimerTaskSource {
+    fn clone(&self) -> TimerTaskSource {
+        TimerTaskSource(self.0.clone(), self.1.clone())
+    }
+}
+
+impl fmt::Debug for TimerTaskSource {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "TimerTaskSource(...)")
+    }
+}
+
+impl TaskSource for TimerTaskSource {
+    const NAME: TaskSourceName = TaskSourceName::Timer;
+
+    fn queue_with_canceller<T>(&self, task: T, canceller: &TaskCanceller) -> Result<(), ()>
+    where
+        T: TaskOnce + 'static,
+    {
+        let msg = CommonScriptMsg::Task(
+            ScriptThreadEventCategory::TimerEvent,
+            Box::new(canceller.wrap_task(task)),
+            Some(self.1),
+            Self::NAME,
+        );
+        self.0.send(msg).map_err(|_| ())
+    }
+}

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -34,8 +34,12 @@ pub struct OneshotTimerHandle(i32);
 pub struct OneshotTimers {
     js_timers: JsTimers,
     #[ignore_malloc_size_of = "Defined in std"]
-    timer_event_chan: IpcSender<TimerEvent>,
+    /// The sender, to be cloned for each timer,
+    /// on which the timer scheduler in the constellation can send an event
+    /// when the timer is due.
+    timer_event_chan: DomRefCell<Option<IpcSender<TimerEvent>>>,
     #[ignore_malloc_size_of = "Defined in std"]
+    /// The sender to the timer scheduler in the constellation.
     scheduler_chan: IpcSender<TimerSchedulerMsg>,
     next_timer_handle: Cell<OneshotTimerHandle>,
     timers: DomRefCell<Vec<OneshotTimer>>,
@@ -109,13 +113,10 @@ impl PartialEq for OneshotTimer {
 }
 
 impl OneshotTimers {
-    pub fn new(
-        timer_event_chan: IpcSender<TimerEvent>,
-        scheduler_chan: IpcSender<TimerSchedulerMsg>,
-    ) -> OneshotTimers {
+    pub fn new(scheduler_chan: IpcSender<TimerSchedulerMsg>) -> OneshotTimers {
         OneshotTimers {
             js_timers: JsTimers::new(),
-            timer_event_chan: timer_event_chan,
+            timer_event_chan: DomRefCell::new(None),
             scheduler_chan: scheduler_chan,
             next_timer_handle: Cell::new(OneshotTimerHandle(1)),
             timers: DomRefCell::new(Vec::new()),
@@ -123,6 +124,12 @@ impl OneshotTimers {
             suspension_offset: Cell::new(Length::new(0)),
             expected_event_id: Cell::new(TimerEventId(0)),
         }
+    }
+
+    pub fn setup_scheduling(&self, timer_event_chan: IpcSender<TimerEvent>) {
+        let mut chan = self.timer_event_chan.borrow_mut();
+        assert!(chan.is_none());
+        *chan = Some(timer_event_chan);
     }
 
     pub fn schedule_callback(
@@ -279,7 +286,10 @@ impl OneshotTimers {
                     .saturating_sub(precise_time_ms().get()),
             );
             let request = TimerEventRequest(
-                self.timer_event_chan.clone(),
+                self.timer_event_chan
+                    .borrow()
+                    .clone()
+                    .expect("Timer event chan not setup to schedule timers."),
                 timer.source,
                 expected_event_id,
                 delay,
@@ -331,6 +341,7 @@ pub struct JsTimerHandle(i32);
 #[derive(DenyPublicFields, JSTraceable, MallocSizeOf)]
 pub struct JsTimers {
     next_timer_handle: Cell<JsTimerHandle>,
+    /// https://html.spec.whatwg.org/multipage/#list-of-active-timers
     active_timers: DomRefCell<HashMap<JsTimerHandle, JsTimerEntry>>,
     /// The nesting level of the currently executing timer task or 0.
     nesting_level: Cell<u32>,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Implements the timer task-source, and folds the IPC glue-code into a single route set by the globalscope. 

Also switches service worker to using a dedicated "time-out" mechanism, which previously relied on the timer mechanism(and I think didn't actually implement script timers). 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #24747 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
