### PR TITLE
Add support for WebGL2 framebuffer attachments

### DIFF
--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -4,8 +4,8 @@
 
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants;
 use crate::dom::bindings::codegen::Bindings::WebGLFramebufferBinding;
-use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextConstants as constants;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
@@ -14,9 +14,10 @@ use crate::dom::webglrenderbuffer::WebGLRenderbuffer;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
 use crate::dom::webgltexture::WebGLTexture;
 use crate::dom::xrsession::XRSession;
-use canvas_traits::webgl::{webgl_channel, WebGLError, WebGLResult};
+use canvas_traits::webgl::{webgl_channel, WebGLError, WebGLResult, WebGLVersion};
 use canvas_traits::webgl::{WebGLCommand, WebGLFramebufferBindingRequest};
 use canvas_traits::webgl::{WebGLFramebufferId, WebGLOpaqueFramebufferId};
+use canvas_traits::webgl::{WebGLRenderbufferId, WebGLTextureId};
 use dom_struct::dom_struct;
 use euclid::Size2D;
 use std::cell::Cell;
@@ -27,6 +28,10 @@ pub enum CompleteForRendering {
     Complete,
     Incomplete,
     MissingColorAttachment,
+}
+
+fn log2(n: u32) -> u32 {
+    31 - n.leading_zeros()
 }
 
 #[unrooted_must_root_lint::must_root]
@@ -84,15 +89,15 @@ pub enum WebGLFramebufferAttachmentRoot {
 #[dom_struct]
 pub struct WebGLFramebuffer {
     webgl_object: WebGLObject,
+    webgl_version: WebGLVersion,
     id: WebGLFramebufferId,
-    /// target can only be gl::FRAMEBUFFER at the moment
     target: Cell<Option<u32>>,
     is_deleted: Cell<bool>,
     size: Cell<Option<(i32, i32)>>,
     status: Cell<u32>,
     // The attachment points for textures and renderbuffers on this
     // FBO.
-    color: DomRefCell<Option<WebGLFramebufferAttachment>>,
+    colors: Vec<DomRefCell<Option<WebGLFramebufferAttachment>>>,
     depth: DomRefCell<Option<WebGLFramebufferAttachment>>,
     stencil: DomRefCell<Option<WebGLFramebufferAttachment>>,
     depthstencil: DomRefCell<Option<WebGLFramebufferAttachment>>,
@@ -106,12 +111,13 @@ impl WebGLFramebuffer {
     fn new_inherited(context: &WebGLRenderingContext, id: WebGLFramebufferId) -> Self {
         Self {
             webgl_object: WebGLObject::new_inherited(context),
+            webgl_version: context.webgl_version(),
             id: id,
             target: Cell::new(None),
             is_deleted: Cell::new(false),
             size: Cell::new(None),
             status: Cell::new(constants::FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT),
-            color: DomRefCell::new(None),
+            colors: vec![DomRefCell::new(None); context.limits().max_color_attachments as usize],
             depth: DomRefCell::new(None),
             stencil: DomRefCell::new(None),
             depthstencil: DomRefCell::new(None),
@@ -213,91 +219,138 @@ impl WebGLFramebuffer {
         self.size.get()
     }
 
+    fn check_attachment_constraints(
+        &self,
+        attachment: &Option<WebGLFramebufferAttachment>,
+        constraints: &[u32],
+        fb_size: &mut Option<(i32, i32)>,
+    ) -> Result<(), u32> {
+        // Get the size of this attachment.
+        let (format, size) = match attachment {
+            Some(WebGLFramebufferAttachment::Renderbuffer(ref att_rb)) => {
+                (Some(att_rb.internal_format()), att_rb.size())
+            },
+            Some(WebGLFramebufferAttachment::Texture {
+                texture: ref att_tex,
+                level,
+            }) => match att_tex.image_info_at_face(0, *level as u32) {
+                Some(info) => (
+                    Some(info.internal_format().as_gl_constant()),
+                    Some((info.width() as i32, info.height() as i32)),
+                ),
+                None => return Err(constants::FRAMEBUFFER_INCOMPLETE_ATTACHMENT),
+            },
+            None => (None, None),
+        };
+
+        // Make sure that, if we've found any other attachment,
+        // that the size matches.
+        if size.is_some() {
+            if fb_size.is_some() && size != *fb_size {
+                return Err(constants::FRAMEBUFFER_INCOMPLETE_DIMENSIONS);
+            } else {
+                *fb_size = size;
+            }
+        }
+
+        if let Some(format) = format {
+            if constraints.iter().all(|c| *c != format) {
+                return Err(constants::FRAMEBUFFER_INCOMPLETE_ATTACHMENT);
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn update_status(&self) {
-        let c = self.color.borrow();
         let z = self.depth.borrow();
         let s = self.stencil.borrow();
         let zs = self.depthstencil.borrow();
-        let has_c = c.is_some();
         let has_z = z.is_some();
         let has_s = s.is_some();
         let has_zs = zs.is_some();
-        let attachments = [&*c, &*z, &*s, &*zs];
+        let attachments = [&*z, &*s, &*zs];
         let attachment_constraints = [
             &[
-                constants::RGBA4,
-                constants::RGB5_A1,
-                constants::RGB565,
-                constants::RGBA,
-                constants::RGB,
+                constants::DEPTH_COMPONENT16,
+                constants::DEPTH_COMPONENT24,
+                constants::DEPTH_COMPONENT32F,
+                constants::DEPTH24_STENCIL8,
+                constants::DEPTH32F_STENCIL8,
             ][..],
-            &[constants::DEPTH_COMPONENT16][..],
-            &[constants::STENCIL_INDEX8][..],
+            &[
+                constants::STENCIL_INDEX8,
+                constants::DEPTH24_STENCIL8,
+                constants::DEPTH32F_STENCIL8,
+            ][..],
             &[constants::DEPTH_STENCIL][..],
         ];
 
-        // From the WebGL spec, 6.6 ("Framebuffer Object Attachments"):
-        //
-        //    "In the WebGL API, it is an error to concurrently attach
-        //     renderbuffers to the following combinations of
-        //     attachment points:
-        //
-        //     DEPTH_ATTACHMENT + DEPTH_STENCIL_ATTACHMENT
-        //     STENCIL_ATTACHMENT + DEPTH_STENCIL_ATTACHMENT
-        //     DEPTH_ATTACHMENT + STENCIL_ATTACHMENT
-        //
-        //     If any of the constraints above are violated, then:
-        //
-        //     checkFramebufferStatus must return FRAMEBUFFER_UNSUPPORTED."
-        if (has_zs && (has_z || has_s)) || (has_z && has_s) {
-            self.status.set(constants::FRAMEBUFFER_UNSUPPORTED);
-            return;
+        let is_supported = match self.webgl_version {
+            // From the WebGL 1.0 spec, 6.6 ("Framebuffer Object Attachments"):
+            //
+            //    "In the WebGL API, it is an error to concurrently attach
+            //     renderbuffers to the following combinations of
+            //     attachment points:
+            //
+            //     DEPTH_ATTACHMENT + DEPTH_STENCIL_ATTACHMENT
+            //     STENCIL_ATTACHMENT + DEPTH_STENCIL_ATTACHMENT
+            //     DEPTH_ATTACHMENT + STENCIL_ATTACHMENT
+            //
+            //     If any of the constraints above are violated, then:
+            //
+            //     checkFramebufferStatus must return FRAMEBUFFER_UNSUPPORTED."
+            WebGLVersion::WebGL1 => !(has_zs && (has_z || has_s)) && !(has_z && has_s),
+
+            // In WebGL 2.0, DEPTH_STENCIL_ATTACHMENT is considered an alias for
+            // DEPTH_ATTACHMENT + STENCIL_ATTACHMENT, i.e., the same image is attached to both DEPTH_ATTACHMENT
+            // and STENCIL_ATTACHMENT, overwriting the original images attached to the two attachment points.
+            // If different images are bound to the depth and stencil attachment points, checkFramebufferStatus
+            // returns FRAMEBUFFER_UNSUPPORTED, and getFramebufferAttachmentParameter with attachment of
+            // DEPTH_STENCIL_ATTACHMENT generates an INVALID_OPERATION error.
+            // -- WebGL 2.0 spec, 4.1.5 Framebuffer Object Attachments
+            WebGLVersion::WebGL2 => {
+                use WebGLFramebufferAttachment::{Renderbuffer, Texture};
+                match (&*z, &*s) {
+                    (Some(Renderbuffer(a)), Some(Renderbuffer(b))) => a.id() == b.id(),
+                    (Some(Texture { texture: a, .. }), Some(Texture { texture: b, .. })) => {
+                        a.id() == b.id()
+                    },
+                    _ => !has_z || !has_s,
+                }
+            },
+        };
+        if !is_supported {
+            return self.status.set(constants::FRAMEBUFFER_UNSUPPORTED);
         }
 
         let mut fb_size = None;
+
         for (attachment, constraints) in attachments.iter().zip(&attachment_constraints) {
-            // Get the size of this attachment.
-            let (format, size) = match **attachment {
-                Some(WebGLFramebufferAttachment::Renderbuffer(ref att_rb)) => {
-                    (Some(att_rb.internal_format()), att_rb.size())
-                },
-                Some(WebGLFramebufferAttachment::Texture {
-                    texture: ref att_tex,
-                    level,
-                }) => match att_tex.image_info_at_face(0, level as u32) {
-                    Some(info) => (
-                        Some(info.internal_format().as_gl_constant()),
-                        Some((info.width() as i32, info.height() as i32)),
-                    ),
-                    None => {
-                        self.status
-                            .set(constants::FRAMEBUFFER_INCOMPLETE_ATTACHMENT);
-                        return;
-                    },
-                },
-                None => (None, None),
-            };
-
-            // Make sure that, if we've found any other attachment,
-            // that the size matches.
-            if size.is_some() {
-                if fb_size.is_some() && size != fb_size {
-                    self.status
-                        .set(constants::FRAMEBUFFER_INCOMPLETE_DIMENSIONS);
-                    return;
-                } else {
-                    fb_size = size;
-                }
-            }
-
-            if let Some(format) = format {
-                if constraints.iter().all(|c| *c != format) {
-                    self.status
-                        .set(constants::FRAMEBUFFER_INCOMPLETE_ATTACHMENT);
-                    return;
-                }
+            if let Err(errnum) =
+                self.check_attachment_constraints(attachment, constraints, &mut fb_size)
+            {
+                return self.status.set(errnum);
             }
         }
+
+        let color_constraints = &[
+            constants::RGBA4,
+            constants::RGB5_A1,
+            constants::RGB565,
+            constants::RGBA,
+            constants::RGB,
+        ][..];
+        let has_c = self.colors.iter().any(|att| att.borrow().is_some());
+        for attachment in self.colors.iter() {
+            let attachment = attachment.borrow();
+            if let Err(errnum) =
+                self.check_attachment_constraints(&*attachment, color_constraints, &mut fb_size)
+            {
+                return self.status.set(errnum);
+            }
+        }
+
         self.size.set(fb_size);
 
         if has_c || has_z || has_zs || has_s {
@@ -339,13 +392,12 @@ impl WebGLFramebuffer {
             return CompleteForRendering::Complete;
         }
 
-        if self.color.borrow().is_none() {
+        if self.colors.iter().any(|att| att.borrow().is_none()) {
             return CompleteForRendering::MissingColorAttachment;
         }
 
         if !self.is_initialized.get() {
             let attachments = [
-                (&self.color, constants::COLOR_BUFFER_BIT),
                 (&self.depth, constants::DEPTH_BUFFER_BIT),
                 (&self.stencil, constants::STENCIL_BUFFER_BIT),
                 (
@@ -359,6 +411,14 @@ impl WebGLFramebuffer {
                     if att.needs_initialization() {
                         att.mark_initialized();
                         clear_bits |= bits;
+                    }
+                }
+            }
+            for attachment in self.colors.iter() {
+                if let Some(ref att) = *attachment.borrow() {
+                    if att.needs_initialization() {
+                        att.mark_initialized();
+                        clear_bits |= constants::COLOR_BUFFER_BIT;
                     }
                 }
             }
@@ -397,7 +457,7 @@ impl WebGLFramebuffer {
         self.upcast::<WebGLObject>()
             .context()
             .send_command(WebGLCommand::FramebufferRenderbuffer(
-                constants::FRAMEBUFFER,
+                self.target.get().unwrap(),
                 attachment,
                 constants::RENDERBUFFER,
                 rb_id,
@@ -436,7 +496,10 @@ impl WebGLFramebuffer {
         attachment: u32,
     ) -> Option<&DomRefCell<Option<WebGLFramebufferAttachment>>> {
         match attachment {
-            constants::COLOR_ATTACHMENT0 => Some(&self.color),
+            constants::COLOR_ATTACHMENT0..=constants::COLOR_ATTACHMENT15 => {
+                let idx = attachment - constants::COLOR_ATTACHMENT0;
+                self.colors.get(idx as usize)
+            },
             constants::DEPTH_ATTACHMENT => Some(&self.depth),
             constants::STENCIL_ATTACHMENT => Some(&self.stencil),
             constants::DEPTH_STENCIL_ATTACHMENT => Some(&self.depthstencil),
@@ -455,7 +518,7 @@ impl WebGLFramebuffer {
                 WebGLFramebufferAttachment::Renderbuffer(ref rb) => {
                     rb.attach_to_framebuffer(self);
                     context.send_command(WebGLCommand::FramebufferRenderbuffer(
-                        constants::FRAMEBUFFER,
+                        self.target.get().unwrap(),
                         attachment_point,
                         constants::RENDERBUFFER,
                         Some(rb.id()),
@@ -464,7 +527,7 @@ impl WebGLFramebuffer {
                 WebGLFramebufferAttachment::Texture { ref texture, level } => {
                     texture.attach_to_framebuffer(self);
                     context.send_command(WebGLCommand::FramebufferTexture2D(
-                        constants::FRAMEBUFFER,
+                        self.target.get().unwrap(),
                         attachment_point,
                         texture.target().expect("missing texture target"),
                         Some(texture.id()),
@@ -517,15 +580,6 @@ impl WebGLFramebuffer {
             // Note, from the GLES 2.0.25 spec, page 113:
             //      "If texture is zero, then textarget and level are ignored."
             Some(texture) => {
-                // From the GLES 2.0.25 spec, page 113:
-                //
-                //     "level specifies the mipmap level of the texture image
-                //      to be attached to the framebuffer and must be
-                //      0. Otherwise, INVALID_VALUE is generated."
-                if level != 0 {
-                    return Err(WebGLError::InvalidValue);
-                }
-
                 //     "If texture is not zero, then texture must either
                 //      name an existing texture object with an target of
                 //      textarget, or texture must name an existing cube
@@ -556,6 +610,16 @@ impl WebGLFramebuffer {
                     _ => return Err(WebGLError::InvalidOperation),
                 }
 
+                let context = self.upcast::<WebGLObject>().context();
+                let max_tex_size = if is_cube {
+                    context.limits().max_cube_map_tex_size
+                } else {
+                    context.limits().max_tex_size
+                };
+                if level < 0 || level as u32 > log2(max_tex_size) {
+                    return Err(WebGLError::InvalidValue);
+                }
+
                 *binding.borrow_mut() = Some(WebGLFramebufferAttachment::Texture {
                     texture: Dom::from_ref(texture),
                     level: level,
@@ -571,7 +635,7 @@ impl WebGLFramebuffer {
         self.upcast::<WebGLObject>()
             .context()
             .send_command(WebGLCommand::FramebufferTexture2D(
-                constants::FRAMEBUFFER,
+                self.target.get().unwrap(),
                 attachment,
                 textarget,
                 tex_id,
@@ -591,27 +655,35 @@ impl WebGLFramebuffer {
     where
         F: FnMut(&DomRefCell<Option<WebGLFramebufferAttachment>>, u32),
     {
+        let rb_id = rb.id();
         let attachments = [
-            (&self.color, constants::COLOR_ATTACHMENT0),
             (&self.depth, constants::DEPTH_ATTACHMENT),
             (&self.stencil, constants::STENCIL_ATTACHMENT),
             (&self.depthstencil, constants::DEPTH_STENCIL_ATTACHMENT),
         ];
 
-        for (attachment, name) in &attachments {
-            let matched = {
-                match *attachment.borrow() {
-                    Some(WebGLFramebufferAttachment::Renderbuffer(ref att_rb))
-                        if rb.id() == att_rb.id() =>
-                    {
-                        true
-                    },
-                    _ => false,
-                }
-            };
+        fn has_matching_id(
+            attachment: &DomRefCell<Option<WebGLFramebufferAttachment>>,
+            target: &WebGLRenderbufferId,
+        ) -> bool {
+            match *attachment.borrow() {
+                Some(WebGLFramebufferAttachment::Renderbuffer(ref att_rb)) => {
+                    att_rb.id() == *target
+                },
+                _ => false,
+            }
+        }
 
-            if matched {
+        for (attachment, name) in &attachments {
+            if has_matching_id(attachment, &rb_id) {
                 closure(attachment, *name);
+            }
+        }
+
+        for (idx, attachment) in self.colors.iter().enumerate() {
+            if has_matching_id(attachment, &rb_id) {
+                let name = constants::COLOR_ATTACHMENT0 + idx as u32;
+                closure(attachment, name);
             }
         }
     }
@@ -620,26 +692,36 @@ impl WebGLFramebuffer {
     where
         F: FnMut(&DomRefCell<Option<WebGLFramebufferAttachment>>, u32),
     {
+        let tex_id = texture.id();
         let attachments = [
-            (&self.color, constants::COLOR_ATTACHMENT0),
             (&self.depth, constants::DEPTH_ATTACHMENT),
             (&self.stencil, constants::STENCIL_ATTACHMENT),
             (&self.depthstencil, constants::DEPTH_STENCIL_ATTACHMENT),
         ];
 
-        for (attachment, name) in &attachments {
-            let matched = {
-                match *attachment.borrow() {
-                    Some(WebGLFramebufferAttachment::Texture {
-                        texture: ref att_texture,
-                        ..
-                    }) if texture.id() == att_texture.id() => true,
-                    _ => false,
-                }
-            };
+        fn has_matching_id(
+            attachment: &DomRefCell<Option<WebGLFramebufferAttachment>>,
+            target: &WebGLTextureId,
+        ) -> bool {
+            match *attachment.borrow() {
+                Some(WebGLFramebufferAttachment::Texture {
+                    texture: ref att_texture,
+                    ..
+                }) if att_texture.id() == *target => true,
+                _ => false,
+            }
+        }
 
-            if matched {
+        for (attachment, name) in &attachments {
+            if has_matching_id(attachment, &tex_id) {
                 closure(attachment, *name);
+            }
+        }
+
+        for (idx, attachment) in self.colors.iter().enumerate() {
+            if has_matching_id(attachment, &tex_id) {
+                let name = constants::COLOR_ATTACHMENT0 + idx as u32;
+                closure(attachment, name);
             }
         }
     }

--- a/components/script/dom/webglrenderbuffer.rs
+++ b/components/script/dom/webglrenderbuffer.rs
@@ -5,9 +5,8 @@
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use crate::dom::bindings::codegen::Bindings::EXTColorBufferHalfFloatBinding::EXTColorBufferHalfFloatConstants;
 use crate::dom::bindings::codegen::Bindings::WEBGLColorBufferFloatBinding::WEBGLColorBufferFloatConstants;
-use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants;
+use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants;
 use crate::dom::bindings::codegen::Bindings::WebGLRenderbufferBinding;
-use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextConstants as constants;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
@@ -15,7 +14,7 @@ use crate::dom::webglframebuffer::WebGLFramebuffer;
 use crate::dom::webglobject::WebGLObject;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
 use canvas_traits::webgl::{
-    webgl_channel, GlType, WebGLCommand, WebGLError, WebGLRenderbufferId, WebGLResult,
+    webgl_channel, GlType, WebGLCommand, WebGLError, WebGLRenderbufferId, WebGLResult, WebGLVersion,
 };
 use dom_struct::dom_struct;
 use std::cell::Cell;
@@ -146,14 +145,21 @@ impl WebGLRenderbuffer {
             constants::RGBA4 | constants::DEPTH_COMPONENT16 | constants::STENCIL_INDEX8 => {
                 internal_format
             },
+            constants::DEPTH_COMPONENT24 |
+            constants::DEPTH_COMPONENT32F |
+            constants::DEPTH24_STENCIL8 |
+            constants::DEPTH32F_STENCIL8 => match self.upcast().context().webgl_version() {
+                WebGLVersion::WebGL1 => return Err(WebGLError::InvalidEnum),
+                _ => internal_format,
+            },
             // https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.8
-            constants::DEPTH_STENCIL => WebGL2RenderingContextConstants::DEPTH24_STENCIL8,
+            constants::DEPTH_STENCIL => constants::DEPTH24_STENCIL8,
             constants::RGB5_A1 => {
                 // 16-bit RGBA formats are not supported on desktop GL.
                 if is_gles {
                     constants::RGB5_A1
                 } else {
-                    WebGL2RenderingContextConstants::RGBA8
+                    constants::RGBA8
                 }
             },
             constants::RGB565 => {
@@ -161,7 +167,7 @@ impl WebGLRenderbuffer {
                 if is_gles {
                     constants::RGB565
                 } else {
-                    WebGL2RenderingContextConstants::RGB8
+                    constants::RGB8
                 }
             },
             EXTColorBufferHalfFloatConstants::RGBA16F_EXT |

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -276,6 +276,10 @@ impl WebGLRenderingContext {
         }
     }
 
+    pub fn webgl_version(&self) -> WebGLVersion {
+        self.webgl_version
+    }
+
     pub fn limits(&self) -> &GLLimits {
         &self.limits
     }
@@ -4264,6 +4268,15 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
 
         if target != constants::FRAMEBUFFER {
             return self.webgl_error(InvalidEnum);
+        }
+
+        // From the GLES 2.0.25 spec, page 113:
+        //
+        //     "level specifies the mipmap level of the texture image
+        //      to be attached to the framebuffer and must be
+        //      0. Otherwise, INVALID_VALUE is generated."
+        if level != 0 {
+            return self.webgl_error(InvalidValue);
         }
 
         match self.bound_draw_framebuffer.get() {

--- a/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
@@ -1,4 +1,91 @@
 [methods-2.html]
+  [WebGL test #11: Property either does not exist or is not a function: compressedTexSubImage3D]
+    expected: FAIL
+
+  [WebGL test #8: Property either does not exist or is not a function: texSubImage3D]
+    expected: FAIL
+
+  [WebGL test #28: Property either does not exist or is not a function: bindVertexArray]
+    expected: FAIL
+
+  [WebGL test #14: Property either does not exist or is not a function: vertexAttribI4iv]
+    expected: FAIL
+
+  [WebGL test #23: Property either does not exist or is not a function: clearBufferfi]
+    expected: FAIL
+
+  [WebGL test #15: Property either does not exist or is not a function: vertexAttribI4ui]
+    expected: FAIL
+
+  [WebGL test #27: Property either does not exist or is not a function: isVertexArray]
+    expected: FAIL
+
+  [WebGL test #20: Property either does not exist or is not a function: clearBufferiv]
+    expected: FAIL
+
+  [WebGL test #22: Property either does not exist or is not a function: clearBufferfv]
+    expected: FAIL
+
+  [WebGL test #6: Property either does not exist or is not a function: texStorage2D]
+    expected: FAIL
+
+  [WebGL test #1: Property either does not exist or is not a function: blitFramebuffer]
+    expected: FAIL
+
+  [WebGL test #13: Property either does not exist or is not a function: vertexAttribI4i]
+    expected: FAIL
+
+  [WebGL test #5: Property either does not exist or is not a function: texImage3D]
+    expected: FAIL
+
+  [WebGL test #21: Property either does not exist or is not a function: clearBufferuiv]
+    expected: FAIL
+
+  [WebGL test #26: Property either does not exist or is not a function: deleteVertexArray]
+    expected: FAIL
+
+  [WebGL test #4: Property either does not exist or is not a function: renderbufferStorageMultisample]
+    expected: FAIL
+
+  [WebGL test #19: Property either does not exist or is not a function: drawBuffers]
+    expected: FAIL
+
+  [WebGL test #10: Property either does not exist or is not a function: compressedTexImage3D]
+    expected: FAIL
+
+  [WebGL test #7: Property either does not exist or is not a function: texStorage3D]
+    expected: FAIL
+
+  [WebGL test #16: Property either does not exist or is not a function: vertexAttribI4uiv]
+    expected: FAIL
+
+  [WebGL test #18: Property either does not exist or is not a function: drawRangeElements]
+    expected: FAIL
+
+  [WebGL test #9: Property either does not exist or is not a function: copyTexSubImage3D]
+    expected: FAIL
+
+  [WebGL test #0: Property either does not exist or is not a function: isContextLost]
+    expected: FAIL
+
+  [WebGL test #17: Property either does not exist or is not a function: vertexAttribIPointer]
+    expected: FAIL
+
+  [WebGL test #24: Property either does not exist or is not a function: getIndexedParameter]
+    expected: FAIL
+
+  [WebGL test #2: Property either does not exist or is not a function: getInternalformatParameter]
+    expected: FAIL
+
+  [WebGL test #25: Property either does not exist or is not a function: createVertexArray]
+    expected: FAIL
+
+  [WebGL test #3: Property either does not exist or is not a function: readBuffer]
+    expected: FAIL
+
+  [WebGL test #12: Property either does not exist or is not a function: getFragDataLocation]
+    expected: FAIL
+
   [WebGL test #16: Property either does not exist or is not a function: vertexAttribI4i]
     expected: FAIL
 
@@ -30,9 +117,6 @@
     expected: FAIL
 
   [WebGL test #29: Property either does not exist or is not a function: deleteVertexArray]
-    expected: FAIL
-
-  [WebGL test #1: Property either does not exist or is not a function: blitFramebuffer]
     expected: FAIL
 
   [WebGL test #11: Property either does not exist or is not a function: texSubImage3D]
@@ -69,9 +153,6 @@
     expected: FAIL
 
   [WebGL test #28: Property either does not exist or is not a function: createVertexArray]
-    expected: FAIL
-
-  [WebGL test #0: Property either does not exist or is not a function: isContextLost]
     expected: FAIL
 
   [WebGL test #25: Property either does not exist or is not a function: clearBufferfv]

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/framebuffer-object-attachment.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/framebuffer-object-attachment.html.ini
@@ -32,3 +32,36 @@
   [WebGL test #59: getError expected: NO_ERROR. Was INVALID_ENUM : Query should not generate error]
     expected: FAIL
 
+  [WebGL test #13: gl.getParameter(gl.RED_BITS) + gl.getParameter(gl.GREEN_BITS) + gl.getParameter(gl.BLUE_BITS) + gl.getParameter(gl.ALPHA_BITS) >= 16 should be true. Was false.]
+    expected: FAIL
+
+  [WebGL test #10: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
+    expected: FAIL
+
+  [WebGL test #21: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
+    expected: FAIL
+
+  [WebGL test #17: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
+    expected: FAIL
+
+  [WebGL test #9: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
+    expected: FAIL
+
+  [WebGL test #11: getError expected: NO_ERROR. Was INVALID_ENUM : ]
+    expected: FAIL
+
+  [WebGL test #19: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
+    expected: FAIL
+
+  [WebGL test #56: getError expected: NO_ERROR. Was INVALID_ENUM : Query should not generate error]
+    expected: FAIL
+
+  [WebGL test #22: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
+    expected: FAIL
+
+  [WebGL test #18: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
+    expected: FAIL
+
+  [WebGL test #27: getError expected: NO_ERROR. Was INVALID_ENUM : ]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/framebuffer-test.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/framebuffer-test.html.ini
@@ -1,164 +1,8 @@
 [framebuffer-test.html]
-  [WebGL test #35: gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_BLUE_SIZE) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #1: getError expected: INVALID_ENUM. Was INVALID_OPERATION : getFramebufferAttachmentParameter(COLOR_ATTACHMENT0) on the default framebuffer.]
-    expected: FAIL
-
-  [WebGL test #31: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #30: getError expected: NO_ERROR. Was INVALID_ENUM : attach a texture to read/draw framebuffer binding point.]
-    expected: FAIL
-
-  [WebGL test #26: getError expected: NO_ERROR. Was INVALID_ENUM : attach a texture to read/draw framebuffer binding point.]
-    expected: FAIL
-
-  [WebGL test #44: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #42: getError expected: NO_ERROR. Was INVALID_ENUM : detach a renderbuffer from a read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #38: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on draw framebuffer with no attachment.]
-    expected: FAIL
-
-  [WebGL test #52: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_RED_SIZE) on read framebuffer with no attachment.]
-    expected: FAIL
-
-  [WebGL test #21: getError expected: NO_ERROR. Was INVALID_VALUE : framebufferTexture2D with an appropriate mipmap level.]
-    expected: FAIL
-
-  [WebGL test #46: getError expected: NO_ERROR. Was INVALID_ENUM : detach a renderbuffer from a read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #29: getError expected: NO_ERROR. Was INVALID_ENUM : detach a texture from read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #33: getError expected: NO_ERROR. Was INVALID_ENUM : detach a texture from read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #40: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #18: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) with no attachment.]
-    expected: FAIL
-
-  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(BACK) on the default framebuffer.]
-    expected: FAIL
-
-  [WebGL test #11: getError expected: NO_ERROR. Was INVALID_ENUM : checkFramebufferStatus(READ_FRAMEBUFFER).]
-    expected: FAIL
-
-  [WebGL test #27: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #37: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #36: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read framebuffer with no attachment.]
-    expected: FAIL
-
-  [WebGL test #16: getError expected: NO_ERROR. Was INVALID_ENUM : framebufferTexImage2D(READ_FRAMEBUFFER).]
-    expected: FAIL
-
-  [WebGL test #17: getError expected: NO_ERROR. Was INVALID_ENUM : framebufferRenderbuffer(READ_FRAMEBUFFER).]
-    expected: FAIL
-
-  [WebGL test #15: getError expected: NO_ERROR. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) with no attachment.]
-    expected: FAIL
-
-  [WebGL test #39: getError expected: NO_ERROR. Was INVALID_ENUM : attaching a renderbuffer to a read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #43: getError expected: NO_ERROR. Was INVALID_ENUM : attaching a renderbuffer to a read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #56: getError expected: NO_ERROR. Was INVALID_ENUM : bind draw framebuffer to default (null) framebuffer.]
-    expected: FAIL
-
-  [WebGL test #12: getError expected: NO_ERROR. Was INVALID_ENUM : bindFramebuffer(READ_FRAMEBUFFER).]
-    expected: FAIL
-
-  [WebGL test #55: getError expected: NO_ERROR. Was INVALID_ENUM : bind read framebuffer to default (null) framebuffer.]
-    expected: FAIL
-
-  [WebGL test #49: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE) on read framebuffer without depth attachment.]
-    expected: FAIL
-
-  [WebGL test #9: getError expected: NO_ERROR. Was INVALID_ENUM : getFramebufferAttachmentParameter(READ_FRAMEBUFFER).]
-    expected: FAIL
-
-  [WebGL test #48: getError expected: NO_ERROR. Was INVALID_ENUM : detach a renderbuffer from a read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #39: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #54: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_RED_SIZE) on read framebuffer with no attachment.]
-    expected: FAIL
-
-  [WebGL test #51: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE) on read framebuffer without depth attachment.]
-    expected: FAIL
-
-  [WebGL test #33: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #46: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #57: getError expected: NO_ERROR. Was INVALID_ENUM : bind read framebuffer to default (null) framebuffer.]
-    expected: FAIL
-
-  [WebGL test #40: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on draw framebuffer with no attachment.]
-    expected: FAIL
-
-  [WebGL test #35: getError expected: NO_ERROR. Was INVALID_ENUM : detach a texture from read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #20: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) with no attachment.]
-    expected: FAIL
-
-  [WebGL test #37: gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_BLUE_SIZE) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #42: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #29: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #23: getError expected: NO_ERROR. Was INVALID_VALUE : framebufferTexture2D with an appropriate mipmap level.]
-    expected: FAIL
-
-  [WebGL test #32: getError expected: NO_ERROR. Was INVALID_ENUM : attach a texture to read/draw framebuffer binding point.]
-    expected: FAIL
-
-  [WebGL test #58: getError expected: NO_ERROR. Was INVALID_ENUM : bind draw framebuffer to default (null) framebuffer.]
-    expected: FAIL
-
-  [WebGL test #44: getError expected: NO_ERROR. Was INVALID_ENUM : detach a renderbuffer from a read/draw framebuffer.]
-    expected: FAIL
-
   [WebGL test #38: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read framebuffer with no attachment.]
     expected: FAIL
 
-  [WebGL test #41: getError expected: NO_ERROR. Was INVALID_ENUM : attaching a renderbuffer to a read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #31: getError expected: NO_ERROR. Was INVALID_ENUM : detach a texture from read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #18: getError expected: NO_ERROR. Was INVALID_ENUM : framebufferTexImage2D(COLOR_ATTACHMENT1).]
-    expected: FAIL
-
-  [WebGL test #45: getError expected: NO_ERROR. Was INVALID_ENUM : attaching a renderbuffer to a read/draw framebuffer.]
-    expected: FAIL
-
-  [WebGL test #19: getError expected: NO_ERROR. Was INVALID_ENUM : framebufferRenderbuffer(COLOR_ATTACHMENT1).]
-    expected: FAIL
-
-  [WebGL test #28: getError expected: NO_ERROR. Was INVALID_ENUM : attach a texture to read/draw framebuffer binding point.]
+  [WebGL test #1: getError expected: INVALID_ENUM. Was INVALID_OPERATION : getFramebufferAttachmentParameter(COLOR_ATTACHMENT0) on the default framebuffer.]
     expected: FAIL
 
   [WebGL test #33: getError expected: NO_ERROR. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
@@ -167,10 +11,34 @@
   [WebGL test #42: getError expected: NO_ERROR. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
     expected: FAIL
 
+  [WebGL test #51: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE) on read framebuffer without depth attachment.]
+    expected: FAIL
+
+  [WebGL test #40: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on draw framebuffer with no attachment.]
+    expected: FAIL
+
   [WebGL test #46: getError expected: NO_ERROR. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
     expected: FAIL
 
+  [WebGL test #54: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_RED_SIZE) on read framebuffer with no attachment.]
+    expected: FAIL
+
+  [WebGL test #20: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) with no attachment.]
+    expected: FAIL
+
   [WebGL test #53: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_RED_SIZE) on draw framebuffer without color attachment.]
+    expected: FAIL
+
+  [WebGL test #37: gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_BLUE_SIZE) should be 0 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_OPERATION : getFramebufferAttachmentParameter(BACK) on the default framebuffer.]
+    expected: FAIL
+
+  [WebGL test #56: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE) on draw framebuffer with no attachment.]
+    expected: FAIL
+
+  [WebGL test #15: getError expected: NO_ERROR. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) with no attachment.]
     expected: FAIL
 
   [WebGL test #29: getError expected: NO_ERROR. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer.]
@@ -188,7 +56,7 @@
   [WebGL test #39: getError expected: NO_ERROR. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on draw framebuffer.]
     expected: FAIL
 
-  [WebGL test #56: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE) on draw framebuffer with no attachment.]
+  [WebGL test #9: getError expected: NO_ERROR. Was INVALID_ENUM : getFramebufferAttachmentParameter(READ_FRAMEBUFFER).]
     expected: FAIL
 
   [WebGL test #30: getError expected: INVALID_OPERATION. Was INVALID_ENUM : getFramebufferAttachmentParameter(FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING) on read/draw framebuffer with no attachment.]

--- a/tests/wpt/webgl/meta/conformance2/rendering/draw-buffers.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/draw-buffers.html.ini
@@ -1,14 +1,5 @@
 [draw-buffers.html]
   expected: ERROR
-  [WebGL test #1: MAX_DRAW_BUFFERS should be at least 4]
-    expected: FAIL
-
-  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : there should be no errors]
-    expected: FAIL
-
-  [WebGL test #4: getError expected: NO_ERROR. Was INVALID_ENUM : should be able to attach to the max attachment point: gl.COLOR_ATTACHMENT0 + 7]
-    expected: FAIL
-
   [WebGL test #5: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/framebuffer-texture-changing-base-level.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/framebuffer-texture-changing-base-level.html.ini
@@ -8,9 +8,24 @@
   [WebGL test #8: getError expected: NO_ERROR. Was INVALID_ENUM : Setup framebuffer with texture should succeed.]
     expected: FAIL
 
+  [WebGL test #3: getError expected: NO_ERROR. Was INVALID_OPERATION : Clearing the texture level 0 to green should succeed.]
+    expected: FAIL
+
+  [WebGL test #9: getError expected: NO_ERROR. Was INVALID_OPERATION : Clearing the texture level 2 to green should succeed.]
+    expected: FAIL
+
+  [WebGL test #6: getError expected: NO_ERROR. Was INVALID_OPERATION : Clearing the texture level 1 to green should succeed.]
+    expected: FAIL
+
+  [WebGL test #14: should be green\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
   [WebGL test #13: getError expected: NO_ERROR. Was INVALID_ENUM : Drawing the texture to default framebuffer with base level 0 should succeed.]
     expected: FAIL
 
   [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : Setup framebuffer with texture should succeed.]
+    expected: FAIL
+
+  [WebGL test #12: getError expected: NO_ERROR. Was INVALID_OPERATION : Clearing the texture level 3 to green should succeed.]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/framebuffer-texture-level1.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/framebuffer-texture-level1.html.ini
@@ -1,10 +1,7 @@
 [framebuffer-texture-level1.html]
-  [WebGL test #3: getError expected: NO_ERROR. Was INVALID_VALUE : Setup framebuffer with texture should succeed.]
+  [WebGL test #1: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36054. Was 36053.]
     expected: FAIL
 
-  [WebGL test #2: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36055.]
-    expected: FAIL
-
-  [WebGL test #1: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36054. Was 36055.]
+  [WebGL test #3: getError expected: NO_ERROR. Was INVALID_ENUM : Setup framebuffer with texture should succeed.]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/state/gl-object-get-calls.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/state/gl-object-get-calls.html.ini
@@ -1,126 +1,6 @@
 [gl-object-get-calls.html]
   expected: ERROR
-  [WebGL test #6: gl.getBufferParameter(gl.COPY_READ_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #7: gl.getBufferParameter(gl.COPY_READ_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #9: gl.getBufferParameter(gl.COPY_WRITE_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
   [WebGL test #10: gl.getBufferParameter(gl.COPY_WRITE_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #12: gl.getBufferParameter(gl.PIXEL_PACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #13: gl.getBufferParameter(gl.PIXEL_PACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #15: gl.getBufferParameter(gl.PIXEL_UNPACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #16: gl.getBufferParameter(gl.PIXEL_UNPACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #18: gl.getBufferParameter(gl.TRANSFORM_FEEDBACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #19: gl.getBufferParameter(gl.TRANSFORM_FEEDBACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #21: gl.getBufferParameter(gl.UNIFORM_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #22: gl.getBufferParameter(gl.UNIFORM_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #26: getError expected: NO_ERROR. Was INVALID_ENUM : ]
-    expected: FAIL
-
-  [WebGL test #28: getError expected: NO_ERROR. Was INVALID_ENUM : ]
-    expected: FAIL
-
-  [WebGL test #29: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36061.]
-    expected: FAIL
-
-  [WebGL test #35: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLRenderbuffer\]. Was null.]
-    expected: FAIL
-
-  [WebGL test #42: getError expected: INVALID_OPERATION. Was INVALID_ENUM : after evaluating: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE)]
-    expected: FAIL
-
-  [WebGL test #48: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.BACK, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #49: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #50: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #63: getError expected: NO_ERROR. Was INVALID_OPERATION : ]
-    expected: FAIL
-
-  [WebGL test #64: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid parameter enum: NO_ERROR]
-    expected: FAIL
-
-  [WebGL test #65: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid target enum: NO_ERROR]
-    expected: FAIL
-
-  [WebGL test #66: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid attachment enum: NO_ERROR]
-    expected: FAIL
-
-  [WebGL test #67: getError expected: NO_ERROR. Was INVALID_ENUM : ]
-    expected: FAIL
-
-  [WebGL test #69: getError expected: NO_ERROR. Was INVALID_ENUM : ]
-    expected: FAIL
-
-  [WebGL test #70: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36061.]
-    expected: FAIL
-
-  [WebGL test #76: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLRenderbuffer\]. Was null.]
-    expected: FAIL
-
-  [WebGL test #83: getError expected: INVALID_OPERATION. Was INVALID_ENUM : after evaluating: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE)]
-    expected: FAIL
-
-  [WebGL test #89: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.BACK, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #90: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #91: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #104: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid parameter enum: NO_ERROR]
-    expected: FAIL
-
-  [WebGL test #105: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid target enum: NO_ERROR]
-    expected: FAIL
-
-  [WebGL test #106: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid attachment enum: NO_ERROR]
-    expected: FAIL
-
-  [WebGL test #131: gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_DEPTH_SIZE) should be non-zero. Was 0]
-    expected: FAIL
-
-  [WebGL test #128: gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_WIDTH) should be 2. Was 0.]
-    expected: FAIL
-
-  [WebGL test #129: gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_HEIGHT) should be 2. Was 0.]
-    expected: FAIL
-
-  [WebGL test #123: gl.getProgramParameter(uniformBlockProgram, gl.ACTIVE_UNIFORM_BLOCKS) should be 1 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #138: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-
-  [WebGL test #89: getError expected: NO_ERROR. Was INVALID_ENUM : ]
     expected: FAIL
 
   [WebGL test #86: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid parameter enum: NO_ERROR]
@@ -132,16 +12,13 @@
   [WebGL test #43: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL) should be 0 (of type number). Was null (of type object).]
     expected: FAIL
 
+  [WebGL test #18: gl.getBufferParameter(gl.TRANSFORM_FEEDBACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
+    expected: FAIL
+
   [WebGL test #70: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.BACK, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #127: getError expected: INVALID_OPERATION. Was INVALID_ENUM : after evaluating: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE)]
-    expected: FAIL
-
-  [WebGL test #172: gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_WIDTH) should be 2. Was 0.]
-    expected: FAIL
-
-  [WebGL test #173: gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_HEIGHT) should be 2. Was 0.]
     expected: FAIL
 
   [WebGL test #114: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER) should be 0 (of type number). Was null (of type object).]
@@ -153,7 +30,16 @@
   [WebGL test #87: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid target enum: NO_ERROR]
     expected: FAIL
 
+  [WebGL test #19: gl.getBufferParameter(gl.TRANSFORM_FEEDBACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #21: gl.getBufferParameter(gl.UNIFORM_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
+    expected: FAIL
+
   [WebGL test #42: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLTexture\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #15: gl.getBufferParameter(gl.PIXEL_UNPACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #88: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid attachment enum: NO_ERROR]
@@ -168,16 +54,28 @@
   [WebGL test #103: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 0, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER) should be 0 (of type number). Was null (of type object).]
     expected: FAIL
 
+  [WebGL test #7: gl.getBufferParameter(gl.COPY_READ_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
+    expected: FAIL
+
   [WebGL test #107: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE) should be 0 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #148: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid parameter enum: NO_ERROR]
     expected: FAIL
 
+  [WebGL test #9: gl.getBufferParameter(gl.COPY_WRITE_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
+    expected: FAIL
+
   [WebGL test #134: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #120: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLRenderbuffer\]. Was null.]
+    expected: FAIL
+
+  [WebGL test #16: gl.getBufferParameter(gl.PIXEL_UNPACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #6: gl.getBufferParameter(gl.COPY_READ_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #44: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE) should be 0 (of type number). Was null (of type object).]
@@ -204,25 +102,25 @@
   [WebGL test #40: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 0, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER) should be 0 (of type number). Was null (of type object).]
     expected: FAIL
 
+  [WebGL test #22: gl.getBufferParameter(gl.UNIFORM_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #12: gl.getBufferParameter(gl.PIXEL_PACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
+    expected: FAIL
+
   [WebGL test #150: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid attachment enum: NO_ERROR]
     expected: FAIL
 
   [WebGL test #182: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
-  [WebGL test #92: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36061.]
+  [WebGL test #13: gl.getBufferParameter(gl.PIXEL_PACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #167: gl.getProgramParameter(uniformBlockProgram, gl.ACTIVE_UNIFORM_BLOCKS) should be 1 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #106: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #91: getError expected: NO_ERROR. Was INVALID_ENUM : ]
-    expected: FAIL
-
-  [WebGL test #175: gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_DEPTH_SIZE) should be non-zero. Was 0]
     expected: FAIL
 
   [WebGL test #149: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid target enum: NO_ERROR]


### PR DESCRIPTION
Adds an initial implementation for the framebuffer attachments introduced with WebGL2 and the related enums and constrains checks.

<!-- Please describe your changes on the following line: -->
Depends on #25765.

cc @jdm @zakorgy 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
