### PR TITLE
Autocomputed content-type header now reaches net request

### DIFF
--- a/tests/wpt/metadata/fetch/api/basic/request-headers.any.js.ini
+++ b/tests/wpt/metadata/fetch/api/basic/request-headers.any.js.ini
@@ -1,47 +1,16 @@
 [request-headers.any.html]
   type: testharness
-  [Fetch with PUT with body]
-    expected: FAIL
-
-  [Fetch with POST with text body]
-    expected: FAIL
-
   [Fetch with POST with FormData body]
-    expected: FAIL
-
-  [Fetch with POST with URLSearchParams body]
-    expected: FAIL
-
-  [Fetch with POST with Blob body with mime type]
     expected: FAIL
 
   [Fetch with Chicken]
     expected: FAIL
-
-  [Fetch with Chicken with body]
-    expected: FAIL
-
 
 [request-headers.any.worker.html]
   type: testharness
-  [Fetch with PUT with body]
-    expected: FAIL
-
-  [Fetch with POST with text body]
-    expected: FAIL
-
   [Fetch with POST with FormData body]
     expected: FAIL
 
-  [Fetch with POST with URLSearchParams body]
-    expected: FAIL
-
-  [Fetch with POST with Blob body with mime type]
-    expected: FAIL
-
   [Fetch with Chicken]
-    expected: FAIL
-
-  [Fetch with Chicken with body]
     expected: FAIL
 


### PR DESCRIPTION
The spec expects that for a DOM Request r, r.headers and r.request can actually refer to the same header list in RAM, with changes to one affecting the other. This is mostly unobservable, but it happens to come up at the point in the Request constructor that auto-infers a content type from the body, so now after inferring the content type it injects it into both header lists instead of one.
Remaining test failures are due to the way Hyper crates normalize semicolons in MIME types, and an actually separate problem about content-lengths that I haven't sniffed out yet.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix some WPT results from #24904

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
