### PR TITLE
Add extra debug assertions for WebGL errors

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -680,10 +680,14 @@ impl WebGLThread {
             )
             .expect("Where's the GL data?");
 
+            // Ensure there are no pending GL errors from other parts of the pipeline.
+            debug_assert_eq!(data.gl.get_error(), gl::NO_ERROR);
+
             // Check to see if any of the current framebuffer bindings are the surface we're about
             // to swap out. If so, we'll have to reset them after destroying the surface.
             let framebuffer_rebinding_info =
                 FramebufferRebindingInfo::detect(&self.device, &data.ctx, &*data.gl);
+            debug_assert_eq!(data.gl.get_error(), gl::NO_ERROR);
 
             debug!("Getting swap chain for {:?}", swap_id);
             let swap_chain = match swap_id {
@@ -698,6 +702,7 @@ impl WebGLThread {
             swap_chain
                 .swap_buffers(&mut self.device, &mut data.ctx)
                 .unwrap();
+            debug_assert_eq!(data.gl.get_error(), gl::NO_ERROR);
 
             // TODO: if preserveDrawingBuffer is true, then blit the front buffer to the back buffer
             // https://github.com/servo/servo/issues/24604
@@ -705,10 +710,12 @@ impl WebGLThread {
             swap_chain
                 .clear_surface(&mut self.device, &mut data.ctx, &*data.gl)
                 .unwrap();
+            debug_assert_eq!(data.gl.get_error(), gl::NO_ERROR);
 
             // Rebind framebuffers as appropriate.
             debug!("Rebinding {:?}", swap_id);
             framebuffer_rebinding_info.apply(&self.device, &data.ctx, &*data.gl);
+            debug_assert_eq!(data.gl.get_error(), gl::NO_ERROR);
 
             let SurfaceInfo {
                 framebuffer_object,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Add some extra debug assertions checking for GL errors, so we'll get a bit more help tracking down issues like #24788 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
