### PR TITLE
Fix iterator invalidation in our forEach implementation.

### DIFF
--- a/tests/wpt/web-platform-tests/WebIDL/ecmascript-binding/iterator-invalidation-foreach.html
+++ b/tests/wpt/web-platform-tests/WebIDL/ecmascript-binding/iterator-invalidation-foreach.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Behavior of iterators when modified within foreach</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://heycam.github.io/webidl/#es-forEach">
+<link rel="author" title="Manish Goregaokar" href="mailto:manishsmail@gmail.com">
+<script>
+test(function() {
+    let params = new URLSearchParams("a=1&b=2&c=3");
+    let arr = [];
+    params.forEach((p) => {
+        arr.push(p);
+        params.delete("b");
+    })
+    assert_array_equals(arr, ["1", "3"]);
+}, "forEach will not iterate over elements removed during iteration");
+test(function() {
+    let params = new URLSearchParams("a=1&b=2&c=3&d=4");
+    let arr = [];
+    params.forEach((p) => {
+        arr.push(p);
+        if (p == "2") {
+            params.delete("a");
+        }
+    })
+    assert_array_equals(arr, ["1", "2", "4"]);
+}, "Removing elements already iterated over during forEach will cause iterator to skip an element");
+test(function() {
+    let params = new URLSearchParams("a=1&b=2&c=3&d=4");
+    let arr = [];
+    params.forEach((p) => {
+        arr.push(p);
+        if (p == "2") {
+            params.append("e", "5");
+        }
+    })
+    assert_array_equals(arr, ["1", "2", "3", "4", "5"]);
+}, "Elements added during iteration with forEach will be reached");
+</script>


### PR DESCRIPTION
Currently we iterate over iterables in forEach based on the length they report when we start iterating, however the inner callback is able to change this.

```js
let params = new URLSearchParams("foo=bar&baz=qux");
params.forEach((p) => {
    console.log(p);
    params.delete("baz");
})
```

This causes us to panic [here](https://github.com/servo/servo/blob/f1aa5d8dbdc32f6f474b09234558652b9bead686/components/script/dom/bindings/codegen/CodegenRust.py#L7412) over an attempt to access out of bounds.

Relevant spec: https://heycam.github.io/webidl/#es-forEach


r? @jdm