### PR TITLE
Link to Gecko’s reftest analyzer

### DIFF
--- a/tests/wpt/README.md
+++ b/tests/wpt/README.md
@@ -189,10 +189,11 @@ with the `--log-raw` option e.g.
     ./mach test-wpt --log-raw wpt.log
 
 This file can then be fed into the
-[reftest analyzer](http://hoppipolla.co.uk/410/reftest-analyser-structured.xhtml)
+[reftest analyzer](https://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer-structured.xhtml)
 which will show all failing tests (not just those with unexpected results).
-Note that this ingests logs in a different format to original version of the
-tool written for gecko reftests.
+Note that this ingests logs in a different format to [original version of the
+tool](https://hg.mozilla.org/mozilla-central/raw-file/tip/layout/tools/reftest/reftest-analyzer.xhtml)
+written for gecko reftests.
 
 The reftest analyzer allows pixel-level comparison of the test and reference
 screenshots. Tests that both fail and have an unexpected result are marked


### PR DESCRIPTION
http://hoppipolla.co.uk/410/reftest-analyser-structured.xhtml seems to be gone