### PR TITLE
mach: fix `bootstrap-android` on Python 3

### DIFF
--- a/python/servo/util.py
+++ b/python/servo/util.py
@@ -107,8 +107,8 @@ def download(desc, src, writer, start_byte=0):
         resp = urllib.request.urlopen(req, **get_urlopen_kwargs())
 
         fsize = None
-        if resp.info().getheader('Content-Length'):
-            fsize = int(resp.info().getheader('Content-Length').strip()) + start_byte
+        if resp.info().get('Content-Length'):
+            fsize = int(resp.info().get('Content-Length').strip()) + start_byte
 
         recved = start_byte
         chunk_size = 64 * 1024


### PR DESCRIPTION
When running `python3 ./mach bootstrap-android`, this error occurs:

```
AttributeError: 'HTTPMessage' object has no attribute 'getheader'

  File "/servo/python/servo/bootstrap_commands.py", line 136, in bootstrap_android
    download("sdk", tools.format(system=system))
  File "/servo/python/servo/bootstrap_commands.py", line 117, in download
    download_file(filename, url, archive)
  File "/servo/python/servo/util.py", line 170, in download_file
    download(desc, src, fd)
  File "/servo/python/servo/util.py", line 110, in download
    if resp.info().getheader('Content-Length'):
```

Use the `get()` function instead, which exists in both Python 3 and 2
(where it is a synonym for `getheader()`).

Fixes #25616.
