### PR TITLE
Fix timeout vs. task-queue race conditions in promise rejection tests

### DIFF
--- a/tests/wpt/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events-onerror.html
+++ b/tests/wpt/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events-onerror.html
@@ -27,11 +27,21 @@ async_test(function(t) {
   };
 
   var p = Promise.reject(e);
-  setTimeout(function() {
-    setTimeout(t.step_func(function() {
+  queueTask(function() {
+    queueTask(t.step_func(function() {
       // This will cause onrejectionhandled
       p.catch(function() {});
-    }), 0);
-  }, 0);
+    }));
+  });
 }, 'Throwing inside an unhandledrejection handler invokes the error handler.');
+
+// This function queues a task in "DOM manipulation task source"
+function queueTask(f) {
+  var d = document.createElement("details");
+  d.ontoggle = function() {
+    f();
+  };
+
+  d.setAttribute("open", "");
+}
 </script>

--- a/tests/wpt/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/support/promise-rejection-events.js
+++ b/tests/wpt/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/support/promise-rejection-events.js
@@ -831,30 +831,29 @@ if ('document' in self) {
 
     var p = Promise.reject();
 
-    setTimeout(function() {
-      queueTask(function() {
-        sequenceOfEvents.push('task before catch');
-        checkSequence();
-      });
-
-      p.catch(function() {
-        sequenceOfEvents.push('catch');
-        checkSequence();
-      });
-
-      queueTask(function() {
-        sequenceOfEvents.push('task after catch');
-        checkSequence();
-      });
-
-      sequenceOfEvents.push('after catch');
-      checkSequence();
-    }, 10);
-
     function unhandled(ev) {
       if (ev.promise === p) {
         sequenceOfEvents.push('unhandled');
         checkSequence();
+        setTimeout(function() {
+          queueTask(function() {
+            sequenceOfEvents.push('task before catch');
+            checkSequence();
+          });
+
+          p.catch(function() {
+            sequenceOfEvents.push('catch');
+            checkSequence();
+          });
+
+          queueTask(function() {
+            sequenceOfEvents.push('task after catch');
+           checkSequence();
+          });
+
+          sequenceOfEvents.push('after catch');
+          checkSequence();
+        }, 10);
       }
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
These two tests were assuming that timeouts and promise rejection events would have a temporal relationship not actually guaranteed by spec, leading to test timeouts if the DOM manipulation task queue was running slower than anticipated.

fix #22207, fix #22295

Of course, the upstream WPT results need looking at to be sure this hasn't done something weird to another browser.
