### PR TITLE
Fix intermittent android build error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4757,9 +4757,9 @@ dependencies = [
 
 [[package]]
 name = "servo-fontconfig-sys"
-version = "4.0.7"
+version = "4.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46d201addcfbd25c1798ad1281d98c40743824e0b0f1e611bd3d5d0d31a7b8d"
+checksum = "62b3e166450f523f4db06c14f02a2d39e76d49b5d8cbd224338d93e3595c156c"
 dependencies = [
  "expat-sys",
  "pkg-config",


### PR DESCRIPTION
Incorporates https://github.com/servo/libfontconfig/pull/42.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24715
- [x] There are tests for these changes