### PR TITLE
Fix canvas wpt test `path-objects/2d.path.rect.zero.4.html`

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -143,11 +143,12 @@ impl<'a> PathBuilderRef<'a> {
             ),
             Point2D::new(rect.origin.x, rect.origin.y + rect.size.height),
         );
-        self.builder.move_to(self.transform.transform_point(first));
-        self.builder.line_to(self.transform.transform_point(second));
-        self.builder.line_to(self.transform.transform_point(third));
-        self.builder.line_to(self.transform.transform_point(fourth));
-        self.builder.close();
+        self.move_to(&first);
+        self.line_to(&second);
+        self.line_to(&third);
+        self.line_to(&fourth);
+        self.close();
+        self.move_to(&first);
     }
 
     fn quadratic_curve_to(&mut self, cp: &Point2D<f32>, endpoint: &Point2D<f32>) {
@@ -209,6 +210,10 @@ impl<'a> PathBuilderRef<'a> {
             Some(point) => Some(inverse.transform_point(Point2D::new(point.x, point.y))),
             None => None,
         }
+    }
+
+    fn close(&mut self) {
+        self.builder.close();
     }
 }
 
@@ -573,7 +578,7 @@ impl<'a> CanvasData<'a> {
     }
 
     pub fn close_path(&mut self) {
-        self.path_builder().builder.close();
+        self.path_builder().close();
     }
 
     fn ensure_path(&mut self) {

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.rect.zero.4.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.rect.zero.4.html.ini
@@ -1,4 +1,0 @@
-[2d.path.rect.zero.4.html]
-  [Canvas test: 2d.path.rect.zero.4]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.rect.zero.4.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.rect.zero.4.html.ini
@@ -1,4 +1,0 @@
-[2d.path.rect.zero.4.html]
-  [OffscreenCanvas test: 2d.path.rect.zero.4]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.rect.zero.4.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.rect.zero.4.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.path.rect.zero.4.worker.html]
-  [2d]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
After connecting the lines of a rectangle, a new subpath has to be created containing the rectangle's origin as the only point in the subpath.
(see step 4 of https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-rect)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix part of #25331

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
