### PR TITLE
apply is: to Document.createElement even when name isn't registered yet

### DIFF
--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -189,14 +189,21 @@ fn create_html_element(
         }
     }
 
-    // Steps 7.1-7.2
+    // Steps 7.1-7.3
     let result = create_native_html_element(name.clone(), prefix, document, creator);
+    match is {
+        Some(is) => {
+            result.set_is(is);
+            result.set_custom_element_state(CustomElementState::Undefined);
+        },
+        None => {
+            if is_valid_custom_element_name(&*name.local) {
+                result.set_custom_element_state(CustomElementState::Undefined);
+            }
+        },
+    };
 
-    // Step 7.3
-    if is_valid_custom_element_name(&*name.local) || is.is_some() {
-        result.set_custom_element_state(CustomElementState::Undefined);
-    }
-
+    // Step 8
     result
 }
 

--- a/tests/wpt/metadata/custom-elements/Document-createElement.html.ini
+++ b/tests/wpt/metadata/custom-elements/Document-createElement.html.ini
@@ -1,7 +1,4 @@
 [Document-createElement.html]
-  [document.createElement with unknown "is" value should create "undefined" state element]
-    expected: FAIL
-
   [document.createElement must create an instance of autonomous custom elements when it has is attribute]
     expected: FAIL
 

--- a/tests/wpt/metadata/custom-elements/builtin-coverage.html.ini
+++ b/tests/wpt/metadata/custom-elements/builtin-coverage.html.ini
@@ -8,437 +8,221 @@
 
   [a: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [a: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [abbr: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [abbr: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [address: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [address: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [area: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [area: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [article: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [article: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [aside: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [aside: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [audio: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [audio: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [b: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [b: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [base: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [base: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [bdi: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [bdi: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [bdo: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [bdo: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [blockquote: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [blockquote: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [body: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [body: document parser should instantiate a customized built-in element]
-    expected: FAIL
   [br: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [br: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [button: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [button: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [canvas: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [canvas: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [caption: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [caption: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [cite: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [cite: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [code: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [code: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [col: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [col: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [colgroup: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [colgroup: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [data: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [data: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [datalist: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [datalist: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [dd: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [dd: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [del: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [del: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [details: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [details: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [dfn: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [dfn: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [dialog: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [dialog: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [div: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [div: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [dl: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [dl: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [dt: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [dt: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [em: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [em: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [embed: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [embed: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [fieldset: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [fieldset: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [figcaption: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [figcaption: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [figure: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [figure: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [footer: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [footer: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [form: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [form: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [h1: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [h1: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [h2: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [h2: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [h3: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [h3: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [h4: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [h4: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [h5: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [h5: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [h6: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [h6: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [header: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [header: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [hgroup: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [hgroup: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [hr: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [hr: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [html: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [html: document parser should instantiate a customized built-in element]
     expected: FAIL
   [i: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [i: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [iframe: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [iframe: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [img: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [img: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [input: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [input: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [ins: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [ins: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [kbd: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [kbd: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [label: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [label: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [legend: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [legend: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [li: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [li: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [link: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [link: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [main: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [main: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [map: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [map: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [mark: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [mark: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [menu: Define a customized built-in element]
     expected: FAIL
   [meta: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [meta: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [meter: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [meter: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [nav: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [nav: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [noscript: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [noscript: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [object: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [object: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [ol: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [ol: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [optgroup: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [optgroup: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [option: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [option: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [output: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [output: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [p: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [p: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [param: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [param: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [picture: Define a customized built-in element]
     expected: FAIL
   [pre: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [pre: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [progress: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [progress: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [q: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [q: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [rp: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [rp: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [rt: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [rt: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [ruby: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [ruby: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [s: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [s: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [samp: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [samp: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [script: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [script: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [section: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [section: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [select: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [select: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [small: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [small: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [source: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [source: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [span: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [span: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [strong: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [strong: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [style: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [style: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [sub: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [sub: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [summary: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [summary: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [sup: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [sup: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [table: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [table: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [tbody: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [tbody: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [td: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [td: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [template: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [template: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [textarea: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [textarea: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [tfoot: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [tfoot: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [th: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [th: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [thead: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [thead: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [time: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [time: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [title: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [title: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [tr: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [tr: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [track: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [track: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [u: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [u: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [ul: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [ul: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [var: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [var: innerHTML should instantiate a customized built-in element]
     expected: FAIL
   [video: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [video: innerHTML should instantiate a customized built-in element]
-    expected: FAIL
   [wbr: Operator 'new' should instantiate a customized built-in element]
-    expected: FAIL
-  [wbr: innerHTML should instantiate a customized built-in element]
     expected: FAIL

--- a/tests/wpt/metadata/custom-elements/upgrading/Document-importNode.html.ini
+++ b/tests/wpt/metadata/custom-elements/upgrading/Document-importNode.html.ini
@@ -1,7 +1,4 @@
 [Document-importNode.html]
-  [built-in: document.importNode() should import "undefined" custom elements successfully]
-    expected: FAIL
-
   [Document-importNode]
     expected: FAIL
 

--- a/tests/wpt/metadata/custom-elements/upgrading/Node-cloneNode.html.ini
+++ b/tests/wpt/metadata/custom-elements/upgrading/Node-cloneNode.html.ini
@@ -1,3 +1,0 @@
-[Node-cloneNode.html]
-  [Node.prototype.cloneNode(false) must be able to clone as a customized built-in element when it has an inconsistent "is" attribute]
-    expected: FAIL


### PR DESCRIPTION
The "is" option to Document.createElement should be respected even when the name hasn't been registered yet, in which case the name gets looked up again at the time the element should be upgraded. This change does that.
I'm now seeing a few test timeouts that aren't in the metadata, but I suspect they're slowness on my local configuration and not actual breakage.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25009 fix #24997 and fix #24998 

<!-- Either: -->
- [X] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
