### PR TITLE
Add &DomRoot<T> lint check

### DIFF
--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -6,7 +6,6 @@
 //! (https://html.spec.whatwg.org/multipage/#serializable-objects).
 
 use crate::dom::bindings::reflector::DomObject;
-use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::structuredclone::StructuredDataHolder;
 use crate::dom::globalscope::GlobalScope;
 
@@ -25,7 +24,7 @@ pub trait Serializable: DomObject {
     fn serialize(&self, sc_holder: &mut StructuredDataHolder) -> Result<StorageKey, ()>;
     /// <https://html.spec.whatwg.org/multipage/#deserialization-steps>
     fn deserialize(
-        owner: &DomRoot<GlobalScope>,
+        owner: &GlobalScope,
         sc_holder: &mut StructuredDataHolder,
         extra_data: StorageKey,
     ) -> Result<(), ()>;

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -56,7 +56,7 @@ enum StructuredCloneTags {
 }
 
 unsafe fn read_blob(
-    owner: &DomRoot<GlobalScope>,
+    owner: &GlobalScope,
     r: *mut JSStructuredCloneReader,
     mut sc_holder: &mut StructuredDataHolder,
 ) -> *mut JSObject {
@@ -88,7 +88,7 @@ unsafe fn read_blob(
 }
 
 unsafe fn write_blob(
-    owner: &DomRoot<GlobalScope>,
+    owner: &GlobalScope,
     blob: DomRoot<Blob>,
     w: *mut JSStructuredCloneWriter,
     sc_holder: &mut StructuredDataHolder,

--- a/components/script/dom/bindings/transferable.rs
+++ b/components/script/dom/bindings/transferable.rs
@@ -6,7 +6,6 @@
 //! (https://html.spec.whatwg.org/multipage/#transferable-objects).
 
 use crate::dom::bindings::reflector::DomObject;
-use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::structuredclone::StructuredDataHolder;
 use crate::dom::globalscope::GlobalScope;
 use js::jsapi::MutableHandleObject;
@@ -14,7 +13,7 @@ use js::jsapi::MutableHandleObject;
 pub trait Transferable: DomObject {
     fn transfer(&self, sc_holder: &mut StructuredDataHolder) -> Result<u64, ()>;
     fn transfer_receive(
-        owner: &DomRoot<GlobalScope>,
+        owner: &GlobalScope,
         sc_holder: &mut StructuredDataHolder,
         extra_data: u64,
         return_object: MutableHandleObject,

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -125,7 +125,7 @@ impl Serializable for Blob {
 
     /// <https://w3c.github.io/FileAPI/#ref-for-deserialization-steps>
     fn deserialize(
-        owner: &DomRoot<GlobalScope>,
+        owner: &GlobalScope,
         sc_holder: &mut StructuredDataHolder,
         storage_key: StorageKey,
     ) -> Result<(), ()> {
@@ -159,7 +159,7 @@ impl Serializable for Blob {
             *blob_impls = None;
         }
 
-        let deserialized_blob = Blob::new(&**owner, blob_impl);
+        let deserialized_blob = Blob::new(&*owner, blob_impl);
 
         let blobs = blobs.get_or_insert_with(|| HashMap::new());
         blobs.insert(storage_key, deserialized_blob);

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -892,7 +892,7 @@ impl GlobalScope {
     }
 
     /// Start tracking a blob
-    pub fn track_blob(&self, dom_blob: &DomRoot<Blob>, blob_impl: BlobImpl) {
+    pub fn track_blob(&self, dom_blob: &Blob, blob_impl: BlobImpl) {
         let blob_id = blob_impl.blob_id();
 
         let blob_info = BlobInfo {
@@ -905,7 +905,7 @@ impl GlobalScope {
     }
 
     /// Start tracking a file
-    pub fn track_file(&self, file: &DomRoot<File>, blob_impl: BlobImpl) {
+    pub fn track_file(&self, file: &File, blob_impl: BlobImpl) {
         let blob_id = blob_impl.blob_id();
 
         let blob_info = BlobInfo {

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -199,7 +199,7 @@ impl Transferable for MessagePort {
 
     /// https://html.spec.whatwg.org/multipage/#message-ports:transfer-receiving-steps
     fn transfer_receive(
-        owner: &DomRoot<GlobalScope>,
+        owner: &GlobalScope,
         sc_holder: &mut StructuredDataHolder,
         extra_data: u64,
         return_object: MutableHandleObject,
@@ -249,7 +249,7 @@ impl Transferable for MessagePort {
         };
 
         let transferred_port =
-            MessagePort::new_transferred(&**owner, id.clone(), port_impl.entangled_port_id());
+            MessagePort::new_transferred(&*owner, id.clone(), port_impl.entangled_port_id());
         owner.track_message_port(&transferred_port, Some(port_impl));
 
         return_object.set(transferred_port.reflector().rootable().get());

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -623,6 +623,7 @@ def check_rust(file_name, lines):
             (r"DomRefCell<Heap<.+>>", "Banned type DomRefCell<Heap<T>> detected. Use MutDom<T> instead", no_filter),
             # No benefit to using &Root<T>
             (r": &Root<", "use &T instead of &Root<T>", no_filter),
+            (r": &DomRoot<", "use &T instead of &DomRoot<T>", no_filter),
             (r"^&&", "operators should go at the end of the first line", no_filter),
             # This particular pattern is not reentrant-safe in script_thread.rs
             (r"match self.documents.borrow", "use a separate variable for the match expression",

--- a/python/tidy/servo_tidy_tests/rust_tidy.rs
+++ b/python/tidy/servo_tidy_tests/rust_tidy.rs
@@ -38,7 +38,7 @@ impl test {
         }
     }
 
-    fn test_fun2(y : &String, z : &Vec<f32>, r: &Root<isize>) -> () {
+    fn test_fun2(y : &String, z : &Vec<f32>, r: &Root<isize>, s: &DomRoot<isize>) -> () {
         let x = true;
         x
             && x;

--- a/python/tidy/servo_tidy_tests/test_tidy.py
+++ b/python/tidy/servo_tidy_tests/test_tidy.py
@@ -112,6 +112,7 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual('use &[T] instead of &Vec<T>', next(errors)[2])
         self.assertEqual('use &str instead of &String', next(errors)[2])
         self.assertEqual('use &T instead of &Root<T>', next(errors)[2])
+        self.assertEqual('use &T instead of &DomRoot<T>', next(errors)[2])
         self.assertEqual('encountered function signature with -> ()', next(errors)[2])
         self.assertEqual('operators should go at the end of the first line', next(errors)[2])
         self.assertNoMoreErrors(errors)


### PR DESCRIPTION
So far, the lint check code appears to work as intended. However, some trait implementations require modification to pass the lint check and I'm not sure how to fix these. Commit 92cf5d5 attempts to correct one of the implementations, but fails to compile with error:
```
  --> components/script/dom/servoparser/xml.rs:76:36
   |
76 |         tree_builder.trace_handles(&tracer);
   |                                    ^^^^^^^ expected struct `dom::bindings::root::Dom`, found struct `dom::node::Node`
   |
   = note: expected struct `dom::bindings::root::Dom<dom::node::Node>`
              found struct `dom::node::Node`
   = note: required for the cast to the object type `dyn html5ever::tree_builder::Tracer<Handle = dom::bindings::root::Dom<dom::node::Node>>`
```
I've tried to debug further but to no avail. I also don't want to mangle too much existing code unnecessarily. Any help is appreciated.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
`./mach test-tidy --all` does, and some are directly related to this PR
- [ ] These changes fix #25342
The fix is a WIP

<!-- Either: -->
- [X] There are tests for these changes

Note that I will clean up the commit history before the final PR.
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
