### PR TITLE
Add input mocking, input sources change event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6450,7 +6450,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#c6abf4c60d165ffc978ad2ebd6bcddc3c21698e1"
+source = "git+https://github.com/servo/webxr#ed1ec1afadce730247401e60994b7f6ff226639d"
 dependencies = [
  "bindgen",
  "euclid",
@@ -6471,7 +6471,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#c6abf4c60d165ffc978ad2ebd6bcddc3c21698e1"
+source = "git+https://github.com/servo/webxr#ed1ec1afadce730247401e60994b7f6ff226639d"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -44,6 +44,7 @@ iceconnectionstatechange
 icegatheringstatechange
 image
 input
+inputsourceschange
 invalid
 keydown
 keypress

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -534,7 +534,8 @@ unsafe_no_jsmanaged_fields!(
     webxr_api::Registry,
     webxr_api::Session,
     webxr_api::Frame,
-    webxr_api::InputSource
+    webxr_api::InputSource,
+    webxr_api::InputId
 );
 unsafe_no_jsmanaged_fields!(ScriptToConstellationChan);
 unsafe_no_jsmanaged_fields!(InteractiveMetrics);

--- a/components/script/dom/fakexrdevice.rs
+++ b/components/script/dom/fakexrdevice.rs
@@ -37,7 +37,8 @@ pub struct FakeXRDevice {
     reflector: Reflector,
     #[ignore_malloc_size_of = "defined in ipc-channel"]
     sender: IpcSender<MockDeviceMsg>,
-    next_input_id: Cell<u32>,
+    #[ignore_malloc_size_of = "defined in webxr-api"]
+    next_input_id: Cell<InputId>,
 }
 
 impl FakeXRDevice {
@@ -45,7 +46,7 @@ impl FakeXRDevice {
         FakeXRDevice {
             reflector: Reflector::new(),
             sender,
-            next_input_id: Cell::new(0),
+            next_input_id: Cell::new(InputId(0)),
         }
     }
 
@@ -191,8 +192,7 @@ impl FakeXRDeviceMethods for FakeXRDevice {
         init: &FakeXRInputSourceInit,
     ) -> Fallible<DomRoot<FakeXRInputController>> {
         let id = self.next_input_id.get();
-        self.next_input_id.set(id + 1);
-        let id = InputId(id);
+        self.next_input_id.set(InputId(id.0 + 1));
 
         let handedness = init.handedness.into();
         let target_ray_mode = init.targetRayMode.into();

--- a/components/script/dom/fakexrdevice.rs
+++ b/components/script/dom/fakexrdevice.rs
@@ -5,6 +5,7 @@
 use crate::dom::bindings::codegen::Bindings::FakeXRDeviceBinding::{
     self, FakeXRDeviceMethods, FakeXRRigidTransformInit, FakeXRViewInit,
 };
+use crate::dom::bindings::codegen::Bindings::XRSessionBinding::XRVisibilityState;
 use crate::dom::bindings::codegen::Bindings::XRViewBinding::XREye;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::refcounted::TrustedPromise;
@@ -20,7 +21,7 @@ use ipc_channel::ipc::IpcSender;
 use ipc_channel::router::ROUTER;
 use profile_traits::ipc;
 use std::rc::Rc;
-use webxr_api::{MockDeviceMsg, MockViewInit, MockViewsInit};
+use webxr_api::{MockDeviceMsg, MockViewInit, MockViewsInit, Visibility};
 
 #[dom_struct]
 pub struct FakeXRDevice {
@@ -163,7 +164,17 @@ impl FakeXRDeviceMethods for FakeXRDevice {
         Ok(())
     }
 
-    /// https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md
+    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-simulatevisibilitychange
+    fn SimulateVisibilityChange(&self, v: XRVisibilityState) {
+        let v = match v {
+            XRVisibilityState::Visible => Visibility::Visible,
+            XRVisibilityState::Visible_blurred => Visibility::VisibleBlurred,
+            XRVisibilityState::Hidden => Visibility::Hidden,
+        };
+        let _ = self.sender.send(MockDeviceMsg::VisibilityChange(v));
+    }
+
+    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrdevice-disconnect
     fn Disconnect(&self) -> Rc<Promise> {
         let global = self.global();
         let p = Promise::new(&global);

--- a/components/script/dom/fakexrinputcontroller.rs
+++ b/components/script/dom/fakexrinputcontroller.rs
@@ -2,13 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::dom::bindings::codegen::Bindings::FakeXRInputControllerBinding::{self};
+use crate::dom::bindings::codegen::Bindings::FakeXRDeviceBinding::FakeXRRigidTransformInit;
+use crate::dom::bindings::codegen::Bindings::FakeXRInputControllerBinding::{
+    self, FakeXRInputControllerMethods,
+};
+use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::DomRoot;
+use crate::dom::fakexrdevice::get_origin;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
-use webxr_api::{InputId, MockDeviceMsg};
+use webxr_api::{InputId, MockDeviceMsg, MockInputMsg};
 
 #[dom_struct]
 pub struct FakeXRInputController {
@@ -38,5 +43,30 @@ impl FakeXRInputController {
             global,
             FakeXRInputControllerBinding::Wrap,
         )
+    }
+
+    fn send_message(&self, msg: MockInputMsg) {
+        let _ = self
+            .sender
+            .send(MockDeviceMsg::MessageInputSource(self.id, msg));
+    }
+}
+
+impl FakeXRInputControllerMethods for FakeXRInputController {
+    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-setpointerorigin
+    fn SetPointerOrigin(&self, origin: &FakeXRRigidTransformInit, _emulated: bool) -> Fallible<()> {
+        self.send_message(MockInputMsg::SetPointerOrigin(Some(get_origin(origin)?)));
+        Ok(())
+    }
+
+    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-setgriporigin
+    fn SetGripOrigin(&self, origin: &FakeXRRigidTransformInit, _emulated: bool) -> Fallible<()> {
+        self.send_message(MockInputMsg::SetGripOrigin(Some(get_origin(origin)?)));
+        Ok(())
+    }
+
+    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-cleargriporigin
+    fn ClearGripOrigin(&self) {
+        self.send_message(MockInputMsg::SetGripOrigin(None))
     }
 }

--- a/components/script/dom/fakexrinputcontroller.rs
+++ b/components/script/dom/fakexrinputcontroller.rs
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::bindings::codegen::Bindings::FakeXRInputControllerBinding::{self};
+use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::globalscope::GlobalScope;
+use dom_struct::dom_struct;
+use ipc_channel::ipc::IpcSender;
+use webxr_api::{InputId, MockDeviceMsg};
+
+#[dom_struct]
+pub struct FakeXRInputController {
+    reflector: Reflector,
+    #[ignore_malloc_size_of = "defined in ipc-channel"]
+    sender: IpcSender<MockDeviceMsg>,
+    #[ignore_malloc_size_of = "defined in webxr-api"]
+    id: InputId,
+}
+
+impl FakeXRInputController {
+    pub fn new_inherited(sender: IpcSender<MockDeviceMsg>, id: InputId) -> FakeXRInputController {
+        FakeXRInputController {
+            reflector: Reflector::new(),
+            sender,
+            id,
+        }
+    }
+
+    pub fn new(
+        global: &GlobalScope,
+        sender: IpcSender<MockDeviceMsg>,
+        id: InputId,
+    ) -> DomRoot<FakeXRInputController> {
+        reflect_dom_object(
+            Box::new(FakeXRInputController::new_inherited(sender, id)),
+            global,
+            FakeXRInputControllerBinding::Wrap,
+        )
+    }
+}

--- a/components/script/dom/fakexrinputcontroller.rs
+++ b/components/script/dom/fakexrinputcontroller.rs
@@ -69,4 +69,14 @@ impl FakeXRInputControllerMethods for FakeXRInputController {
     fn ClearGripOrigin(&self) {
         self.send_message(MockInputMsg::SetGripOrigin(None))
     }
+
+    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-disconnect
+    fn Disconnect(&self) {
+        self.send_message(MockInputMsg::Disconnect)
+    }
+
+    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-reconnect
+    fn Reconnect(&self) {
+        self.send_message(MockInputMsg::Reconnect)
+    }
 }

--- a/components/script/dom/fakexrinputcontroller.rs
+++ b/components/script/dom/fakexrinputcontroller.rs
@@ -13,7 +13,7 @@ use crate::dom::fakexrdevice::get_origin;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
-use webxr_api::{InputId, MockDeviceMsg, MockInputMsg};
+use webxr_api::{InputId, MockDeviceMsg, MockInputMsg, SelectEvent, SelectKind};
 
 #[dom_struct]
 pub struct FakeXRInputController {
@@ -78,5 +78,29 @@ impl FakeXRInputControllerMethods for FakeXRInputController {
     /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-reconnect
     fn Reconnect(&self) {
         self.send_message(MockInputMsg::Reconnect)
+    }
+
+    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-startselection
+    fn StartSelection(&self) {
+        self.send_message(MockInputMsg::TriggerSelect(
+            SelectKind::Select,
+            SelectEvent::Start,
+        ))
+    }
+
+    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-endselection
+    fn EndSelection(&self) {
+        self.send_message(MockInputMsg::TriggerSelect(
+            SelectKind::Select,
+            SelectEvent::End,
+        ))
+    }
+
+    /// https://immersive-web.github.io/webxr-test-api/#dom-fakexrinputcontroller-simulateselect
+    fn SimulateSelect(&self) {
+        self.send_message(MockInputMsg::TriggerSelect(
+            SelectKind::Select,
+            SelectEvent::Select,
+        ))
     }
 }

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -301,6 +301,7 @@ pub mod eventtarget;
 pub mod extendableevent;
 pub mod extendablemessageevent;
 pub mod fakexrdevice;
+pub mod fakexrinputcontroller;
 pub mod file;
 pub mod filelist;
 pub mod filereader;

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -565,6 +565,7 @@ pub mod xrframe;
 pub mod xrinputsource;
 pub mod xrinputsourcearray;
 pub mod xrinputsourceevent;
+pub mod xrinputsourceschangeevent;
 pub mod xrpose;
 pub mod xrreferencespace;
 pub mod xrrenderstate;

--- a/components/script/dom/webidls/FakeXRDevice.webidl
+++ b/components/script/dom/webidls/FakeXRDevice.webidl
@@ -10,9 +10,6 @@ interface FakeXRDevice {
   // requestAnimationFrame() callbacks.
   [Throws] void setViews(sequence<FakeXRViewInit> views);
 
-  // // behaves as if device was disconnected
-  // Promise<void> disconnect();
-
   [Throws] void setViewerOrigin(FakeXRRigidTransformInit origin, optional boolean emulatedPosition = false);
   void clearViewerOrigin();
 
@@ -20,12 +17,9 @@ interface FakeXRDevice {
   void clearFloorOrigin();
 
   // // Simulates devices focusing and blurring sessions.
-  // void simulateVisibilityChange(XRVisibilityState);
+  void simulateVisibilityChange(XRVisibilityState state);
 
   // void setBoundsGeometry(sequence<FakeXRBoundsPoint> boundsCoodinates);
-  // // Sets eye level used for calculating floor-level spaces
-  // void setEyeLevel(float eyeLevel);
-
 
   // Promise<FakeXRInputController>
   //     simulateInputSourceConnection(FakeXRInputSourceInit);

--- a/components/script/dom/webidls/FakeXRDevice.webidl
+++ b/components/script/dom/webidls/FakeXRDevice.webidl
@@ -21,8 +21,7 @@ interface FakeXRDevice {
 
   // void setBoundsGeometry(sequence<FakeXRBoundsPoint> boundsCoodinates);
 
-  // Promise<FakeXRInputController>
-  //     simulateInputSourceConnection(FakeXRInputSourceInit);
+  [Throws] FakeXRInputController simulateInputSourceConnection(FakeXRInputSourceInit init);
 
   // behaves as if device was disconnected
   Promise<void> disconnect();

--- a/components/script/dom/webidls/FakeXRInputController.webidl
+++ b/components/script/dom/webidls/FakeXRInputController.webidl
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://immersive-web.github.io/webxr-test-api/#fakexrinputcontroller
+
+[Exposed=Window, Pref="dom.webxr.test"]
+interface FakeXRInputController {
+  // void setHandedness(XRHandedness handedness);
+  // void setTargetRayMode(XRTargetRayMode targetRayMode);
+  // void setProfiles(sequence<DOMString> profiles);
+  // void setGripOrigin(FakeXRRigidTransformInit gripOrigin, optional boolean emulatedPosition = false);
+  // void clearGripOrigin();
+  // void setPointerOrigin(FakeXRRigidTransformInit pointerOrigin, optional boolean emulatedPosition = false);
+
+  // void disconnect();
+  // void reconnect();
+
+  // void startSelection();
+  // void endSelection();
+  // void simulateSelect();
+
+  // void setSupportedButtons(sequence<FakeXRButtonStateInit> supportedButtons);
+  // void updateButtonState(FakeXRButtonStateInit buttonState);
+};
+
+dictionary FakeXRInputSourceInit {
+  required XRHandedness handedness;
+  required XRTargetRayMode targetRayMode;
+  required FakeXRRigidTransformInit pointerOrigin;
+  required sequence<DOMString> profiles;
+  boolean selectionStarted = false;
+  boolean selectionClicked = false;
+  sequence<FakeXRButtonStateInit> supportedButtons;
+  FakeXRRigidTransformInit gripOrigin;
+};
+
+enum FakeXRButtonType {
+  "grip",
+  "touchpad",
+  "thumbstick",
+  "optional-button",
+  "optional-thumbstick"
+};
+
+dictionary FakeXRButtonStateInit {
+  required FakeXRButtonType buttonType;
+  required boolean pressed;
+  required boolean touched;
+  required float pressedValue;
+  float xValue = 0.0;
+  float yValue = 0.0;
+};

--- a/components/script/dom/webidls/FakeXRInputController.webidl
+++ b/components/script/dom/webidls/FakeXRInputController.webidl
@@ -16,9 +16,9 @@ interface FakeXRInputController {
   void disconnect();
   void reconnect();
 
-  // void startSelection();
-  // void endSelection();
-  // void simulateSelect();
+  void startSelection();
+  void endSelection();
+  void simulateSelect();
 
   // void setSupportedButtons(sequence<FakeXRButtonStateInit> supportedButtons);
   // void updateButtonState(FakeXRButtonStateInit buttonState);

--- a/components/script/dom/webidls/FakeXRInputController.webidl
+++ b/components/script/dom/webidls/FakeXRInputController.webidl
@@ -13,8 +13,8 @@ interface FakeXRInputController {
   void clearGripOrigin();
   [Throws] void setPointerOrigin(FakeXRRigidTransformInit pointerOrigin, optional boolean emulatedPosition = false);
 
-  // void disconnect();
-  // void reconnect();
+  void disconnect();
+  void reconnect();
 
   // void startSelection();
   // void endSelection();

--- a/components/script/dom/webidls/FakeXRInputController.webidl
+++ b/components/script/dom/webidls/FakeXRInputController.webidl
@@ -9,9 +9,9 @@ interface FakeXRInputController {
   // void setHandedness(XRHandedness handedness);
   // void setTargetRayMode(XRTargetRayMode targetRayMode);
   // void setProfiles(sequence<DOMString> profiles);
-  // void setGripOrigin(FakeXRRigidTransformInit gripOrigin, optional boolean emulatedPosition = false);
-  // void clearGripOrigin();
-  // void setPointerOrigin(FakeXRRigidTransformInit pointerOrigin, optional boolean emulatedPosition = false);
+  [Throws] void setGripOrigin(FakeXRRigidTransformInit gripOrigin, optional boolean emulatedPosition = false);
+  void clearGripOrigin();
+  [Throws] void setPointerOrigin(FakeXRRigidTransformInit pointerOrigin, optional boolean emulatedPosition = false);
 
   // void disconnect();
   // void reconnect();

--- a/components/script/dom/webidls/XRInputSource.webidl
+++ b/components/script/dom/webidls/XRInputSource.webidl
@@ -19,7 +19,7 @@ enum XRTargetRayMode {
 [SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]
 interface XRInputSource {
   readonly attribute XRHandedness handedness;
-  // [SameObject] readonly attribute XRTargetRayMode targetRayMode;
+  readonly attribute XRTargetRayMode targetRayMode;
   [SameObject] readonly attribute XRSpace targetRaySpace;
   [SameObject] readonly attribute XRSpace? gripSpace;
   // [SameObject] readonly attribute Gamepad? gamepad;

--- a/components/script/dom/webidls/XRInputSourcesChangeEvent.webidl
+++ b/components/script/dom/webidls/XRInputSourcesChangeEvent.webidl
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://immersive-web.github.io/webxr/#xrinputsourceschangedevent-interface
+
+[SecureContext, Exposed=Window, Pref="dom.webxr.test"]
+interface XRInputSourcesChangeEvent : Event {
+  constructor(DOMString type, XRInputSourcesChangeEventInit eventInitDict);
+  [SameObject] readonly attribute XRSession session;
+  /* [SameObject] */ readonly attribute /* FrozenArray<XRInputSource> */ any added;
+  /* [SameObject] */ readonly attribute /* FrozenArray<XRInputSource> */ any removed;
+};
+
+dictionary XRInputSourcesChangeEventInit : EventInit {
+  required XRSession session;
+  required sequence<XRInputSource> added;
+  required sequence<XRInputSource> removed;
+};

--- a/components/script/dom/webidls/XRSession.webidl
+++ b/components/script/dom/webidls/XRSession.webidl
@@ -40,7 +40,7 @@ interface XRSession : EventTarget {
   attribute EventHandler onend;
   attribute EventHandler onselect;
   attribute EventHandler onsqueeze;
-  // attribute EventHandler oninputsourceschange;
+  attribute EventHandler oninputsourceschange;
   attribute EventHandler onselectstart;
   attribute EventHandler onselectend;
   attribute EventHandler onsqueezestart;

--- a/components/script/dom/xrinputsource.rs
+++ b/components/script/dom/xrinputsource.rs
@@ -75,7 +75,7 @@ impl XRInputSourceMethods for XRInputSource {
     /// https://immersive-web.github.io/webxr/#dom-xrinputsource-gripspace
     fn GetGripSpace(&self) -> Option<DomRoot<XRSpace>> {
         if self.info.supports_grip {
-            Some(self.target_ray_space.or_init(|| {
+            Some(self.grip_space.or_init(|| {
                 let global = self.global();
                 XRSpace::new_inputspace(&global, &self.session, &self, true)
             }))

--- a/components/script/dom/xrinputsource.rs
+++ b/components/script/dom/xrinputsource.rs
@@ -4,7 +4,7 @@
 
 use crate::dom::bindings::codegen::Bindings::XRInputSourceBinding;
 use crate::dom::bindings::codegen::Bindings::XRInputSourceBinding::{
-    XRHandedness, XRInputSourceMethods,
+    XRHandedness, XRInputSourceMethods, XRTargetRayMode,
 };
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
@@ -12,7 +12,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrsession::XRSession;
 use crate::dom::xrspace::XRSpace;
 use dom_struct::dom_struct;
-use webxr_api::{Handedness, InputId, InputSource};
+use webxr_api::{Handedness, InputId, InputSource, TargetRayMode};
 
 #[dom_struct]
 pub struct XRInputSource {
@@ -61,6 +61,15 @@ impl XRInputSourceMethods for XRInputSource {
             Handedness::None => XRHandedness::None,
             Handedness::Left => XRHandedness::Left,
             Handedness::Right => XRHandedness::Right,
+        }
+    }
+
+    /// https://immersive-web.github.io/webxr/#dom-xrinputsource-targetraymode
+    fn TargetRayMode(&self) -> XRTargetRayMode {
+        match self.info.target_ray_mode {
+            TargetRayMode::Gaze => XRTargetRayMode::Gaze,
+            TargetRayMode::TrackedPointer => XRTargetRayMode::Tracked_pointer,
+            TargetRayMode::Screen => XRTargetRayMode::Screen,
         }
     }
 

--- a/components/script/dom/xrinputsourcearray.rs
+++ b/components/script/dom/xrinputsourcearray.rs
@@ -5,13 +5,16 @@
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::XRInputSourceArrayBinding;
 use crate::dom::bindings::codegen::Bindings::XRInputSourceArrayBinding::XRInputSourceArrayMethods;
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::event::Event;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::xrinputsource::XRInputSource;
+use crate::dom::xrinputsourceschangeevent::XRInputSourcesChangeEvent;
 use crate::dom::xrsession::XRSession;
 use dom_struct::dom_struct;
-use webxr_api::InputId;
+use webxr_api::{InputId, InputSource};
 
 #[dom_struct]
 pub struct XRInputSourceArray {
@@ -46,6 +49,56 @@ impl XRInputSourceArray {
                 input_sources.push(Dom::from_ref(&input));
             }
         });
+    }
+
+    pub fn add_input_source(&self, session: &XRSession, info: InputSource) {
+        let mut input_sources = self.input_sources.borrow_mut();
+        let global = self.global();
+        let input = XRInputSource::new(&global, &session, info);
+        debug_assert!(
+            input_sources.iter().find(|i| i.id() == info.id).is_none(),
+            "Should never add a duplicate input id!"
+        );
+        input_sources.push(Dom::from_ref(&input));
+
+        let added = [input];
+
+        let event = XRInputSourcesChangeEvent::new(
+            &global,
+            atom!("inputsourceschange"),
+            false,
+            true,
+            session,
+            &added,
+            &[],
+        );
+        // Release the refcell guard
+        drop(input_sources);
+        event.upcast::<Event>().fire(session.upcast());
+    }
+
+    pub fn remove_input_source(&self, session: &XRSession, id: InputId) {
+        let mut input_sources = self.input_sources.borrow_mut();
+        let global = self.global();
+        let removed = if let Some(i) = input_sources.iter().find(|i| i.id() == id) {
+            [DomRoot::from_ref(&**i)]
+        } else {
+            return;
+        };
+
+        let event = XRInputSourcesChangeEvent::new(
+            &global,
+            atom!("inputsourceschange"),
+            false,
+            true,
+            session,
+            &[],
+            &removed,
+        );
+        input_sources.retain(|i| i.id() != id);
+        // release the refcell guard
+        drop(input_sources);
+        event.upcast::<Event>().fire(session.upcast());
     }
 
     pub fn find(&self, id: InputId) -> Option<DomRoot<XRInputSource>> {

--- a/components/script/dom/xrinputsourceschangeevent.rs
+++ b/components/script/dom/xrinputsourceschangeevent.rs
@@ -66,10 +66,10 @@ impl XRInputSourcesChangeEvent {
         let cx = global.get_cx();
         unsafe {
             rooted!(in(*cx) let mut added_val = UndefinedValue());
-            rooted!(in(*cx) let mut removed_val  = UndefinedValue());
             added.to_jsval(*cx, added_val.handle_mut());
-            removed.to_jsval(*cx, removed_val.handle_mut());
             changeevent.added.set(added_val.get());
+            rooted!(in(*cx) let mut removed_val = UndefinedValue());
+            removed.to_jsval(*cx, removed_val.handle_mut());
             changeevent.added.set(removed_val.get());
         }
 

--- a/components/script/dom/xrinputsourceschangeevent.rs
+++ b/components/script/dom/xrinputsourceschangeevent.rs
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::bindings::codegen::Bindings::EventBinding::EventBinding::EventMethods;
+use crate::dom::bindings::codegen::Bindings::XRInputSourcesChangeEventBinding::{
+    self, XRInputSourcesChangeEventMethods,
+};
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
+use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::bindings::str::DOMString;
+use crate::dom::event::Event;
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::window::Window;
+use crate::dom::xrinputsource::XRInputSource;
+use crate::dom::xrsession::XRSession;
+use crate::script_runtime::JSContext;
+use dom_struct::dom_struct;
+use js::conversions::ToJSValConvertible;
+use js::jsapi::Heap;
+use js::jsval::{JSVal, UndefinedValue};
+use servo_atoms::Atom;
+
+#[dom_struct]
+pub struct XRInputSourcesChangeEvent {
+    event: Event,
+    session: Dom<XRSession>,
+    #[ignore_malloc_size_of = "mozjs"]
+    added: Heap<JSVal>,
+    #[ignore_malloc_size_of = "mozjs"]
+    removed: Heap<JSVal>,
+}
+
+impl XRInputSourcesChangeEvent {
+    #[allow(unrooted_must_root)]
+    fn new_inherited(session: &XRSession) -> XRInputSourcesChangeEvent {
+        XRInputSourcesChangeEvent {
+            event: Event::new_inherited(),
+            session: Dom::from_ref(session),
+            added: Heap::default(),
+            removed: Heap::default(),
+        }
+    }
+
+    #[allow(unsafe_code)]
+    pub fn new(
+        global: &GlobalScope,
+        type_: Atom,
+        bubbles: bool,
+        cancelable: bool,
+        session: &XRSession,
+        added: &[DomRoot<XRInputSource>],
+        removed: &[DomRoot<XRInputSource>],
+    ) -> DomRoot<XRInputSourcesChangeEvent> {
+        let changeevent = reflect_dom_object(
+            Box::new(XRInputSourcesChangeEvent::new_inherited(session)),
+            global,
+            XRInputSourcesChangeEventBinding::Wrap,
+        );
+        {
+            let event = changeevent.upcast::<Event>();
+            event.init_event(type_, bubbles, cancelable);
+        }
+
+        let cx = global.get_cx();
+        unsafe {
+            rooted!(in(*cx) let mut added_val = UndefinedValue());
+            rooted!(in(*cx) let mut removed_val  = UndefinedValue());
+            added.to_jsval(*cx, added_val.handle_mut());
+            removed.to_jsval(*cx, removed_val.handle_mut());
+            changeevent.added.set(added_val.get());
+            changeevent.added.set(removed_val.get());
+        }
+
+        changeevent
+    }
+
+    pub fn Constructor(
+        window: &Window,
+        type_: DOMString,
+        init: &XRInputSourcesChangeEventBinding::XRInputSourcesChangeEventInit,
+    ) -> DomRoot<XRInputSourcesChangeEvent> {
+        XRInputSourcesChangeEvent::new(
+            &window.global(),
+            Atom::from(type_),
+            init.parent.bubbles,
+            init.parent.cancelable,
+            &init.session,
+            &*init.added,
+            &*init.removed,
+        )
+    }
+}
+
+impl XRInputSourcesChangeEventMethods for XRInputSourcesChangeEvent {
+    // https://immersive-web.github.io/webxr/#dom-xrinputsourceschangeevent-session
+    fn Session(&self) -> DomRoot<XRSession> {
+        DomRoot::from_ref(&*self.session)
+    }
+
+    // https://immersive-web.github.io/webxr/#dom-xrinputsourceschangeevent-added
+    fn Added(&self, _cx: JSContext) -> JSVal {
+        self.added.get()
+    }
+
+    // https://immersive-web.github.io/webxr/#dom-xrinputsourceschangeevent-removed
+    fn Removed(&self, _cx: JSContext) -> JSVal {
+        self.removed.get()
+    }
+
+    // https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
+    }
+}

--- a/components/script/dom/xrinputsourceschangeevent.rs
+++ b/components/script/dom/xrinputsourceschangeevent.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::enter_realm;
 use crate::dom::bindings::codegen::Bindings::EventBinding::EventBinding::EventMethods;
 use crate::dom::bindings::codegen::Bindings::XRInputSourcesChangeEventBinding::{
     self, XRInputSourcesChangeEventMethods,
@@ -62,7 +63,7 @@ impl XRInputSourcesChangeEvent {
             let event = changeevent.upcast::<Event>();
             event.init_event(type_, bubbles, cancelable);
         }
-
+        let _ac = enter_realm(&*global);
         let cx = global.get_cx();
         unsafe {
             rooted!(in(*cx) let mut added_val = UndefinedValue());

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -289,7 +289,12 @@ impl XRSession {
                 );
                 event.upcast::<Event>().fire(self.upcast());
             },
-            _ => (), // XXXManishearth TBD
+            XREvent::AddInput(info) => {
+                self.input_sources.add_input_source(self, info);
+            },
+            XREvent::RemoveInput(id) => {
+                self.input_sources.remove_input_source(self, id);
+            },
         }
     }
 
@@ -430,6 +435,13 @@ impl XRSessionMethods for XRSession {
         visibilitychange,
         GetOnvisibilitychange,
         SetOnvisibilitychange
+    );
+
+    /// https://immersive-web.github.io/webxr/#eventdef-xrsession-inputsourceschange
+    event_handler!(
+        inputsourceschange,
+        GetOninputsourceschange,
+        SetOninputsourceschange
     );
 
     // https://immersive-web.github.io/webxr/#dom-xrsession-renderstate

--- a/components/script/dom/xrviewerpose.rs
+++ b/components/script/dom/xrviewerpose.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::compartments::enter_realm;
 use crate::dom::bindings::codegen::Bindings::XRViewBinding::XREye;
 use crate::dom::bindings::codegen::Bindings::XRViewerPoseBinding;
 use crate::dom::bindings::codegen::Bindings::XRViewerPoseBinding::XRViewerPoseMethods;
@@ -40,6 +41,7 @@ impl XRViewerPose {
         session: &XRSession,
         pose: ApiViewerPose,
     ) -> DomRoot<XRViewerPose> {
+        let _ac = enter_realm(&*global);
         rooted_vec!(let mut views);
         session.with_session(|s| match s.views() {
             Views::Inline => views.push(XRView::new(

--- a/tests/wpt/metadata/webxr/events_input_source_recreation.https.html.ini
+++ b/tests/wpt/metadata/webxr/events_input_source_recreation.https.html.ini
@@ -1,4 +1,5 @@
 [events_input_source_recreation.https.html]
+  expected: ERROR
   [Input sources are re-created when handedness or target ray mode changes]
     expected: FAIL
 

--- a/tests/wpt/metadata/webxr/events_session_select.https.html.ini
+++ b/tests/wpt/metadata/webxr/events_session_select.https.html.ini
@@ -1,4 +1,0 @@
-[events_session_select.https.html]
-  [XRInputSources primary input presses properly fires off the right events]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webxr/events_session_select_subframe.https.html.ini
+++ b/tests/wpt/metadata/webxr/events_session_select_subframe.https.html.ini
@@ -1,4 +1,0 @@
-[events_session_select_subframe.https.html]
-  [Ensures that an XRInputSources primary input being pressed and released in the space of a single frame properly fires off the right events]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webxr/gamepads-module/xrInputSource_gamepad_disconnect.https.html.ini
+++ b/tests/wpt/metadata/webxr/gamepads-module/xrInputSource_gamepad_disconnect.https.html.ini
@@ -1,4 +1,5 @@
 [xrInputSource_gamepad_disconnect.https.html]
+  expected: ERROR
   [WebXR InputSource's gamepad gets disconnected when the input source is removed]
     expected: FAIL
 

--- a/tests/wpt/metadata/webxr/gamepads-module/xrInputSource_gamepad_input_registered.https.html.ini
+++ b/tests/wpt/metadata/webxr/gamepads-module/xrInputSource_gamepad_input_registered.https.html.ini
@@ -1,4 +1,5 @@
 [xrInputSource_gamepad_input_registered.https.html]
+  expected: ERROR
   [WebXR InputSource's gamepad properly registers input]
     expected: FAIL
 

--- a/tests/wpt/metadata/webxr/getInputPose_handedness.https.html.ini
+++ b/tests/wpt/metadata/webxr/getInputPose_handedness.https.html.ini
@@ -1,4 +1,5 @@
 [getInputPose_handedness.https.html]
+  expected: ERROR
   [XRInputSources properly communicate their handedness]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/webxr/idlharness.https.window.js.ini
+++ b/tests/wpt/metadata/webxr/idlharness.https.window.js.ini
@@ -2,19 +2,10 @@
   [XR interface: attribute ondevicechange]
     expected: FAIL
 
-  [XRInputSourcesChangeEvent interface: attribute session]
-    expected: FAIL
-
-  [XRInputSourcesChangeEvent interface object name]
-    expected: FAIL
-
   [XRInputSourceArray interface: iterable<XRInputSource>]
     expected: FAIL
 
   [XR interface: calling supportsSession(XRSessionMode) on navigator.xr with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [XRInputSourcesChangeEvent interface object length]
     expected: FAIL
 
   [XRReferenceSpaceEvent interface: attribute referenceSpace]
@@ -32,9 +23,6 @@
   [XRPose interface: attribute emulatedPosition]
     expected: FAIL
 
-  [XRInputSource interface: attribute targetRayMode]
-    expected: FAIL
-
   [XRBoundedReferenceSpace interface object length]
     expected: FAIL
 
@@ -50,13 +38,7 @@
   [WebGLRenderingContext interface: operation makeXRCompatible()]
     expected: FAIL
 
-  [XRInputSourcesChangeEvent interface: attribute added]
-    expected: FAIL
-
   [XRBoundedReferenceSpace interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [XRInputSourcesChangeEvent interface: attribute removed]
     expected: FAIL
 
   [XRReferenceSpaceEvent interface: existence and properties of interface object]
@@ -83,9 +65,6 @@
   [XRBoundedReferenceSpace interface: existence and properties of interface prototype object's @@unscopables property]
     expected: FAIL
 
-  [XRInputSourcesChangeEvent interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
   [XRBoundedReferenceSpace interface: attribute boundsGeometry]
     expected: FAIL
 
@@ -96,12 +75,6 @@
     expected: FAIL
 
   [XRInputSource interface: attribute gamepad]
-    expected: FAIL
-
-  [XRInputSourcesChangeEvent interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [XRInputSourcesChangeEvent interface: existence and properties of interface object]
     expected: FAIL
 
   [XRReferenceSpace interface: attribute onreset]
@@ -125,9 +98,6 @@
   [XRInputSource interface: attribute profiles]
     expected: FAIL
 
-  [XRInputSourcesChangeEvent interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
   [XR interface: operation requestSession(XRSessionMode, XRSessionInit)]
     expected: FAIL
 
@@ -138,9 +108,6 @@
     expected: FAIL
 
   [XRWebGLLayer interface: attribute ignoreDepthValues]
-    expected: FAIL
-
-  [XRSession interface: attribute oninputsourceschange]
     expected: FAIL
 
   [XRBoundedReferenceSpace interface: existence and properties of interface prototype object]

--- a/tests/wpt/metadata/webxr/xrInputSource_add_remove.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrInputSource_add_remove.https.html.ini
@@ -1,4 +1,0 @@
-[xrInputSource_add_remove.https.html]
-  [XRInputSources can be properly added and removed from the session]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webxr/xrInputSource_sameObject.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrInputSource_sameObject.https.html.ini
@@ -1,4 +1,0 @@
-[xrInputSource_sameObject.https.html]
-  [XRInputSource attributes meet [SameObject\] requirement]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webxr/xrPose_transform_sameObject.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrPose_transform_sameObject.https.html.ini
@@ -1,4 +1,0 @@
-[xrPose_transform_sameObject.https.html]
-  [XRPose.transform meets [SameObject\] requirement]
-    expected: FAIL
-

--- a/tests/wpt/metadata/webxr/xrReferenceSpace_originOffsetBounded.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrReferenceSpace_originOffsetBounded.https.html.ini
@@ -1,4 +1,5 @@
 [xrReferenceSpace_originOffsetBounded.https.html]
+  expected: ERROR
   [Updating XRBoundedReferenceSpace origin offset updates view, input matrices, and bounds geometry.]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/metadata/webxr/xrSession_sameObject.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_sameObject.https.html.ini
@@ -1,4 +1,5 @@
 [xrSession_sameObject.https.html]
+  expected: ERROR
   [XRSession attributes meet [SameObject\] requirement]
-    expected: FAIL
+    expected: TIMEOUT
 

--- a/tests/wpt/web-platform-tests/webxr/xrInputSource_add_remove.https.html
+++ b/tests/wpt/web-platform-tests/webxr/xrInputSource_add_remove.https.html
@@ -46,7 +46,7 @@ let testFunction = (session, fakeDeviceController, t) => new Promise((resolve) =
           assert_equals(input_sources[1].handedness, "none");
         });
 
-        fakeDeviceController.removeInputSource(input_source_1);
+        input_source_1.disconnect();
 
         session.requestAnimationFrame((time, xrFrame) => {
           let input_sources = session.inputSources;


### PR DESCRIPTION
Depends on  https://github.com/servo/webxr/pull/118

Also fixes some bugs I found.

Wanted to finish and merge this before I started on hit testing since the transient hit test stuff might have overlap.

There are a bunch of missing mock pieces that I'll probably do in a separate PR.

Still need to run tests.

Some things I skipped:
 - Doing handedness/target ray setting: See https://github.com/immersive-web/webxr-test-api/issues/46 , this would require making our impl support these changing
 - Handling button initial state: Would require some mock changes, but I ran out of time
 - Handling profiles/etc: We don't yet have impl support for these

r? @jdm