### PR TITLE
Update windows llvm to 8.0.1.

### DIFF
--- a/python/servo/packages.py
+++ b/python/servo/packages.py
@@ -4,7 +4,7 @@
 
 WINDOWS_MSVC = {
     "cmake": "3.14.3",
-    "llvm": "8.0.0",
+    "llvm": "8.0.1",
     "moztools": "3.2",
     "ninja": "1.7.1",
     "nuget": "08-08-2019",


### PR DESCRIPTION
This makes it possible to build mozjs with llvm's clang-cl and MSVC 2019's header files; otherwise the headers check the clang version and abort compilation because it's 8.0 is too old.