### PR TITLE
Remove obsolete HasInstance behavior per heycam/webidl #356

### DIFF
--- a/tests/wpt/metadata/WebIDL/ecmascript-binding/has-instance.html.ini
+++ b/tests/wpt/metadata/WebIDL/ecmascript-binding/has-instance.html.ini
@@ -1,5 +1,0 @@
-[has-instance.html]
-  type: testharness
-  [instanceof must return false across different globals, for platform objects]
-    expected: FAIL
-


### PR DESCRIPTION
This turns one WPT test from fail to pass and it leaves Servo with a little less platform object special-case code to worry about.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25039

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
