### PR TITLE
mach: fix error on Python 3 when specifying a target

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -1019,7 +1019,7 @@ install them, let us know by filing a bug!")
                 if component.encode("utf-8") not in installed:
                     check_call(["rustup", "component", "add", "--toolchain", toolchain, component])
 
-            if target and "uwp" not in target and target not in check_output(
+            if target and "uwp" not in target and target.encode("utf-8") not in check_output(
                 ["rustup", "target", "list", "--installed", "--toolchain", toolchain]
             ):
                 check_call(["rustup", "target", "add", "--toolchain", toolchain, target])


### PR DESCRIPTION
Previously, when running Mach on Python 3, specifying a target when building
causes this error:

```
TypeError: a bytes-like object is required, not 'str'

  File "/servo/python/servo/build_commands.py", line 241, in build
    self.ensure_bootstrapped(target=target)
  File "/servo/python/servo/command_base.py", line 1023, in ensure_bootstrapped
    ["rustup", "target", "list", "--installed", "--toolchain", toolchain]
```

This change encodes the target using utf-8 before comparing.

Fixes #25614.