### PR TITLE
Only start WebGPU thread if an adapter is requested

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4639,6 +4639,7 @@ dependencies = [
  "serde",
  "servo_atoms",
  "servo_url",
+ "smallvec 0.6.10",
  "style_traits",
  "time",
  "url",

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -48,7 +48,6 @@ use std::process;
 use std::rc::Rc;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use webgpu::WebGPU;
 use webvr_traits::WebVRMsg;
 
 /// A `Pipeline` is the constellation's view of a `Document`. Each pipeline has an
@@ -194,9 +193,6 @@ pub struct InitialPipelineState {
     /// A channel to the WebGL thread.
     pub webgl_chan: Option<WebGLPipeline>,
 
-    /// A channel to the WebGPU threads.
-    pub webgpu: Option<WebGPU>,
-
     /// A channel to the webvr thread.
     pub webvr_chan: Option<IpcSender<WebVRMsg>>,
 
@@ -309,7 +305,6 @@ impl Pipeline {
                     webrender_document: state.webrender_document,
                     webgl_chan: state.webgl_chan,
                     webvr_chan: state.webvr_chan,
-                    webgpu: state.webgpu,
                     webxr_registry: state.webxr_registry,
                     player_context: state.player_context,
                 };
@@ -516,7 +511,6 @@ pub struct UnprivilegedPipelineContent {
     webrender_image_api_sender: net_traits::WebrenderIpcSender,
     webrender_document: webrender_api::DocumentId,
     webgl_chan: Option<WebGLPipeline>,
-    webgpu: Option<WebGPU>,
     webvr_chan: Option<IpcSender<WebVRMsg>>,
     webxr_registry: webxr_api::Registry,
     player_context: WindowGLContext,
@@ -569,7 +563,6 @@ impl UnprivilegedPipelineContent {
                 pipeline_namespace_id: self.pipeline_namespace_id,
                 content_process_shutdown_chan: content_process_shutdown_chan,
                 webgl_chan: self.webgl_chan,
-                webgpu: self.webgpu,
                 webvr_chan: self.webvr_chan,
                 webxr_registry: self.webxr_registry,
                 webrender_document: self.webrender_document,

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -521,6 +521,7 @@ unsafe_no_jsmanaged_fields!(WebGLTextureId);
 unsafe_no_jsmanaged_fields!(WebGLVertexArrayId);
 unsafe_no_jsmanaged_fields!(WebGLVersion);
 unsafe_no_jsmanaged_fields!(WebGLSLVersion);
+unsafe_no_jsmanaged_fields!(RefCell<Option<WebGPU>>);
 unsafe_no_jsmanaged_fields!(RefCell<Identities>);
 unsafe_no_jsmanaged_fields!(WebGPU);
 unsafe_no_jsmanaged_fields!(WebGPUAdapter);

--- a/components/script/dom/gpu.rs
+++ b/components/script/dom/gpu.rs
@@ -132,9 +132,7 @@ impl GPUMethods for GPU {
             ))
             .is_err()
         {
-            promise.reject_error(Error::Type(
-                "Failed to send adapter request to constellation...".to_owned(),
-            ));
+            promise.reject_error(Error::Operation);
         }
         promise
     }
@@ -153,10 +151,7 @@ impl AsyncWGPUListener for GPU {
                 );
                 promise.resolve_native(&adapter);
             },
-            response => promise.reject_error(Error::Type(format!(
-                "Wrong response received for GPU from WebGPU thread {:?}",
-                response,
-            ))),
+            _ => promise.reject_error(Error::Operation),
         }
     }
 }

--- a/components/script/dom/gpuadapter.rs
+++ b/components/script/dom/gpuadapter.rs
@@ -102,12 +102,10 @@ impl GPUAdapterMethods for GPUAdapter {
                 .send(WebGPURequest::RequestDevice(sender, self.adapter, desc, id))
                 .is_err()
             {
-                promise.reject_error(Error::Type(
-                    "Failed to send RequestDevice message...".to_owned(),
-                ));
+                promise.reject_error(Error::Operation);
             }
         } else {
-            promise.reject_error(Error::Type("No WebGPU thread...".to_owned()))
+            promise.reject_error(Error::Operation);
         };
         promise
     }
@@ -127,9 +125,7 @@ impl AsyncWGPUListener for GPUAdapter {
                 );
                 promise.resolve_native(&device);
             },
-            _ => promise.reject_error(Error::Type(
-                "Wrong response type from WebGPU thread...".to_owned(),
-            )),
+            _ => promise.reject_error(Error::Operation),
         }
     }
 }

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -180,7 +180,7 @@ impl GPUDeviceMethods for GPUDevice {
                     id,
                     wgpu_descriptor,
                 ))
-                .unwrap();
+                .expect("Failed to create WebGPU buffer");
         } else {
             unimplemented!()
         };
@@ -218,7 +218,7 @@ impl GPUDeviceMethods for GPUDevice {
                     id,
                     wgpu_descriptor.clone(),
                 ))
-                .unwrap()
+                .expect("Failed to create WebGPU buffer");
         } else {
             return vec![js_val.get()];
         };

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -135,7 +135,6 @@ use style::str::HTML_SPACE_CHARACTERS;
 use style::stylesheets::CssRuleType;
 use style_traits::{CSSPixel, DevicePixel, ParsingMode};
 use url::Position;
-use webgpu::WebGPU;
 use webrender_api::units::{DeviceIntPoint, DeviceIntSize, LayoutPixel};
 use webrender_api::{DocumentId, ExternalScrollId};
 use webvr_traits::WebVRMsg;
@@ -266,10 +265,6 @@ pub struct Window {
     /// A handle for communicating messages to the WebGL thread, if available.
     #[ignore_malloc_size_of = "channels are hard"]
     webgl_chan: Option<WebGLChan>,
-
-    #[ignore_malloc_size_of = "channels are hard"]
-    /// A handle for communicating messages to the WebGPU threads.
-    webgpu: Option<WebGPU>,
 
     /// A handle for communicating messages to the webvr thread, if available.
     #[ignore_malloc_size_of = "channels are hard"]
@@ -464,10 +459,6 @@ impl Window {
         self.webgl_chan
             .as_ref()
             .map(|chan| WebGLCommandSender::new(chan.clone(), self.get_event_loop_waker()))
-    }
-
-    pub fn webgpu_channel(&self) -> Option<WebGPU> {
-        self.webgpu.clone()
     }
 
     pub fn webvr_thread(&self) -> Option<IpcSender<WebVRMsg>> {
@@ -2213,7 +2204,6 @@ impl Window {
         navigation_start: u64,
         navigation_start_precise: u64,
         webgl_chan: Option<WebGLChan>,
-        webgpu: Option<WebGPU>,
         webvr_chan: Option<IpcSender<WebVRMsg>>,
         webxr_registry: webxr_api::Registry,
         microtask_queue: Rc<MicrotaskQueue>,
@@ -2292,7 +2282,6 @@ impl Window {
             media_query_lists: DOMTracker::new(),
             test_runner: Default::default(),
             webgl_chan,
-            webgpu,
             webvr_chan,
             webxr_registry,
             permission_state_invocation_results: Default::default(),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -164,7 +164,6 @@ use style::dom::OpaqueNode;
 use style::thread_state::{self, ThreadState};
 use time::{at_utc, get_time, precise_time_ns, Timespec};
 use url::Position;
-use webgpu::WebGPU;
 use webrender_api::units::LayoutPixel;
 use webrender_api::DocumentId;
 use webvr_traits::{WebVREvent, WebVRMsg};
@@ -629,9 +628,6 @@ pub struct ScriptThread {
 
     /// A handle to the WebGL thread
     webgl_chan: Option<WebGLPipeline>,
-
-    /// A handle to the WebGPU threads
-    webgpu: Option<WebGPU>,
 
     /// A handle to the webvr thread, if available
     webvr_chan: Option<IpcSender<WebVRMsg>>,
@@ -1339,7 +1335,6 @@ impl ScriptThread {
             layout_to_constellation_chan: state.layout_to_constellation_chan,
 
             webgl_chan: state.webgl_chan,
-            webgpu: state.webgpu,
             webvr_chan: state.webvr_chan,
             webxr_registry: state.webxr_registry,
 
@@ -3201,7 +3196,6 @@ impl ScriptThread {
             incomplete.navigation_start,
             incomplete.navigation_start_precise,
             self.webgl_chan.as_ref().map(|chan| chan.channel()),
-            self.webgpu.clone(),
             self.webvr_chan.clone(),
             self.webxr_registry.clone(),
             self.microtask_queue.clone(),

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -36,6 +36,7 @@ profile_traits = {path = "../profile_traits"}
 serde = "1.0"
 servo_atoms = {path = "../atoms"}
 servo_url = {path = "../url"}
+smallvec = "0.6"
 style_traits = {path = "../style_traits", features = ["servo"]}
 time = "0.1.12"
 url = "2.0"

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -65,7 +65,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use style_traits::CSSPixel;
 use style_traits::SpeculativePainter;
-use webgpu::WebGPU;
 use webrender_api::units::{
     DeviceIntSize, DevicePixel, LayoutPixel, LayoutPoint, LayoutSize, WorldPoint,
 };
@@ -665,8 +664,6 @@ pub struct InitialScriptState {
     pub content_process_shutdown_chan: Sender<()>,
     /// A channel to the WebGL thread used in this pipeline.
     pub webgl_chan: Option<WebGLPipeline>,
-    /// A channel to the WebGPU threads.
-    pub webgpu: Option<WebGPU>,
     /// A channel to the webvr thread, if available.
     pub webvr_chan: Option<IpcSender<WebVRMsg>>,
     /// The XR device registry

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -30,10 +30,12 @@ use net_traits::storage_thread::StorageType;
 use net_traits::CoreResourceMsg;
 use servo_url::ImmutableOrigin;
 use servo_url::ServoUrl;
+use smallvec::SmallVec;
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use style_traits::viewport::ViewportConstraints;
 use style_traits::CSSPixel;
+use webgpu::{wgpu, WebGPUResponseResult};
 use webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 
 /// A particular iframe's size, associated with a browsing context.
@@ -257,6 +259,12 @@ pub enum ScriptMsg {
     /// Notifies the constellation about media session events
     /// (i.e. when there is metadata for the active media session, playback state changes...).
     MediaSessionEvent(PipelineId, MediaSessionEvent),
+    /// Create a WebGPU Adapter instance
+    RequestAdapter(
+        IpcSender<WebGPUResponseResult>,
+        wgpu::instance::RequestAdapterOptions,
+        SmallVec<[wgpu::id::AdapterId; 4]>,
+    ),
 }
 
 impl fmt::Debug for ScriptMsg {
@@ -309,6 +317,7 @@ impl fmt::Debug for ScriptMsg {
             GetScreenSize(..) => "GetScreenSize",
             GetScreenAvailSize(..) => "GetScreenAvailSize",
             MediaSessionEvent(..) => "MediaSessionEvent",
+            RequestAdapter(..) => "RequestAdapter",
         };
         write!(formatter, "ScriptMsg::{}", variant)
     }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -874,8 +874,6 @@ fn create_constellation(
 
     let resource_sender = public_resource_threads.sender();
 
-    let webgpu = webgpu::WebGPU::new();
-
     let initial_state = InitialConstellationState {
         compositor_proxy,
         embedder_proxy,
@@ -890,7 +888,6 @@ fn create_constellation(
         webrender_document,
         webrender_api_sender,
         webgl_threads,
-        webgpu,
         webvr_chan,
         webxr_registry,
         glplayer_threads,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This addresses 1 and 2 from https://github.com/servo/servo/issues/24706#issuecomment-555491438
We send a message to constellation instead of creating the `WebGPU` thread on the start. We send back the result to script and set the `Window`'s `web_gpu` component there.
cc @jdm @imiklos 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/servo/25030)
<!-- Reviewable:end -->
