### PR TITLE
use create_html_element for HTMLAudioElement and HTMLImageElement

### DIFF
--- a/components/script/dom/htmlaudioelement.rs
+++ b/components/script/dom/htmlaudioelement.rs
@@ -10,12 +10,12 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
-use crate::dom::element::Element;
+use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
 use crate::dom::htmlmediaelement::HTMLMediaElement;
 use crate::dom::node::Node;
 use crate::dom::window::Window;
 use dom_struct::dom_struct;
-use html5ever::{LocalName, Prefix};
+use html5ever::{LocalName, Prefix, QualName};
 
 #[dom_struct]
 pub struct HTMLAudioElement {
@@ -50,8 +50,15 @@ impl HTMLAudioElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-audio
     pub fn Audio(window: &Window, src: Option<DOMString>) -> Fallible<DomRoot<HTMLAudioElement>> {
-        let document = window.Document();
-        let audio = HTMLAudioElement::new(local_name!("audio"), None, &document);
+        let element = Element::create(
+            QualName::new(None, ns!(html), local_name!("audio")),
+            None,
+            &window.Document(),
+            ElementCreator::ScriptCreated,
+            CustomElementCreationMode::Synchronous,
+        );
+
+        let audio = DomRoot::downcast::<HTMLAudioElement>(element).unwrap();
 
         audio
             .upcast::<Element>()

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -22,7 +22,9 @@ use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::document::Document;
 use crate::dom::element::{cors_setting_for_element, referrer_policy_for_element};
 use crate::dom::element::{reflect_cross_origin_attribute, set_cross_origin_attribute};
-use crate::dom::element::{AttributeMutation, Element, RawLayoutElementHelpers};
+use crate::dom::element::{
+    AttributeMutation, CustomElementCreationMode, Element, ElementCreator, RawLayoutElementHelpers,
+};
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
@@ -51,7 +53,7 @@ use app_units::{Au, AU_PER_PX};
 use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use euclid::Point2D;
-use html5ever::{LocalName, Prefix};
+use html5ever::{LocalName, Prefix, QualName};
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use mime::{self, Mime};
@@ -1256,8 +1258,15 @@ impl HTMLImageElement {
         width: Option<u32>,
         height: Option<u32>,
     ) -> Fallible<DomRoot<HTMLImageElement>> {
-        let document = window.Document();
-        let image = HTMLImageElement::new(local_name!("img"), None, &document);
+        let element = Element::create(
+            QualName::new(None, ns!(html), local_name!("img")),
+            None,
+            &window.Document(),
+            ElementCreator::ScriptCreated,
+            CustomElementCreationMode::Synchronous,
+        );
+
+        let image = DomRoot::downcast::<HTMLImageElement>(element).unwrap();
         if let Some(w) = width {
             image.SetWidth(w);
         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Updated the Image and Audio constructors to use `create_html_element` via the Element::create method. This was done to meet these specifications of "Let (audio/image) be the result of **creating an element** given document, audio, and the HTML namespace." for [dom-image](https://html.spec.whatwg.org/multipage/embedded-content.html#dom-image) and [dom-audio](https://html.spec.whatwg.org/multipage/media.html#dom-audio)
Not sure what _is_ is according to the [create-element guidelines](https://dom.spec.whatwg.org/#concept-create-element) so I left it as None copying from #25393. Also copied the ElementCreator and CustomElementCreationMode from #25393 as I do not know what they do.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25421 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it is a small swap out of the way used to generate these HTML elements. The pre-existing tests should be sufficient.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
