### PR TITLE
Allow mach bootstrap to run on windows

### DIFF
--- a/python/mach_bootstrap.py
+++ b/python/mach_bootstrap.py
@@ -248,6 +248,23 @@ def bootstrap_command_only(topdir):
 
     context = DummyContext()
     context.topdir = topdir
+
+    # Taken from command_base.py#CommandBase, which we can't depend on during bootstrapping.
+    config_path = os.path.join(context.topdir, ".servobuild")
+    if os.path.exists(config_path):
+        import toml
+        with open(config_path) as f:
+            config = toml.loads(f.read())
+    else:
+        config = {}
+
+    # Handle missing/default items
+    config.setdefault("tools", {})
+    default_cache_dir = os.environ.get("SERVO_CACHE_DIR",
+                                       os.path.join(context.topdir, ".servo"))
+    config["tools"].setdefault("cache-dir", default_cache_dir)
+    context.sharedir = os.path.join(context.topdir, os.path.expanduser(config["tools"]["cache-dir"]))
+
     force = False
     if len(sys.argv) == 3 and sys.argv[2] == "-f":
         force = True


### PR DESCRIPTION
Fix mach bootstrap, so that it works under windows [and any potential other platforms using a shared dependency download dir]

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25224
- [X] These changes do not require tests because mach bootstrap is non-critical tooling, which shouldn't be changed very often and thus should not break.

Question: Is there some kind of formatting I have to/can run on this file?
Also this PR is more of a suggestion, maybe someone can verify this and/or come up with a more clever version not requiring code duplication (though I guess there is hardly anything we can do about that)

Another thing to discuss is whether this shouldn't be done as suggested in #25224, completely hardcoded, without env vars or config files, but that's a more political decision and I belive that it's okay, because I also run mach bootstrap regularly (at least when I get warned by mach) to upgrade my dependencies (in my gecko workflow, that is). In this use-case it should support honoring the config.

I guess @SimonSapin is the Python Guy here?