### PR TITLE
move ConstellationMsg to compositing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,6 +779,7 @@ dependencies = [
  "num-traits",
  "pixels",
  "profile_traits",
+ "rust-webvr",
  "script_traits",
  "servo-media",
  "servo_geometry",
@@ -788,7 +789,6 @@ dependencies = [
  "toml",
  "webrender",
  "webrender_api",
- "webvr",
  "webvr_traits",
  "webxr",
 ]
@@ -6585,6 +6585,7 @@ name = "webdriver_server"
 version = "0.0.1"
 dependencies = [
  "base64",
+ "compositing",
  "cookie",
  "crossbeam-channel",
  "euclid",
@@ -6703,6 +6704,7 @@ name = "webvr"
 version = "0.0.1"
 dependencies = [
  "canvas_traits",
+ "compositing",
  "crossbeam-channel",
  "euclid",
  "ipc-channel",
@@ -6710,7 +6712,6 @@ dependencies = [
  "msg",
  "rust-webvr",
  "rust-webvr-api",
- "script_traits",
  "servo_config",
  "sparkle",
  "webvr_traits",

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -31,6 +31,7 @@ net_traits = {path = "../net_traits"}
 num-traits = "0.2"
 pixels = {path = "../pixels", optional = true}
 profile_traits = {path = "../profile_traits"}
+rust-webvr = {version = "0.16", features = ["mock", "openvr", "vrexternal"]}
 script_traits = {path = "../script_traits"}
 servo_geometry = {path = "../geometry"}
 servo-media = {git = "https://github.com/servo/media"}
@@ -40,7 +41,6 @@ time = "0.1.17"
 webrender = {git = "https://github.com/servo/webrender", features = ["capture"]}
 webrender_api = {git = "https://github.com/servo/webrender"}
 webvr_traits = {path = "../webvr_traits"}
-webvr = {path = "../webvr"}
 webxr = {git = "https://github.com/servo/webxr"}
 
 [build-dependencies]

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -10,8 +10,7 @@ use crate::touch::{TouchAction, TouchHandler};
 use crate::windowing::{
     self, EmbedderCoordinates, MouseWindowEvent, WebRenderDebugOption, WindowMethods,
 };
-use crate::CompositionPipeline;
-use crate::SendableFrameTree;
+use crate::{CompositionPipeline, ConstellationMsg, SendableFrameTree};
 use crossbeam_channel::Sender;
 use embedder_traits::Cursor;
 use euclid::{Point2D, Rect, Scale, Vector2D};
@@ -28,7 +27,7 @@ use num_traits::FromPrimitive;
 use pixels::PixelFormat;
 use profile_traits::time::{self as profile_time, profile, ProfilerCategory};
 use script_traits::CompositorEvent::{MouseButtonEvent, MouseMoveEvent, TouchEvent, WheelEvent};
-use script_traits::{AnimationState, AnimationTickType, ConstellationMsg, LayoutControlMsg};
+use script_traits::{AnimationState, AnimationTickType, LayoutControlMsg};
 use script_traits::{
     MouseButton, MouseEventType, ScrollState, TouchEventType, TouchId, WheelDelta,
 };

--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -5,7 +5,7 @@
 //! Communication with the compositor thread.
 
 use crate::compositor::CompositingReason;
-use crate::SendableFrameTree;
+use crate::{ConstellationMsg, SendableFrameTree};
 use crossbeam_channel::{Receiver, Sender};
 use embedder_traits::EventLoopWaker;
 use euclid::Rect;
@@ -15,7 +15,7 @@ use msg::constellation_msg::{PipelineId, TopLevelBrowsingContextId};
 use net_traits::image::base::Image;
 use profile_traits::mem;
 use profile_traits::time;
-use script_traits::{AnimationState, ConstellationMsg, EventResult, MouseButton, MouseEventType};
+use script_traits::{AnimationState, EventResult, MouseButton, MouseEventType};
 use std::fmt::{Debug, Error, Formatter};
 use style_traits::viewport::ViewportConstraints;
 use style_traits::CSSPixel;

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -11,10 +11,24 @@ pub use crate::compositor::CompositingReason;
 pub use crate::compositor::IOCompositor;
 pub use crate::compositor::ShutdownState;
 pub use crate::compositor_thread::CompositorProxy;
+use embedder_traits::Cursor;
+use gfx_traits::Epoch;
 use ipc_channel::ipc::IpcSender;
+use keyboard_types::KeyboardEvent;
 use msg::constellation_msg::PipelineId;
 use msg::constellation_msg::TopLevelBrowsingContextId;
-use script_traits::{ConstellationControlMsg, LayoutControlMsg};
+use msg::constellation_msg::{BrowsingContextId, TraversalDirection};
+use script_traits::{
+    AnimationTickType, LogEntry, WebDriverCommandMsg, WindowSizeData, WindowSizeType,
+};
+use script_traits::{
+    CompositorEvent, ConstellationControlMsg, LayoutControlMsg, MediaSessionActionType,
+};
+use servo_url::ServoUrl;
+use std::collections::HashMap;
+use std::fmt;
+use std::time::Duration;
+use webvr_traits::WebVREvent;
 
 mod compositor;
 pub mod compositor_thread;
@@ -35,4 +49,99 @@ pub struct CompositionPipeline {
     pub top_level_browsing_context_id: TopLevelBrowsingContextId,
     pub script_chan: IpcSender<ConstellationControlMsg>,
     pub layout_chan: IpcSender<LayoutControlMsg>,
+}
+
+/// Messages to the constellation.
+pub enum ConstellationMsg {
+    /// Exit the constellation.
+    Exit,
+    /// Request that the constellation send the BrowsingContextId corresponding to the document
+    /// with the provided pipeline id
+    GetBrowsingContext(PipelineId, IpcSender<Option<BrowsingContextId>>),
+    /// Request that the constellation send the current pipeline id for the provided
+    /// browsing context id, over a provided channel.
+    GetPipeline(BrowsingContextId, IpcSender<Option<PipelineId>>),
+    /// Request that the constellation send the current focused top-level browsing context id,
+    /// over a provided channel.
+    GetFocusTopLevelBrowsingContext(IpcSender<Option<TopLevelBrowsingContextId>>),
+    /// Query the constellation to see if the current compositor output is stable
+    IsReadyToSaveImage(HashMap<PipelineId, Epoch>),
+    /// Inform the constellation of a key event.
+    Keyboard(KeyboardEvent),
+    /// Whether to allow script to navigate.
+    AllowNavigationResponse(PipelineId, bool),
+    /// Request to load a page.
+    LoadUrl(TopLevelBrowsingContextId, ServoUrl),
+    /// Request to traverse the joint session history of the provided browsing context.
+    TraverseHistory(TopLevelBrowsingContextId, TraversalDirection),
+    /// Inform the constellation of a window being resized.
+    WindowSize(
+        Option<TopLevelBrowsingContextId>,
+        WindowSizeData,
+        WindowSizeType,
+    ),
+    /// Requests that the constellation instruct layout to begin a new tick of the animation.
+    TickAnimation(PipelineId, AnimationTickType),
+    /// Dispatch a webdriver command
+    WebDriverCommand(WebDriverCommandMsg),
+    /// Reload a top-level browsing context.
+    Reload(TopLevelBrowsingContextId),
+    /// A log entry, with the top-level browsing context id and thread name
+    LogEntry(Option<TopLevelBrowsingContextId>, Option<String>, LogEntry),
+    /// Dispatch WebVR events to the subscribed script threads.
+    WebVREvents(Vec<PipelineId>, Vec<WebVREvent>),
+    /// Create a new top level browsing context.
+    NewBrowser(ServoUrl, TopLevelBrowsingContextId),
+    /// Close a top level browsing context.
+    CloseBrowser(TopLevelBrowsingContextId),
+    /// Panic a top level browsing context.
+    SendError(Option<TopLevelBrowsingContextId>, String),
+    /// Make browser visible.
+    SelectBrowser(TopLevelBrowsingContextId),
+    /// Forward an event to the script task of the given pipeline.
+    ForwardEvent(PipelineId, CompositorEvent),
+    /// Requesting a change to the onscreen cursor.
+    SetCursor(Cursor),
+    /// Enable the sampling profiler, with a given sampling rate and max total sampling duration.
+    EnableProfiler(Duration, Duration),
+    /// Disable the sampling profiler.
+    DisableProfiler,
+    /// Request to exit from fullscreen mode
+    ExitFullScreen(TopLevelBrowsingContextId),
+    /// Media session action.
+    MediaSessionAction(MediaSessionActionType),
+}
+
+impl fmt::Debug for ConstellationMsg {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        use self::ConstellationMsg::*;
+        let variant = match *self {
+            Exit => "Exit",
+            GetBrowsingContext(..) => "GetBrowsingContext",
+            GetPipeline(..) => "GetPipeline",
+            GetFocusTopLevelBrowsingContext(..) => "GetFocusTopLevelBrowsingContext",
+            IsReadyToSaveImage(..) => "IsReadyToSaveImage",
+            Keyboard(..) => "Keyboard",
+            AllowNavigationResponse(..) => "AllowNavigationResponse",
+            LoadUrl(..) => "LoadUrl",
+            TraverseHistory(..) => "TraverseHistory",
+            WindowSize(..) => "WindowSize",
+            TickAnimation(..) => "TickAnimation",
+            WebDriverCommand(..) => "WebDriverCommand",
+            Reload(..) => "Reload",
+            LogEntry(..) => "LogEntry",
+            WebVREvents(..) => "WebVREvents",
+            NewBrowser(..) => "NewBrowser",
+            CloseBrowser(..) => "CloseBrowser",
+            SendError(..) => "SendError",
+            SelectBrowser(..) => "SelectBrowser",
+            ForwardEvent(..) => "ForwardEvent",
+            SetCursor(..) => "SetCursor",
+            EnableProfiler(..) => "EnableProfiler",
+            DisableProfiler => "DisableProfiler",
+            ExitFullScreen(..) => "ExitFullScreen",
+            MediaSessionAction(..) => "MediaSessionAction",
+        };
+        write!(formatter, "ConstellationMsg::{}", variant)
+    }
 }

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -20,10 +20,10 @@ use std::rc::Rc;
 use std::time::Duration;
 use style_traits::DevicePixel;
 
+use rust_webvr::VRServiceManager;
 use webrender_api::units::DevicePoint;
 use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 use webrender_api::ScrollLocation;
-use webvr::VRServiceManager;
 use webvr_traits::WebVRMainThreadHeartbeat;
 
 #[derive(Clone)]

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -109,7 +109,7 @@ use canvas_traits::canvas::{CanvasId, CanvasMsg};
 use canvas_traits::webgl::WebGLThreads;
 use compositing::compositor_thread::CompositorProxy;
 use compositing::compositor_thread::Msg as ToCompositorMsg;
-use compositing::SendableFrameTree;
+use compositing::{ConstellationMsg as FromCompositorMsg, SendableFrameTree};
 use crossbeam_channel::{after, never, unbounded, Receiver, Sender};
 use devtools_traits::{ChromeToDevtoolsControlMsg, DevtoolsControlMsg};
 use embedder_traits::{Cursor, EmbedderMsg, EmbedderProxy, EventLoopWaker};
@@ -145,9 +145,7 @@ use script_traits::{webdriver_msg, LogEntry, ScriptToConstellationChan, ServiceW
 use script_traits::{
     AnimationState, AnimationTickType, AuxiliaryBrowsingContextLoadInfo, CompositorEvent,
 };
-use script_traits::{
-    ConstellationControlMsg, ConstellationMsg as FromCompositorMsg, DiscardBrowsingContext,
-};
+use script_traits::{ConstellationControlMsg, DiscardBrowsingContext};
 use script_traits::{DocumentActivity, DocumentState, LayoutControlMsg, LoadData, LoadOrigin};
 use script_traits::{HistoryEntryReplacement, IFrameSizeMsg, WindowSizeData, WindowSizeType};
 use script_traits::{

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -419,7 +419,7 @@ pub enum EventPhase {
 /// helps us to prevent such events from being [sent to the constellation][msg] where it will be
 /// handled once again for page scrolling (which is definitely not what we'd want).
 ///
-/// [msg]: https://doc.servo.org/script_traits/enum.ConstellationMsg.html#variant.KeyEvent
+/// [msg]: https://doc.servo.org/compositing/enum.ConstellationMsg.html#variant.KeyEvent
 ///
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]
 pub enum EventDefault {

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -28,7 +28,7 @@ use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::WebGLPipeline;
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, WorkerId};
-use embedder_traits::{Cursor, EventLoopWaker};
+use embedder_traits::EventLoopWaker;
 use euclid::{default::Point2D, Length, Rect, Scale, Size2D, UnknownUnit, Vector2D};
 use gfx_traits::Epoch;
 use http::HeaderMap;
@@ -44,7 +44,7 @@ use msg::constellation_msg::BackgroundHangMonitorRegister;
 use msg::constellation_msg::{
     BlobId, BrowsingContextId, HistoryStateId, MessagePortId, PipelineId,
 };
-use msg::constellation_msg::{PipelineNamespaceId, TopLevelBrowsingContextId, TraversalDirection};
+use msg::constellation_msg::{PipelineNamespaceId, TopLevelBrowsingContextId};
 use net_traits::image::base::Image;
 use net_traits::image_cache::ImageCache;
 use net_traits::request::Referrer;
@@ -62,7 +62,6 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use std::time::Duration;
 use style_traits::CSSPixel;
 use style_traits::SpeculativePainter;
 use webrender_api::units::{
@@ -834,102 +833,6 @@ pub enum WebDriverCommandMsg {
         Option<Rect<f32, CSSPixel>>,
         IpcSender<Option<Image>>,
     ),
-}
-
-/// Messages to the constellation.
-#[derive(Deserialize, Serialize)]
-pub enum ConstellationMsg {
-    /// Exit the constellation.
-    Exit,
-    /// Request that the constellation send the BrowsingContextId corresponding to the document
-    /// with the provided pipeline id
-    GetBrowsingContext(PipelineId, IpcSender<Option<BrowsingContextId>>),
-    /// Request that the constellation send the current pipeline id for the provided
-    /// browsing context id, over a provided channel.
-    GetPipeline(BrowsingContextId, IpcSender<Option<PipelineId>>),
-    /// Request that the constellation send the current focused top-level browsing context id,
-    /// over a provided channel.
-    GetFocusTopLevelBrowsingContext(IpcSender<Option<TopLevelBrowsingContextId>>),
-    /// Query the constellation to see if the current compositor output is stable
-    IsReadyToSaveImage(HashMap<PipelineId, Epoch>),
-    /// Inform the constellation of a key event.
-    Keyboard(KeyboardEvent),
-    /// Whether to allow script to navigate.
-    AllowNavigationResponse(PipelineId, bool),
-    /// Request to load a page.
-    LoadUrl(TopLevelBrowsingContextId, ServoUrl),
-    /// Request to traverse the joint session history of the provided browsing context.
-    TraverseHistory(TopLevelBrowsingContextId, TraversalDirection),
-    /// Inform the constellation of a window being resized.
-    WindowSize(
-        Option<TopLevelBrowsingContextId>,
-        WindowSizeData,
-        WindowSizeType,
-    ),
-    /// Requests that the constellation instruct layout to begin a new tick of the animation.
-    TickAnimation(PipelineId, AnimationTickType),
-    /// Dispatch a webdriver command
-    WebDriverCommand(WebDriverCommandMsg),
-    /// Reload a top-level browsing context.
-    Reload(TopLevelBrowsingContextId),
-    /// A log entry, with the top-level browsing context id and thread name
-    LogEntry(Option<TopLevelBrowsingContextId>, Option<String>, LogEntry),
-    /// Dispatch WebVR events to the subscribed script threads.
-    WebVREvents(Vec<PipelineId>, Vec<WebVREvent>),
-    /// Create a new top level browsing context.
-    NewBrowser(ServoUrl, TopLevelBrowsingContextId),
-    /// Close a top level browsing context.
-    CloseBrowser(TopLevelBrowsingContextId),
-    /// Panic a top level browsing context.
-    SendError(Option<TopLevelBrowsingContextId>, String),
-    /// Make browser visible.
-    SelectBrowser(TopLevelBrowsingContextId),
-    /// Forward an event to the script task of the given pipeline.
-    ForwardEvent(PipelineId, CompositorEvent),
-    /// Requesting a change to the onscreen cursor.
-    SetCursor(Cursor),
-    /// Enable the sampling profiler, with a given sampling rate and max total sampling duration.
-    EnableProfiler(Duration, Duration),
-    /// Disable the sampling profiler.
-    DisableProfiler,
-    /// Request to exit from fullscreen mode
-    ExitFullScreen(TopLevelBrowsingContextId),
-    /// Media session action.
-    MediaSessionAction(MediaSessionActionType),
-}
-
-impl fmt::Debug for ConstellationMsg {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        use self::ConstellationMsg::*;
-        let variant = match *self {
-            Exit => "Exit",
-            GetBrowsingContext(..) => "GetBrowsingContext",
-            GetPipeline(..) => "GetPipeline",
-            GetFocusTopLevelBrowsingContext(..) => "GetFocusTopLevelBrowsingContext",
-            IsReadyToSaveImage(..) => "IsReadyToSaveImage",
-            Keyboard(..) => "Keyboard",
-            AllowNavigationResponse(..) => "AllowNavigationResponse",
-            LoadUrl(..) => "LoadUrl",
-            TraverseHistory(..) => "TraverseHistory",
-            WindowSize(..) => "WindowSize",
-            TickAnimation(..) => "TickAnimation",
-            WebDriverCommand(..) => "WebDriverCommand",
-            Reload(..) => "Reload",
-            LogEntry(..) => "LogEntry",
-            WebVREvents(..) => "WebVREvents",
-            NewBrowser(..) => "NewBrowser",
-            CloseBrowser(..) => "CloseBrowser",
-            SendError(..) => "SendError",
-            SelectBrowser(..) => "SelectBrowser",
-            ForwardEvent(..) => "ForwardEvent",
-            SetCursor(..) => "SetCursor",
-            EnableProfiler(..) => "EnableProfiler",
-            DisableProfiler => "DisableProfiler",
-            ExitFullScreen(..) => "ExitFullScreen",
-            MediaSessionAction(..) => "MediaSessionAction",
-        };
-        write!(formatter, "ConstellationMsg::{}", variant)
-    }
 }
 
 /// Resources required by workerglobalscopes

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -71,7 +71,7 @@ use compositing::compositor_thread::{
     CompositorProxy, CompositorReceiver, InitialCompositorState, Msg,
 };
 use compositing::windowing::{EmbedderMethods, WindowEvent, WindowMethods};
-use compositing::{CompositingReason, IOCompositor, ShutdownState};
+use compositing::{CompositingReason, ConstellationMsg, IOCompositor, ShutdownState};
 #[cfg(all(
     not(target_os = "windows"),
     not(target_os = "ios"),
@@ -106,9 +106,7 @@ use profile::time as profile_time;
 use profile_traits::mem;
 use profile_traits::time;
 use script::JSEngineSetup;
-use script_traits::{
-    ConstellationMsg, SWManagerSenders, ScriptToConstellationChan, WindowSizeData,
-};
+use script_traits::{SWManagerSenders, ScriptToConstellationChan, WindowSizeData};
 use servo_config::opts;
 use servo_config::{pref, prefs};
 use servo_media::player::context::GlContext;

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -12,6 +12,7 @@ path = "lib.rs"
 
 [dependencies]
 base64 = "0.10"
+compositing = {path = "../compositing"}
 cookie = "0.11"
 crossbeam-channel = "0.3"
 euclid = "0.20"

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -3,10 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::Handler;
+use compositing::ConstellationMsg;
 use ipc_channel::ipc;
 use keyboard_types::webdriver::KeyInputState;
 use script_traits::webdriver_msg::WebDriverScriptCommand;
-use script_traits::{ConstellationMsg, MouseButton, MouseEventType, WebDriverCommandMsg};
+use script_traits::{MouseButton, MouseEventType, WebDriverCommandMsg};
 use std::cmp;
 use std::collections::HashSet;
 use std::thread;

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -21,6 +21,7 @@ mod capabilities;
 use crate::actions::{InputSourceState, PointerInputState};
 use base64;
 use capabilities::ServoCapabilities;
+use compositing::ConstellationMsg;
 use crossbeam_channel::{after, unbounded, Receiver, Sender};
 use euclid::{Rect, Size2D};
 use hyper::Method;
@@ -34,7 +35,7 @@ use script_traits::webdriver_msg::{LoadStatus, WebDriverCookieError, WebDriverFr
 use script_traits::webdriver_msg::{
     WebDriverJSError, WebDriverJSResult, WebDriverJSValue, WebDriverScriptCommand,
 };
-use script_traits::{ConstellationMsg, LoadData, LoadOrigin, WebDriverCommandMsg};
+use script_traits::{LoadData, LoadOrigin, WebDriverCommandMsg};
 use serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
 use serde::ser::{Serialize, Serializer};
 use serde_json::{json, Value};

--- a/components/webvr/Cargo.toml
+++ b/components/webvr/Cargo.toml
@@ -16,6 +16,7 @@ oculusvr = ['rust-webvr/oculusvr']
 
 [dependencies]
 canvas_traits = {path = "../canvas_traits"}
+compositing = {path = "../compositing"}
 crossbeam-channel = "0.3"
 euclid = "0.20"
 ipc-channel = "0.12"
@@ -23,7 +24,6 @@ log = "0.4"
 msg = {path = "../msg"}
 rust-webvr = {version = "0.16", features = ["mock", "openvr", "vrexternal"]}
 rust-webvr-api = "0.16"
-script_traits = {path = "../script_traits"}
 servo_config = {path = "../config"}
 sparkle = "0.1"
 webvr_traits = {path = "../webvr_traits" }

--- a/components/webvr/webvr_thread.rs
+++ b/components/webvr/webvr_thread.rs
@@ -3,13 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use canvas_traits::webgl;
+use compositing::ConstellationMsg;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use euclid::default::Size2D;
 use ipc_channel::ipc;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use msg::constellation_msg::PipelineId;
 use rust_webvr::VRServiceManager;
-use script_traits::ConstellationMsg;
 use servo_config::pref;
 use sparkle::gl::Gl;
 use std::collections::hash_map::Entry;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`ConstellationMsg` enum in script_traits is moved to compositing since it's not used by script_traits. The other enums mentioned in the issue, `LayoutControllerMsg` and `LayoutMsg` cannot be moved out of script_traits since script_traits depends on both of them and moving out would create cyclic dependencies.

r?@gterzian

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #20758  (GitHub issue number if applicable)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
