### PR TITLE
Update devtools server for Firefox 71.

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -39,9 +39,7 @@ impl EncodableConsoleMessage for CachedConsoleMessage {
 }
 
 #[derive(Serialize)]
-struct StartedListenersTraits {
-    customNetworkRequest: bool,
-}
+struct StartedListenersTraits;
 
 #[derive(Serialize)]
 struct StartedListenersReply {
@@ -309,13 +307,15 @@ impl Actor for ConsoleActor {
 
             "startListeners" => {
                 //TODO: actually implement listener filters that support starting/stopping
+                let listeners = msg.get("listeners").unwrap().as_array().unwrap().to_owned();
                 let msg = StartedListenersReply {
                     from: self.name(),
                     nativeConsoleAPI: true,
-                    startedListeners: vec!["PageError".to_owned(), "ConsoleAPI".to_owned()],
-                    traits: StartedListenersTraits {
-                        customNetworkRequest: true,
-                    },
+                    startedListeners: listeners
+                        .into_iter()
+                        .map(|s| s.as_str().unwrap().to_owned())
+                        .collect(),
+                    traits: StartedListenersTraits,
                 };
                 stream.write_json_packet(&msg);
                 ActorMessageStatus::Processed

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -41,7 +41,7 @@ impl Actor for DeviceActor {
                     from: self.name(),
                     value: SystemInfo {
                         apptype: "servo".to_string(),
-                        platformVersion: "63.0".to_string(),
+                        platformVersion: "71.0".to_string(),
                     },
                 };
                 stream.write_json_packet(&msg);

--- a/components/devtools/actors/preference.rs
+++ b/components/devtools/actors/preference.rs
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
+use crate::protocol::JsonPacketStream;
+use serde_json::{Map, Value};
+use std::net::TcpStream;
+
+pub struct PreferenceActor {
+    name: String,
+}
+
+impl PreferenceActor {
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+}
+
+impl Actor for PreferenceActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &self,
+        _registry: &ActorRegistry,
+        msg_type: &str,
+        _msg: &Map<String, Value>,
+        stream: &mut TcpStream,
+    ) -> Result<ActorMessageStatus, ()> {
+        Ok(match msg_type {
+            "getBoolPref" => {
+                let reply = BoolReply {
+                    from: self.name(),
+                    value: false,
+                };
+                stream.write_json_packet(&reply);
+                ActorMessageStatus::Processed
+            },
+
+            "getCharPref" => {
+                let reply = CharReply {
+                    from: self.name(),
+                    value: "".to_owned(),
+                };
+                stream.write_json_packet(&reply);
+                ActorMessageStatus::Processed
+            },
+
+            "getIntPref" => {
+                let reply = IntReply {
+                    from: self.name(),
+                    value: 0,
+                };
+                stream.write_json_packet(&reply);
+                ActorMessageStatus::Processed
+            },
+
+            _ => ActorMessageStatus::Ignored,
+        })
+    }
+}
+
+#[derive(Serialize)]
+struct BoolReply {
+    from: String,
+    value: bool,
+}
+
+#[derive(Serialize)]
+struct CharReply {
+    from: String,
+    value: String,
+}
+
+#[derive(Serialize)]
+struct IntReply {
+    from: String,
+    value: i32,
+}

--- a/components/devtools/actors/process.rs
+++ b/components/devtools/actors/process.rs
@@ -8,19 +8,26 @@ use serde_json::{Map, Value};
 use std::net::TcpStream;
 
 #[derive(Serialize)]
-struct GetStyleSheetsReply {
+struct ListWorkersReply {
     from: String,
-    styleSheets: Vec<u32>, // TODO: real JSON structure.
+    workers: Vec<u32>, // TODO: use proper JSON structure.
 }
 
-pub struct StyleSheetsActor {
-    pub name: String,
+pub struct ProcessActor {
+    name: String,
 }
 
-impl Actor for StyleSheetsActor {
+impl ProcessActor {
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+}
+
+impl Actor for ProcessActor {
     fn name(&self) -> String {
         self.name.clone()
     }
+
     fn handle_message(
         &self,
         _registry: &ActorRegistry,
@@ -29,22 +36,16 @@ impl Actor for StyleSheetsActor {
         stream: &mut TcpStream,
     ) -> Result<ActorMessageStatus, ()> {
         Ok(match msg_type {
-            "getStyleSheets" => {
-                let msg = GetStyleSheetsReply {
+            "listWorkers" => {
+                let reply = ListWorkersReply {
                     from: self.name(),
-                    styleSheets: vec![],
+                    workers: vec![],
                 };
-                stream.write_json_packet(&msg);
+                stream.write_json_packet(&reply);
                 ActorMessageStatus::Processed
             },
 
             _ => ActorMessageStatus::Ignored,
         })
-    }
-}
-
-impl StyleSheetsActor {
-    pub fn new(name: String) -> StyleSheetsActor {
-        StyleSheetsActor { name: name }
     }
 }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -26,6 +26,8 @@ use crate::actors::framerate::FramerateActor;
 use crate::actors::inspector::InspectorActor;
 use crate::actors::network_event::{EventActor, NetworkEventActor, ResponseStartMsg};
 use crate::actors::performance::PerformanceActor;
+use crate::actors::preference::PreferenceActor;
+use crate::actors::process::ProcessActor;
 use crate::actors::profiler::ProfilerActor;
 use crate::actors::root::RootActor;
 use crate::actors::stylesheets::StyleSheetsActor;
@@ -60,6 +62,8 @@ mod actors {
     pub mod network_event;
     pub mod object;
     pub mod performance;
+    pub mod preference;
+    pub mod process;
     pub mod profiler;
     pub mod root;
     pub mod stylesheets;
@@ -156,15 +160,23 @@ fn run_server(
 
     let device = DeviceActor::new(registry.new_name("device"));
 
+    let preference = PreferenceActor::new(registry.new_name("preference"));
+
+    let process = ProcessActor::new(registry.new_name("process"));
+
     let root = Box::new(RootActor {
         tabs: vec![],
         device: device.name(),
         performance: performance.name(),
+        preference: preference.name(),
+        process: process.name(),
     });
 
     registry.register(root);
     registry.register(Box::new(performance));
     registry.register(Box::new(device));
+    registry.register(Box::new(preference));
+    registry.register(Box::new(process));
     registry.find::<RootActor>("root");
 
     let actors = registry.create_shareable();


### PR DESCRIPTION
Based on reading code under https://searchfox.org/mozilla-central/source/devtools/shared/specs/, https://searchfox.org/mozilla-central/source/devtools/shared/front/, https://searchfox.org/mozilla-central/source/devtools/shared/specs/, and https://searchfox.org/mozilla-central/source/devtools/server/actors/, as well as dumping the protocol output when using Firefox to debug itself. This makes the JS console usable again in nightly Firefox from about:debugging.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24092
- [x] These changes do not require tests because ha ha ha devtools tests.