### PR TITLE
Split stacking context fragments into sections in layout_2020

### DIFF
--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -191,7 +191,7 @@ impl FragmentTreeRoot {
             );
         }
 
-        stacking_context.sort_stacking_contexts();
+        stacking_context.sort();
         stacking_context.build_display_list(builder);
     }
 

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/stack-floats-003.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/stack-floats-003.xht.ini
@@ -1,2 +1,0 @@
-[stack-floats-003.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/stack-floats-004.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/stack-floats-004.xht.ini
@@ -1,2 +1,0 @@
-[stack-floats-004.xht]
-  expected: FAIL


### PR DESCRIPTION
This allows rendering stacking context content in the proper order. We
also need to add a new pseudo stacking context for atomic inlines in
order to preserve proper rendering order in some cases.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
