### PR TITLE
Refactor ServoParser Tokenizer to return TokenizerResult

### DIFF
--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -272,7 +272,8 @@ impl Tokenizer {
         tokenizer
     }
 
-    pub fn feed(&mut self, input: &mut BufferQueue) -> Result<(), DomRoot<HTMLScriptElement>> {
+    #[must_use]
+    pub fn feed(&mut self, input: &mut BufferQueue) -> TokenizerResult<DomRoot<HTMLScriptElement>> {
         let mut send_tendrils = VecDeque::new();
         while let Some(str) = input.pop_front() {
             send_tendrils.push_back(SendTendril::from(str));
@@ -296,7 +297,7 @@ impl Tokenizer {
                 ToTokenizerMsg::TokenizerResultDone { updated_input } => {
                     let buffer_queue = create_buffer_queue(updated_input);
                     *input = buffer_queue;
-                    return Ok(());
+                    return TokenizerResult::Done;
                 },
                 ToTokenizerMsg::TokenizerResultScript {
                     script,
@@ -305,7 +306,7 @@ impl Tokenizer {
                     let buffer_queue = create_buffer_queue(updated_input);
                     *input = buffer_queue;
                     let script = self.get_node(&script.id);
-                    return Err(DomRoot::from_ref(script.downcast().unwrap()));
+                    return TokenizerResult::Script(DomRoot::from_ref(script.downcast().unwrap()));
                 },
                 ToTokenizerMsg::End => unreachable!(),
             };

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -77,10 +77,13 @@ impl Tokenizer {
         Tokenizer { inner: inner }
     }
 
-    pub fn feed(&mut self, input: &mut BufferQueue) -> Result<(), DomRoot<HTMLScriptElement>> {
+    #[must_use]
+    pub fn feed(&mut self, input: &mut BufferQueue) -> TokenizerResult<DomRoot<HTMLScriptElement>> {
         match self.inner.feed(input) {
-            TokenizerResult::Done => Ok(()),
-            TokenizerResult::Script(script) => Err(DomRoot::from_ref(script.downcast().unwrap())),
+            TokenizerResult::Done => TokenizerResult::Done,
+            TokenizerResult::Script(script) => {
+                TokenizerResult::Script(DomRoot::from_ref(script.downcast().unwrap()))
+            },
         }
     }
 

--- a/components/script/dom/servoparser/xml.rs
+++ b/components/script/dom/servoparser/xml.rs
@@ -10,6 +10,7 @@ use crate::dom::document::Document;
 use crate::dom::htmlscriptelement::HTMLScriptElement;
 use crate::dom::node::Node;
 use crate::dom::servoparser::{ParsingAlgorithm, Sink};
+use html5ever::tokenizer::TokenizerResult;
 use js::jsapi::JSTracer;
 use servo_url::ServoUrl;
 use xml5ever::buffer_queue::BufferQueue;
@@ -39,12 +40,13 @@ impl Tokenizer {
         Tokenizer { inner: tok }
     }
 
-    pub fn feed(&mut self, input: &mut BufferQueue) -> Result<(), DomRoot<HTMLScriptElement>> {
+    #[must_use]
+    pub fn feed(&mut self, input: &mut BufferQueue) -> TokenizerResult<DomRoot<HTMLScriptElement>> {
         self.inner.run(input);
-        if let Some(script) = self.inner.sink.sink.script.take() {
-            return Err(script);
+        match self.inner.sink.sink.script.take() {
+            Some(script) => TokenizerResult::Script(script),
+            None => TokenizerResult::Done,
         }
-        Ok(())
     }
 
     pub fn end(&mut self) {


### PR DESCRIPTION
As stated in  #25516, this PR refactors the feed functions in the following files to return an Option instead of a Result:

- components/script/dom/servoparser/async_html.rs
- components/script/dom/servoparser/html.rs
- components/script/dom/servoparser/xml.rs
- components/script/dom/servoparser/mod.rs

Originally, these functions were returning the Err values for situations that didn't actually result in an error. This PR fixes that.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25516 

<!-- Either: -->
- [X] These changes do not require tests because it is a refactor.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
