### PR TITLE
Increase parallelism in macOS WPT testing

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -664,8 +664,8 @@ def macos_wpt():
         macos_run_task,
         build_task,
         repo_dir="repo",
-        total_chunks=30,
-        processes=4,
+        total_chunks=20,
+        processes=8,
     )
 
 


### PR DESCRIPTION
… now that remaining dual-core workers have been upgraded to quad-cores.

Also reduces the number of WPT chunks since per-task overhead becomes more siginificant when tasks are becoming shorter.