### PR TITLE
Make CanvasRenderingContext2D.createPattern() return null for incomplete images

### DIFF
--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -388,6 +388,14 @@ impl CanvasState {
                 self.draw_offscreen_canvas(&canvas, htmlcanvas, sx, sy, sw, sh, dx, dy, dw, dh)
             },
             CanvasImageSource::HTMLImageElement(ref image) => {
+                // https://html.spec.whatwg.org/multipage/#drawing-images
+                // 2. Let usability be the result of checking the usability of image.
+                // 3. If usability is bad, then return (without drawing anything).
+                if !image.is_usable()? {
+                    return Ok(());
+                }
+
+                // TODO(pylbrecht): is it possible for image.get_url() to return None after the usability check?
                 // https://html.spec.whatwg.org/multipage/#img-error
                 // If the image argument is an HTMLImageElement object that is in the broken state,
                 // then throw an InvalidStateError exception

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -382,9 +382,19 @@ impl CanvasState {
     ) -> ErrorResult {
         let result = match image {
             CanvasImageSource::HTMLCanvasElement(ref canvas) => {
+                // https://html.spec.whatwg.org/multipage/#check-the-usability-of-the-image-argument
+                if !canvas.is_valid() {
+                    return Err(Error::InvalidState);
+                }
+
                 self.draw_html_canvas_element(&canvas, htmlcanvas, sx, sy, sw, sh, dx, dy, dw, dh)
             },
             CanvasImageSource::OffscreenCanvas(ref canvas) => {
+                // https://html.spec.whatwg.org/multipage/#check-the-usability-of-the-image-argument
+                if !canvas.is_valid() {
+                    return Err(Error::InvalidState);
+                }
+
                 self.draw_offscreen_canvas(&canvas, htmlcanvas, sx, sy, sw, sh, dx, dy, dw, dh)
             },
             CanvasImageSource::HTMLImageElement(ref image) => {

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -566,7 +566,7 @@ impl CanvasRenderingContext2DMethods for CanvasRenderingContext2D {
         &self,
         image: CanvasImageSource,
         repetition: DOMString,
-    ) -> Fallible<DomRoot<CanvasPattern>> {
+    ) -> Fallible<Option<DomRoot<CanvasPattern>>> {
         self.canvas_state
             .borrow()
             .create_pattern(&self.global(), image, repetition)

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -13,7 +13,7 @@ use crate::dom::bindings::codegen::Bindings::HTMLImageElementBinding::HTMLImageE
 use crate::dom::bindings::codegen::Bindings::MouseEventBinding::MouseEventMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeBinding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
-use crate::dom::bindings::error::Fallible;
+use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomObject;
@@ -163,6 +163,26 @@ pub struct HTMLImageElement {
 impl HTMLImageElement {
     pub fn get_url(&self) -> Option<ServoUrl> {
         self.current_request.borrow().parsed_url.clone()
+    }
+    // https://html.spec.whatwg.org/multipage/#check-the-usability-of-the-image-argument
+    pub fn is_usable(&self) -> Fallible<bool> {
+        // If image has an intrinsic width or intrinsic height (or both) equal to zero, then return bad.
+        match &self.current_request.borrow().image {
+            Some(image) => {
+                if image.width == 0 || image.height == 0 {
+                    return Ok(false);
+                }
+            },
+            None => return Ok(false),
+        }
+
+        match self.current_request.borrow().state {
+            // If image's current request's state is broken, then throw an "InvalidStateError" DOMException.
+            State::Broken => Err(Error::InvalidState),
+            State::CompletelyAvailable => Ok(true),
+            // If image is not fully decodable, then return bad.
+            State::PartiallyAvailable | State::Unavailable => Ok(false),
+        }
     }
 }
 

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -138,6 +138,10 @@ impl OffscreenCanvas {
         ));
         Some(context)
     }
+
+    pub fn is_valid(&self) -> bool {
+        self.Width() != 0 && self.Height() != 0
+    }
 }
 
 impl OffscreenCanvasMethods for OffscreenCanvas {

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -210,7 +210,7 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
         &self,
         image: CanvasImageSource,
         repetition: DOMString,
-    ) -> Fallible<DomRoot<CanvasPattern>> {
+    ) -> Fallible<Option<DomRoot<CanvasPattern>>> {
         self.canvas_state
             .borrow()
             .create_pattern(&self.global(), image, repetition)

--- a/components/script/dom/paintrenderingcontext2d.rs
+++ b/components/script/dom/paintrenderingcontext2d.rs
@@ -340,7 +340,7 @@ impl PaintRenderingContext2DMethods for PaintRenderingContext2D {
         &self,
         image: CanvasImageSource,
         repetition: DOMString,
-    ) -> Fallible<DomRoot<CanvasPattern>> {
+    ) -> Fallible<Option<DomRoot<CanvasPattern>>> {
         self.context.CreatePattern(image, repetition)
     }
 

--- a/components/script/dom/webidls/CanvasRenderingContext2D.webidl
+++ b/components/script/dom/webidls/CanvasRenderingContext2D.webidl
@@ -93,7 +93,7 @@ interface mixin CanvasFillStrokeStyles {
   [Throws]
   CanvasGradient createRadialGradient(double x0, double y0, double r0, double x1, double y1, double r1);
   [Throws]
-  CanvasPattern createPattern(CanvasImageSource image, [TreatNullAs=EmptyString] DOMString repetition);
+  CanvasPattern? createPattern(CanvasImageSource image, [TreatNullAs=EmptyString] DOMString repetition);
 };
 
 [Exposed=(PaintWorklet, Window, Worker)]

--- a/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.broken.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.broken.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.broken.html]
-  type: testharness
-  [Canvas test: 2d.drawImage.broken]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.emptysrc.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.emptysrc.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.incomplete.emptysrc.html]
-  type: testharness
-  [Canvas test: 2d.drawImage.incomplete.emptysrc]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.immediate.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.immediate.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.incomplete.immediate.html]
-  type: testharness
-  [Canvas test: 2d.drawImage.incomplete.immediate]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.nosrc.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.nosrc.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.incomplete.nosrc.html]
-  type: testharness
-  [Canvas test: 2d.drawImage.incomplete.nosrc]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.reload.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.reload.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.incomplete.reload.html]
-  type: testharness
-  [Canvas test: 2d.drawImage.incomplete.reload]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.removedsrc.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.incomplete.removedsrc.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.incomplete.removedsrc.html]
-  type: testharness
-  [Canvas test: 2d.drawImage.incomplete.removedsrc]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.zerocanvas.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/2d.drawImage.zerocanvas.html.ini
@@ -1,5 +1,0 @@
-[2d.drawImage.zerocanvas.html]
-  type: testharness
-  [Canvas test: 2d.drawImage.zerocanvas]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/drawimage_html_image.html.ini
+++ b/tests/wpt/metadata/2dcontext/drawing-images-to-the-canvas/drawimage_html_image.html.ini
@@ -1,8 +1,5 @@
 [drawimage_html_image.html]
   type: testharness
-  [Draw 100x100 image to 100x100 canvas at 0,0.]
-    expected: FAIL
-
   [Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 70,99 should be light purple.]
     expected: FAIL
 

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.image.broken.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.image.broken.html.ini
@@ -1,0 +1,5 @@
+[2d.pattern.image.broken.html]
+  type: testharness
+  [Canvas test: 2d.pattern.image.broken]
+    expected: FAIL
+

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.image.incomplete.emptysrc.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.image.incomplete.emptysrc.html.ini
@@ -1,5 +1,0 @@
-[2d.pattern.image.incomplete.emptysrc.html]
-  type: testharness
-  [Canvas test: 2d.pattern.image.incomplete.emptysrc]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.image.incomplete.immediate.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.image.incomplete.immediate.html.ini
@@ -1,5 +1,0 @@
-[2d.pattern.image.incomplete.immediate.html]
-  type: testharness
-  [Canvas test: 2d.pattern.image.incomplete.immediate]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.image.incomplete.nosrc.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.image.incomplete.nosrc.html.ini
@@ -1,5 +1,0 @@
-[2d.pattern.image.incomplete.nosrc.html]
-  type: testharness
-  [Canvas test: 2d.pattern.image.incomplete.nosrc]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.image.incomplete.reload.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.image.incomplete.reload.html.ini
@@ -1,5 +1,0 @@
-[2d.pattern.image.incomplete.reload.html]
-  type: testharness
-  [Canvas test: 2d.pattern.image.incomplete.reload]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.image.incomplete.removedsrc.html.ini
+++ b/tests/wpt/metadata/2dcontext/fill-and-stroke-styles/2d.pattern.image.incomplete.removedsrc.html.ini
@@ -1,5 +1,0 @@
-[2d.pattern.image.incomplete.removedsrc.html]
-  type: testharness
-  [Canvas test: 2d.pattern.image.incomplete.removedsrc]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/drawing-images-to-the-canvas/2d.drawImage.zerocanvas.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/drawing-images-to-the-canvas/2d.drawImage.zerocanvas.html.ini
@@ -1,4 +1,0 @@
-[2d.drawImage.zerocanvas.html]
-  [OffscreenCanvas test: 2d.drawImage.zerocanvas]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/drawing-images-to-the-canvas/2d.drawImage.zerocanvas.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/drawing-images-to-the-canvas/2d.drawImage.zerocanvas.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.drawImage.zerocanvas.worker.html]
-  [2d]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`createPattern()` should return `null` if the passed `image` argument is not usable.

References:
- https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createpattern
- https://html.spec.whatwg.org/multipage/canvas.html#check-the-usability-of-the-image-argument
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix part of #25331

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
