### PR TITLE
Do not wake up embedder on each animation tick

### DIFF
--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -125,7 +125,9 @@ impl Debug for Msg {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match *self {
             Msg::ShutdownComplete => write!(f, "ShutdownComplete"),
-            Msg::ChangeRunningAnimationsState(..) => write!(f, "ChangeRunningAnimationsState"),
+            Msg::ChangeRunningAnimationsState(_, state) => {
+                write!(f, "ChangeRunningAnimationsState({:?})", state)
+            },
             Msg::SetFrameTree(..) => write!(f, "SetFrameTree"),
             Msg::Recomposite(..) => write!(f, "Recomposite"),
             Msg::TouchEventProcessed(..) => write!(f, "TouchEventProcessed"),

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3144,11 +3144,16 @@ where
         pipeline_id: PipelineId,
         animation_state: AnimationState,
     ) {
-        self.compositor_proxy
-            .send(ToCompositorMsg::ChangeRunningAnimationsState(
-                pipeline_id,
-                animation_state,
-            ))
+        if let Some(pipeline) = self.pipelines.get_mut(&pipeline_id) {
+            if pipeline.animation_state != animation_state {
+                pipeline.animation_state = animation_state;
+                self.compositor_proxy
+                    .send(ToCompositorMsg::ChangeRunningAnimationsState(
+                        pipeline_id,
+                        animation_state,
+                    ))
+            }
+        }
     }
 
     fn handle_tick_animation(&mut self, pipeline_id: PipelineId, tick_type: AnimationTickType) {

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -30,7 +30,9 @@ use net_traits::image_cache::ImageCache;
 use net_traits::{IpcSend, ResourceThreads};
 use profile_traits::mem as profile_mem;
 use profile_traits::time;
-use script_traits::{ConstellationControlMsg, DiscardBrowsingContext, ScriptToConstellationChan};
+use script_traits::{
+    AnimationState, ConstellationControlMsg, DiscardBrowsingContext, ScriptToConstellationChan,
+};
 use script_traits::{DocumentActivity, InitialScriptState};
 use script_traits::{LayoutControlMsg, LayoutMsg, LoadData};
 use script_traits::{NewLayoutInfo, SWManagerMsg, SWManagerSenders};
@@ -81,7 +83,7 @@ pub struct Pipeline {
 
     /// Whether this pipeline is currently running animations. Pipelines that are running
     /// animations cause composites to be continually scheduled.
-    pub running_animations: bool,
+    pub animation_state: AnimationState,
 
     /// The child browsing contexts of this pipeline (these are iframes in the document).
     pub children: Vec<BrowsingContextId>,
@@ -377,7 +379,7 @@ impl Pipeline {
             compositor_proxy: compositor_proxy,
             url: load_data.url.clone(),
             children: vec![],
-            running_animations: false,
+            animation_state: AnimationState::NoAnimationsPresent,
             load_data: load_data,
             history_state_id: None,
             history_states: HashSet::new(),

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -450,7 +450,7 @@ pub enum DocumentState {
 
 /// For a given pipeline, whether any animations are currently running
 /// and any animation callbacks are queued
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum AnimationState {
     /// Animations are active but no callbacks are queued
     AnimationsPresent,


### PR DESCRIPTION
The constellation should only update the compositor if the animation state actually changed.