### PR TITLE
Correctly install 'nigthtly' (without a date) if it’s not installed already

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -1009,7 +1009,12 @@ install them, let us know by filing a bug!")
             self.ensure_rustup_version()
             toolchain = self.rust_toolchain()
 
-            if toolchain.encode("utf-8") not in check_output(["rustup", "toolchain", "list"]):
+            status = subprocess.call(
+                ["rustup", "run", toolchain.encode("utf-8"), "rustc", "--version"],
+                stdout=open(os.devnull, "wb"),
+                stderr=subprocess.STDOUT,
+            )
+            if status:
                 check_call(["rustup", "toolchain", "install", "--profile", "minimal", toolchain])
 
             installed = check_output(


### PR DESCRIPTION
Should fix errors like:

https://community-tc.services.mozilla.com/tasks/WWNv1op4QUau10ixVuJfFQ/runs/0/logs/https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FWWNv1op4QUau10ixVuJfFQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L364-401

… where the previous code would find the string `nightly` in the output of `rustup toolchain list` in a line like `nightly-2020-01-16-x86_64-unknown-linux-gnu` and conclude that that toolchain was already installed.