### PR TITLE
Mitigation for #25498

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4799,6 +4799,7 @@ dependencies = [
  "osmesa-sys",
  "rust-webvr",
  "servo-media",
+ "shellwords",
  "sig",
  "tinyfiledialogs",
  "webxr",
@@ -5187,6 +5188,16 @@ checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
 dependencies = [
  "lazy_static",
  "libc",
+]
+
+[[package]]
+name = "shellwords"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685f0e9b0efe23d26e60a780d8dcd3ac95e90975814de9bc6f48e5d609b5d0f5"
+dependencies = [
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]

--- a/ports/glutin/Cargo.toml
+++ b/ports/glutin/Cargo.toml
@@ -62,6 +62,7 @@ libc = "0.2"
 log = "0.4"
 rust-webvr = { version = "0.16", features = ["glwindow"] }
 servo-media = {git = "https://github.com/servo/media"}
+shellwords = "1.0.0"
 tinyfiledialogs = "3.0"
 webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
 webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless"] }


### PR DESCRIPTION
This is not a complete solution:
* The alert string can get a bit mangled in some cases, but not to the point of unreadability.
* tinyfiledialogs has many codepaths that can pass strings to various different potentially-dialog-displaying executables; I do not know if some of those executables have their own unique escaping requirements.
* If some form of the same problem exists on OSX or Windows, this does not address them.

While imperfect, this is an improvement over continuing to have a known way for page authors to execute arbitrary shell script.