### PR TITLE
Fix Python Unicode error in './mach filter-intermittents'

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -563,12 +563,9 @@ class MachCommands(CommandBase):
             else:
                 actual_failures.append(failure["output"])
 
-        def format(outputs, description, file=None):
+        def format(outputs, description, file=sys.stdout):
             formatted = "%s %s:\n%s" % (len(outputs), description, "\n".join(outputs))
-            if file:
-                file.write(formatted.encode("utf-8"))
-            else:
-                print(formatted)
+            file.write(formatted.encode("utf-8"))
 
         if log_intermittents:
             with open(log_intermittents, "wb") as file:


### PR DESCRIPTION
Fix https://github.com/servo/servo/issues/25062

I’ve reproduced the error on my macbook, and this fixed it.