### PR TITLE
Prevent double encoding

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -24,6 +24,7 @@ import shutil
 import subprocess
 from xml.etree.ElementTree import XML
 from six import iteritems
+import io
 
 from mach.registrar import Registrar
 from mach.decorators import (
@@ -560,15 +561,15 @@ class MachCommands(CommandBase):
 
         def format(outputs, description, file=sys.stdout):
             formatted = "%s %s:\n%s" % (len(outputs), description, "\n".join(outputs))
-            file.write(formatted.encode("utf-8"))
+            file.write(formatted)
 
         if log_intermittents:
-            with open(log_intermittents, "wb") as file:
+            with io.open(log_intermittents, "w", encoding="utf-8") as file:
                 format(intermittents, "known-intermittent unexpected results", file)
 
         description = "unexpected results that are NOT known-intermittents"
         if log_filteredsummary:
-            with open(log_filteredsummary, "wb") as file:
+            with io.open(log_filteredsummary, "w", encoding="utf-8") as file:
                 format(actual_failures, description, file)
 
         if actual_failures:


### PR DESCRIPTION
Fixes servo/servo#25233

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25233 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because testing_commands.py has no tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
