### PR TITLE
Add ALPN and signature algorithms to OpenSSL config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+
+[[package]]
 name = "azure"
 version = "0.37.0"
 source = "git+https://github.com/servo/rust-azure#1dbd223157997b5b5301e7da73bff37f928a7418"
@@ -2354,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
+checksum = "2790658cddc82e82b08e25176c431d7015a0adeb1718498715cbd20138a0bf68"
 dependencies = [
  "bytes",
  "fnv",
@@ -2392,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.12.33"
+version = "0.12.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb44cbce9d8ee4fb36e4c0ad7b794ac44ebaad924b9c8291a63215bb44c2c8f"
+checksum = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
 dependencies = [
  "bytes",
  "futures",
@@ -2422,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-openssl"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a137dee5fc025f1afdd4f9d1eb6405689e4c687d07b687ba287adb7d55f791"
+checksum = "f52657b5cdb2a8067efd29a02e011b7cf656b473ec8a5c34e86645e85d763006"
 dependencies = [
  "antidote",
  "bytes",
@@ -3684,9 +3690,9 @@ checksum = "51ecbcb821e1bd256d456fe858aaa7f380b63863eab2eb86eee1bd9f33dd6682"
 
 [[package]]
 name = "openssl"
-version = "0.10.11"
+version = "0.10.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c24d3508b4fb6da175c10baac54c578b33f09c89ae90c6fe9788b3b4768efdc"
+checksum = "3a3cc5799d98e1088141b8e01ff760112bbd9f19d850c124500566ca6901a585"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3704,10 +3710,11 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.35"
+version = "0.9.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912f301a749394e1025d9dcddef6106ddee9252620e6d0a0e5f8d0681de9b129"
+checksum = "465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f"
 dependencies = [
+ "autocfg",
  "cc",
  "libc",
  "pkg-config",

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::connector::{create_http_client, Connector};
+use crate::connector::{create_http_client, Connector, TlsConfig};
 use crate::cookie;
 use crate::cookie_storage::CookieStorage;
 use crate::decoder::Decoder;
@@ -46,7 +46,6 @@ use net_traits::{CookieSource, FetchMetadata, NetworkError, ReferrerPolicy};
 use net_traits::{
     RedirectEndValue, RedirectStartValue, ResourceAttribute, ResourceFetchTiming, ResourceTimeValue,
 };
-use openssl::ssl::SslConnectorBuilder;
 use servo_arc::Arc;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use std::collections::{HashMap, HashSet};
@@ -90,7 +89,7 @@ pub struct HttpState {
 }
 
 impl HttpState {
-    pub fn new(ssl_connector_builder: SslConnectorBuilder) -> HttpState {
+    pub fn new(tls_config: TlsConfig) -> HttpState {
         HttpState {
             hsts_list: RwLock::new(HstsList::new()),
             cookie_jar: RwLock::new(CookieStorage::new(150)),
@@ -98,7 +97,7 @@ impl HttpState {
             history_states: RwLock::new(HashMap::new()),
             http_cache: RwLock::new(HttpCache::new()),
             http_cache_state: Mutex::new(HashMap::new()),
-            client: create_http_client(ssl_connector_builder, HANDLE.lock().unwrap().executor()),
+            client: create_http_client(tls_config, HANDLE.lock().unwrap().executor()),
         }
     }
 }

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -4,7 +4,7 @@
 
 //! A thread that takes a URL and streams back the binary data.
 
-use crate::connector::{create_http_client, create_ssl_connector_builder};
+use crate::connector::{create_http_client, create_tls_config, ALPN_H2_H1};
 use crate::cookie;
 use crate::cookie_storage::CookieStorage;
 use crate::fetch::cors_cache::CorsCache;
@@ -149,7 +149,7 @@ fn create_http_states(
         http_cache: RwLock::new(http_cache),
         http_cache_state: Mutex::new(HashMap::new()),
         client: create_http_client(
-            create_ssl_connector_builder(&certs),
+            create_tls_config(&certs, ALPN_H2_H1),
             HANDLE.lock().unwrap().executor(),
         ),
     };
@@ -162,7 +162,7 @@ fn create_http_states(
         http_cache: RwLock::new(HttpCache::new()),
         http_cache_state: Mutex::new(HashMap::new()),
         client: create_http_client(
-            create_ssl_connector_builder(&certs),
+            create_tls_config(&certs, ALPN_H2_H1),
             HANDLE.lock().unwrap().executor(),
         ),
     };

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::connector::create_ssl_connector_builder;
+use crate::connector::{create_tls_config, ALPN_H1};
 use crate::cookie::Cookie;
 use crate::fetch::methods::should_be_blocked_due_to_bad_port;
 use crate::hosts::replace_host;
@@ -167,8 +167,9 @@ impl<'a> Handler for Client<'a> {
                 WebSocketErrorKind::Protocol,
                 format!("Unable to parse domain from {}. Needed for SSL.", url),
             ))?;
-        let connector = create_ssl_connector_builder(&certs).build();
-        connector
+        let tls_config = create_tls_config(&certs, ALPN_H1);
+        tls_config
+            .build()
             .connect(domain, stream)
             .map_err(WebSocketError::from)
     }


### PR DESCRIPTION
* Updated http crate from 0.1.17 [to 0.1.20](https://github.com/hyperium/http/blob/master/CHANGELOG.md#0120-november-26-2019).
* Updated hyper from 0.12.33 [to 0.12.35](https://github.com/hyperium/hyper/compare/v0.12.33...v0.12.35).
* Updated hyper-openssl from 0.7.0 [to 0.7.1](https://github.com/sfackler/hyper-openssl/blob/master/CHANGELOG.md#v071---2019-03-01).
* Updated openssl crate from 0.10.11 [to 0.10.26](https://github.com/sfackler/rust-openssl/blob/master/openssl/CHANGELOG.md#v01026---2019-11-22).
  * Set ALPN to h2+http/1.1 for https (Enabled HTTP2) and http/1.1 for websockets.
  * Restricted signature algorithms to the same list across platforms: EdDSA at first, then ECDSA, then TLS 1.3's RSA(-PSS), then classic RSA (PKCS#1 1.5).
Thereby we disabled the [following](https://www.ssllabs.com/ssltest/viewClient.html?name=OpenSSL&version=1.1.1c&key=165) non-web-standard signature algorithms: SHA512/ECDSA, SHA224/ECDSA, SHA1/ECDSA, SHA224/RSA, SHA224/DSA, SHA1/DSA, SHA256/DSA, SHA384/DSA, SHA512/DSA. [SHA1/RSA](https://tools.ietf.org/html/draft-ietf-tls-md5-sha1-deprecate-00) is almost dead and now only used by a few old and broken F5 load balancers: Like TLS 1.0 deprecation, we can again deprecate this some months earlier than other browsers.
  * Added Chacha20 to TLS 1.2 ciphersuite list and preferred it like Firefox and [Rustls](https://github.com/ctz/rustls/blob/4b13a322c05c9310173513782c5d12c5afedfaf5/rustls/src/suites.rs#L377). Removed legacy and privacy-hostile plain RSA (AES256-SHA, AES128-SHA).
Compared to [Mozilla intermediate v5](https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29) we keep ECDHE-RSA-AES256-SHA and ECDHE-RSA-AES128-SHA for now, but won't reintroduce deprecated DHE.
  * Switched server-side to [Mozilla intermediate v5](https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29) in components/net/tests/main.rs. (The new `modern` would have been TLSv1.3-only, therefore only worked with OpenSSL 1.1.1 which is unfortunately not yet used on every target.)
  * Renamed `ssl_connector_builder(certs)` to the more neutral and long-term better fitting `create_tls_config(certs, alpn)` as it was done in #24764.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
