### PR TITLE
do less on abort if not done

### DIFF
--- a/tests/wpt/metadata/xhr/abort-during-open.any.js.ini
+++ b/tests/wpt/metadata/xhr/abort-during-open.any.js.ini
@@ -1,9 +1,0 @@
-[abort-during-open.any.worker.html]
-  [XMLHttpRequest: abort() during OPEN]
-    expected: FAIL
-
-
-[abort-during-open.any.html]
-  [XMLHttpRequest: abort() during OPEN]
-    expected: FAIL
-

--- a/tests/wpt/metadata/xhr/abort-event-abort.any.js.ini
+++ b/tests/wpt/metadata/xhr/abort-event-abort.any.js.ini
@@ -1,9 +1,0 @@
-[abort-event-abort.any.html]
-  [XMLHttpRequest: The abort() method: do not fire abort event in OPENED state when send() flag is unset.]
-    expected: FAIL
-
-
-[abort-event-abort.any.worker.html]
-  [XMLHttpRequest: The abort() method: do not fire abort event in OPENED state when send() flag is unset.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/xhr/send-data-unexpected-tostring.htm.ini
+++ b/tests/wpt/metadata/xhr/send-data-unexpected-tostring.htm.ini
@@ -1,8 +1,5 @@
 [send-data-unexpected-tostring.htm]
   type: testharness
-  [abort() called from data stringification]
-    expected: FAIL
-
   [open() called from data stringification]
     expected: FAIL
 


### PR DESCRIPTION
Abort() was resetting state when it didn't need to, and possibly also not resetting as much of it as it needed to. I'm not sure if this is a completely correct fix but it passes some WPT tests.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #24931 

<!-- Either: -->
- [X] There are tests for these change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
