### PR TITLE
Add support for overflow:scroll and overflow:hidden to layout_2020

### DIFF
--- a/components/style/properties/longhands/box.mako.rs
+++ b/components/style/properties/longhands/box.mako.rs
@@ -131,7 +131,6 @@ ${helpers.single_keyword(
         "Overflow",
         "computed::Overflow::Visible",
         engines="gecko servo-2013 servo-2020",
-        servo_2020_pref="layout.2020.unimplemented",
         logical_group="overflow",
         logical=logical,
         animation_value_type="discrete",

--- a/components/style/properties/shorthands/box.mako.rs
+++ b/components/style/properties/shorthands/box.mako.rs
@@ -9,7 +9,7 @@ ${helpers.two_properties_shorthand(
     "overflow-x",
     "overflow-y",
     "specified::Overflow::parse",
-    engines="gecko servo-2013",
+    engines="gecko servo-2013 servo-2020",
     flags="SHORTHAND_IN_GETCS",
     needs_context=False,
     spec="https://drafts.csswg.org/css-overflow/#propdef-overflow",

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-repeat/background-repeat-repeat-x.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-repeat/background-repeat-repeat-x.xht.ini
@@ -1,2 +1,0 @@
-[background-repeat-repeat-x.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-repeat/background-repeat-repeat-y.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-repeat/background-repeat-repeat-y.xht.ini
@@ -1,2 +1,0 @@
-[background-repeat-repeat-y.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-size/background-size-contain.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-size/background-size-contain.xht.ini
@@ -1,2 +1,0 @@
-[background-size-contain.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-size/background-size-cover.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-size/background-size-cover.xht.ini
@@ -1,2 +1,0 @@
-[background-size-cover.xht]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/acid2_ref.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/acid2_ref.html.ini
@@ -1,2 +1,0 @@
-[acid2_ref.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/border_radius_clip_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/border_radius_clip_a.html.ini
@@ -1,2 +1,0 @@
-[border_radius_clip_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-bottom.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-bottom.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-bottom.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-top.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-top.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-top.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_auto.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_auto.html.ini
@@ -1,2 +1,0 @@
-[overflow_auto.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_position_abs_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_position_abs_simple_a.html.ini
@@ -1,2 +1,0 @@
-[overflow_position_abs_simple_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_scroll.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_scroll.html.ini
@@ -1,2 +1,0 @@
-[overflow_scroll.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_simple_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_simple_a.html.ini
@@ -1,2 +1,0 @@
-[overflow_simple_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/overflow_xy_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/overflow_xy_a.html.ini
@@ -1,2 +1,0 @@
-[overflow_xy_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_overflow_ellipsis.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_overflow_ellipsis.html.ini
@@ -1,2 +1,0 @@
-[text_overflow_ellipsis.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/text_overflow_string.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/text_overflow_string.html.ini
@@ -1,2 +1,0 @@
-[text_overflow_string.html]
-  expected: FAIL


### PR DESCRIPTION
This adds clipping and interactive scrolling support, but scrolling from
script is still not functional.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
