### PR TITLE
Workarounds for form-submission-0 tests with about:blank onloads

### DIFF
--- a/tests/wpt/metadata/html/semantics/forms/form-submission-0/constructing-form-data-set.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/form-submission-0/constructing-form-data-set.html.ini
@@ -1,6 +1,3 @@
 [constructing-form-data-set.html]
-  [_charset_ control sets the expected encoding name.]
-    expected: FAIL
-
   [The button cannot be setted if it is not a submitter.]
     expected: FAIL

--- a/tests/wpt/metadata/html/semantics/forms/form-submission-0/form-submission-algorithm.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/form-submission-0/form-submission-algorithm.html.ini
@@ -1,7 +1,4 @@
 [form-submission-algorithm.html]
-  [If form's firing submission events is true, then return; 'submit' event]
-    expected: FAIL
-
   [If form's firing submission events is true, then return; 'invalid' event]
     expected: FAIL
 

--- a/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-0/constructing-form-data-set.html
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-0/constructing-form-data-set.html
@@ -34,11 +34,13 @@ test(() => {
 }, 'FormData constructor always produces UTF-8 _charset_ value.');
 
 async_test(t => {
-  frame1.onload = t.step_func_done(() => {
-    assert_not_equals(frame1.contentDocument.URL.indexOf('_charset_=windows-1252'), -1);
+  frame1.onload = t.step_func(() => {
+    if (frame1.contentWindow.location.href == "about:blank") { return; }
+    assert_not_equals(frame1.contentDocument.URL.indexOf('_charset_=windows-1252'), -1,"should see _charset_=windows-1252 in "+frame1.contentDocument.URL);
+    t.done();
   });
   form1.submit();
-}, '_charset_ control sets the expected encoding name.');
+},'_charset_ control sets the expected encoding name.');
 
 async_test(t => {
   frame2.onload = t.step_func_done(() => {

--- a/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-0/form-submission-algorithm.html
+++ b/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-0/form-submission-algorithm.html
@@ -60,8 +60,12 @@ async_test(t => {
   };
   submitter1.click();
   // We actually submit the form in order to check which 'click()' submits it.
-  iframe.onload = t.step_func_done(() => {
+  iframe.onload = t.step_func(() => {
+    // The initial about:blank load event can be fired before the form navigation occurs.
+    // See https://github.com/whatwg/html/issues/490 for more information.
+    if(iframe.contentWindow.location.href == "about:blank") { return; }
     assert_not_equals(iframe.contentWindow.location.search.indexOf('n=i'), -1);
+    t.done();
   });
 }, "If form's firing submission events is true, then return; 'submit' event");
 
@@ -127,9 +131,13 @@ async_test(t => {
   // Request to load '/common/dummy.xhtml', and immediately submit the form to
   // the same frame. If the form submission is aborted, the first request
   // will be completed.
-  iframe.onload = t.step_func_done(() => {
+  // This may be complicated by loads of the initial about:blank;
+  // we need to ignore them and only look at a load that isn't about:blank.
+  iframe.onload = t.step_func(() => {
+    if(iframe.contentWindow.location=="about:blank") { return; }
     wasLoaded = true;
     assert_true(iframe.contentWindow.location.search.indexOf('n1=v1') == -1);
+    t.done();
   });
   iframe.src = '/common/dummy.xhtml';
   assert_false(wasLoaded, 'Make sure the first loading is ongoing.');


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Following the model of https://github.com/servo/servo/commit/3b9ab3460029b15fc0979883fa8523443851f713 these changes replace some naive onload events with equivalents that do nothing if they see an about:blank load event. Two test cases now pass, and one failing test case is now failing for a less ambiguous reason (#25154) 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25151 and fix #25152.

<!-- Either: -->
- [X] These changes do not require tests because these are fixes to tests only, not code changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
