### PR TITLE
Implement MessageEvent.InitMessageEvent

### DIFF
--- a/components/script/dom/webidls/MessageEvent.webidl
+++ b/components/script/dom/webidls/MessageEvent.webidl
@@ -11,6 +11,17 @@ interface MessageEvent : Event {
   readonly attribute DOMString lastEventId;
   readonly attribute MessageEventSource? source;
   readonly attribute /*FrozenArray<MessagePort>*/any ports;
+
+  void initMessageEvent(
+    DOMString type,
+    optional boolean bubbles = false,
+    optional boolean cancelable = false,
+    optional any data = null,
+    optional DOMString origin = "",
+    optional DOMString lastEventId = "",
+    optional MessageEventSource? source = null,
+    optional sequence<MessagePort> ports = []
+  );
 };
 
 dictionary MessageEventInit : EventInit {

--- a/tests/wpt/metadata/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/metadata/html/dom/idlharness.https.html.ini
@@ -245,9 +245,6 @@
   [SVGElement interface: attribute onchange]
     expected: FAIL
 
-  [MessageEvent interface: calling initMessageEvent(DOMString, boolean, boolean, any, USVString, DOMString, MessageEventSource, [object Object\]) on new MessageEvent("message", { data: 5 }) with too few arguments must throw TypeError]
-    expected: FAIL
-
   [OffscreenCanvasRenderingContext2D interface: operation bezierCurveTo(unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double, unrestricted double)]
     expected: FAIL
 
@@ -431,9 +428,6 @@
   [BarProp interface: attribute visible]
     expected: FAIL
 
-  [MessageEvent interface: operation initMessageEvent(DOMString, boolean, boolean, any, USVString, DOMString, MessageEventSource, [object Object\])]
-    expected: FAIL
-
   [DragEvent interface object name]
     expected: FAIL
 
@@ -549,9 +543,6 @@
     expected: FAIL
 
   [SVGElement interface: attribute onsuspend]
-    expected: FAIL
-
-  [MessageEvent interface: new MessageEvent("message", { data: 5 }) must inherit property "initMessageEvent(DOMString, boolean, boolean, any, USVString, DOMString, MessageEventSource, [object Object\])" with the proper type]
     expected: FAIL
 
   [DragEvent interface: existence and properties of interface prototype object]

--- a/tests/wpt/metadata/html/dom/idlharness.worker.js.ini
+++ b/tests/wpt/metadata/html/dom/idlharness.worker.js.ini
@@ -92,9 +92,6 @@
   [OffscreenCanvasRenderingContext2D interface: operation beginPath()]
     expected: FAIL
 
-  [MessageEvent interface: calling initMessageEvent(DOMString, boolean, boolean, any, USVString, DOMString, MessageEventSource, [object Object\]) on new MessageEvent("message", { data: 5 }) with too few arguments must throw TypeError]
-    expected: FAIL
-
   [OffscreenCanvasRenderingContext2D interface: attribute lineWidth]
     expected: FAIL
 
@@ -152,9 +149,6 @@
   [Path2D interface object name]
     expected: FAIL
 
-  [MessageEvent interface: operation initMessageEvent(DOMString, boolean, boolean, any, USVString, DOMString, MessageEventSource, [object Object\])]
-    expected: FAIL
-
   [OffscreenCanvasRenderingContext2D interface: operation quadraticCurveTo(unrestricted double, unrestricted double, unrestricted double, unrestricted double)]
     expected: FAIL
 
@@ -207,9 +201,6 @@
     expected: FAIL
 
   [Path2D interface: operation quadraticCurveTo(unrestricted double, unrestricted double, unrestricted double, unrestricted double)]
-    expected: FAIL
-
-  [MessageEvent interface: new MessageEvent("message", { data: 5 }) must inherit property "initMessageEvent(DOMString, boolean, boolean, any, USVString, DOMString, MessageEventSource, [object Object\])" with the proper type]
     expected: FAIL
 
   [OffscreenCanvasRenderingContext2D interface: attribute lineCap]

--- a/tests/wpt/metadata/html/webappapis/scripting/events/messageevent-constructor.https.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/events/messageevent-constructor.https.html.ini
@@ -1,21 +1,12 @@
 [messageevent-constructor.https.html]
   type: testharness
-  [Default event values]
-    expected: FAIL
-
   [ports attribute should be a FrozenArray]
-    expected: FAIL
-
-  [initMessageEvent operation]
     expected: FAIL
 
   [All parameters to initMessageEvent should be mandatory]
     expected: FAIL
 
   [Passing ServiceWorker for source member]
-    expected: FAIL
-
-  [initMessageEvent operation default parameter values]
     expected: FAIL
 
   [MessageEvent constructor]


### PR DESCRIPTION

<!-- Please describe your changes on the following line: -->
InitMessageEvent had to be implemented as required by wpt. For this few keys of struct `MessageEvent` are now wrapped inside DomRefCell wrapper.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [x] These changes fix #25192  (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
