### PR TITLE
Add default arguments so that ./mach test --all works

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -331,7 +331,7 @@ class MachCommands(CommandBase):
     @CommandArgument('--stylo', default=False, action="store_true",
                      help="Only handle files in the stylo tree")
     @CommandArgument('--force-cpp', default=False, action="store_true", help="Force CPP check")
-    def test_tidy(self, all_files, no_wpt, no_progress, self_test, stylo, force_cpp):
+    def test_tidy(self, all_files, no_progress, self_test, stylo, force_cpp=False, no_wpt=False):
         if self_test:
             return test_tidy.do_tests()
         else:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fix `./mach test --all` not getting any default values for `force_cpp` and `no_wpt` in [python/servo/testing_commands.py](https://github.com/servo/servo/blob/2a594821ba44ba2c13e9a39c6fd8c5a450bd06f4/python/servo/testing_commands.py#L319-L334). For `./mach test-tidy` the default values are obtained using the `@CommandArgument` decorator, but this does not apply for calling `test_tidy()` when using `./mach test --all` (which calls the function directly). This call is found on line 109 of `registrar.py` which should be located in something like `python/_virtualenv2.7/python2.7/site-packages/mach/registrar.py` (but not located in this git repository). 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25554 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because the change is minimal and non breaking. Any existing code should be able to work if it uses keyword arguments because the default values will be overriden. If there is code that calls `test_tidy()` with arguments by position this would cause breakage, but I do not believe this happens anywhere in the `testing_command.py` file. `./mach test-tidy` should still work because the arguments are set using the `@CommandArgument` decorator.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
