### PR TITLE
Increase parallelism on Linux WPT testing

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -682,7 +682,7 @@ def linux_wpt_common(total_chunks, layout_2020):
     def linux_run_task(name):
         return linux_task(name).with_dockerfile(dockerfile_path("run")).with_repo_bundle()
     wpt_chunks("Linux x64", linux_run_task, release_build_task, repo_dir="/repo",
-               processes=12, total_chunks=total_chunks, layout_2020=layout_2020)
+               processes=20, total_chunks=total_chunks, layout_2020=layout_2020)
 
 
 def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,

--- a/tests/wpt/metadata/webdriver/tests/execute_script/cyclic.py.ini
+++ b/tests/wpt/metadata/webdriver/tests/execute_script/cyclic.py.ini
@@ -3,4 +3,5 @@
     expected: FAIL
 
   [test_element_in_collection]
-    expected: FAIL
+    expected:
+      if os == "mac": FAIL


### PR DESCRIPTION
The time taken by each chunk is uneven, with WPT-1 the longest before this change at 30 ~ 45 minutes. This reduces it to 15 ~ 20 minutes.

Surprisingly, increasing the number of processes seems to also make `test_element_in_collection` in `/webdriver/tests/execute_script/cyclic.py` **unexpectedly pass**. This happened reliably in three different runs:

https://community-tc.services.mozilla.com/tasks/S9O27WJvSa6j2PSjcRcbBA/runs/2