### PR TITLE
Prompt user to install OpenXR package if not installed

### DIFF
--- a/support/hololens/ServoApp/BrowserPage.cpp
+++ b/support/hololens/ServoApp/BrowserPage.cpp
@@ -18,6 +18,23 @@ namespace winrt::ServoApp::implementation {
 BrowserPage::BrowserPage() {
   InitializeComponent();
   BindServoEvents();
+  if (!xrPkgChecker.IsInstalled()) {
+    XRPkgWarning().Visibility(Visibility::Visible);
+    xrPkgChecker.OnInstalled(
+        [=] { XRPkgWarning().Visibility(Visibility::Collapsed); },
+        std::chrono::seconds{5});
+  }
+}
+
+void BrowserPage::OnXRPkgWarningDismissClick(IInspectable const &,
+                                             RoutedEventArgs const &) {
+  xrPkgChecker.StopTracking();
+  XRPkgWarning().Visibility(Visibility::Collapsed);
+}
+
+void BrowserPage::OnXRPkgWarningInstallClick(IInspectable const &,
+                                             RoutedEventArgs const &) {
+  xrPkgChecker.OpenStore();
 }
 
 void BrowserPage::BindServoEvents() {

--- a/support/hololens/ServoApp/BrowserPage.h
+++ b/support/hololens/ServoApp/BrowserPage.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "BrowserPage.g.h"
+#include "XRPkgChecker.h"
 #include "ServoControl\ServoControl.h"
 
 namespace winrt::ServoApp::implementation {
@@ -34,9 +35,14 @@ public:
   void LoadServoURI(Windows::Foundation::Uri uri);
   void SetTransientMode(bool);
   void SetArgs(hstring);
+  void OnXRPkgWarningInstallClick(Windows::Foundation::IInspectable const &,
+                                  Windows::UI::Xaml::RoutedEventArgs const &);
+  void OnXRPkgWarningDismissClick(Windows::Foundation::IInspectable const &,
+                                  Windows::UI::Xaml::RoutedEventArgs const &);
 
 private:
   void BindServoEvents();
+  XRPkgChecker xrPkgChecker;
 };
 } // namespace winrt::ServoApp::implementation
 

--- a/support/hololens/ServoApp/BrowserPage.xaml
+++ b/support/hololens/ServoApp/BrowserPage.xaml
@@ -84,6 +84,7 @@
             <RowDefinition Height="auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto"/>
         </Grid.RowDefinitions>
         <Grid Grid.Row="0" x:Name="navigationBar" Background="{ThemeResource InkToolbarButtonBackgroundThemeBrush}">
             <Grid.ColumnDefinitions>
@@ -126,5 +127,12 @@
         </Grid>
         <local:ServoControl TabIndex="0" x:Name="servoControl" Grid.Row="1"/>
         <ProgressBar x:Name="transientLoadingIndicator" Visibility="Collapsed" Grid.Row="2"/>
+        <StackPanel Grid.Row="2" Background="LightYellow" Padding="10" BorderThickness="0,2,0,0" BorderBrush="Black" x:Name="XRPkgWarning" Visibility="Collapsed">
+            <TextBlock Margin="0,0" VerticalAlignment="Center">The package "Windows OpenXR Developer Preview" is not installed. WebXR pages won't work.</TextBlock>
+            <StackPanel Orientation="Horizontal">
+                <Button Margin="0,10,10,0" Click="OnXRPkgWarningInstallClick">Install Package</Button>
+                <Button Margin="0,10,10,0" Click="OnXRPkgWarningDismissClick">Dismiss</Button>
+            </StackPanel>
+        </StackPanel>
     </Grid>
 </Page>

--- a/support/hololens/ServoApp/Package.appxmanifest
+++ b/support/hololens/ServoApp/Package.appxmanifest
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" IgnorableNamespaces="uap mp uap5">
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" 
+  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap mp uap5 rescap">
   <Identity Name="1d265729-8836-4bd3-9992-4cb111d1068b" Publisher="CN=Allizom" Version="1.0.0.0" />
   <mp:PhoneIdentity PhoneProductId="1d265729-8836-4bd3-9992-4cb111d1068b" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -44,6 +50,7 @@
     </Application>
   </Applications>
   <Capabilities>
+    <rescap:Capability Name="packageQuery" />
     <Capability Name="internetClient" />
     <Capability Name="codeGeneration" />
     <Capability Name="privateNetworkClientServer" />

--- a/support/hololens/ServoApp/ServoApp.vcxproj
+++ b/support/hololens/ServoApp/ServoApp.vcxproj
@@ -133,6 +133,7 @@
     <ClInclude Include="ServoControl\Servo.h" />
     <ClInclude Include="ServoControl\ServoControl.h" />
     <ClInclude Include="DefaultUrl.h" />
+    <ClInclude Include="XRPkgChecker.h" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -928,6 +929,7 @@
     <ClCompile Include="ServoControl\OpenGLES.cpp" />
     <ClCompile Include="ServoControl\Servo.cpp" />
     <ClCompile Include="ServoControl\ServoControl.cpp" />
+    <ClCompile Include="XRPkgChecker.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="App.idl">

--- a/support/hololens/ServoApp/ServoApp.vcxproj.filters
+++ b/support/hololens/ServoApp/ServoApp.vcxproj.filters
@@ -22,6 +22,7 @@
     <ClCompile Include="ServoControl\ServoControl.cpp">
       <Filter>ServoControl</Filter>
     </ClCompile>
+    <ClCompile Include="XRPkgChecker.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -38,6 +39,7 @@
       <Filter>ServoControl</Filter>
     </ClInclude>
     <ClInclude Include="DefaultUrl.h" />
+    <ClInclude Include="XRPkgChecker.h" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="Assets\Wide310x150Logo.scale-200.png">

--- a/support/hololens/ServoApp/XRPkgChecker.cpp
+++ b/support/hololens/ServoApp/XRPkgChecker.cpp
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "pch.h"
+#include "XRPkgChecker.h"
+#include "logs.h"
+#include "winrt/Windows.Management.Deployment.h"
+
+using namespace winrt::Windows::Management::Deployment;
+
+namespace winrt {
+
+void XRPkgChecker::OnInstalled(std::function<void()> callback,
+                               winrt::Windows::Foundation::TimeSpan interval) {
+  timer.Stop();
+  timer.Interval(interval);
+  installed_callback = std::make_unique<std::function<void()>>(callback);
+  timer.Tick({this, &XRPkgChecker::CheckXRPkgTick});
+  timer.Start();
+}
+
+void XRPkgChecker::StopTracking() {
+  installed_callback.reset();
+  timer.Stop();
+}
+
+void XRPkgChecker::CheckXRPkgTick(Windows::Foundation::IInspectable const &,
+                                  Windows::Foundation::IInspectable const &) {
+  if (IsInstalled()) {
+    (*installed_callback)();
+    StopTracking();
+  }
+}
+
+void XRPkgChecker::OpenStore() {
+  std::wstring url = L"ms-windows-store://pdp/?PFN=";
+  Windows::Foundation::Uri uri{url + OPENXR_PACKAGE_NAME};
+  Windows::System::Launcher::LaunchUriAsync(uri);
+}
+
+bool XRPkgChecker::IsInstalled() {
+  auto current_user = L"";
+  for (auto package : PackageManager().FindPackagesForUser(current_user)) {
+    if (package.Id().Name() == OPENXR_PACKAGE_SHORT_NAME) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace winrt

--- a/support/hololens/ServoApp/XRPkgChecker.h
+++ b/support/hololens/ServoApp/XRPkgChecker.h
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include "pch.h"
+
+namespace winrt {
+class XRPkgChecker {
+
+public:
+  void OnInstalled(std::function<void()> callback,
+                   winrt::Windows::Foundation::TimeSpan interval);
+  bool IsInstalled();
+  void StopTracking();
+  void OpenStore();
+
+private:
+  std::unique_ptr<std::function<void()>> installed_callback;
+  void CheckXRPkgTick(Windows::Foundation::IInspectable const &,
+                      Windows::Foundation::IInspectable const &);
+  Windows::UI::Xaml::DispatcherTimer timer;
+  inline static const hstring OPENXR_PACKAGE_NAME =
+      L"Microsoft.MixedRealityRuntimeDeveloperPreview_8wekyb3d8bbwe";
+  inline static const hstring OPENXR_PACKAGE_SHORT_NAME =
+      L"Microsoft.MixedRealityRuntimeDeveloperPreview";
+};
+
+} // namespace winrt


### PR DESCRIPTION
Fix #24086

It's important to note that this PR introduces a restricted capability. During the app store submission process we will need to justify why we want to use that capability.

This piece of UI is important for the Emulator, where OpenXR is not available by default.