### PR TITLE
fix zip extraction for python 3

### DIFF
--- a/python/servo/util.py
+++ b/python/servo/util.py
@@ -187,6 +187,21 @@ class ZipFileWithUnixPermissions(zipfile.ZipFile):
         os.chmod(extracted, mode)
         return extracted
 
+    # For Python 3.x
+    def _extract_member(self, member, targetpath, pwd):
+        if sys.version_info[0] >= 3:
+            if not isinstance(member, zipfile.ZipInfo):
+                member = self.getinfo(member)
+
+            targetpath = super()._extract_member(member, targetpath, pwd)
+
+            attr = member.external_attr >> 16
+            if attr != 0:
+                os.chmod(targetpath, attr)
+            return targetpath
+        else:
+            return super(ZipFileWithUnixPermissions, self)._extract_member(member, targetpath, pwd)
+
 
 def extract(src, dst, movedir=None, remove=True):
     assert src.endswith(".zip")


### PR DESCRIPTION
Fix #25618 

Confirmed that this worked in Python 3.6 and Python 2.7.

Ref: https://stackoverflow.com/questions/805066/call-a-parent-classs-method-from-child-class

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25618 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
