### PR TITLE
What if we unsilence all the "Why are errors silenced here?" errors?

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -555,8 +555,8 @@ impl Document {
                     );
                     let event = event.upcast::<Event>();
                     event.set_trusted(true);
-                    // FIXME(nox): Why are errors silenced here?
-                    let _ = window.dispatch_event_with_target_override(
+
+                    window.dispatch_event_with_target_override(
                         &event,
                     );
                 }),
@@ -1864,7 +1864,7 @@ impl Document {
             );
             let event = event.upcast::<Event>();
             event.set_trusted(true);
-            let _ = self.window.dispatch_event_with_target_override(&event);
+            self.window.dispatch_event_with_target_override(&event);
             // TODO Step 6, document visibility steps.
         }
         // Step 7
@@ -1878,7 +1878,7 @@ impl Document {
             event.set_trusted(true);
             let event_target = self.window.upcast::<EventTarget>();
             let has_listeners = event.has_listeners_for(&event_target, &atom!("unload"));
-            let _ = self.window.dispatch_event_with_target_override(&event);
+            self.window.dispatch_event_with_target_override(&event);
             self.fired_unload.set(true);
             // Step 9
             if has_listeners {
@@ -1973,8 +1973,7 @@ impl Document {
                     update_with_current_time_ms(&document.load_event_start);
 
                     debug!("About to dispatch load for {:?}", document.url());
-                    // FIXME(nox): Why are errors silenced here?
-                    let _ = window.dispatch_event_with_target_override(
+                    window.dispatch_event_with_target_override(
                         &event,
                     );
 
@@ -2017,8 +2016,7 @@ impl Document {
                         let event = event.upcast::<Event>();
                         event.set_trusted(true);
 
-                        // FIXME(nox): Why are errors silenced here?
-                        let _ = window.dispatch_event_with_target_override(
+                        window.dispatch_event_with_target_override(
                             &event,
                         );
                     }),
@@ -4223,6 +4221,7 @@ impl DocumentMethods for Document {
 
         let url = self.url();
         let (tx, rx) = profile_ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        // FIXME: Why is send silencing errors but recv unwrapping them?
         let _ = self
             .window
             .upcast::<GlobalScope>()
@@ -4248,6 +4247,8 @@ impl DocumentMethods for Document {
             vec![]
         };
 
+        // FIXME: Why are we silencing errors here? Is it really okay to return
+        // immediately and leave the set-cookies message asynchronous?
         let _ = self
             .window
             .upcast::<GlobalScope>()

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -75,16 +75,19 @@ impl VirtualMethods for HTMLDetailsElement {
 
             let window = window_from_node(self);
             let this = Trusted::new(self);
-            // FIXME(nox): Why are errors silenced here?
-            let _ = window.task_manager().dom_manipulation_task_source().queue(
-                task!(details_notification_task_steps: move || {
-                    let this = this.root();
-                    if counter == this.toggle_counter.get() {
-                        this.upcast::<EventTarget>().fire_event(atom!("toggle"));
-                    }
-                }),
-                window.upcast(),
-            );
+            window
+                .task_manager()
+                .dom_manipulation_task_source()
+                .queue(
+                    task!(details_notification_task_steps: move || {
+                        let this = this.root();
+                        if counter == this.toggle_counter.get() {
+                            this.upcast::<EventTarget>().fire_event(atom!("toggle"));
+                        }
+                    }),
+                    window.upcast(),
+                )
+                .expect("Couldn't queue task to fire toggle event for details element");
         }
     }
 }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -278,13 +278,16 @@ impl HTMLIFrameElement {
         {
             let this = Trusted::new(self);
             let pipeline_id = self.pipeline_id().unwrap();
-            // FIXME(nox): Why are errors silenced here?
-            let _ = window.task_manager().dom_manipulation_task_source().queue(
-                task!(iframe_load_event_steps: move || {
-                    this.root().iframe_load_event_steps(pipeline_id);
-                }),
-                window.upcast(),
-            );
+            window
+                .task_manager()
+                .dom_manipulation_task_source()
+                .queue(
+                    task!(iframe_load_event_steps: move || {
+                        this.root().iframe_load_event_steps(pipeline_id);
+                    }),
+                    window.upcast(),
+                )
+                .expect("Couldn't queue task for iframe load event steps");
             return;
         }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1968,17 +1968,18 @@ impl Window {
                         new_url);
                     event.upcast::<Event>().fire(this.upcast::<EventTarget>());
                 });
-                // FIXME(nox): Why are errors silenced here?
-                let _ = self.script_chan.send(CommonScriptMsg::Task(
-                    ScriptThreadEventCategory::DomEvent,
-                    Box::new(
-                        self.task_manager
-                            .task_canceller(TaskSourceName::DOMManipulation)
-                            .wrap_task(task),
-                    ),
-                    self.pipeline_id(),
-                    TaskSourceName::DOMManipulation,
-                ));
+                self.script_chan
+                    .send(CommonScriptMsg::Task(
+                        ScriptThreadEventCategory::DomEvent,
+                        Box::new(
+                            self.task_manager
+                                .task_canceller(TaskSourceName::DOMManipulation)
+                                .wrap_task(task),
+                        ),
+                        self.pipeline_id(),
+                        TaskSourceName::DOMManipulation,
+                    ))
+                    .expect("Couldn't send hashchange task in load_url");
                 doc.set_url(load_data.url.clone());
                 return;
             }
@@ -2464,19 +2465,20 @@ impl Window {
                 );
             }
         });
-        // FIXME(nox): Why are errors silenced here?
         // TODO(#12718): Use the "posted message task source".
         // TODO: When switching to the right task source, update the task_canceller call too.
-        let _ = self.script_chan.send(CommonScriptMsg::Task(
-            ScriptThreadEventCategory::DomEvent,
-            Box::new(
-                self.task_manager
-                    .task_canceller(TaskSourceName::DOMManipulation)
-                    .wrap_task(task),
-            ),
-            self.pipeline_id(),
-            TaskSourceName::DOMManipulation,
-        ));
+        self.script_chan
+            .send(CommonScriptMsg::Task(
+                ScriptThreadEventCategory::DomEvent,
+                Box::new(
+                    self.task_manager
+                        .task_canceller(TaskSourceName::DOMManipulation)
+                        .wrap_task(task),
+                ),
+                self.pipeline_id(),
+                TaskSourceName::DOMManipulation,
+            ))
+            .expect("Couldn't send task to post serialized message");
     }
 }
 

--- a/components/script/serviceworkerjob.rs
+++ b/components/script/serviceworkerjob.rs
@@ -309,14 +309,15 @@ fn queue_settle_promise_for_job(
 ) {
     let global = job.client.global();
     let promise = TrustedPromise::new(job.promise.clone());
-    // FIXME(nox): Why are errors silenced here?
-    let _ = task_source.queue(
-        task!(settle_promise_for_job: move || {
-            let promise = promise.root();
-            settle_job_promise(&promise, settle)
-        }),
-        &*global,
-    );
+    task_source
+        .queue(
+            task!(settle_promise_for_job: move || {
+                let promise = promise.root();
+                settle_job_promise(&promise, settle)
+            }),
+            &*global,
+        )
+        .expect("Couldn't queue task to settle_job_promise");
 }
 
 // https://w3c.github.io/ServiceWorker/#reject-job-promise-algorithm

--- a/components/script/task_source/media_element.rs
+++ b/components/script/task_source/media_element.rs
@@ -46,6 +46,7 @@ impl TaskSource for MediaElementTaskSource {
 impl MediaElementTaskSource {
     pub fn queue_simple_event(&self, target: &EventTarget, name: Atom, window: &Window) {
         let target = Trusted::new(target);
-        let _ = self.queue(SimpleEventTask { target, name }, window.upcast());
+        self.queue(SimpleEventTask { target, name }, window.upcast())
+            .expect("Couldn't queue media element task");
     }
 }

--- a/components/script/task_source/performance_timeline.rs
+++ b/components/script/task_source/performance_timeline.rs
@@ -50,12 +50,12 @@ impl TaskSource for PerformanceTimelineTaskSource {
 impl PerformanceTimelineTaskSource {
     pub fn queue_notification(&self, global: &GlobalScope) {
         let owner = Trusted::new(&*global.performance());
-        // FIXME(nox): Why are errors silenced here?
-        let _ = self.queue(
+        self.queue(
             task!(notify_performance_observers: move || {
                 owner.root().notify_observers();
             }),
             global,
-        );
+        )
+        .expect("Couldn't queue task to notify performance observers");
     }
 }


### PR DESCRIPTION
This might reveal interesting race conditions, or just let us clean out some unnecessary FIXMEs.

Worth noting: the dispatch_event_with_target ones were just an outdated comment; nothing there IS an error, since the events are uncancelable and the return value's always going to be NotCanceled.