### PR TITLE
Implement "translate" attribute

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -514,6 +514,25 @@ impl Element {
             debug_assert!(false, "Trying to detach a non-attached shadow root");
         }
     }
+
+    // https://html.spec.whatwg.org/multipage/#translation-mode
+    pub fn is_translate_enabled(&self) -> bool {
+        // TODO change this to local_name! when html5ever updates
+        let name = &LocalName::from("translate");
+        if self.has_attribute(name) {
+            match &*self.get_string_attribute(name) {
+                "yes" | "" => return true,
+                "no" => return false,
+                _ => {},
+            }
+        }
+        if let Some(parent) = self.upcast::<Node>().GetParentNode() {
+            if let Some(elem) = parent.downcast::<Element>() {
+                return elem.is_translate_enabled();
+            }
+        }
+        true // whatwg/html#5239
+    }
 }
 
 #[allow(unsafe_code)]

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -516,6 +516,23 @@ impl HTMLElementMethods for HTMLElement {
         // Step 7.
         Node::replace_all(Some(fragment.upcast()), self.upcast::<Node>());
     }
+
+    // https://html.spec.whatwg.org/multipage/#dom-translate
+    fn Translate(&self) -> bool {
+        self.upcast::<Element>().is_translate_enabled()
+    }
+
+    // https://html.spec.whatwg.org/multipage/#dom-translate
+    fn SetTranslate(&self, yesno: bool) {
+        self.upcast::<Element>().set_string_attribute(
+            // TODO change this to local_name! when html5ever updates
+            &LocalName::from("translate"),
+            match yesno {
+                true => DOMString::from("yes"),
+                false => DOMString::from("no"),
+            },
+        );
+    }
 }
 
 fn append_text_node_to_fragment(document: &Document, fragment: &DocumentFragment, text: String) {

--- a/components/script/dom/webidls/HTMLElement.webidl
+++ b/components/script/dom/webidls/HTMLElement.webidl
@@ -12,8 +12,8 @@ interface HTMLElement : Element {
            attribute DOMString title;
   [CEReactions]
            attribute DOMString lang;
-  // [CEReactions]
-  //         attribute boolean translate;
+  [CEReactions]
+           attribute boolean translate;
   // [CEReactions]
   //         attribute DOMString dir;
   readonly attribute DOMStringMap dataset;

--- a/tests/wpt/metadata/custom-elements/reactions/HTMLElement.html.ini
+++ b/tests/wpt/metadata/custom-elements/reactions/HTMLElement.html.ini
@@ -1,11 +1,5 @@
 [HTMLElement.html]
   type: testharness
-  [translate on HTMLElement must enqueue an attributeChanged reaction when adding translate content attribute]
-    expected: FAIL
-
-  [translate on HTMLElement must enqueue an attributeChanged reaction when replacing an existing attribute]
-    expected: FAIL
-
   [dir on HTMLElement must enqueue an attributeChanged reaction when adding dir content attribute]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/dom/elements/global-attributes/the-translate-attribute-007.html.ini
+++ b/tests/wpt/metadata/html/dom/elements/global-attributes/the-translate-attribute-007.html.ini
@@ -1,5 +1,0 @@
-[the-translate-attribute-007.html]
-  type: testharness
-  [In the default case, ie. with no translate attribute in the page, javascript will detect the translation mode of text as translate-enabled.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/elements/global-attributes/the-translate-attribute-008.html.ini
+++ b/tests/wpt/metadata/html/dom/elements/global-attributes/the-translate-attribute-008.html.ini
@@ -1,5 +1,0 @@
-[the-translate-attribute-008.html]
-  type: testharness
-  [If the translate attribute is set to yes, javascript will detect the translation mode of text as translate-enabled.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/elements/global-attributes/the-translate-attribute-009.html.ini
+++ b/tests/wpt/metadata/html/dom/elements/global-attributes/the-translate-attribute-009.html.ini
@@ -1,5 +1,0 @@
-[the-translate-attribute-009.html]
-  type: testharness
-  [If the translate attribute is set to no, javascript will detect the translation mode of text as no-translate.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/elements/global-attributes/the-translate-attribute-010.html.ini
+++ b/tests/wpt/metadata/html/dom/elements/global-attributes/the-translate-attribute-010.html.ini
@@ -1,5 +1,0 @@
-[the-translate-attribute-010.html]
-  type: testharness
-  [If the translate attribute is set to no, javascript will detect the translation mode of elements inside that element with no translate flag as no-translate.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/elements/global-attributes/the-translate-attribute-011.html.ini
+++ b/tests/wpt/metadata/html/dom/elements/global-attributes/the-translate-attribute-011.html.ini
@@ -1,5 +1,0 @@
-[the-translate-attribute-011.html]
-  type: testharness
-  [If the translate attribute is set to yes on an element inside an element with the translate attribute set to no, javascript will detect the translation mode of text in the inner element as translate-enabled.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/elements/global-attributes/the-translate-attribute-012.html.ini
+++ b/tests/wpt/metadata/html/dom/elements/global-attributes/the-translate-attribute-012.html.ini
@@ -1,5 +1,0 @@
-[the-translate-attribute-012.html]
-  type: testharness
-  [If the translate attribute is set to a null string, javascript will detect the translation mode of text as translate-enabled.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/metadata/html/dom/idlharness.https.html.ini
@@ -2424,9 +2424,6 @@
   [HTMLObjectElement interface: attribute name]
     expected: FAIL
 
-  [HTMLElement interface: document.createElement("noscript") must inherit property "translate" with the proper type]
-    expected: FAIL
-
   [HTMLFrameElement interface: document.createElement("frame") must inherit property "contentWindow" with the proper type]
     expected: FAIL
 
@@ -3763,9 +3760,6 @@
     expected: FAIL
 
   [HTMLAreaElement interface: attribute hostname]
-    expected: FAIL
-
-  [HTMLElement interface: attribute translate]
     expected: FAIL
 
   [HTMLTableColElement interface: attribute span]


### PR DESCRIPTION
This attribute is almost a straightforward enumerated one, but the getter value inherits from parents when the content attribute is absent, even when the parents are non-HTML elements. This initial commit is using LocalName::from on a static string; once html5ever has a release with "translate" in the built-in local name list, a small change will be needed.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25628

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
