### PR TITLE
Extend WPT update job timeout.

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -587,7 +587,7 @@ def update_wpt():
         .with_features("taskclusterProxy")
         .with_scopes("secrets:get:project/servo/wpt-sync")
         .with_index_and_artifacts_expire_in(log_artifacts_expire_in)
-        .with_max_run_time_minutes(6 * 60)
+        .with_max_run_time_minutes(8 * 60)
         # Not using the bundle, pushing the new changes to the git remote requires a full repo.
         .with_repo(alternate_object_dir="/var/cache/servo.git/objects")
     )


### PR DESCRIPTION
https://community-tc.services.mozilla.com/tasks/HIGiBAoHQQ-iiw0q-oYX0Q was a job on a machine with no stale processes and no clear problems running the tests. It does include an upstream change that causes a bunch of CSS interpolation tests to start running, so I think we're just hitting the timeout naturally again.