### PR TITLE
Named form getter

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -143,12 +143,14 @@ use style::values::specified::Length;
 use tendril::fmt::UTF8;
 use tendril::stream::LossyDecoder;
 use tendril::{StrTendril, TendrilSink};
-use time::{Duration, Timespec};
+use time::{Duration, Timespec, Tm};
 use uuid::Uuid;
 use webgpu::{WebGPU, WebGPUAdapter};
 use webrender_api::{DocumentId, ImageKey, RenderApiSender};
 use webvr_traits::{WebVRGamepadData, WebVRGamepadHand, WebVRGamepadState};
 use webxr_api::SwapChainId as WebXRSwapChainId;
+
+unsafe_no_jsmanaged_fields!(Tm);
 
 /// A trait to allow tracing (only) DOM objects.
 pub unsafe trait JSTraceable {

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -274,7 +274,8 @@ impl HTMLFormElementMethods for HTMLFormElement {
                 .downcast::<HTMLElement>()
                 .map_or(false, |c| c.is_listed_element())
             {
-                if child.has_attribute(&local_name!("id")) ||
+                if (child.has_attribute(&local_name!("id")) &&
+                    child.get_string_attribute(&local_name!("id")) == name) ||
                     (child.has_attribute(&local_name!("name")) &&
                         child.get_string_attribute(&local_name!("name")) == name)
                 {
@@ -286,7 +287,8 @@ impl HTMLFormElementMethods for HTMLFormElement {
         if candidates.len() == 0 {
             for child in controls.iter() {
                 if child.is::<HTMLImageElement>() {
-                    if child.has_attribute(&local_name!("id")) ||
+                    if (child.has_attribute(&local_name!("id")) &&
+                        child.get_string_attribute(&local_name!("id")) == name) ||
                         (child.has_attribute(&local_name!("name")) &&
                             child.get_string_attribute(&local_name!("name")) == name)
                     {
@@ -459,13 +461,16 @@ impl HTMLFormElementMethods for HTMLFormElement {
         // Step 6
         sourcedNamesVec.retain(|sn| !sn.name.to_string().is_empty());
 
-        // Step 7
-        // Q1. Unable to clearly understand. It seems to contradict with step 4.
-
-        // Step 8
+        // Step 7-8
         let mut namesVec: Vec<DOMString> = Vec::new();
         for elem in sourcedNamesVec.iter() {
-            namesVec.push(elem.name.clone());
+            if namesVec
+                .iter()
+                .find(|name| name.to_string() == elem.name.to_string())
+                .is_none()
+            {
+                namesVec.push(elem.name.clone());
+            }
         }
 
         return namesVec;

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -256,18 +256,18 @@ impl HTMLFormElementMethods for HTMLFormElement {
         elements.IndexedGetter(index)
     }
 
+    // https://html.spec.whatwg.org/multipage/#the-form-element%3Adetermine-the-value-of-a-named-property
     fn NamedGetter(&self, name: DOMString) -> Option<RadioNodeListOrElement> {
         // return Option::Some::<RadioNodeListOrElement>;
         unimplemented!();
     }
 
-    // https://html.spec.whatwg.org/multipage/forms.html#the-form-element:supported-property-names
+    // https://html.spec.whatwg.org/multipage/#the-form-element:supported-property-names
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
-
         enum SourcedNameSource {
             Id,
             Name,
-            Past(std::time::Duration)
+            Past(std::time::Duration),
         }
 
         struct SourcedName {
@@ -285,16 +285,23 @@ impl HTMLFormElementMethods for HTMLFormElement {
         // controls - list of form elements
         // check all listed elements first, push to sourcedNamesVec as per spec
         for child in controls.iter() {
-
-            if child.is_html_element() { // if child.is_listed()
+            if child.is_html_element() {
+                // if child.is_listed()
 
                 if child.has_attribute(&local_name!("id")) {
                     // https://learning-rust.github.io/docs/b2.structs.html
-                    let entry = SourcedName {name: child.get_string_attribute(&local_name!("id")), element: child.root_element(), source: SourcedNameSource::Id};
+                    let entry = SourcedName {
+                        name: child.get_string_attribute(&local_name!("id")),
+                        element: child.root_element(),
+                        source: SourcedNameSource::Id,
+                    };
                     sourcedNamesVec.push(entry);
-                }
-                else if child.has_attribute(&local_name!("name")) {
-                    let entry = SourcedName {name: child.get_string_attribute(&local_name!("name")), element: child.root_element(), source: SourcedNameSource::Name};
+                } else if child.has_attribute(&local_name!("name")) {
+                    let entry = SourcedName {
+                        name: child.get_string_attribute(&local_name!("name")),
+                        element: child.root_element(),
+                        source: SourcedNameSource::Name,
+                    };
                     sourcedNamesVec.push(entry);
                 }
             }
@@ -307,14 +314,20 @@ impl HTMLFormElementMethods for HTMLFormElement {
 
             // https://users.rust-lang.org/t/how-check-type-of-variable/33845/7
             if child.is::<HTMLImageElement>() {
-
                 if child.has_attribute(&local_name!("id")) {
                     // https://learning-rust.github.io/docs/b2.structs.html
-                    let entry = SourcedName {name: child.get_string_attribute(&local_name!("id")), element: child.root_element(), source: SourcedNameSource::Id};
+                    let entry = SourcedName {
+                        name: child.get_string_attribute(&local_name!("id")),
+                        element: child.root_element(),
+                        source: SourcedNameSource::Id,
+                    };
                     sourcedNamesVec.push(entry);
-                }
-                else if child.has_attribute(&local_name!("name")) {
-                    let entry = SourcedName {name: child.get_string_attribute(&local_name!("name")), element: child.root_element(), source: SourcedNameSource::Name};
+                } else if child.has_attribute(&local_name!("name")) {
+                    let entry = SourcedName {
+                        name: child.get_string_attribute(&local_name!("name")),
+                        element: child.root_element(),
+                        source: SourcedNameSource::Name,
+                    };
                     sourcedNamesVec.push(entry);
                 }
             }

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -363,7 +363,8 @@ impl HTMLFormElementMethods for HTMLFormElement {
                         source: SourcedNameSource::Id,
                     };
                     sourcedNamesVec.push(entry);
-                } else if child.has_attribute(&local_name!("name")) {
+                }
+                if child.has_attribute(&local_name!("name")) {
                     let entry = SourcedName {
                         name: child.get_string_attribute(&local_name!("name")),
                         element: DomRoot::from_ref(&*child),
@@ -384,7 +385,8 @@ impl HTMLFormElementMethods for HTMLFormElement {
                         source: SourcedNameSource::Id,
                     };
                     sourcedNamesVec.push(entry);
-                } else if child.has_attribute(&local_name!("name")) {
+                }
+                if child.has_attribute(&local_name!("name")) {
                     let entry = SourcedName {
                         name: child.get_string_attribute(&local_name!("name")),
                         element: DomRoot::from_ref(&*child),
@@ -394,6 +396,28 @@ impl HTMLFormElementMethods for HTMLFormElement {
                 }
             }
         }
+
+        // Step 4
+        let past_names_map = self.past_names_map.borrow();
+        for (key, val) in past_names_map.iter() {
+            let entry = SourcedName {
+                name: key.clone(),
+                element: DomRoot::from_ref(&*val.0),
+                source: SourcedNameSource::Past(now()-val.1), // calculate difference now()-val.1 to find age
+            };
+            sourcedNamesVec.push(entry);
+        }
+
+        // Step 5
+        // TODO need to sort as per spec. This is a partially implemented function.
+        // Kindly guide us on how to refine this function further.
+        sourcedNamesVec.sort_by(|a, b| a.name.partial_cmp(&b.name).unwrap());
+
+        // Step 6
+        sourcedNamesVec.retain(|sn| !sn.name.to_string().is_empty());
+
+        // Step 7
+        // Q1. Unable to clearly understand. It seems to contradict with step 4.
 
         // Step 8
         let mut namesVec: Vec<DOMString> = Vec::new();

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -285,21 +285,21 @@ impl HTMLFormElementMethods for HTMLFormElement {
         // controls - list of form elements
         // check all listed elements first, push to sourcedNamesVec as per spec
         for child in controls.iter() {
-            if child.is_html_element() {
+            if child.downcast::<HTMLElement>().map_or(false, |c| c.is_listed_element()) {
                 // if child.is_listed()
 
                 if child.has_attribute(&local_name!("id")) {
                     // https://learning-rust.github.io/docs/b2.structs.html
                     let entry = SourcedName {
                         name: child.get_string_attribute(&local_name!("id")),
-                        element: child.root_element(),
+                        element: DomRoot::from_ref(&*child),
                         source: SourcedNameSource::Id,
                     };
                     sourcedNamesVec.push(entry);
                 } else if child.has_attribute(&local_name!("name")) {
                     let entry = SourcedName {
                         name: child.get_string_attribute(&local_name!("name")),
-                        element: child.root_element(),
+                        element: DomRoot::from_ref(&*child),
                         source: SourcedNameSource::Name,
                     };
                     sourcedNamesVec.push(entry);
@@ -318,14 +318,14 @@ impl HTMLFormElementMethods for HTMLFormElement {
                     // https://learning-rust.github.io/docs/b2.structs.html
                     let entry = SourcedName {
                         name: child.get_string_attribute(&local_name!("id")),
-                        element: child.root_element(),
+                        element: DomRoot::from_ref(&*child),
                         source: SourcedNameSource::Id,
                     };
                     sourcedNamesVec.push(entry);
                 } else if child.has_attribute(&local_name!("name")) {
                     let entry = SourcedName {
                         name: child.get_string_attribute(&local_name!("name")),
-                        element: child.root_element(),
+                        element: DomRoot::from_ref(&*child),
                         source: SourcedNameSource::Name,
                     };
                     sourcedNamesVec.push(entry);

--- a/components/script/dom/webidls/HTMLFormElement.webidl
+++ b/components/script/dom/webidls/HTMLFormElement.webidl
@@ -29,7 +29,7 @@ interface HTMLFormElement : HTMLElement {
   [SameObject] readonly attribute HTMLFormControlsCollection elements;
   readonly attribute unsigned long length;
   getter Element? (unsigned long index);
-  //getter (RadioNodeList or Element) (DOMString name);
+  getter (RadioNodeList or Element) (DOMString name);
 
   void submit();
   [CEReactions]

--- a/tests/wpt/metadata/html/semantics/forms/form-submission-0/form-double-submit-2.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/form-submission-0/form-double-submit-2.html.ini
@@ -1,5 +1,5 @@
 [form-double-submit-2.html]
-  expected: ERROR
+  expected: TIMEOUT
   [preventDefault should allow onclick submit() to succeed]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/html/semantics/forms/form-submission-0/form-double-submit.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/form-submission-0/form-double-submit.html.ini
@@ -1,5 +1,5 @@
 [form-double-submit.html]
-  expected: ERROR
+  expected: TIMEOUT
   [default submit action should supersede onclick submit()]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/forms/form-submission-0/form-submission-algorithm.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/form-submission-0/form-submission-algorithm.html.ini
@@ -17,3 +17,6 @@
   [firing an event named submit; form.requestSubmit()]
     expected: FAIL
 
+  [Cannot navigate (after constructing the entry list)]
+    expected: FAIL
+

--- a/tests/wpt/metadata/html/semantics/forms/the-fieldset-element/HTMLFieldSetElement.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-fieldset-element/HTMLFieldSetElement.html.ini
@@ -6,6 +6,3 @@
   [The elements must return an HTMLFormControlsCollection object]
     expected: FAIL
 
-  [The controls must root at the fieldset element]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/forms/the-form-element/form-nameditem.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-form-element/form-nameditem.html.ini
@@ -3,31 +3,16 @@
   [Name for a single element should work]
     expected: FAIL
 
-  [Calling item() on the NodeList returned from the named getter should work]
-    expected: FAIL
-
-  [Indexed getter on the NodeList returned from the named getter should work]
-    expected: FAIL
-
   [All listed elements except input type=image should be present in the form]
     expected: FAIL
 
   [Named elements should override builtins]
     expected: FAIL
 
-  [The form attribute should be taken into account for named getters (single element)]
-    expected: FAIL
-
   [The form attribute should be taken into account for named getters (multiple elements)]
     expected: FAIL
 
-  [Input should only be a named property on the innermost form that contains it]
-    expected: FAIL
-
   [Trying to set an expando that would shadow an already-existing named property]
-    expected: FAIL
-
-  [Trying to set an expando that shadows a named property that gets added later]
     expected: FAIL
 
   [Past names map should work correctly]


### PR DESCRIPTION
This PR contains changes related to adding named getter in Servo for getting the list of all meaningful property names for a HTMLFormElement object, and getting the value of a specific property name. The following changes have been made:

* uncomment the [named getter](https://github.com/servo/servo/blob/f63b404e0cbf30380c4043700861110d06e548bb/components/script/dom/webidls/HTMLFormElement.webidl#L30) from HTMLFormElement.webidl
* add the missing `NamedGetter` and `SupportedPropertyNames` methods to [HTMLFormElement](https://github.com/servo/servo/blob/f63b404e0cbf30380c4043700861110d06e548bb/components/script/dom/htmlformelement.rs#L113)
* implement `SupportedPropertyNames` according to [the specification](https://html.spec.whatwg.org/multipage/forms.html#the-form-element:supported-property-names):
  * create an enum to represent the `id`, `name`, and `past` states for the sourced names
  * create a vector of `(SourcedName, DomRoot<HTMLElement>)` by iterating over `self.controls` and checking the element type and calling methods like `HTMLElement::is_listed_element`
---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #16479 (GitHub issue number if applicable)