### PR TITLE
Initial implementation of GPUBindGroup for WebGPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6763,7 +6763,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.1.0"
-source = "git+https://github.com/gfx-rs/wgpu#881222a9477036e9e3504045452d88abfe5ae177"
+source = "git+https://github.com/gfx-rs/wgpu#d4a46cb60e71d6b108e9052cc581e52e44a16a44"
 dependencies = [
  "arrayvec 0.5.1",
  "battery",

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -152,7 +152,8 @@ use tendril::{StrTendril, TendrilSink};
 use time::{Duration, Timespec, Tm};
 use uuid::Uuid;
 use webgpu::{
-    WebGPU, WebGPUAdapter, WebGPUBindGroupLayout, WebGPUBuffer, WebGPUDevice, WebGPUPipelineLayout,
+    WebGPU, WebGPUAdapter, WebGPUBindGroup, WebGPUBindGroupLayout, WebGPUBuffer, WebGPUDevice,
+    WebGPUPipelineLayout,
 };
 use webrender_api::{DocumentId, ImageKey};
 use webvr_traits::{WebVRGamepadData, WebVRGamepadHand, WebVRGamepadState};
@@ -532,6 +533,7 @@ unsafe_no_jsmanaged_fields!(WebGPU);
 unsafe_no_jsmanaged_fields!(WebGPUAdapter);
 unsafe_no_jsmanaged_fields!(WebGPUDevice);
 unsafe_no_jsmanaged_fields!(WebGPUBuffer);
+unsafe_no_jsmanaged_fields!(WebGPUBindGroup);
 unsafe_no_jsmanaged_fields!(WebGPUBindGroupLayout);
 unsafe_no_jsmanaged_fields!(WebGPUPipelineLayout);
 unsafe_no_jsmanaged_fields!(GPUBufferState);

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -94,7 +94,7 @@ use std::sync::Arc;
 use time::{get_time, Timespec};
 use uuid::Uuid;
 use webgpu::wgpu::{
-    id::{AdapterId, BindGroupLayoutId, BufferId, DeviceId, PipelineLayoutId},
+    id::{AdapterId, BindGroupId, BindGroupLayoutId, BufferId, DeviceId, PipelineLayoutId},
     Backend,
 };
 
@@ -1983,6 +1983,10 @@ impl GlobalScope {
 
     pub fn wgpu_create_adapter_ids(&self) -> SmallVec<[AdapterId; 4]> {
         self.gpu_id_hub.borrow_mut().create_adapter_ids()
+    }
+
+    pub fn wgpu_create_bind_group_id(&self, backend: Backend) -> BindGroupId {
+        self.gpu_id_hub.borrow_mut().create_bind_group_id(backend)
     }
 
     pub fn wgpu_create_bind_group_layout_id(&self, backend: Backend) -> BindGroupLayoutId {

--- a/components/script/dom/gpubindgroup.rs
+++ b/components/script/dom/gpubindgroup.rs
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::GPUBindGroupBinding::{
+    GPUBindGroupBinding, GPUBindGroupMethods,
+};
+use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::globalscope::GlobalScope;
+use dom_struct::dom_struct;
+use std::cell::Cell;
+use webgpu::WebGPUBindGroup;
+
+#[dom_struct]
+pub struct GPUBindGroup {
+    reflector_: Reflector,
+    label: DomRefCell<Option<DOMString>>,
+    bind_group: WebGPUBindGroup,
+    valid: Cell<bool>,
+}
+
+impl GPUBindGroup {
+    fn new_inherited(bind_group: WebGPUBindGroup, valid: bool) -> GPUBindGroup {
+        Self {
+            reflector_: Reflector::new(),
+            label: DomRefCell::new(None),
+            bind_group,
+            valid: Cell::new(valid),
+        }
+    }
+
+    pub fn new(
+        global: &GlobalScope,
+        bind_group: WebGPUBindGroup,
+        valid: bool,
+    ) -> DomRoot<GPUBindGroup> {
+        reflect_dom_object(
+            Box::new(GPUBindGroup::new_inherited(bind_group, valid)),
+            global,
+            GPUBindGroupBinding::Wrap,
+        )
+    }
+}
+
+impl GPUBindGroupMethods for GPUBindGroup {
+    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    fn GetLabel(&self) -> Option<DOMString> {
+        self.label.borrow().clone()
+    }
+
+    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    fn SetLabel(&self, value: Option<DOMString>) {
+        *self.label.borrow_mut() = value;
+    }
+}

--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -79,6 +79,20 @@ impl GPUBuffer {
     }
 }
 
+impl GPUBuffer {
+    pub fn id(&self) -> WebGPUBuffer {
+        self.buffer
+    }
+
+    pub fn size(&self) -> GPUBufferSize {
+        self.size
+    }
+
+    pub fn usage(&self) -> u32 {
+        self.usage
+    }
+}
+
 impl Drop for GPUBuffer {
     fn drop(&mut self) {
         self.Destroy()

--- a/components/script/dom/identityhub.rs
+++ b/components/script/dom/identityhub.rs
@@ -5,7 +5,7 @@
 use smallvec::SmallVec;
 use webgpu::wgpu::{
     hub::IdentityManager,
-    id::{AdapterId, BindGroupLayoutId, BufferId, DeviceId, PipelineLayoutId},
+    id::{AdapterId, BindGroupId, BindGroupLayoutId, BufferId, DeviceId, PipelineLayoutId},
     Backend,
 };
 
@@ -14,6 +14,7 @@ pub struct IdentityHub {
     adapters: IdentityManager,
     devices: IdentityManager,
     buffers: IdentityManager,
+    bind_groups: IdentityManager,
     bind_group_layouts: IdentityManager,
     pipeline_layouts: IdentityManager,
     backend: Backend,
@@ -25,6 +26,7 @@ impl IdentityHub {
             adapters: IdentityManager::default(),
             devices: IdentityManager::default(),
             buffers: IdentityManager::default(),
+            bind_groups: IdentityManager::default(),
             bind_group_layouts: IdentityManager::default(),
             pipeline_layouts: IdentityManager::default(),
             backend,
@@ -41,6 +43,10 @@ impl IdentityHub {
 
     fn create_buffer_id(&mut self) -> BufferId {
         self.buffers.alloc(self.backend)
+    }
+
+    fn create_bind_group_id(&mut self) -> BindGroupId {
+        self.bind_groups.alloc(self.backend)
     }
 
     fn create_bind_group_layout_id(&mut self) -> BindGroupLayoutId {
@@ -129,6 +135,20 @@ impl Identities {
             #[cfg(any(target_os = "ios", target_os = "macos"))]
             Backend::Metal => self.metal_hub.create_buffer_id(),
             _ => self.dummy_hub.create_buffer_id(),
+        }
+    }
+
+    pub fn create_bind_group_id(&mut self, backend: Backend) -> BindGroupId {
+        match backend {
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            Backend::Vulkan => self.vk_hub.create_bind_group_id(),
+            #[cfg(target_os = "windows")]
+            Backend::Dx12 => self.dx12_hub.create_bind_group_id(),
+            #[cfg(target_os = "windows")]
+            Backend::Dx11 => self.dx11_hub.create_bind_group_id(),
+            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            Backend::Metal => self.metal_hub.create_bind_group_id(),
+            _ => self.dummy_hub.create_bind_group_id(),
         }
     }
 

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -318,6 +318,7 @@ pub mod gamepadlist;
 pub mod globalscope;
 pub mod gpu;
 pub mod gpuadapter;
+pub mod gpubindgroup;
 pub mod gpubindgrouplayout;
 pub mod gpubuffer;
 pub mod gpubufferusage;

--- a/components/script/dom/webidls/GPUBindGroup.webidl
+++ b/components/script/dom/webidls/GPUBindGroup.webidl
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://gpuweb.github.io/gpuweb/#gpubindgrouplayout
+[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom.webgpu.enabled"]
+interface GPUBindGroup {
+};
+GPUBindGroup includes GPUObjectBase;
+
+dictionary GPUBindGroupDescriptor : GPUObjectDescriptorBase {
+    required GPUBindGroupLayout layout;
+    required sequence<GPUBindGroupBindings> bindings;
+};
+
+typedef /*(GPUSampler or GPUTextureView or*/ GPUBufferBindings/*)*/ GPUBindingResource;
+
+// Note: Servo codegen doesn't like the name `GPUBindGroupBinding` because it's already occupied
+// dictionary GPUBindGroupBinding {
+dictionary GPUBindGroupBindings {
+    required unsigned long binding;
+    required GPUBindingResource resource;
+};
+
+// Note: Servo codegen doesn't like the name `GPUBufferBinding` because it's already occupied
+// dictionary GPUBufferBinding {
+dictionary GPUBufferBindings {
+    required GPUBuffer buffer;
+    GPUBufferSize offset = 0;
+    GPUBufferSize size;
+};

--- a/components/script/dom/webidls/GPUDevice.webidl
+++ b/components/script/dom/webidls/GPUDevice.webidl
@@ -17,9 +17,9 @@ interface GPUDevice : EventTarget {
 
     GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor);
     GPUPipelineLayout createPipelineLayout(GPUPipelineLayoutDescriptor descriptor);
-    /*GPUBindGroup createBindGroup(GPUBindGroupDescriptor descriptor);
+    GPUBindGroup createBindGroup(GPUBindGroupDescriptor descriptor);
 
-    GPUShaderModule createShaderModule(GPUShaderModuleDescriptor descriptor);
+    /*GPUShaderModule createShaderModule(GPUShaderModuleDescriptor descriptor);
     GPUComputePipeline createComputePipeline(GPUComputePipelineDescriptor descriptor);
     GPURenderPipeline createRenderPipeline(GPURenderPipelineDescriptor descriptor);
 


### PR DESCRIPTION
Added WebIDL bindings for `GPUBindGroup`.
Implemented the `createBindGroup` function of `GPUDevice`
Renamed `GPUBindGroupBinding` to `GPUBindGroupBindings` and `GPUBufferBinding` to `GPUBufferBindings` in the WebIDL, because these names are already occupied.

<!-- Please describe your changes on the following line: -->
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes addresses a part of #24706 

cc @kvark @jdm @zakorgy

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
