### PR TITLE
Make nulling out an inline event handler remove it from the list order

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -404,9 +404,15 @@ impl EventTarget {
         });
 
         match idx {
-            Some(idx) => {
-                entries[idx].listener =
-                    EventListenerType::Inline(listener.unwrap_or(InlineEventListener::Null));
+            Some(idx) => match listener {
+                // Replace if there's something to replace with,
+                // but remove entirely if there isn't.
+                Some(listener) => {
+                    entries[idx].listener = EventListenerType::Inline(listener);
+                },
+                None => {
+                    entries.remove(idx);
+                },
             },
             None => {
                 if let Some(listener) = listener {

--- a/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-removal.window.js.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/events/event-handler-removal.window.js.ini
@@ -1,10 +1,3 @@
 [event-handler-removal.window.html]
   [Event handler set through content attribute should be deactivated when the content attribute is removed.]
     expected: FAIL
-
-  [Event handler set through IDL should be deactivated when the IDL attribute is set to null.]
-    expected: FAIL
-
-  [Event handler set through content attribute should be removed when they are set to null.]
-    expected: FAIL
-


### PR DESCRIPTION
Setting a content attribute or IDL attribute to null now removes event handlers like it's supposed to; the removeAttribute case seems to be something deeper which this change doesn't fix.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25196, but not the related #25652

<!-- Either: -->
- [X] There are tests for these changes 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
