### PR TITLE
Removed createEvent cases, removed now-unused new_uninitializeds

### DIFF
--- a/components/script/dom/closeevent.rs
+++ b/components/script/dom/closeevent.rs
@@ -33,14 +33,6 @@ impl CloseEvent {
         }
     }
 
-    pub fn new_uninitialized(global: &GlobalScope) -> DomRoot<CloseEvent> {
-        reflect_dom_object(
-            Box::new(CloseEvent::new_inherited(false, 0, DOMString::new())),
-            global,
-            CloseEventBinding::Wrap,
-        )
-    }
-
     pub fn new(
         global: &GlobalScope,
         type_: Atom,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -38,7 +38,6 @@ use crate::dom::bindings::xmlname::{
     namespace_from_domstring, validate_and_extract, xml_name_type,
 };
 use crate::dom::cdatasection::CDATASection;
-use crate::dom::closeevent::CloseEvent;
 use crate::dom::comment::Comment;
 use crate::dom::compositionevent::CompositionEvent;
 use crate::dom::cssstylesheet::CSSStyleSheet;
@@ -52,7 +51,6 @@ use crate::dom::element::CustomElementCreationMode;
 use crate::dom::element::{
     Element, ElementCreator, ElementPerformFullscreenEnter, ElementPerformFullscreenExit,
 };
-use crate::dom::errorevent::ErrorEvent;
 use crate::dom::event::{Event, EventBubbles, EventCancelable, EventDefault, EventStatus};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::focusevent::FocusEvent;
@@ -81,9 +79,7 @@ use crate::dom::node::{LayoutNodeHelpers, Node, NodeDamage, NodeFlags, ShadowInc
 use crate::dom::nodeiterator::NodeIterator;
 use crate::dom::nodelist::NodeList;
 use crate::dom::pagetransitionevent::PageTransitionEvent;
-use crate::dom::popstateevent::PopStateEvent;
 use crate::dom::processinginstruction::ProcessingInstruction;
-use crate::dom::progressevent::ProgressEvent;
 use crate::dom::promise::Promise;
 use crate::dom::range::Range;
 use crate::dom::servoparser::ServoParser;
@@ -97,7 +93,6 @@ use crate::dom::touchlist::TouchList;
 use crate::dom::treewalker::TreeWalker;
 use crate::dom::uievent::UIEvent;
 use crate::dom::virtualmethods::vtable_for;
-use crate::dom::webglcontextevent::WebGLContextEvent;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
 use crate::dom::wheelevent::WheelEvent;
 use crate::dom::window::{ReflowReason, Window};
@@ -3814,15 +3809,11 @@ impl DocumentMethods for Document {
             "compositionevent" | "textevent" => Ok(DomRoot::upcast(
                 CompositionEvent::new_uninitialized(&self.window),
             )),
-            "closeevent" => Ok(DomRoot::upcast(CloseEvent::new_uninitialized(
-                self.window.upcast(),
-            ))),
             "customevent" => Ok(DomRoot::upcast(CustomEvent::new_uninitialized(
                 self.window.upcast(),
             ))),
-            "errorevent" => Ok(DomRoot::upcast(ErrorEvent::new_uninitialized(
-                self.window.upcast(),
-            ))),
+            // FIXME(#25136): devicemotionevent, deviceorientationevent
+            // FIXME(#7529): dragevent
             "events" | "event" | "htmlevents" | "svgevents" => {
                 Ok(Event::new_uninitialized(&self.window.upcast()))
             },
@@ -3839,15 +3830,6 @@ impl DocumentMethods for Document {
             "mouseevent" | "mouseevents" => {
                 Ok(DomRoot::upcast(MouseEvent::new_uninitialized(&self.window)))
             },
-            "pagetransitionevent" => Ok(DomRoot::upcast(PageTransitionEvent::new_uninitialized(
-                &self.window,
-            ))),
-            "popstateevent" => Ok(DomRoot::upcast(PopStateEvent::new_uninitialized(
-                &self.window,
-            ))),
-            "progressevent" => Ok(DomRoot::upcast(ProgressEvent::new_uninitialized(
-                self.window.upcast(),
-            ))),
             "storageevent" => Ok(DomRoot::upcast(StorageEvent::new_uninitialized(
                 &self.window,
                 "".into(),
@@ -3859,9 +3841,6 @@ impl DocumentMethods for Document {
                 &TouchList::new(&self.window, &[]),
             ))),
             "uievent" | "uievents" => Ok(DomRoot::upcast(UIEvent::new_uninitialized(&self.window))),
-            "webglcontextevent" => Ok(DomRoot::upcast(WebGLContextEvent::new_uninitialized(
-                &self.window,
-            ))),
             _ => Err(Error::NotSupported),
         }
     }

--- a/components/script/dom/progressevent.rs
+++ b/components/script/dom/progressevent.rs
@@ -32,13 +32,6 @@ impl ProgressEvent {
             total: total,
         }
     }
-    pub fn new_uninitialized(global: &GlobalScope) -> DomRoot<ProgressEvent> {
-        reflect_dom_object(
-            Box::new(ProgressEvent::new_inherited(false, 0, 0)),
-            global,
-            ProgressEventBinding::Wrap,
-        )
-    }
     pub fn new(
         global: &GlobalScope,
         type_: Atom,

--- a/components/script/dom/webglcontextevent.rs
+++ b/components/script/dom/webglcontextevent.rs
@@ -42,18 +42,6 @@ impl WebGLContextEvent {
         }
     }
 
-    pub fn new_uninitialized(window: &Window) -> DomRoot<WebGLContextEvent> {
-        // according to https://www.khronos.org/registry/webgl/specs/1.0/#5.15 this is
-        // additional information or the empty string if no additional information is
-        // available.
-        let status_message = DOMString::new();
-        reflect_dom_object(
-            Box::new(WebGLContextEvent::new_inherited(status_message)),
-            window,
-            WebGLContextEventBinding::Wrap,
-        )
-    }
-
     pub fn new(
         window: &Window,
         type_: Atom,

--- a/tests/wpt/metadata/dom/nodes/Document-createEvent.https.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-createEvent.https.html.ini
@@ -5,22 +5,13 @@
   [DEVICEMOTIONEVENT should be an alias for DeviceMotionEvent.]
     expected: FAIL
 
-  [Should throw NOT_SUPPORTED_ERR for non-legacy event interface "CloseEvent"]
-    expected: FAIL
-
   [createEvent('DeviceMotionEvent') should be initialized correctly.]
-    expected: FAIL
-
-  [Should throw NOT_SUPPORTED_ERR for non-legacy event interface "ProgressEvent"]
     expected: FAIL
 
   [devicemotionevent should be an alias for DeviceMotionEvent.]
     expected: FAIL
 
   [createEvent('DeviceOrientationEvent') should be initialized correctly.]
-    expected: FAIL
-
-  [Should throw NOT_SUPPORTED_ERR for non-legacy event interface "PageTransitionEvent"]
     expected: FAIL
 
   [DRAGEVENT should be an alias for DragEvent.]
@@ -44,25 +35,16 @@
   [dragevent should be an alias for DragEvent.]
     expected: FAIL
 
-  [Should throw NOT_SUPPORTED_ERR for non-legacy event interface "PopStateEvent"]
-    expected: FAIL
-
   [deviceorientationevent should be an alias for DeviceOrientationEvent.]
     expected: FAIL
 
   [DeviceOrientationEvent should be an alias for DeviceOrientationEvent.]
     expected: FAIL
 
-  [Should throw NOT_SUPPORTED_ERR for non-legacy event interface "WebGLContextEvent"]
-    expected: FAIL
-
   [createEvent('DEVICEORIENTATIONEVENT') should be initialized correctly.]
     expected: FAIL
 
   [createEvent('DragEvent') should be initialized correctly.]
-    expected: FAIL
-
-  [Should throw NOT_SUPPORTED_ERR for non-legacy event interface "ErrorEvent"]
     expected: FAIL
 
   [createEvent('deviceorientationevent') should be initialized correctly.]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
document.createEvent was creating some event types WHATWG now says shouldn't be created that way. This was the only caller of a few new_uninitialized methods, so those are removed too.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25137

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
