### PR TITLE
Ensure SpiderMonkey shuts down cleanly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3397,7 +3397,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.12.1"
-source = "git+https://github.com/servo/rust-mozjs#c2896b9c9f8681070890bc9582378472d0139b13"
+source = "git+https://github.com/servo/rust-mozjs#9b0d063ba062f4cc60c3bab9250218d6935d647b"
 dependencies = [
  "cc",
  "lazy_static",

--- a/components/script/init.rs
+++ b/components/script/init.rs
@@ -4,6 +4,7 @@
 
 use crate::dom::bindings::codegen::RegisterBindings;
 use crate::dom::bindings::proxyhandler;
+use crate::script_runtime::JSEngineSetup;
 use crate::serviceworker_manager::ServiceWorkerManager;
 use script_traits::SWManagerSenders;
 
@@ -56,7 +57,7 @@ pub fn init_service_workers(sw_senders: SWManagerSenders) {
 }
 
 #[allow(unsafe_code)]
-pub fn init() {
+pub fn init() -> JSEngineSetup {
     unsafe {
         proxyhandler::init();
 
@@ -66,4 +67,6 @@ pub fn init() {
     }
 
     perform_platform_specific_initialization();
+
+    JSEngineSetup::new()
 }

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -113,6 +113,7 @@ mod unpremultiplytable;
 mod webdriver_handlers;
 
 pub use init::{init, init_service_workers};
+pub use script_runtime::JSEngineSetup;
 
 /// A module with everything layout can use from script.
 ///

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -816,7 +816,7 @@ unsafe fn set_gc_zeal_options(cx: *mut RawJSContext) {
     use js::jsapi::{JS_SetGCZeal, JS_DEFAULT_ZEAL_FREQ};
 
     let level = match pref!(js.mem.gc.zeal.level) {
-        level @ 0...14 => level as u8,
+        level @ 0..=14 => level as u8,
         _ => return,
     };
     let frequency = match pref!(js.mem.gc.zeal.frequency) {


### PR DESCRIPTION
This is the alternate solution that I described in #24845. Given how much simpler the resulting code is, I'm now much more in favour of this design. Depends on https://github.com/servo/rust-mozjs/pull/487.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21696 and fix #22276
- [x] There are tests for these changes