### PR TITLE
Print OSMesa environment variables when starting debugger under WPT.

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -222,7 +222,7 @@ def append_to_path_env(string, env, name):
     env[name] = variable
 
 
-def set_osmesa_env(bin_path, env):
+def set_osmesa_env(bin_path, env, show_vars):
     """Set proper LD_LIBRARY_PATH and DRIVE for software rendering on Linux and OSX"""
     if is_linux():
         dep_path = find_dep_path_newest('osmesa-src', bin_path)
@@ -231,6 +231,9 @@ def set_osmesa_env(bin_path, env):
         osmesa_path = path.join(dep_path, "out", "lib", "gallium")
         append_to_path_env(osmesa_path, env, "LD_LIBRARY_PATH")
         env["GALLIUM_DRIVER"] = "softpipe"
+        if show_vars:
+            print("GALLIUM_DRIVER=" + env["GALLIUM_DRIVER"])
+            print("LD_LIBRARY_PATH=" + env["LD_LIBRARY_PATH"])
     elif is_macosx():
         osmesa_dep_path = find_dep_path_newest('osmesa-src', bin_path)
         if not osmesa_dep_path:
@@ -241,6 +244,9 @@ def set_osmesa_env(bin_path, env):
                                "out", "src", "mapi", "shared-glapi", ".libs")
         append_to_path_env(osmesa_path + ":" + glapi_path, env, "DYLD_LIBRARY_PATH")
         env["GALLIUM_DRIVER"] = "softpipe"
+        if show_vars:
+            print("GALLIUM_DRIVER=" + env["GALLIUM_DRIVER"])
+            print("DYLD_LIBRARY_PATH=" + env["DYLD_LIBRARY_PATH"])
     return env
 
 

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -197,7 +197,7 @@ class MachCommands(CommandBase):
     @CommandArgument('--submit', '-a', default=False, action="store_true",
                      help="submit the data to perfherder")
     def test_perf(self, base=None, date=None, submit=False):
-        self.set_software_rendering_env(True)
+        self.set_software_rendering_env(True, False)
 
         self.ensure_bootstrapped()
         env = self.build_env()
@@ -445,7 +445,7 @@ class MachCommands(CommandBase):
 
     # Helper for test_css and test_wpt:
     def wptrunner(self, run_file, **kwargs):
-        self.set_software_rendering_env(kwargs['release'])
+        self.set_software_rendering_env(kwargs['release'], kwargs['debugger'])
 
         # By default, Rayon selects the number of worker threads
         # based on the available CPU count. This doesn't work very
@@ -760,12 +760,12 @@ class MachCommands(CommandBase):
         return check_call(
             [run_file, "|".join(tests), bin_path, base_dir])
 
-    def set_software_rendering_env(self, use_release):
+    def set_software_rendering_env(self, use_release, show_vars):
         # On Linux and mac, find the OSMesa software rendering library and
         # add it to the dynamic linker search path.
         try:
             bin_path = self.get_binary_path(use_release, not use_release)
-            if not set_osmesa_env(bin_path, os.environ):
+            if not set_osmesa_env(bin_path, os.environ, show_vars):
                 print("Warning: Cannot set the path to OSMesa library.")
         except BuildNotFound:
             # This can occur when cross compiling (e.g. arm64), in which case


### PR DESCRIPTION
This helps with #25231 by making it easy to set the appropriate environment variables inside lldb before running a headless debugging session.