### PR TITLE
Add support for WebGL2 clear buffer operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5531,9 +5531,9 @@ dependencies = [
 
 [[package]]
 name = "sparkle"
-version = "0.1.16"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ff56f232996280b7ac243ad746194fcd7a008104ffc70f0ed3494d07bc442a"
+checksum = "7574caaf01cfad60fedbb0fde776df021073d3d49426219f0851576590764724"
 dependencies = [
  "gl_generator 0.13.1",
 ]

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -37,7 +37,7 @@ raqote = {git = "https://github.com/jrmuizel/raqote", optional = true}
 time = { version = "0.1.0", optional = true }
 pixels = {path = "../pixels"}
 servo_config = {path = "../config"}
-sparkle = "0.1.16"
+sparkle = "0.1.17"
 webrender = {git = "https://github.com/servo/webrender"}
 webrender_api = {git = "https://github.com/servo/webrender"}
 webrender_traits = {path = "../webrender_traits"}

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1956,6 +1956,18 @@ impl WebGLImpl {
                 offset as isize,
                 size as isize,
             ),
+            WebGLCommand::ClearBufferfv(buffer, draw_buffer, ref value) => {
+                gl.clear_buffer_fv(buffer, draw_buffer, value)
+            },
+            WebGLCommand::ClearBufferiv(buffer, draw_buffer, ref value) => {
+                gl.clear_buffer_iv(buffer, draw_buffer, value)
+            },
+            WebGLCommand::ClearBufferuiv(buffer, draw_buffer, ref value) => {
+                gl.clear_buffer_uiv(buffer, draw_buffer, value)
+            },
+            WebGLCommand::ClearBufferfi(buffer, draw_buffer, depth, stencil) => {
+                gl.clear_buffer_fi(buffer, draw_buffer, depth, stencil)
+            },
         }
 
         // If debug asertions are enabled, then check the error state.

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -529,6 +529,10 @@ pub enum WebGLCommand {
     GetSamplerParameterInt(WebGLSamplerId, u32, WebGLSender<i32>),
     BindBufferBase(u32, u32, Option<WebGLBufferId>),
     BindBufferRange(u32, u32, Option<WebGLBufferId>, i64, i64),
+    ClearBufferfv(u32, i32, Vec<f32>),
+    ClearBufferiv(u32, i32, Vec<i32>),
+    ClearBufferuiv(u32, i32, Vec<u32>),
+    ClearBufferfi(u32, i32, f32, i32),
 }
 
 macro_rules! nonzero_type {

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -481,14 +481,14 @@ interface mixin WebGL2RenderingContextBase
   /* Multiple Render Targets */
   // void drawBuffers(sequence<GLenum> buffers);
 
-  // void clearBufferfv(GLenum buffer, GLint drawbuffer, Float32List values,
-  //                    optional GLuint srcOffset = 0);
-  // void clearBufferiv(GLenum buffer, GLint drawbuffer, Int32List values,
-  //                    optional GLuint srcOffset = 0);
-  // void clearBufferuiv(GLenum buffer, GLint drawbuffer, Uint32List values,
-  //                     optional GLuint srcOffset = 0);
+  void clearBufferfv(GLenum buffer, GLint drawbuffer, Float32List values,
+                     optional GLuint srcOffset = 0);
+  void clearBufferiv(GLenum buffer, GLint drawbuffer, Int32List values,
+                     optional GLuint srcOffset = 0);
+  void clearBufferuiv(GLenum buffer, GLint drawbuffer, Uint32List values,
+                      optional GLuint srcOffset = 0);
 
-  // void clearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
+  void clearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
 
   /* Query Objects */
   WebGLQuery? createQuery();

--- a/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
@@ -1,91 +1,4 @@
 [methods-2.html]
-  [WebGL test #11: Property either does not exist or is not a function: compressedTexSubImage3D]
-    expected: FAIL
-
-  [WebGL test #8: Property either does not exist or is not a function: texSubImage3D]
-    expected: FAIL
-
-  [WebGL test #28: Property either does not exist or is not a function: bindVertexArray]
-    expected: FAIL
-
-  [WebGL test #14: Property either does not exist or is not a function: vertexAttribI4iv]
-    expected: FAIL
-
-  [WebGL test #23: Property either does not exist or is not a function: clearBufferfi]
-    expected: FAIL
-
-  [WebGL test #15: Property either does not exist or is not a function: vertexAttribI4ui]
-    expected: FAIL
-
-  [WebGL test #27: Property either does not exist or is not a function: isVertexArray]
-    expected: FAIL
-
-  [WebGL test #20: Property either does not exist or is not a function: clearBufferiv]
-    expected: FAIL
-
-  [WebGL test #22: Property either does not exist or is not a function: clearBufferfv]
-    expected: FAIL
-
-  [WebGL test #6: Property either does not exist or is not a function: texStorage2D]
-    expected: FAIL
-
-  [WebGL test #1: Property either does not exist or is not a function: blitFramebuffer]
-    expected: FAIL
-
-  [WebGL test #13: Property either does not exist or is not a function: vertexAttribI4i]
-    expected: FAIL
-
-  [WebGL test #5: Property either does not exist or is not a function: texImage3D]
-    expected: FAIL
-
-  [WebGL test #21: Property either does not exist or is not a function: clearBufferuiv]
-    expected: FAIL
-
-  [WebGL test #26: Property either does not exist or is not a function: deleteVertexArray]
-    expected: FAIL
-
-  [WebGL test #4: Property either does not exist or is not a function: renderbufferStorageMultisample]
-    expected: FAIL
-
-  [WebGL test #19: Property either does not exist or is not a function: drawBuffers]
-    expected: FAIL
-
-  [WebGL test #10: Property either does not exist or is not a function: compressedTexImage3D]
-    expected: FAIL
-
-  [WebGL test #7: Property either does not exist or is not a function: texStorage3D]
-    expected: FAIL
-
-  [WebGL test #16: Property either does not exist or is not a function: vertexAttribI4uiv]
-    expected: FAIL
-
-  [WebGL test #18: Property either does not exist or is not a function: drawRangeElements]
-    expected: FAIL
-
-  [WebGL test #9: Property either does not exist or is not a function: copyTexSubImage3D]
-    expected: FAIL
-
-  [WebGL test #0: Property either does not exist or is not a function: isContextLost]
-    expected: FAIL
-
-  [WebGL test #17: Property either does not exist or is not a function: vertexAttribIPointer]
-    expected: FAIL
-
-  [WebGL test #24: Property either does not exist or is not a function: getIndexedParameter]
-    expected: FAIL
-
-  [WebGL test #2: Property either does not exist or is not a function: getInternalformatParameter]
-    expected: FAIL
-
-  [WebGL test #25: Property either does not exist or is not a function: createVertexArray]
-    expected: FAIL
-
-  [WebGL test #3: Property either does not exist or is not a function: readBuffer]
-    expected: FAIL
-
-  [WebGL test #12: Property either does not exist or is not a function: getFragDataLocation]
-    expected: FAIL
-
   [WebGL test #16: Property either does not exist or is not a function: vertexAttribI4i]
     expected: FAIL
 
@@ -107,16 +20,13 @@
   [WebGL test #4: Property either does not exist or is not a function: invalidateFramebuffer]
     expected: FAIL
 
-  [WebGL test #30: Property either does not exist or is not a function: isVertexArray]
-    expected: FAIL
-
   [WebGL test #7: Property either does not exist or is not a function: renderbufferStorageMultisample]
     expected: FAIL
 
   [WebGL test #10: Property either does not exist or is not a function: texStorage3D]
     expected: FAIL
 
-  [WebGL test #29: Property either does not exist or is not a function: deleteVertexArray]
+  [WebGL test #1: Property either does not exist or is not a function: blitFramebuffer]
     expected: FAIL
 
   [WebGL test #11: Property either does not exist or is not a function: texSubImage3D]
@@ -125,19 +35,22 @@
   [WebGL test #20: Property either does not exist or is not a function: vertexAttribIPointer]
     expected: FAIL
 
-  [WebGL test #27: Property either does not exist or is not a function: getIndexedParameter]
+  [WebGL test #25: Property either does not exist or is not a function: deleteVertexArray]
+    expected: FAIL
+
+  [WebGL test #23: Property either does not exist or is not a function: getIndexedParameter]
+    expected: FAIL
+
+  [WebGL test #26: Property either does not exist or is not a function: isVertexArray]
     expected: FAIL
 
   [WebGL test #3: Property either does not exist or is not a function: getInternalformatParameter]
     expected: FAIL
 
-  [WebGL test #23: Property either does not exist or is not a function: clearBufferiv]
-    expected: FAIL
-
   [WebGL test #21: Property either does not exist or is not a function: drawRangeElements]
     expected: FAIL
 
-  [WebGL test #26: Property either does not exist or is not a function: clearBufferfi]
+  [WebGL test #27: Property either does not exist or is not a function: bindVertexArray]
     expected: FAIL
 
   [WebGL test #13: Property either does not exist or is not a function: compressedTexImage3D]
@@ -152,16 +65,13 @@
   [WebGL test #8: Property either does not exist or is not a function: texImage3D]
     expected: FAIL
 
-  [WebGL test #28: Property either does not exist or is not a function: createVertexArray]
-    expected: FAIL
-
-  [WebGL test #25: Property either does not exist or is not a function: clearBufferfv]
-    expected: FAIL
-
-  [WebGL test #24: Property either does not exist or is not a function: clearBufferuiv]
+  [WebGL test #0: Property either does not exist or is not a function: isContextLost]
     expected: FAIL
 
   [WebGL test #9: Property either does not exist or is not a function: texStorage2D]
+    expected: FAIL
+
+  [WebGL test #24: Property either does not exist or is not a function: createVertexArray]
     expected: FAIL
 
   [WebGL test #6: Property either does not exist or is not a function: readBuffer]
@@ -171,8 +81,5 @@
     expected: FAIL
 
   [WebGL test #14: Property either does not exist or is not a function: compressedTexSubImage3D]
-    expected: FAIL
-
-  [WebGL test #31: Property either does not exist or is not a function: bindVertexArray]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/clear-srgb-color-buffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/clear-srgb-color-buffer.html.ini
@@ -1,11 +1,10 @@
 [clear-srgb-color-buffer.html]
-  expected: ERROR
   [WebGL test #1: Framebuffer incomplete.]
     expected: FAIL
 
-  [WebGL test #3: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #2: \nat (0, 0) expected: 124,193,222,255 was 0,0,0,0]
     expected: FAIL
 
-  [WebGL test #2: \nat (0, 0) expected: 124,193,222,255 was 0,0,0,0]
+  [WebGL test #3: \nat (0, 0) expected: 124,193,222,255 was 0,0,0,0]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/clearbuffer-sub-source.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/clearbuffer-sub-source.html.ini
@@ -1,8 +1,49 @@
 [clearbuffer-sub-source.html]
-  expected: ERROR
+  [WebGL test #14: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : clearBuffer with srcOffset = 2 should succeed]
+    expected: FAIL
+
+  [WebGL test #5: clearBuffer fails to work. Expected: 1,2,3,4, got: 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : clearBuffer with no srcOffset should succeed]
+    expected: FAIL
+
+  [WebGL test #11: clearBuffer fails to work. Expected: 1,2,3,4, got: 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #13: clearBuffer fails to work. Expected: 1,2,3,4, got: 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #9: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+    expected: FAIL
+
+  [WebGL test #10: getError expected: NO_ERROR. Was INVALID_ENUM : clearBuffer with no srcOffset should succeed]
+    expected: FAIL
+
+  [WebGL test #16: getError expected: INVALID_VALUE. Was INVALID_FRAMEBUFFER_OPERATION : clearBuffer with srcOffset = 4 should fail: out of bounds]
+    expected: FAIL
+
+  [WebGL test #4: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : clearBuffer with srcOffset = 0 should succeed]
+    expected: FAIL
+
+  [WebGL test #15: clearBuffer fails to work. Expected: 3,4,5,6, got: 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #8: getError expected: INVALID_VALUE. Was INVALID_FRAMEBUFFER_OPERATION : clearBuffer with srcOffset = 4 should fail: out of bounds]
+    expected: FAIL
+
+  [WebGL test #6: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : clearBuffer with srcOffset = 2 should succeed]
+    expected: FAIL
+
+  [WebGL test #7: clearBuffer fails to work. Expected: 3,4,5,6, got: 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #12: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : clearBuffer with srcOffset = 0 should succeed]
+    expected: FAIL
+
   [WebGL test #1: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
     expected: FAIL
 
-  [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #3: clearBuffer fails to work. Expected: 1,2,3,4, got: 0,0,0,0]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/clearbufferfv-with-alpha-false.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/clearbufferfv-with-alpha-false.html.ini
@@ -1,5 +1,0 @@
-[clearbufferfv-with-alpha-false.html]
-  expected: ERROR
-  [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-


### PR DESCRIPTION
Adds support for the following WebGL2 methods:

- `clearBufferfv`
- `clearBufferiv`
- `clearBufferuiv`
- `clearBufferfi`

See: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.11

<!-- Please describe your changes on the following line: -->

cc @jdm @zakorgy 

Note: While the code itself doesn't depend on any other PRs, some of the tests do require WebGL2 framebuffer/renderbuffer support (#25785).


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
