### PR TITLE
let document.createElement[NS] accept a string for options

### DIFF
--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -9,6 +9,7 @@ use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
     DocumentMethods, ElementCreationOptions,
 };
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
+use crate::dom::bindings::codegen::UnionTypes::StringOrElementCreationOptions;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
@@ -105,10 +106,13 @@ impl DOMImplementationMethods for DOMImplementation {
         let maybe_elem = if qname.is_empty() {
             None
         } else {
-            let options = ElementCreationOptions { is: None };
+            let options =
+                StringOrElementCreationOptions::ElementCreationOptions(ElementCreationOptions {
+                    is: None,
+                });
             match doc
                 .upcast::<Document>()
-                .CreateElementNS(maybe_namespace, qname, &options)
+                .CreateElementNS(maybe_namespace, qname, options)
             {
                 Err(error) => return Err(error),
                 Ok(elem) => Some(elem),

--- a/components/script/dom/webidls/Document.webidl
+++ b/components/script/dom/webidls/Document.webidl
@@ -34,9 +34,10 @@ interface Document : Node {
   HTMLCollection getElementsByClassName(DOMString classNames);
 
   [CEReactions, NewObject, Throws]
-  Element createElement(DOMString localName, optional ElementCreationOptions options = {});
+  Element createElement(DOMString localName, optional (DOMString or ElementCreationOptions) options = {});
   [CEReactions, NewObject, Throws]
-  Element createElementNS(DOMString? namespace, DOMString qualifiedName, optional ElementCreationOptions options = {});
+  Element createElementNS(DOMString? namespace, DOMString qualifiedName,
+                          optional (DOMString or ElementCreationOptions) options = {});
   [NewObject]
   DocumentFragment createDocumentFragment();
   [NewObject]

--- a/tests/wpt/metadata/custom-elements/Document-createElement.html.ini
+++ b/tests/wpt/metadata/custom-elements/Document-createElement.html.ini
@@ -4,7 +4,3 @@
 
   [document.createElement must create an instance of autonomous custom elements when it has is attribute]
     expected: FAIL
-
-  [document.createElement()'s second argument is to be ignored when it's a string]
-    expected: FAIL
-

--- a/tests/wpt/metadata/custom-elements/Document-createElementNS.html.ini
+++ b/tests/wpt/metadata/custom-elements/Document-createElementNS.html.ini
@@ -1,4 +1,0 @@
-[Document-createElementNS.html]
-  [document.createElementNS()'s third argument is to be ignored when it's a string]
-    expected: FAIL
-


### PR DESCRIPTION
The string actually does nothing, but spec and WPT don't want it to do anything. https://dom.spec.whatwg.org/#dom-document-createelement only cares about the options value when it's a dictionary, and the WPT test on the string case is just that it isn't throwing an exception.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25008

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
