### PR TITLE
Allow dumping the fragment tree in layout_2020

### DIFF
--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -17,6 +17,7 @@ use crate::replaced::ReplacedContent;
 use crate::sizing::ContentSizesRequest;
 use crate::style_ext::{Display, DisplayGeneratingBox, DisplayInside};
 use crate::DefiniteContainingBlock;
+use gfx_traits::print_tree::PrintTree;
 use script_layout_interface::wrapper_traits::LayoutNode;
 use servo_arc::Arc;
 use style::properties::ComputedValues;
@@ -152,6 +153,13 @@ impl FragmentTreeRoot {
         };
         for fragment in &self.0 {
             fragment.build_display_list(builder, &containing_block)
+        }
+    }
+
+    pub fn print(&self) {
+        let mut print_tree = PrintTree::new("Fragment Tree".to_string());
+        for fragment in &self.0 {
+            fragment.print(&mut print_tree);
         }
     }
 }

--- a/components/layout_2020/geom.rs
+++ b/components/layout_2020/geom.rs
@@ -45,7 +45,7 @@ pub(crate) mod flow_relative {
         pub block: T,
     }
 
-    #[derive(Clone, Debug)]
+    #[derive(Clone)]
     pub(crate) struct Rect<T> {
         pub start_corner: Vec2<T>,
         pub size: Vec2<T>,
@@ -197,6 +197,19 @@ impl flow_relative::Rect<Length> {
             start_corner: flow_relative::Vec2::zero(),
             size: flow_relative::Vec2::zero(),
         }
+    }
+}
+
+impl fmt::Debug for flow_relative::Rect<Length> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Rect(i{}×b{} @ (i{},b{}))",
+            self.size.inline.px(),
+            self.size.block.px(),
+            self.start_corner.inline.px(),
+            self.start_corner.block.px(),
+        )
     }
 }
 


### PR DESCRIPTION
This is done when the dump-flow-tree debug option is passed.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this just adds debug output.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
