### PR TITLE
Do not include request progress/total values on XHR timeout

### DIFF
--- a/tests/wpt/metadata/xhr/abort-during-upload.any.js.ini
+++ b/tests/wpt/metadata/xhr/abort-during-upload.any.js.ini
@@ -1,8 +1,0 @@
-[abort-during-upload.any.html]
-  [XMLHttpRequest: abort() while sending data]
-    expected: PASS
-
-
-[abort-during-upload.any.worker.html]
-  [XMLHttpRequest: abort() while sending data]
-    expected: PASS

--- a/tests/wpt/metadata/xhr/abort-during-upload.any.js.ini
+++ b/tests/wpt/metadata/xhr/abort-during-upload.any.js.ini
@@ -1,9 +1,8 @@
 [abort-during-upload.any.html]
   [XMLHttpRequest: abort() while sending data]
-    expected: FAIL
+    expected: PASS
 
 
 [abort-during-upload.any.worker.html]
   [XMLHttpRequest: abort() while sending data]
-    expected: FAIL
-
+    expected: PASS

--- a/tests/wpt/metadata/xhr/abort-event-order.htm.ini
+++ b/tests/wpt/metadata/xhr/abort-event-order.htm.ini
@@ -1,5 +1,4 @@
 [abort-event-order.htm]
   type: testharness
   [XMLHttpRequest: The abort() method: abort and loadend events]
-    expected: FAIL
-
+    expected: PASS

--- a/tests/wpt/metadata/xhr/abort-event-order.htm.ini
+++ b/tests/wpt/metadata/xhr/abort-event-order.htm.ini
@@ -1,4 +1,0 @@
-[abort-event-order.htm]
-  type: testharness
-  [XMLHttpRequest: The abort() method: abort and loadend events]
-    expected: PASS

--- a/tests/wpt/metadata/xhr/event-error-order.sub.html.ini
+++ b/tests/wpt/metadata/xhr/event-error-order.sub.html.ini
@@ -1,5 +1,4 @@
 [event-error-order.sub.html]
   type: testharness
   [XMLHttpRequest: event - error (order of events)]
-    expected: FAIL
-
+    expected: PASS

--- a/tests/wpt/metadata/xhr/event-error-order.sub.html.ini
+++ b/tests/wpt/metadata/xhr/event-error-order.sub.html.ini
@@ -1,4 +1,0 @@
-[event-error-order.sub.html]
-  type: testharness
-  [XMLHttpRequest: event - error (order of events)]
-    expected: PASS

--- a/tests/wpt/metadata/xhr/event-timeout-order.any.js.ini
+++ b/tests/wpt/metadata/xhr/event-timeout-order.any.js.ini
@@ -1,9 +1,8 @@
 [event-timeout-order.any.html]
   [XMLHttpRequest: event - timeout (order of events)]
-    expected: FAIL
+    expected: PASS
 
 
 [event-timeout-order.any.worker.html]
   [XMLHttpRequest: event - timeout (order of events)]
-    expected: FAIL
-
+    expected: PASS

--- a/tests/wpt/metadata/xhr/event-timeout-order.any.js.ini
+++ b/tests/wpt/metadata/xhr/event-timeout-order.any.js.ini
@@ -1,8 +1,0 @@
-[event-timeout-order.any.html]
-  [XMLHttpRequest: event - timeout (order of events)]
-    expected: PASS
-
-
-[event-timeout-order.any.worker.html]
-  [XMLHttpRequest: event - timeout (order of events)]
-    expected: PASS

--- a/tests/wpt/metadata/xhr/send-timeout-events.htm.ini
+++ b/tests/wpt/metadata/xhr/send-timeout-events.htm.ini
@@ -1,4 +1,0 @@
-[send-timeout-events.htm]
-  type: testharness
-  [XMLHttpRequest: The send() method: timeout is not 0 ]
-    expected: PASS

--- a/tests/wpt/metadata/xhr/send-timeout-events.htm.ini
+++ b/tests/wpt/metadata/xhr/send-timeout-events.htm.ini
@@ -1,5 +1,4 @@
 [send-timeout-events.htm]
   type: testharness
   [XMLHttpRequest: The send() method: timeout is not 0 ]
-    expected: FAIL
-
+    expected: PASS


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Do not include request progress/total values on XHR timeout as [the specification]( https://xhr.spec.whatwg.org/#request-error-steps) states that upload events when errors occur should always pass 0 for both values. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24286

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
