### PR TITLE
Support inline sessions (with spatial tracking!)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6391,7 +6391,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#e44552df536a6f424d58ccd068aa0301fee5fa1e"
+source = "git+https://github.com/servo/webxr#29f4f1f28695553c45d6c020172048c0035c49ed"
 dependencies = [
  "bindgen",
  "euclid",
@@ -6411,7 +6411,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#e44552df536a6f424d58ccd068aa0301fee5fa1e"
+source = "git+https://github.com/servo/webxr#29f4f1f28695553c45d6c020172048c0035c49ed"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -61,7 +61,7 @@ use cssparser::RGBA;
 use devtools_traits::{CSSError, TimelineMarkerType, WorkerId};
 use embedder_traits::{EventLoopWaker, MediaMetadata};
 use encoding_rs::{Decoder, Encoding};
-use euclid::default::{Point2D, Rect, Rotation3D, Transform2D, Transform3D};
+use euclid::default::{Point2D, Rect, Rotation3D, Transform2D};
 use euclid::Length as EuclidLength;
 use html5ever::buffer_queue::BufferQueue;
 use html5ever::{LocalName, Namespace, Prefix, QualName};
@@ -534,7 +534,7 @@ unsafe_no_jsmanaged_fields!(Mutex<MediaFrameRenderer>);
 unsafe_no_jsmanaged_fields!(ResourceFetchTiming);
 unsafe_no_jsmanaged_fields!(Timespec);
 unsafe_no_jsmanaged_fields!(HTMLMediaElementFetchContext);
-unsafe_no_jsmanaged_fields!(Rotation3D<f64>, Transform2D<f32>, Transform3D<f64>);
+unsafe_no_jsmanaged_fields!(Rotation3D<f64>, Transform2D<f32>);
 unsafe_no_jsmanaged_fields!(Point2D<f32>, Rect<Au>);
 unsafe_no_jsmanaged_fields!(Rect<f32>);
 unsafe_no_jsmanaged_fields!(CascadeData);
@@ -659,6 +659,20 @@ unsafe impl<T, U> JSTraceable for euclid::RigidTransform3D<f32, T, U> {
 }
 
 unsafe impl<T, U> JSTraceable for euclid::RigidTransform3D<f64, T, U> {
+    #[inline]
+    unsafe fn trace(&self, _trc: *mut JSTracer) {
+        // Do nothing
+    }
+}
+
+unsafe impl<T, U> JSTraceable for euclid::Transform3D<f32, T, U> {
+    #[inline]
+    unsafe fn trace(&self, _trc: *mut JSTracer) {
+        // Do nothing
+    }
+}
+
+unsafe impl<T, U> JSTraceable for euclid::Transform3D<f64, T, U> {
     #[inline]
     unsafe fn trace(&self, _trc: *mut JSTracer) {
         // Do nothing

--- a/components/script/dom/webidls/XRRenderState.webidl
+++ b/components/script/dom/webidls/XRRenderState.webidl
@@ -7,11 +7,13 @@
 dictionary XRRenderStateInit {
   double depthNear;
   double depthFar;
+  double inlineVerticalFieldOfView;
   XRWebGLLayer baseLayer;
 };
 
 [SecureContext, Exposed=Window, Pref="dom.webxr.enabled"] interface XRRenderState {
   readonly attribute double depthNear;
   readonly attribute double depthFar;
+  readonly attribute double inlineVerticalFieldOfView;
   readonly attribute XRWebGLLayer? baseLayer;
 };

--- a/components/script/dom/webidls/XRWebGLLayer.webidl
+++ b/components/script/dom/webidls/XRWebGLLayer.webidl
@@ -30,7 +30,7 @@ interface XRWebGLLayer {
   readonly attribute boolean stencil;
   readonly attribute boolean alpha;
 
-  readonly attribute WebGLFramebuffer framebuffer;
+  readonly attribute WebGLFramebuffer? framebuffer;
   readonly attribute unsigned long framebufferWidth;
   readonly attribute unsigned long framebufferHeight;
 

--- a/components/script/dom/xrrenderstate.rs
+++ b/components/script/dom/xrrenderstate.rs
@@ -17,6 +17,7 @@ pub struct XRRenderState {
     reflector_: Reflector,
     depth_near: Cell<f64>,
     depth_far: Cell<f64>,
+    inline_vertical_fov: Cell<f64>,
     layer: MutNullableDom<XRWebGLLayer>,
 }
 
@@ -24,12 +25,14 @@ impl XRRenderState {
     pub fn new_inherited(
         depth_near: f64,
         depth_far: f64,
+        inline_vertical_fov: f64,
         layer: Option<&XRWebGLLayer>,
     ) -> XRRenderState {
         XRRenderState {
             reflector_: Reflector::new(),
             depth_near: Cell::new(depth_near),
             depth_far: Cell::new(depth_far),
+            inline_vertical_fov: Cell::new(inline_vertical_fov),
             layer: MutNullableDom::new(layer),
         }
     }
@@ -38,10 +41,16 @@ impl XRRenderState {
         global: &GlobalScope,
         depth_near: f64,
         depth_far: f64,
+        inline_vertical_fov: f64,
         layer: Option<&XRWebGLLayer>,
     ) -> DomRoot<XRRenderState> {
         reflect_dom_object(
-            Box::new(XRRenderState::new_inherited(depth_near, depth_far, layer)),
+            Box::new(XRRenderState::new_inherited(
+                depth_near,
+                depth_far,
+                inline_vertical_fov,
+                layer,
+            )),
             global,
             XRRenderStateBinding::Wrap,
         )
@@ -52,6 +61,7 @@ impl XRRenderState {
             &self.global(),
             self.depth_near.get(),
             self.depth_far.get(),
+            self.inline_vertical_fov.get(),
             self.layer.get().as_ref().map(|x| &**x),
         )
     }
@@ -61,6 +71,9 @@ impl XRRenderState {
     }
     pub fn set_depth_far(&self, depth: f64) {
         self.depth_far.set(depth)
+    }
+    pub fn set_inline_vertical_fov(&self, fov: f64) {
+        self.inline_vertical_fov.set(fov)
     }
     pub fn set_layer(&self, layer: Option<&XRWebGLLayer>) {
         self.layer.set(layer)
@@ -76,6 +89,11 @@ impl XRRenderStateMethods for XRRenderState {
     /// https://immersive-web.github.io/webxr/#dom-xrrenderstate-depthfar
     fn DepthFar(&self) -> Finite<f64> {
         Finite::wrap(self.depth_far.get())
+    }
+
+    /// https://immersive-web.github.io/webxr/#dom-xrrenderstate-inlineverticalfieldofview
+    fn InlineVerticalFieldOfView(&self) -> Finite<f64> {
+        Finite::wrap(self.inline_vertical_fov.get())
     }
 
     /// https://immersive-web.github.io/webxr/#dom-xrrenderstate-baselayer

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -8,6 +8,7 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorBinding::NavigatorMethods;
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowBinding::WindowMethods;
+use crate::dom::bindings::codegen::Bindings::XRBinding::XRSessionMode;
 use crate::dom::bindings::codegen::Bindings::XRReferenceSpaceBinding::XRReferenceSpaceType;
 use crate::dom::bindings::codegen::Bindings::XRRenderStateBinding::XRRenderStateInit;
 use crate::dom::bindings::codegen::Bindings::XRRenderStateBinding::XRRenderStateMethods;
@@ -56,6 +57,7 @@ pub struct XRSession {
     eventtarget: EventTarget,
     base_layer: MutNullableDom<XRWebGLLayer>,
     blend_mode: XREnvironmentBlendMode,
+    mode: XRSessionMode,
     visibility_state: Cell<XRVisibilityState>,
     viewer_space: MutNullableDom<XRSpace>,
     #[ignore_malloc_size_of = "defined in webxr"]
@@ -85,11 +87,13 @@ impl XRSession {
         session: Session,
         render_state: &XRRenderState,
         input_sources: &XRInputSourceArray,
+        mode: XRSessionMode,
     ) -> XRSession {
         XRSession {
             eventtarget: EventTarget::new_inherited(),
             base_layer: Default::default(),
             blend_mode: session.environment_blend_mode().into(),
+            mode,
             visibility_state: Cell::new(XRVisibilityState::Visible),
             viewer_space: Default::default(),
             session: DomRefCell::new(session),
@@ -107,7 +111,7 @@ impl XRSession {
         }
     }
 
-    pub fn new(global: &GlobalScope, session: Session) -> DomRoot<XRSession> {
+    pub fn new(global: &GlobalScope, session: Session, mode: XRSessionMode) -> DomRoot<XRSession> {
         let render_state = XRRenderState::new(global, 0.1, 1000.0, None);
         let input_sources = XRInputSourceArray::new(global);
         let ret = reflect_dom_object(
@@ -115,6 +119,7 @@ impl XRSession {
                 session,
                 &render_state,
                 &input_sources,
+                mode,
             )),
             global,
             XRSessionBinding::Wrap,

--- a/components/script/dom/xrviewerpose.rs
+++ b/components/script/dom/xrviewerpose.rs
@@ -42,7 +42,13 @@ impl XRViewerPose {
     ) -> DomRoot<XRViewerPose> {
         rooted_vec!(let mut views);
         session.with_session(|s| match s.views() {
-            Views::Inline => unimplemented!(),
+            Views::Inline => views.push(XRView::new(
+                global,
+                session,
+                &session.inline_view(),
+                XREye::None,
+                &pose,
+            )),
             Views::Mono(view) => {
                 views.push(XRView::new(global, session, &view, XREye::None, &pose))
             },

--- a/components/script/dom/xrviewerpose.rs
+++ b/components/script/dom/xrviewerpose.rs
@@ -42,6 +42,7 @@ impl XRViewerPose {
     ) -> DomRoot<XRViewerPose> {
         rooted_vec!(let mut views);
         session.with_session(|s| match s.views() {
+            Views::Inline => unimplemented!(),
             Views::Mono(view) => {
                 views.push(XRView::new(global, session, &view, XREye::None, &pose))
             },

--- a/tests/wpt/metadata/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/metadata/webxr/idlharness.https.window.js.ini
@@ -107,9 +107,6 @@
   [XRReferenceSpace interface: attribute onreset]
     expected: FAIL
 
-  [XRRenderState interface: attribute inlineVerticalFieldOfView]
-    expected: FAIL
-
   [XRRay interface: attribute origin]
     expected: FAIL
 
@@ -169,3 +166,4 @@
 
   [WebGLRenderingContext includes WebGLRenderingContextBase: member names are unique]
     expected: FAIL
+

--- a/tests/wpt/metadata/webxr/xrDevice_requestSession_immersive.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrDevice_requestSession_immersive.https.html.ini
@@ -1,7 +1,0 @@
-[xrDevice_requestSession_immersive.https.html]
-  [Tests requestSession ignores unknown optionalFeatures]
-    expected: FAIL
-
-  [Tests requestSession accepts XRSessionInit dictionary]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webxr/xrDevice_requestSession_optionalFeatures.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrDevice_requestSession_optionalFeatures.https.html.ini
@@ -2,12 +2,3 @@
   [Tests requestSession ignores unknown optionalFeatures]
     expected: FAIL
 
-  [Tests requestSession accepts XRSessionInit dictionary with empty feature lists]
-    expected: FAIL
-
-  [Tests requestSession ignores unknown objects in optionalFeatures]
-    expected: FAIL
-
-  [Tests requestSession ignores unknown strings in optionalFeatures]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webxr/xrFrame_getPose.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrFrame_getPose.https.html.ini
@@ -1,4 +1,0 @@
-[xrFrame_getPose.https.html]
-  [XRFrame.getPose works for non-immersive sessions]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webxr/xrFrame_lifetime.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrFrame_lifetime.https.html.ini
@@ -1,4 +1,0 @@
-[xrFrame_lifetime.https.html]
-  [XRFrame methods throw exceptions outside of the requestAnimationFrame callback for non-immersive sessions]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webxr/xrSession_end.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_end.https.html.ini
@@ -1,4 +1,0 @@
-[xrSession_end.https.html]
-  [end event fires when non-immersive session ends]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webxr/xrSession_requestAnimationFrame_callback_calls.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_requestAnimationFrame_callback_calls.https.html.ini
@@ -1,4 +1,0 @@
-[xrSession_requestAnimationFrame_callback_calls.https.html]
-  [XRSession requestAnimationFrame calls the provided callback a non-immersive session]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webxr/xrSession_requestAnimationFrame_timestamp.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_requestAnimationFrame_timestamp.https.html.ini
@@ -1,7 +1,8 @@
 [xrSession_requestAnimationFrame_timestamp.https.html]
+  expected: TIMEOUT
   [XRFrame getViewerPose updates on the next frame for immersive]
     expected: FAIL
 
   [XRFrame getViewerPose updates on the next frame for non-immersive]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/webxr/xrSession_requestReferenceSpace_features.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_requestReferenceSpace_features.https.html.ini
@@ -1,34 +1,7 @@
 [xrSession_requestReferenceSpace_features.https.html]
-  [Non-immersive session rejects unbounded space even when requested]
-    expected: FAIL
-
-  [Immersive session supports local space by default]
-    expected: FAIL
-
-  [Non-immersive session supports local-floor space when required]
-    expected: FAIL
-
   [Immersive session rejects local-floor space if not requested]
     expected: FAIL
 
-  [Immersive session supports local-floor space when required]
-    expected: FAIL
-
-  [Non-immersive session rejects bounded-floor space even when requested]
-    expected: FAIL
-
-  [Non-immersive session supports local space when optional]
-    expected: FAIL
-
-  [Immersive session supports local-floor space when optional]
-    expected: FAIL
-
-  [Non-immersive session supports local space when required]
-    expected: FAIL
-
   [Non-immersive session rejects local space if not requested]
-    expected: FAIL
-
-  [Immersive session supports viewer space by default]
     expected: FAIL
 

--- a/tests/wpt/metadata/webxr/xrSession_viewer_referenceSpace.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_viewer_referenceSpace.https.html.ini
@@ -1,4 +1,0 @@
-[xrSession_viewer_referenceSpace.https.html]
-  [Identity reference space provides correct poses for immersive sessions]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webxr/xrView_eyes.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrView_eyes.https.html.ini
@@ -1,4 +1,0 @@
-[xrView_eyes.https.html]
-  [XRView.eye is correct for non-immersive sessions]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webxr/xrView_oneframeupdate.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrView_oneframeupdate.https.html.ini
@@ -1,5 +1,5 @@
 [xrView_oneframeupdate.https.html]
-  expected: ERROR
+  expected: TIMEOUT
   [XRView projection matrices update near and far depths on the next frame]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/webxr/xrView_oneframeupdate.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrView_oneframeupdate.https.html.ini
@@ -1,5 +1,4 @@
 [xrView_oneframeupdate.https.html]
-  expected: TIMEOUT
   [XRView projection matrices update near and far depths on the next frame]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/webxr/xrWebGLLayer_opaque_framebuffer.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrWebGLLayer_opaque_framebuffer.https.html.ini
@@ -1,4 +1,0 @@
-[xrWebGLLayer_opaque_framebuffer.https.html]
-  [Ensure that the framebuffer given by the WebGL layer is opaque for non-immersive]
-    expected: FAIL
-

--- a/tests/wpt/web-platform-tests/webxr/xrView_oneframeupdate.https.html
+++ b/tests/wpt/web-platform-tests/webxr/xrView_oneframeupdate.https.html
@@ -76,7 +76,7 @@ let testFunction = function(session, fakeDeviceController, t) {
         counter++;
       }
 
-      session.requestAnimationFrame(onFrame);
+      session.requestAnimationFrame(t.step_func(onFrame));
   }));
 };
 


### PR DESCRIPTION
This assumes that your WebXR backend can tolerate being spawned multiple times in inline mode. Currently there is only one backend that allows inline mode (headless), and it works there. This can be improved with https://github.com/servo/servo/issues/35499 .

Todo:

 - [ ] Add a default inline device to webxr so that there is always a tracking-free inline session available (followup: https://github.com/servo/servo/issues/35495)
 - [x] WPT update
 - [ ] Make inline with spatial tracking a feature request (followup: https://github.com/servo/servo/issues/24270)

fixes https://github.com/servo/servo/issues/24186

Depends on https://github.com/servo/webxr/pull/100