### PR TITLE
Run eventsource wpt tests with Python3

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -734,7 +734,13 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
         if this_chunk == 0:
             task.with_script("""
                 ./mach test-wpt-failure
-                time ./mach test-wpt --release --binary-arg=--multiprocess \
+                time python2 ./mach test-wpt --release --binary-arg=--multiprocess \
+                    --processes $PROCESSES \
+                    --log-raw test-wpt-mp.log \
+                    --log-errorsummary wpt-mp-errorsummary.log \
+                    eventsource \
+                    | cat
+                time env PYTHONIOENCODING=utf-8 python3 ./mach test-wpt --release --binary-arg=--multiprocess \
                     --processes $PROCESSES \
                     --log-raw test-wpt-mp.log \
                     --log-errorsummary wpt-mp-errorsummary.log \

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -658,7 +658,7 @@ def macos_wpt():
     priority = "high" if CONFIG.git_ref == "refs/heads/auto" else None
     build_task = macos_release_build_with_debug_assertions(priority=priority)
     def macos_run_task(name):
-        task = macos_task(name).with_python2() \
+        task = macos_task(name).with_python2().with_python3() \
             .with_repo_bundle(alternate_object_dir="/var/cache/servo.git/objects")
         return with_homebrew(task, ["etc/taskcluster/macos/Brewfile"])
     wpt_chunks(

--- a/etc/taskcluster/decisionlib.py
+++ b/etc/taskcluster/decisionlib.py
@@ -693,6 +693,12 @@ class MacOsGenericWorkerTask(UnixTaskMixin, GenericWorkerTask):
             pip install --user virtualenv
         """)
 
+    def with_python3(self):
+        return self.with_early_script("""
+            python3 -m ensurepip --user
+            python3 -m pip install --user virtualenv
+        """)
+
     def with_rustup(self):
         return self.with_early_script("""
             export PATH="$HOME/.cargo/bin:$PATH"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,8 +5,8 @@ blessings == 1.6
 distro == 1.4
 mach == 1.0.0
 mozdebug == 0.1
-mozinfo == 0.8
-mozlog == 3.6
+mozinfo == 1.1.0
+mozlog == 5.0
 setuptools == 39.0
 toml == 0.9.2
 

--- a/tests/wpt/run.py
+++ b/tests/wpt/run.py
@@ -34,7 +34,7 @@ def run_tests(**kwargs):
     set_defaults(kwargs)
 
     mozlog.commandline.log_formatters["servo"] = \
-        (grouping_formatter.ServoFormatter, "Servo’s grouping output formatter")
+        (grouping_formatter.ServoFormatter, "Servo's grouping output formatter")
     mozlog.commandline.log_formatters["servojson"] = \
         (grouping_formatter.ServoJsonFormatter, "Servo's JSON logger of unexpected results")
 


### PR DESCRIPTION
I deliberately changed the CI to run the WPT tests using Python3 to see if it works.
Even if we don't want to change the CI right now, the first commit with only the python requirements update can be merged.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
