### PR TITLE
Improve the name the NodeGeometryQuery

### DIFF
--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -396,14 +396,14 @@ pub fn process_content_boxes_request(
     iterator.rects
 }
 
-struct FragmentLocatingFragmentIterator {
+struct FragmentClientRectQueryIterator {
     node_address: OpaqueNode,
     client_rect: Rect<i32>,
 }
 
-impl FragmentLocatingFragmentIterator {
-    fn new(node_address: OpaqueNode) -> FragmentLocatingFragmentIterator {
-        FragmentLocatingFragmentIterator {
+impl FragmentClientRectQueryIterator {
+    fn new(node_address: OpaqueNode) -> FragmentClientRectQueryIterator {
+        FragmentClientRectQueryIterator {
             node_address: node_address,
             client_rect: Rect::zero(),
         }
@@ -461,7 +461,7 @@ impl ParentOffsetBorderBoxIterator {
     }
 }
 
-impl FragmentBorderBoxIterator for FragmentLocatingFragmentIterator {
+impl FragmentBorderBoxIterator for FragmentClientRectQueryIterator {
     fn process(&mut self, fragment: &Fragment, _: i32, border_box: &Rect<Au>) {
         let style_structs::Border {
             border_top_width: top_width,
@@ -679,11 +679,11 @@ impl FragmentBorderBoxIterator for ParentOffsetBorderBoxIterator {
     }
 }
 
-pub fn process_node_geometry_request(
+pub fn process_client_rect_query(
     requested_node: OpaqueNode,
     layout_root: &mut dyn Flow,
 ) -> Rect<i32> {
-    let mut iterator = FragmentLocatingFragmentIterator::new(requested_node);
+    let mut iterator = FragmentClientRectQueryIterator::new(requested_node);
     sequential::iterate_through_flow_tree_fragment_border_boxes(layout_root, &mut iterator);
     iterator.client_rect
 }

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -51,10 +51,10 @@ use layout::flow_ref::FlowRef;
 use layout::incremental::{RelayoutMode, SpecialRestyleDamage};
 use layout::layout_debug;
 use layout::parallel;
+use layout::query::{process_client_rect_query, process_element_inner_text_query};
 use layout::query::{
     process_content_box_request, process_content_boxes_request, LayoutRPCImpl, LayoutThreadData,
 };
-use layout::query::{process_element_inner_text_query, process_node_geometry_request};
 use layout::query::{process_node_scroll_area_request, process_node_scroll_id_request};
 use layout::query::{
     process_offset_parent_query, process_resolved_style_request, process_style_query,
@@ -1292,7 +1292,7 @@ impl LayoutThread {
                         &QueryMsg::NodesFromPointQuery(..) => {
                             rw_data.nodes_from_point_response = Vec::new();
                         },
-                        &QueryMsg::NodeGeometryQuery(_) => {
+                        &QueryMsg::ClientRectQuery(_) => {
                             rw_data.client_rect_response = Rect::zero();
                         },
                         &QueryMsg::NodeScrollGeometryQuery(_) => {
@@ -1618,8 +1618,8 @@ impl LayoutThread {
                     rw_data.text_index_response =
                         TextIndexResponse(rw_data.indexable_text.text_index(node, point_in_node));
                 },
-                &QueryMsg::NodeGeometryQuery(node) => {
-                    rw_data.client_rect_response = process_node_geometry_request(node, root_flow);
+                &QueryMsg::ClientRectQuery(node) => {
+                    rw_data.client_rect_response = process_client_rect_query(node, root_flow);
                 },
                 &QueryMsg::NodeScrollGeometryQuery(node) => {
                     rw_data.scroll_area_response =

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -952,7 +952,7 @@ impl LayoutThread {
                         &QueryMsg::NodesFromPointQuery(..) => {
                             rw_data.nodes_from_point_response = Vec::new();
                         },
-                        &QueryMsg::NodeGeometryQuery(_) => {
+                        &QueryMsg::ClientRectQuery(_) => {
                             rw_data.client_rect_response = Rect::zero();
                         },
                         &QueryMsg::NodeScrollGeometryQuery(_) => {
@@ -1233,7 +1233,7 @@ impl LayoutThread {
                     );
                     rw_data.text_index_response = process_text_index_request(node, point_in_node);
                 },
-                &QueryMsg::NodeGeometryQuery(node) => {
+                &QueryMsg::ClientRectQuery(node) => {
                     rw_data.client_rect_response = process_node_geometry_request(node);
                 },
                 &QueryMsg::NodeScrollGeometryQuery(node) => {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1763,7 +1763,7 @@ impl Window {
     }
 
     pub fn client_rect_query(&self, node: &Node) -> UntypedRect<i32> {
-        if !self.layout_reflow(QueryMsg::NodeGeometryQuery(node.to_opaque())) {
+        if !self.layout_reflow(QueryMsg::ClientRectQuery(node.to_opaque())) {
             return Rect::zero();
         }
         self.layout_rpc.node_geometry().client_rect
@@ -2351,7 +2351,7 @@ fn debug_reflow_events(id: PipelineId, reflow_goal: &ReflowGoal, reason: &Reflow
             &QueryMsg::ContentBoxQuery(_n) => "\tContentBoxQuery",
             &QueryMsg::ContentBoxesQuery(_n) => "\tContentBoxesQuery",
             &QueryMsg::NodesFromPointQuery(..) => "\tNodesFromPointQuery",
-            &QueryMsg::NodeGeometryQuery(_n) => "\tNodeGeometryQuery",
+            &QueryMsg::ClientRectQuery(_n) => "\tClientRectQuery",
             &QueryMsg::NodeScrollGeometryQuery(_n) => "\tNodeScrollGeometryQuery",
             &QueryMsg::NodeScrollIdQuery(_n) => "\tNodeScrollIdQuery",
             &QueryMsg::ResolvedStyleQuery(_, _, _) => "\tResolvedStyleQuery",

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -115,7 +115,7 @@ pub enum NodesFromPointQueryType {
 pub enum QueryMsg {
     ContentBoxQuery(OpaqueNode),
     ContentBoxesQuery(OpaqueNode),
-    NodeGeometryQuery(OpaqueNode),
+    ClientRectQuery(OpaqueNode),
     NodeScrollGeometryQuery(OpaqueNode),
     OffsetParentQuery(OpaqueNode),
     TextIndexQuery(OpaqueNode, Point2D<f32>),
@@ -152,7 +152,7 @@ impl ReflowGoal {
                 QueryMsg::ElementInnerTextQuery(_) => true,
                 QueryMsg::ContentBoxQuery(_) |
                 QueryMsg::ContentBoxesQuery(_) |
-                QueryMsg::NodeGeometryQuery(_) |
+                QueryMsg::ClientRectQuery(_) |
                 QueryMsg::NodeScrollGeometryQuery(_) |
                 QueryMsg::NodeScrollIdQuery(_) |
                 QueryMsg::ResolvedStyleQuery(..) |
@@ -173,7 +173,7 @@ impl ReflowGoal {
                 QueryMsg::ElementInnerTextQuery(_) => true,
                 QueryMsg::ContentBoxQuery(_) |
                 QueryMsg::ContentBoxesQuery(_) |
-                QueryMsg::NodeGeometryQuery(_) |
+                QueryMsg::ClientRectQuery(_) |
                 QueryMsg::NodeScrollGeometryQuery(_) |
                 QueryMsg::NodeScrollIdQuery(_) |
                 QueryMsg::ResolvedStyleQuery(..) |


### PR DESCRIPTION
This query is used to get the clientTop, clientWidth, clientHeight,
clientLeft properties of DOM objects. "NodeGeometry" doesn't really
capture what these properties do as they often are returning the width
of an element's border.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
