### PR TITLE
GStreamer plugin should use GLMemory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4788,6 +4788,7 @@ dependencies = [
  "gstreamer",
  "gstreamer-base",
  "gstreamer-gl",
+ "gstreamer-gl-sys",
  "gstreamer-video",
  "lazy_static",
  "libservo",

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -490,7 +490,9 @@ def windows_unit(cached=True):
             "mach smoketest --angle",
             "mach package --dev",
             "mach build --dev --libsimpleservo",
-            "mach build --dev -p servo-gst-plugin",
+            # We're getting link errors on windows, due to the x11 feature being
+            # enabled on gstreamer-gl. https://github.com/servo/media/pull/304/
+            "mach build --dev --media-stack=dummy -p servo-gst-plugin",
 
         )
         .with_artifacts("repo/target/debug/msi/Servo.exe",

--- a/ports/gstplugin/Cargo.toml
+++ b/ports/gstplugin/Cargo.toml
@@ -21,7 +21,8 @@ gleam = "0.6"
 glib = { version = "0.8", features = ["subclassing"] }
 gstreamer = { version = "0.14", features = ["subclassing"] }
 gstreamer-base = { version = "0.14", features = ["subclassing"] }
-gstreamer-gl = { version = "0.14", features = ["v1_16"] }
+gstreamer-gl = { version = "0.14" }
+gstreamer-gl-sys = { version = "0.8" }
 gstreamer-video = { version = "0.14", features = ["subclassing"] }
 log = "0.4"
 lazy_static = "1.4"

--- a/ports/gstplugin/README.md
+++ b/ports/gstplugin/README.md
@@ -24,18 +24,19 @@ To run locally:
 ```
 GST_PLUGIN_PATH=target/gstplugins \
   gst-launch-1.0 servosrc \
-    ! queue \
-    ! video/x-raw,framerate=25/1,width=512,height=512 \
-    ! videoflip video-direction=vert \
-    ! autovideosink
+    ! videorate \
+    ! video/x-raw\(memory:GLMemory\),framerate=50/1,width=1920,height=1080,format=RGBA \
+    ! glimagesink rotate-method=vertical-flip
 ```
+
+*Note*: the following don't work, for some reason the pipeline isn't providing GLMemory.
 
 To stream over the network:
 ```
-GST_PLUGIN_PATH=target/gstplugins \
   gst-launch-1.0 servosrc \
-    ! queue \
-    ! video/x-raw,framerate=25/1,width=512,height=512 \
+    ! videorate \
+    ! video/x-raw\(memory:GLMemory\),framerate=50/1,width=1920,height=1080,format=RGBA \
+    ! gldownload \
     ! videoconvert \
     ! videoflip video-direction=vert \
     ! theoraenc \
@@ -46,9 +47,9 @@ GST_PLUGIN_PATH=target/gstplugins \
 To  save to a file:
 ```
 GST_PLUGIN_PATH=target/gstplugins \
-  gst-launch-1.0 servosrc num-buffers=2000 \
-    ! queue \
-    ! video/x-raw,framerate=25/1,width=512,height=512 \
+    ! videorate \
+    ! video/x-raw\(memory:GLMemory\),framerate=50/1,width=1920,height=1080,format=RGBA \
+    ! gldownload \
     ! videoconvert \
     ! videoflip video-direction=vert \
     ! theoraenc \


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Get the gstreamer servosrc plugin to generate frames in GLMemory rather than main memory.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24831 
- [x] These changes do not require tests because it's an embedding perf issue

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
