### PR TITLE
Initial implementation of GPUQueue

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -154,7 +154,7 @@ use uuid::Uuid;
 use webgpu::{
     WebGPU, WebGPUAdapter, WebGPUBindGroup, WebGPUBindGroupLayout, WebGPUBuffer,
     WebGPUCommandBuffer, WebGPUCommandEncoder, WebGPUComputePipeline, WebGPUDevice,
-    WebGPUPipelineLayout, WebGPUShaderModule,
+    WebGPUPipelineLayout, WebGPUQueue, WebGPUShaderModule,
 };
 use webrender_api::{DocumentId, ImageKey};
 use webvr_traits::{WebVRGamepadData, WebVRGamepadHand, WebVRGamepadState};
@@ -537,6 +537,7 @@ unsafe_no_jsmanaged_fields!(WebGPUBindGroup);
 unsafe_no_jsmanaged_fields!(WebGPUBindGroupLayout);
 unsafe_no_jsmanaged_fields!(WebGPUComputePipeline);
 unsafe_no_jsmanaged_fields!(WebGPUPipelineLayout);
+unsafe_no_jsmanaged_fields!(WebGPUQueue);
 unsafe_no_jsmanaged_fields!(WebGPUShaderModule);
 unsafe_no_jsmanaged_fields!(WebGPUCommandBuffer);
 unsafe_no_jsmanaged_fields!(WebGPUCommandEncoder);

--- a/components/script/dom/gpuadapter.rs
+++ b/components/script/dom/gpuadapter.rs
@@ -107,7 +107,7 @@ impl GPUAdapterMethods for GPUAdapter {
 impl AsyncWGPUListener for GPUAdapter {
     fn handle_response(&self, response: WebGPUResponse, promise: &Rc<Promise>) {
         match response {
-            WebGPUResponse::RequestDevice(device_id, _descriptor) => {
+            WebGPUResponse::RequestDevice(device_id, queue_id, _descriptor) => {
                 let device = GPUDevice::new(
                     &self.global(),
                     self.channel.clone(),
@@ -115,6 +115,7 @@ impl AsyncWGPUListener for GPUAdapter {
                     Heap::default(),
                     Heap::default(),
                     device_id,
+                    queue_id,
                 );
                 promise.resolve_native(&device);
             },

--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::GPUBufferBinding::{
     self, GPUBufferMethods, GPUBufferSize,
 };
@@ -91,6 +91,10 @@ impl GPUBuffer {
     pub fn usage(&self) -> u32 {
         self.usage
     }
+
+    pub fn state(&self) -> Ref<GPUBufferState> {
+        self.state.borrow()
+    }
 }
 
 impl Drop for GPUBuffer {
@@ -106,6 +110,7 @@ impl GPUBufferMethods for GPUBuffer {
             .0
             .send(WebGPURequest::UnmapBuffer(self.buffer))
             .unwrap();
+        *self.state.borrow_mut() = GPUBufferState::Unmapped;
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpubuffer-destroy

--- a/components/script/dom/gpucommandbuffer.rs
+++ b/components/script/dom/gpucommandbuffer.rs
@@ -2,16 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::GPUCommandBufferBinding::{
     self, GPUCommandBufferMethods,
 };
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
+use crate::dom::bindings::root::Dom;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::gpubuffer::GPUBuffer;
 use dom_struct::dom_struct;
+use std::collections::HashSet;
+use std::hash::{Hash, Hasher};
 use webgpu::{WebGPU, WebGPUCommandBuffer};
+
+impl Eq for DomRoot<GPUBuffer> {}
+impl Hash for DomRoot<GPUBuffer> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id().hash(state);
+    }
+}
 
 #[dom_struct]
 pub struct GPUCommandBuffer {
@@ -20,15 +31,21 @@ pub struct GPUCommandBuffer {
     channel: WebGPU,
     label: DomRefCell<Option<DOMString>>,
     command_buffer: WebGPUCommandBuffer,
+    buffers: DomRefCell<HashSet<Dom<GPUBuffer>>>,
 }
 
 impl GPUCommandBuffer {
-    pub fn new_inherited(channel: WebGPU, command_buffer: WebGPUCommandBuffer) -> GPUCommandBuffer {
+    fn new_inherited(
+        channel: WebGPU,
+        command_buffer: WebGPUCommandBuffer,
+        buffers: HashSet<DomRoot<GPUBuffer>>,
+    ) -> GPUCommandBuffer {
         GPUCommandBuffer {
             channel,
             reflector_: Reflector::new(),
             label: DomRefCell::new(None),
             command_buffer,
+            buffers: DomRefCell::new(buffers.into_iter().map(|b| Dom::from_ref(&*b)).collect()),
         }
     }
 
@@ -36,12 +53,27 @@ impl GPUCommandBuffer {
         global: &GlobalScope,
         channel: WebGPU,
         command_buffer: WebGPUCommandBuffer,
+        buffers: HashSet<DomRoot<GPUBuffer>>,
     ) -> DomRoot<GPUCommandBuffer> {
         reflect_dom_object(
-            Box::new(GPUCommandBuffer::new_inherited(channel, command_buffer)),
+            Box::new(GPUCommandBuffer::new_inherited(
+                channel,
+                command_buffer,
+                buffers,
+            )),
             global,
             GPUCommandBufferBinding::Wrap,
         )
+    }
+}
+
+impl GPUCommandBuffer {
+    pub fn id(&self) -> WebGPUCommandBuffer {
+        self.command_buffer
+    }
+
+    pub fn buffers(&self) -> Ref<HashSet<Dom<GPUBuffer>>> {
+        self.buffers.borrow()
     }
 }
 

--- a/components/script/dom/gpuqueue.rs
+++ b/components/script/dom/gpuqueue.rs
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::GPUQueueBinding::{self, GPUQueueMethods};
+use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::gpubuffer::GPUBufferState;
+use crate::dom::gpucommandbuffer::GPUCommandBuffer;
+use dom_struct::dom_struct;
+use webgpu::{WebGPU, WebGPUQueue, WebGPURequest};
+
+#[dom_struct]
+pub struct GPUQueue {
+    reflector_: Reflector,
+    #[ignore_malloc_size_of = "defined in webgpu"]
+    channel: WebGPU,
+    label: DomRefCell<Option<DOMString>>,
+    queue: WebGPUQueue,
+}
+
+impl GPUQueue {
+    fn new_inherited(channel: WebGPU, queue: WebGPUQueue) -> GPUQueue {
+        GPUQueue {
+            channel,
+            reflector_: Reflector::new(),
+            label: DomRefCell::new(None),
+            queue,
+        }
+    }
+
+    pub fn new(global: &GlobalScope, channel: WebGPU, queue: WebGPUQueue) -> DomRoot<GPUQueue> {
+        reflect_dom_object(
+            Box::new(GPUQueue::new_inherited(channel, queue)),
+            global,
+            GPUQueueBinding::Wrap,
+        )
+    }
+}
+
+impl GPUQueueMethods for GPUQueue {
+    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    fn GetLabel(&self) -> Option<DOMString> {
+        self.label.borrow().clone()
+    }
+
+    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    fn SetLabel(&self, value: Option<DOMString>) {
+        *self.label.borrow_mut() = value;
+    }
+
+    /// https://gpuweb.github.io/gpuweb/#dom-gpuqueue-submit
+    fn Submit(&self, command_buffers: Vec<DomRoot<GPUCommandBuffer>>) {
+        let valid = command_buffers.iter().all(|cb| {
+            cb.buffers().iter().all(|b| match *b.state() {
+                GPUBufferState::Unmapped => true,
+                _ => false,
+            })
+        });
+        if !valid {
+            // TODO: Generate error to the ErrorScope
+            return;
+        }
+        let buffer_ids = command_buffers.iter().map(|cb| cb.id().0).collect();
+        self.channel
+            .0
+            .send(WebGPURequest::Submit(self.queue.0, buffer_ids))
+            .unwrap();
+    }
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -328,6 +328,7 @@ pub mod gpucomputepassencoder;
 pub mod gpucomputepipeline;
 pub mod gpudevice;
 pub mod gpupipelinelayout;
+pub mod gpuqueue;
 pub mod gpushadermodule;
 pub mod gpushaderstage;
 pub mod hashchangeevent;

--- a/components/script/dom/webidls/GPUDevice.webidl
+++ b/components/script/dom/webidls/GPUDevice.webidl
@@ -5,13 +5,14 @@
 // https://gpuweb.github.io/gpuweb/#gpudevice
 [Exposed=(Window, DedicatedWorker)/*, Serializable */, Pref="dom.webgpu.enabled"]
 interface GPUDevice : EventTarget {
-    readonly attribute GPUAdapter adapter;
+    /*[SameObject]*/ readonly attribute GPUAdapter adapter;
     readonly attribute object extensions;
     readonly attribute object limits;
 
+    [SameObject] readonly attribute GPUQueue defaultQueue;
+
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
     GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor);
-    // Promise<GPUMappedBuffer> createBufferMappedAsync(GPUBufferDescriptor descriptor);
     // GPUTexture createTexture(GPUTextureDescriptor descriptor);
     // GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});
 
@@ -25,8 +26,6 @@ interface GPUDevice : EventTarget {
 
     GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {});
     // GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
-
-    // GPUQueue getQueue();
 };
 GPUDevice includes GPUObjectBase;
 

--- a/components/script/dom/webidls/GPUQueue.webidl
+++ b/components/script/dom/webidls/GPUQueue.webidl
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://gpuweb.github.io/gpuweb/#gpuqueue
+[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom.webgpu.enabled"]
+interface GPUQueue {
+    void submit(sequence<GPUCommandBuffer> commandBuffers);
+
+    // GPUFence createFence(optional GPUFenceDescriptor descriptor = {});
+    // void signal(GPUFence fence, unsigned long long signalValue);
+
+    // void copyImageBitmapToTexture(
+    //     GPUImageBitmapCopyView source,
+    //     GPUTextureCopyView destination,
+    //     GPUExtent3D copySize);
+};
+GPUQueue includes GPUObjectBase;


### PR DESCRIPTION
Added WebIDL bindings for `GPUQueue`.
Implemented the `submit` function of `GPUQueue` and `defaultQueue` function of `GPUDevice`.

<!-- Please describe your changes on the following line: -->

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes addresses a part of #24706

<!-- Either: -->
cc @kvark @jdm @zakorgy

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
