### PR TITLE
Fix unloading, active BC, and clearing js runtime

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1389,7 +1389,18 @@ impl Window {
 
         self.current_state.set(WindowState::Zombie);
         *self.js_runtime.borrow_mut() = None;
-        self.window_proxy.set(None);
+
+        // If this is the currently active pipeline,
+        // nullify the window_proxy.
+        if let Some(proxy) = self.window_proxy.get() {
+            let pipeline_id = self.upcast::<GlobalScope>().pipeline_id();
+            if let Some(currently_active) = proxy.currently_active() {
+                if currently_active == pipeline_id {
+                    self.window_proxy.set(None);
+                }
+            }
+        }
+
         if let Some(performance) = self.performance.get() {
             performance.clear_and_disable_performance_entry_buffer();
         }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3118,7 +3118,8 @@ impl ScriptThread {
         opener: Option<BrowsingContextId>,
     ) -> DomRoot<WindowProxy> {
         if let Some(window_proxy) = self.window_proxies.borrow().get(&browsing_context_id) {
-            window_proxy.set_currently_active(&*window);
+            // Note: we do not set the window to be the currently-active one,
+            // this will be done instead when the script-thread handles the `SetDocumentActivity` msg.
             return DomRoot::from_ref(window_proxy);
         }
         let iframe = parent_info.and_then(|parent_id| {

--- a/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/execution-timing/083.html.ini
+++ b/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/execution-timing/083.html.ini
@@ -1,6 +1,5 @@
 [083.html]
   type: testharness
-  expected: ERROR
   [ scheduler: event listener defined by script in a document in history]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Do not set the window to be the currently active one for the windowproxy as part of `load`, as it will be done later when the document activity is set. And doing it later means that when unload runs, it is with the unloaded pipeline as the active window. 

Only nullify the window proxy if it's not used by another (currently-active) window.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #24591 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
