### PR TITLE
Block the gstreamer plugin waiting for the next frame

### DIFF
--- a/ports/gstplugin/README.md
+++ b/ports/gstplugin/README.md
@@ -24,7 +24,6 @@ To run locally:
 ```
 GST_PLUGIN_PATH=target/gstplugins \
   gst-launch-1.0 servowebsrc \
-    ! videorate \
     ! video/x-raw\(memory:GLMemory\),framerate=50/1,width=1920,height=1080,format=RGBA \
     ! glimagesink rotate-method=vertical-flip
 ```
@@ -33,7 +32,6 @@ To stream over the network:
 ```
 GST_PLUGIN_PATH=target/gstplugins \
   gst-launch-1.0 servowebsrc \
-    ! videorate \
     ! video/x-raw\(memory:GLMemory\),framerate=50/1,width=512,height=256 \
     ! glcolorconvert \
     ! gldownload \
@@ -47,7 +45,6 @@ To  save to a file:
 ```
 GST_PLUGIN_PATH=target/gstplugins \
   gst-launch-1.0 servowebsrc \
-    ! videorate \
     ! video/x-raw\(memory:GLMemory\),framerate=50/1,width=512,height=256 \
     ! glcolorconvert \
     ! gldownload \
@@ -126,7 +123,6 @@ GST_PLUGIN_SCANNER=$PWD/support/linux/gstreamer/gst/libexec/gstreamer-1.0/gst-pl
 LD_LIBRARY_PATH=$PWD/support/linux/gstreamer/gst/lib \
 LD_PRELOAD=$PWD/target/gstplugins/libgstservoplugin.so \
   gst-launch-1.0 servowebsrc \
-    ! queue \
     ! videoflip video-direction=vert \
     ! ximagesink
 ```


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Get the GStreamer plugin to produce frames at the requested rate rather than relying on downstream elements to perform throttling.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24833 
- [x] These changes do not require tests because 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
