### PR TITLE
Make error events only pass the extra error-event arguments to global listeners

### DIFF
--- a/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-processing-algorithm-error/document-synthetic-errorevent.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-processing-algorithm-error/document-synthetic-errorevent.html.ini
@@ -1,5 +1,0 @@
-[document-synthetic-errorevent.html]
-  type: testharness
-  [error event is normal (return true does not cancel; one arg) on Document, with a synthetic ErrorEvent]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-processing-algorithm-error/script-element.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-processing-algorithm-error/script-element.html.ini
@@ -1,5 +1,0 @@
-[script-element.html]
-  type: testharness
-  [error event behaves normally (return true does not cancel; one arg) on a script element, with a synthetic ErrorEvent]
-    expected: FAIL
-


### PR DESCRIPTION
Error event handlers were getting lineno, etc. arguments even when they weren't on globals, failing two WPT tests; this fixes that.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25197

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
