### PR TITLE
implement composition event creation in Document.createEvent

### DIFF
--- a/components/script/dom/compositionevent.rs
+++ b/components/script/dom/compositionevent.rs
@@ -21,6 +21,21 @@ pub struct CompositionEvent {
 }
 
 impl CompositionEvent {
+    pub fn new_inherited() -> CompositionEvent {
+        CompositionEvent {
+            uievent: UIEvent::new_inherited(),
+            data: DOMString::new(),
+        }
+    }
+
+    pub fn new_uninitialized(window: &Window) -> DomRoot<CompositionEvent> {
+        reflect_dom_object(
+            Box::new(CompositionEvent::new_inherited()),
+            window,
+            CompositionEventBinding::Wrap,
+        )
+    }
+
     pub fn new(
         window: &Window,
         type_: DOMString,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3811,6 +3811,9 @@ impl DocumentMethods for Document {
             "beforeunloadevent" => Ok(DomRoot::upcast(BeforeUnloadEvent::new_uninitialized(
                 &self.window,
             ))),
+            "compositionevent" | "textevent" => Ok(DomRoot::upcast(
+                CompositionEvent::new_uninitialized(&self.window),
+            )),
             "closeevent" => Ok(DomRoot::upcast(CloseEvent::new_uninitialized(
                 self.window.upcast(),
             ))),

--- a/tests/wpt/metadata/dom/events/EventTarget-dispatchEvent.html.ini
+++ b/tests/wpt/metadata/dom/events/EventTarget-dispatchEvent.html.ini
@@ -3,9 +3,6 @@
   [If the event's initialized flag is not set, an InvalidStateError must be thrown (AnimationEvent).]
     expected: FAIL
 
-  [If the event's initialized flag is not set, an InvalidStateError must be thrown (CompositionEvent).]
-    expected: FAIL
-
   [If the event's initialized flag is not set, an InvalidStateError must be thrown (DeviceMotionEvent).]
     expected: FAIL
 
@@ -22,9 +19,6 @@
     expected: FAIL
 
   [If the event's initialized flag is not set, an InvalidStateError must be thrown (SVGZoomEvents).]
-    expected: FAIL
-
-  [If the event's initialized flag is not set, an InvalidStateError must be thrown (TextEvent).]
     expected: FAIL
 
   [If the event's initialized flag is not set, an InvalidStateError must be thrown (TrackEvent).]

--- a/tests/wpt/metadata/dom/nodes/Document-createEvent.https.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-createEvent.https.html.ini
@@ -1,10 +1,4 @@
 [Document-createEvent.https.html]
-  [createEvent('TextEvent') should be initialized correctly.]
-    expected: FAIL
-
-  [compositionevent should be an alias for CompositionEvent.]
-    expected: FAIL
-
   [createEvent('DRAGEVENT') should be initialized correctly.]
     expected: FAIL
 
@@ -20,12 +14,6 @@
   [Should throw NOT_SUPPORTED_ERR for non-legacy event interface "ProgressEvent"]
     expected: FAIL
 
-  [TEXTEVENT should be an alias for CompositionEvent.]
-    expected: FAIL
-
-  [createEvent('compositionevent') should be initialized correctly.]
-    expected: FAIL
-
   [devicemotionevent should be an alias for DeviceMotionEvent.]
     expected: FAIL
 
@@ -38,22 +26,10 @@
   [DRAGEVENT should be an alias for DragEvent.]
     expected: FAIL
 
-  [TextEvent should be an alias for CompositionEvent.]
-    expected: FAIL
-
-  [createEvent('COMPOSITIONEVENT') should be initialized correctly.]
-    expected: FAIL
-
   [DEVICEORIENTATIONEVENT should be an alias for DeviceOrientationEvent.]
     expected: FAIL
 
   [createEvent('dragevent') should be initialized correctly.]
-    expected: FAIL
-
-  [createEvent('textevent') should be initialized correctly.]
-    expected: FAIL
-
-  [CompositionEvent should be an alias for CompositionEvent.]
     expected: FAIL
 
   [createEvent('DEVICEMOTIONEVENT') should be initialized correctly.]
@@ -68,13 +44,7 @@
   [dragevent should be an alias for DragEvent.]
     expected: FAIL
 
-  [textevent should be an alias for CompositionEvent.]
-    expected: FAIL
-
   [Should throw NOT_SUPPORTED_ERR for non-legacy event interface "PopStateEvent"]
-    expected: FAIL
-
-  [createEvent('CompositionEvent') should be initialized correctly.]
     expected: FAIL
 
   [deviceorientationevent should be an alias for DeviceOrientationEvent.]
@@ -89,16 +59,10 @@
   [createEvent('DEVICEORIENTATIONEVENT') should be initialized correctly.]
     expected: FAIL
 
-  [createEvent('TEXTEVENT') should be initialized correctly.]
-    expected: FAIL
-
   [createEvent('DragEvent') should be initialized correctly.]
     expected: FAIL
 
   [Should throw NOT_SUPPORTED_ERR for non-legacy event interface "ErrorEvent"]
-    expected: FAIL
-
-  [COMPOSITIONEVENT should be an alias for CompositionEvent.]
     expected: FAIL
 
   [createEvent('deviceorientationevent') should be initialized correctly.]


### PR DESCRIPTION
Solved the problem mentioned in https://github.com/servo/servo/issues/24724#issuecomment-562326328

Add logic to create composition event for Document.createEvent. This resolved some WPT test failure, so updated the metadata as well

Ref: https://developer.mozilla.org/en-US/docs/Web/API/Document/createEvent


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
