### PR TITLE
Throwing errors on event compilation, without panics and at least sometimes test-passingly

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -553,8 +553,8 @@ impl EventTarget {
             // Step 3.7
             unsafe {
                 let _ac = JSAutoRealm::new(*cx, self.reflector().get_jsobject().get());
-                // FIXME(#13152): dispatch error event.
-                report_pending_exception(*cx, false);
+                // FIXME(#13152): this might not be timed correctly
+                report_pending_exception(*cx, true);
             }
             return None;
         }

--- a/components/script/dom/htmlframesetelement.rs
+++ b/components/script/dom/htmlframesetelement.rs
@@ -2,13 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLFrameSetElementBinding;
 use crate::dom::bindings::codegen::Bindings::HTMLFrameSetElementBinding::HTMLFrameSetElementMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
+use crate::dom::element::AttributeMutation;
+use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlelement::HTMLElement;
-use crate::dom::node::{document_from_node, Node};
+use crate::dom::node::{document_from_node, window_from_node, Node};
+use crate::dom::virtualmethods::VirtualMethods;
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix};
 
@@ -47,4 +53,35 @@ impl HTMLFrameSetElement {
 impl HTMLFrameSetElementMethods for HTMLFrameSetElement {
     // https://html.spec.whatwg.org/multipage/#windoweventhandlers
     window_event_handlers!(ForwardToWindow);
+}
+
+impl VirtualMethods for HTMLFrameSetElement {
+    fn super_type(&self) -> Option<&dyn VirtualMethods> {
+        Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
+    }
+
+    fn attribute_mutated(&self, attr: &Attr, mutation: AttributeMutation) {
+        use crate::dom::macros::BODY_FRAMESET_EVENT_HANDLERS;
+        match (attr.local_name(), mutation) {
+            (name, AttributeMutation::Set(_)) if name.starts_with("on") => {
+                // https://html.spec.whatwg.org/multipage/
+                // #event-handlers-on-elements,-document-objects,-and-window-objects:event-handlers-3
+                if BODY_FRAMESET_EVENT_HANDLERS.contains(name) {
+                    let window = window_from_node(self);
+                    let evtarget = window.upcast::<EventTarget>(); // forwarded event
+                    let source_line = 1; //TODO(#9604) obtain current JS execution line
+                    evtarget.set_event_handler_uncompiled(
+                        window.get_url(),
+                        source_line,
+                        &name[2..],
+                        DOMString::from((**attr.value()).to_owned()),
+                    );
+                    // No need to call supertype mutation checks; we're done
+                    return;
+                }
+            },
+            _ => (),
+        };
+        self.super_type().unwrap().attribute_mutated(attr, mutation);
+    }
 }

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -428,152 +428,184 @@ macro_rules! window_owned_beforeunload_event_handler(
 // https://html.spec.whatwg.org/multipage/#globaleventhandlers
 // see webidls/EventHandler.webidl
 // As more methods get added, just update them here.
-macro_rules! global_event_handlers(
-    () => (
-        // These are special when on body/frameset elements
-        event_handler!(blur, GetOnblur, SetOnblur);
-        error_event_handler!(error, GetOnerror, SetOnerror);
-        event_handler!(focus, GetOnfocus, SetOnfocus);
-        event_handler!(load, GetOnload, SetOnload);
-        event_handler!(resize, GetOnresize, SetOnresize);
-        event_handler!(scroll, GetOnscroll, SetOnscroll);
-        global_event_handlers!(NoOnload);
-
-    );
-    (NoOnload) => (
-        event_handler!(abort, GetOnabort, SetOnabort);
-        event_handler!(cancel, GetOncancel, SetOncancel);
-        event_handler!(canplay, GetOncanplay, SetOncanplay);
-        event_handler!(canplaythrough, GetOncanplaythrough, SetOncanplaythrough);
-        event_handler!(change, GetOnchange, SetOnchange);
-        event_handler!(click, GetOnclick, SetOnclick);
-        event_handler!(close, GetOnclose, SetOnclose);
-        event_handler!(contextmenu, GetOncontextmenu, SetOncontextmenu);
-        event_handler!(cuechange, GetOncuechange, SetOncuechange);
-        event_handler!(dblclick, GetOndblclick, SetOndblclick);
-        event_handler!(drag, GetOndrag, SetOndrag);
-        event_handler!(dragend, GetOndragend, SetOndragend);
-        event_handler!(dragenter, GetOndragenter, SetOndragenter);
-        event_handler!(dragexit, GetOndragexit, SetOndragexit);
-        event_handler!(dragleave, GetOndragleave, SetOndragleave);
-        event_handler!(dragover, GetOndragover, SetOndragover);
-        event_handler!(dragstart, GetOndragstart, SetOndragstart);
-        event_handler!(drop, GetOndrop, SetOndrop);
-        event_handler!(durationchange, GetOndurationchange, SetOndurationchange);
-        event_handler!(emptied, GetOnemptied, SetOnemptied);
-        event_handler!(ended, GetOnended, SetOnended);
-        event_handler!(formdata, GetOnformdata, SetOnformdata);
-        event_handler!(input, GetOninput, SetOninput);
-        event_handler!(invalid, GetOninvalid, SetOninvalid);
-        event_handler!(keydown, GetOnkeydown, SetOnkeydown);
-        event_handler!(keypress, GetOnkeypress, SetOnkeypress);
-        event_handler!(keyup, GetOnkeyup, SetOnkeyup);
-        event_handler!(loadeddata, GetOnloadeddata, SetOnloadeddata);
-        event_handler!(loadedmetadata, GetOnloadedmetadata, SetOnloadedmetadata);
-        event_handler!(loadstart, GetOnloadstart, SetOnloadstart);
-        event_handler!(mousedown, GetOnmousedown, SetOnmousedown);
-        event_handler!(mouseenter, GetOnmouseenter, SetOnmouseenter);
-        event_handler!(mouseleave, GetOnmouseleave, SetOnmouseleave);
-        event_handler!(mousemove, GetOnmousemove, SetOnmousemove);
-        event_handler!(mouseout, GetOnmouseout, SetOnmouseout);
-        event_handler!(mouseover, GetOnmouseover, SetOnmouseover);
-        event_handler!(mouseup, GetOnmouseup, SetOnmouseup);
-        event_handler!(wheel, GetOnwheel, SetOnwheel);
-        event_handler!(pause, GetOnpause, SetOnpause);
-        event_handler!(play, GetOnplay, SetOnplay);
-        event_handler!(playing, GetOnplaying, SetOnplaying);
-        event_handler!(progress, GetOnprogress, SetOnprogress);
-        event_handler!(ratechange, GetOnratechange, SetOnratechange);
-        event_handler!(reset, GetOnreset, SetOnreset);
-        event_handler!(seeked, GetOnseeked, SetOnseeked);
-        event_handler!(seeking, GetOnseeking, SetOnseeking);
-        event_handler!(select, GetOnselect, SetOnselect);
-        event_handler!(selectionchange, GetOnselectionchange, SetOnselectionchange);
-        event_handler!(selectstart, GetOnselectstart, SetOnselectstart);
-        event_handler!(show, GetOnshow, SetOnshow);
-        event_handler!(stalled, GetOnstalled, SetOnstalled);
-        event_handler!(submit, GetOnsubmit, SetOnsubmit);
-        event_handler!(suspend, GetOnsuspend, SetOnsuspend);
-        event_handler!(timeupdate, GetOntimeupdate, SetOntimeupdate);
-        event_handler!(toggle, GetOntoggle, SetOntoggle);
-        event_handler!(transitionend, GetOntransitionend, SetOntransitionend);
-        event_handler!(volumechange, GetOnvolumechange, SetOnvolumechange);
-        event_handler!(waiting, GetOnwaiting, SetOnwaiting);
-    )
-);
+macro_rules! global_event_handlers_list{
+    ($macro:ident) => {
+        global_event_handlers_list!($macro @
+            // These are special when on body/frameset elements
+            (blur, GetOnblur, SetOnblur, event_handler;
+            error, GetOnerror, SetOnerror, error_event_handler;
+            focus, GetOnfocus, SetOnfocus, event_handler;
+            load, GetOnload, SetOnload, event_handler;
+            resize, GetOnresize, SetOnresize, event_handler;
+            scroll, GetOnscroll, SetOnscroll, event_handler;)
+        );
+    };
+    ($macro:ident, NoOnload) => {
+        global_event_handlers_list!($macro @ ());
+    };
+    ($macro:ident @ ($($tt:tt)*)) => {
+        $macro![
+            abort, GetOnabort, SetOnabort, event_handler;
+            cancel, GetOncancel, SetOncancel, event_handler;
+            canplay, GetOncanplay, SetOncanplay, event_handler;
+            canplaythrough, GetOncanplaythrough, SetOncanplaythrough, event_handler;
+            change, GetOnchange, SetOnchange, event_handler;
+            click, GetOnclick, SetOnclick, event_handler;
+            close, GetOnclose, SetOnclose, event_handler;
+            contextmenu, GetOncontextmenu, SetOncontextmenu, event_handler;
+            cuechange, GetOncuechange, SetOncuechange, event_handler;
+            dblclick, GetOndblclick, SetOndblclick, event_handler;
+            drag, GetOndrag, SetOndrag, event_handler;
+            dragend, GetOndragend, SetOndragend, event_handler;
+            dragenter, GetOndragenter, SetOndragenter, event_handler;
+            dragexit, GetOndragexit, SetOndragexit, event_handler;
+            dragleave, GetOndragleave, SetOndragleave, event_handler;
+            dragover, GetOndragover, SetOndragover, event_handler;
+            dragstart, GetOndragstart, SetOndragstart, event_handler;
+            drop, GetOndrop, SetOndrop, event_handler;
+            durationchange, GetOndurationchange, SetOndurationchange, event_handler;
+            emptied, GetOnemptied, SetOnemptied, event_handler;
+            ended, GetOnended, SetOnended, event_handler;
+            formdata, GetOnformdata, SetOnformdata, event_handler;
+            input, GetOninput, SetOninput, event_handler;
+            invalid, GetOninvalid, SetOninvalid, event_handler;
+            keydown, GetOnkeydown, SetOnkeydown, event_handler;
+            keypress, GetOnkeypress, SetOnkeypress, event_handler;
+            keyup, GetOnkeyup, SetOnkeyup, event_handler;
+            loadeddata, GetOnloadeddata, SetOnloadeddata, event_handler;
+            loadedmetadata, GetOnloadedmetadata, SetOnloadedmetadata, event_handler;
+            loadstart, GetOnloadstart, SetOnloadstart, event_handler;
+            mousedown, GetOnmousedown, SetOnmousedown, event_handler;
+            mouseenter, GetOnmouseenter, SetOnmouseenter, event_handler;
+            mouseleave, GetOnmouseleave, SetOnmouseleave, event_handler;
+            mousemove, GetOnmousemove, SetOnmousemove, event_handler;
+            mouseout, GetOnmouseout, SetOnmouseout, event_handler;
+            mouseover, GetOnmouseover, SetOnmouseover, event_handler;
+            mouseup, GetOnmouseup, SetOnmouseup, event_handler;
+            wheel, GetOnwheel, SetOnwheel, event_handler;
+            pause, GetOnpause, SetOnpause, event_handler;
+            play, GetOnplay, SetOnplay, event_handler;
+            playing, GetOnplaying, SetOnplaying, event_handler;
+            progress, GetOnprogress, SetOnprogress, event_handler;
+            ratechange, GetOnratechange, SetOnratechange, event_handler;
+            reset, GetOnreset, SetOnreset, event_handler;
+            seeked, GetOnseeked, SetOnseeked, event_handler;
+            seeking, GetOnseeking, SetOnseeking, event_handler;
+            select, GetOnselect, SetOnselect, event_handler;
+            selectionchange, GetOnselectionchange, SetOnselectionchange, event_handler;
+            selectstart, GetOnselectstart, SetOnselectstart, event_handler;
+            show, GetOnshow, SetOnshow, event_handler;
+            stalled, GetOnstalled, SetOnstalled, event_handler;
+            submit, GetOnsubmit, SetOnsubmit, event_handler;
+            suspend, GetOnsuspend, SetOnsuspend, event_handler;
+            timeupdate, GetOntimeupdate, SetOntimeupdate, event_handler;
+            toggle, GetOntoggle, SetOntoggle, event_handler;
+            transitionend, GetOntransitionend, SetOntransitionend, event_handler;
+            volumechange, GetOnvolumechange, SetOnvolumechange, event_handler;
+            waiting, GetOnwaiting, SetOnwaiting, event_handler;
+            $($tt)*
+        ];
+    }
+}
 
 // https://html.spec.whatwg.org/multipage/#windoweventhandlers
 // see webidls/EventHandler.webidl
 // As more methods get added, just update them here.
-macro_rules! window_event_handlers(
-    () => (
-        event_handler!(afterprint, GetOnafterprint, SetOnafterprint);
-        event_handler!(beforeprint, GetOnbeforeprint, SetOnbeforeprint);
-        beforeunload_event_handler!(beforeunload, GetOnbeforeunload,
-                                    SetOnbeforeunload);
-        event_handler!(hashchange, GetOnhashchange, SetOnhashchange);
-        event_handler!(languagechange, GetOnlanguagechange,
-                       SetOnlanguagechange);
-        event_handler!(message, GetOnmessage, SetOnmessage);
-        event_handler!(messageerror, GetOnmessageerror, SetOnmessageerror);
-        event_handler!(offline, GetOnoffline, SetOnoffline);
-        event_handler!(online, GetOnonline, SetOnonline);
-        event_handler!(pagehide, GetOnpagehide, SetOnpagehide);
-        event_handler!(pageshow, GetOnpageshow, SetOnpageshow);
-        event_handler!(popstate, GetOnpopstate, SetOnpopstate);
-        event_handler!(rejectionhandled, GetOnrejectionhandled,
-                       SetOnrejectionhandled);
-        event_handler!(storage, GetOnstorage, SetOnstorage);
-        event_handler!(unhandledrejection, GetOnunhandledrejection,
-                       SetOnunhandledrejection);
-        event_handler!(unload, GetOnunload, SetOnunload);
-        event_handler!(vrdisplayconnect, GetOnvrdisplayconnect, SetOnvrdisplayconnect);
-        event_handler!(vrdisplaydisconnect, GetOnvrdisplaydisconnect, SetOnvrdisplaydisconnect);
-        event_handler!(vrdisplayactivate, GetOnvrdisplayactivate, SetOnvrdisplayactivate);
-        event_handler!(vrdisplaydeactivate, GetOnvrdisplaydeactivate, SetOnvrdisplaydeactivate);
-        event_handler!(vrdisplayblur, GetOnvrdisplayblur, SetOnvrdisplayblur);
-        event_handler!(vrdisplayfocus, GetOnvrdisplayfocus, SetOnvrdisplayfocus);
-        event_handler!(vrdisplaypresentchange, GetOnvrdisplaypresentchange, SetOnvrdisplaypresentchange);
+macro_rules! window_event_handlers_list(
+    ($macro:ident) => (
+        $macro![
+            afterprint, GetOnafterprint, SetOnafterprint, event_handler;
+            beforeprint, GetOnbeforeprint, SetOnbeforeprint, event_handler;
+            beforeunload, GetOnbeforeunload, SetOnbeforeunload, beforeunload_event_handler;
+            hashchange, GetOnhashchange, SetOnhashchange, event_handler;
+            languagechange, GetOnlanguagechange, SetOnlanguagechange, event_handler;
+            message, GetOnmessage, SetOnmessage, event_handler;
+            messageerror, GetOnmessageerror, SetOnmessageerror, event_handler;
+            offline, GetOnoffline, SetOnoffline, event_handler;
+            online, GetOnonline, SetOnonline, event_handler;
+            pagehide, GetOnpagehide, SetOnpagehide, event_handler;
+            pageshow, GetOnpageshow, SetOnpageshow, event_handler;
+            popstate, GetOnpopstate, SetOnpopstate, event_handler;
+            rejectionhandled, GetOnrejectionhandled, SetOnrejectionhandled, event_handler;
+            storage, GetOnstorage, SetOnstorage, event_handler;
+            unhandledrejection, GetOnunhandledrejection, SetOnunhandledrejection, event_handler;
+            unload, GetOnunload, SetOnunload, event_handler;
+            vrdisplayconnect, GetOnvrdisplayconnect, SetOnvrdisplayconnect, event_handler;
+            vrdisplaydisconnect, GetOnvrdisplaydisconnect, SetOnvrdisplaydisconnect, event_handler;
+            vrdisplayactivate, GetOnvrdisplayactivate, SetOnvrdisplayactivate, event_handler;
+            vrdisplaydeactivate, GetOnvrdisplaydeactivate, SetOnvrdisplaydeactivate, event_handler;
+            vrdisplayblur, GetOnvrdisplayblur, SetOnvrdisplayblur, event_handler;
+            vrdisplayfocus, GetOnvrdisplayfocus, SetOnvrdisplayfocus, event_handler;
+            vrdisplaypresentchange, GetOnvrdisplaypresentchange, SetOnvrdisplaypresentchange, event_handler;
+        ];
     );
-    (ForwardToWindow) => (
-        window_owned_event_handler!(afterprint, GetOnafterprint,
-                                    SetOnafterprint);
-        window_owned_event_handler!(beforeprint, GetOnbeforeprint,
-                                    SetOnbeforeprint);
-        window_owned_beforeunload_event_handler!(beforeunload,
-                                                 GetOnbeforeunload,
-                                                 SetOnbeforeunload);
-        window_owned_event_handler!(hashchange, GetOnhashchange,
-                                    SetOnhashchange);
-        window_owned_event_handler!(languagechange, GetOnlanguagechange,
-                                    SetOnlanguagechange);
-        window_owned_event_handler!(message, GetOnmessage, SetOnmessage);
-        window_owned_event_handler!(messageerror, GetOnmessageerror, SetOnmessageerror);
-        window_owned_event_handler!(offline, GetOnoffline, SetOnoffline);
-        window_owned_event_handler!(online, GetOnonline, SetOnonline);
-        window_owned_event_handler!(pagehide, GetOnpagehide, SetOnpagehide);
-        window_owned_event_handler!(pageshow, GetOnpageshow, SetOnpageshow);
-        window_owned_event_handler!(popstate, GetOnpopstate, SetOnpopstate);
-        window_owned_event_handler!(rejectionhandled, GetOnrejectionhandled,
-                                    SetOnrejectionhandled);
-        window_owned_event_handler!(storage, GetOnstorage, SetOnstorage);
-        window_owned_event_handler!(unhandledrejection, GetOnunhandledrejection,
-                                    SetOnunhandledrejection);
-        window_owned_event_handler!(unload, GetOnunload, SetOnunload);
-
-        window_owned_event_handler!(vrdisplayconnect, GetOnvrdisplayconnect, SetOnvrdisplayconnect);
-        window_owned_event_handler!(vrdisplaydisconnect, GetOnvrdisplaydisconnect, SetOnvrdisplaydisconnect);
-        window_owned_event_handler!(vrdisplayactivate, GetOnvrdisplayactivate, SetOnvrdisplayactivate);
-        window_owned_event_handler!(vrdisplaydeactivate, GetOnvrdisplaydeactivate, SetOnvrdisplaydeactivate);
-        window_owned_event_handler!(vrdisplayblur, GetOnvrdisplayblur, SetOnvrdisplayblur);
-        window_owned_event_handler!(vrdisplayfocus, GetOnvrdisplayfocus, SetOnvrdisplayfocus);
-        window_owned_event_handler!(vrdisplaypresentchange, GetOnvrdisplaypresentchange, SetOnvrdisplaypresentchange);
+    ($macro:ident, ForwardToWindow) => (
+        $macro![
+            afterprint, GetOnafterprint, SetOnafterprint, window_owned_event_handler;
+            beforeprint, GetOnbeforeprint, SetOnbeforeprint, window_owned_event_handler;
+            beforeunload, GetOnbeforeunload, SetOnbeforeunload, window_owned_beforeunload_event_handler;
+            hashchange, GetOnhashchange, SetOnhashchange, window_owned_event_handler;
+            languagechange, GetOnlanguagechange, SetOnlanguagechange, window_owned_event_handler;
+            message, GetOnmessage, SetOnmessage, window_owned_event_handler;
+            messageerror, GetOnmessageerror, SetOnmessageerror, window_owned_event_handler;
+            offline, GetOnoffline, SetOnoffline, window_owned_event_handler;
+            online, GetOnonline, SetOnonline, window_owned_event_handler;
+            pagehide, GetOnpagehide, SetOnpagehide, window_owned_event_handler;
+            pageshow, GetOnpageshow, SetOnpageshow, window_owned_event_handler;
+            popstate, GetOnpopstate, SetOnpopstate, window_owned_event_handler;
+            rejectionhandled, GetOnrejectionhandled, SetOnrejectionhandled, window_owned_event_handler;
+            storage, GetOnstorage, SetOnstorage, window_owned_event_handler;
+            unhandledrejection, GetOnunhandledrejection, SetOnunhandledrejection, window_owned_event_handler;
+            unload, GetOnunload, SetOnunload, window_owned_event_handler;
+            vrdisplayconnect, GetOnvrdisplayconnect, SetOnvrdisplayconnect, window_owned_event_handler;
+            vrdisplaydisconnect, GetOnvrdisplaydisconnect, SetOnvrdisplaydisconnect, window_owned_event_handler;
+            vrdisplayactivate, GetOnvrdisplayactivate, SetOnvrdisplayactivate, window_owned_event_handler;
+            vrdisplaydeactivate, GetOnvrdisplaydeactivate, SetOnvrdisplaydeactivate, window_owned_event_handler;
+            vrdisplayblur, GetOnvrdisplayblur, SetOnvrdisplayblur, window_owned_event_handler;
+            vrdisplayfocus, GetOnvrdisplayfocus, SetOnvrdisplayfocus, window_owned_event_handler;
+            vrdisplaypresentchange, GetOnvrdisplaypresentchange,
+                SetOnvrdisplaypresentchange, window_owned_event_handler;
+        ];
     );
 );
 
+macro_rules! run_event_handler {
+    ($($name:ident, $get:ident, $set:ident, $event_macro:ident;)+) => {
+        $($event_macro!($name, $get, $set);)+
+    };
+}
+
+macro_rules! global_event_handlers {
+    () => {
+        global_event_handlers_list!(run_event_handler);
+    };
+    (NoOnload) => {
+        global_event_handlers_list!(run_event_handler, NoOnload);
+    };
+}
+
+macro_rules! window_event_handlers {
+    () => {
+        window_event_handlers_list!(run_event_handler);
+    };
+    (ForwardToWindow) => {
+        window_event_handlers_list!(run_event_handler, ForwardToWindow);
+    };
+}
+
+macro_rules! make_array {
+    ($($name:ident, $get:ident, $set:ident, $event_macro:ident;)+) => {
+        &[$(concat!("on", stringify!($name))),+]
+    };
+}
+
+static GLOBAL_EVENT_HANDLERS: &[&str] = global_event_handlers_list!(make_array);
+static WINDOW_DELEGATE_EVENT_HANDLERS: &[&str] =
+    window_event_handlers_list!(make_array, ForwardToWindow);
+
 // https://html.spec.whatwg.org/multipage/#documentandelementeventhandlers
 // see webidls/EventHandler.webidl
-// As more methods get added, just update them here.
+// As more methods get added, just update them here and in DOCUMENT_AND_ELEMENT_EVENT_HANDLERS
 macro_rules! document_and_element_event_handlers(
     () => (
         event_handler!(cut, GetOncut, SetOncut);
@@ -581,6 +613,26 @@ macro_rules! document_and_element_event_handlers(
         event_handler!(paste, GetOnpaste, SetOnpaste);
     )
 );
+
+static DOCUMENT_AND_ELEMENT_EVENT_HANDLERS: &[&str] = &["oncut", "oncopy", "onpaste"];
+
+// XXXManishearth ideally we can construct these maps at compile time using phf map and a proc macro
+use html5ever::LocalName;
+use std::collections::HashSet;
+lazy_static! {
+    pub static ref ELEMENT_EVENT_HANDLERS: HashSet<LocalName> = GLOBAL_EVENT_HANDLERS
+        .iter()
+        .chain(DOCUMENT_AND_ELEMENT_EVENT_HANDLERS.iter())
+        .copied()
+        .map(Into::into)
+        .collect();
+    pub static ref BODY_FRAMESET_EVENT_HANDLERS: HashSet<LocalName> =
+        WINDOW_DELEGATE_EVENT_HANDLERS
+            .iter()
+            .copied()
+            .map(Into::into)
+            .collect();
+}
 
 #[macro_export]
 macro_rules! rooted_vec {

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -25,6 +25,7 @@ use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlfieldsetelement::HTMLFieldSetElement;
 use crate::dom::htmlfontelement::HTMLFontElement;
 use crate::dom::htmlformelement::HTMLFormElement;
+use crate::dom::htmlframesetelement::HTMLFrameSetElement;
 use crate::dom::htmlheadelement::HTMLHeadElement;
 use crate::dom::htmlhrelement::HTMLHRElement;
 use crate::dom::htmliframeelement::HTMLIFrameElement;
@@ -167,6 +168,9 @@ pub fn vtable_for(node: &Node) -> &dyn VirtualMethods {
         },
         NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLBodyElement)) => {
             node.downcast::<HTMLBodyElement>().unwrap() as &dyn VirtualMethods
+        },
+        NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLFrameSetElement)) => {
+            node.downcast::<HTMLFrameSetElement>().unwrap() as &dyn VirtualMethods
         },
         NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLButtonElement)) => {
             node.downcast::<HTMLButtonElement>().unwrap() as &dyn VirtualMethods

--- a/tests/wpt/metadata/html/webappapis/scripting/events/compile-event-handler-lexical-scopes.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/events/compile-event-handler-lexical-scopes.html.ini
@@ -7,5 +7,5 @@
     expected: FAIL
 
   [The EventHandler is not an element's event handler (i.e. Window's event handler) and has no form owner.]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/webappapis/scripting/events/invalid-uncompiled-raw-handler-compiled-once.window.js.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/events/invalid-uncompiled-raw-handler-compiled-once.window.js.ini
@@ -1,4 +1,0 @@
-[invalid-uncompiled-raw-handler-compiled-once.window.html]
-  [Invalid uncompiled raw handlers should only be compiled once]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/webappapis/scripting/events/invalid-uncompiled-raw-handler-keeps-position.window.js.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/events/invalid-uncompiled-raw-handler-keeps-position.window.js.ini
@@ -1,4 +1,0 @@
-[invalid-uncompiled-raw-handler-keeps-position.window.html]
-  [Compiling invalid uncompiled raw handlers should keep the position in event listener list]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/webappapis/scripting/processing-model-2/compile-error-in-attribute.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/processing-model-2/compile-error-in-attribute.html.ini
@@ -1,8 +1,0 @@
-[compile-error-in-attribute.html]
-  type: testharness
-  [window.onerror - compile error in attribute]
-    expected: FAIL
-
-  [window.onerror - compile error in attribute (column)]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -18870,7 +18870,7 @@
    "testharness"
   ],
   "mozilla/event_handler_syntax_error.html": [
-   "78962c67d2cd2093ce9e241596b151ee2ce466ec",
+   "1b16187681198a8fcec49cb4d658dccc5fb53692",
    "testharness"
   ],
   "mozilla/event_listener.html": [

--- a/tests/wpt/mozilla/tests/mozilla/event_handler_syntax_error.html
+++ b/tests/wpt/mozilla/tests/mozilla/event_handler_syntax_error.html
@@ -9,15 +9,25 @@
 <body>
   <a id="a" onclick="{">link</a>
   <script>
+  setup({ allow_uncaught_exception: true });
   test(function() {
-    var a = document.getElementById("a");
-    assert_equals(a.onclick, null, "invalid onclick attribute");
+    try {
+      var a = document.getElementById("a");
+      assert_equals(a.onclick, null, "invalid onclick attribute");
 
-    document.body.setAttribute("onx", "{");
-    document.body.setAttribute("ony", "}");
+      document.body.setAttribute("onclick", "{");
+      document.body.setAttribute("onx", "{");
+      document.body.setAttribute("ony", "}");
 
-    assert_equals(document.body.getAttribute("onx"), "{");
-    assert_equals(document.body.getAttribute("ony"), "}");
+      assert_equals(document.body.getAttribute("onclick"),"{");
+      assert_equals(document.onclick, null);
+
+      assert_equals(document.body.getAttribute("onx"), "{");
+      assert_equals(document.body.getAttribute("ony"), "}");
+    }
+    catch(e) {
+      assert_unreached("Saw an exception, not just an ErrorEvent");
+    }
   });
   </script>
 </body>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Error events on event handler attribute string compilation were disabled a few years ago (#13152) for fear of a double-borrow panic; event propagation code has changed enough since then that enabling the events is possible and makes some WPT cases happy.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25200 and make progress on #13152 

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
