### PR TITLE
Put target element, form owner, and element document on scope chain of compiled events

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11453,6 +11453,12 @@
      {}
     ]
    ],
+   "mozilla/compile-event-handler-lexical-scopes-simple.html": [
+    [
+     "mozilla/compile-event-handler-lexical-scopes-simple.html",
+     {}
+    ]
+   ],
    "mozilla/createEvent-storageevent.html": [
     [
      "mozilla/createEvent-storageevent.html",
@@ -18587,6 +18593,10 @@
   ],
   "mozilla/collections.html": [
    "8e06ffcc0933719b4b79ea6656d6635cc121d900",
+   "testharness"
+  ],
+  "mozilla/compile-event-handler-lexical-scopes-simple.html": [
+   "7d1e1839390ea16183bffd09eef4e3445d5d8e16",
    "testharness"
   ],
   "mozilla/createEvent-storageevent.html": [

--- a/tests/wpt/mozilla/tests/mozilla/compile-event-handler-lexical-scopes-simple.html
+++ b/tests/wpt/mozilla/tests/mozilla/compile-event-handler-lexical-scopes-simple.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Lexical scopes when compiling an inline event handler (easy mode)</title>
+<link rel="help" href="https://html.spec.whatwg.org/C/#getting-the-current-value-of-the-event-handler">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+setup({allow_uncaught_exception: true});
+</script>
+
+<!-- Testing just the core of
+     html/webappapis/scripting/events/compile-event-handler-lexical-scopes.html
+     to have a test for it that works while #25199 is open -->
+
+<form method="POST">
+  <input value="hello" onclick="
+    window.testResults.value = value;
+    window.testResults.self = this;
+    window.testResults.method = method;
+    window.testResults.contentType = contentType;
+    window.testResults.input_var = input_var;
+    window.testResults.form_var = form_var;
+    window.testResults.doc_var = doc_var;
+    ">
+</form>
+
+<script>
+"use strict";
+
+test(() => {
+  window.testResults = {};
+
+  document.querySelector("input").input_var = 1;
+  document.querySelector("form").form_var = 2;
+  document.doc_var = 3;
+
+  document.querySelector("input").click();
+
+  assert_equals(window.testResults.value, "hello");
+  assert_in_array(window.testResults.method, ["POST","post"]);
+  assert_equals(window.testResults.contentType, "text/html");
+  assert_equals(window.testResults.self, document.querySelector("input"));
+  assert_equals(window.testResults.input_var, 1);
+  assert_equals(window.testResults.form_var, 2);
+  assert_equals(window.testResults.doc_var, 3);
+}, "Element, form owner, and document all expose expandos and IDL properties");
+</script>


### PR DESCRIPTION
Event listeners that are created from a function object just get whatever closure the function object had, but event listeners created from a string need a special closure that acts like they were defined inside a series of `with` statements. This now happens. The existing WPT test for it, html/webappapis/scripting/events/compile-event-handler-lexical-scopes.html, also relies on other behavior we don't have, so I added an easier version of the test that doesn't involve bubbling or capturing and doesn't check any IDL properties we don't have. This new test will eventually be redundant when we have everything else the upstream test expects.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25517

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
