### PR TITLE
Allow deletions from overflowed textinput

### DIFF
--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -450,12 +450,6 @@ impl<T: ClipboardProvider> TextInput<T> {
         let allowed_to_insert_count = if let Some(max_length) = self.max_length {
             let len_after_selection_replaced =
                 self.utf16_len().saturating_sub(self.selection_utf16_len());
-            if len_after_selection_replaced >= max_length {
-                // If, after deleting the selection, the len is still greater than the max
-                // length, then don't delete/insert anything
-                return;
-            }
-
             max_length.saturating_sub(len_after_selection_replaced)
         } else {
             UTF16CodeUnits(usize::MAX)

--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -162,6 +162,28 @@ fn test_single_line_textinput_with_max_length_doesnt_allow_appending_characters_
 }
 
 #[test]
+fn test_single_line_textinput_with_max_length_allows_deletion_when_replacing_a_selection() {
+    let mut textinput = TextInput::new(
+        Lines::Single,
+        DOMString::from("abcde"),
+        DummyClipboardContext::new(""),
+        Some(UTF16CodeUnits(1)),
+        None,
+        SelectionDirection::None,
+    );
+
+    textinput.adjust_horizontal(UTF8Bytes::one(), Direction::Forward, Selection::NotSelected);
+    textinput.adjust_horizontal(UTF8Bytes(2), Direction::Forward, Selection::Selected);
+
+    // Selection is now "abcde"
+    //                    --
+
+    textinput.replace_selection(DOMString::from("only deletion should be applied"));
+
+    assert_eq!(textinput.get_content(), "ade");
+}
+
+#[test]
 fn test_single_line_textinput_with_max_length_multibyte() {
     let mut textinput = TextInput::new(
         Lines::Single,


### PR DESCRIPTION
Allow deletions from textinput when the length is greater than the max length.

---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25420
- [X] There are tests for these changes