### PR TITLE
Remove Optional pipeline_id

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -320,24 +320,20 @@ impl DedicatedWorkerGlobalScope {
                     .credentials_mode(CredentialsMode::CredentialsSameOrigin)
                     .parser_metadata(ParserMetadata::NotParserInserted)
                     .use_url_credentials(true)
-                    .pipeline_id(pipeline_id)
+                    .pipeline_id(Some(pipeline_id))
                     .referrer(referrer)
                     .referrer_policy(referrer_policy)
                     .origin(origin);
 
                 let runtime = unsafe {
-                    if let Some(pipeline_id) = pipeline_id {
-                        let task_source = NetworkingTaskSource(
-                            Box::new(WorkerThreadWorkerChan {
-                                sender: own_sender.clone(),
-                                worker: worker.clone(),
-                            }),
-                            pipeline_id,
-                        );
-                        new_child_runtime(parent, Some(task_source))
-                    } else {
-                        new_child_runtime(parent, None)
-                    }
+                    let task_source = NetworkingTaskSource(
+                        Box::new(WorkerThreadWorkerChan {
+                            sender: own_sender.clone(),
+                            worker: worker.clone(),
+                        }),
+                        pipeline_id,
+                    );
+                    new_child_runtime(parent, Some(task_source))
                 };
 
                 let (devtools_mpsc_chan, devtools_mpsc_port) = unbounded();
@@ -375,7 +371,7 @@ impl DedicatedWorkerGlobalScope {
                             .send(CommonScriptMsg::Task(
                                 WorkerEvent,
                                 Box::new(SimpleWorkerErrorHandler::new(worker)),
-                                pipeline_id,
+                                Some(pipeline_id),
                                 TaskSourceName::DOMManipulation,
                             ))
                             .unwrap();

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -289,7 +289,7 @@ impl ServiceWorkerGlobalScope {
                     .credentials_mode(CredentialsMode::Include)
                     .parser_metadata(ParserMetadata::NotParserInserted)
                     .use_url_credentials(true)
-                    .pipeline_id(pipeline_id)
+                    .pipeline_id(Some(pipeline_id))
                     .referrer(referrer)
                     .referrer_policy(referrer_policy)
                     .origin(origin);

--- a/components/script/dom/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworkerregistration.rs
@@ -110,7 +110,7 @@ impl ServiceWorkerRegistration {
         let worker_load_origin = WorkerScriptLoadOrigin {
             referrer_url: None,
             referrer_policy: None,
-            pipeline_id: Some(global.pipeline_id()),
+            pipeline_id: global.pipeline_id(),
         };
 
         let worker_id = WorkerId(Uuid::new_v4());

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -97,7 +97,7 @@ impl Worker {
         let worker_load_origin = WorkerScriptLoadOrigin {
             referrer_url: None,
             referrer_policy: None,
-            pipeline_id: Some(global.pipeline_id()),
+            pipeline_id: global.pipeline_id(),
         };
 
         let (devtools_sender, devtools_receiver) = ipc::channel().unwrap();

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -962,7 +962,7 @@ pub struct WorkerScriptLoadOrigin {
     /// the referrer policy which is used
     pub referrer_policy: Option<ReferrerPolicy>,
     /// the pipeline id of the entity requesting the load
-    pub pipeline_id: Option<PipelineId>,
+    pub pipeline_id: PipelineId,
 }
 
 /// Errors from executing a paint worklet


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
All code that creates a WorkerScriptLoadOrigin passes a Some value for the pipeline, so we should remove the Option from the struct member field. 

I changed the `WorkerScriptLoadOrigin` struct in `components/script_traits/lib.rs` to have a PipelineId and not an Option<PipelineId>. In `components/script/dom/worker.rs` and `components/script/dom/serviceworkerregistration.rs` it was changed so that `WorkerScriptLoadOrigin` was instantiated with a non-Optional. In `components/script/dom/dedicatedworkerglobalscope.rs` testing for if pipeline_id is an Optional is removed. 

In `components/script/dom/serviceworkerglobalscope.rs` and `components/script/dom/dedicatedworkerglobalscope.rs` a `PipelineId` was provided as an Optional to a `RequestBuilder` and I changed it to provide a `Some(pipeline_id)` instead. I am not sure changing the [RequestBuilder struct](https://github.com/warren-fisher/servo/blob/5c3bda025144118fc8dd67a3f975d8f91fd25e78/components/net_traits/request.rs#L118-L159) at line 147 to accept a non-optional was within this issue so I left it as is.

I was able to successfully build it so I assume these changes worked, however I am not sure about the implications of the changes made in the unsafe block in `components/script/dom/dedicatedworkerglobalscope.rs`.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24772 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the issue says so

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
