### PR TITLE
Make `mach test-tidy --self-test` compatible with Python3

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -213,7 +213,7 @@ def linux_tidy_unit():
             python3 ./mach build --dev --features layout-2020
             python3 ./mach build --dev --libsimpleservo
             python3 ./mach build --dev -p servo-gst-plugin
-            ./mach test-tidy --no-progress --self-test
+            python3 ./mach test-tidy --no-progress --self-test
 
             ./etc/memory_reports_over_time.py --test
             ./etc/taskcluster/mock.py

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -447,8 +447,8 @@ def check_shell(file_name, lines):
     if not file_name.endswith(".sh"):
         raise StopIteration
 
-    shebang = b"#!/usr/bin/env bash"
-    required_options = {"set -o errexit", "set -o nounset", "set -o pipefail"}
+    shebang = "#!/usr/bin/env bash"
+    required_options = ["set -o errexit", "set -o nounset", "set -o pipefail"]
 
     did_shebang_check = False
 
@@ -456,7 +456,7 @@ def check_shell(file_name, lines):
         yield (0, 'script is an empty file')
         return
 
-    if lines[0].rstrip() != shebang:
+    if lines[0].rstrip() != shebang.encode("utf-8"):
         yield (1, 'script does not have shebang "{}"'.format(shebang))
 
     for idx, line in enumerate(map(lambda line: line.decode("utf-8"), lines[1:])):
@@ -506,7 +506,7 @@ def check_manifest_dirs(config_file, print_text=True):
         return
 
     # Load configs from include.ini
-    with open(config_file) as content:
+    with open(config_file, "rb") as content:
         conf_file = content.read()
         lines = conf_file.splitlines(True)
 
@@ -808,7 +808,7 @@ def check_yaml(file_name, contents):
         line = e.problem_mark.line + 1 if hasattr(e, 'problem_mark') else None
         yield (line, e)
     except KeyError as e:
-        yield (None, "Duplicated Key ({})".format(e.message))
+        yield (None, "Duplicated Key ({})".format(e.args[0]))
     except voluptuous.MultipleInvalid as e:
         yield (None, str(e))
 
@@ -844,11 +844,11 @@ def check_json(filename, contents):
     try:
         json.loads(contents, object_pairs_hook=check_json_requirements(filename))
     except ValueError as e:
-        match = re.search(r"line (\d+) ", e.message)
+        match = re.search(r"line (\d+) ", e.args[0])
         line_no = match and match.group(1)
-        yield (line_no, e.message)
+        yield (line_no, e.args[0])
     except KeyError as e:
-        yield (None, e.message)
+        yield (None, e.args[0])
 
 
 def check_spec(file_name, lines):

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -22,24 +22,24 @@ def iterFile(name):
 class CheckTidiness(unittest.TestCase):
     def assertNoMoreErrors(self, errors):
         with self.assertRaises(StopIteration):
-            errors.next()
+            next(errors)
 
     def test_tidy_config(self):
         errors = tidy.check_config_file(os.path.join(base_path, 'servo-tidy.toml'), print_text=False)
-        self.assertEqual("invalid config key 'key-outside'", errors.next()[2])
-        self.assertEqual("invalid config key 'wrong-key'", errors.next()[2])
-        self.assertEqual('invalid config table [wrong]', errors.next()[2])
-        self.assertEqual("ignored file './fake/file.html' doesn't exist", errors.next()[2])
-        self.assertEqual("ignored directory './fake/dir' doesn't exist", errors.next()[2])
+        self.assertEqual("invalid config key 'key-outside'", next(errors)[2])
+        self.assertEqual("invalid config key 'wrong-key'", next(errors)[2])
+        self.assertEqual('invalid config table [wrong]', next(errors)[2])
+        self.assertEqual("ignored file './fake/file.html' doesn't exist", next(errors)[2])
+        self.assertEqual("ignored directory './fake/dir' doesn't exist", next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_non_existing_wpt_manifest_checks(self):
         wrong_path = "/wrong/path.ini"
         errors = tidy.check_manifest_dirs(wrong_path, print_text=False)
-        self.assertEqual("%s manifest file is required but was not found" % wrong_path, errors.next()[2])
+        self.assertEqual("%s manifest file is required but was not found" % wrong_path, next(errors)[2])
         self.assertNoMoreErrors(errors)
         errors = tidy.check_manifest_dirs(os.path.join(base_path, 'manifest-include.ini'), print_text=False)
-        self.assertTrue(errors.next()[2].endswith("never_going_to_exist"))
+        self.assertTrue(next(errors)[2].endswith("never_going_to_exist"))
         self.assertNoMoreErrors(errors)
 
     def test_directory_checks(self):
@@ -49,151 +49,151 @@ class CheckTidiness(unittest.TestCase):
             }
         errors = tidy.check_directory_files(dirs)
         error_dir = os.path.join(base_path, "dir_check/webidl_plus")
-        self.assertEqual("Unexpected extension found for test.rs. We only expect files with webidl, test extensions in {0}".format(error_dir), errors.next()[2])
-        self.assertEqual("Unexpected extension found for test2.rs. We only expect files with webidl, test extensions in {0}".format(error_dir), errors.next()[2])
+        self.assertEqual("Unexpected extension found for test.rs. We only expect files with webidl, test extensions in {0}".format(error_dir), next(errors)[2])
+        self.assertEqual("Unexpected extension found for test2.rs. We only expect files with webidl, test extensions in {0}".format(error_dir), next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_spaces_correctnes(self):
         errors = tidy.collect_errors_for_files(iterFile('wrong_space.rs'), [], [tidy.check_by_line], print_text=False)
-        self.assertEqual('trailing whitespace', errors.next()[2])
-        self.assertEqual('no newline at EOF', errors.next()[2])
-        self.assertEqual('tab on line', errors.next()[2])
-        self.assertEqual('CR on line', errors.next()[2])
-        self.assertEqual('no newline at EOF', errors.next()[2])
+        self.assertEqual('trailing whitespace', next(errors)[2])
+        self.assertEqual('no newline at EOF', next(errors)[2])
+        self.assertEqual('tab on line', next(errors)[2])
+        self.assertEqual('CR on line', next(errors)[2])
+        self.assertEqual('no newline at EOF', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_empty_file(self):
         errors = tidy.collect_errors_for_files(iterFile('empty_file.rs'), [], [tidy.check_by_line], print_text=False)
-        self.assertEqual('file is empty', errors.next()[2])
+        self.assertEqual('file is empty', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_long_line(self):
         errors = tidy.collect_errors_for_files(iterFile('long_line.rs'), [], [tidy.check_by_line], print_text=False)
-        self.assertEqual('Line is longer than 120 characters', errors.next()[2])
+        self.assertEqual('Line is longer than 120 characters', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_whatwg_link(self):
         errors = tidy.collect_errors_for_files(iterFile('whatwg_link.rs'), [], [tidy.check_by_line], print_text=False)
-        self.assertTrue('link to WHATWG may break in the future, use this format instead:' in errors.next()[2])
-        self.assertTrue('links to WHATWG single-page url, change to multi page:' in errors.next()[2])
+        self.assertTrue('link to WHATWG may break in the future, use this format instead:' in next(errors)[2])
+        self.assertTrue('links to WHATWG single-page url, change to multi page:' in next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_license(self):
         errors = tidy.collect_errors_for_files(iterFile('incorrect_license.rs'), [], [tidy.check_license], print_text=False)
-        self.assertEqual('incorrect license', errors.next()[2])
+        self.assertEqual('incorrect license', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_shebang_license(self):
         errors = tidy.collect_errors_for_files(iterFile('shebang_license.py'), [], [tidy.check_license], print_text=False)
-        self.assertEqual('missing blank line after shebang', errors.next()[2])
+        self.assertEqual('missing blank line after shebang', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_shell(self):
         errors = tidy.collect_errors_for_files(iterFile('shell_tidy.sh'), [], [tidy.check_shell], print_text=False)
-        self.assertEqual('script does not have shebang "#!/usr/bin/env bash"', errors.next()[2])
-        self.assertEqual('script is missing options "set -o errexit", "set -o pipefail"', errors.next()[2])
-        self.assertEqual('script should not use backticks for command substitution', errors.next()[2])
-        self.assertEqual('variable substitutions should use the full \"${VAR}\" form', errors.next()[2])
-        self.assertEqual('script should use `[[` instead of `[` for conditional testing', errors.next()[2])
-        self.assertEqual('script should use `[[` instead of `[` for conditional testing', errors.next()[2])
+        self.assertEqual('script does not have shebang "#!/usr/bin/env bash"', next(errors)[2])
+        self.assertEqual('script is missing options "set -o errexit", "set -o pipefail"', next(errors)[2])
+        self.assertEqual('script should not use backticks for command substitution', next(errors)[2])
+        self.assertEqual('variable substitutions should use the full \"${VAR}\" form', next(errors)[2])
+        self.assertEqual('script should use `[[` instead of `[` for conditional testing', next(errors)[2])
+        self.assertEqual('script should use `[[` instead of `[` for conditional testing', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_apache2_incomplete(self):
         errors = tidy.collect_errors_for_files(iterFile('apache2_license.rs'), [], [tidy.check_license])
-        self.assertEqual('incorrect license', errors.next()[2])
+        self.assertEqual('incorrect license', next(errors)[2])
 
     def test_rust(self):
         errors = tidy.collect_errors_for_files(iterFile('rust_tidy.rs'), [], [tidy.check_rust], print_text=False)
-        self.assertTrue('mod declaration is not in alphabetical order' in errors.next()[2])
-        self.assertEqual('mod declaration spans multiple lines', errors.next()[2])
-        self.assertTrue('extern crate declaration is not in alphabetical order' in errors.next()[2])
-        self.assertTrue('derivable traits list is not in alphabetical order' in errors.next()[2])
-        self.assertEqual('found an empty line following a {', errors.next()[2])
-        self.assertEqual('use &[T] instead of &Vec<T>', errors.next()[2])
-        self.assertEqual('use &str instead of &String', errors.next()[2])
-        self.assertEqual('use &T instead of &Root<T>', errors.next()[2])
-        self.assertEqual('encountered function signature with -> ()', errors.next()[2])
-        self.assertEqual('operators should go at the end of the first line', errors.next()[2])
+        self.assertTrue('mod declaration is not in alphabetical order' in next(errors)[2])
+        self.assertEqual('mod declaration spans multiple lines', next(errors)[2])
+        self.assertTrue('extern crate declaration is not in alphabetical order' in next(errors)[2])
+        self.assertTrue('derivable traits list is not in alphabetical order' in next(errors)[2])
+        self.assertEqual('found an empty line following a {', next(errors)[2])
+        self.assertEqual('use &[T] instead of &Vec<T>', next(errors)[2])
+        self.assertEqual('use &str instead of &String', next(errors)[2])
+        self.assertEqual('use &T instead of &Root<T>', next(errors)[2])
+        self.assertEqual('encountered function signature with -> ()', next(errors)[2])
+        self.assertEqual('operators should go at the end of the first line', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
         feature_errors = tidy.collect_errors_for_files(iterFile('lib.rs'), [], [tidy.check_rust], print_text=False)
 
-        self.assertTrue('feature attribute is not in alphabetical order' in feature_errors.next()[2])
-        self.assertTrue('feature attribute is not in alphabetical order' in feature_errors.next()[2])
-        self.assertTrue('feature attribute is not in alphabetical order' in feature_errors.next()[2])
-        self.assertTrue('feature attribute is not in alphabetical order' in feature_errors.next()[2])
+        self.assertTrue('feature attribute is not in alphabetical order' in next(feature_errors)[2])
+        self.assertTrue('feature attribute is not in alphabetical order' in next(feature_errors)[2])
+        self.assertTrue('feature attribute is not in alphabetical order' in next(feature_errors)[2])
+        self.assertTrue('feature attribute is not in alphabetical order' in next(feature_errors)[2])
         self.assertNoMoreErrors(feature_errors)
 
         ban_errors = tidy.collect_errors_for_files(iterFile('ban.rs'), [], [tidy.check_rust], print_text=False)
-        self.assertEqual('Banned type Cell<JSVal> detected. Use MutDom<JSVal> instead', ban_errors.next()[2])
+        self.assertEqual('Banned type Cell<JSVal> detected. Use MutDom<JSVal> instead', next(ban_errors)[2])
         self.assertNoMoreErrors(ban_errors)
 
         ban_errors = tidy.collect_errors_for_files(iterFile('ban-domrefcell.rs'), [], [tidy.check_rust], print_text=False)
-        self.assertEqual('Banned type DomRefCell<Dom<T>> detected. Use MutDom<T> instead', ban_errors.next()[2])
+        self.assertEqual('Banned type DomRefCell<Dom<T>> detected. Use MutDom<T> instead', next(ban_errors)[2])
         self.assertNoMoreErrors(ban_errors)
 
     def test_spec_link(self):
         tidy.SPEC_BASE_PATH = base_path
         errors = tidy.collect_errors_for_files(iterFile('speclink.rs'), [], [tidy.check_spec], print_text=False)
-        self.assertEqual('method declared in webidl is missing a comment with a specification link', errors.next()[2])
-        self.assertEqual('method declared in webidl is missing a comment with a specification link', errors.next()[2])
+        self.assertEqual('method declared in webidl is missing a comment with a specification link', next(errors)[2])
+        self.assertEqual('method declared in webidl is missing a comment with a specification link', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_script_thread(self):
         errors = tidy.collect_errors_for_files(iterFile('script_thread.rs'), [], [tidy.check_rust], print_text=False)
-        self.assertEqual('use a separate variable for the match expression', errors.next()[2])
-        self.assertEqual('use a separate variable for the match expression', errors.next()[2])
+        self.assertEqual('use a separate variable for the match expression', next(errors)[2])
+        self.assertEqual('use a separate variable for the match expression', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_webidl(self):
         errors = tidy.collect_errors_for_files(iterFile('spec.webidl'), [tidy.check_webidl_spec], [], print_text=False)
-        self.assertEqual('No specification link found.', errors.next()[2])
+        self.assertEqual('No specification link found.', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_toml(self):
-        errors = tidy.collect_errors_for_files(iterFile('Cargo.toml'), [tidy.check_toml], [], print_text=False)
-        self.assertEqual('found asterisk instead of minimum version number', errors.next()[2])
-        self.assertEqual('.toml file should contain a valid license.', errors.next()[2])
+        errors = tidy.collect_errors_for_files(iterFile('Cargo.toml'), [], [tidy.check_toml], print_text=False)
+        self.assertEqual('found asterisk instead of minimum version number', next(errors)[2])
+        self.assertEqual('.toml file should contain a valid license.', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_modeline(self):
         errors = tidy.collect_errors_for_files(iterFile('modeline.txt'), [], [tidy.check_modeline], print_text=False)
-        self.assertEqual('vi modeline present', errors.next()[2])
-        self.assertEqual('vi modeline present', errors.next()[2])
-        self.assertEqual('vi modeline present', errors.next()[2])
-        self.assertEqual('emacs file variables present', errors.next()[2])
-        self.assertEqual('emacs file variables present', errors.next()[2])
+        self.assertEqual('vi modeline present', next(errors)[2])
+        self.assertEqual('vi modeline present', next(errors)[2])
+        self.assertEqual('vi modeline present', next(errors)[2])
+        self.assertEqual('emacs file variables present', next(errors)[2])
+        self.assertEqual('emacs file variables present', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_malformed_json(self):
         errors = tidy.collect_errors_for_files(iterFile('malformed_json.json'), [tidy.check_json], [], print_text=False)
-        self.assertEqual('Invalid control character at: line 3 column 40 (char 61)', errors.next()[2])
+        self.assertEqual('Invalid control character at: line 3 column 40 (char 61)', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_json_with_duplicate_key(self):
         errors = tidy.collect_errors_for_files(iterFile('duplicate_key.json'), [tidy.check_json], [], print_text=False)
-        self.assertEqual('Duplicated Key (the_duplicated_key)', errors.next()[2])
+        self.assertEqual('Duplicated Key (the_duplicated_key)', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_json_with_unordered_keys(self):
         tidy.config["check-ordered-json-keys"].append('python/tidy/servo_tidy_tests/unordered_key.json')
         errors = tidy.collect_errors_for_files(iterFile('unordered_key.json'), [tidy.check_json], [], print_text=False)
-        self.assertEqual('Unordered key (found b before a)', errors.next()[2])
+        self.assertEqual('Unordered key (found b before a)', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_yaml_with_duplicate_key(self):
         errors = tidy.collect_errors_for_files(iterFile('duplicate_keys_buildbot_steps.yml'), [tidy.check_yaml], [], print_text=False)
-        self.assertEqual('Duplicated Key (duplicate_yaml_key)', errors.next()[2])
+        self.assertEqual('Duplicated Key (duplicate_yaml_key)', next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_non_list_mapped_buildbot_steps(self):
         errors = tidy.collect_errors_for_files(iterFile('non_list_mapping_buildbot_steps.yml'), [tidy.check_yaml], [], print_text=False)
-        self.assertEqual("expected a list for dictionary value @ data['non-list-key']", errors.next()[2])
+        self.assertEqual("expected a list for dictionary value @ data['non-list-key']", next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_non_string_list_mapping_buildbot_steps(self):
         errors = tidy.collect_errors_for_files(iterFile('non_string_list_buildbot_steps.yml'), [tidy.check_yaml], [], print_text=False)
-        self.assertEqual("expected str @ data['mapping_key'][0]", errors.next()[2])
+        self.assertEqual("expected str @ data['mapping_key'][0]", next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_lock(self):
@@ -202,13 +202,13 @@ class CheckTidiness(unittest.TestCase):
 \t\x1b[93mThe following packages depend on version 0.4.9 from 'crates.io':\x1b[0m
 \t\ttest2
 \t\x1b[93mThe following packages depend on version 0.5.1 from 'crates.io':\x1b[0m"""
-        self.assertEqual(msg, errors.next()[2])
+        self.assertEqual(msg, next(errors)[2])
         msg2 = """duplicate versions for package `test3`
 \t\x1b[93mThe following packages depend on version 0.5.1 from 'crates.io':\x1b[0m
 \t\ttest4
 \t\x1b[93mThe following packages depend on version 0.5.1 from 'https://github.com/user/test3':\x1b[0m
 \t\ttest5"""
-        self.assertEqual(msg2, errors.next()[2])
+        self.assertEqual(msg2, next(errors)[2])
         self.assertNoMoreErrors(errors)
 
     def test_lock_ignore_without_duplicates(self):
@@ -219,13 +219,13 @@ class CheckTidiness(unittest.TestCase):
             "duplicates for `test2` are allowed, but only single version found"
             "\n\t\x1b[93mThe following packages depend on version 0.1.0 from 'https://github.com/user/test2':\x1b[0m"
         )
-        self.assertEqual(msg, errors.next()[2])
+        self.assertEqual(msg, next(errors)[2])
 
         msg2 = (
             "duplicates for `test5` are allowed, but only single version found"
             "\n\t\x1b[93mThe following packages depend on version 0.1.0 from 'https://github.com/':\x1b[0m"
         )
-        self.assertEqual(msg2, errors.next()[2])
+        self.assertEqual(msg2, next(errors)[2])
 
         self.assertNoMoreErrors(errors)
 
@@ -241,8 +241,8 @@ class CheckTidiness(unittest.TestCase):
             "Package test_unneeded_exception is not required to be an exception of blocked package rand."
         )
 
-        self.assertEqual(msg, errors.next()[2])
-        self.assertEqual(msg2, errors.next()[2])
+        self.assertEqual(msg, next(errors)[2])
+        self.assertEqual(msg2, next(errors)[2])
         self.assertNoMoreErrors(errors)
 
         # needed to not raise errors in other test cases


### PR DESCRIPTION
It now runs in CI to avoid future regressions.
See #23607

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
