### PR TITLE
Ensure SpiderMonkey shuts down cleanly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3145,7 +3145,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.12.1"
-source = "git+https://github.com/servo/rust-mozjs#c2896b9c9f8681070890bc9582378472d0139b13"
+source = "git+https://github.com/jdm/rust-mozjs?branch=shutdown#ed90d3a3654a80c1dc41d54ac8ed3fd85c51fdb6"
 dependencies = [
  "cc",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ opt-level = 3
 mio = { git = "https://github.com/servo/mio.git", branch = "servo" }
 # https://github.com/retep998/winapi-rs/pull/816
 winapi = { git = "https://github.com/servo/winapi-rs", branch = "patch-1" }
+
+[patch."https://github.com/servo/rust-mozjs"]
+mozjs = { git = "https://github.com/jdm/rust-mozjs", branch = "shutdown" }

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -112,7 +112,7 @@ mod unpremultiplytable;
 #[warn(deprecated)]
 mod webdriver_handlers;
 
-pub use init::{init, init_service_workers};
+pub use init::{init, init_service_workers, init_with_shutdown_receiver};
 
 /// A module with everything layout can use from script.
 ///

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -794,7 +794,7 @@ unsafe fn set_gc_zeal_options(cx: *mut RawJSContext) {
     use js::jsapi::{JS_SetGCZeal, JS_DEFAULT_ZEAL_FREQ};
 
     let level = match pref!(js.mem.gc.zeal.level) {
-        level @ 0...14 => level as u8,
+        level @ 0..=14 => level as u8,
         _ => return,
     };
     let frequency = match pref!(js.mem.gc.zeal.frequency) {


### PR DESCRIPTION
These changes (along with https://github.com/servo/rust-mozjs/pull/487/) ensure that the JS engine is initialized on a thread which is kept alive until the end of the program, when we can safely shut down the engine.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21696 and fix #22276
- [x] There are tests for these changes