### PR TITLE
Implement HTMLMenuElement

### DIFF
--- a/components/script/dom/bindings/htmlconstructor.rs
+++ b/components/script/dom/bindings/htmlconstructor.rs
@@ -36,6 +36,7 @@ use crate::dom::bindings::codegen::Bindings::HTMLLabelElementBinding;
 use crate::dom::bindings::codegen::Bindings::HTMLLegendElementBinding;
 use crate::dom::bindings::codegen::Bindings::HTMLLinkElementBinding;
 use crate::dom::bindings::codegen::Bindings::HTMLMapElementBinding;
+use crate::dom::bindings::codegen::Bindings::HTMLMenuElementBinding;
 use crate::dom::bindings::codegen::Bindings::HTMLMetaElementBinding;
 use crate::dom::bindings::codegen::Bindings::HTMLMeterElementBinding;
 use crate::dom::bindings::codegen::Bindings::HTMLModElementBinding;
@@ -279,6 +280,7 @@ pub fn get_constructor_object_from_local_name(
         local_name!("map") => get_constructor!(HTMLMapElementBinding),
         local_name!("mark") => get_constructor!(HTMLElementBinding),
         local_name!("marquee") => get_constructor!(HTMLElementBinding),
+        local_name!("menu") => get_constructor!(HTMLMenuElementBinding),
         local_name!("meta") => get_constructor!(HTMLMetaElementBinding),
         local_name!("meter") => get_constructor!(HTMLMeterElementBinding),
         local_name!("nav") => get_constructor!(HTMLElementBinding),

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -46,6 +46,7 @@ use crate::dom::htmllegendelement::HTMLLegendElement;
 use crate::dom::htmllielement::HTMLLIElement;
 use crate::dom::htmllinkelement::HTMLLinkElement;
 use crate::dom::htmlmapelement::HTMLMapElement;
+use crate::dom::htmlmenuelement::HTMLMenuElement;
 use crate::dom::htmlmetaelement::HTMLMetaElement;
 use crate::dom::htmlmeterelement::HTMLMeterElement;
 use crate::dom::htmlmodelement::HTMLModElement;
@@ -309,6 +310,7 @@ pub fn create_native_html_element(
         local_name!("map") => make!(HTMLMapElement),
         local_name!("mark") => make!(HTMLElement),
         local_name!("marquee") => make!(HTMLElement),
+        local_name!("menu") => make!(HTMLMenuElement),
         local_name!("meta") => make!(HTMLMetaElement),
         local_name!("meter") => make!(HTMLMeterElement),
         // https://html.spec.whatwg.org/multipage/#other-elements,-attributes-and-apis:multicol

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -1127,6 +1127,7 @@ fn is_extendable_element_interface(element: &str) -> bool {
         element == "map" ||
         element == "mark" ||
         element == "marquee" ||
+        element == "menu" ||
         element == "meta" ||
         element == "meter" ||
         element == "nav" ||

--- a/components/script/dom/htmlmenuelement.rs
+++ b/components/script/dom/htmlmenuelement.rs
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::bindings::codegen::Bindings::HTMLMenuElementBinding;
+use crate::dom::bindings::codegen::Bindings::HTMLMenuElementBinding::HTMLMenuElementMethods;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::document::Document;
+use crate::dom::htmlelement::HTMLElement;
+use crate::dom::node::Node;
+use dom_struct::dom_struct;
+use html5ever::{LocalName, Prefix};
+
+#[dom_struct]
+pub struct HTMLMenuElement {
+    htmlelement: HTMLElement,
+}
+
+impl HTMLMenuElement {
+    fn new_inherited(
+        local_name: LocalName,
+        prefix: Option<Prefix>,
+        document: &Document,
+    ) -> HTMLMenuElement {
+        HTMLMenuElement {
+            htmlelement: HTMLElement::new_inherited(local_name, prefix, document),
+        }
+    }
+
+    #[allow(unrooted_must_root)]
+    pub fn new(
+        local_name: LocalName,
+        prefix: Option<Prefix>,
+        document: &Document,
+    ) -> DomRoot<HTMLMenuElement> {
+        Node::reflect_node(
+            Box::new(HTMLMenuElement::new_inherited(local_name, prefix, document)),
+            document,
+            HTMLMenuElementBinding::Wrap,
+        )
+    }
+}
+
+impl HTMLMenuElementMethods for HTMLMenuElement {
+    // spec just mandates that compact reflects the content attribute,
+    // with no other semantics. Layout could use it to
+    // change line spacing, but nothing requires it to do so.
+
+    // https://html.spec.whatwg.org/multipage/#dom-menu-compact
+    make_bool_setter!(SetCompact, "compact");
+
+    // https://html.spec.whatwg.org/multipage/#dom-menu-compact
+    make_bool_getter!(Compact, "compact");
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -364,6 +364,7 @@ pub mod htmllielement;
 pub mod htmllinkelement;
 pub mod htmlmapelement;
 pub mod htmlmediaelement;
+pub mod htmlmenuelement;
 pub mod htmlmetaelement;
 pub mod htmlmeterelement;
 pub mod htmlmodelement;

--- a/components/script/dom/webidls/HTMLMenuElement.webidl
+++ b/components/script/dom/webidls/HTMLMenuElement.webidl
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://html.spec.whatwg.org/multipage/#htmlmenuelement
+[Exposed=Window]
+interface HTMLMenuElement : HTMLElement {
+  [HTMLConstructor] constructor();
+
+  // also has obsolete members
+};
+
+// https://html.spec.whatwg.org/multipage/#HTMLMenuElement-partial
+partial interface HTMLMenuElement {
+   [CEReactions]
+            attribute boolean compact;
+};

--- a/tests/wpt/metadata/custom-elements/builtin-coverage.html.ini
+++ b/tests/wpt/metadata/custom-elements/builtin-coverage.html.ini
@@ -128,7 +128,7 @@
     expected: FAIL
   [mark: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
-  [menu: Define a customized built-in element]
+  [menu: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL
   [meta: Operator 'new' should instantiate a customized built-in element]
     expected: FAIL

--- a/tests/wpt/metadata/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/metadata/html/dom/idlharness.https.html.ini
@@ -1872,9 +1872,6 @@
   [HTMLInputElement interface: createInput("time") must inherit property "useMap" with the proper type]
     expected: FAIL
 
-  [HTMLMenuElement interface: attribute compact]
-    expected: FAIL
-
   [HTMLInputElement interface: createInput("datetime-local") must inherit property "validity" with the proper type]
     expected: FAIL
 
@@ -1948,9 +1945,6 @@
     expected: FAIL
 
   [HTMLIFrameElement interface: attribute marginHeight]
-    expected: FAIL
-
-  [HTMLMenuElement interface: existence and properties of interface prototype object]
     expected: FAIL
 
   [HTMLFormElement interface: document.createElement("form") must inherit property "reportValidity()" with the proper type]
@@ -2571,9 +2565,6 @@
   [HTMLProgressElement interface: document.createElement("progress") must inherit property "value" with the proper type]
     expected: FAIL
 
-  [HTMLMenuElement interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
   [HTMLEmbedElement interface: attribute name]
     expected: FAIL
 
@@ -2649,9 +2640,6 @@
   [HTMLAnchorElement interface: attribute type]
     expected: FAIL
 
-  [Stringification of document.createElement("menu")]
-    expected: FAIL
-
   [HTMLCanvasElement interface: calling toBlob(BlobCallback, DOMString, any) on document.createElement("canvas") with too few arguments must throw TypeError]
     expected: FAIL
 
@@ -2695,9 +2683,6 @@
     expected: FAIL
 
   [HTMLSlotElement interface: operation assignedElements(AssignedNodesOptions)]
-    expected: FAIL
-
-  [HTMLMenuElement interface object length]
     expected: FAIL
 
   [HTMLInputElement interface: attribute files]
@@ -2746,9 +2731,6 @@
     expected: FAIL
 
   [HTMLObjectElement interface: document.createElement("object") must inherit property "width" with the proper type]
-    expected: FAIL
-
-  [HTMLMenuElement interface: existence and properties of interface object]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("file") must inherit property "checkValidity()" with the proper type]
@@ -3045,9 +3027,6 @@
   [HTMLInputElement interface: createInput("time") must inherit property "willValidate" with the proper type]
     expected: FAIL
 
-  [HTMLMenuElement interface object name]
-    expected: FAIL
-
   [HTMLFrameElement interface: attribute frameBorder]
     expected: FAIL
 
@@ -3142,9 +3121,6 @@
     expected: FAIL
 
   [HTMLMeterElement interface: attribute high]
-    expected: FAIL
-
-  [HTMLMenuElement interface: document.createElement("menu") must inherit property "compact" with the proper type]
     expected: FAIL
 
   [HTMLInputElement interface: createInput("reset") must inherit property "useMap" with the proper type]
@@ -3855,9 +3831,6 @@
   [HTMLInputElement interface: createInput("color") must inherit property "align" with the proper type]
     expected: FAIL
 
-  [HTMLMenuElement interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
   [HTMLModElement interface: document.createElement("ins") must inherit property "cite" with the proper type]
     expected: FAIL
 
@@ -4240,9 +4213,6 @@
     expected: FAIL
 
   [HTMLTableElement interface: document.createElement("table") must inherit property "cellPadding" with the proper type]
-    expected: FAIL
-
-  [HTMLMenuElement must be primary interface of document.createElement("menu")]
     expected: FAIL
 
   [HTMLAreaElement interface: attribute username]

--- a/tests/wpt/metadata/html/dom/reflection-misc.html.ini
+++ b/tests/wpt/metadata/html/dom/reflection-misc.html.ini
@@ -6402,114 +6402,6 @@
   [menu.label: IDL set to object "test-valueOf" followed by IDL get]
     expected: FAIL
 
-  [menu.compact: typeof IDL attribute]
-    expected: FAIL
-
-  [menu.compact: IDL get with DOM attribute unset]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to "" followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to " foo " followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to undefined followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to null followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to 7 followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to true followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to false followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to NaN followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to Infinity followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to "\\0" followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to object "test-valueOf" followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to "compact" followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: IDL set to "" followed by hasAttribute()]
-    expected: FAIL
-
-  [menu.compact: IDL set to "" followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: IDL set to " foo " followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: IDL set to undefined followed by hasAttribute()]
-    expected: FAIL
-
-  [menu.compact: IDL set to undefined followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: IDL set to null followed by hasAttribute()]
-    expected: FAIL
-
-  [menu.compact: IDL set to null followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: IDL set to 7 followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: IDL set to 1.5 followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: IDL set to false followed by hasAttribute()]
-    expected: FAIL
-
-  [menu.compact: IDL set to object "[object Object\]" followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: IDL set to NaN followed by hasAttribute()]
-    expected: FAIL
-
-  [menu.compact: IDL set to NaN followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: IDL set to Infinity followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: IDL set to -Infinity followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: IDL set to "\\0" followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: IDL set to object "test-toString" followed by IDL get]
-    expected: FAIL
-
-  [menu.compact: IDL set to object "test-valueOf" followed by IDL get]
-    expected: FAIL
-
   [menu.itemScope: typeof IDL attribute]
     expected: FAIL
 
@@ -15669,96 +15561,6 @@
   [menu.label: IDL set to object "test-valueOf"]
     expected: FAIL
 
-  [menu.compact: setAttribute() to ""]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to " foo "]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to undefined]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to null]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to 7]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to 1.5]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to true]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to false]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to object "[object Object\]"]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to NaN]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to Infinity]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to -Infinity]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to "\\0"]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to object "test-toString"]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to object "test-valueOf"]
-    expected: FAIL
-
-  [menu.compact: setAttribute() to "compact"]
-    expected: FAIL
-
-  [menu.compact: IDL set to ""]
-    expected: FAIL
-
-  [menu.compact: IDL set to " foo "]
-    expected: FAIL
-
-  [menu.compact: IDL set to undefined]
-    expected: FAIL
-
-  [menu.compact: IDL set to null]
-    expected: FAIL
-
-  [menu.compact: IDL set to 7]
-    expected: FAIL
-
-  [menu.compact: IDL set to 1.5]
-    expected: FAIL
-
-  [menu.compact: IDL set to false]
-    expected: FAIL
-
-  [menu.compact: IDL set to object "[object Object\]"]
-    expected: FAIL
-
-  [menu.compact: IDL set to NaN]
-    expected: FAIL
-
-  [menu.compact: IDL set to Infinity]
-    expected: FAIL
-
-  [menu.compact: IDL set to -Infinity]
-    expected: FAIL
-
-  [menu.compact: IDL set to "\\0"]
-    expected: FAIL
-
-  [menu.compact: IDL set to object "test-toString"]
-    expected: FAIL
-
-  [menu.compact: IDL set to object "test-valueOf"]
-    expected: FAIL
-
   [menuitem.dir: setAttribute() to ""]
     expected: FAIL
 
@@ -19131,12 +18933,6 @@
   [template.dir: IDL set to "5%"]
     expected: FAIL
 
-  [menu.compact: setAttribute() to "5%"]
-    expected: FAIL
-
-  [menu.compact: IDL set to "5%"]
-    expected: FAIL
-
   [ins.cite: setAttribute() to "5%"]
     expected: FAIL
 
@@ -19440,9 +19236,6 @@
   [slot.name: setAttribute() to ".5"]
     expected: FAIL
 
-  [menu.compact: setAttribute() to "+100"]
-    expected: FAIL
-
   [script.accessKey: IDL set to ".5"]
     expected: FAIL
 
@@ -19569,9 +19362,6 @@
   [undefinedelement.enterKeyHint: setAttribute() to ".5"]
     expected: FAIL
 
-  [menu.compact: setAttribute() to ".5"]
-    expected: FAIL
-
   [del.dateTime: setAttribute() to "+100"]
     expected: FAIL
 
@@ -19627,9 +19417,6 @@
     expected: FAIL
 
   [dialog.accessKey: setAttribute() to ".5"]
-    expected: FAIL
-
-  [menu.compact: IDL set to ".5"]
     expected: FAIL
 
   [del.cite: setAttribute() to ".5"]
@@ -19708,9 +19495,6 @@
     expected: FAIL
 
   [del.accessKey: IDL set to "+100"]
-    expected: FAIL
-
-  [menu.compact: IDL set to "+100"]
     expected: FAIL
 
   [summary.dir: setAttribute() to "+100"]

--- a/tests/wpt/metadata/html/semantics/interfaces.html.ini
+++ b/tests/wpt/metadata/html/semantics/interfaces.html.ini
@@ -3,9 +3,6 @@
   [Interfaces for marquee]
     expected: FAIL
 
-  [Interfaces for menu]
-    expected: FAIL
-
   [Interfaces for noembed]
     expected: FAIL
 
@@ -13,9 +10,6 @@
     expected: FAIL
 
   [Interfaces for MARQUEE]
-    expected: FAIL
-
-  [Interfaces for MENU]
     expected: FAIL
 
   [Interfaces for NOEMBED]

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -19032,7 +19032,7 @@
    "testharness"
   ],
   "mozilla/interfaces.html": [
-   "945a8b33a109b0cc37db9351f94b9afd3eac798e",
+   "114ec29df620cc0526d39a41928f72d9359890a9",
    "testharness"
   ],
   "mozilla/interfaces.js": [

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.html
@@ -124,6 +124,7 @@ test_interfaces([
   "HTMLLinkElement",
   "HTMLMapElement",
   "HTMLMediaElement",
+  "HTMLMenuElement",
   "HTMLMetaElement",
   "HTMLMeterElement",
   "HTMLModElement",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Per spec, "The menu element is simply a semantic alternative to ul to express an unordered list of commands (a "toolbar")." We already have the CSS for it in user-agent.css, and this gives us the interface object.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] These changes fix #24990

<!-- Either: -->
- [X] There are tests for these changes 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
