### PR TITLE
Add "active parser was aborted boolean" to Document

### DIFF
--- a/tests/wpt/metadata/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/aborted-parser.window.js.ini
+++ b/tests/wpt/metadata/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/aborted-parser.window.js.ini
@@ -1,7 +1,0 @@
-[aborted-parser.window.html]
-  [document.open() after parser is aborted]
-    expected: FAIL
-
-  [async document.open() after parser is aborted]
-    expected: FAIL
-


### PR DESCRIPTION
Aborting the document now definitely prevents a subsequent document.open from working, per spec as seen in #24458.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [x] These changes fix #24458 and fix #21279

<!-- Either: -->
- [X] There are tests for these changes (currently intermittent in #21279, this will make them deterministically pass)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
