### PR TITLE
Kill off hanging crashtests.

### DIFF
--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -332,6 +332,8 @@ class ServoCrashtestExecutor(ProcessTestExecutor):
         self.test = test
         success, data = ServoTimedRunner(self.logger, self.do_crashtest, self.protocol,
                                          test_url, timeout, self.extra_timeout).run()
+        # Ensure that no processes hang around if they timeout.
+        self.proc.kill()
 
         if success:
             return self.convert_result(test, data)


### PR DESCRIPTION
The reason that complex-glsl-does-not-crash.html kept leaving zombie processes is the following:
* WPT introduced the notion of crash tests (ie. tests that verify that they do not crash)
* if a timeout expires while running a crash test and the test has not finished running, it is reported as a failure and potential hang
* there is no code that causes a hanging test to stop running
* any test filename that ends in `-crash` is automatically treated as a crashtest