### PR TITLE
Try to avoid panicking during I/O in the signal and panic handlers.

### DIFF
--- a/ports/glutin/backtrace.rs
+++ b/ports/glutin/backtrace.rs
@@ -13,8 +13,8 @@ use std::fmt::{self, Write};
 use backtrace::{BytesOrWideString, PrintFmt};
 
 #[inline(never)]
-pub(crate) fn print() {
-    println!("{:?}", Print {
+pub(crate) fn print(w: &mut dyn std::io::Write) -> Result<(), std::io::Error> {
+    write!(w, "{:?}", Print {
         print_fn_address: print as usize,
     })
 }


### PR DESCRIPTION
A bunch of mac WPT processes are sitting in zombie states where a thread has hit a double panic while printing the backtrace. These changes attempt to prevent this issue by ignoring any I/O failures that occur while printing, instead of panicking.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25513
- [x] These changes do not require tests because they address an intermittent edge case

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
