### PR TITLE
Remove dependency of constellation on canvas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,6 +534,7 @@ dependencies = [
 name = "canvas_traits"
 version = "0.0.1"
 dependencies = [
+ "crossbeam-channel",
  "cssparser",
  "euclid",
  "ipc-channel",
@@ -806,7 +807,6 @@ dependencies = [
  "background_hang_monitor",
  "backtrace",
  "bluetooth_traits",
- "canvas",
  "canvas_traits",
  "compositing",
  "crossbeam-channel",

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::canvas_data::*;
-use crate::ConstellationCanvasMsg;
 use canvas_traits::canvas::*;
+use canvas_traits::ConstellationCanvasMsg;
 use crossbeam_channel::{select, unbounded, Sender};
 use euclid::default::Size2D;
 use ipc_channel::ipc::{self, IpcSender};

--- a/components/canvas/lib.rs
+++ b/components/canvas/lib.rs
@@ -4,10 +4,6 @@
 
 #![deny(unsafe_code)]
 
-use canvas_traits::canvas::CanvasId;
-use crossbeam_channel::Sender;
-use euclid::default::Size2D;
-
 #[macro_use]
 extern crate bitflags;
 #[macro_use]
@@ -26,13 +22,3 @@ pub mod canvas_paint_thread;
 mod webgl_limits;
 mod webgl_mode;
 pub mod webgl_thread;
-
-pub enum ConstellationCanvasMsg {
-    Create {
-        id_sender: Sender<CanvasId>,
-        size: Size2D<u64>,
-        webrender_sender: webrender_api::RenderApiSender,
-        antialias: bool,
-    },
-    Exit,
-}

--- a/components/canvas_traits/Cargo.toml
+++ b/components/canvas_traits/Cargo.toml
@@ -14,6 +14,7 @@ path = "lib.rs"
 webgl_backtrace = []
 
 [dependencies]
+crossbeam-channel = "0.3"
 cssparser = "0.27"
 euclid = "0.20"
 ipc-channel = "0.12"

--- a/components/canvas_traits/lib.rs
+++ b/components/canvas_traits/lib.rs
@@ -6,6 +6,10 @@
 #![crate_type = "rlib"]
 #![deny(unsafe_code)]
 
+use crate::canvas::CanvasId;
+use crossbeam_channel::Sender;
+use euclid::default::Size2D;
+
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -17,3 +21,13 @@ pub mod canvas;
 #[macro_use]
 pub mod webgl;
 mod webgl_channel;
+
+pub enum ConstellationCanvasMsg {
+    Create {
+        id_sender: Sender<CanvasId>,
+        size: Size2D<u64>,
+        webrender_sender: webrender_api::RenderApiSender,
+        antialias: bool,
+    },
+    Exit,
+}

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -10,15 +10,10 @@ publish = false
 name = "constellation"
 path = "lib.rs"
 
-[features]
-canvas2d-azure = ["canvas/canvas2d-azure"]
-canvas2d-raqote = ["canvas/canvas2d-raqote"]
-
 [dependencies]
 background_hang_monitor = { path = "../background_hang_monitor"}
 backtrace = "0.3"
 bluetooth_traits = { path = "../bluetooth_traits" }
-canvas = {path = "../canvas", default-features = false}
 canvas_traits = {path = "../canvas_traits"}
 compositing = {path = "../compositing"}
 crossbeam-channel = "0.3"

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -103,10 +103,9 @@ use crate::timer_scheduler::TimerScheduler;
 use background_hang_monitor::HangMonitorRegister;
 use backtrace::Backtrace;
 use bluetooth_traits::BluetoothRequest;
-use canvas::canvas_paint_thread::CanvasPaintThread;
-use canvas::ConstellationCanvasMsg;
 use canvas_traits::canvas::{CanvasId, CanvasMsg};
 use canvas_traits::webgl::WebGLThreads;
+use canvas_traits::ConstellationCanvasMsg;
 use compositing::compositor_thread::CompositorProxy;
 use compositing::compositor_thread::Msg as ToCompositorMsg;
 use compositing::{ConstellationMsg as FromCompositorMsg, SendableFrameTree};
@@ -811,6 +810,8 @@ where
         is_running_problem_test: bool,
         hard_fail: bool,
         enable_canvas_antialiasing: bool,
+        canvas_chan: Sender<ConstellationCanvasMsg>,
+        ipc_canvas_chan: IpcSender<CanvasMsg>,
     ) -> (Sender<FromCompositorMsg>, IpcSender<SWManagerMsg>) {
         let (compositor_sender, compositor_receiver) = unbounded();
 
@@ -900,8 +901,6 @@ where
                         )
                     }),
                 );
-
-                let (canvas_chan, ipc_canvas_chan) = CanvasPaintThread::start();
 
                 let mut constellation: Constellation<Message, LTF, STF> = Constellation {
                     namespace_receiver,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -892,6 +892,9 @@ fn create_constellation(
         player_context,
         event_loop_waker,
     };
+
+    let (canvas_chan, ipc_canvas_chan) = canvas::canvas_paint_thread::CanvasPaintThread::start();
+
     let (constellation_chan, from_swmanager_sender) = Constellation::<
         script_layout_interface::message::Msg,
         layout_thread::LayoutThread,
@@ -904,6 +907,8 @@ fn create_constellation(
         opts.is_running_problem_test,
         opts.hard_fail,
         opts.enable_canvas_antialiasing,
+        canvas_chan,
+        ipc_canvas_chan,
     );
 
     if let Some(webvr_constellation_sender) = webvr_constellation_sender {


### PR DESCRIPTION
move `ConstellationCanvasMsg` to canvas_traits and start canvas paint thread
to components/servo. This, however, does not remove dependency for conditional
compilation options.

https://github.com/servo/servo/blob/5f55cd5d71df9c555fbc24777168396ddd539f28/components/constellation/Cargo.toml#L13-L15

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] These changes fix #24891  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
