### PR TITLE
Support translation in webxr on desktop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6011,7 +6011,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#0ae9b56ef7e646c54382f75fe79012e0f889363d"
+source = "git+https://github.com/servo/webxr#27c83fde49d820bc3ffd0396d9aea01a3b5c5729"
 dependencies = [
  "bindgen",
  "euclid",
@@ -6031,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#0ae9b56ef7e646c54382f75fe79012e0f889363d"
+source = "git+https://github.com/servo/webxr#27c83fde49d820bc3ffd0396d9aea01a3b5c5729"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/ports/glutin/headed_window.rs
+++ b/ports/glutin/headed_window.rs
@@ -540,13 +540,15 @@ impl webxr::glwindow::GlWindow for Window {
 
     fn size(&self) -> UntypedSize2D<gl::GLsizei> {
         let dpr = self.device_hidpi_factor().get() as f64;
-        let LogicalSize { width, height } = self
+        let size = self
             .gl_context
             .borrow()
             .window()
             .get_inner_size()
             .expect("Failed to get window inner size.");
-        Size2D::new(width * dpr, height *dpr).to_i32()
+        let size = size.to_physical(dpr);
+        let (w, h): (u32, u32) = size.into();
+        Size2D::new(w as i32, h as i32)
     }
 
     fn get_rotation(&self) -> Rotation3D<f32, UnknownUnit, UnknownUnit> {

--- a/ports/glutin/headless_window.rs
+++ b/ports/glutin/headless_window.rs
@@ -5,7 +5,7 @@
 //! A headless window implementation.
 
 use crate::window_trait::WindowPortsMethods;
-use euclid::{default::Size2D as UntypedSize2D, Point2D, Rotation3D, Scale, Size2D, UnknownUnit};
+use euclid::{default::Size2D as UntypedSize2D, Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vector3D};
 use gleam::gl;
 use glutin;
 use servo::compositing::windowing::{AnimationState, WindowEvent};
@@ -245,5 +245,9 @@ impl webxr::glwindow::GlWindow for Window {
     }
     fn get_rotation(&self) -> Rotation3D<f32, UnknownUnit, UnknownUnit> {
         Rotation3D::identity()
+    }
+
+    fn get_translation(&self) -> Vector3D<f32, UnknownUnit> {
+        Vector3D::zero()
     }
 }


### PR DESCRIPTION
This makes it possible to roam around webxr scenes using the WASD keys, and the arrow keys continue to change the user's orientation.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24773
- [x] These changes do not require tests because no tests for interactive webxr content