### PR TITLE
Update README with new brew bundle file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Xcode version 10.2 or above is recommended.
 
 ``` sh
 brew bundle install --file=etc/taskcluster/macos/Brewfile
-brew bundle install --file=etc/taskcluster/macos/Brewfile-gstreamer
+brew bundle install --file=etc/taskcluster/macos/Brewfile-build
 pip install virtualenv
 ```
 


### PR DESCRIPTION
This is a follow up from 203a06ff24966d3e5ee20b9c190addb9e05d3809 (PR https://github.com/servo/servo/pull/24811/).

The old instructions lead to the following error:

```
$ brew bundle install --file=etc/taskcluster/macos/Brewfile-gstreamer

Error: No Brewfile found
```

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this is just an update to the README

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
