### PR TITLE
 Always pass InRealm to GlobalScope::from_context to avoid getting a null global

### DIFF
--- a/components/script/dom/bindings/codegen/Bindings.conf
+++ b/components/script/dom/bindings/codegen/Bindings.conf
@@ -57,7 +57,7 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'inRealms': ['Fetch'],
+    'inRealms': ['Fetch', 'Opener'],
 },
 
 'WorkerGlobalScope': {

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -14,6 +14,7 @@ use crate::dom::bindings::conversions::{
 use crate::dom::bindings::str::USVString;
 use crate::dom::domexception::{DOMErrorName, DOMException};
 use crate::dom::globalscope::GlobalScope;
+use crate::realms::InRealm;
 use crate::script_runtime::JSContext as SafeJSContext;
 #[cfg(feature = "js_backtrace")]
 use backtrace::Backtrace;
@@ -231,7 +232,7 @@ impl ErrorInfo {
 ///
 /// The `dispatch_event` argument is temporary and non-standard; passing false
 /// prevents dispatching the `error` event.
-pub unsafe fn report_pending_exception(cx: *mut JSContext, dispatch_event: bool) {
+pub unsafe fn report_pending_exception(cx: *mut JSContext, dispatch_event: bool, realm: InRealm) {
     if !JS_IsExceptionPending(cx) {
         return;
     }
@@ -285,7 +286,7 @@ pub unsafe fn report_pending_exception(cx: *mut JSContext, dispatch_event: bool)
     }
 
     if dispatch_event {
-        GlobalScope::from_context(cx).report_an_error(error_info, value.handle());
+        GlobalScope::from_context(cx, realm).report_an_error(error_info, value.handle());
     }
 }
 

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -81,9 +81,9 @@ use crate::dom::htmlulistelement::HTMLUListElement;
 use crate::dom::htmlunknownelement::HTMLUnknownElement;
 use crate::dom::htmlvideoelement::HTMLVideoElement;
 use crate::dom::svgsvgelement::SVGSVGElement;
+use crate::realms::{enter_realm, InRealm};
 use crate::script_thread::ScriptThread;
 use html5ever::{LocalName, Prefix, QualName};
-use js::jsapi::JSAutoRealm;
 use servo_config::pref;
 
 fn create_svg_element(
@@ -157,10 +157,9 @@ fn create_html_element(
 
                             // Step 6.1.1
                             unsafe {
-                                let _ac =
-                                    JSAutoRealm::new(*cx, global.reflector().get_jsobject().get());
+                                let ar = enter_realm(&*global);
                                 throw_dom_exception(cx, &global, error);
-                                report_pending_exception(*cx, true);
+                                report_pending_exception(*cx, true, InRealm::Entered(&ar));
                             }
 
                             // Step 6.1.2

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -31,7 +31,7 @@ use crate::dom::node::{document_from_node, window_from_node, Node, ShadowIncludi
 use crate::dom::promise::Promise;
 use crate::dom::window::Window;
 use crate::microtask::Microtask;
-use crate::realms::InRealm;
+use crate::realms::{enter_realm, InRealm};
 use crate::script_runtime::JSContext;
 use crate::script_thread::ScriptThread;
 use dom_struct::dom_struct;
@@ -652,8 +652,9 @@ pub fn upgrade_element(definition: Rc<CustomElementDefinition>, element: &Elemen
         let global = GlobalScope::current().expect("No current global");
         let cx = global.get_cx();
         unsafe {
+            let ar = enter_realm(&*global);
             throw_dom_exception(cx, &global, error);
-            report_pending_exception(*cx, true);
+            report_pending_exception(*cx, true, InRealm::Entered(&ar));
         }
 
         return;

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -34,10 +34,10 @@ use crate::dom::node::document_from_node;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
-use crate::realms::enter_realm;
+use crate::realms::{enter_realm, InRealm};
 use dom_struct::dom_struct;
 use fnv::FnvHasher;
-use js::jsapi::{JSAutoRealm, JSFunction, JS_GetFunctionObject, SourceText};
+use js::jsapi::{JSFunction, JS_GetFunctionObject, SourceText};
 use js::rust::wrappers::CompileFunction;
 use js::rust::{AutoObjectVectorWrapper, CompileOptionsWrapper};
 use libc::c_char;
@@ -552,9 +552,9 @@ impl EventTarget {
         if !rv || handler.get().is_null() {
             // Step 3.7
             unsafe {
-                let _ac = JSAutoRealm::new(*cx, self.reflector().get_jsobject().get());
+                let ar = enter_realm(&*self);
                 // FIXME(#13152): dispatch error event.
-                report_pending_exception(*cx, false);
+                report_pending_exception(*cx, false, InRealm::Entered(&ar));
             }
             return None;
         }

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -48,7 +48,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::url::URL;
-use crate::realms::InRealm;
+use crate::realms::{AlreadyInRealm, InRealm};
 use crate::script_runtime::JSContext as SafeJSContext;
 use crate::timers::OneshotTimerCallback;
 use dom_struct::dom_struct;
@@ -1015,7 +1015,10 @@ impl TestBindingMethods for TestBinding {
         impl Callback for SimpleHandler {
             #[allow(unsafe_code)]
             fn callback(&self, cx: *mut JSContext, v: HandleValue) {
-                let global = unsafe { GlobalScope::from_context(cx) };
+                let global = unsafe {
+                    let in_realm_proof = AlreadyInRealm::assert_for_cx(SafeJSContext::from_ptr(cx));
+                    GlobalScope::from_context(cx, InRealm::Already(&in_realm_proof))
+                };
                 let _ = self.handler.Call_(&*global, v, ExceptionHandling::Report);
             }
         }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -673,7 +673,7 @@ impl WindowMethods for Window {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-opener
-    fn Opener(&self, cx: JSContext) -> JSVal {
+    fn Opener(&self, cx: JSContext, in_realm_proof: InRealm) -> JSVal {
         // Step 1, Let current be this Window object's browsing context.
         let current = match self.window_proxy.get() {
             Some(proxy) => proxy,
@@ -688,7 +688,7 @@ impl WindowMethods for Window {
             return NullValue();
         }
         // Step 3 to 5.
-        current.opener(*cx)
+        current.opener(*cx, in_realm_proof)
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -17,7 +17,7 @@ use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::window::Window;
-use crate::realms::enter_realm;
+use crate::realms::{enter_realm, AlreadyInRealm, InRealm};
 use crate::script_runtime::JSContext as SafeJSContext;
 use crate::script_thread::ScriptThread;
 use dom_struct::dom_struct;
@@ -370,7 +370,7 @@ impl WindowProxy {
 
     #[allow(unsafe_code)]
     // https://html.spec.whatwg.org/multipage/#dom-opener
-    pub fn opener(&self, cx: *mut JSContext) -> JSVal {
+    pub fn opener(&self, cx: *mut JSContext, in_realm_proof: InRealm) -> JSVal {
         if self.disowned.get() {
             return NullValue();
         }
@@ -387,7 +387,8 @@ impl WindowProxy {
                     opener_id,
                 ) {
                     Some(opener_top_id) => {
-                        let global_to_clone_from = unsafe { GlobalScope::from_context(cx) };
+                        let global_to_clone_from =
+                            unsafe { GlobalScope::from_context(cx, in_realm_proof) };
                         WindowProxy::new_dissimilar_origin(
                             &*global_to_clone_from,
                             opener_id,
@@ -982,10 +983,11 @@ pub fn new_window_proxy_handler() -> WindowProxyHandler {
 // defined in the DissimilarOriginWindow IDL.
 
 #[allow(unsafe_code)]
-unsafe fn throw_security_error(cx: *mut JSContext) -> bool {
+unsafe fn throw_security_error(cx: *mut JSContext, realm: InRealm) -> bool {
     if !JS_IsExceptionPending(cx) {
-        let global = GlobalScope::from_context(cx);
-        throw_dom_exception(SafeJSContext::from_ptr(cx), &*global, Error::Security);
+        let safe_context = SafeJSContext::from_ptr(cx);
+        let global = GlobalScope::from_context(cx, realm);
+        throw_dom_exception(safe_context, &*global, Error::Security);
     }
     false
 }
@@ -1006,7 +1008,8 @@ unsafe extern "C" fn has_xorigin(
         *bp = true;
         true
     } else {
-        throw_security_error(cx)
+        let in_realm_proof = AlreadyInRealm::assert_for_cx(SafeJSContext::from_ptr(cx));
+        throw_security_error(cx, InRealm::Already(&in_realm_proof))
     }
 }
 
@@ -1032,7 +1035,8 @@ unsafe extern "C" fn set_xorigin(
     _: RawHandleValue,
     _: *mut ObjectOpResult,
 ) -> bool {
-    throw_security_error(cx)
+    let in_realm_proof = AlreadyInRealm::assert_for_cx(SafeJSContext::from_ptr(cx));
+    throw_security_error(cx, InRealm::Already(&in_realm_proof))
 }
 
 #[allow(unsafe_code)]
@@ -1042,7 +1046,8 @@ unsafe extern "C" fn delete_xorigin(
     _: RawHandleId,
     _: *mut ObjectOpResult,
 ) -> bool {
-    throw_security_error(cx)
+    let in_realm_proof = AlreadyInRealm::assert_for_cx(SafeJSContext::from_ptr(cx));
+    throw_security_error(cx, InRealm::Already(&in_realm_proof))
 }
 
 #[allow(unsafe_code, non_snake_case)]
@@ -1065,7 +1070,8 @@ unsafe extern "C" fn defineProperty_xorigin(
     _: RawHandle<PropertyDescriptor>,
     _: *mut ObjectOpResult,
 ) -> bool {
-    throw_security_error(cx)
+    let in_realm_proof = AlreadyInRealm::assert_for_cx(SafeJSContext::from_ptr(cx));
+    throw_security_error(cx, InRealm::Already(&in_realm_proof))
 }
 
 #[allow(unsafe_code, non_snake_case)]
@@ -1074,7 +1080,8 @@ unsafe extern "C" fn preventExtensions_xorigin(
     _: RawHandleObject,
     _: *mut ObjectOpResult,
 ) -> bool {
-    throw_security_error(cx)
+    let in_realm_proof = AlreadyInRealm::assert_for_cx(SafeJSContext::from_ptr(cx));
+    throw_security_error(cx, InRealm::Already(&in_realm_proof))
 }
 
 static XORIGIN_PROXY_HANDLER: ProxyTraps = ProxyTraps {


### PR DESCRIPTION


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25348
- [x] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
