### PR TITLE
Wip/rib/windows build fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ export LIBCLANG_PATH=$(llvm-config --prefix)/lib64
 
 You should change the installation to install the "Add python.exe to Path" feature.
 
+You will also need to set the `PYTHON2` environment variable, e.g., to 'C:\Python27\python.exe' by doing:
+```
+setx PYTHON2 "C:\Python27\python.exe" /m
+```
+
 2. Install Python 3.7 for Windows (https://www.python.org/downloads/release/python-374/). The Windows x86-64 MSI installer is fine. This is required in order to build the JavaScript engine, SpiderMonkey.
 
 You will also need to set the `PYTHON3` environment variable, e.g., to 'C:\Python37\python.exe' by doing:

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -972,7 +972,7 @@ def package_msvc_dlls(servo_exe_dir, target, vcinstalldir, vs_version):
         if os.path.isdir(redist_dir):
             for p in os.listdir(redist_dir)[::-1]:
                 redist_path = path.join(redist_dir, p)
-                for v in ["VC141", "VC150", "VC160"]:
+                for v in ["VC141", "VC142", "VC150", "VC160"]:
                     # there are two possible paths
                     # `x64\Microsoft.VC*.CRT` or `onecore\x64\Microsoft.VC*.CRT`
                     redist1 = path.join(redist_path, vs_platform, "Microsoft.{}.CRT".format(v))


### PR DESCRIPTION
These were minor changes I needed to make to build Servo on Windows based on following the existing instructions. In particular:

Even though I have C:\Python27 with python.exe in my PATH the build failed at some point when it failed to find python27.exe and I found that explicitly setting the PYTHON2 environment variable resolved this failure.

The end of the build failed to package MSVC redistributable DLLs and that was simply because I have a version (142) installed that wasn't checked for by build_commands.py.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix builds on Windows if you have version 142 MSVC redistributable DLLs and if you don't have a python2.7exe or python27.exe in your PATH.

<!-- Either: -->
- [x] These changes do not require tests because they don't change any servo code

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
