### PR TITLE
Past names expire when form owner is reset

### DIFF
--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1081,6 +1081,13 @@ impl HTMLFormElement {
             .iter()
             .position(|c| &**c == control)
             .map(|idx| controls.remove(idx));
+
+        // https://html.spec.whatwg.org/multipage#forms.html#the-form-element:past-names-map-5
+        // "If an element listed in a form element's past names map
+        // changes form owner, then its entries must be removed
+        // from that map."
+        let mut past_names_map = self.past_names_map.borrow_mut();
+        past_names_map.retain(|_k, v| v.0 != control);
     }
 }
 

--- a/tests/wpt/metadata/html/semantics/forms/the-form-element/form-nameditem.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-form-element/form-nameditem.html.ini
@@ -15,6 +15,3 @@
   [Trying to set an expando that would shadow an already-existing named property]
     expected: FAIL
 
-  [Past names map should work correctly]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
On their way out of form.controls, elements now also leave form.past_names_map, passing one WPT test. We're already scanning linearly through form.controls linearly to get the index of the control there, so additionally scanning through the past names map by value shouldn't raise any particular performance concern.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25429

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
