### PR TITLE
RadioNodeList liveness

### DIFF
--- a/components/script/dom/htmlformcontrolscollection.rs
+++ b/components/script/dom/htmlformcontrolscollection.rs
@@ -6,16 +6,17 @@ use crate::dom::bindings::codegen::Bindings::HTMLCollectionBinding::HTMLCollecti
 use crate::dom::bindings::codegen::Bindings::HTMLFormControlsCollectionBinding;
 use crate::dom::bindings::codegen::Bindings::HTMLFormControlsCollectionBinding::HTMLFormControlsCollectionMethods;
 use crate::dom::bindings::codegen::UnionTypes::RadioNodeListOrElement;
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::element::Element;
 use crate::dom::htmlcollection::{CollectionFilter, HTMLCollection};
+use crate::dom::htmlformelement::HTMLFormElement;
 use crate::dom::node::Node;
 use crate::dom::radionodelist::RadioNodeList;
 use crate::dom::window::Window;
 use dom_struct::dom_struct;
-use std::iter;
 
 #[dom_struct]
 pub struct HTMLFormControlsCollection {
@@ -24,17 +25,17 @@ pub struct HTMLFormControlsCollection {
 
 impl HTMLFormControlsCollection {
     fn new_inherited(
-        root: &Node,
+        root: &HTMLFormElement,
         filter: Box<dyn CollectionFilter + 'static>,
     ) -> HTMLFormControlsCollection {
         HTMLFormControlsCollection {
-            collection: HTMLCollection::new_inherited(root, filter),
+            collection: HTMLCollection::new_inherited(root.upcast::<Node>(), filter),
         }
     }
 
     pub fn new(
         window: &Window,
-        root: &Node,
+        root: &HTMLFormElement,
         filter: Box<dyn CollectionFilter + 'static>,
     ) -> DomRoot<HTMLFormControlsCollection> {
         reflect_dom_object(
@@ -76,12 +77,16 @@ impl HTMLFormControlsCollectionMethods for HTMLFormControlsCollection {
                 Some(RadioNodeListOrElement::Element(elem))
             } else {
                 // Step 4-5
-                let once = iter::once(DomRoot::upcast::<Node>(elem));
-                let list = once.chain(peekable.map(DomRoot::upcast));
                 let global = self.global();
                 let window = global.as_window();
+                // okay to unwrap: root's type was checked in the constructor
+                let collection_root = self.collection.root_node();
+                let form = collection_root.downcast::<HTMLFormElement>().unwrap();
+                // There is only one way to get an HTMLCollection,
+                // specifically HTMLFormElement::Elements(),
+                // and the collection filter excludes image inputs.
                 Some(RadioNodeListOrElement::RadioNodeList(
-                    RadioNodeList::new_simple_list(window, list),
+                    RadioNodeList::new_controls_except_image_inputs(window, form, name),
                 ))
             }
         // Step 3

--- a/components/script/dom/radionodelist.rs
+++ b/components/script/dom/radionodelist.rs
@@ -8,11 +8,12 @@ use crate::dom::bindings::codegen::Bindings::RadioNodeListBinding;
 use crate::dom::bindings::codegen::Bindings::RadioNodeListBinding::RadioNodeListMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object;
-use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::htmlformelement::HTMLFormElement;
 use crate::dom::htmlinputelement::{HTMLInputElement, InputType};
 use crate::dom::node::Node;
-use crate::dom::nodelist::{NodeList, NodeListType};
+use crate::dom::nodelist::{NodeList, NodeListType, RadioList, RadioListMode};
 use crate::dom::window::Window;
 use dom_struct::dom_struct;
 
@@ -38,18 +39,33 @@ impl RadioNodeList {
         )
     }
 
-    pub fn new_simple_list<T>(window: &Window, iter: T) -> DomRoot<RadioNodeList>
-    where
-        T: Iterator<Item = DomRoot<Node>>,
-    {
+    pub fn new_controls_except_image_inputs(
+        window: &Window,
+        form: &HTMLFormElement,
+        name: DOMString,
+    ) -> DomRoot<RadioNodeList> {
         RadioNodeList::new(
             window,
-            NodeListType::Simple(iter.map(|r| Dom::from_ref(&*r)).collect()),
+            NodeListType::Radio(RadioList::new(
+                form,
+                RadioListMode::ControlsExceptImageInputs,
+                name,
+            )),
         )
     }
 
-    // FIXME: This shouldn't need to be implemented here since NodeList (the parent of
-    // RadioNodeList) implements Length
+    pub fn new_images(
+        window: &Window,
+        form: &HTMLFormElement,
+        name: DOMString,
+    ) -> DomRoot<RadioNodeList> {
+        RadioNodeList::new(
+            window,
+            NodeListType::Radio(RadioList::new(form, RadioListMode::Images, name)),
+        )
+    }
+
+    // https://dom.spec.whatwg.org/#dom-nodelist-length
     // https://github.com/servo/servo/issues/5875
     pub fn Length(&self) -> u32 {
         self.node_list.Length()
@@ -60,7 +76,6 @@ impl RadioNodeListMethods for RadioNodeList {
     // https://html.spec.whatwg.org/multipage/#dom-radionodelist-value
     fn Value(&self) -> DOMString {
         self.upcast::<NodeList>()
-            .as_simple_list()
             .iter()
             .filter_map(|node| {
                 // Step 1
@@ -85,7 +100,7 @@ impl RadioNodeListMethods for RadioNodeList {
 
     // https://html.spec.whatwg.org/multipage/#dom-radionodelist-value
     fn SetValue(&self, value: DOMString) {
-        for node in self.upcast::<NodeList>().as_simple_list().iter() {
+        for node in self.upcast::<NodeList>().iter() {
             // Step 1
             if let Some(input) = node.downcast::<HTMLInputElement>() {
                 match input.input_type() {

--- a/tests/wpt/metadata/html/semantics/forms/the-form-element/form-elements-nameditem-01.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-form-element/form-elements-nameditem-01.html.ini
@@ -1,8 +1,5 @@
 [form-elements-nameditem-01.html]
   type: testharness
-  [elements collection should return elements or RadioNodeLists]
-    expected: FAIL
-
   [elements collection should include fieldsets]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/forms/the-form-element/form-nameditem.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-form-element/form-nameditem.html.ini
@@ -1,8 +1,5 @@
 [form-nameditem.html]
   type: testharness
-  [All listed elements except input type=image should be present in the form]
-    expected: FAIL
-
   [Named elements should override builtins]
     expected: FAIL
 


### PR DESCRIPTION
When the named getter of a form's .elements gets a list, that list is now a live view into the form, passing a WPT test that removes a node and then looks at the list again.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] These changes fix #25415 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
