### PR TITLE
Stop iframes from including their ancestors

### DIFF
--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -287,7 +287,30 @@ impl HTMLIFrameElement {
 
         let url = self.get_url();
 
-        // TODO: check ancestor browsing contexts for same URL
+        // TODO(#25748):
+        // By spec, we return early if there's an ancestor browsing context
+        // "whose active document's url, ignoring fragments, is equal".
+        // However, asking about ancestor browsing contexts is more nuanced than
+        // it sounds and not implemented here.
+        // Within a single origin, we can do it by walking window proxies,
+        // and this check covers only that single-origin case, protecting
+        // against simple typo self-includes but nothing more elaborate.
+        let mut ancestor = window.GetParent();
+        while let Some(a) = ancestor {
+            if let Some(ancestor_url) = a.document().map(|d| d.url()) {
+                if ancestor_url.scheme() == url.scheme() &&
+                    ancestor_url.username() == url.username() &&
+                    ancestor_url.password() == url.password() &&
+                    ancestor_url.host() == url.host() &&
+                    ancestor_url.port() == url.port() &&
+                    ancestor_url.path() == url.path() &&
+                    ancestor_url.query() == url.query()
+                {
+                    return;
+                }
+            }
+            ancestor = a.parent().map(|p| DomRoot::from_ref(p));
+        }
 
         let creator_pipeline_id = if url.as_str() == "about:blank" {
             Some(window.upcast::<GlobalScope>().pipeline_id())


### PR DESCRIPTION
An iframe that included itself would just keep loading until running out of resources; the spec includes protection against that, and now Servo follows (some of) the spec about it.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix the same-origin case presented in #3931 but not a case in which an intermediate cross-origin iframe is hiding a same-origin ancestor further up.
<!-- Either: -->
- [X] There is a manual test for these changes in #3931

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
