### PR TITLE
Enable Mozilla CSS tests for layout_2020 and add expectations

### DIFF
--- a/tests/wpt/include-layout-2020.ini
+++ b/tests/wpt/include-layout-2020.ini
@@ -1,4 +1,8 @@
 skip: true
+[_mozilla]
+  skip: true
+  [css]
+    skip: false
 [css]
   skip: true
   [CSS2]

--- a/tests/wpt/mozilla/meta-layout-2020/css/abs_float_pref_width.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/abs_float_pref_width.html.ini
@@ -1,0 +1,2 @@
+[abs_float_pref_width.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/absolute_block_format_ctx.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/absolute_block_format_ctx.html.ini
@@ -1,0 +1,2 @@
+[absolute_block_format_ctx.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/absolute_hypothetical_with_intervening_inline_block_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/absolute_hypothetical_with_intervening_inline_block_a.html.ini
@@ -1,0 +1,2 @@
+[absolute_hypothetical_with_intervening_inline_block_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/absolute_inline_containing_block_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/absolute_inline_containing_block_a.html.ini
@@ -1,0 +1,2 @@
+[absolute_inline_containing_block_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/absolute_z_index_auto_paint_order_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/absolute_z_index_auto_paint_order_a.html.ini
@@ -1,0 +1,2 @@
+[absolute_z_index_auto_paint_order_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/acid1_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/acid1_a.html.ini
@@ -1,0 +1,2 @@
+[acid1_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/acid2-wrapper.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/acid2-wrapper.html.ini
@@ -1,0 +1,2 @@
+[acid2-wrapper.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/acid2_noscroll.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/acid2_noscroll.html.ini
@@ -1,0 +1,2 @@
+[acid2_noscroll.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/acid2_ref.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/acid2_ref.html.ini
@@ -1,0 +1,2 @@
+[acid2_ref.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/alpha_gif_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/alpha_gif_a.html.ini
@@ -1,0 +1,2 @@
+[alpha_gif_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/alpha_png_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/alpha_png_a.html.ini
@@ -1,0 +1,2 @@
+[alpha_png_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/animations/basic-linear-width.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/animations/basic-linear-width.html.ini
@@ -1,0 +1,5 @@
+[basic-linear-width.html]
+  expected: ERROR
+  [Animation test: Linear animation repeated infinitely.]
+    expected: TIMEOUT
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/animations/basic-transition.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/animations/basic-transition.html.ini
@@ -1,0 +1,5 @@
+[basic-transition.html]
+  expected: ERROR
+  [Transition test]
+    expected: TIMEOUT
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/animations/mixed-units.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/animations/mixed-units.html.ini
@@ -1,0 +1,5 @@
+[mixed-units.html]
+  expected: ERROR
+  [Animation test: mixed units.]
+    expected: TIMEOUT
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/animations/transition-raf.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/animations/transition-raf.html.ini
@@ -1,0 +1,2 @@
+[transition-raf.html]
+  expected: ERROR

--- a/tests/wpt/mozilla/meta-layout-2020/css/background_position_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/background_position_a.html.ini
@@ -1,0 +1,2 @@
+[background_position_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/background_position_keyword.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/background_position_keyword.html.ini
@@ -1,0 +1,2 @@
+[background_position_keyword.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/background_position_percent.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/background_position_percent.html.ini
@@ -1,0 +1,2 @@
+[background_position_percent.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/background_repeat_both_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/background_repeat_both_a.html.ini
@@ -1,0 +1,2 @@
+[background_repeat_both_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/block_formatting_context_margin_collapse_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/block_formatting_context_margin_collapse_a.html.ini
@@ -1,0 +1,2 @@
+[block_formatting_context_margin_collapse_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/block_formatting_context_margin_inout_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/block_formatting_context_margin_inout_a.html.ini
@@ -1,0 +1,2 @@
+[block_formatting_context_margin_inout_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/block_formatting_context_max_width_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/block_formatting_context_max_width_a.html.ini
@@ -1,0 +1,2 @@
+[block_formatting_context_max_width_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/block_replaced_content_b.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/block_replaced_content_b.html.ini
@@ -1,0 +1,2 @@
+[block_replaced_content_b.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/blur_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/blur_a.html.ini
@@ -1,0 +1,2 @@
+[blur_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/border-image-linear-gradient.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/border-image-linear-gradient.html.ini
@@ -1,0 +1,2 @@
+[border-image-linear-gradient.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/border_collapse_row_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/border_collapse_row_a.html.ini
@@ -1,0 +1,2 @@
+[border_collapse_row_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/border_collapse_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/border_collapse_simple_a.html.ini
@@ -1,0 +1,2 @@
+[border_collapse_simple_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/border_inline_split.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/border_inline_split.html.ini
@@ -1,0 +1,2 @@
+[border_inline_split.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/border_radius_clip_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/border_radius_clip_a.html.ini
@@ -1,0 +1,2 @@
+[border_radius_clip_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/border_radius_clipping_contents_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/border_radius_clipping_contents_a.html.ini
@@ -1,0 +1,2 @@
+[border_radius_clipping_contents_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/border_radius_zero_sizes_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/border_radius_zero_sizes_a.html.ini
@@ -1,0 +1,2 @@
+[border_radius_zero_sizes_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/border_spacing_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/border_spacing_a.html.ini
@@ -1,0 +1,2 @@
+[border_spacing_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/border_spacing_auto_layout_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/border_spacing_auto_layout_a.html.ini
@@ -1,0 +1,2 @@
+[border_spacing_auto_layout_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/border_spacing_fixed_layout_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/border_spacing_fixed_layout_a.html.ini
@@ -1,0 +1,2 @@
+[border_spacing_fixed_layout_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/borders_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/borders_a.html.ini
@@ -1,0 +1,2 @@
+[borders_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/box_shadow_bg.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/box_shadow_bg.html.ini
@@ -1,0 +1,2 @@
+[box_shadow_bg.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/box_shadow_blur_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/box_shadow_blur_a.html.ini
@@ -1,0 +1,2 @@
+[box_shadow_blur_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/box_shadow_border_box_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/box_shadow_border_box_a.html.ini
@@ -1,0 +1,2 @@
+[box_shadow_border_box_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/box_shadow_inset_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/box_shadow_inset_a.html.ini
@@ -1,0 +1,2 @@
+[box_shadow_inset_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/box_shadow_inset_bg.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/box_shadow_inset_bg.html.ini
@@ -1,0 +1,2 @@
+[box_shadow_inset_bg.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/box_shadow_paint_order_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/box_shadow_paint_order_a.html.ini
@@ -1,0 +1,2 @@
+[box_shadow_paint_order_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/box_shadow_spread_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/box_shadow_spread_a.html.ini
@@ -1,0 +1,2 @@
+[box_shadow_spread_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/box_sizing_border_box_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/box_sizing_border_box_a.html.ini
@@ -1,0 +1,2 @@
+[box_sizing_border_box_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/br.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/br.html.ini
@@ -1,0 +1,2 @@
+[br.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/button_css_width.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/button_css_width.html.ini
@@ -1,0 +1,2 @@
+[button_css_width.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/canvas_as_block_element_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/canvas_as_block_element_a.html.ini
@@ -1,0 +1,2 @@
+[canvas_as_block_element_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/canvas_linear_gradient_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/canvas_linear_gradient_a.html.ini
@@ -1,0 +1,2 @@
+[canvas_linear_gradient_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/canvas_over_area.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/canvas_over_area.html.ini
@@ -1,0 +1,2 @@
+[canvas_over_area.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/canvas_radial_gradient_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/canvas_radial_gradient_a.html.ini
@@ -1,0 +1,2 @@
+[canvas_radial_gradient_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/clip_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/clip_a.html.ini
@@ -1,0 +1,2 @@
+[clip_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/content_color.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/content_color.html.ini
@@ -1,0 +1,2 @@
+[content_color.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/counters_nested_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/counters_nested_a.html.ini
@@ -1,0 +1,2 @@
+[counters_nested_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/counters_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/counters_simple_a.html.ini
@@ -1,0 +1,2 @@
+[counters_simple_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-bottom.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-bottom.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-bottom.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-flexbox.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-flexbox.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-flexbox.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-get-bounding-client-rect.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-get-bounding-client-rect.html.ini
@@ -1,0 +1,10 @@
+[position-sticky-get-bounding-client-rect.html]
+  [sticky positioned element should be observable by getBoundingClientRect.]
+    expected: FAIL
+
+  [getBoundingClientRect should be correct for sticky after script insertion]
+    expected: FAIL
+
+  [getBoundingClientRect should be correct for sticky after script-caused layout]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-grid.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-grid.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-grid.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-inflow-position.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-inflow-position.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-inflow-position.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-inline.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-inline.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-inline.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-left.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-left.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-left.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-margins.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-margins.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-margins.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-nested-bottom.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-nested-bottom.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-nested-bottom.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-nested-inline.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-nested-inline.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-nested-inline.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-nested-left.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-nested-left.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-nested-left.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-nested-right.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-nested-right.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-nested-right.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-nested-table.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-nested-table.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-nested-table.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-nested-top.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-nested-top.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-nested-top.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-offset-top-left.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-offset-top-left.html.ini
@@ -1,0 +1,7 @@
+[position-sticky-offset-top-left.html]
+  [offsetTop/offsetLeft should be correct for sticky after script insertion]
+    expected: FAIL
+
+  [offsetTop/offsetLeft should be correct for sticky after script-caused layout]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-overflow-padding.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-overflow-padding.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-overflow-padding.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-parsing.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-parsing.html.ini
@@ -1,0 +1,4 @@
+[position-sticky-parsing.html]
+  [The value of sticky for the position property should be parsed correctly]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-right.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-right.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-right.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-tfoot-bottom.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-tfoot-bottom.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-table-tfoot-bottom.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-th-bottom.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-th-bottom.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-table-th-bottom.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-th-left.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-th-left.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-table-th-left.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-th-right.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-th-right.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-table-th-right.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-th-top.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-th-top.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-table-th-top.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-thead-top.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-thead-top.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-table-thead-top.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-tr-bottom.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-tr-bottom.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-table-tr-bottom.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-tr-top.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-table-tr-top.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-table-tr-top.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-top.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-top.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-top.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-writing-modes.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-writing-modes.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-writing-modes.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/dirty_viewport.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/dirty_viewport.html.ini
@@ -1,0 +1,2 @@
+[dirty_viewport.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/ellipsis_font_panic.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/ellipsis_font_panic.html.ini
@@ -1,0 +1,2 @@
+[ellipsis_font_panic.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/empty_cells_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/empty_cells_a.html.ini
@@ -1,0 +1,2 @@
+[empty_cells_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/filter_sepia_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/filter_sepia_a.html.ini
@@ -1,0 +1,2 @@
+[filter_sepia_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/fixed_position_css_clip.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/fixed_position_css_clip.html.ini
@@ -1,0 +1,2 @@
+[fixed_position_css_clip.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/flex-item-assign-inline-size.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/flex-item-assign-inline-size.html.ini
@@ -1,0 +1,4 @@
+[flex-item-assign-inline-size.html]
+  [Test inline size against percentage]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/flex_row_direction.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/flex_row_direction.html.ini
@@ -1,0 +1,2 @@
+[flex_row_direction.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/float-abspos.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/float-abspos.html.ini
@@ -1,0 +1,4 @@
+[float-abspos.html]
+  [A positioned element's float value computes to none]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/float_cleared_with_just_height.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/float_cleared_with_just_height.html.ini
@@ -1,0 +1,2 @@
+[float_cleared_with_just_height.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/float_intrinsic_width_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/float_intrinsic_width_a.html.ini
@@ -1,0 +1,2 @@
+[float_intrinsic_width_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/float_relative_to_position.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/float_relative_to_position.html.ini
@@ -1,0 +1,4 @@
+[float_relative_to_position.html]
+  [Tests the relationship between float and position]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/float_right_intrinsic_width_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/float_right_intrinsic_width_a.html.ini
@@ -1,0 +1,2 @@
+[float_right_intrinsic_width_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/float_table_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/float_table_a.html.ini
@@ -1,0 +1,2 @@
+[float_table_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/floated_negative_margins_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/floated_negative_margins_a.html.ini
@@ -1,0 +1,2 @@
+[floated_negative_margins_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/floats_inline_margins_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/floats_inline_margins_a.html.ini
@@ -1,0 +1,2 @@
+[floats_inline_margins_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/floats_margin_collapse_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/floats_margin_collapse_a.html.ini
@@ -1,0 +1,2 @@
+[floats_margin_collapse_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/floats_margin_collapse_with_clearance_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/floats_margin_collapse_with_clearance_a.html.ini
@@ -1,0 +1,2 @@
+[floats_margin_collapse_with_clearance_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/font_fallback_01.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/font_fallback_01.html.ini
@@ -1,0 +1,2 @@
+[font_fallback_01.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/font_fallback_02.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/font_fallback_02.html.ini
@@ -1,0 +1,2 @@
+[font_fallback_02.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/font_fallback_03.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/font_fallback_03.html.ini
@@ -1,0 +1,2 @@
+[font_fallback_03.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/get-computed-style-for-url.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/get-computed-style-for-url.html.ini
@@ -1,0 +1,31 @@
+[get-computed-style-for-url.html]
+  [getComputedStyle(elem) and elem.style for url() borderImage correctly return "none"]
+    expected: FAIL
+
+  [getComputedStyle(elem) for url() listStyle uses the resolved URL and elem.style uses the original URL]
+    expected: FAIL
+
+  [getComputedStyle(elem) for url() backgroundImage uses the resolved URL and elem.style uses the original URL]
+    expected: FAIL
+
+  [getComputedStyle(elem) and elem.style for url() listStyleImage correctly return "none"]
+    expected: FAIL
+
+  [getComputedStyle(elem) and elem.style for url() listStyle correctly return "none"]
+    expected: FAIL
+
+  [getComputedStyle(elem) for url() borderImage uses the resolved URL and elem.style uses the original URL]
+    expected: FAIL
+
+  [getComputedStyle(elem) for url() listStyleImage uses the resolved URL and elem.style uses the original URL]
+    expected: FAIL
+
+  [getComputedStyle(elem) for url() background uses the resolved URL and elem.style uses the original URL]
+    expected: FAIL
+
+  [getComputedStyle(elem) and elem.style for url() background correctly return "none"]
+    expected: FAIL
+
+  [getComputedStyle(elem) and elem.style for url() backgroundImage correctly return "none"]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/iframe/bg_color.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/iframe/bg_color.html.ini
@@ -1,0 +1,2 @@
+[bg_color.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/iframe/hide_and_show.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/iframe/hide_and_show.html.ini
@@ -1,0 +1,2 @@
+[hide_and_show.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/iframe/overflow.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/iframe/overflow.html.ini
@@ -1,0 +1,2 @@
+[overflow.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/iframe/positioning_margin.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/iframe/positioning_margin.html.ini
@@ -1,0 +1,2 @@
+[positioning_margin.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple.html.ini
@@ -1,0 +1,2 @@
+[simple.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple_inline_default.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple_inline_default.html.ini
@@ -1,0 +1,2 @@
+[simple_inline_default.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple_inline_height.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple_inline_height.html.ini
@@ -1,0 +1,2 @@
+[simple_inline_height.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple_inline_max.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple_inline_max.html.ini
@@ -1,0 +1,2 @@
+[simple_inline_max.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple_inline_min.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple_inline_min.html.ini
@@ -1,0 +1,2 @@
+[simple_inline_min.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple_inline_width.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple_inline_width.html.ini
@@ -1,0 +1,2 @@
+[simple_inline_width.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple_inline_width_height.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple_inline_width_height.html.ini
@@ -1,0 +1,2 @@
+[simple_inline_width_height.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple_inline_width_percentage.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/iframe/simple_inline_width_percentage.html.ini
@@ -1,0 +1,2 @@
+[simple_inline_width_percentage.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/iframe/size_attributes_vertical_writing_mode.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/iframe/size_attributes_vertical_writing_mode.html.ini
@@ -1,0 +1,2 @@
+[size_attributes_vertical_writing_mode.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/image_percentage_dimen.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/image_percentage_dimen.html.ini
@@ -1,0 +1,2 @@
+[image_percentage_dimen.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/img_width_style_intrinsic_width_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/img_width_style_intrinsic_width_a.html.ini
@@ -1,0 +1,2 @@
+[img_width_style_intrinsic_width_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_absolute_hypothetical_baseline_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_absolute_hypothetical_baseline_a.html.ini
@@ -1,0 +1,2 @@
+[inline_absolute_hypothetical_baseline_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_absolute_hypothetical_clip_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_absolute_hypothetical_clip_a.html.ini
@@ -1,0 +1,2 @@
+[inline_absolute_hypothetical_clip_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_absolute_hypothetical_line_metrics_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_absolute_hypothetical_line_metrics_a.html.ini
@@ -1,0 +1,2 @@
+[inline_absolute_hypothetical_line_metrics_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_absolute_hypothetical_metrics_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_absolute_hypothetical_metrics_a.html.ini
@@ -1,0 +1,2 @@
+[inline_absolute_hypothetical_metrics_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_block_baseline_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_block_baseline_a.html.ini
@@ -1,0 +1,2 @@
+[inline_block_baseline_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_block_block_direction_margins_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_block_block_direction_margins_a.html.ini
@@ -1,0 +1,2 @@
+[inline_block_block_direction_margins_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_block_centering_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_block_centering_a.html.ini
@@ -1,0 +1,2 @@
+[inline_block_centering_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_block_explicit_height_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_block_explicit_height_a.html.ini
@@ -1,0 +1,2 @@
+[inline_block_explicit_height_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_block_img_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_block_img_a.html.ini
@@ -1,0 +1,2 @@
+[inline_block_img_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_block_margin_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_block_margin_a.html.ini
@@ -1,0 +1,2 @@
+[inline_block_margin_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_block_parent_padding_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_block_parent_padding_a.html.ini
@@ -1,0 +1,2 @@
+[inline_block_parent_padding_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_block_with_margin_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_block_with_margin_a.html.ini
@@ -1,0 +1,2 @@
+[inline_block_with_margin_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_border_baseline_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_border_baseline_a.html.ini
@@ -1,0 +1,2 @@
+[inline_border_baseline_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_element_border_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_element_border_a.html.ini
@@ -1,0 +1,2 @@
+[inline_element_border_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_element_padding_margin.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_element_padding_margin.html.ini
@@ -1,0 +1,2 @@
+[inline_element_padding_margin.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_hypothetical_box_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_hypothetical_box_a.html.ini
@@ -1,0 +1,2 @@
+[inline_hypothetical_box_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/input_alignment_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/input_alignment_a.html.ini
@@ -1,0 +1,2 @@
+[input_alignment_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/input_button_margins_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/input_button_margins_a.html.ini
@@ -1,0 +1,2 @@
+[input_button_margins_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/input_insertion_point_empty_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/input_insertion_point_empty_a.html.ini
@@ -1,0 +1,2 @@
+[input_insertion_point_empty_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/input_selection_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/input_selection_a.html.ini
@@ -1,0 +1,2 @@
+[input_selection_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/input_selection_incremental_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/input_selection_incremental_a.html.ini
@@ -1,0 +1,2 @@
+[input_selection_incremental_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/input_whitespace.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/input_whitespace.html.ini
@@ -1,0 +1,2 @@
+[input_whitespace.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/legacy_cellspacing_attribute_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/legacy_cellspacing_attribute_a.html.ini
@@ -1,0 +1,2 @@
+[legacy_cellspacing_attribute_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/line_break_nowrap.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/line_break_nowrap.html.ini
@@ -1,0 +1,2 @@
+[line_break_nowrap.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/line_breaking_whitespace_collapse_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/line_breaking_whitespace_collapse_a.html.ini
@@ -1,0 +1,2 @@
+[line_breaking_whitespace_collapse_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/line_height_float_placement_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/line_height_float_placement_a.html.ini
@@ -1,0 +1,2 @@
+[line_height_float_placement_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/linear_gradients_non_square_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/linear_gradients_non_square_a.html.ini
@@ -1,0 +1,2 @@
+[linear_gradients_non_square_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/linear_gradients_reverse_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/linear_gradients_reverse_a.html.ini
@@ -1,0 +1,2 @@
+[linear_gradients_reverse_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/linebreak_inline_span_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/linebreak_inline_span_a.html.ini
@@ -1,0 +1,2 @@
+[linebreak_inline_span_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/linebreak_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/linebreak_simple_a.html.ini
@@ -1,0 +1,2 @@
+[linebreak_simple_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/list_item_marker_around_float.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/list_item_marker_around_float.html.ini
@@ -1,0 +1,2 @@
+[list_item_marker_around_float.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/list_style_position_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/list_style_position_a.html.ini
@@ -1,0 +1,2 @@
+[list_style_position_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/list_style_type_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/list_style_type_a.html.ini
@@ -1,0 +1,2 @@
+[list_style_type_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/many_brs_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/many_brs_a.html.ini
@@ -1,0 +1,2 @@
+[many_brs_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/margin_padding_inline_block_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/margin_padding_inline_block_a.html.ini
@@ -1,0 +1,2 @@
+[margin_padding_inline_block_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/marker_block_direction_placement_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/marker_block_direction_placement_a.html.ini
@@ -1,0 +1,2 @@
+[marker_block_direction_placement_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/matchMedia.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/matchMedia.html.ini
@@ -1,0 +1,23 @@
+[matchMedia.html]
+  expected: TIMEOUT
+  [MediaQueryList.matches for "(width: 200px)"]
+    expected: FAIL
+
+  [Listeners are called in the order which they have been added]
+    expected: NOTRUN
+
+  [window.matchMedia exists]
+    expected: FAIL
+
+  [MediaQueryList.matches for "(min-aspect-ratio: 1/1)"]
+    expected: FAIL
+
+  [MediaQueryList.matches for "(min-width: 150px)"]
+    expected: FAIL
+
+  [Listener added twice is only called once.]
+    expected: NOTRUN
+
+  [Resize iframe from 200x100 to 200x50, then to 100x50]
+    expected: NOTRUN
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/max_inline_block_size_canvas.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/max_inline_block_size_canvas.html.ini
@@ -1,0 +1,2 @@
+[max_inline_block_size_canvas.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/media_bogus_query_sequence.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/media_bogus_query_sequence.html.ini
@@ -1,0 +1,4 @@
+[media_bogus_query_sequence.html]
+  [Media query with a bogus query doesn't turn the whole media query list invalid]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/meta_viewport_resize.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/meta_viewport_resize.html.ini
@@ -1,0 +1,5 @@
+[meta_viewport_resize.html]
+  expected: TIMEOUT
+  [<body> inside <iframe> has the <iframe>’s width]
+    expected: TIMEOUT
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/min_width_percent_root_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/min_width_percent_root_a.html.ini
@@ -1,0 +1,2 @@
+[min_width_percent_root_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/minimum_line_height_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/minimum_line_height_a.html.ini
@@ -1,0 +1,2 @@
+[minimum_line_height_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/mix_blend_mode_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/mix_blend_mode_a.html.ini
@@ -1,0 +1,2 @@
+[mix_blend_mode_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/object_element_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/object_element_a.html.ini
@@ -1,0 +1,2 @@
+[object_element_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/offset_properties_inline.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/offset_properties_inline.html.ini
@@ -1,0 +1,4 @@
+[offset_properties_inline.html]
+  [offsetParent]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/ol_japanese_iroha_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/ol_japanese_iroha_a.html.ini
@@ -1,0 +1,2 @@
+[ol_japanese_iroha_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/ol_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/ol_simple_a.html.ini
@@ -1,0 +1,2 @@
+[ol_simple_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/opacity_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/opacity_simple_a.html.ini
@@ -1,0 +1,2 @@
+[opacity_simple_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/outline_offset_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/outline_offset_a.html.ini
@@ -1,0 +1,2 @@
+[outline_offset_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/outlines_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/outlines_simple_a.html.ini
@@ -1,0 +1,2 @@
+[outlines_simple_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/outlines_wrap_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/outlines_wrap_a.html.ini
@@ -1,0 +1,2 @@
+[outlines_wrap_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overconstrained_block.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overconstrained_block.html.ini
@@ -1,0 +1,2 @@
+[overconstrained_block.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_auto.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_auto.html.ini
@@ -1,0 +1,2 @@
+[overflow_auto.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_border_radius.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_border_radius.html.ini
@@ -1,0 +1,2 @@
+[overflow_border_radius.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_clipping.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_clipping.html.ini
@@ -1,0 +1,2 @@
+[overflow_clipping.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_position_abs_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_position_abs_simple_a.html.ini
@@ -1,0 +1,2 @@
+[overflow_position_abs_simple_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_scroll.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_scroll.html.ini
@@ -1,0 +1,2 @@
+[overflow_scroll.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_simple_a.html.ini
@@ -1,0 +1,2 @@
+[overflow_simple_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_transformed_sc.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_transformed_sc.html.ini
@@ -1,0 +1,2 @@
+[overflow_transformed_sc.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_transformed_sc_rotate.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_transformed_sc_rotate.html.ini
@@ -1,0 +1,2 @@
+[overflow_transformed_sc_rotate.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_wrap_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_wrap_a.html.ini
@@ -1,0 +1,2 @@
+[overflow_wrap_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_xy_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_xy_a.html.ini
@@ -1,0 +1,2 @@
+[overflow_xy_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/per_glyph_font_fallback_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/per_glyph_font_fallback_a.html.ini
@@ -1,0 +1,2 @@
+[per_glyph_font_fallback_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/percentage_width_inline_block_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/percentage_width_inline_block_a.html.ini
@@ -1,0 +1,2 @@
+[percentage_width_inline_block_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/perspective.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/perspective.html.ini
@@ -1,0 +1,4 @@
+[perspective.html]
+  [Parsing of the perspective property]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/pixel_snapping_glyphs.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/pixel_snapping_glyphs.html.ini
@@ -1,0 +1,2 @@
+[pixel_snapping_glyphs.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_abs_cb_with_non_cb_kid_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_abs_cb_with_non_cb_kid_a.html.ini
@@ -1,0 +1,2 @@
+[position_abs_cb_with_non_cb_kid_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_abs_height_width_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_abs_height_width_a.html.ini
@@ -1,0 +1,2 @@
+[position_abs_height_width_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_abs_nested_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_abs_nested_a.html.ini
@@ -1,0 +1,2 @@
+[position_abs_nested_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_abs_pseudo_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_abs_pseudo_a.html.ini
@@ -1,0 +1,2 @@
+[position_abs_pseudo_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_abs_replaced_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_abs_replaced_simple_a.html.ini
@@ -1,0 +1,2 @@
+[position_abs_replaced_simple_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_abs_static_y_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_abs_static_y_a.html.ini
@@ -1,0 +1,2 @@
+[position_abs_static_y_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_fixed_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_fixed_a.html.ini
@@ -1,0 +1,2 @@
+[position_fixed_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_fixed_static_y_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_fixed_static_y_a.html.ini
@@ -1,0 +1,2 @@
+[position_fixed_static_y_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_relative_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_relative_a.html.ini
@@ -1,0 +1,2 @@
+[position_relative_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_relative_painting_order_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_relative_painting_order_a.html.ini
@@ -1,0 +1,2 @@
+[position_relative_painting_order_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_relative_stacking_context_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_relative_stacking_context_a.html.ini
@@ -1,0 +1,2 @@
+[position_relative_stacking_context_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_relative_stacking_context_contents_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_relative_stacking_context_contents_a.html.ini
@@ -1,0 +1,2 @@
+[position_relative_stacking_context_contents_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_relative_top_percentage_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_relative_top_percentage_a.html.ini
@@ -1,0 +1,2 @@
+[position_relative_top_percentage_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/pseudo_content_with_layers.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/pseudo_content_with_layers.html.ini
@@ -1,0 +1,2 @@
+[pseudo_content_with_layers.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/pseudo_element_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/pseudo_element_a.html.ini
@@ -1,0 +1,2 @@
+[pseudo_element_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/pseudo_element_spacing_margin.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/pseudo_element_spacing_margin.html.ini
@@ -1,0 +1,2 @@
+[pseudo_element_spacing_margin.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/pseudo_element_spacing_padding.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/pseudo_element_spacing_padding.html.ini
@@ -1,0 +1,2 @@
+[pseudo_element_spacing_padding.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/pseudo_inherit.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/pseudo_inherit.html.ini
@@ -1,0 +1,2 @@
+[pseudo_inherit.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/quotes_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/quotes_simple_a.html.ini
@@ -1,0 +1,2 @@
+[quotes_simple_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/relative_position_clip_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/relative_position_clip_a.html.ini
@@ -1,0 +1,2 @@
+[relative_position_clip_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/root_height_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/root_height_a.html.ini
@@ -1,0 +1,2 @@
+[root_height_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/rtl_body.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/rtl_body.html.ini
@@ -1,0 +1,2 @@
+[rtl_body.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/rtl_margin_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/rtl_margin_a.html.ini
@@ -1,0 +1,2 @@
+[rtl_margin_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/simple_inline_absolute_containing_block_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/simple_inline_absolute_containing_block_a.html.ini
@@ -1,0 +1,2 @@
+[simple_inline_absolute_containing_block_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/stacked_layers.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/stacked_layers.html.ini
@@ -1,0 +1,2 @@
+[stacked_layers.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/stacking_context_overflow_relative_outline_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/stacking_context_overflow_relative_outline_a.html.ini
@@ -1,0 +1,2 @@
+[stacking_context_overflow_relative_outline_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/stacking_order_overflow_auto.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/stacking_order_overflow_auto.html.ini
@@ -1,0 +1,2 @@
+[stacking_order_overflow_auto.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/stacking_order_overflow_scroll.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/stacking_order_overflow_scroll.html.ini
@@ -1,0 +1,2 @@
+[stacking_order_overflow_scroll.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/stylesheet_media_queries.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/stylesheet_media_queries.html.ini
@@ -1,0 +1,4 @@
+[stylesheet_media_queries.html]
+  [Media queries within stylesheets]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/submit_focus_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/submit_focus_a.html.ini
@@ -1,0 +1,2 @@
+[submit_focus_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_caption_bottom_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_caption_bottom_a.html.ini
@@ -1,0 +1,2 @@
+[table_caption_bottom_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_caption_top_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_caption_top_a.html.ini
@@ -1,0 +1,2 @@
+[table_caption_top_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_cell_float_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_cell_float_a.html.ini
@@ -1,0 +1,2 @@
+[table_cell_float_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_center_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_center_a.html.ini
@@ -1,0 +1,2 @@
+[table_center_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_colspan_fixed_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_colspan_fixed_a.html.ini
@@ -1,0 +1,2 @@
+[table_colspan_fixed_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_colspan_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_colspan_simple_a.html.ini
@@ -1,0 +1,2 @@
+[table_colspan_simple_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_colspan_spacing_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_colspan_spacing_a.html.ini
@@ -1,0 +1,2 @@
+[table_colspan_spacing_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_expansion_to_fit_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_expansion_to_fit_a.html.ini
@@ -1,0 +1,2 @@
+[table_expansion_to_fit_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_intrinsic_style_specified_width_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_intrinsic_style_specified_width_a.html.ini
@@ -1,0 +1,2 @@
+[table_intrinsic_style_specified_width_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_margin_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_margin_a.html.ini
@@ -1,0 +1,2 @@
+[table_margin_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_margin_auto_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_margin_auto_a.html.ini
@@ -1,0 +1,2 @@
+[table_margin_auto_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_padding_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_padding_a.html.ini
@@ -1,0 +1,2 @@
+[table_padding_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_percentage_width_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_percentage_width_a.html.ini
@@ -1,0 +1,2 @@
+[table_percentage_width_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_rowspan_notequal_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_rowspan_notequal_a.html.ini
@@ -1,0 +1,2 @@
+[table_rowspan_notequal_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_rowspan_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_rowspan_simple_a.html.ini
@@ -1,0 +1,2 @@
+[table_rowspan_simple_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_specified_width_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_specified_width_a.html.ini
@@ -1,0 +1,2 @@
+[table_specified_width_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_vertical_align_absolute_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_vertical_align_absolute_a.html.ini
@@ -1,0 +1,2 @@
+[table_vertical_align_absolute_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/table_vertical_align_margin_padding.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/table_vertical_align_margin_padding.html.ini
@@ -1,0 +1,2 @@
+[table_vertical_align_margin_padding.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/test_variable_legal_values.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/test_variable_legal_values.html.ini
@@ -1,0 +1,70 @@
+[test_variable_legal_values.html]
+  [number]
+    expected: FAIL
+
+  [CDO_not_at_top_level_value_unused]
+    expected: FAIL
+
+  [unbalanced_close_bracket_at_toplevel]
+    expected: FAIL
+
+  [braces]
+    expected: FAIL
+
+  [at_keyword_unknown_and_block]
+    expected: FAIL
+
+  [brackets]
+    expected: FAIL
+
+  [unbalanced_close_paren_at_toplevel]
+    expected: FAIL
+
+  [CDC_at_top_level]
+    expected: FAIL
+
+  [percentage]
+    expected: FAIL
+
+  [unbalanced_close_paren_in_something_balanced]
+    expected: FAIL
+
+  [function]
+    expected: FAIL
+
+  [nested_function]
+    expected: FAIL
+
+  [at_keyword_unknown]
+    expected: FAIL
+
+  [CDO_at_top_level]
+    expected: FAIL
+
+  [unbalanced_close_brace_in_something_balanced]
+    expected: FAIL
+
+  [at_keyword_known_and_block]
+    expected: FAIL
+
+  [semicolon_not_at_top_level_value_unused]
+    expected: FAIL
+
+  [parentheses]
+    expected: FAIL
+
+  [unbalanced_close_bracket_in_something_balanced]
+    expected: FAIL
+
+  [CDC_not_at_top_level_value_unused]
+    expected: FAIL
+
+  [length]
+    expected: FAIL
+
+  [time]
+    expected: FAIL
+
+  [at_keyword_known]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/test_variable_serialization_computed.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/test_variable_serialization_computed.html.ini
@@ -1,0 +1,91 @@
+[test_variable_serialization_computed.html]
+  [subtest #23 with `counter-reset: var(--a)red; --a:orange;`]
+    expected: FAIL
+
+  [subtest #24 with `--a: var(--b)var(--c); --c:[c\]; --b:('ab`]
+    expected: FAIL
+
+  [subtest #28 with `--a: "`]
+    expected: FAIL
+
+  [subtest #25 with `--a: '`]
+    expected: FAIL
+
+  [subtest #26 with `--a: '\\`]
+    expected: FAIL
+
+  [subtest #19 with `--a: var(--b)red; --b:orange;`]
+    expected: FAIL
+
+  [subtest #37 with `--a: url("http://example.org/\\`]
+    expected: FAIL
+
+  [subtest #30 with `--a: /* abc `]
+    expected: FAIL
+
+  [subtest #20 with `--a: var(--b)var(--c); --b:orange; --c:red;`]
+    expected: FAIL
+
+  [subtest #33 with `--a: url(http://example.org/\\`]
+    expected: FAIL
+
+  [subtest #11 with `--a: var(--b); --b: 1px`]
+    expected: FAIL
+
+  [subtest #17 with `--a: a var(--b) c; --b:b`]
+    expected: FAIL
+
+  [subtest #0 with ``]
+    expected: FAIL
+
+  [subtest #8 with `--a: 1px`]
+    expected: FAIL
+
+  [subtest #1 with `--a: `]
+    expected: FAIL
+
+  [subtest #27 with `--a: \\`]
+    expected: FAIL
+
+  [subtest #22 with `--a: var(--b,orange)var(--c); --c:red;`]
+    expected: FAIL
+
+  [subtest #35 with `--a: url('http://example.org/\\`]
+    expected: FAIL
+
+  [subtest #12 with `--a: var(--b, 1px)`]
+    expected: FAIL
+
+  [subtest #15 with `--a: something 3px url(whereever) calc(var(--b,1em) + 1px)`]
+    expected: FAIL
+
+  [subtest #5 with `--z: inherit`]
+    expected: FAIL
+
+  [subtest #32 with `--a: url(http://example.org/`]
+    expected: FAIL
+
+  [subtest #18 with `--a: a var(--b,b var(--c) d) e; --c:c`]
+    expected: FAIL
+
+  [subtest #31 with `--a: /* abc *`]
+    expected: FAIL
+
+  [subtest #16 with `--a: var(--b, var(--c, var(--d, Black)))`]
+    expected: FAIL
+
+  [subtest #36 with `--a: url("http://example.org/`]
+    expected: FAIL
+
+  [subtest #34 with `--a: url('http://example.org/`]
+    expected: FAIL
+
+  [subtest #29 with `--a: "\\`]
+    expected: FAIL
+
+  [subtest #21 with `--a: var(--b)var(--c,red); --b:orange;`]
+    expected: FAIL
+
+  [subtest #7 with `--z: unset`]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_align_complex_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_align_complex_a.html.ini
@@ -1,0 +1,2 @@
+[text_align_complex_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_align_justify_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_align_justify_a.html.ini
@@ -1,0 +1,2 @@
+[text_align_justify_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_align_start_end.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_align_start_end.html.ini
@@ -1,0 +1,2 @@
+[text_align_start_end.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_decoration_smoke_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_decoration_smoke_a.html.ini
@@ -1,0 +1,2 @@
+[text_decoration_smoke_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_decoration_underline_subpx_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_decoration_underline_subpx_a.html.ini
@@ -1,0 +1,2 @@
+[text_decoration_underline_subpx_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_indent_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_indent_a.html.ini
@@ -1,0 +1,2 @@
+[text_indent_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_overflow_basic_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_overflow_basic_a.html.ini
@@ -1,0 +1,2 @@
+[text_overflow_basic_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_overflow_ellipsis.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_overflow_ellipsis.html.ini
@@ -1,0 +1,2 @@
+[text_overflow_ellipsis.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_overflow_string.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_overflow_string.html.ini
@@ -1,0 +1,2 @@
+[text_overflow_string.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_shadow_decorations_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_shadow_decorations_a.html.ini
@@ -1,0 +1,2 @@
+[text_shadow_decorations_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_shadow_multiple_shadows_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_shadow_multiple_shadows_a.html.ini
@@ -1,0 +1,2 @@
+[text_shadow_multiple_shadows_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_shadow_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_shadow_simple_a.html.ini
@@ -1,0 +1,2 @@
+[text_shadow_simple_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_transform_capitalize_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_transform_capitalize_a.html.ini
@@ -1,0 +1,2 @@
+[text_transform_capitalize_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_transform_lowercase_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_transform_lowercase_a.html.ini
@@ -1,0 +1,2 @@
+[text_transform_lowercase_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_transform_uppercase_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_transform_uppercase_a.html.ini
@@ -1,0 +1,2 @@
+[text_transform_uppercase_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/transform_3d.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/transform_3d.html.ini
@@ -1,0 +1,2 @@
+[transform_3d.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/transform_3d_from_outside_viewport.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/transform_3d_from_outside_viewport.html.ini
@@ -1,0 +1,2 @@
+[transform_3d_from_outside_viewport.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/transform_optimization.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/transform_optimization.html.ini
@@ -1,0 +1,2 @@
+[transform_optimization.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/transform_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/transform_simple_a.html.ini
@@ -1,0 +1,2 @@
+[transform_simple_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/translate_clip.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/translate_clip.html.ini
@@ -1,0 +1,2 @@
+[translate_clip.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/translate_clip_nested.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/translate_clip_nested.html.ini
@@ -1,0 +1,2 @@
+[translate_clip_nested.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/vertical-lr-blocks.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/vertical-lr-blocks.html.ini
@@ -1,0 +1,2 @@
+[vertical-lr-blocks.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_bottom_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_bottom_a.html.ini
@@ -1,0 +1,2 @@
+[vertical_align_bottom_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_inline_block_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_inline_block_a.html.ini
@@ -1,0 +1,2 @@
+[vertical_align_inline_block_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_middle_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_middle_a.html.ini
@@ -1,0 +1,2 @@
+[vertical_align_middle_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_sub_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_sub_a.html.ini
@@ -1,0 +1,2 @@
+[vertical_align_sub_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_super_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_super_a.html.ini
@@ -1,0 +1,2 @@
+[vertical_align_super_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_text_bottom_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_text_bottom_a.html.ini
@@ -1,0 +1,2 @@
+[vertical_align_text_bottom_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_top_bottom_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_top_bottom_a.html.ini
@@ -1,0 +1,2 @@
+[vertical_align_top_bottom_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/viewport_meta.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/viewport_meta.html.ini
@@ -1,0 +1,2 @@
+[viewport_meta.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/viewport_rule.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/viewport_rule.html.ini
@@ -1,0 +1,2 @@
+[viewport_rule.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/visibility_hidden.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/visibility_hidden.html.ini
@@ -1,0 +1,2 @@
+[visibility_hidden.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/white-space-mixed-002.htm.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/white-space-mixed-002.htm.ini
@@ -1,0 +1,2 @@
+[white-space-mixed-002.htm]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/white-space-pre-wrap.htm.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/white-space-pre-wrap.htm.ini
@@ -1,0 +1,2 @@
+[white-space-pre-wrap.htm]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/white_space_intrinsic_sizes_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/white_space_intrinsic_sizes_a.html.ini
@@ -1,0 +1,2 @@
+[white_space_intrinsic_sizes_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/whitespace_nowrap_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/whitespace_nowrap_a.html.ini
@@ -1,0 +1,2 @@
+[whitespace_nowrap_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/whitespace_pre.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/whitespace_pre.html.ini
@@ -1,0 +1,2 @@
+[whitespace_pre.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/word-break-keep-all-005.htm.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/word-break-keep-all-005.htm.ini
@@ -1,0 +1,2 @@
+[word-break-keep-all-005.htm]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/word-break-keep-all-006.htm.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/word-break-keep-all-006.htm.ini
@@ -1,0 +1,2 @@
+[word-break-keep-all-006.htm]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/word-break-keep-all-007.htm.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/word-break-keep-all-007.htm.ini
@@ -1,0 +1,2 @@
+[word-break-keep-all-007.htm]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/word_break_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/word_break_a.html.ini
@@ -1,0 +1,2 @@
+[word_break_a.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/writing-mode_change_display.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/writing-mode_change_display.html.ini
@@ -1,0 +1,4 @@
+[writing-mode_change_display.html]
+  [The span's `display` should change from `inline` to `inline-block`, because of its writing-mode.]
+    expected: FAIL
+

--- a/tests/wpt/run.py
+++ b/tests/wpt/run.py
@@ -97,6 +97,7 @@ def set_defaults(kwargs):
 
     if kwargs.pop("layout_2020"):
         kwargs["test_paths"]["/"]["metadata_path"] = wpt_path("metadata-layout-2020")
+        kwargs["test_paths"]["/_mozilla/"]["metadata_path"] = wpt_path("mozilla/meta-layout-2020")
         kwargs["include_manifest"] = wpt_path("include-layout-2020.ini")
 
 

--- a/tests/wpt/update.py
+++ b/tests/wpt/update.py
@@ -36,6 +36,7 @@ def set_defaults(kwargs):
 
     if kwargs.pop("layout_2020"):
         kwargs["test_paths"]["/"]["metadata_path"] = wpt_path("metadata-layout-2020")
+        kwargs["test_paths"]["/_mozilla/"]["metadata_path"] = wpt_path("mozilla/meta-layout-2020")
         kwargs["include_manifest"] = wpt_path("include-layout-2020.ini")
 
 


### PR DESCRIPTION
This change allows mach to run the Mozilla CSS tests when running with the ``--layout2020` argument. This is useful because we can mark tests as passing as features are added.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they are tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
