### PR TITLE
mach clean now finds the right virtualenv to remove

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -756,7 +756,8 @@ class MachCommands(CommandBase):
     def clean(self, manifest_path=None, params=[], verbose=False):
         self.ensure_bootstrapped()
 
-        virtualenv_path = path.join(self.get_top_dir(), 'python', '_virtualenv')
+        virtualenv_fname = '_virtualenv%d.%d' % (sys.version_info[0], sys.version_info[1])
+        virtualenv_path = path.join(self.get_top_dir(), 'python', virtualenv_fname)
         if path.exists(virtualenv_path):
             print('Removing virtualenv directory: %s' % virtualenv_path)
             shutil.rmtree(virtualenv_path)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
mach clean now knows about the https://github.com/servo/servo/commit/00cf7452ef2bcb272dafb09a711301a2ef280ae2 change and will remove _virtualenv2.7 appropriately

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix problems discussed today with SimonSapin in IRC

<!-- Either: -->
- [X] These changes do not require tests because the functionality being changed uninstalls some of the test framework

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
