### PR TITLE
Give attribute-change callbacks a realm so they can to_jsval

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -897,6 +897,10 @@ impl CustomElementReactionStack {
                 }
 
                 let cx = element.global().get_cx();
+                // We might be here during HTML parsing, rather than
+                // during Javscript execution, and so we typically aren't
+                // already in a realm here.
+                let _ac = JSAutoRealm::new(*cx, element.global().reflector().get_jsobject().get());
 
                 let local_name = DOMString::from(&*local_name);
                 rooted!(in(*cx) let mut name_value = UndefinedValue());

--- a/tests/wpt/metadata/custom-elements/parser/parser-sets-attributes-and-children.html.ini
+++ b/tests/wpt/metadata/custom-elements/parser/parser-sets-attributes-and-children.html.ini
@@ -1,2 +1,4 @@
 [parser-sets-attributes-and-children.html]
-  expected: CRASH
+  [HTML parser should call connectedCallback before appending child nodes.]
+    expected: FAIL
+


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The new failing case is #25746, which is about the connected callback rather than the attribute-change one and not directly related to this code change.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #19917 

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
