### PR TITLE
UWP: Handle touch events

### DIFF
--- a/support/hololens/ServoApp/ServoControl/Servo.h
+++ b/support/hololens/ServoApp/ServoControl/Servo.h
@@ -62,6 +62,18 @@ public:
   void MouseUp(float x, float y, capi::CMouseButton b) {
     capi::mouse_up(x, y, b);
   }
+  void TouchDown(float x, float y, int32_t id) {
+    capi::touch_down(x, y, id);
+  }
+  void TouchUp(float x, float y, int32_t id) {
+    capi::touch_up(x, y, id);
+  }
+  void TouchMove(float x, float y, int32_t id) {
+    capi::touch_move(x, y, id);
+  }
+  void TouchCancel(float x, float y, int32_t id) {
+    capi::touch_cancel(x, y, id);
+  }
   void MouseMove(float x, float y) { capi::mouse_move(x, y); }
 
   void Reload() { capi::reload(); }

--- a/support/hololens/ServoApp/ServoControl/ServoControl.h
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.h
@@ -115,7 +115,8 @@ private:
 
   void OnSurfacePointerPressed(
       IInspectable const &,
-      Windows::UI::Xaml::Input::PointerRoutedEventArgs const &);
+      Windows::UI::Xaml::Input::PointerRoutedEventArgs const &,
+      bool);
 
   void OnSurfacePointerCanceled(
       IInspectable const &,


### PR DESCRIPTION
Fixes https://github.com/servo/servo/issues/24698

This means that we can start using the click emulation from https://github.com/servo/servo/blob/master/components/compositing/touch.rs , which is better at handling this than UWP. UWP requires a specific short tap to trigger OnTapped, and lots of folks seem to have trouble doing that.

I'm not 100% sure if this is correct since it doesn't quite disable the existing scroll handling (the ManipulationDelta stuff); I'm wondering if we should. Removing that code seems to make scrolling a bit jumpy (i also got some random zoom events?), which is counterintuitive -- if anything it should be jumpy when we have multiple scroll systems active! If the existing manipulation delta code is not removed, `preventDefault()` on touch events does not prevent scrolling, which isn't great.

r? @paulrouget 

cc @jdm 