### PR TITLE
Use a glmemory bufferpool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4789,6 +4789,7 @@ dependencies = [
  "gstreamer-base",
  "gstreamer-gl",
  "gstreamer-gl-sys",
+ "gstreamer-sys",
  "gstreamer-video",
  "lazy_static",
  "libservo",

--- a/ports/gstplugin/Cargo.toml
+++ b/ports/gstplugin/Cargo.toml
@@ -23,6 +23,7 @@ gstreamer = { version = "0.14", features = ["subclassing"] }
 gstreamer-base = { version = "0.14", features = ["subclassing"] }
 gstreamer-gl = { version = "0.14" }
 gstreamer-gl-sys = { version = "0.8" }
+gstreamer-sys = { version = "0.8" }
 gstreamer-video = { version = "0.14", features = ["subclassing"] }
 log = "0.4"
 lazy_static = "1.4"

--- a/ports/gstplugin/README.md
+++ b/ports/gstplugin/README.md
@@ -29,15 +29,14 @@ GST_PLUGIN_PATH=target/gstplugins \
     ! glimagesink rotate-method=vertical-flip
 ```
 
-*Note*: the following don't work, for some reason the pipeline isn't providing GLMemory.
-
 To stream over the network:
 ```
+GST_PLUGIN_PATH=target/gstplugins \
   gst-launch-1.0 servosrc \
     ! videorate \
-    ! video/x-raw\(memory:GLMemory\),framerate=50/1,width=1920,height=1080,format=RGBA \
+    ! video/x-raw\(memory:GLMemory\),framerate=50/1,width=512,height=256 \
+    ! glcolorconvert \
     ! gldownload \
-    ! videoconvert \
     ! videoflip video-direction=vert \
     ! theoraenc \
     ! oggmux \
@@ -47,10 +46,11 @@ To stream over the network:
 To  save to a file:
 ```
 GST_PLUGIN_PATH=target/gstplugins \
+  gst-launch-1.0 servosrc \
     ! videorate \
-    ! video/x-raw\(memory:GLMemory\),framerate=50/1,width=1920,height=1080,format=RGBA \
+    ! video/x-raw\(memory:GLMemory\),framerate=50/1,width=512,height=256 \
+    ! glcolorconvert \
     ! gldownload \
-    ! videoconvert \
     ! videoflip video-direction=vert \
     ! theoraenc \
     ! oggmux \

--- a/ports/gstplugin/test.html
+++ b/ports/gstplugin/test.html
@@ -5,10 +5,11 @@
 <p>Start the video stream with:</p>
 
 <pre>
-  gst-launch-1.0 servosrc \
-    ! queue \
-    ! video/x-raw,framerate=25/1,width=512,height=512 \
-    ! videoconvert \
+  gst-launch-1.0 servosrc url=https://mrdoob.neocities.org/018/ \
+    ! videorate \
+    ! video/x-raw\(memory:GLMemory\),framerate=50/1,width=512,height=256 \
+    ! glcolorconvert \
+    ! gldownload \
     ! videoflip video-direction=vert \
     ! theoraenc \
     ! oggmux \


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This ensures the gstreamer plugin is always using GLMemory.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25121
- [x] These changes do not require tests because

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
