### PR TITLE
Remove `origin` parameter from `Worker::handle_message`

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -538,9 +538,8 @@ impl DedicatedWorkerGlobalScope {
         let worker = self.worker.borrow().as_ref().unwrap().clone();
         let global_scope = self.upcast::<GlobalScope>();
         let pipeline_id = global_scope.pipeline_id();
-        let origin = global_scope.origin().immutable().ascii_serialization();
         let task = Box::new(task!(post_worker_message: move || {
-            Worker::handle_message(worker, origin, data);
+            Worker::handle_message(worker, data);
         }));
         self.parent_sender
             .send(CommonScriptMsg::Task(

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -140,11 +140,7 @@ impl Worker {
         self.terminated.get()
     }
 
-    pub fn handle_message(
-        address: TrustedWorkerAddress,
-        origin: String,
-        data: StructuredSerializedData,
-    ) {
+    pub fn handle_message(address: TrustedWorkerAddress, data: StructuredSerializedData) {
         let worker = address.root();
 
         if worker.is_terminated() {
@@ -156,14 +152,7 @@ impl Worker {
         let _ac = enter_realm(target);
         rooted!(in(*global.get_cx()) let mut message = UndefinedValue());
         if let Ok(ports) = structuredclone::read(&global, data, message.handle_mut()) {
-            MessageEvent::dispatch_jsval(
-                target,
-                &global,
-                message.handle(),
-                Some(&origin),
-                None,
-                ports,
-            );
+            MessageEvent::dispatch_jsval(target, &global, message.handle(), None, None, ports);
         } else {
             // Step 4 of the "port post message steps" of the implicit messageport, fire messageerror.
             MessageEvent::dispatch_error(target, &global);

--- a/tests/wpt/metadata/workers/interfaces/DedicatedWorkerGlobalScope/postMessage/message-event.html.ini
+++ b/tests/wpt/metadata/workers/interfaces/DedicatedWorkerGlobalScope/postMessage/message-event.html.ini
@@ -1,5 +1,0 @@
-[message-event.html]
-  type: testharness
-  [Properties of the 'message' event]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Test in  `workers/interfaces/DedicatedWorkerGlobalScope/postMessage/message-event.html` was failing because worker.onmessage was seeing non-empty event.origin. Removing `origin` parameter from `Worker::handle_message` and sending `None` to `MessageEvent::dispatch_jsval` solves the issue.

r?@jdm

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25149  (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
