### PR TITLE
Use filename instead of opened file descriptor when calling ZipFile

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -112,7 +112,7 @@ def archive_deterministically(dir_to_archive, dest_archive, prepend_path=None):
         temp_file = '{}.temp~'.format(dest_archive)
         with os.fdopen(os.open(temp_file, os.O_WRONLY | os.O_CREAT, 0o644), 'wb') as out_file:
             if dest_archive.endswith('.zip'):
-                with zipfile.ZipFile(out_file, 'w', zipfile.ZIP_DEFLATED) as zip_file:
+                with zipfile.ZipFile(temp_file, 'w', zipfile.ZIP_DEFLATED) as zip_file:
                     for entry in file_list:
                         arcname = entry
                         if prepend_path is not None:


### PR DESCRIPTION
This should fix #25251

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
