### PR TITLE
Took out the special mouseover cancel case

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -227,14 +227,13 @@ impl CompiledEventListener {
                             rooted!(in(*cx) let value = value);
                             let value = value.handle();
 
-                            //Step 4
-                            let should_cancel = match event.type_() {
-                                atom!("mouseover") => {
-                                    value.is_boolean() && value.to_boolean() == true
-                                },
-                                _ => value.is_boolean() && value.to_boolean() == false,
-                            };
+                            //Step 5
+                            let should_cancel = value.is_boolean() && value.to_boolean() == false;
+
                             if should_cancel {
+                                // spec says to set the cancelled flag directly
+                                // here, not just to prevent default;
+                                // can that ever make a difference?
                                 event.PreventDefault();
                             }
                         }

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -231,7 +231,7 @@ impl CompiledEventListener {
                             let should_cancel = value.is_boolean() && value.to_boolean() == false;
 
                             if should_cancel {
-                                // spec says to set the cancelled flag directly
+                                // FIXME: spec says to set the cancelled flag directly
                                 // here, not just to prevent default;
                                 // can that ever make a difference?
                                 event.PreventDefault();

--- a/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-processing-algorithm.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-processing-algorithm.html.ini
@@ -3,16 +3,3 @@
   [beforeunload listener returning null cancels event]
     bug: https://github.com/servo/servo/issues/10787
     expected: FAIL
-
-  [mouseover listener returning false cancels event (using Event)]
-    expected: FAIL
-
-  [mouseover listener returning false cancels event (using MouseEvent)]
-    expected: FAIL
-
-  [mouseover listener returning true doesn't cancel event (using Event)]
-    expected: FAIL
-
-  [mouseover listener returning true doesn't cancel event (using MouseEvent)]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
eventtarget.rs was checking the event type to see if it was a mouseover; now it doesn't. Other special-case events like error and beforeunload go down other code paths entirely, so this one has no special cases left.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25190

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
