### PR TITLE
Properly send TouchEvents to Servo

### DIFF
--- a/support/hololens/ServoApp/ServoControl/Servo.h
+++ b/support/hololens/ServoApp/ServoControl/Servo.h
@@ -62,6 +62,12 @@ public:
   void MouseUp(float x, float y, capi::CMouseButton b) {
     capi::mouse_up(x, y, b);
   }
+  void TouchDown(float x, float y, int32_t id) { capi::touch_down(x, y, id); }
+  void TouchUp(float x, float y, int32_t id) { capi::touch_up(x, y, id); }
+  void TouchMove(float x, float y, int32_t id) { capi::touch_move(x, y, id); }
+  void TouchCancel(float x, float y, int32_t id) {
+    capi::touch_cancel(x, y, id);
+  }
   void MouseMove(float x, float y) { capi::mouse_move(x, y); }
 
   void Reload() { capi::reload(); }

--- a/support/hololens/ServoApp/ServoControl/ServoControl.h
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.h
@@ -115,9 +115,17 @@ private:
 
   void OnSurfacePointerPressed(
       IInspectable const &,
-      Windows::UI::Xaml::Input::PointerRoutedEventArgs const &);
+      Windows::UI::Xaml::Input::PointerRoutedEventArgs const &, bool);
 
   void OnSurfacePointerCanceled(
+      IInspectable const &,
+      Windows::UI::Xaml::Input::PointerRoutedEventArgs const &);
+
+  void OnSurfacePointerExited(
+      IInspectable const &,
+      Windows::UI::Xaml::Input::PointerRoutedEventArgs const &);
+
+  void OnSurfacePointerLost(
       IInspectable const &,
       Windows::UI::Xaml::Input::PointerRoutedEventArgs const &);
 


### PR DESCRIPTION
This PR is based on #24778. It fixes some UWP platform weirdness (click not registering, and non-expected touch move events).