### PR TITLE
Fix "Tried to use SpatialId before it was defined" layout panic

### DIFF
--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -606,9 +606,15 @@ impl Fragment {
                 true
             },
             // FIXME: In the future, if #15144 is fixed we can remove this case. See #18510.
-            SpecificFragmentInfo::TruncatedFragment(ref mut info) => info
-                .full
-                .collect_stacking_contexts_for_blocklike_fragment(state),
+            SpecificFragmentInfo::TruncatedFragment(ref mut info) => {
+                let _ = info
+                    .full
+                    .collect_stacking_contexts_for_blocklike_fragment(state);
+                // To ensure the caller updates this fragment's stacking context
+                // appropriately based on the un-truncated fragment's status,
+                // we don't pass on the result of collecting stacking contexts.
+                false
+            },
             _ => false,
         }
     }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -7511,6 +7511,18 @@
      {}
     ]
    ],
+   "mozilla/text-overflow-ellipsis-stacking-context.html": [
+    [
+     "mozilla/text-overflow-ellipsis-stacking-context.html",
+     [
+      [
+       "/_mozilla/mozilla/text-overflow-ellipsis-stacking-context-ref.html",
+       "=="
+      ]
+     ],
+     {}
+    ]
+   ],
    "mozilla/textarea_placeholder.html": [
     [
      "mozilla/textarea_placeholder.html",
@@ -9731,6 +9743,9 @@
     []
    ],
    "mozilla/test.txt": [
+    []
+   ],
+   "mozilla/text-overflow-ellipsis-stacking-context-ref.html": [
     []
    ],
    "mozilla/textarea_placeholder_ref.html": [
@@ -19497,6 +19512,14 @@
   "mozilla/test.txt": [
    "9235007d960cc6c804a93c89f24881bedc3613c3",
    "support"
+  ],
+  "mozilla/text-overflow-ellipsis-stacking-context-ref.html": [
+   "14215e780ab4a0cf00ef23b8472636a393aeacf1",
+   "support"
+  ],
+  "mozilla/text-overflow-ellipsis-stacking-context.html": [
+   "791f028522972f0bffd31b6663369c896b39c088",
+   "reftest"
   ],
   "mozilla/textarea_placeholder.html": [
    "6dd1f1e1e0c8250532db1afc1f6b876bfa1b6f8c",

--- a/tests/wpt/mozilla/tests/mozilla/text-overflow-ellipsis-stacking-context-ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/text-overflow-ellipsis-stacking-context-ref.html
@@ -1,0 +1,1 @@
+This page should successfully load.<p><span style="padding-left: 1px">…</span>

--- a/tests/wpt/mozilla/tests/mozilla/text-overflow-ellipsis-stacking-context.html
+++ b/tests/wpt/mozilla/tests/mozilla/text-overflow-ellipsis-stacking-context.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<link rel="match" href="text-overflow-ellipsis-stacking-context-ref.html">
+<style>
+  .ellipsis-overflow {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: inline-block;
+      width: 10px;
+  }
+
+  .stacking-context {
+      transform: translateX(1px);
+      display: inline-block;
+      width: 1px;
+
+  }
+</style>
+This page should successfully load.<p>
+<div class="stacking-context">
+  <div class="ellipsis-overflow"></div>
+</div>


### PR DESCRIPTION
In the case where an element uses `text-overflow: ellipsis` and causes overflow, we create a TruncatedFragment that wraps the original overflowing fragment. When collecting stacking contexts for the truncated fragment, https://github.com/servo/servo/pull/18510 addressed the case where the wrapped fragment wouldn't be processed, but neglected the case where that fragment ends up creating a new stacking context. When that happens, the TruncatedFragment would be stuck with the updated scrolling/clipping information based on the new stacking context, but it would be a child of the parent stacking context. Since the new scrolling/clipping nodes do not exist in the display list until the new stacking context display item is created, this led to the observed panic.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24895 and fix #19281 and fix #22826. 
- [x] There are tests for these changes