### PR TITLE
Implement OS Version Detection for the User Agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3773,6 +3773,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 
 [[package]]
+name = "os_info"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec82f1f4e6c7e0c231c26ce8ea961bbb5fc6e969e7486573a88081bf9cb0bc60"
+dependencies = [
+ "lazy_static",
+ "log",
+ "regex",
+ "serde",
+ "serde_derive",
+ "winapi",
+]
+
+[[package]]
 name = "osmesa-src"
 version = "0.1.1"
 source = "git+https://github.com/servo/osmesa-src#1a9519c3675ebc1117cbb18ed6db420b5941cb8b"
@@ -5031,6 +5045,7 @@ dependencies = [
  "lazy_static",
  "log",
  "num_cpus",
+ "os_info",
  "serde",
  "serde_json",
  "servo_config_plugins",

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -32,3 +32,6 @@ std_test_override = { path = "../std_test_override" }
 
 [target.'cfg(not(any(target_os = "android", feature = "uwp")))'.dependencies]
 dirs = "1.0"
+
+[target.'cfg(all(target_os = "windows", not(target_vendor = "uwp")))'.dependencies]
+os_info = "1.2.0"

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -465,6 +465,10 @@ mod gen {
                 },
                 mime: {
                     sniff: bool,
+                },
+                user_agent: {
+                    #[serde(rename = "network.user-agent.spoof")]
+                    spoof: bool,
                 }
             },
             session_history: {

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -90,6 +90,7 @@
   "media.testing.enabled": false,
   "network.http-cache.disabled": false,
   "network.mime.sniff": false,
+  "network.user-agent.spoof": false,
   "session-history.max-length": 20,
   "shell.homepage": "https://servo.org",
   "shell.keep_screen_on.enabled": false,


### PR DESCRIPTION
User Agent now correctly reports Windows 7, 8.1, 10, ...

---
- [X] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [X] These changes fix #18194
- [X] These changes do not require tests, because that would involve testing servo across all windows versions, to be meaningful