### PR TITLE
Correct handling of whitespace in base64 URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,6 +1022,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d33fe99ccedd6e84bc035f1931bb2e6be79739d6242bd895e7311c886c50dc9c"
+dependencies = [
+ "matches",
+]
+
+[[package]]
 name = "dbus"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3460,6 +3469,7 @@ dependencies = [
  "content-security-policy",
  "cookie",
  "crossbeam-channel",
+ "data-url",
  "devtools_traits",
  "embedder_traits",
  "flate2",

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -20,6 +20,7 @@ bytes = "0.4"
 content-security-policy = {version = "0.3.0", features = ["serde"]}
 cookie_rs = {package = "cookie", version = "0.11"}
 crossbeam-channel = "0.3"
+data-url = "0.1.0"
 devtools_traits = {path = "../devtools_traits"}
 embedder_traits = { path = "../embedder_traits" }
 flate2 = "1"

--- a/components/net/data_loader.rs
+++ b/components/net/data_loader.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base64;
+use data_url::forgiving_base64;
 use mime::Mime;
 use percent_encoding::percent_decode;
 use servo_url::ServoUrl;
@@ -16,6 +16,10 @@ pub enum DecodeError {
 pub type DecodeData = (Mime, Vec<u8>);
 
 pub fn decode(url: &ServoUrl) -> Result<DecodeData, DecodeError> {
+    // data_url could do all of this work for us,
+    // except that it currently (Nov 2019) parses mime types into a
+    // different Mime class than other code expects
+
     assert_eq!(url.scheme(), "data");
     // Split out content type and data.
     let parts: Vec<&str> = url[Position::BeforePath..Position::AfterQuery]
@@ -44,15 +48,7 @@ pub fn decode(url: &ServoUrl) -> Result<DecodeData, DecodeError> {
 
     let mut bytes = percent_decode(parts[1].as_bytes()).collect::<Vec<_>>();
     if is_base64 {
-        // FIXME(#2909):
-        // infra.spec.whatwg.org/#forgiving-base64-decode does a pretty good
-        // job of telling us what to do here. Most WPT tests are working;
-        // the base64 string "ab=" in particular is not.
-        bytes = bytes
-            .into_iter()
-            .filter(|&b| b != b' ' && b != b'\x0C' && b != b'\n' && b != b'\r' && b != b'\t')
-            .collect::<Vec<u8>>();
-        match base64::decode_config(&bytes, base64::STANDARD.decode_allow_trailing_bits(true)) {
+        match forgiving_base64::decode_to_vec(&bytes) {
             Err(..) => return Err(DecodeError::NonBase64DataUri),
             Ok(data) => bytes = data,
         }

--- a/components/net/data_loader.rs
+++ b/components/net/data_loader.rs
@@ -45,12 +45,12 @@ pub fn decode(url: &ServoUrl) -> Result<DecodeData, DecodeError> {
     let mut bytes = percent_decode(parts[1].as_bytes()).collect::<Vec<_>>();
     if is_base64 {
         // FIXME(#2909):
-	// infra.spec.whatwg.org/#forgiving-base64-decode does a pretty good
-	// job of telling us what to do here. Most WPT tests are working;
-	// the base64 string "ab=" in particular is not.
+        // infra.spec.whatwg.org/#forgiving-base64-decode does a pretty good
+        // job of telling us what to do here. Most WPT tests are working;
+        // the base64 string "ab=" in particular is not.
         bytes = bytes
             .into_iter()
-            .filter(|&b| b != b' ' && b!= b'\x0C' && b!= b'\n' && b!=b'\r' && b!=b'\t') 
+            .filter(|&b| b != b' ' && b != b'\x0C' && b != b'\n' && b != b'\r' && b != b'\t')
             .collect::<Vec<u8>>();
         match base64::decode_config(&bytes, base64::STANDARD.decode_allow_trailing_bits(true)) {
             Err(..) => return Err(DecodeError::NonBase64DataUri),

--- a/tests/wpt/metadata/fetch/data-urls/base64.any.js.ini
+++ b/tests/wpt/metadata/fetch/data-urls/base64.any.js.ini
@@ -2,32 +2,6 @@
   [data: URL base64 handling: "ab="]
     expected: FAIL
 
-  [data: URL base64 handling: "ab\\fcd"]
-    expected: FAIL
-
-  [data: URL base64 handling: "ab\\t\\n\\f\\r cd"]
-    expected: FAIL
-
-  [data: URL base64 handling: " \\t\\n\\f\\r ab\\t\\n\\f\\r cd\\t\\n\\f\\r "]
-    expected: FAIL
-
-  [data: URL base64 handling: "ab\\t\\n\\f\\r =\\t\\n\\f\\r =\\t\\n\\f\\r "]
-    expected: FAIL
-
-
 [base64.any.html]
   [data: URL base64 handling: "ab="]
     expected: FAIL
-
-  [data: URL base64 handling: "ab\\fcd"]
-    expected: FAIL
-
-  [data: URL base64 handling: "ab\\t\\n\\f\\r cd"]
-    expected: FAIL
-
-  [data: URL base64 handling: " \\t\\n\\f\\r ab\\t\\n\\f\\r cd\\t\\n\\f\\r "]
-    expected: FAIL
-
-  [data: URL base64 handling: "ab\\t\\n\\f\\r =\\t\\n\\f\\r =\\t\\n\\f\\r "]
-    expected: FAIL
-

--- a/tests/wpt/metadata/fetch/data-urls/base64.any.js.ini
+++ b/tests/wpt/metadata/fetch/data-urls/base64.any.js.ini
@@ -1,7 +1,0 @@
-[base64.any.worker.html]
-  [data: URL base64 handling: "ab="]
-    expected: FAIL
-
-[base64.any.html]
-  [data: URL base64 handling: "ab="]
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Whitespace handling in base64 url parsing now treats tabs, form-feeds, and linefeeds the same way it treats regular spaces

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix (part of) #2909

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
