### PR TITLE
Now using eq_ignore_case on WASM mimetype, per #25317

### DIFF
--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -915,16 +915,13 @@ unsafe extern "C" fn consume_stream(
         let mimetype = unwrapped_source.Headers().extract_mime_type();
 
         //Step 2.3 If mimeType is not `application/wasm`, return with a TypeError and abort these substeps.
-        match &mimetype[..] {
-            b"application/wasm" | b"APPLICATION/wasm" | b"APPLICATION/WASM" => {},
-            _ => {
-                throw_dom_exception(
-                    cx,
-                    &global,
-                    Error::Type("Response has unsupported MIME type".to_string()),
-                );
-                return false;
-            },
+        if !&mimetype[..].eq_ignore_ascii_case(b"application/wasm") {
+            throw_dom_exception(
+                cx,
+                &global,
+                Error::Type("Response has unsupported MIME type".to_string()),
+            );
+            return false;
         }
 
         //Step 2.4 If response is not CORS-same-origin, return with a TypeError and abort these substeps.


### PR DESCRIPTION
I have no idea how this would be tested.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25317

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
