### PR TITLE
Rename the ServoSrc type to ServoGstSrc to avoid a name clash

### DIFF
--- a/ports/gstplugin/lib.rs
+++ b/ports/gstplugin/lib.rs
@@ -4,7 +4,7 @@
 
 use glib::subclass::types::ObjectSubclass;
 use gstreamer::gst_plugin_define;
-use servosrc::ServoSrc;
+use servosrc::ServoGstSrc;
 
 mod logging;
 mod resources;
@@ -35,6 +35,6 @@ fn plugin_init(plugin: &gstreamer::Plugin) -> Result<(), glib::BoolError> {
         Some(plugin),
         "servosrc",
         gstreamer::Rank::None,
-        ServoSrc::get_type(),
+        ServoGstSrc::get_type(),
     )
 }

--- a/ports/gstplugin/servosrc.rs
+++ b/ports/gstplugin/servosrc.rs
@@ -92,7 +92,7 @@ use std::rc::Rc;
 use std::sync::Mutex;
 use std::thread;
 
-pub struct ServoSrc {
+pub struct ServoGstSrc {
     sender: Sender<ServoSrcMsg>,
     swap_chain: SwapChain,
     url: Mutex<Option<String>>,
@@ -420,8 +420,8 @@ const CAPS: &str = "video/x-raw(memory:GLMemory),
   height=[1,2147483647],
   framerate=[0/1,2147483647/1]";
 
-impl ObjectSubclass for ServoSrc {
-    const NAME: &'static str = "ServoSrc";
+impl ObjectSubclass for ServoGstSrc {
+    const NAME: &'static str = "ServoGstSrc";
     // gstreamer-gl doesn't have support for GLBaseSrc yet
     // https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/issues/219
     type ParentType = BaseSrc;
@@ -464,7 +464,7 @@ impl ObjectSubclass for ServoSrc {
     glib_object_subclass!();
 }
 
-impl ObjectImpl for ServoSrc {
+impl ObjectImpl for ServoGstSrc {
     glib_object_impl!();
 
     fn constructed(&self, obj: &glib::Object) {
@@ -499,12 +499,12 @@ impl ObjectImpl for ServoSrc {
     }
 }
 
-impl ElementImpl for ServoSrc {}
+impl ElementImpl for ServoGstSrc {}
 
 thread_local! {
     static GL: RefCell<Option<Rc<Gl>>> = RefCell::new(None);
 }
-impl BaseSrcImpl for ServoSrc {
+impl BaseSrcImpl for ServoGstSrc {
     fn set_caps(&self, src: &BaseSrc, outcaps: &Caps) -> Result<(), LoggableError> {
         // Save the video info for later use
         let info = VideoInfo::from_caps(outcaps)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

There's a name clash with the type name `ServoSrc`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25051 
- [x] These changes do not require tests because

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
