### PR TITLE
Add support for WebGL2 uniform array operations

### DIFF
--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -389,7 +389,7 @@ impl WebGL2RenderingContext {
         }
     }
 
-    fn uniform_vec_section(
+    fn uniform_vec_section_uint(
         &self,
         vec: Uint32ArrayOrUnsignedLongSequence,
         offset: u32,
@@ -401,35 +401,8 @@ impl WebGL2RenderingContext {
             Uint32ArrayOrUnsignedLongSequence::Uint32Array(v) => v.to_vec(),
             Uint32ArrayOrUnsignedLongSequence::UnsignedLongSequence(v) => v,
         };
-
-        let offset = offset as usize;
-        if offset > vec.len() {
-            return Err(InvalidValue);
-        }
-
-        let length = if length > 0 {
-            length as usize
-        } else {
-            vec.len() - offset
-        };
-        if offset + length > vec.len() {
-            return Err(InvalidValue);
-        }
-
-        let vec = if offset == 0 && length == vec.len() {
-            vec
-        } else {
-            vec[offset..offset + length].to_vec()
-        };
-
-        if vec.len() < uniform_size || vec.len() % uniform_size != 0 {
-            return Err(InvalidValue);
-        }
-        if uniform_location.size().is_none() && vec.len() != uniform_size {
-            return Err(InvalidOperation);
-        }
-
-        Ok(vec)
+        self.base
+            .uniform_vec_section::<u32>(vec, offset, length, uniform_size, uniform_location)
     }
 }
 
@@ -1498,8 +1471,14 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
-    fn Uniform1iv(&self, location: Option<&WebGLUniformLocation>, v: Int32ArrayOrLongSequence) {
-        self.base.Uniform1iv(location, v)
+    fn Uniform1iv(
+        &self,
+        location: Option<&WebGLUniformLocation>,
+        v: Int32ArrayOrLongSequence,
+        src_offset: u32,
+        src_length: u32,
+    ) {
+        self.base.Uniform1iv(location, v, src_offset, src_length)
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
@@ -1532,7 +1511,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
                 _ => return Err(InvalidOperation),
             }
 
-            let val = self.uniform_vec_section(val, src_offset, src_length, 1, location)?;
+            let val = self.uniform_vec_section_uint(val, src_offset, src_length, 1, location)?;
 
             match location.type_() {
                 constants::SAMPLER_2D | constants::SAMPLER_CUBE => {
@@ -1558,8 +1537,10 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         &self,
         location: Option<&WebGLUniformLocation>,
         v: Float32ArrayOrUnrestrictedFloatSequence,
+        src_offset: u32,
+        src_length: u32,
     ) {
-        self.base.Uniform1fv(location, v);
+        self.base.Uniform1fv(location, v, src_offset, src_length);
     }
 
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
@@ -1572,8 +1553,10 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         &self,
         location: Option<&WebGLUniformLocation>,
         v: Float32ArrayOrUnrestrictedFloatSequence,
+        src_offset: u32,
+        src_length: u32,
     ) {
-        self.base.Uniform2fv(location, v);
+        self.base.Uniform2fv(location, v, src_offset, src_length);
     }
 
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
@@ -1582,8 +1565,14 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
-    fn Uniform2iv(&self, location: Option<&WebGLUniformLocation>, v: Int32ArrayOrLongSequence) {
-        self.base.Uniform2iv(location, v)
+    fn Uniform2iv(
+        &self,
+        location: Option<&WebGLUniformLocation>,
+        v: Int32ArrayOrLongSequence,
+        src_offset: u32,
+        src_length: u32,
+    ) {
+        self.base.Uniform2iv(location, v, src_offset, src_length)
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
@@ -1612,7 +1601,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
                 constants::BOOL_VEC2 | constants::UNSIGNED_INT_VEC2 => {},
                 _ => return Err(InvalidOperation),
             }
-            let val = self.uniform_vec_section(val, src_offset, src_length, 2, location)?;
+            let val = self.uniform_vec_section_uint(val, src_offset, src_length, 2, location)?;
             self.base
                 .send_command(WebGLCommand::Uniform2uiv(location.id(), val));
             Ok(())
@@ -1629,8 +1618,10 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         &self,
         location: Option<&WebGLUniformLocation>,
         v: Float32ArrayOrUnrestrictedFloatSequence,
+        src_offset: u32,
+        src_length: u32,
     ) {
-        self.base.Uniform3fv(location, v);
+        self.base.Uniform3fv(location, v, src_offset, src_length);
     }
 
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
@@ -1639,8 +1630,14 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
-    fn Uniform3iv(&self, location: Option<&WebGLUniformLocation>, v: Int32ArrayOrLongSequence) {
-        self.base.Uniform3iv(location, v)
+    fn Uniform3iv(
+        &self,
+        location: Option<&WebGLUniformLocation>,
+        v: Int32ArrayOrLongSequence,
+        src_offset: u32,
+        src_length: u32,
+    ) {
+        self.base.Uniform3iv(location, v, src_offset, src_length)
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
@@ -1669,7 +1666,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
                 constants::BOOL_VEC3 | constants::UNSIGNED_INT_VEC3 => {},
                 _ => return Err(InvalidOperation),
             }
-            let val = self.uniform_vec_section(val, src_offset, src_length, 3, location)?;
+            let val = self.uniform_vec_section_uint(val, src_offset, src_length, 3, location)?;
             self.base
                 .send_command(WebGLCommand::Uniform3uiv(location.id(), val));
             Ok(())
@@ -1682,8 +1679,14 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10
-    fn Uniform4iv(&self, location: Option<&WebGLUniformLocation>, v: Int32ArrayOrLongSequence) {
-        self.base.Uniform4iv(location, v)
+    fn Uniform4iv(
+        &self,
+        location: Option<&WebGLUniformLocation>,
+        v: Int32ArrayOrLongSequence,
+        src_offset: u32,
+        src_length: u32,
+    ) {
+        self.base.Uniform4iv(location, v, src_offset, src_length)
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.8
@@ -1712,7 +1715,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
                 constants::BOOL_VEC4 | constants::UNSIGNED_INT_VEC4 => {},
                 _ => return Err(InvalidOperation),
             }
-            let val = self.uniform_vec_section(val, src_offset, src_length, 4, location)?;
+            let val = self.uniform_vec_section_uint(val, src_offset, src_length, 4, location)?;
             self.base
                 .send_command(WebGLCommand::Uniform4uiv(location.id(), val));
             Ok(())
@@ -1729,8 +1732,10 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         &self,
         location: Option<&WebGLUniformLocation>,
         v: Float32ArrayOrUnrestrictedFloatSequence,
+        src_offset: u32,
+        src_length: u32,
     ) {
-        self.base.Uniform4fv(location, v);
+        self.base.Uniform4fv(location, v, src_offset, src_length);
     }
 
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -430,24 +430,6 @@ interface mixin WebGL2RenderingContextBase
   void uniform3ui(WebGLUniformLocation? location, GLuint v0, GLuint v1, GLuint v2);
   void uniform4ui(WebGLUniformLocation? location, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
 
-  // void uniform1fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
-  //                 optional GLuint srcLength = 0);
-  // void uniform2fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
-  //                 optional GLuint srcLength = 0);
-  // void uniform3fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
-  //                 optional GLuint srcLength = 0);
-  // void uniform4fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
-  //                 optional GLuint srcLength = 0);
-
-  // void uniform1iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
-  //                 optional GLuint srcLength = 0);
-  // void uniform2iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
-  //                 optional GLuint srcLength = 0);
-  // void uniform3iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
-  //                 optional GLuint srcLength = 0);
-  // void uniform4iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
-  //                 optional GLuint srcLength = 0);
-
   void uniform1uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0,
                    optional GLuint srcLength = 0);
   void uniform2uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0,

--- a/components/script/dom/webidls/WebGLRenderingContext.webidl
+++ b/components/script/dom/webidls/WebGLRenderingContext.webidl
@@ -650,15 +650,23 @@ interface mixin WebGLRenderingContextBase
     void uniform3i(WebGLUniformLocation? location, GLint x, GLint y, GLint z);
     void uniform4i(WebGLUniformLocation? location, GLint x, GLint y, GLint z, GLint w);
 
-    void uniform1fv(WebGLUniformLocation? location, Float32List v);
-    void uniform2fv(WebGLUniformLocation? location, Float32List v);
-    void uniform3fv(WebGLUniformLocation? location, Float32List v);
-    void uniform4fv(WebGLUniformLocation? location, Float32List v);
+    void uniform1fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
+                    optional GLuint srcLength = 0);
+    void uniform2fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
+                    optional GLuint srcLength = 0);
+    void uniform3fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
+                    optional GLuint srcLength = 0);
+    void uniform4fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
+                    optional GLuint srcLength = 0);
 
-    void uniform1iv(WebGLUniformLocation? location, Int32List v);
-    void uniform2iv(WebGLUniformLocation? location, Int32List v);
-    void uniform3iv(WebGLUniformLocation? location, Int32List v);
-    void uniform4iv(WebGLUniformLocation? location, Int32List v);
+    void uniform1iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
+                    optional GLuint srcLength = 0);
+    void uniform2iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
+                    optional GLuint srcLength = 0);
+    void uniform3iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
+                    optional GLuint srcLength = 0);
+    void uniform4iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
+                    optional GLuint srcLength = 0);
 
     void uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List value);
     void uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List value);

--- a/tests/wpt/webgl/meta/conformance2/uniforms/gl-uniform-arrays-sub-source.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/uniforms/gl-uniform-arrays-sub-source.html.ini
@@ -1,93 +1,6 @@
 [gl-uniform-arrays-sub-source.html]
   expected: ERROR
-  [WebGL test #49: value put in (99) matches value pulled out (16)]
-    expected: FAIL
-
-  [WebGL test #149: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform1iv with 0 data]
-    expected: FAIL
-
-  [WebGL test #144: value put in (99) matches value pulled out (16)]
-    expected: FAIL
-
-  [WebGL test #46: value put in (15) matches value pulled out (0)]
-    expected: FAIL
-
-  [WebGL test #69: value put in (99) matches value pulled out (16)]
-    expected: FAIL
-
-  [WebGL test #147: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform1iv with srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #72: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform1fv with srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #118: value put in (16) matches value pulled out (0)]
-    expected: FAIL
-
-  [WebGL test #131: value put in (15) matches value pulled out (0)]
-    expected: FAIL
-
-  [WebGL test #43: value put in (16) matches value pulled out (0)]
-    expected: FAIL
-
-  [WebGL test #146: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform1iv with srcOffset out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #73: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform1fv with srcOffset + srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #53: value put in (16) matches value pulled out (0)]
-    expected: FAIL
-
-  [WebGL test #74: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform1fv with 0 data]
-    expected: FAIL
-
-  [WebGL test #138: value put in (16) matches value pulled out (0)]
-    expected: FAIL
-
-  [WebGL test #150: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-
-  [WebGL test #134: value put in (99) matches value pulled out (16)]
-    expected: FAIL
-
-  [WebGL test #56: value put in (15) matches value pulled out (0)]
-    expected: FAIL
-
-  [WebGL test #128: value put in (16) matches value pulled out (0)]
-    expected: FAIL
-
-  [WebGL test #121: value put in (15) matches value pulled out (0)]
-    expected: FAIL
-
-  [WebGL test #63: value put in (16) matches value pulled out (0)]
-    expected: FAIL
-
-  [WebGL test #141: value put in (15) matches value pulled out (0)]
-    expected: FAIL
-
-  [WebGL test #66: value put in (15) matches value pulled out (0)]
-    expected: FAIL
-
-  [WebGL test #124: value put in (99) matches value pulled out (16)]
-    expected: FAIL
-
-  [WebGL test #59: value put in (99) matches value pulled out (16)]
-    expected: FAIL
-
-  [WebGL test #71: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform1fv with srcOffset out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #148: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform1iv with srcOffset + srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #296: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform2fv with srcOffset out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #752: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform4fv with srcOffset out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #364: value put in (16,15) matches value pulled out (0,16)]
+  [WebGL test #1135: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix4fv with 0 data]
     expected: FAIL
 
   [WebGL test #1058: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix3fv with srcOffset + srcLength out-of-bounds]
@@ -96,25 +9,10 @@
   [WebGL test #959: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniformMatrix2fv with srcOffset = 3 / srcLength = 0]
     expected: FAIL
 
-  [WebGL test #820: value put in (16,15,14,13) matches value pulled out (0,0,0,16)]
+  [WebGL test #1121: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniformMatrix4fv with srcOffset = 2 / srcLength = 16]
     expected: FAIL
 
-  [WebGL test #351: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniform2iv with srcOffset = 1 / srcLength = 0]
-    expected: FAIL
-
-  [WebGL test #604: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform3iv with array length minus srcOffset not multiple of ivec3]
-    expected: FAIL
-
-  [WebGL test #603: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform3iv with 0 data]
-    expected: FAIL
-
-  [WebGL test #828: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform4iv with srcOffset out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #753: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform4fv with srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #1135: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix4fv with 0 data]
+  [WebGL test #1059: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix3fv with 0 data]
     expected: FAIL
 
   [WebGL test #1132: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix4fv with srcOffset out-of-bounds]
@@ -126,25 +24,7 @@
   [WebGL test #1133: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix4fv with srcLength out-of-bounds]
     expected: FAIL
 
-  [WebGL test #601: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform3iv with srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #754: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform4fv with srcOffset + srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #830: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform4iv with srcOffset + srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #797: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniform4iv with srcOffset = 3]
-    expected: FAIL
-
-  [WebGL test #528: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform3fv with array length minus srcOffset not multiple of vec3]
-    expected: FAIL
-
-  [WebGL test #807: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniform4iv with srcOffset = 3 / srcLength = 0]
-    expected: FAIL
-
-  [WebGL test #298: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform2fv with srcOffset + srcLength out-of-bounds]
+  [WebGL test #1057: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix3fv with srcLength out-of-bounds]
     expected: FAIL
 
   [WebGL test #1137: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
@@ -156,103 +36,16 @@
   [WebGL test #1045: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniformMatrix3fv with srcOffset = 3 / srcLength = 9]
     expected: FAIL
 
-  [WebGL test #375: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform2iv with 0 data]
-    expected: FAIL
-
-  [WebGL test #294: value put in (99,99) matches value pulled out (13,0)]
-    expected: FAIL
-
-  [WebGL test #525: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform3fv with srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #275: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniform2fv with srcOffset = 1 / srcLength = 0]
-    expected: FAIL
-
-  [WebGL test #526: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform3fv with srcOffset + srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #370: value put in (99,99) matches value pulled out (13,0)]
-    expected: FAIL
-
-  [WebGL test #747: value put in (12,11,10,9) matches value pulled out (15,14,13,12)]
-    expected: FAIL
-
-  [WebGL test #519: value put in (13,12,11) matches value pulled out (14,13,12)]
-    expected: FAIL
-
   [WebGL test #1056: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix3fv with srcOffset out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #522: value put in (99,99,99) matches value pulled out (11,0,0)]
-    expected: FAIL
-
-  [WebGL test #731: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniform4fv with srcOffset = 3 / srcLength = 0]
-    expected: FAIL
-
-  [WebGL test #516: value put in (16,15,14) matches value pulled out (0,16,15)]
-    expected: FAIL
-
-  [WebGL test #288: value put in (16,15) matches value pulled out (0,16)]
-    expected: FAIL
-
-  [WebGL test #527: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform3fv with 0 data]
-    expected: FAIL
-
-  [WebGL test #569: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniform3iv with srcOffset = 1]
-    expected: FAIL
-
-  [WebGL test #374: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform2iv with srcOffset + srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #592: value put in (16,15,14) matches value pulled out (0,16,15)]
-    expected: FAIL
-
-  [WebGL test #602: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform3iv with srcOffset + srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #524: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform3fv with srcOffset out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #600: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform3iv with srcOffset out-of-bounds]
     expected: FAIL
 
   [WebGL test #981: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix2fv with srcLength out-of-bounds]
     expected: FAIL
 
-  [WebGL test #721: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniform4fv with srcOffset = 3]
-    expected: FAIL
-
-  [WebGL test #299: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform2fv with 0 data]
-    expected: FAIL
-
   [WebGL test #1101: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniformMatrix4fv with srcOffset = 2]
     expected: FAIL
 
-  [WebGL test #826: value put in (99,99,99,99) matches value pulled out (11,10,9,0)]
-    expected: FAIL
-
-  [WebGL test #300: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform2fv with array length minus srcOffset not multiple of vec2]
-    expected: FAIL
-
-  [WebGL test #750: value put in (99,99,99,99) matches value pulled out (11,10,9,0)]
-    expected: FAIL
-
-  [WebGL test #1121: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniformMatrix4fv with srcOffset = 2 / srcLength = 16]
-    expected: FAIL
-
-  [WebGL test #367: value put in (14,13) matches value pulled out (15,14)]
-    expected: FAIL
-
-  [WebGL test #595: value put in (13,12,11) matches value pulled out (14,13,12)]
-    expected: FAIL
-
-  [WebGL test #579: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniform3iv with srcOffset = 1 / srcLength = 0]
-    expected: FAIL
-
-  [WebGL test #297: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform2fv with srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #291: value put in (14,13) matches value pulled out (15,14)]
+  [WebGL test #1134: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix4fv with srcOffset + srcLength out-of-bounds]
     expected: FAIL
 
   [WebGL test #978: value put in (99,99,99,99) matches value pulled out (11,10,9,0)]
@@ -264,75 +57,21 @@
   [WebGL test #980: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix2fv with srcOffset out-of-bounds]
     expected: FAIL
 
-  [WebGL test #829: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform4iv with srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #1057: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix3fv with srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #823: value put in (12,11,10,9) matches value pulled out (15,14,13,12)]
-    expected: FAIL
-
   [WebGL test #1035: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniformMatrix3fv with srcOffset = 3 / srcLength = 0]
-    expected: FAIL
-
-  [WebGL test #755: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform4fv with 0 data]
-    expected: FAIL
-
-  [WebGL test #832: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform4iv with array length minus srcOffset not multiple of ivec4]
-    expected: FAIL
-
-  [WebGL test #831: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform4iv with 0 data]
-    expected: FAIL
-
-  [WebGL test #744: value put in (16,15,14,13) matches value pulled out (0,0,0,16)]
     expected: FAIL
 
   [WebGL test #1025: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniformMatrix3fv with srcOffset = 3]
     expected: FAIL
 
-  [WebGL test #341: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniform2iv with srcOffset = 1]
-    expected: FAIL
-
-  [WebGL test #503: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniform3fv with srcOffset = 1 / srcLength = 0]
-    expected: FAIL
-
-  [WebGL test #265: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniform2fv with srcOffset = 1]
-    expected: FAIL
-
-  [WebGL test #493: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniform3fv with srcOffset = 1]
-    expected: FAIL
-
-  [WebGL test #598: value put in (99,99,99) matches value pulled out (11,0,0)]
-    expected: FAIL
-
   [WebGL test #982: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix2fv with srcOffset + srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #983: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix2fv with 0 data]
     expected: FAIL
 
   [WebGL test #949: getError expected: NO_ERROR. Was INVALID_VALUE : can set an array of uniforms with gl.uniformMatrix2fv with srcOffset = 3]
     expected: FAIL
 
-  [WebGL test #756: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform4fv with array length minus srcOffset not multiple of vec4]
-    expected: FAIL
-
-  [WebGL test #1059: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix3fv with 0 data]
-    expected: FAIL
-
-  [WebGL test #373: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform2iv with srcLength out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #376: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform2iv with array length minus srcOffset not multiple of ivec2]
+  [WebGL test #983: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix2fv with 0 data]
     expected: FAIL
 
   [WebGL test #975: value put in (12,11,10,9) matches value pulled out (15,14,13,12)]
-    expected: FAIL
-
-  [WebGL test #372: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniform2iv with srcOffset out-of-bounds]
-    expected: FAIL
-
-  [WebGL test #1134: getError expected: INVALID_VALUE. Was NO_ERROR : gl.uniformMatrix4fv with srcOffset + srcLength out-of-bounds]
     expected: FAIL
 


### PR DESCRIPTION
Adds support for the WebGL2 overloads of `uniform[1234][if]v`.

<!-- Please describe your changes on the following line: -->

WebGL2 adds two optional parameters for the `uniform[1234][if]v` functions to allow specifying input data ranges. However, because they have the same name and overlapping parameters, the Codegen cannot make a difference between their GL1 and 2 variants. As a workaround, I've added the new parameters to the WebGL1 side, which which isn't strictly what the spec says, but shouldn't break things either. (Note: Firefox devs also run into this issue: [[1](https://searchfox.org/mozilla-central/source/dom/webidl/WebGLRenderingContext.webidl#794), [2](https://bugzilla.mozilla.org/show_bug.cgi?id=1324543)]).

cc @jdm @zakorgy @imiklos 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
