### PR TITLE
Fix canvas wpt test ensuring there's a subpath when drawing bezier curves

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -771,8 +771,8 @@ impl<'a> CanvasData<'a> {
     }
 
     pub fn quadratic_curve_to(&mut self, cp: &Point2D<f32>, endpoint: &Point2D<f32>) {
-        if self.path_builder().current_point().is_none() {
-            self.path_builder().move_to(cp);
+        if self.path_state.is_none() {
+            self.move_to(cp);
         }
         self.path_builder().quadratic_curve_to(cp, endpoint);
     }
@@ -783,6 +783,9 @@ impl<'a> CanvasData<'a> {
         cp2: &Point2D<f32>,
         endpoint: &Point2D<f32>,
     ) {
+        if self.path_state.is_none() {
+            self.move_to(cp1);
+        }
         self.path_builder().bezier_curve_to(cp1, cp2, endpoint);
     }
 

--- a/tests/wpt/metadata/2dcontext/building-paths/canvas_complexshapes_beziercurveto_001.htm.ini
+++ b/tests/wpt/metadata/2dcontext/building-paths/canvas_complexshapes_beziercurveto_001.htm.ini
@@ -1,2 +1,0 @@
-[canvas_complexshapes_beziercurveto_001.htm]
-  expected: FAIL

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.bezierCurveTo.ensuresubpath.2.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.bezierCurveTo.ensuresubpath.2.html.ini
@@ -1,4 +1,0 @@
-[2d.path.bezierCurveTo.ensuresubpath.2.html]
-  [If there is no subpath, the first control point is added]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.bezierCurveTo.ensuresubpath.2.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.bezierCurveTo.ensuresubpath.2.html.ini
@@ -1,4 +1,0 @@
-[2d.path.bezierCurveTo.ensuresubpath.2.html]
-  [If there is no subpath, the first control point is added]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.bezierCurveTo.ensuresubpath.2.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.bezierCurveTo.ensuresubpath.2.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.path.bezierCurveTo.ensuresubpath.2.worker.html]
-  [If there is no subpath, the first control point is added]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
These changes will ensure there's a subpath when drawing bezier curves.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix part of #25331 

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
