### PR TITLE
Remove unnecessary LocalName::from(constant) calls

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1293,7 +1293,7 @@ impl HTMLImageElement {
             .filter_map(DomRoot::downcast::<HTMLMapElement>)
             .find(|n| {
                 n.upcast::<Element>()
-                    .get_string_attribute(&LocalName::from("name")) ==
+                    .get_string_attribute(&local_name!("name")) ==
                     last
             });
 

--- a/components/script/dom/servoparser/prefetch.rs
+++ b/components/script/dom/servoparser/prefetch.rs
@@ -128,7 +128,7 @@ impl TokenSink for PrefetchSink {
                         self.origin.clone(),
                         self.pipeline_id,
                         self.get_cors_settings(tag, local_name!("crossorigin")),
-                        self.get_referrer_policy(tag, LocalName::from("referrerpolicy")),
+                        self.get_referrer_policy(tag, local_name!("referrerpolicy")),
                         FromPictureOrSrcSet::No,
                     );
                     let _ = self
@@ -145,7 +145,7 @@ impl TokenSink for PrefetchSink {
                             let cors_setting =
                                 self.get_cors_settings(tag, local_name!("crossorigin"));
                             let referrer_policy =
-                                self.get_referrer_policy(tag, LocalName::from("referrerpolicy"));
+                                self.get_referrer_policy(tag, local_name!("referrerpolicy"));
                             let integrity_metadata = self
                                 .get_attr(tag, local_name!("integrity"))
                                 .map(|attr| String::from(&attr.value))


### PR DESCRIPTION
Changing calls to LocalName::from with a constant argument to use the interned local name instead doesn't really save a meaningful amount of time (when it's not in a loop or on a critical path), but it's good for codebase consistency.
