### PR TITLE
Add `track_list` member to AudioTrack, VideoTrack, TextTrack structs

### DIFF
--- a/components/script/dom/audiotracklist.rs
+++ b/components/script/dom/audiotracklist.rs
@@ -104,9 +104,14 @@ impl AudioTrackList {
 
     pub fn add(&self, track: &AudioTrack) {
         self.tracks.borrow_mut().push(Dom::from_ref(track));
+        track.add_track_list(self);
     }
 
     pub fn clear(&self) {
+        self.tracks
+            .borrow()
+            .iter()
+            .for_each(|t| t.remove_track_list());
         self.tracks.borrow_mut().clear();
     }
 }

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -2362,6 +2362,7 @@ impl HTMLMediaElementMethods for HTMLMediaElement {
             label,
             language,
             TextTrackMode::Hidden,
+            None,
         );
         // Step 3 & 4
         self.TextTracks().add(&track);

--- a/components/script/dom/htmltrackelement.rs
+++ b/components/script/dom/htmltrackelement.rs
@@ -59,6 +59,7 @@ impl HTMLTrackElement {
             Default::default(),
             Default::default(),
             Default::default(),
+            None,
         );
         Node::reflect_node(
             Box::new(HTMLTrackElement::new_inherited(

--- a/components/script/dom/texttrack.rs
+++ b/components/script/dom/texttrack.rs
@@ -2,16 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::TextTrackBinding::{
     self, TextTrackKind, TextTrackMethods, TextTrackMode,
 };
 use crate::dom::bindings::error::{Error, ErrorResult};
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
-use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::texttrackcue::TextTrackCue;
 use crate::dom::texttrackcuelist::TextTrackCueList;
+use crate::dom::texttracklist::TextTrackList;
 use crate::dom::window::Window;
 use dom_struct::dom_struct;
 use std::cell::Cell;
@@ -25,6 +27,7 @@ pub struct TextTrack {
     id: String,
     mode: Cell<TextTrackMode>,
     cue_list: MutNullableDom<TextTrackCueList>,
+    track_list: DomRefCell<Option<Dom<TextTrackList>>>,
 }
 
 impl TextTrack {
@@ -34,6 +37,7 @@ impl TextTrack {
         label: DOMString,
         language: DOMString,
         mode: TextTrackMode,
+        track_list: Option<&TextTrackList>,
     ) -> TextTrack {
         TextTrack {
             eventtarget: EventTarget::new_inherited(),
@@ -43,6 +47,7 @@ impl TextTrack {
             id: id.into(),
             mode: Cell::new(mode),
             cue_list: Default::default(),
+            track_list: DomRefCell::new(track_list.map(|t| Dom::from_ref(t))),
         }
     }
 
@@ -53,9 +58,12 @@ impl TextTrack {
         label: DOMString,
         language: DOMString,
         mode: TextTrackMode,
+        track_list: Option<&TextTrackList>,
     ) -> DomRoot<TextTrack> {
         reflect_dom_object(
-            Box::new(TextTrack::new_inherited(id, kind, label, language, mode)),
+            Box::new(TextTrack::new_inherited(
+                id, kind, label, language, mode, track_list,
+            )),
             window,
             TextTrackBinding::Wrap,
         )
@@ -68,6 +76,14 @@ impl TextTrack {
 
     pub fn id(&self) -> &str {
         &self.id
+    }
+
+    pub fn add_track_list(&self, track_list: &TextTrackList) {
+        *self.track_list.borrow_mut() = Some(Dom::from_ref(track_list));
+    }
+
+    pub fn remove_track_list(&self) {
+        *self.track_list.borrow_mut() = None;
     }
 }
 

--- a/components/script/dom/texttracklist.rs
+++ b/components/script/dom/texttracklist.rs
@@ -94,6 +94,7 @@ impl TextTrackList {
                 }),
                 &canceller,
             );
+            track.add_track_list(self);
         }
     }
 
@@ -101,6 +102,9 @@ impl TextTrackList {
     // removed from the TextTrackList.
     #[allow(dead_code)]
     pub fn remove(&self, idx: usize) {
+        if let Some(track) = self.dom_tracks.borrow().get(idx) {
+            track.remove_track_list();
+        }
         self.dom_tracks.borrow_mut().remove(idx);
         self.upcast::<EventTarget>()
             .fire_event(atom!("removetrack"));

--- a/components/script/dom/videotrack.rs
+++ b/components/script/dom/videotrack.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::VideoTrackBinding::{self, VideoTrackMethods};
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -19,7 +20,7 @@ pub struct VideoTrack {
     label: DOMString,
     language: DOMString,
     selected: Cell<bool>,
-    track_list: Option<Dom<VideoTrackList>>,
+    track_list: DomRefCell<Option<Dom<VideoTrackList>>>,
 }
 
 impl VideoTrack {
@@ -37,7 +38,7 @@ impl VideoTrack {
             label: label.into(),
             language: language.into(),
             selected: Cell::new(false),
-            track_list: track_list.map(|t| Dom::from_ref(t)),
+            track_list: DomRefCell::new(track_list.map(|t| Dom::from_ref(t))),
         }
     }
 
@@ -73,6 +74,14 @@ impl VideoTrack {
     pub fn set_selected(&self, value: bool) {
         self.selected.set(value);
     }
+
+    pub fn add_track_list(&self, track_list: &VideoTrackList) {
+        *self.track_list.borrow_mut() = Some(Dom::from_ref(track_list));
+    }
+
+    pub fn remove_track_list(&self) {
+        *self.track_list.borrow_mut() = None;
+    }
 }
 
 impl VideoTrackMethods for VideoTrack {
@@ -103,7 +112,7 @@ impl VideoTrackMethods for VideoTrack {
 
     // https://html.spec.whatwg.org/multipage/#dom-videotrack-selected
     fn SetSelected(&self, value: bool) {
-        if let Some(list) = self.track_list.as_ref() {
+        if let Some(list) = self.track_list.borrow().as_ref() {
             if let Some(idx) = list.find(self) {
                 list.set_selected(idx, value);
             }

--- a/components/script/dom/videotracklist.rs
+++ b/components/script/dom/videotracklist.rs
@@ -113,9 +113,14 @@ impl VideoTrackList {
                 self.set_selected(idx, false);
             }
         }
+        track.add_track_list(self);
     }
 
     pub fn clear(&self) {
+        self.tracks
+            .borrow()
+            .iter()
+            .for_each(|t| t.remove_track_list());
         self.tracks.borrow_mut().clear();
     }
 }


### PR DESCRIPTION
Add member to the track structs pointing at their associated tracklist
and update it when the track is added or removed from a tracklist.

r?@jdm

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #22912  (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
