### PR TITLE
Return the highest priority error from the descendant instead of return the very first one

### DIFF
--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -633,6 +633,7 @@ impl ModuleTree {
         }
 
         // 5-6.
+        let mut errors: Vec<ModuleError> = Vec::new();
         let descendant_urls = module_tree.get_descendant_urls().borrow();
 
         for descendant_module in descendant_urls
@@ -650,13 +651,13 @@ impl ModuleTree {
                 ModuleTree::find_first_parse_error(&global, &descendant_module, discovered_urls);
 
             // 8-4.
-            if child_parse_error.is_some() {
-                return child_parse_error;
+            if let Some(child_error) = child_parse_error {
+                errors.push(child_error);
             }
         }
 
         // Step 9.
-        return None;
+        return errors.into_iter().max();
     }
 }
 

--- a/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/module/error-type-1.html.ini
+++ b/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/module/error-type-1.html.ini
@@ -1,4 +1,0 @@
-[error-type-1.html]
-  [network error has higher priority than parse error]
-    expected: FAIL
-


### PR DESCRIPTION
The test failed because we didn't return the highest priority error (which is network error in this case).

As Manish mentioned in https://github.com/servo/servo/issues/25436#issuecomment-571065323, that's because we're using the Promise.all trick to signal loads.

If we can avoid relying on Promise.all, maybe we don't need to do a complex logic like this; instead, ideally, we should always finish the module load immediately when we hit network failure so that we don't even need to do the `max()` comparison.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25436 
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
