### PR TITLE
Attr is a Node, with consequences for many Node methods

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -5,15 +5,14 @@
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::AttrBinding::{self, AttrMethods};
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::customelementregistry::CallbackReaction;
+use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::mutationobserver::{Mutation, MutationObserver};
 use crate::dom::node::Node;
 use crate::dom::virtualmethods::vtable_for;
-use crate::dom::window::Window;
 use crate::script_thread::ScriptThread;
 use devtools_traits::AttrInfo;
 use dom_struct::dom_struct;
@@ -27,7 +26,7 @@ use style::attr::{AttrIdentifier, AttrValue};
 // https://dom.spec.whatwg.org/#interface-attr
 #[dom_struct]
 pub struct Attr {
-    reflector_: Reflector,
+    node_: Node,
     identifier: AttrIdentifier,
     value: DomRefCell<AttrValue>,
 
@@ -37,6 +36,7 @@ pub struct Attr {
 
 impl Attr {
     fn new_inherited(
+        document: &Document,
         local_name: LocalName,
         value: AttrValue,
         name: LocalName,
@@ -45,7 +45,7 @@ impl Attr {
         owner: Option<&Element>,
     ) -> Attr {
         Attr {
-            reflector_: Reflector::new(),
+            node_: Node::new_inherited(document),
             identifier: AttrIdentifier {
                 local_name: local_name,
                 name: name,
@@ -58,7 +58,7 @@ impl Attr {
     }
 
     pub fn new(
-        window: &Window,
+        document: &Document,
         local_name: LocalName,
         value: AttrValue,
         name: LocalName,
@@ -66,11 +66,11 @@ impl Attr {
         prefix: Option<Prefix>,
         owner: Option<&Element>,
     ) -> DomRoot<Attr> {
-        reflect_dom_object(
+        Node::reflect_node(
             Box::new(Attr::new_inherited(
-                local_name, value, name, namespace, prefix, owner,
+                document, local_name, value, name, namespace, prefix, owner,
             )),
-            window,
+            document,
             AttrBinding::Wrap,
         )
     }
@@ -114,35 +114,10 @@ impl AttrMethods for Attr {
         }
     }
 
-    // https://dom.spec.whatwg.org/#dom-attr-textcontent
-    fn TextContent(&self) -> DOMString {
-        self.Value()
-    }
-
-    // https://dom.spec.whatwg.org/#dom-attr-textcontent
-    fn SetTextContent(&self, value: DOMString) {
-        self.SetValue(value)
-    }
-
-    // https://dom.spec.whatwg.org/#dom-attr-nodevalue
-    fn NodeValue(&self) -> DOMString {
-        self.Value()
-    }
-
-    // https://dom.spec.whatwg.org/#dom-attr-nodevalue
-    fn SetNodeValue(&self, value: DOMString) {
-        self.SetValue(value)
-    }
-
     // https://dom.spec.whatwg.org/#dom-attr-name
     fn Name(&self) -> DOMString {
         // FIXME(ajeffrey): convert directly from LocalName to DOMString
         DOMString::from(&*self.identifier.name)
-    }
-
-    // https://dom.spec.whatwg.org/#dom-attr-nodename
-    fn NodeName(&self) -> DOMString {
-        self.Name()
     }
 
     // https://dom.spec.whatwg.org/#dom-attr-namespaceuri
@@ -248,6 +223,13 @@ impl Attr {
             namespace: (*self.identifier.namespace).to_owned(),
             name: String::from(self.Name()),
             value: String::from(self.Value()),
+        }
+    }
+
+    pub fn qualified_name(&self) -> DOMString {
+        match self.prefix() {
+            Some(ref prefix) => DOMString::from(format!("{}:{}", prefix, &**self.local_name())),
+            None => DOMString::from(&**self.local_name()),
         }
     }
 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3685,7 +3685,7 @@ impl DocumentMethods for Document {
         let value = AttrValue::String("".to_owned());
 
         Ok(Attr::new(
-            &self.window,
+            &self,
             name.clone(),
             value,
             name,
@@ -3705,7 +3705,7 @@ impl DocumentMethods for Document {
         let value = AttrValue::String("".to_owned());
         let qualified_name = LocalName::from(qualified_name);
         Ok(Attr::new(
-            &self.window,
+            &self,
             local_name,
             value,
             qualified_name,

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1336,9 +1336,8 @@ impl Element {
         namespace: Namespace,
         prefix: Option<Prefix>,
     ) {
-        let window = window_from_node(self);
         let attr = Attr::new(
-            &window,
+            &self.node.owner_doc(),
             local_name,
             value,
             name,

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -986,6 +986,7 @@ impl RangeMethods for Range {
             NodeTypeId::CharacterData(CharacterDataTypeId::Text(_)) => node.GetParentElement(),
             NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) |
             NodeTypeId::DocumentType => unreachable!(),
+            NodeTypeId::Attr => unreachable!(),
         };
 
         // Step 2.

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -253,6 +253,7 @@ impl<'a> Serialize for &'a Node {
 
                     NodeTypeId::Document(_) => panic!("Can't serialize Document node itself"),
                     NodeTypeId::Element(_) => panic!("Element shouldn't appear here"),
+                    NodeTypeId::Attr => panic!("Attr shouldn't appear here"),
                 },
             }
         }

--- a/components/script/dom/webidls/Attr.webidl
+++ b/components/script/dom/webidls/Attr.webidl
@@ -8,7 +8,7 @@
  */
 
 [Exposed=Window]
-interface Attr {
+interface Attr : Node {
   [Constant]
   readonly attribute DOMString? namespaceURI;
   [Constant]
@@ -17,14 +17,8 @@ interface Attr {
   readonly attribute DOMString localName;
   [Constant]
   readonly attribute DOMString name;
-  [Constant]
-  readonly attribute DOMString nodeName; // historical alias of .name
   [CEReactions, Pure]
            attribute DOMString value;
-  [CEReactions, Pure]
-           attribute DOMString textContent; // historical alias of .value
-  [CEReactions, Pure]
-           attribute DOMString nodeValue; // historical alias of .value
 
   [Pure]
   readonly attribute Element? ownerElement;

--- a/tests/wpt/metadata/dom/idlharness.window.js.ini
+++ b/tests/wpt/metadata/dom/idlharness.window.js.ini
@@ -1,176 +1,3 @@
-[idlharness.window.html?include=Node]
-  [Node interface: calling isSameNode(Node) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "TEXT_NODE" with the proper type]
-    expected: FAIL
-
-  [Node interface: calling removeChild(Node) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: calling isEqualNode(Node) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "lookupPrefix(DOMString)" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "nextSibling" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "isConnected" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "isSameNode(Node)" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "nodeType" with the proper type]
-    expected: FAIL
-
-  [Node interface: calling replaceChild(Node, Node) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "DOCUMENT_POSITION_FOLLOWING" with the proper type]
-    expected: FAIL
-
-  [Node interface: calling getRootNode(GetRootNodeOptions) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "cloneNode(boolean)" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "ENTITY_NODE" with the proper type]
-    expected: FAIL
-
-  [Node interface: calling contains(Node) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "CDATA_SECTION_NODE" with the proper type]
-    expected: FAIL
-
-  [Node interface: calling cloneNode(boolean) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "appendChild(Node)" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "parentNode" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "removeChild(Node)" with the proper type]
-    expected: FAIL
-
-  [Node interface: calling lookupPrefix(DOMString) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "PROCESSING_INSTRUCTION_NODE" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "baseURI" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "DOCUMENT_POSITION_DISCONNECTED" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "compareDocumentPosition(Node)" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "replaceChild(Node, Node)" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "DOCUMENT_POSITION_PRECEDING" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "isEqualNode(Node)" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "COMMENT_NODE" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "ATTRIBUTE_NODE" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "DOCUMENT_POSITION_CONTAINS" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "DOCUMENT_NODE" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "childNodes" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "parentElement" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "isDefaultNamespace(DOMString)" with the proper type]
-    expected: FAIL
-
-  [Node interface: calling isDefaultNamespace(DOMString) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "ownerDocument" with the proper type]
-    expected: FAIL
-
-  [Node interface: calling appendChild(Node) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: calling insertBefore(Node, Node) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "ELEMENT_NODE" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "DOCUMENT_POSITION_CONTAINED_BY" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "lookupNamespaceURI(DOMString)" with the proper type]
-    expected: FAIL
-
-  [Node interface: calling lookupNamespaceURI(DOMString) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "firstChild" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "normalize()" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "DOCUMENT_FRAGMENT_NODE" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "contains(Node)" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "getRootNode(GetRootNodeOptions)" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "DOCUMENT_TYPE_NODE" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "hasChildNodes()" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "lastChild" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "previousSibling" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "insertBefore(Node, Node)" with the proper type]
-    expected: FAIL
-
-  [Node interface: calling compareDocumentPosition(Node) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "ENTITY_REFERENCE_NODE" with the proper type]
-    expected: FAIL
-
-  [Node interface: document.querySelector("[id\]").attributes[0\] must inherit property "NOTATION_NODE" with the proper type]
-    expected: FAIL
-
-
 [idlharness.window.html?exclude=Node]
   [EventTarget interface: new AbortController().signal must inherit property "addEventListener(DOMString, EventListener, [object Object\],[object Object\])" with the proper type]
     expected: FAIL
@@ -265,9 +92,6 @@
   [AbortController interface: attribute signal]
     expected: FAIL
 
-  [EventTarget interface: document.querySelector("[id\]").attributes[0\] must inherit property "dispatchEvent(Event)" with the proper type]
-    expected: FAIL
-
   [Element interface: calling attachShadow(ShadowRootInit) on element with too few arguments must throw TypeError]
     expected: FAIL
 
@@ -292,9 +116,6 @@
   [Event interface: operation composedPath()]
     expected: FAIL
 
-  [EventTarget interface: calling dispatchEvent(Event) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
   [AbstractRange interface: attribute endContainer]
     expected: FAIL
 
@@ -302,9 +123,6 @@
     expected: FAIL
 
   [AbortController interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [EventTarget interface: document.querySelector("[id\]").attributes[0\] must inherit property "removeEventListener(DOMString, EventListener, [object Object\],[object Object\])" with the proper type]
     expected: FAIL
 
   [CharacterData interface: operation remove()]
@@ -409,9 +227,6 @@
   [AbortSignal interface: existence and properties of interface prototype object's "constructor" property]
     expected: FAIL
 
-  [EventTarget interface: calling addEventListener(DOMString, EventListener, [object Object\],[object Object\]) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Document interface: xmlDoc must inherit property "origin" with the proper type]
     expected: FAIL
 
@@ -422,9 +237,6 @@
     expected: FAIL
 
   [AbortSignal interface: attribute onabort]
-    expected: FAIL
-
-  [EventTarget interface: calling removeEventListener(DOMString, EventListener, [object Object\],[object Object\]) on document.querySelector("[id\]").attributes[0\] with too few arguments must throw TypeError]
     expected: FAIL
 
   [AbortSignal interface: existence and properties of interface prototype object]
@@ -460,9 +272,6 @@
   [CharacterData interface: operation before([object Object\],[object Object\])]
     expected: FAIL
 
-  [EventTarget interface: document.querySelector("[id\]").attributes[0\] must inherit property "addEventListener(DOMString, EventListener, [object Object\],[object Object\])" with the proper type]
-    expected: FAIL
-
   [Stringification of new AbortController()]
     expected: FAIL
 
@@ -475,9 +284,6 @@
   [Event interface: document.createEvent("Event") must inherit property "composed" with the proper type]
     expected: FAIL
 
-  [Attr interface: existence and properties of interface object]
-    expected: FAIL
-
   [DocumentType interface: operation remove()]
     expected: FAIL
 
@@ -485,9 +291,6 @@
     expected: FAIL
 
   [Element interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [Attr interface: existence and properties of interface prototype object]
     expected: FAIL
 
   [Element interface: operation replaceWith([object Object\],[object Object\])]

--- a/tests/wpt/metadata/dom/nodes/Document-importNode.html.ini
+++ b/tests/wpt/metadata/dom/nodes/Document-importNode.html.ini
@@ -1,4 +1,0 @@
-[Document-importNode.html]
-  [Import an Attr node with namespace/prefix correctly.]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Attr is now a Node, as current WHATWG specs require. I think I did some unidiomatic things to make compareDocumentPosition work and it could use a look by someone more familiar with how to write concise Rust code. I also think the new cases in compareDocumentPosition lack tests; it is possible to compare the position of two attributes, or of an attribute and an element, and I don't think any tests are exercising that functionality.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25124

<!-- Either: -->
- [ ] There are tests for these changes (existing cases of Node methods are well-tested, and there is a WPT test specifically for whether Attr is Node, but I'm not sure about new Node method cases)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
