### PR TITLE
hidden field named _charset_ now appears in FormData as UTF-8

### DIFF
--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -55,7 +55,7 @@ impl FormData {
         form: Option<&HTMLFormElement>,
     ) -> Fallible<DomRoot<FormData>> {
         if let Some(opt_form) = form {
-            return match opt_form.get_form_dataset(None) {
+            return match opt_form.get_form_dataset(None, None) {
                 Some(form_datums) => Ok(FormData::new(Some(form_datums), global)),
                 None => Err(Error::InvalidState),
             };

--- a/tests/wpt/metadata/html/semantics/forms/form-submission-0/constructing-form-data-set.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/form-submission-0/constructing-form-data-set.html.ini
@@ -1,7 +1,4 @@
 [constructing-form-data-set.html]
-  [FormData constructor always produces UTF-8 _charset_ value.]
-    expected: FAIL
-
   [_charset_ control sets the expected encoding name.]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
HTMLInputElement now has special case logic for putting a hidden field named `_charset_` in an entry set. To support this, the encoding used when constructing a form dataset is now being passed further down the callchain than it was before.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25150

<!-- Either: -->
- [X] There are tests for these changes 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
