### PR TITLE
Make HTMLFormControlsCollection rooted at the form's root, not rooted at the form itself

### DIFF
--- a/tests/wpt/metadata/html/semantics/forms/the-form-element/form-elements-filter.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-form-element/form-elements-filter.html.ini
@@ -1,8 +1,5 @@
 [form-elements-filter.html]
   type: testharness
-  [form.elements must contain all listed elements with the form owner]
-    expected: FAIL
-
   [form.elements only includes elements from the same shadow tree]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
We'd been misreading the first line of https://html.spec.whatwg.org/#dom-form-elements. The collection needs to be rooted higher than the form itself, so it can contain form controls elsewhere in the document with a form= content attribute. It is, as far as I can tell, unspecified whether "rooted at the form's root" is meant to live-update to a new root if the form is moved to another tree, and I'm assuming it doesn't have to.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25711

<!-- Either: -->
- [X] There are tests for these changes 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
