### PR TITLE
Give error and resize special getter/setters for body/frameset reflection

### DIFF
--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -5,6 +5,7 @@
 use crate::dom::activation::{synthetic_click_activation, ActivationSource};
 use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
+use crate::dom::bindings::codegen::Bindings::EventHandlerBinding::OnErrorEventHandlerNonNull;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLLabelElementBinding::HTMLLabelElementMethods;
@@ -181,6 +182,35 @@ impl HTMLElementMethods for HTMLElement {
         self.dataset.or_init(|| DOMStringMap::new(self))
     }
 
+    // https://html.spec.whatwg.org/multipage/#handler-onerror
+    fn GetOnerror(&self) -> Option<Rc<OnErrorEventHandlerNonNull>> {
+        if self.is_body_or_frameset() {
+            let document = document_from_node(self);
+            if document.has_browsing_context() {
+                document.window().GetOnerror()
+            } else {
+                None
+            }
+        } else {
+            self.upcast::<EventTarget>()
+                .get_event_handler_common("error")
+        }
+    }
+
+    // https://html.spec.whatwg.org/multipage/#handler-onerror
+    fn SetOnerror(&self, listener: Option<Rc<OnErrorEventHandlerNonNull>>) {
+        if self.is_body_or_frameset() {
+            let document = document_from_node(self);
+            if document.has_browsing_context() {
+                document.window().SetOnerror(listener)
+            }
+        } else {
+            // special setter for error
+            self.upcast::<EventTarget>()
+                .set_error_event_handler("error", listener)
+        }
+    }
+
     // https://html.spec.whatwg.org/multipage/#handler-onload
     fn GetOnload(&self) -> Option<Rc<EventHandlerNonNull>> {
         if self.is_body_or_frameset() {
@@ -206,34 +236,6 @@ impl HTMLElementMethods for HTMLElement {
         } else {
             self.upcast::<EventTarget>()
                 .set_event_handler_common("load", listener)
-        }
-    }
-
-    // https://html.spec.whatwg.org/multipage/#handler-onresize
-    fn GetOnresize(&self) -> Option<Rc<EventHandlerNonNull>> {
-        if self.is_body_or_frameset() {
-            let document = document_from_node(self);
-            if document.has_browsing_context() {
-                document.window().GetOnload()
-            } else {
-                None
-            }
-        } else {
-            self.upcast::<EventTarget>()
-                .get_event_handler_common("resize")
-        }
-    }
-
-    // https://html.spec.whatwg.org/multipage/#handler-onresize
-    fn SetOnresize(&self, listener: Option<Rc<EventHandlerNonNull>>) {
-        if self.is_body_or_frameset() {
-            let document = document_from_node(self);
-            if document.has_browsing_context() {
-                document.window().SetOnresize(listener);
-            }
-        } else {
-            self.upcast::<EventTarget>()
-                .set_event_handler_common("resize", listener)
         }
     }
 
@@ -290,6 +292,34 @@ impl HTMLElementMethods for HTMLElement {
         } else {
             self.upcast::<EventTarget>()
                 .set_event_handler_common("focus", listener)
+        }
+    }
+
+    // https://html.spec.whatwg.org/multipage/#handler-onresize
+    fn GetOnresize(&self) -> Option<Rc<EventHandlerNonNull>> {
+        if self.is_body_or_frameset() {
+            let document = document_from_node(self);
+            if document.has_browsing_context() {
+                document.window().GetOnresize()
+            } else {
+                None
+            }
+        } else {
+            self.upcast::<EventTarget>()
+                .get_event_handler_common("resize")
+        }
+    }
+
+    // https://html.spec.whatwg.org/multipage/#handler-onresize
+    fn SetOnresize(&self, listener: Option<Rc<EventHandlerNonNull>>) {
+        if self.is_body_or_frameset() {
+            let document = document_from_node(self);
+            if document.has_browsing_context() {
+                document.window().SetOnresize(listener)
+            }
+        } else {
+            self.upcast::<EventTarget>()
+                .set_event_handler_common("resize", listener)
         }
     }
 

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -430,7 +430,9 @@ macro_rules! window_owned_beforeunload_event_handler(
 // As more methods get added, just update them here.
 macro_rules! global_event_handlers(
     () => (
+        // These are special when on body/frameset elements
         event_handler!(blur, GetOnblur, SetOnblur);
+        error_event_handler!(error, GetOnerror, SetOnerror);
         event_handler!(focus, GetOnfocus, SetOnfocus);
         event_handler!(load, GetOnload, SetOnload);
         event_handler!(resize, GetOnresize, SetOnresize);
@@ -460,7 +462,6 @@ macro_rules! global_event_handlers(
         event_handler!(durationchange, GetOndurationchange, SetOndurationchange);
         event_handler!(emptied, GetOnemptied, SetOnemptied);
         event_handler!(ended, GetOnended, SetOnended);
-        error_event_handler!(error, GetOnerror, SetOnerror);
         event_handler!(formdata, GetOnformdata, SetOnformdata);
         event_handler!(input, GetOninput, SetOninput);
         event_handler!(invalid, GetOninvalid, SetOninvalid);

--- a/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-attributes-body-window.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-attributes-body-window.html.ini
@@ -1,12 +1,7 @@
 [event-handler-attributes-body-window.html]
   type: testharness
-  [error]
-    expected: FAIL
 
   [HTMLBodyElement event handlers]
-    expected: FAIL
-
-  [shadowed error (document.body)]
     expected: FAIL
 
   [not shadowed auxclick (document.body)]
@@ -27,9 +22,6 @@
   [not shadowed paste (document.body)]
     expected: FAIL
 
-  [shadowed error (document.createElement("body"))]
-    expected: FAIL
-
   [not shadowed auxclick (document.createElement("body"))]
     expected: FAIL
 
@@ -48,25 +40,13 @@
   [not shadowed paste (document.createElement("body"))]
     expected: FAIL
 
-  [shadowed resize (window)]
-    expected: FAIL
-
   [not shadowed loadend (window)]
-    expected: FAIL
-
-  [shadowed resize (document.body)]
-    expected: FAIL
-
-  [shadowed resize (document.createElement("body"))]
     expected: FAIL
 
   [not shadowed securitypolicyviolation (window)]
     expected: FAIL
 
   [not shadowed auxclick (window)]
-    expected: FAIL
-
-  [shadowed error (window)]
     expected: FAIL
 
   [not shadowed slotchange (window)]
@@ -113,4 +93,3 @@
 
   [not shadowed webkitanimationstart (window)]
     expected: FAIL
-

--- a/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-attributes-frameset-window.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-attributes-frameset-window.html.ini
@@ -1,17 +1,5 @@
 [event-handler-attributes-frameset-window.html]
-  [shadowed resize (window)]
-    expected: FAIL
-
-  [shadowed error (document.createElement("frameset"))]
-    expected: FAIL
-
   [not shadowed paste (document.createElement("frameset"))]
-    expected: FAIL
-
-  [shadowed resize (document.body)]
-    expected: FAIL
-
-  [shadowed resize (document.createElement("frameset"))]
     expected: FAIL
 
   [not shadowed securitypolicyviolation (document.body)]
@@ -44,9 +32,6 @@
   [not shadowed paste (document.body)]
     expected: FAIL
 
-  [shadowed error (document.body)]
-    expected: FAIL
-
   [not shadowed copy (document.body)]
     expected: FAIL
 
@@ -54,9 +39,6 @@
     expected: FAIL
 
   [not shadowed cut (document.createElement("frameset"))]
-    expected: FAIL
-
-  [shadowed error (window)]
     expected: FAIL
 
   [not shadowed auxclick (document.createElement("frameset"))]
@@ -106,4 +88,3 @@
 
   [not shadowed webkitanimationiteration (document.body)]
     expected: FAIL
-

--- a/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-attributes-windowless-body.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-attributes-windowless-body.html.ini
@@ -2,9 +2,6 @@
   [event-handler-attributes-windowless-body]
     expected: FAIL
 
-  [Ignore setting of error window event handlers on windowless body]
-    expected: FAIL
-
   [auxclick is unaffected on a windowless body]
     expected: FAIL
 
@@ -12,9 +9,6 @@
     expected: FAIL
 
   [securitypolicyviolation is unaffected on a windowless body]
-    expected: FAIL
-
-  [Ignore setting of error window event handlers on windowless frameset]
     expected: FAIL
 
   [auxclick is unaffected on a windowless frameset]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Most of the event handlers that needed to be reflected between body and window were doing so via special getter/setters in htmlelement.rs, but error and resize were missing; they are now included, passing the tests for whether these are reflected.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25186 for the case that isn't a bad test or an unimplemented event type, and fix #25187 

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
