### PR TITLE
Let hyper automatically set the host header if needed

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -27,11 +27,8 @@ use headers::{
 };
 use headers::{AccessControlAllowOrigin, AccessControlMaxAge};
 use headers::{CacheControl, ContentEncoding, ContentLength};
-use headers::{
-    Host, IfModifiedSince, LastModified, Origin as HyperOrigin, Pragma, Referer, UserAgent,
-};
+use headers::{IfModifiedSince, LastModified, Origin as HyperOrigin, Pragma, Referer, UserAgent};
 use http::header::{self, HeaderName, HeaderValue};
-use http::uri::Authority;
 use http::{HeaderMap, Request as HyperRequest};
 use hyper::{Body, Client, Method, Response as HyperResponse, StatusCode};
 use hyper_serde::Serde;
@@ -997,24 +994,7 @@ fn http_network_or_cache_fetch(
 
     // Step 5.16
     let current_url = http_request.current_url();
-    if let Ok(host) = format!(
-        "{}{}",
-        current_url.host_str().unwrap(),
-        current_url
-            .port()
-            .map(|v| format!(":{}", v))
-            .unwrap_or("".into())
-    )
-    .parse::<Authority>()
-    .map(Host::from)
-    {
-        http_request.headers.typed_insert(host);
-    } else {
-        // This error should only happen in cases where hyper and rust-url disagree
-        // about how to parse an authority.
-        // https://github.com/servo/servo/issues/24175
-        error!("Failed to parse {} as authority", current_url);
-    }
+    http_request.headers.remove(header::HOST);
 
     // unlike http_loader, we should not set the accept header
     // here, according to the fetch spec
@@ -1436,7 +1416,7 @@ fn http_network_fetch(
     };
 
     if log_enabled!(log::Level::Info) {
-        info!("response for {}", url);
+        info!("{:?} response for {}", res.version(), url);
         for header in res.headers().iter() {
             info!(" - {:?}", header);
         }

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -4,7 +4,7 @@
 
 //! A thread that takes a URL and streams back the binary data.
 
-use crate::connector::{create_http_client, create_tls_config, ALPN_H1};
+use crate::connector::{create_http_client, create_tls_config, ALPN_H2_H1};
 use crate::cookie;
 use crate::cookie_storage::CookieStorage;
 use crate::fetch::cors_cache::CorsCache;
@@ -149,7 +149,7 @@ fn create_http_states(
         http_cache: RwLock::new(http_cache),
         http_cache_state: Mutex::new(HashMap::new()),
         client: create_http_client(
-            create_tls_config(&certs, ALPN_H1),
+            create_tls_config(&certs, ALPN_H2_H1),
             HANDLE.lock().unwrap().executor(),
         ),
     };
@@ -162,7 +162,7 @@ fn create_http_states(
         http_cache: RwLock::new(HttpCache::new()),
         http_cache_state: Mutex::new(HashMap::new()),
         client: create_http_client(
-            create_tls_config(&certs, ALPN_H1),
+            create_tls_config(&certs, ALPN_H2_H1),
             HANDLE.lock().unwrap().executor(),
         ),
     };

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -14,11 +14,8 @@ use devtools_traits::HttpRequest as DevtoolsHttpRequest;
 use devtools_traits::HttpResponse as DevtoolsHttpResponse;
 use headers::{AccessControlAllowCredentials, AccessControlAllowHeaders, AccessControlAllowOrigin};
 use headers::{AccessControlAllowMethods, AccessControlMaxAge, HeaderMapExt};
-use headers::{
-    CacheControl, ContentLength, ContentType, Expires, Host, LastModified, Pragma, UserAgent,
-};
+use headers::{CacheControl, ContentLength, ContentType, Expires, LastModified, Pragma, UserAgent};
 use http::header::{self, HeaderMap, HeaderName, HeaderValue};
-use http::uri::Authority;
 use http::{Method, StatusCode};
 use hyper::body::Body;
 use hyper::{Request as HyperRequest, Response as HyperResponse};
@@ -1067,11 +1064,6 @@ fn test_fetch_with_devtools() {
         header::ACCEPT_ENCODING,
         HeaderValue::from_static("gzip, deflate, br"),
     );
-    headers.typed_insert(Host::from(
-        format!("{}:{}", url.host_str().unwrap(), url.port().unwrap())
-            .parse::<Authority>()
-            .unwrap(),
-    ));
 
     headers.insert(header::ACCEPT, HeaderValue::from_static("*/*"));
 

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -257,11 +257,6 @@ fn test_request_and_response_data_with_network_messages() {
         header::ACCEPT_ENCODING,
         HeaderValue::from_static("gzip, deflate, br"),
     );
-    headers.typed_insert(Host::from(
-        format!("{}:{}", url.host_str().unwrap(), url.port().unwrap())
-            .parse::<Authority>()
-            .unwrap(),
-    ));
 
     headers.insert(
         header::ACCEPT,


### PR DESCRIPTION
Google's gws web server did not expect to receive an unneeded Host header via HTTP/2, therefore it responded with 400 Bad Request over a working HTTP/2 connection.

https://tools.ietf.org/html/rfc7540#page-55
> Clients that generate HTTP/2 requests directly SHOULD use the ":authority" pseudo-header field instead of the Host header field.

It's hyper's job to take care of this for the HTTP/1 case, therefore we can remove old code.
When calling [Client::builder()](https://github.com/servo/servo/blob/1974c875a1fb12103a6916c58ed2cbef8c3e32a2/components/net/connector.rs#L116-L119) we do not disable hyper's default [set_host](https://github.com/hyperium/hyper/blob/4b6099c7aa558e6b1fda146ce6179cb0c67858d7/src/client/mod.rs#L1019-L1024) config option, therefore hyper [automatically adds a Host header for non-HTTP/2 connections](https://github.com/hyperium/hyper/blob/4b6099c7aa558e6b1fda146ce6179cb0c67858d7/src/client/mod.rs#L289-L292)  based on the [URI](https://github.com/servo/servo/blob/3f663d7ab216a841e6250b5b10ce64d34caff97c/components/net/http_loader.rs#L418-L421).

r? @jdm

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25286.