### PR TITLE
Launch vcvarsall.bat for the recognized VS Installation Directory from python instead of making mach.bat try that on hardcoded paths.

### DIFF
--- a/mach.bat
+++ b/mach.bat
@@ -1,65 +1,8 @@
 @echo off
 
-setlocal
-
-if EXIST "%VCINSTALLDIR%" (
-  GOTO mach
-)
-
-pushd .
-
-IF EXIST "%ProgramFiles(x86)%" (
-  set "ProgramFiles32=%ProgramFiles(x86)%"
-) ELSE (
-  set "ProgramFiles32=%ProgramFiles%"
-)
-
-for %%v in (2019 2017) do (
-  for %%e in (Enterprise Professional Community BuildTools) do (
-    IF EXIST "%ProgramFiles32%\Microsoft Visual Studio\%%v\%%e\VC\Auxiliary\Build\vcvarsall.bat" (
-      set "VS_VCVARS=%ProgramFiles32%\Microsoft Visual Studio\%%v\%%e\VC\Auxiliary\Build\vcvarsall.bat"
-      GOTO vcvars
-    )
-  )
-)
-
-set VC14VARS=%VS140COMNTOOLS%..\..\VC\vcvarsall.bat
-IF EXIST "%VC14VARS%" (
-  set "VS_VCVARS=%VC14VARS%"
-)
-
-:vcvars
-IF EXIST "%VS_VCVARS%" (
-  IF NOT DEFINED Platform (
-    IF EXIST "%ProgramFiles(x86)%" (
-      call "%VS_VCVARS%" x64
-    ) ELSE (
-      ECHO 32-bit Windows is currently unsupported.
-      GOTO bad_exit
-    )
-  )
-) ELSE (
-  ECHO Visual Studio 2015, 2017, or 2019 is not installed.
-  ECHO Download and install Visual Studio from https://www.visualstudio.com/
-  GOTO bad_exit
-)
-
-popd
-
-:mach
 where /Q py.exe
 IF %ERRORLEVEL% NEQ 0 (
   python mach %*
 ) ELSE (
   py -2 mach %*
 )
-
-GOTO exit
-
-:bad_exit
-endlocal
-EXIT /B 1
-
-:exit
-endlocal
-exit /B

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -10,6 +10,7 @@
 from __future__ import print_function, unicode_literals
 
 import datetime
+import locale
 import os
 import os.path as path
 import platform
@@ -317,6 +318,16 @@ class MachCommands(CommandBase):
                 self.msvc_package_dir("gstreamer-uwp"), arch['gst_root'],
                 "lib", "pkgconfig"
             )
+
+        if 'windows' in host:
+            process = subprocess.Popen('("%s" %s > nul) && "python" -c "import os; print(repr(os.environ))"' %
+                                       (os.path.join(vs_dirs['vcdir'], "Auxiliary", "Build", "vcvarsall.bat"), "x64"),
+                                       stdout=subprocess.PIPE, shell=True)
+            stdout, _ = process.communicate()
+            exitcode = process.wait()
+            encoding = locale.getpreferredencoding()  # See https://stackoverflow.com/a/9228117
+            if exitcode == 0:
+                os.environ.update(eval(stdout.decode(encoding)))
 
         # Ensure that GStreamer libraries are accessible when linking.
         if 'windows' in target_triple:


### PR DESCRIPTION
Move the Execution of vcvars (which sets up the environment for visual studio tools) from mach.bat to python, so that ./mach works under mozilla-build and that #25300 can be used.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25360 #25336 
- [X] These changes do not require tests because changes to build infra