### PR TITLE
Add support for WebGL2 `MAX_COLOR_ATTACHMENTS` and `MAX_DRAW_BUFFERS`

### DIFF
--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -535,6 +535,8 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             constants::UNIFORM_BUFFER_OFFSET_ALIGNMENT => {
                 Some(self.base.limits().uniform_buffer_offset_alignment)
             },
+            constants::MAX_COLOR_ATTACHMENTS => Some(self.base.limits().max_color_attachments),
+            constants::MAX_DRAW_BUFFERS => Some(self.base.limits().max_draw_buffers),
             _ => None,
         };
         if let Some(limit) = limit {

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/framebuffer-test.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/framebuffer-test.html.ini
@@ -95,3 +95,75 @@
   [WebGL test #9: getError expected: NO_ERROR. Was INVALID_ENUM : getFramebufferAttachmentParameter(READ_FRAMEBUFFER).]
     expected: FAIL
 
+  [WebGL test #48: getError expected: NO_ERROR. Was INVALID_ENUM : detach a renderbuffer from a read/draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #39: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #54: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_RED_SIZE) on read framebuffer with no attachment.]
+    expected: FAIL
+
+  [WebGL test #51: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE) on read framebuffer without depth attachment.]
+    expected: FAIL
+
+  [WebGL test #33: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #46: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #57: getError expected: NO_ERROR. Was INVALID_ENUM : bind read framebuffer to default (null) framebuffer.]
+    expected: FAIL
+
+  [WebGL test #40: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on draw framebuffer with no attachment.]
+    expected: FAIL
+
+  [WebGL test #35: getError expected: NO_ERROR. Was INVALID_ENUM : detach a texture from read/draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #20: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) with no attachment.]
+    expected: FAIL
+
+  [WebGL test #37: gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_BLUE_SIZE) should be 0 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #42: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #29: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #23: getError expected: NO_ERROR. Was INVALID_VALUE : framebufferTexture2D with an appropriate mipmap level.]
+    expected: FAIL
+
+  [WebGL test #32: getError expected: NO_ERROR. Was INVALID_ENUM : attach a texture to read/draw framebuffer binding point.]
+    expected: FAIL
+
+  [WebGL test #58: getError expected: NO_ERROR. Was INVALID_ENUM : bind draw framebuffer to default (null) framebuffer.]
+    expected: FAIL
+
+  [WebGL test #44: getError expected: NO_ERROR. Was INVALID_ENUM : detach a renderbuffer from a read/draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #38: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read framebuffer with no attachment.]
+    expected: FAIL
+
+  [WebGL test #41: getError expected: NO_ERROR. Was INVALID_ENUM : attaching a renderbuffer to a read/draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #31: getError expected: NO_ERROR. Was INVALID_ENUM : detach a texture from read/draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #18: getError expected: NO_ERROR. Was INVALID_ENUM : framebufferTexImage2D(COLOR_ATTACHMENT1).]
+    expected: FAIL
+
+  [WebGL test #45: getError expected: NO_ERROR. Was INVALID_ENUM : attaching a renderbuffer to a read/draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #19: getError expected: NO_ERROR. Was INVALID_ENUM : framebufferRenderbuffer(COLOR_ATTACHMENT1).]
+    expected: FAIL
+
+  [WebGL test #28: getError expected: NO_ERROR. Was INVALID_ENUM : attach a texture to read/draw framebuffer binding point.]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/rendering/draw-buffers.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/draw-buffers.html.ini
@@ -1,7 +1,14 @@
 [draw-buffers.html]
+  expected: ERROR
   [WebGL test #1: MAX_DRAW_BUFFERS should be at least 4]
     expected: FAIL
 
   [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : there should be no errors]
+    expected: FAIL
+
+  [WebGL test #4: getError expected: NO_ERROR. Was INVALID_ENUM : should be able to attach to the max attachment point: gl.COLOR_ATTACHMENT0 + 7]
+    expected: FAIL
+
+  [WebGL test #5: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/state/gl-object-get-calls.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/state/gl-object-get-calls.html.ini
@@ -120,3 +120,114 @@
   [WebGL test #138: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #89: getError expected: NO_ERROR. Was INVALID_ENUM : ]
+    expected: FAIL
+
+  [WebGL test #86: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid parameter enum: NO_ERROR]
+    expected: FAIL
+
+  [WebGL test #57: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLRenderbuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #43: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL) should be 0 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #70: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.BACK, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #127: getError expected: INVALID_OPERATION. Was INVALID_ENUM : after evaluating: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE)]
+    expected: FAIL
+
+  [WebGL test #172: gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_WIDTH) should be 2. Was 0.]
+    expected: FAIL
+
+  [WebGL test #173: gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_HEIGHT) should be 2. Was 0.]
+    expected: FAIL
+
+  [WebGL test #114: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER) should be 0 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #135: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 0 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #87: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid target enum: NO_ERROR]
+    expected: FAIL
+
+  [WebGL test #42: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLTexture\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #88: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid attachment enum: NO_ERROR]
+    expected: FAIL
+
+  [WebGL test #41: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 5890 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #104: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 5890 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #103: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 0, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER) should be 0 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #107: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE) should be 0 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #148: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid parameter enum: NO_ERROR]
+    expected: FAIL
+
+  [WebGL test #134: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #120: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLRenderbuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #44: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE) should be 0 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #85: getError expected: NO_ERROR. Was INVALID_OPERATION : ]
+    expected: FAIL
+
+  [WebGL test #72: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #105: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLTexture\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #133: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.BACK, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #71: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #64: getError expected: INVALID_OPERATION. Was INVALID_ENUM : after evaluating: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE)]
+    expected: FAIL
+
+  [WebGL test #40: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 0, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER) should be 0 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #150: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid attachment enum: NO_ERROR]
+    expected: FAIL
+
+  [WebGL test #182: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL
+
+  [WebGL test #92: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36061.]
+    expected: FAIL
+
+  [WebGL test #167: gl.getProgramParameter(uniformBlockProgram, gl.ACTIVE_UNIFORM_BLOCKS) should be 1 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #106: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL) should be 0 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #91: getError expected: NO_ERROR. Was INVALID_ENUM : ]
+    expected: FAIL
+
+  [WebGL test #175: gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_DEPTH_SIZE) should be non-zero. Was 0]
+    expected: FAIL
+
+  [WebGL test #149: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid target enum: NO_ERROR]
+    expected: FAIL
+
+  [WebGL test #51: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER) should be 0 (of type number). Was null (of type object).]
+    expected: FAIL
+


### PR DESCRIPTION
Adds support for using the WebGL2 enums `MAX_COLOR_ATTACHMENTS` and `MAX_DRAW_BUFFERS` with `GetParameter`.

See https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2

<!-- Please describe your changes on the following line: -->

cc @jdm @zakorgy

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
