### PR TITLE
Make `mach test-tidy --no-wpt` compatible with Python3

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -3943,8 +3943,8 @@ class CGMemberJITInfo(CGThing):
                 depth=self.descriptor.interface.inheritanceDepth(),
                 opType=opType,
                 aliasSet=aliasSet,
-                returnType=reduce(CGMemberJITInfo.getSingleReturnType, returnTypes,
-                                  ""),
+                returnType=functools.reduce(CGMemberJITInfo.getSingleReturnType, returnTypes,
+                                            ""),
                 isInfallible=toStringBool(infallible),
                 isMovable=toStringBool(movable),
                 # FIXME(nox): https://github.com/servo/servo/issues/10991
@@ -4131,8 +4131,8 @@ class CGMemberJITInfo(CGThing):
             if u.hasNullableType:
                 # Might be null or not
                 return "JSVAL_TYPE_UNKNOWN"
-            return reduce(CGMemberJITInfo.getSingleReturnType,
-                          u.flatMemberTypes, "")
+            return functools.reduce(CGMemberJITInfo.getSingleReturnType,
+                                    u.flatMemberTypes, "")
         if t.isDictionary():
             return "JSVAL_TYPE_OBJECT"
         if t.isDate():
@@ -4202,8 +4202,8 @@ class CGMemberJITInfo(CGThing):
         if t.isUnion():
             u = t.unroll()
             type = "JSJitInfo::Null as i32" if u.hasNullableType else ""
-            return reduce(CGMemberJITInfo.getSingleArgType,
-                          u.flatMemberTypes, type)
+            return functools.reduce(CGMemberJITInfo.getSingleArgType,
+                                    u.flatMemberTypes, type)
         if t.isDictionary():
             return "JSJitInfo_ArgType::Object as i32"
         if t.isDate():
@@ -5858,7 +5858,7 @@ class CGInterfaceTrait(CGThing):
         def contains_unsafe_arg(arguments):
             if not arguments or len(arguments) == 0:
                 return False
-            return reduce((lambda x, y: x or y[1] == '*mut JSContext'), arguments, False)
+            return functools.reduce((lambda x, y: x or y[1] == '*mut JSContext'), arguments, False)
 
         methods = []
         for name, arguments, rettype in members():

--- a/components/script/dom/bindings/codegen/Configuration.py
+++ b/components/script/dom/bindings/codegen/Configuration.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import functools
 import os
 
 from WebIDL import IDLExternalInterface, IDLSequenceType, IDLWrapperType, WebIDLError
@@ -15,7 +16,7 @@ class Configuration:
     def __init__(self, filename, parseData):
         # Read the configuration file.
         glbl = {}
-        execfile(filename, glbl)
+        exec(compile(open(filename).read(), filename, 'exec'), glbl)
         config = glbl['DOMInterfaces']
 
         # Build descriptors for all the interfaces we have in the parse data.
@@ -62,7 +63,8 @@ class Configuration:
                           c.isCallback() and not c.isInterface()]
 
         # Keep the descriptor list sorted for determinism.
-        self.descriptors.sort(lambda x, y: cmp(x.name, y.name))
+        cmp = lambda x, y: (x > y) - (x < y)
+        self.descriptors.sort(key=functools.cmp_to_key(lambda x, y: cmp(x.name, y.name)))
 
     def getInterface(self, ifname):
         return self.interfaces[ifname]

--- a/etc/ci/performance/test_differ.py
+++ b/etc/ci/performance/test_differ.py
@@ -54,9 +54,9 @@ for key in keys:
     value1 = data1.get(key)
     value2 = data2.get(key)
     if value1 and not(value2):
-        print ("{}Test {}: missing from {}.{}".format(WARNING, key, args.file2, END))
+        print("{}Test {}: missing from {}.{}".format(WARNING, key, args.file2, END))
     elif value2 and not(value1):
-        print ("{}Test {}: missing from {}.{}".format(WARNING, key, args.file1, END))
+        print("{}Test {}: missing from {}.{}".format(WARNING, key, args.file1, END))
     elif value1 and value2:
         total1 += value1
         total2 += value2

--- a/etc/memory_reports_over_time.py
+++ b/etc/memory_reports_over_time.py
@@ -69,7 +69,7 @@ def transform_report_for_test(report):
     while remaining:
         (name, value) = remaining.pop()
         transformed[name] = '%s %s' % (value['amount'], value['unit'])
-        remaining += map(lambda (k, v): (name + '/' + k, v), list(value['children'].items()))
+        remaining += map(lambda k_v: (name + '/' + k_v[0], k_v[1]), list(value['children'].items()))
     return transformed
 
 

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -205,6 +205,7 @@ def linux_tidy_unit():
         .with_treeherder("Linux x64", "Tidy+Unit")
         .with_script("""
             ./mach test-tidy --no-progress --all
+            python3 ./mach test-tidy --no-progress --all --no-wpt
             python3 ./mach build --dev
             python3 ./mach test-unit
             python3 ./mach package --dev

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -635,7 +635,7 @@ class MachCommands(CommandBase):
         opts = ["-Ztimings=info"] + opts
 
         if very_verbose:
-            print (["Calling", "cargo", "build"] + opts)
+            print(["Calling", "cargo", "build"] + opts)
             for key in env:
                 print((key, env[key]))
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -627,7 +627,7 @@ install them, let us know by filing a bug!")
     def build_env(self, hosts_file_path=None, target=None, is_build=False, test_unit=False, uwp=False, features=None):
         """Return an extended environment dictionary."""
         env = os.environ.copy()
-        if sys.platform == "win32" and type(env['PATH']) == unicode:
+        if sys.platform == "win32" and type(env['PATH']) == six.text_type:
             # On win32, the virtualenv's activate_this.py script sometimes ends up
             # turning os.environ['PATH'] into a unicode string.  This doesn't work
             # for passing env vars in to a process, so we force it back to ascii.

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -776,7 +776,7 @@ class MachCommands(CommandBase):
 def setup_clangfmt(env):
     cmd = "clang-format.exe" if sys.platform == "win32" else "clang-format"
     try:
-        version = check_output([cmd, "--version"], env=env).rstrip()
+        version = check_output([cmd, "--version"], env=env, universal_newlines=True).rstrip()
         print(version)
         if not version.startswith("clang-format version {}.".format(CLANGFMT_VERSION)):
             print("clang-format: wrong version (v{} required). Skipping CPP formatting.".format(CLANGFMT_VERSION))
@@ -785,7 +785,7 @@ def setup_clangfmt(env):
         print("clang-format not installed. Skipping CPP formatting.")
         return False, None, None
     gitcmd = ['git', 'ls-files']
-    gitfiles = check_output(gitcmd + CLANGFMT_CPP_DIRS).splitlines()
+    gitfiles = check_output(gitcmd + CLANGFMT_CPP_DIRS, universal_newlines=True).splitlines()
     filtered = [line for line in gitfiles if line.endswith(".h") or line.endswith(".cpp")]
     return True, cmd, filtered
 

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -700,20 +700,20 @@ class MachCommands(CommandBase):
             width_col4 = max([len(str(x)) for x in result['Difference(%)']])
 
             for p, q, r, s in zip(['Test'], ['First Run'], ['Second Run'], ['Difference(%)']):
-                print ("\033[1m" + "{}|{}|{}|{}".format(p.ljust(width_col1), q.ljust(width_col2), r.ljust(width_col3),
-                       s.ljust(width_col4)) + "\033[0m" + "\n" + "--------------------------------------------------"
-                       + "-------------------------------------------------------------------------")
+                print("\033[1m" + "{}|{}|{}|{}".format(p.ljust(width_col1), q.ljust(width_col2), r.ljust(width_col3),
+                      s.ljust(width_col4)) + "\033[0m" + "\n" + "--------------------------------------------------"
+                      + "-------------------------------------------------------------------------")
 
             for a1, b1, c1, d1 in zip(result['Test'], result['Prev_Time'], result['Cur_Time'], result['Difference(%)']):
                 if d1 > 0:
-                    print ("\033[91m" + "{}|{}|{}|{}".format(a1.ljust(width_col1),
-                           str(b1).ljust(width_col2), str(c1).ljust(width_col3), str(d1).ljust(width_col4)) + "\033[0m")
+                    print("\033[91m" + "{}|{}|{}|{}".format(a1.ljust(width_col1),
+                          str(b1).ljust(width_col2), str(c1).ljust(width_col3), str(d1).ljust(width_col4)) + "\033[0m")
                 elif d1 < 0:
-                    print ("\033[92m" + "{}|{}|{}|{}".format(a1.ljust(width_col1),
-                           str(b1).ljust(width_col2), str(c1).ljust(width_col3), str(d1).ljust(width_col4)) + "\033[0m")
+                    print("\033[92m" + "{}|{}|{}|{}".format(a1.ljust(width_col1),
+                          str(b1).ljust(width_col2), str(c1).ljust(width_col3), str(d1).ljust(width_col4)) + "\033[0m")
                 else:
-                    print ("{}|{}|{}|{}".format(a1.ljust(width_col1), str(b1).ljust(width_col2),
-                           str(c1).ljust(width_col3), str(d1).ljust(width_col4)))
+                    print("{}|{}|{}|{}".format(a1.ljust(width_col1), str(b1).ljust(width_col2),
+                          str(c1).ljust(width_col3), str(d1).ljust(width_col4)))
 
     def jquery_test_runner(self, cmd, release, dev):
         self.ensure_bootstrapped()

--- a/tests/heartbeats/characterize.py
+++ b/tests/heartbeats/characterize.py
@@ -4,6 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from __future__ import print_function
+
 import sys
 import os
 from os import path
@@ -12,6 +14,7 @@ import datetime
 import argparse
 import platform
 import subprocess
+import six
 
 TOP_DIR = path.join("..", "..")
 GUARD_TIME = 10
@@ -133,7 +136,7 @@ def execute(base_dir, build_target, renderer, page, profile, trial, layout_threa
     log_dir = path.join(base_dir, "logs_l" + str(layout_thread_count),
                         "trial_" + str(trial))
     if os.path.exists(log_dir):
-        print "Log directory already exists: " + log_dir
+        print("Log directory already exists: " + log_dir)
         sys.exit(1)
     os.makedirs(log_dir)
 
@@ -142,16 +145,16 @@ def execute(base_dir, build_target, renderer, page, profile, trial, layout_threa
 
     # Execute
     start_energy_reader()
-    print 'sleep ' + str(GUARD_TIME)
+    print('sleep ' + str(GUARD_TIME))
     time.sleep(GUARD_TIME)
     time_start = time.time()
     energy_start = read_energy()
-    print cmd
+    print(cmd)
     os.system(cmd)
     energy_end = read_energy()
     time_end = time.time()
     stop_energy_reader()
-    print 'sleep ' + str(GUARD_TIME)
+    print('sleep ' + str(GUARD_TIME))
     time.sleep(GUARD_TIME)
 
     uj = energy_end - energy_start
@@ -172,11 +175,11 @@ def execute(base_dir, build_target, renderer, page, profile, trial, layout_threa
         f.write("\nPower (W): " + str(watts))
 
 
-def characterize(build_target, base_dir, (min_layout_threads, max_layout_threads), renderer, page, profile, trials):
+def characterize(build_target, base_dir, layout_threads_limits, renderer, page, profile, trials):
     """Run all configurations and capture results.
     """
-    for layout_thread_count in xrange(min_layout_threads, max_layout_threads + 1):
-        for trial in xrange(1, trials + 1):
+    for layout_thread_count in six.moves.xrange(layout_threads_limits[0], layout_threads_limits[1] + 1):
+        for trial in six.moves.xrange(1, trials + 1):
             execute(base_dir, build_target, renderer, page, profile, trial, layout_thread_count)
 
 
@@ -250,7 +253,7 @@ def main():
         trials = args.trials
 
     if os.path.exists(output_dir):
-        print "Output directory already exists: " + output_dir
+        print("Output directory already exists: " + output_dir)
         sys.exit(1)
     os.makedirs(output_dir)
 

--- a/tests/heartbeats/characterize_android.py
+++ b/tests/heartbeats/characterize_android.py
@@ -4,6 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from __future__ import print_function
+
 import sys
 import os
 from os import path
@@ -43,15 +45,15 @@ def execute(base_dir, renderer, page, profile, trial, layout_thread_count):
     log_dir = path.join(base_dir, "logs_l" + str(layout_thread_count),
                         "trial_" + str(trial))
     if os.path.exists(log_dir):
-        print "Log directory already exists: " + log_dir
+        print("Log directory already exists: " + log_dir)
         sys.exit(1)
     os.makedirs(log_dir)
 
     # Execute
     cmd = get_command(layout_thread_count, renderer, page, profile)
-    print cmd
+    print(cmd)
     os.system(cmd)
-    print 'sleep ' + str(GUARD_TIME)
+    print('sleep ' + str(GUARD_TIME))
     time.sleep(GUARD_TIME)
 
     # Write a file that describes this execution
@@ -109,7 +111,7 @@ def main():
         profile = args.profile
 
     if os.path.exists(output_dir):
-        print "Output directory already exists: " + output_dir
+        print("Output directory already exists: " + output_dir)
         sys.exit(1)
     os.makedirs(output_dir)
 

--- a/tests/heartbeats/process_logs.py
+++ b/tests/heartbeats/process_logs.py
@@ -4,11 +4,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from __future__ import print_function
+
 import argparse
 import matplotlib.pyplot as plt
 import numpy as np
 import os
 from os import path
+import six
 import sys
 import warnings
 
@@ -196,7 +199,7 @@ def plot_trial_time_series(config, trial, trial_data, max_end_time, max_power, o
 
     i = 10
     for (p, ts, te, es, ee) in trial_data:
-        xranges = [(ts[j] / 1000000.0, (te[j] - ts[j]) / 1000000.0) for j in xrange(len(ts))]
+        xranges = [(ts[j] / 1000000.0, (te[j] - ts[j]) / 1000000.0) for j in six.moves.xrange(len(ts))]
         ax1.broken_barh(xranges, (i - 0.5 * width, width))
         i += 10
     # place a vbar at the final time for this trial
@@ -385,20 +388,20 @@ def main():
         android = args.android
 
     if not os.path.exists(directory):
-        print "Input directory does not exist: " + directory
+        print("Input directory does not exist: " + directory)
         sys.exit(1)
 
     if os.path.exists(output_dir):
-        print "Output directory already exists: " + output_dir
+        print("Output directory already exists: " + output_dir)
         sys.exit(1)
 
     res = process_logs(directory)
 
     if not android:
         best = find_best_executions(directory)
-        print 'Best time:', best[0]
-        print 'Best energy:', best[1]
-        print 'Best power:', best[2]
+        print('Best time:', best[0])
+        print('Best energy:', best[1])
+        print('Best power:', best[2])
 
     os.makedirs(output_dir)
     plot_all_raw_totals(res, output_dir)


### PR DESCRIPTION
Make `mach test-tidy --no-wpt` compatible with Python3
See also #23607

After this pull request, all python files (except WPT) will be checked for Python3 syntax compatibility.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
