### PR TITLE
Workaround for #24984 - Solve crashes when panicking / Hang Monitoring by using cargo's patch mechanism to work around a bug in libbacktrace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,9 +206,8 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"
+version = "0.3.40"
+source = "git+https://github.com/MeFisto94/backtrace-rs?branch=fix-strtab-freeing-crash#91a0aa4a5d649151878cddd883b92ba7057ca41c"
 dependencies = [
  "backtrace-sys",
  "cfg-if",
@@ -218,9 +217,8 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
+version = "0.1.32"
+source = "git+https://github.com/MeFisto94/backtrace-rs?branch=fix-strtab-freeing-crash#91a0aa4a5d649151878cddd883b92ba7057ca41c"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ mio = { git = "https://github.com/servo/mio.git", branch = "servo" }
 # https://github.com/retep998/winapi-rs/pull/816
 winapi = { git = "https://github.com/servo/winapi-rs", branch = "patch-1" }
 spirv_cross = { git = "https://github.com/kvark/spirv_cross", branch = "wgpu" }
+backtrace = { git = "https://github.com/MeFisto94/backtrace-rs", branch = "fix-strtab-freeing-crash" }


### PR DESCRIPTION
Temporarly patch backtrace-rs

---
libbacktrace contains an error leading to invalid pointers when trying to backtrace a stacktrace.
These invalid pointers led to a crash, whenever a panic or Hang Monitoring happened (which is where the stack is captured).
Since fixing the issue properly at gcc will require some time, I've created a small and patched version of backtrace-rs, which will be used as patch here.

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #24984 
- [X] These changes do not require tests because they fix a native crash which is a) really obvious and b) shouldn't be a regular case.
