### PR TITLE
Issue warning to devtools when module scripts in use.

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -970,6 +970,29 @@ impl GlobalScope {
         self.devtools_chan.as_ref()
     }
 
+    pub fn issue_page_warning(&self, warning: &str) {
+        if let Some(ref chan) = self.devtools_chan {
+            let _ = chan.send(ScriptToDevtoolsControlMsg::ReportPageError(
+                self.pipeline_id.clone(),
+                PageError {
+                    type_: "PageError".to_string(),
+                    errorMessage: warning.to_string(),
+                    sourceName: self.get_url().to_string(),
+                    lineText: "".to_string(),
+                    lineNumber: 0,
+                    columnNumber: 0,
+                    category: "script".to_string(),
+                    timeStamp: 0, //TODO
+                    error: false,
+                    warning: true,
+                    exception: true,
+                    strict: false,
+                    private: false,
+                },
+            ));
+        }
+    }
+
     /// Get a sender to the memory profiler thread.
     pub fn mem_profiler_chan(&self) -> &profile_mem::ProfilerChan {
         &self.mem_profiler_chan

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -559,6 +559,10 @@ impl HTMLScriptElement {
                         "{} is a module script. It should be fixed after #23545 landed.",
                         url.clone()
                     );
+                    self.global().issue_page_warning(&format!(
+                        "Module scripts are not supported; {} will not be executed.",
+                        url.clone()
+                    ));
                 },
             }
         } else {
@@ -577,6 +581,9 @@ impl HTMLScriptElement {
                 warn!(
                     "{} is a module script. It should be fixed after #23545 landed.",
                     base_url.clone()
+                );
+                self.global().issue_page_warning(
+                    "Module scripts are not supported; ignoring inline module script.",
                 );
                 return;
             }


### PR DESCRIPTION
This makes it easier to identify why content isn't working in environments which don't have access to the RUST_LOG output.