### PR TITLE
Add WebGL2 specific version strings

### DIFF
--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -441,6 +441,16 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.3
     fn GetParameter(&self, cx: JSContext, parameter: u32) -> JSVal {
         match parameter {
+            constants::VERSION => unsafe {
+                rooted!(in(*cx) let mut rval = UndefinedValue());
+                "WebGL 2.0".to_jsval(*cx, rval.handle_mut());
+                return rval.get();
+            },
+            constants::SHADING_LANGUAGE_VERSION => unsafe {
+                rooted!(in(*cx) let mut rval = UndefinedValue());
+                "WebGL GLSL ES 3.00".to_jsval(*cx, rval.handle_mut());
+                return rval.get();
+            },
             constants::MAX_CLIENT_WAIT_TIMEOUT_WEBGL => {
                 return Int32Value(
                     self.base.limits().max_client_wait_timeout_webgl.as_nanos() as i32

--- a/tests/wpt/webgl/meta/conformance2/state/gl-getstring.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/state/gl-getstring.html.ini
@@ -1,7 +1,0 @@
-[gl-getstring.html]
-  [WebGL test #1: getParameter(gl.VERSION) did not start with WebGL 2.0]
-    expected: FAIL
-
-  [WebGL test #2: getParameter(gl.SHADING_LANGUAGE_VERSION) did not start with WebGL GLSL ES 3.00]
-    expected: FAIL
-


### PR DESCRIPTION
Updated the `VERSION` and `SHADING_LANGUAGE_VERSION` WebGL parameters to report the correct version strings when WebGL2 is in use.

See: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2

<!-- Please describe your changes on the following line: -->
cc @jdm @zakorgy @imiklos 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
