### PR TITLE
Remove unnecessary thread in filereader, add stream TODO

### DIFF
--- a/components/script/task_source/file_reading.rs
+++ b/components/script/task_source/file_reading.rs
@@ -8,7 +8,6 @@ use crate::script_runtime::{CommonScriptMsg, ScriptChan, ScriptThreadEventCatego
 use crate::task::{TaskCanceller, TaskOnce};
 use crate::task_source::{TaskSource, TaskSourceName};
 use msg::constellation_msg::PipelineId;
-use std::sync::Arc;
 
 #[derive(JSTraceable)]
 pub struct FileReadingTaskSource(pub Box<dyn ScriptChan + Send + 'static>, pub PipelineId);
@@ -46,7 +45,7 @@ pub enum FileReadingTask {
     ProcessRead(TrustedFileReader, GenerationId),
     ProcessReadData(TrustedFileReader, GenerationId),
     ProcessReadError(TrustedFileReader, GenerationId, DOMErrorName),
-    ProcessReadEOF(TrustedFileReader, GenerationId, ReadMetaData, Arc<Vec<u8>>),
+    ProcessReadEOF(TrustedFileReader, GenerationId, ReadMetaData, Vec<u8>),
 }
 
 impl FileReadingTask {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

I think there are no benefits to queuing the various `FileReadingTask` from a thread, and reading the actual blob bytes are still done on the main-thread. We could try to move the reading off the main-thread(but note the `Blob` is not something you would want to move to another thread "as-is" since it's a `DomObject`), and I think we should just aim for implementing streams and follow the spec instead. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
