### PR TITLE
Implement mach bootstrap-gstreamer for Windows

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -56,7 +56,7 @@ class MachCommands(CommandBase):
         return bootstrap.bootstrap(self.context, force=force, specific="salt")
 
     @Command('bootstrap-gstreamer',
-             description='Set up a local copy of the gstreamer libraries (linux only).',
+             description='Set up a local copy of the gstreamer libraries (linux and windows only).',
              category='bootstrap')
     @CommandArgument('--force', '-f',
                      action='store_true',


### PR DESCRIPTION
Download and Install GStreamer's MSIs into .servo/msvc-dependencies

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25335 
- [X] These changes do not require tests because mach commands are untested currently