### PR TITLE
Disable H2 ALPN.

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -4,7 +4,7 @@
 
 //! A thread that takes a URL and streams back the binary data.
 
-use crate::connector::{create_http_client, create_tls_config, ALPN_H2_H1};
+use crate::connector::{create_http_client, create_tls_config, ALPN_H1};
 use crate::cookie;
 use crate::cookie_storage::CookieStorage;
 use crate::fetch::cors_cache::CorsCache;
@@ -149,7 +149,7 @@ fn create_http_states(
         http_cache: RwLock::new(http_cache),
         http_cache_state: Mutex::new(HashMap::new()),
         client: create_http_client(
-            create_tls_config(&certs, ALPN_H2_H1),
+            create_tls_config(&certs, ALPN_H1),
             HANDLE.lock().unwrap().executor(),
         ),
     };
@@ -162,7 +162,7 @@ fn create_http_states(
         http_cache: RwLock::new(HttpCache::new()),
         http_cache_state: Mutex::new(HashMap::new()),
         client: create_http_client(
-            create_tls_config(&certs, ALPN_H2_H1),
+            create_tls_config(&certs, ALPN_H1),
             HANDLE.lock().unwrap().executor(),
         ),
     };


### PR DESCRIPTION
This was introduced by #24976, and it breaks loading https://google.com. Without any network specialists currently contributing to Servo regularly, I would rather revert the particular change that broke it rather than attempt to continue investigating.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25286
- [x] These changes do not require tests because no H2 testing, no HTTPS configuration testing.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
