### PR TITLE
Implement queueMicrotask

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -4,6 +4,7 @@
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::EventSourceBinding::EventSourceBinding::EventSourceMethods;
+use crate::dom::bindings::codegen::Bindings::VoidFunctionBinding::VoidFunction;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::codegen::Bindings::WorkerGlobalScopeBinding::WorkerGlobalScopeMethods;
 use crate::dom::bindings::conversions::{root_from_object, root_from_object_static};
@@ -32,7 +33,7 @@ use crate::dom::performance::Performance;
 use crate::dom::window::Window;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::dom::workletglobalscope::WorkletGlobalScope;
-use crate::microtask::{Microtask, MicrotaskQueue};
+use crate::microtask::{Microtask, MicrotaskQueue, UserMicrotask};
 use crate::script_module::ModuleTree;
 use crate::script_runtime::{CommonScriptMsg, JSContext as SafeJSContext, ScriptChan, ScriptPort};
 use crate::script_thread::{MainThreadScriptChan, ScriptThread};
@@ -1770,6 +1771,13 @@ impl GlobalScope {
 
     pub fn clear_timeout_or_interval(&self, handle: i32) {
         self.timers.clear_timeout_or_interval(self, handle);
+    }
+
+    pub fn queue_function_as_microtask(&self, callback: Rc<VoidFunction>) {
+        self.enqueue_microtask(Microtask::User(UserMicrotask {
+            callback: callback,
+            pipeline: self.pipeline_id(),
+        }))
     }
 
     pub fn fire_timer(&self, handle: TimerEventId) {

--- a/components/script/dom/webidls/WindowOrWorkerGlobalScope.webidl
+++ b/components/script/dom/webidls/WindowOrWorkerGlobalScope.webidl
@@ -20,6 +20,9 @@ interface mixin WindowOrWorkerGlobalScope {
   long setInterval(TimerHandler handler, optional long timeout = 0, any... arguments);
   void clearInterval(optional long handle = 0);
 
+  // microtask queuing
+  void queueMicrotask(VoidFunction callback);
+
   // ImageBitmap
   // Promise<ImageBitmap> createImageBitmap(ImageBitmapSource image, optional ImageBitmapOptions options);
   // Promise<ImageBitmap> createImageBitmap(

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -11,6 +11,7 @@ use crate::dom::bindings::codegen::Bindings::HistoryBinding::HistoryBinding::His
 use crate::dom::bindings::codegen::Bindings::MediaQueryListBinding::MediaQueryListBinding::MediaQueryListMethods;
 use crate::dom::bindings::codegen::Bindings::PermissionStatusBinding::PermissionState;
 use crate::dom::bindings::codegen::Bindings::RequestBinding::RequestInit;
+use crate::dom::bindings::codegen::Bindings::VoidFunctionBinding::VoidFunction;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::{
     self, FrameRequestCallback, WindowMethods, WindowPostMessageOptions,
 };
@@ -869,6 +870,12 @@ impl WindowMethods for Window {
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-clearinterval
     fn ClearInterval(&self, handle: i32) {
         self.ClearTimeout(handle);
+    }
+
+    // https://html.spec.whatwg.org/multipage/#dom-queuemicrotask
+    fn QueueMicrotask(&self, callback: Rc<VoidFunction>) {
+        self.upcast::<GlobalScope>()
+            .queue_function_as_microtask(callback);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-window

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -5,6 +5,7 @@
 use crate::compartments::InCompartment;
 use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::RequestBinding::RequestInit;
+use crate::dom::bindings::codegen::Bindings::VoidFunctionBinding::VoidFunction;
 use crate::dom::bindings::codegen::Bindings::WorkerBinding::WorkerType;
 use crate::dom::bindings::codegen::Bindings::WorkerGlobalScopeBinding::WorkerGlobalScopeMethods;
 use crate::dom::bindings::codegen::UnionTypes::{RequestOrUSVString, StringOrFunction};
@@ -339,6 +340,12 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
     // https://html.spec.whatwg.org/multipage/#dom-windowtimers-clearinterval
     fn ClearInterval(&self, handle: i32) {
         self.ClearTimeout(handle);
+    }
+
+    // https://html.spec.whatwg.org/multipage/#dom-queuemicrotask
+    fn QueueMicrotask(&self, callback: Rc<VoidFunction>) {
+        self.upcast::<GlobalScope>()
+            .queue_function_as_microtask(callback);
     }
 
     #[allow(unrooted_must_root)]

--- a/tests/wpt/metadata/html/browsers/the-window-object/window-properties.https.html.ini
+++ b/tests/wpt/metadata/html/browsers/the-window-object/window-properties.https.html.ini
@@ -53,6 +53,3 @@
   [Window method: createImageBitmap]
     expected: FAIL
 
-  [Window method: queueMicrotask]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/metadata/html/dom/idlharness.https.html.ini
@@ -1501,9 +1501,6 @@
   [Document interface: attribute all]
     expected: FAIL
 
-  [Window interface: window must inherit property "queueMicrotask(VoidFunction)" with the proper type]
-    expected: FAIL
-
   [Document interface: calling execCommand(DOMString, boolean, DOMString) on new Document() with too few arguments must throw TypeError]
     expected: FAIL
 
@@ -1568,9 +1565,6 @@
     expected: FAIL
 
   [Window interface: window must inherit property "scrollbars" with the proper type]
-    expected: FAIL
-
-  [Window interface: calling queueMicrotask(VoidFunction) on window with too few arguments must throw TypeError]
     expected: FAIL
 
   [Window interface: attribute personalbar]
@@ -1709,9 +1703,6 @@
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "queryCommandState(DOMString)" with the proper type]
-    expected: FAIL
-
-  [Window interface: operation queueMicrotask(VoidFunction)]
     expected: FAIL
 
   [Window interface: internal [[SetPrototypeOf\]\] method of interface prototype object - setting to a new value via Object.setPrototypeOf should throw a TypeError]

--- a/tests/wpt/metadata/html/dom/idlharness.worker.js.ini
+++ b/tests/wpt/metadata/html/dom/idlharness.worker.js.ini
@@ -98,9 +98,6 @@
   [OffscreenCanvasRenderingContext2D interface: attribute shadowColor]
     expected: FAIL
 
-  [WorkerGlobalScope interface: self must inherit property "queueMicrotask(VoidFunction)" with the proper type]
-    expected: FAIL
-
   [DedicatedWorkerGlobalScope interface: attribute name]
     expected: FAIL
 
@@ -123,9 +120,6 @@
     expected: FAIL
 
   [OffscreenCanvasRenderingContext2D interface: operation translate(unrestricted double, unrestricted double)]
-    expected: FAIL
-
-  [WorkerGlobalScope interface: operation queueMicrotask(VoidFunction)]
     expected: FAIL
 
   [Path2D interface: operation moveTo(unrestricted double, unrestricted double)]
@@ -156,9 +150,6 @@
     expected: FAIL
 
   [WorkerGlobalScope interface: self must inherit property "createImageBitmap(ImageBitmapSource, ImageBitmapOptions)" with the proper type]
-    expected: FAIL
-
-  [WorkerGlobalScope interface: calling queueMicrotask(VoidFunction) on self with too few arguments must throw TypeError]
     expected: FAIL
 
   [DedicatedWorkerGlobalScope interface: self must inherit property "cancelAnimationFrame(unsigned long)" with the proper type]

--- a/tests/wpt/metadata/html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js.ini
+++ b/tests/wpt/metadata/html/webappapis/microtask-queuing/queue-microtask-exceptions.any.js.ini
@@ -1,8 +1,3 @@
-[queue-microtask-exceptions.any.html]
-  [It rethrows exceptions]
-    expected: FAIL
-
-
 [queue-microtask-exceptions.any.serviceworker.html]
   expected: ERROR
   [queue-microtask-exceptions]
@@ -18,9 +13,3 @@
   expected: ERROR
   [queue-microtask-exceptions]
     expected: FAIL
-
-
-[queue-microtask-exceptions.any.worker.html]
-  [It rethrows exceptions]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/webappapis/microtask-queuing/queue-microtask.any.js.ini
+++ b/tests/wpt/metadata/html/webappapis/microtask-queuing/queue-microtask.any.js.ini
@@ -1,20 +1,3 @@
-[queue-microtask.any.html]
-  [It exists and is a function]
-    expected: FAIL
-
-  [It does not pass any arguments]
-    expected: FAIL
-
-  [It calls the callback asynchronously]
-    expected: FAIL
-
-  [It throws when given non-functions]
-    expected: FAIL
-
-  [It interleaves with promises as expected]
-    expected: FAIL
-
-
 [queue-microtask.any.serviceworker.html]
   expected: ERROR
   [queue-microtask]
@@ -31,21 +14,3 @@
   expected: TIMEOUT
   [queue-microtask]
     expected: FAIL
-
-
-[queue-microtask.any.worker.html]
-  [It exists and is a function]
-    expected: FAIL
-
-  [It does not pass any arguments]
-    expected: FAIL
-
-  [It calls the callback asynchronously]
-    expected: FAIL
-
-  [It throws when given non-functions]
-    expected: FAIL
-
-  [It interleaves with promises as expected]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/webappapis/microtask-queuing/queue-microtask.window.js.ini
+++ b/tests/wpt/metadata/html/webappapis/microtask-queuing/queue-microtask.window.js.ini
@@ -1,7 +1,0 @@
-[queue-microtask.window.html]
-  [It interleaves with MutationObservers and promises together as expected]
-    expected: FAIL
-
-  [It interleaves with MutationObservers as expected]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The VoidFunction of a user-queued microtask is identical to a PromiseJobCallback in everything but type name, so implementing this method turned out to be just a matter of attaching a WebIDL frontend to a copy-and-pasted backend. All the remaining queueMicrotask WPT failures are because we don't have shared/service workers.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #21574

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
