### PR TITLE
Update jemalloc-sys to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2379,11 +2385,12 @@ checksum = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
 
 [[package]]
 name = "jemalloc-sys"
-version = "0.1.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479294d130502fada93c7a957e8d059b632b03d6204aca37af557dee947f30a9"
+checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
 dependencies = [
  "cc",
+ "fs_extra",
  "libc",
 ]
 

--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 path = "lib.rs"
 
 [target.'cfg(not(windows))'.dependencies]
-jemalloc-sys = { version = "0.1.4" }
+jemalloc-sys = { version = "0.3.2" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["heapapi"] }


### PR DESCRIPTION
Update jemalloc-sys to 0.3.2 to avoid issue where jemalloc occasionally keeps
spinning in `je_spin_adaptive`.

- [X] `./mach build --release` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #24791