### PR TITLE
Make name content attributes consistently atoms and put them in rare_data for fast access

### DIFF
--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -84,6 +84,7 @@ radio
 range
 ratechange
 readystatechange
+referrer
 reftest-wait
 rejectionhandled
 removetrack

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -823,6 +823,7 @@ impl Document {
     }
 
     fn get_anchor_by_name(&self, name: &str) -> Option<DomRoot<Element>> {
+        // TODO faster name lookups (see #25548)
         let check_anchor = |node: &HTMLAnchorElement| {
             let elem = node.upcast::<Element>();
             elem.get_attribute(&ns!(), &local_name!("name"))
@@ -4091,9 +4092,7 @@ impl DocumentMethods for Document {
             if element.namespace() != &ns!(html) {
                 return false;
             }
-            element
-                .get_attribute(&ns!(), &local_name!("name"))
-                .map_or(false, |attr| &**attr.value() == &*name)
+            element.get_name().map_or(false, |atom| *atom == *name)
         })
     }
 
@@ -4303,6 +4302,7 @@ impl DocumentMethods for Document {
         }
         // https://html.spec.whatwg.org/multipage/#dom-document-nameditem-filter
         fn filter_by_name(name: &Atom, node: &Node) -> bool {
+            // TODO faster name lookups (see #25548)
             let html_elem_type = match node.type_id() {
                 NodeTypeId::Element(ElementTypeId::HTMLElement(type_)) => type_,
                 _ => return false,

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1401,11 +1401,28 @@ impl Element {
     // https://dom.spec.whatwg.org/#concept-element-attributes-get-by-name
     pub fn get_attribute_by_name(&self, name: DOMString) -> Option<DomRoot<Attr>> {
         let name = &self.parsed_name(name);
-        self.attrs
+        let maybe_attribute = self
+            .attrs
             .borrow()
             .iter()
             .find(|a| a.name() == name)
-            .map(|js| DomRoot::from_ref(&**js))
+            .map(|js| DomRoot::from_ref(&**js));
+
+        fn id_and_name_must_be_atoms(name: &LocalName, maybe_attr: &Option<DomRoot<Attr>>) -> bool {
+            if *name == local_name!("id") || *name == local_name!("name") {
+                match maybe_attr {
+                    None => true,
+                    Some(ref attr) => match *attr.value() {
+                        AttrValue::Atom(_) => true,
+                        _ => false,
+                    },
+                }
+            } else {
+                true
+            }
+        }
+        debug_assert!(id_and_name_must_be_atoms(name, &maybe_attribute));
+        maybe_attribute
     }
 
     pub fn set_attribute_from_parser(
@@ -1800,6 +1817,14 @@ impl Element {
         let other = other.upcast::<Element>();
         self.root_element() == other.root_element()
     }
+
+    pub fn get_id(&self) -> Option<Atom> {
+        self.id_attribute.borrow().clone()
+    }
+
+    pub fn get_name(&self) -> Option<Atom> {
+        self.rare_data().as_ref()?.name_attribute.clone()
+    }
 }
 
 impl ElementMethods for Element {
@@ -1836,6 +1861,8 @@ impl ElementMethods for Element {
     }
 
     // https://dom.spec.whatwg.org/#dom-element-id
+    // This always returns a string; if you'd rather see None
+    // on a null id, call get_id
     fn Id(&self) -> DOMString {
         self.get_string_attribute(&local_name!("id"))
     }
@@ -2783,6 +2810,20 @@ impl VirtualMethods for Element {
                     }
                 }
             },
+            &local_name!("name") => {
+                // Keep the name in rare data for fast access
+                self.ensure_rare_data().name_attribute =
+                    mutation.new_value(attr).and_then(|value| {
+                        let value = value.as_atom();
+                        if value != &atom!("") {
+                            Some(value.clone())
+                        } else {
+                            None
+                        }
+                    });
+                // TODO: notify the document about the name change
+                // once it has a name_map (#25548)
+            },
             _ => {
                 // FIXME(emilio): This is pretty dubious, and should be done in
                 // the relevant super-classes.
@@ -2801,6 +2842,7 @@ impl VirtualMethods for Element {
     fn parse_plain_attribute(&self, name: &LocalName, value: DOMString) -> AttrValue {
         match name {
             &local_name!("id") => AttrValue::from_atomic(value.into()),
+            &local_name!("name") => AttrValue::from_atomic(value.into()),
             &local_name!("class") => AttrValue::from_serialized_tokenlist(value.into()),
             _ => self
                 .super_type()

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -152,7 +152,7 @@ impl HTMLAnchorElementMethods for HTMLAnchorElement {
     make_getter!(Name, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-name
-    make_setter!(SetName, "name");
+    make_atomic_setter!(SetName, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-a-rev
     make_getter!(Rev, "rev");

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -142,7 +142,7 @@ impl HTMLButtonElementMethods for HTMLButtonElement {
     make_getter!(Name, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-fe-name
-    make_setter!(SetName, "name");
+    make_atomic_setter!(SetName, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-button-value
     make_getter!(Value, "value");

--- a/components/script/dom/htmlcollection.rs
+++ b/components/script/dom/htmlcollection.rs
@@ -366,11 +366,12 @@ impl HTMLCollectionMethods for HTMLCollection {
             return None;
         }
 
+        let key = Atom::from(key);
+
         // Step 2.
         self.elements_iter().find(|elem| {
-            elem.get_string_attribute(&local_name!("id")) == key ||
-                (elem.namespace() == &ns!(html) &&
-                    elem.get_string_attribute(&local_name!("name")) == key)
+            elem.get_id().map_or(false, |id| id == key) ||
+                (elem.namespace() == &ns!(html) && elem.get_name().map_or(false, |id| id == key))
         })
     }
 
@@ -392,17 +393,20 @@ impl HTMLCollectionMethods for HTMLCollection {
         // Step 2
         for elem in self.elements_iter() {
             // Step 2.1
-            let id_attr = elem.get_string_attribute(&local_name!("id"));
-            if !id_attr.is_empty() && !result.contains(&id_attr) {
-                result.push(id_attr)
+            if let Some(id_atom) = elem.get_id() {
+                let id_str = DOMString::from(&*id_atom);
+                if !result.contains(&id_str) {
+                    result.push(id_str);
+                }
             }
             // Step 2.2
-            let name_attr = elem.get_string_attribute(&local_name!("name"));
-            if !name_attr.is_empty() &&
-                !result.contains(&name_attr) &&
-                *elem.namespace() == ns!(html)
-            {
-                result.push(name_attr)
+            if *elem.namespace() == ns!(html) {
+                if let Some(name_atom) = elem.get_name() {
+                    let name_str = DOMString::from(&*name_atom);
+                    if !result.contains(&name_str) {
+                        result.push(name_str)
+                    }
+                }
             }
         }
 

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -7,6 +7,7 @@ use crate::dom::bindings::codegen::Bindings::HTMLFieldSetElementBinding;
 use crate::dom::bindings::codegen::Bindings::HTMLFieldSetElementBinding::HTMLFieldSetElementMethods;
 use crate::dom::bindings::inheritance::{Castable, ElementTypeId, HTMLElementTypeId, NodeTypeId};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element};
 use crate::dom::htmlcollection::{CollectionFilter, HTMLCollection};
@@ -87,6 +88,12 @@ impl HTMLFieldSetElementMethods for HTMLFieldSetElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-fieldset-disabled
     make_bool_setter!(SetDisabled, "disabled");
+
+    // https://html.spec.whatwg.org/multipage/#dom-fe-name
+    make_atomic_setter!(SetName, "name");
+
+    // https://html.spec.whatwg.org/multipage/#dom-fe-name
+    make_getter!(Name, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-fae-form
     fn GetForm(&self) -> Option<DomRoot<HTMLFormElement>> {

--- a/components/script/dom/htmlformcontrolscollection.rs
+++ b/components/script/dom/htmlformcontrolscollection.rs
@@ -18,6 +18,7 @@ use crate::dom::node::Node;
 use crate::dom::radionodelist::RadioNodeList;
 use crate::dom::window::Window;
 use dom_struct::dom_struct;
+use servo_atoms::Atom;
 
 #[dom_struct]
 pub struct HTMLFormControlsCollection {
@@ -67,9 +68,11 @@ impl HTMLFormControlsCollectionMethods for HTMLFormControlsCollection {
             return None;
         }
 
+        let name = Atom::from(name);
+
         let mut filter_map = self.collection.elements_iter().filter_map(|elem| {
-            if elem.get_string_attribute(&local_name!("name")) == name ||
-                elem.get_string_attribute(&local_name!("id")) == name
+            if elem.get_name().map_or(false, |n| n == name) ||
+                elem.get_id().map_or(false, |i| i == name)
             {
                 Some(elem)
             } else {
@@ -90,7 +93,7 @@ impl HTMLFormControlsCollectionMethods for HTMLFormControlsCollection {
                 // specifically HTMLFormElement::Elements(),
                 // and the collection filter excludes image inputs.
                 Some(RadioNodeListOrElement::RadioNodeList(
-                    RadioNodeList::new_controls_except_image_inputs(window, &*self.form, name),
+                    RadioNodeList::new_controls_except_image_inputs(window, &*self.form, &name),
                 ))
             }
         // Step 3

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -58,7 +58,7 @@ impl HTMLHeadElement {
             .traverse_preorder(ShadowIncluding::No)
             .filter_map(DomRoot::downcast::<Element>)
             .filter(|elem| elem.is::<HTMLMetaElement>())
-            .filter(|elem| elem.get_string_attribute(&local_name!("name")) == "referrer")
+            .filter(|elem| elem.get_name() == Some(atom!("referrer")))
             .filter(|elem| {
                 elem.get_attribute(&ns!(), &local_name!("content"))
                     .is_some()

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1313,8 +1313,8 @@ impl HTMLImageElement {
             .filter_map(DomRoot::downcast::<HTMLMapElement>)
             .find(|n| {
                 n.upcast::<Element>()
-                    .get_string_attribute(&local_name!("name")) ==
-                    last
+                    .get_name()
+                    .map_or(false, |n| *n == *last)
             });
 
         useMapElements.map(|mapElem| mapElem.get_area_elements())
@@ -1649,7 +1649,6 @@ impl VirtualMethods for HTMLImageElement {
 
     fn parse_plain_attribute(&self, name: &LocalName, value: DOMString) -> AttrValue {
         match name {
-            &local_name!("name") => AttrValue::from_atomic(value.into()),
             &local_name!("width") | &local_name!("height") => {
                 AttrValue::from_dimension(value.into())
             },

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1466,10 +1466,13 @@ impl HTMLInputElement {
 
     // https://html.spec.whatwg.org/multipage/#radio-button-group
     fn radio_group_name(&self) -> Option<Atom> {
-        self.upcast::<Element>()
-            .get_attribute(&ns!(), &local_name!("name"))
-            .map(|name| name.value().as_atom().clone())
-            .filter(|name| name != &atom!(""))
+        self.upcast::<Element>().get_name().and_then(|name| {
+            if name == atom!("") {
+                None
+            } else {
+                Some(name)
+            }
+        })
     }
 
     fn update_checked_state(&self, checked: bool, dirty: bool) {
@@ -2158,7 +2161,6 @@ impl VirtualMethods for HTMLInputElement {
     fn parse_plain_attribute(&self, name: &LocalName, value: DOMString) -> AttrValue {
         match name {
             &local_name!("accept") => AttrValue::from_comma_separated_tokenlist(value.into()),
-            &local_name!("name") => AttrValue::from_atomic(value.into()),
             &local_name!("size") => AttrValue::from_limited_u32(value.into(), DEFAULT_INPUT_SIZE),
             &local_name!("type") => AttrValue::from_atomic(value.into()),
             &local_name!("maxlength") => {

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -26,7 +26,6 @@ use parking_lot::RwLock;
 use servo_arc::Arc;
 use servo_config::pref;
 use std::sync::atomic::AtomicBool;
-use style::attr::AttrValue;
 use style::media_queries::MediaList;
 use style::str::HTML_SPACE_CHARACTERS;
 use style::stylesheets::{CssRule, CssRules, Origin, Stylesheet, StylesheetContents, ViewportRule};
@@ -86,8 +85,8 @@ impl HTMLMetaElement {
 
     fn process_attributes(&self) {
         let element = self.upcast::<Element>();
-        if let Some(ref name) = element.get_attribute(&ns!(), &local_name!("name")) {
-            let name = name.value().to_ascii_lowercase();
+        if let Some(ref name) = element.get_name() {
+            let name = name.to_ascii_lowercase();
             let name = name.trim_matches(HTML_SPACE_CHARACTERS);
 
             if name == "viewport" {
@@ -137,8 +136,8 @@ impl HTMLMetaElement {
 
     fn process_referrer_attribute(&self) {
         let element = self.upcast::<Element>();
-        if let Some(ref name) = element.get_attribute(&ns!(), &local_name!("name")) {
-            let name = name.value().to_ascii_lowercase();
+        if let Some(ref name) = element.get_name() {
+            let name = name.to_ascii_lowercase();
             let name = name.trim_matches(HTML_SPACE_CHARACTERS);
 
             if name == "referrer" {
@@ -183,16 +182,6 @@ impl VirtualMethods for HTMLMetaElement {
 
         if context.tree_connected {
             self.process_attributes();
-        }
-    }
-
-    fn parse_plain_attribute(&self, name: &LocalName, value: DOMString) -> AttrValue {
-        match name {
-            &local_name!("name") => AttrValue::from_atomic(value.into()),
-            _ => self
-                .super_type()
-                .unwrap()
-                .parse_plain_attribute(name, value),
         }
     }
 

--- a/components/script/dom/htmloutputelement.rs
+++ b/components/script/dom/htmloutputelement.rs
@@ -114,6 +114,12 @@ impl HTMLOutputElementMethods for HTMLOutputElement {
     fn Type(&self) -> DOMString {
         return DOMString::from("output");
     }
+
+    // https://html.spec.whatwg.org/multipage/#dom-fe-name
+    make_atomic_setter!(SetName, "name");
+
+    // https://html.spec.whatwg.org/multipage/#dom-fe-name
+    make_getter!(Name, "name");
 }
 
 impl VirtualMethods for HTMLOutputElement {

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -234,7 +234,7 @@ impl HTMLSelectElementMethods for HTMLSelectElement {
     make_getter!(Name, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-fe-name
-    make_setter!(SetName, "name");
+    make_atomic_setter!(SetName, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-select-size
     make_uint_getter!(Size, "size", DEFAULT_SELECT_SIZE);

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -220,7 +220,7 @@ impl HTMLTextAreaElementMethods for HTMLTextAreaElement {
     make_getter!(Name, "name");
 
     // https://html.spec.whatwg.org/multipage/#attr-fe-name
-    make_setter!(SetName, "name");
+    make_atomic_setter!(SetName, "name");
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-placeholder
     make_getter!(Placeholder, "placeholder");

--- a/components/script/dom/nodelist.rs
+++ b/components/script/dom/nodelist.rs
@@ -7,12 +7,12 @@ use crate::dom::bindings::codegen::Bindings::NodeListBinding;
 use crate::dom::bindings::codegen::Bindings::NodeListBinding::NodeListMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
-use crate::dom::bindings::str::DOMString;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlformelement::HTMLFormElement;
 use crate::dom::node::{ChildrenMutation, Node};
 use crate::dom::window::Window;
 use dom_struct::dom_struct;
+use servo_atoms::Atom;
 use std::cell::Cell;
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -381,11 +381,11 @@ pub enum RadioListMode {
 pub struct RadioList {
     form: Dom<HTMLFormElement>,
     mode: RadioListMode,
-    name: DOMString,
+    name: Atom,
 }
 
 impl RadioList {
-    pub fn new(form: &HTMLFormElement, mode: RadioListMode, name: DOMString) -> RadioList {
+    pub fn new(form: &HTMLFormElement, mode: RadioListMode, name: Atom) -> RadioList {
         RadioList {
             form: Dom::from_ref(form),
             mode: mode,

--- a/components/script/dom/radionodelist.rs
+++ b/components/script/dom/radionodelist.rs
@@ -16,6 +16,7 @@ use crate::dom::node::Node;
 use crate::dom::nodelist::{NodeList, NodeListType, RadioList, RadioListMode};
 use crate::dom::window::Window;
 use dom_struct::dom_struct;
+use servo_atoms::Atom;
 
 #[dom_struct]
 pub struct RadioNodeList {
@@ -42,14 +43,14 @@ impl RadioNodeList {
     pub fn new_controls_except_image_inputs(
         window: &Window,
         form: &HTMLFormElement,
-        name: DOMString,
+        name: &Atom,
     ) -> DomRoot<RadioNodeList> {
         RadioNodeList::new(
             window,
             NodeListType::Radio(RadioList::new(
                 form,
                 RadioListMode::ControlsExceptImageInputs,
-                name,
+                name.clone(),
             )),
         )
     }
@@ -57,11 +58,11 @@ impl RadioNodeList {
     pub fn new_images(
         window: &Window,
         form: &HTMLFormElement,
-        name: DOMString,
+        name: &Atom,
     ) -> DomRoot<RadioNodeList> {
         RadioNodeList::new(
             window,
-            NodeListType::Radio(RadioList::new(form, RadioListMode::Images, name)),
+            NodeListType::Radio(RadioList::new(form, RadioListMode::Images, name.clone())),
         )
     }
 

--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -9,6 +9,7 @@ use crate::dom::customelementregistry::{
 use crate::dom::mutationobserver::RegisteredObserver;
 use crate::dom::node::UniqueId;
 use crate::dom::shadowroot::ShadowRoot;
+use servo_atoms::Atom;
 use std::rc::Rc;
 
 //XXX(ferjm) Ideally merge NodeRareData and ElementRareData so they share
@@ -42,4 +43,7 @@ pub struct ElementRareData {
     pub custom_element_definition: Option<Rc<CustomElementDefinition>>,
     /// <https://dom.spec.whatwg.org/#concept-element-custom-element-state>
     pub custom_element_state: CustomElementState,
+    /// The "name" content attribute; not used as frequently as id, but used
+    /// in named getter loops so it's worth looking up quickly when present
+    pub name_attribute: Option<Atom>,
 }

--- a/components/script/dom/webidls/HTMLFieldSetElement.webidl
+++ b/components/script/dom/webidls/HTMLFieldSetElement.webidl
@@ -10,8 +10,8 @@ interface HTMLFieldSetElement : HTMLElement {
   [CEReactions]
            attribute boolean disabled;
   readonly attribute HTMLFormElement? form;
-  // [CEReactions]
-  //         attribute DOMString name;
+  [CEReactions]
+           attribute DOMString name;
 
   //readonly attribute DOMString type;
 

--- a/components/script/dom/webidls/HTMLOutputElement.webidl
+++ b/components/script/dom/webidls/HTMLOutputElement.webidl
@@ -9,8 +9,8 @@ interface HTMLOutputElement : HTMLElement {
 
   // [SameObject, PutForwards=value] readonly attribute DOMTokenList htmlFor;
   readonly attribute HTMLFormElement? form;
-  // [CEReactions]
-  //          attribute DOMString name;
+  [CEReactions]
+           attribute DOMString name;
 
   [Pure] readonly attribute DOMString type;
   [CEReactions]

--- a/components/script/dom/webidls/HTMLTextAreaElement.webidl
+++ b/components/script/dom/webidls/HTMLTextAreaElement.webidl
@@ -24,6 +24,7 @@ interface HTMLTextAreaElement : HTMLElement {
            attribute long maxLength;
   [CEReactions, SetterThrows]
            attribute long minLength;
+  [CEReactions]
            attribute DOMString name;
   [CEReactions]
            attribute DOMString placeholder;

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -81,7 +81,8 @@ pub struct WindowProxy {
     /// In the case that this is a top-level window, this is our id.
     top_level_browsing_context_id: TopLevelBrowsingContextId,
 
-    /// The name of the browsing context
+    /// The name of the browsing context (sometimes, but not always,
+    /// equal to the name of a container element)
     name: DomRefCell<DOMString>,
     /// The pipeline id of the currently active document.
     /// May be None, when the currently active document is in another script thread.

--- a/tests/wpt/metadata/custom-elements/reactions/HTMLFieldSetElement.html.ini
+++ b/tests/wpt/metadata/custom-elements/reactions/HTMLFieldSetElement.html.ini
@@ -1,7 +1,0 @@
-[HTMLFieldSetElement.html]
-  [name on HTMLFieldSetElement must enqueue an attributeChanged reaction when adding a new attribute]
-    expected: FAIL
-
-  [name on HTMLFieldSetElement must enqueue an attributeChanged reaction when replacing an existing attribute]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/browsers/windows/nested-browsing-contexts/name-attribute.window.js.ini
+++ b/tests/wpt/metadata/html/browsers/windows/nested-browsing-contexts/name-attribute.window.js.ini
@@ -9,38 +9,20 @@
   [same-origin <frame name=>]
     expected: TIMEOUT
 
-  [cross-origin <iframe name=initialvalue>]
-    expected: FAIL
-
   [cross-origin <embed name=initialvalue>]
     expected: TIMEOUT
-
-  [same-origin <iframe name=>]
-    expected: FAIL
 
   [same-origin <embed>]
     expected: TIMEOUT
 
-  [cross-origin <iframe>]
-    expected: FAIL
-
   [cross-origin <frame name=initialvalue>]
     expected: TIMEOUT
-
-  [cross-origin <iframe name=>]
-    expected: FAIL
 
   [same-origin <object name=initialvalue>]
     expected: TIMEOUT
 
   [cross-origin <object name=initialvalue>]
     expected: TIMEOUT
-
-  [same-origin <iframe>]
-    expected: FAIL
-
-  [same-origin <iframe name=initialvalue>]
-    expected: FAIL
 
   [same-origin <object name=>]
     expected: TIMEOUT

--- a/tests/wpt/metadata/html/dom/elements/name-content-attribute-and-property.html.ini
+++ b/tests/wpt/metadata/html/dom/elements/name-content-attribute-and-property.html.ini
@@ -1,0 +1,18 @@
+[name-content-attribute-and-property.html]
+  [embed element\'s name property reflects its content attribute]
+    expected: FAIL
+
+  [frame element\'s name property reflects its content attribute]
+    expected: FAIL
+
+  [map element\'s name property reflects its content attribute]
+    expected: FAIL
+
+  [object element\'s name property reflects its content attribute]
+    expected: FAIL
+
+  [param element\'s name property reflects its content attribute]
+    expected: FAIL
+
+  [slot element\'s name property reflects its content attribute]
+    expected: FAIL

--- a/tests/wpt/metadata/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/metadata/html/dom/idlharness.https.html.ini
@@ -2241,9 +2241,6 @@
   [HTMLInputElement interface: createInput("image") must inherit property "align" with the proper type]
     expected: FAIL
 
-  [HTMLOutputElement interface: attribute name]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("url") must inherit property "reportValidity()" with the proper type]
     expected: FAIL
 
@@ -3009,9 +3006,6 @@
   [HTMLImageElement interface: document.createElement("img") must inherit property "referrerPolicy" with the proper type]
     expected: FAIL
 
-  [HTMLOutputElement interface: document.createElement("output") must inherit property "name" with the proper type]
-    expected: FAIL
-
   [HTMLElement interface: document.createElement("noscript") must inherit property "dir" with the proper type]
     expected: FAIL
 
@@ -3415,9 +3409,6 @@
     expected: FAIL
 
   [HTMLInputElement interface: calling setCustomValidity(DOMString) on createInput("range") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [HTMLFieldSetElement interface: attribute name]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("time") must inherit property "reportValidity()" with the proper type]
@@ -4466,4 +4457,3 @@
 
   [HTMLElement interface: document.createElement("noscript") must inherit property "onwebkittransitionend" with the proper type]
     expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/reflection-forms.html.ini
+++ b/tests/wpt/metadata/html/dom/reflection-forms.html.ini
@@ -12,9 +12,6 @@
   [form.dir: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
     expected: FAIL
 
-  [form.dir: setAttribute() to undefined followed by IDL get]
-    expected: FAIL
-
   [form.dir: setAttribute() to 7 followed by IDL get]
     expected: FAIL
 
@@ -1186,135 +1183,6 @@
     expected: FAIL
 
   [fieldset.tabIndex: IDL set to -2147483648 followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: typeof IDL attribute]
-    expected: FAIL
-
-  [fieldset.name: IDL get with DOM attribute unset]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to "" followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to undefined followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to 7 followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to true followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to false followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to NaN followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to Infinity followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to "\\0" followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to null followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to object "test-valueOf" followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: IDL set to "" followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: IDL set to undefined followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: IDL set to undefined followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: IDL set to 7 followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: IDL set to 7 followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: IDL set to 1.5 followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: IDL set to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: IDL set to true followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: IDL set to true followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: IDL set to false followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: IDL set to false followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: IDL set to object "[object Object\]" followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: IDL set to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: IDL set to NaN followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: IDL set to NaN followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: IDL set to Infinity followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: IDL set to Infinity followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: IDL set to -Infinity followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: IDL set to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: IDL set to "\\0" followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: IDL set to null followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: IDL set to null followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: IDL set to object "test-toString" followed by getAttribute()]
-    expected: FAIL
-
-  [fieldset.name: IDL set to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [fieldset.name: IDL set to object "test-valueOf" followed by IDL get]
     expected: FAIL
 
   [fieldset.itemScope: typeof IDL attribute]
@@ -12261,135 +12129,6 @@
   [output.tabIndex: IDL set to -2147483648 followed by getAttribute()]
     expected: FAIL
 
-  [output.name: typeof IDL attribute]
-    expected: FAIL
-
-  [output.name: IDL get with DOM attribute unset]
-    expected: FAIL
-
-  [output.name: setAttribute() to "" followed by IDL get]
-    expected: FAIL
-
-  [output.name: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by IDL get]
-    expected: FAIL
-
-  [output.name: setAttribute() to undefined followed by IDL get]
-    expected: FAIL
-
-  [output.name: setAttribute() to 7 followed by IDL get]
-    expected: FAIL
-
-  [output.name: setAttribute() to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [output.name: setAttribute() to true followed by IDL get]
-    expected: FAIL
-
-  [output.name: setAttribute() to false followed by IDL get]
-    expected: FAIL
-
-  [output.name: setAttribute() to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [output.name: setAttribute() to NaN followed by IDL get]
-    expected: FAIL
-
-  [output.name: setAttribute() to Infinity followed by IDL get]
-    expected: FAIL
-
-  [output.name: setAttribute() to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [output.name: setAttribute() to "\\0" followed by IDL get]
-    expected: FAIL
-
-  [output.name: setAttribute() to null followed by IDL get]
-    expected: FAIL
-
-  [output.name: setAttribute() to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [output.name: setAttribute() to object "test-valueOf" followed by IDL get]
-    expected: FAIL
-
-  [output.name: IDL set to "" followed by getAttribute()]
-    expected: FAIL
-
-  [output.name: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo " followed by getAttribute()]
-    expected: FAIL
-
-  [output.name: IDL set to undefined followed by getAttribute()]
-    expected: FAIL
-
-  [output.name: IDL set to undefined followed by IDL get]
-    expected: FAIL
-
-  [output.name: IDL set to 7 followed by getAttribute()]
-    expected: FAIL
-
-  [output.name: IDL set to 7 followed by IDL get]
-    expected: FAIL
-
-  [output.name: IDL set to 1.5 followed by getAttribute()]
-    expected: FAIL
-
-  [output.name: IDL set to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [output.name: IDL set to true followed by getAttribute()]
-    expected: FAIL
-
-  [output.name: IDL set to true followed by IDL get]
-    expected: FAIL
-
-  [output.name: IDL set to false followed by getAttribute()]
-    expected: FAIL
-
-  [output.name: IDL set to false followed by IDL get]
-    expected: FAIL
-
-  [output.name: IDL set to object "[object Object\]" followed by getAttribute()]
-    expected: FAIL
-
-  [output.name: IDL set to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [output.name: IDL set to NaN followed by getAttribute()]
-    expected: FAIL
-
-  [output.name: IDL set to NaN followed by IDL get]
-    expected: FAIL
-
-  [output.name: IDL set to Infinity followed by getAttribute()]
-    expected: FAIL
-
-  [output.name: IDL set to Infinity followed by IDL get]
-    expected: FAIL
-
-  [output.name: IDL set to -Infinity followed by getAttribute()]
-    expected: FAIL
-
-  [output.name: IDL set to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [output.name: IDL set to "\\0" followed by getAttribute()]
-    expected: FAIL
-
-  [output.name: IDL set to null followed by getAttribute()]
-    expected: FAIL
-
-  [output.name: IDL set to null followed by IDL get]
-    expected: FAIL
-
-  [output.name: IDL set to object "test-toString" followed by getAttribute()]
-    expected: FAIL
-
-  [output.name: IDL set to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [output.name: IDL set to object "test-valueOf" followed by IDL get]
-    expected: FAIL
-
   [output.itemScope: typeof IDL attribute]
     expected: FAIL
 
@@ -16840,96 +16579,6 @@
     expected: FAIL
 
   [fieldset.tabIndex: IDL set to -2147483648]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to ""]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to undefined]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to 7]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to 1.5]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to true]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to false]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to object "[object Object\]"]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to NaN]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to Infinity]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to -Infinity]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to "\\0"]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to null]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to object "test-toString"]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to object "test-valueOf"]
-    expected: FAIL
-
-  [fieldset.name: IDL set to ""]
-    expected: FAIL
-
-  [fieldset.name: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
-    expected: FAIL
-
-  [fieldset.name: IDL set to undefined]
-    expected: FAIL
-
-  [fieldset.name: IDL set to 7]
-    expected: FAIL
-
-  [fieldset.name: IDL set to 1.5]
-    expected: FAIL
-
-  [fieldset.name: IDL set to true]
-    expected: FAIL
-
-  [fieldset.name: IDL set to false]
-    expected: FAIL
-
-  [fieldset.name: IDL set to object "[object Object\]"]
-    expected: FAIL
-
-  [fieldset.name: IDL set to NaN]
-    expected: FAIL
-
-  [fieldset.name: IDL set to Infinity]
-    expected: FAIL
-
-  [fieldset.name: IDL set to -Infinity]
-    expected: FAIL
-
-  [fieldset.name: IDL set to "\\0"]
-    expected: FAIL
-
-  [fieldset.name: IDL set to null]
-    expected: FAIL
-
-  [fieldset.name: IDL set to object "test-toString"]
-    expected: FAIL
-
-  [fieldset.name: IDL set to object "test-valueOf"]
     expected: FAIL
 
   [legend.dir: setAttribute() to ""]
@@ -22830,96 +22479,6 @@
   [output.tabIndex: IDL set to -2147483648]
     expected: FAIL
 
-  [output.name: setAttribute() to ""]
-    expected: FAIL
-
-  [output.name: setAttribute() to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
-    expected: FAIL
-
-  [output.name: setAttribute() to undefined]
-    expected: FAIL
-
-  [output.name: setAttribute() to 7]
-    expected: FAIL
-
-  [output.name: setAttribute() to 1.5]
-    expected: FAIL
-
-  [output.name: setAttribute() to true]
-    expected: FAIL
-
-  [output.name: setAttribute() to false]
-    expected: FAIL
-
-  [output.name: setAttribute() to object "[object Object\]"]
-    expected: FAIL
-
-  [output.name: setAttribute() to NaN]
-    expected: FAIL
-
-  [output.name: setAttribute() to Infinity]
-    expected: FAIL
-
-  [output.name: setAttribute() to -Infinity]
-    expected: FAIL
-
-  [output.name: setAttribute() to "\\0"]
-    expected: FAIL
-
-  [output.name: setAttribute() to null]
-    expected: FAIL
-
-  [output.name: setAttribute() to object "test-toString"]
-    expected: FAIL
-
-  [output.name: setAttribute() to object "test-valueOf"]
-    expected: FAIL
-
-  [output.name: IDL set to ""]
-    expected: FAIL
-
-  [output.name: IDL set to " \\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07 \\b\\t\\n\\v\\f\\r\\x0e\\x0f \\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17 \\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f  foo "]
-    expected: FAIL
-
-  [output.name: IDL set to undefined]
-    expected: FAIL
-
-  [output.name: IDL set to 7]
-    expected: FAIL
-
-  [output.name: IDL set to 1.5]
-    expected: FAIL
-
-  [output.name: IDL set to true]
-    expected: FAIL
-
-  [output.name: IDL set to false]
-    expected: FAIL
-
-  [output.name: IDL set to object "[object Object\]"]
-    expected: FAIL
-
-  [output.name: IDL set to NaN]
-    expected: FAIL
-
-  [output.name: IDL set to Infinity]
-    expected: FAIL
-
-  [output.name: IDL set to -Infinity]
-    expected: FAIL
-
-  [output.name: IDL set to "\\0"]
-    expected: FAIL
-
-  [output.name: IDL set to null]
-    expected: FAIL
-
-  [output.name: IDL set to object "test-toString"]
-    expected: FAIL
-
-  [output.name: IDL set to object "test-valueOf"]
-    expected: FAIL
-
   [progress.dir: setAttribute() to ""]
     expected: FAIL
 
@@ -24135,9 +23694,6 @@
   [button.autofocus: IDL set to "5%"]
     expected: FAIL
 
-  [fieldset.name: setAttribute() to "5%"]
-    expected: FAIL
-
   [button.accessKey: IDL set to "5%"]
     expected: FAIL
 
@@ -24151,9 +23707,6 @@
     expected: FAIL
 
   [form.accessKey: setAttribute() to "5%"]
-    expected: FAIL
-
-  [fieldset.name: IDL set to "5%"]
     expected: FAIL
 
   [textarea.autofocus: setAttribute() to "5%"]
@@ -24231,8 +23784,6 @@
   [option.accessKey: IDL set to "5%"]
     expected: FAIL
 
-  [output.name: IDL set to "5%"]
-    expected: FAIL
 
   [select.accessKey: setAttribute() to "5%"]
     expected: FAIL
@@ -24247,9 +23798,6 @@
     expected: FAIL
 
   [textarea.autofocus: IDL set to "5%"]
-    expected: FAIL
-
-  [output.name: setAttribute() to "5%"]
     expected: FAIL
 
   [meter.accessKey: setAttribute() to "5%"]
@@ -24513,9 +24061,6 @@
   [select.autocomplete: IDL set to "+100"]
     expected: FAIL
 
-  [fieldset.name: IDL set to ".5"]
-    expected: FAIL
-
   [optgroup.dir: setAttribute() to ".5"]
     expected: FAIL
 
@@ -24567,9 +24112,6 @@
   [form.dir: IDL set to ".5"]
     expected: FAIL
 
-  [output.name: IDL set to "+100"]
-    expected: FAIL
-
   [textarea.accessKey: setAttribute() to ".5"]
     expected: FAIL
 
@@ -24592,9 +24134,6 @@
     expected: FAIL
 
   [input.accessKey: IDL set to "+100"]
-    expected: FAIL
-
-  [fieldset.name: IDL set to "+100"]
     expected: FAIL
 
   [optgroup.dir: setAttribute() to "+100"]
@@ -24672,9 +24211,6 @@
   [button.dir: IDL set to ".5"]
     expected: FAIL
 
-  [output.name: setAttribute() to ".5"]
-    expected: FAIL
-
   [form.accessKey: setAttribute() to ".5"]
     expected: FAIL
 
@@ -24687,9 +24223,6 @@
   [textarea.autocomplete: IDL set to "+100"]
     expected: FAIL
 
-  [output.name: IDL set to ".5"]
-    expected: FAIL
-
   [button.dir: IDL set to "+100"]
     expected: FAIL
 
@@ -24700,9 +24233,6 @@
     expected: FAIL
 
   [textarea.dir: setAttribute() to "+100"]
-    expected: FAIL
-
-  [output.name: setAttribute() to "+100"]
     expected: FAIL
 
   [progress.accessKey: IDL set to ".5"]
@@ -24816,9 +24346,6 @@
   [label.dir: IDL set to "+100"]
     expected: FAIL
 
-  [fieldset.name: setAttribute() to "+100"]
-    expected: FAIL
-
   [legend.align: setAttribute() to ".5"]
     expected: FAIL
 
@@ -24835,9 +24362,6 @@
     expected: FAIL
 
   [label.dir: setAttribute() to ".5"]
-    expected: FAIL
-
-  [fieldset.name: setAttribute() to ".5"]
     expected: FAIL
 
   [meter.accessKey: setAttribute() to "+100"]

--- a/tests/wpt/metadata/html/semantics/forms/the-form-element/form-elements-nameditem-01.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-form-element/form-elements-nameditem-01.html.ini
@@ -1,5 +1,0 @@
-[form-elements-nameditem-01.html]
-  type: testharness
-  [elements collection should include fieldsets]
-    expected: FAIL
-

--- a/tests/wpt/web-platform-tests/html/dom/elements/name-content-attribute-and-property.html
+++ b/tests/wpt/web-platform-tests/html/dom/elements/name-content-attribute-and-property.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<title>Only certain HTML elements reflect the name content attribute as a property</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+  function doesReflect(tagName) {
+    var element = document.createElement(tagName);
+    element.setAttribute("name", "foo");
+    assert_equals(element.getAttribute("name"), "foo", "setAttribute should change content attribute");
+    element.name = "bar";
+    assert_equals(element.getAttribute("name"), "bar", "assignment to .name should change content attribute");
+  }
+
+  function doesNotReflect(tagName) {
+    var element = document.createElement(tagName);
+    element.setAttribute("name", "foo");
+    assert_equals(element.getAttribute("name"), "foo", "setAttribute should change content attribute");
+    element.name = "bar";
+    assert_equals(element.getAttribute("name"), "foo", "assignment to .name should not change content attribute");
+  }
+
+  var nonReflectingTagNames = [
+    "abbr", "acronym", "address", "area", "article", "aside", "audio",
+    "b", "base", "bdi", "bdo", "bgsound", "big", "blink", "blockquote", "body","br",
+    "canvas", "caption", "center", "cite", "code", "col", "colgroup",
+    "data", "datalist", "dd", "del", "details", "dfn", "dialog", "dir", "div", "dl", "dt",
+    "em",
+    "figcaption", "figure", "font", "footer", "frameset",
+    "h1", "h2", "h3", "h4", "h5", "h6", "head", "header", "hgroup", "hr", "html",
+    "i", "ins", "isindex",
+    "kbd",
+    "label", "legend", "li", "link", "listing",
+    "main", "mark", "marquee", "meter", "multicol",
+    "nav", "nextid", "nobr", "noframes", "noscript",
+    "option",
+    "p", "picture", "plaintext", "pre", "progress",
+    "q",
+    "rp", "rt", "ruby",
+    "s", "samp", "script", "section", "small", "source", "spacer",
+    "span", "strike", "strong", "style", "sub", "summary", "sup",
+    "table", "tbody", "td", "template", "tfoot",
+    "th", "thead", "time", "title", "tr", "tt", "track",
+    "u", "ul",
+    "var", "video",
+    "wbr",
+    "xmp",
+    "unknown"
+  ];
+
+  var reflectingTagNames = [
+    "a", "button", "embed",
+    "fieldset", "form", "frame",
+    "iframe", "img", "input",
+    "map", "meta",
+    "object", "output",
+    "param",
+    "select", "slot",
+    "textarea",
+  ];
+
+  reflectingTagNames.forEach(function(tagName) {
+    test(function() {
+      doesReflect(tagName)
+    }, tagName + " element's name property reflects its content attribute");
+  });
+
+  nonReflectingTagNames.forEach(function(tagName) {
+    test(function() {
+      doesNotReflect(tagName)
+    }, tagName + " element's name property does not reflect its content attribute");
+  });
+</script>
+


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
All codepaths setting the name content attribute now use an atom, which is also stored in rare_data for direct lookup by a get_name method. 

Paralleling the get_name method, I added a get_id method, which makes some internal id-lookup cases nicer.

A new test tests for a name setter on every HTML element type. In addition to its overt and upstreamable purpose of checking IDL property reflection semantics, for us this test also hits some Servo assertions that make sure the name is an atom in every case. If the test doesn't crash, even a failed test case still has the attribute as an atom rather than some other type. The failed cases are for elements that we have unimplemented or completely stubbed; I added a few missing name IDL properties to otherwise implemented elements.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25570 and make progress on #25057

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
