### PR TITLE
Take origin from current window instead of creating a new one in event of reflow

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3227,14 +3227,14 @@ where
                     },
                 }
             },
-            AnimationTickType::Layout => {
-                let msg = LayoutControlMsg::TickAnimations;
-                match self.pipelines.get(&pipeline_id) {
-                    Some(pipeline) => pipeline.layout_chan.send(msg),
-                    None => {
-                        return warn!("Pipeline {:?} got layout tick after closure.", pipeline_id);
-                    },
-                }
+            AnimationTickType::Layout => match self.pipelines.get(&pipeline_id) {
+                Some(pipeline) => {
+                    let msg = LayoutControlMsg::TickAnimations(pipeline.load_data.url.origin());
+                    pipeline.layout_chan.send(msg)
+                },
+                None => {
+                    return warn!("Pipeline {:?} got layout tick after closure.", pipeline_id);
+                },
             },
         };
         if let Err(e) = result {

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -140,6 +140,7 @@ impl<'a> LayoutContext<'a> {
                     state: PendingImageState::Unrequested(url),
                     node: node.to_untrusted_node_address(),
                     id: id,
+                    origin: self.origin.clone(),
                 };
                 self.pending_images
                     .as_ref()
@@ -160,6 +161,7 @@ impl<'a> LayoutContext<'a> {
                         state: PendingImageState::PendingResponse,
                         node: node.to_untrusted_node_address(),
                         id: id,
+                        origin: self.origin.clone(),
                     };
                     pending_images.lock().unwrap().push(image);
                 }

--- a/components/layout_2020/context.rs
+++ b/components/layout_2020/context.rs
@@ -88,6 +88,7 @@ impl<'a> LayoutContext<'a> {
                     state: PendingImageState::Unrequested(url),
                     node: node.into(),
                     id: id,
+                    origin: self.origin.clone(),
                 };
                 self.pending_images
                     .as_ref()
@@ -108,6 +109,7 @@ impl<'a> LayoutContext<'a> {
                         state: PendingImageState::PendingResponse,
                         node: node.into(),
                         id: id,
+                        origin: self.origin.clone(),
                     };
                     pending_images.lock().unwrap().push(image);
                 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1548,7 +1548,11 @@ impl Window {
     /// forces a reflow if `tick` is true.
     pub fn advance_animation_clock(&self, delta: i32, tick: bool) {
         self.layout_chan
-            .send(Msg::AdvanceClockMs(delta, tick))
+            .send(Msg::AdvanceClockMs(
+                delta,
+                tick,
+                self.origin().immutable().clone(),
+            ))
             .unwrap();
     }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1622,6 +1622,7 @@ impl Window {
             document: self.Document().upcast::<Node>().to_trusted_node_address(),
             stylesheets_changed,
             window_size: self.window_size.get(),
+            origin: self.origin().immutable().clone(),
             reflow_goal,
             script_join_chan: join_chan,
             dom_count: self.Document().dom_count(),

--- a/components/script_layout_interface/lib.rs
+++ b/components/script_layout_interface/lib.rs
@@ -23,7 +23,7 @@ use ipc_channel::ipc::IpcSender;
 use libc::c_void;
 use net_traits::image_cache::PendingImageId;
 use script_traits::UntrustedNodeAddress;
-use servo_url::ServoUrl;
+use servo_url::{ImmutableOrigin, ServoUrl};
 use std::ptr::NonNull;
 use std::sync::atomic::AtomicIsize;
 use style::data::ElementData;
@@ -138,6 +138,7 @@ pub struct PendingImage {
     pub state: PendingImageState,
     pub node: UntrustedNodeAddress,
     pub id: PendingImageId,
+    pub origin: ImmutableOrigin,
 }
 
 pub struct HTMLMediaData {

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -47,13 +47,13 @@ pub enum Msg {
     GetRPC(Sender<Box<dyn LayoutRPC + Send>>),
 
     /// Requests that the layout thread render the next frame of all animations.
-    TickAnimations,
+    TickAnimations(ImmutableOrigin),
 
     /// Updates layout's timer for animation testing from script.
     ///
     /// The inner field is the number of *milliseconds* to advance, and the bool
     /// field is whether animations should be force-ticked.
-    AdvanceClockMs(i32, bool),
+    AdvanceClockMs(i32, bool, ImmutableOrigin),
 
     /// Destroys layout data associated with a DOM node.
     ///

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -18,7 +18,7 @@ use script_traits::{ConstellationControlMsg, LayoutControlMsg, LayoutMsg as Cons
 use script_traits::{ScrollState, UntrustedNodeAddress, WindowSizeData};
 use servo_arc::Arc as ServoArc;
 use servo_atoms::Atom;
-use servo_url::ServoUrl;
+use servo_url::{ImmutableOrigin, ServoUrl};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use style::context::QuirksMode;
@@ -216,6 +216,8 @@ pub struct ScriptReflow {
     pub reflow_goal: ReflowGoal,
     /// The number of objects in the dom #10110
     pub dom_count: u32,
+    /// The current window origin
+    pub origin: ImmutableOrigin,
 }
 
 pub struct LayoutThreadInit {

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -124,7 +124,7 @@ pub enum LayoutControlMsg {
     /// Requests the current epoch (layout counter) from this layout.
     GetCurrentEpoch(IpcSender<Epoch>),
     /// Asks layout to run another step in its animation.
-    TickAnimations,
+    TickAnimations(ImmutableOrigin),
     /// Tells layout about the new scrolling offsets of each scrollable stacking context.
     SetScrollStates(Vec<ScrollState>),
     /// Requests the current load state of Web fonts. `true` is returned if fonts are still loading


### PR DESCRIPTION
Everytime a new `LayoutContext` was created, it created a new origin which
caused endless stream of image loads to occur in case of reflow. The reason
for this was that the existing image, although cached successfully, was not
used because the entry in hashmap did not match because of different(new)
origin.
This is solved by storing the origin of a window in enum `ScriptReflow` and
used in creating new `LayoutContext` in case of reflow.

<!-- Please describe your changes on the following line: -->
r?@jdm

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #24720  (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
