### PR TITLE
Always trigger an input sources change event on session creation

### DIFF
--- a/components/script/dom/xr.rs
+++ b/components/script/dom/xr.rs
@@ -284,7 +284,6 @@ impl XR {
                 return;
             },
         };
-
         let session = XRSession::new(&self.global(), session, mode, frame_receiver);
         if mode == XRSessionMode::Inline {
             self.active_inline_sessions
@@ -294,6 +293,9 @@ impl XR {
             self.set_active_immersive_session(&session);
         }
         promise.resolve_native(&session);
+        // https://github.com/immersive-web/webxr/issues/961
+        // This must be called _after_ the promise is resolved
+        session.setup_initial_inputs();
     }
 
     pub fn get_displays(&self) -> Result<Vec<DomRoot<VRDisplay>>, ()> {

--- a/components/script/dom/xrinputsourcearray.rs
+++ b/components/script/dom/xrinputsourcearray.rs
@@ -38,30 +38,22 @@ impl XRInputSourceArray {
         )
     }
 
-    pub fn set_initial_inputs(&self, session: &XRSession) {
+    pub fn add_input_sources(&self, session: &XRSession, inputs: &[InputSource]) {
         let mut input_sources = self.input_sources.borrow_mut();
         let global = self.global();
-        session.with_session(|sess| {
-            for info in sess.initial_inputs() {
-                // XXXManishearth we should be able to listen for updates
-                // to the input sources
-                let input = XRInputSource::new(&global, &session, info.clone());
-                input_sources.push(Dom::from_ref(&input));
-            }
-        });
-    }
 
-    pub fn add_input_source(&self, session: &XRSession, info: InputSource) {
-        let mut input_sources = self.input_sources.borrow_mut();
-        let global = self.global();
-        debug_assert!(
-            input_sources.iter().find(|i| i.id() == info.id).is_none(),
-            "Should never add a duplicate input id!"
-        );
-        let input = XRInputSource::new(&global, &session, info);
-        input_sources.push(Dom::from_ref(&input));
-
-        let added = [input];
+        let mut added = vec![];
+        for info in inputs {
+            // This is quadratic, but won't be a problem for the only case
+            // where we add multiple input sources (the initial input sources case)
+            debug_assert!(
+                input_sources.iter().find(|i| i.id() == info.id).is_none(),
+                "Should never add a duplicate input id!"
+            );
+            let input = XRInputSource::new(&global, &session, info.clone());
+            input_sources.push(Dom::from_ref(&input));
+            added.push(input);
+        }
 
         let event = XRInputSourcesChangeEvent::new(
             &global,


### PR DESCRIPTION
Fixes our behavior to match the spec, and to specifically do it in a way
that makes sense. This is also what Chromium does currently, though I'm
not sure if it does the scheduling the same way.

The spec for this may change, see https://github.com/immersive-web/webxr/issues/961.

This fix, along with https://github.com/servo/servo/pull/25770 , makes
three.js content work on servo. Instead of this fix we can also wait for
https://github.com/mrdoob/three.js/issues/18638 to land (which isn't
certain until we figure out more about
https://github.com/immersive-web/webxr/issues/961 )

Even if https://github.com/immersive-web/webxr/issues/961 decides to
choose the option that obviates this patch, we should probably keep it
for now since there's already content out in the wild relying on this
behavior.

r? @jdm @asajeffrey