### PR TITLE
Add support for WebGL2 framebuffer invalidation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5489,9 +5489,9 @@ dependencies = [
 
 [[package]]
 name = "sparkle"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7574caaf01cfad60fedbb0fde776df021073d3d49426219f0851576590764724"
+checksum = "f334407d95c9450dc10f8ca90ba2555f3739052848feedb4c60cb83e1dc94b29"
 dependencies = [
  "gl_generator 0.13.1",
 ]

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -35,7 +35,7 @@ raqote = {git = "https://github.com/jrmuizel/raqote"}
 time = { version = "0.1.0", optional = true }
 pixels = {path = "../pixels"}
 servo_config = {path = "../config"}
-sparkle = "0.1.17"
+sparkle = "0.1.19"
 webrender = {git = "https://github.com/servo/webrender"}
 webrender_api = {git = "https://github.com/servo/webrender"}
 webrender_traits = {path = "../webrender_traits"}

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1968,6 +1968,12 @@ impl WebGLImpl {
             WebGLCommand::ClearBufferfi(buffer, draw_buffer, depth, stencil) => {
                 gl.clear_buffer_fi(buffer, draw_buffer, depth, stencil)
             },
+            WebGLCommand::InvalidateFramebuffer(target, ref attachments) => {
+                gl.invalidate_framebuffer(target, attachments)
+            },
+            WebGLCommand::InvalidateSubFramebuffer(target, ref attachments, x, y, w, h) => {
+                gl.invalidate_sub_framebuffer(target, attachments, x, y, w, h)
+            },
         }
 
         // If debug asertions are enabled, then check the error state.

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -533,6 +533,8 @@ pub enum WebGLCommand {
     ClearBufferiv(u32, i32, Vec<i32>),
     ClearBufferuiv(u32, i32, Vec<u32>),
     ClearBufferfi(u32, i32, f32, i32),
+    InvalidateFramebuffer(u32, Vec<u32>),
+    InvalidateSubFramebuffer(u32, Vec<u32>, i32, i32, i32, i32),
 }
 
 macro_rules! nonzero_type {

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -314,9 +314,9 @@ interface mixin WebGL2RenderingContextBase
   //                      GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
   // void framebufferTextureLayer(GLenum target, GLenum attachment, WebGLTexture? texture, GLint level,
   //                              GLint layer);
-  // void invalidateFramebuffer(GLenum target, sequence<GLenum> attachments);
-  // void invalidateSubFramebuffer(GLenum target, sequence<GLenum> attachments,
-  //                               GLint x, GLint y, GLsizei width, GLsizei height);
+  void invalidateFramebuffer(GLenum target, sequence<GLenum> attachments);
+  void invalidateSubFramebuffer(GLenum target, sequence<GLenum> attachments,
+                                GLint x, GLint y, GLsizei width, GLsizei height);
   // void readBuffer(GLenum src);
 
   /* Renderbuffer objects */

--- a/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
@@ -1,85 +1,79 @@
 [methods-2.html]
-  [WebGL test #16: Property either does not exist or is not a function: vertexAttribI4i]
+  [WebGL test #20: Property either does not exist or is not a function: drawBuffers]
     expected: FAIL
 
-  [WebGL test #19: Property either does not exist or is not a function: vertexAttribI4uiv]
+  [WebGL test #9: Property either does not exist or is not a function: texSubImage3D]
     expected: FAIL
 
   [WebGL test #2: Property either does not exist or is not a function: framebufferTextureLayer]
     expected: FAIL
 
-  [WebGL test #18: Property either does not exist or is not a function: vertexAttribI4ui]
+  [WebGL test #7: Property either does not exist or is not a function: texStorage2D]
     expected: FAIL
 
-  [WebGL test #15: Property either does not exist or is not a function: getFragDataLocation]
+  [WebGL test #8: Property either does not exist or is not a function: texStorage3D]
     expected: FAIL
 
-  [WebGL test #17: Property either does not exist or is not a function: vertexAttribI4iv]
+  [WebGL test #15: Property either does not exist or is not a function: vertexAttribI4iv]
     expected: FAIL
 
-  [WebGL test #4: Property either does not exist or is not a function: invalidateFramebuffer]
+  [WebGL test #5: Property either does not exist or is not a function: renderbufferStorageMultisample]
     expected: FAIL
 
-  [WebGL test #7: Property either does not exist or is not a function: renderbufferStorageMultisample]
+  [WebGL test #16: Property either does not exist or is not a function: vertexAttribI4ui]
     expected: FAIL
 
-  [WebGL test #10: Property either does not exist or is not a function: texStorage3D]
+  [WebGL test #22: Property either does not exist or is not a function: createVertexArray]
+    expected: FAIL
+
+  [WebGL test #4: Property either does not exist or is not a function: readBuffer]
+    expected: FAIL
+
+  [WebGL test #11: Property either does not exist or is not a function: compressedTexImage3D]
     expected: FAIL
 
   [WebGL test #1: Property either does not exist or is not a function: blitFramebuffer]
     expected: FAIL
 
-  [WebGL test #11: Property either does not exist or is not a function: texSubImage3D]
+  [WebGL test #24: Property either does not exist or is not a function: isVertexArray]
     expected: FAIL
 
-  [WebGL test #20: Property either does not exist or is not a function: vertexAttribIPointer]
+  [WebGL test #12: Property either does not exist or is not a function: compressedTexSubImage3D]
     expected: FAIL
 
-  [WebGL test #25: Property either does not exist or is not a function: deleteVertexArray]
+  [WebGL test #18: Property either does not exist or is not a function: vertexAttribIPointer]
     expected: FAIL
 
-  [WebGL test #23: Property either does not exist or is not a function: getIndexedParameter]
-    expected: FAIL
-
-  [WebGL test #26: Property either does not exist or is not a function: isVertexArray]
+  [WebGL test #6: Property either does not exist or is not a function: texImage3D]
     expected: FAIL
 
   [WebGL test #3: Property either does not exist or is not a function: getInternalformatParameter]
     expected: FAIL
 
-  [WebGL test #21: Property either does not exist or is not a function: drawRangeElements]
+  [WebGL test #21: Property either does not exist or is not a function: getIndexedParameter]
     expected: FAIL
 
-  [WebGL test #27: Property either does not exist or is not a function: bindVertexArray]
-    expected: FAIL
-
-  [WebGL test #13: Property either does not exist or is not a function: compressedTexImage3D]
-    expected: FAIL
-
-  [WebGL test #12: Property either does not exist or is not a function: copyTexSubImage3D]
-    expected: FAIL
-
-  [WebGL test #22: Property either does not exist or is not a function: drawBuffers]
-    expected: FAIL
-
-  [WebGL test #8: Property either does not exist or is not a function: texImage3D]
+  [WebGL test #13: Property either does not exist or is not a function: getFragDataLocation]
     expected: FAIL
 
   [WebGL test #0: Property either does not exist or is not a function: isContextLost]
     expected: FAIL
 
-  [WebGL test #9: Property either does not exist or is not a function: texStorage2D]
+  [WebGL test #10: Property either does not exist or is not a function: copyTexSubImage3D]
     expected: FAIL
 
-  [WebGL test #24: Property either does not exist or is not a function: createVertexArray]
+  [WebGL test #25: Property either does not exist or is not a function: bindVertexArray]
     expected: FAIL
 
-  [WebGL test #6: Property either does not exist or is not a function: readBuffer]
+  [WebGL test #17: Property either does not exist or is not a function: vertexAttribI4uiv]
     expected: FAIL
 
-  [WebGL test #5: Property either does not exist or is not a function: invalidateSubFramebuffer]
+  [WebGL test #19: Property either does not exist or is not a function: drawRangeElements]
     expected: FAIL
 
-  [WebGL test #14: Property either does not exist or is not a function: compressedTexSubImage3D]
+  [WebGL test #14: Property either does not exist or is not a function: vertexAttribI4i]
+    expected: FAIL
+
+  [WebGL test #23: Property either does not exist or is not a function: deleteVertexArray]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/extensions/webgl_multiview.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/extensions/webgl_multiview.html.ini
@@ -1,7 +1,0 @@
-[webgl_multiview.html]
-  [WebGL test #3: getError expected: INVALID_ENUM. Was INVALID_OPERATION : Can't query FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR without enabling WEBGL_multiview]
-    expected: FAIL
-
-  [WebGL test #2: getError expected: INVALID_ENUM. Was INVALID_OPERATION : Can't query FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR without enabling WEBGL_multiview]
-    expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance2/state/gl-get-calls.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/state/gl-get-calls.html.ini
@@ -8,9 +8,6 @@
   [WebGL test #80: context.getParameter(context.MIN_PROGRAM_TEXEL_OFFSET) is not an instance of Number]
     expected: FAIL
 
-  [WebGL test #41: context.getParameter(context.MAX_DRAW_BUFFERS) should be >= 4. Was null (of type object).]
-    expected: FAIL
-
   [WebGL test #33: context.getParameter(context.MAX_ARRAY_TEXTURE_LAYERS) should be >= 256. Was null (of type object).]
     expected: FAIL
 
@@ -89,13 +86,7 @@
   [WebGL test #48: context.getParameter(context.MAX_FRAGMENT_INPUT_COMPONENTS) is not an instance of Number]
     expected: FAIL
 
-  [WebGL test #37: context.getParameter(context.MAX_COLOR_ATTACHMENTS) should be >= 4. Was null (of type object).]
-    expected: FAIL
-
   [WebGL test #9: context.getParameter(context.PACK_SKIP_ROWS) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #42: context.getParameter(context.MAX_DRAW_BUFFERS) is not an instance of Number]
     expected: FAIL
 
   [WebGL test #34: context.getParameter(context.MAX_ARRAY_TEXTURE_LAYERS) is not an instance of Number]
@@ -105,9 +96,6 @@
     expected: FAIL
 
   [WebGL test #12: context.getParameter(context.RASTERIZER_DISCARD) should be false (of type boolean). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #38: context.getParameter(context.MAX_COLOR_ATTACHMENTS) is not an instance of Number]
     expected: FAIL
 
   [WebGL test #44: context.getParameter(context.MAX_ELEMENT_INDEX) is not an instance of Number]

--- a/tests/wpt/webgl/meta/conformance2/state/gl-object-get-calls.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/state/gl-object-get-calls.html.ini
@@ -3,31 +3,7 @@
   [WebGL test #10: gl.getBufferParameter(gl.COPY_WRITE_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
     expected: FAIL
 
-  [WebGL test #86: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid parameter enum: NO_ERROR]
-    expected: FAIL
-
-  [WebGL test #57: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLRenderbuffer\]. Was null.]
-    expected: FAIL
-
-  [WebGL test #43: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
   [WebGL test #18: gl.getBufferParameter(gl.TRANSFORM_FEEDBACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #70: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.BACK, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #127: getError expected: INVALID_OPERATION. Was INVALID_ENUM : after evaluating: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE)]
-    expected: FAIL
-
-  [WebGL test #114: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #135: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #87: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid target enum: NO_ERROR]
     expected: FAIL
 
   [WebGL test #19: gl.getBufferParameter(gl.TRANSFORM_FEEDBACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
@@ -36,40 +12,13 @@
   [WebGL test #21: gl.getBufferParameter(gl.UNIFORM_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
     expected: FAIL
 
-  [WebGL test #42: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLTexture\]. Was null.]
-    expected: FAIL
-
   [WebGL test #15: gl.getBufferParameter(gl.PIXEL_UNPACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #88: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid attachment enum: NO_ERROR]
-    expected: FAIL
-
-  [WebGL test #41: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 5890 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #104: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 5890 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #103: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 0, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER) should be 0 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #7: gl.getBufferParameter(gl.COPY_READ_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
     expected: FAIL
 
-  [WebGL test #107: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #148: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid parameter enum: NO_ERROR]
-    expected: FAIL
-
   [WebGL test #9: gl.getBufferParameter(gl.COPY_WRITE_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #134: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #120: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLRenderbuffer\]. Was null.]
     expected: FAIL
 
   [WebGL test #16: gl.getBufferParameter(gl.PIXEL_UNPACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
@@ -78,40 +27,10 @@
   [WebGL test #6: gl.getBufferParameter(gl.COPY_READ_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
     expected: FAIL
 
-  [WebGL test #44: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #85: getError expected: NO_ERROR. Was INVALID_OPERATION : ]
-    expected: FAIL
-
-  [WebGL test #72: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.STENCIL, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #105: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME) should be [object WebGLTexture\]. Was null.]
-    expected: FAIL
-
-  [WebGL test #133: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.BACK, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #71: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE) should be 33304 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #64: getError expected: INVALID_OPERATION. Was INVALID_ENUM : after evaluating: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE)]
-    expected: FAIL
-
-  [WebGL test #40: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 0, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
   [WebGL test #22: gl.getBufferParameter(gl.UNIFORM_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #12: gl.getBufferParameter(gl.PIXEL_PACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #150: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid attachment enum: NO_ERROR]
-    expected: FAIL
-
-  [WebGL test #182: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
   [WebGL test #13: gl.getBufferParameter(gl.PIXEL_PACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
@@ -120,12 +39,5 @@
   [WebGL test #167: gl.getProgramParameter(uniformBlockProgram, gl.ACTIVE_UNIFORM_BLOCKS) should be 1 (of type number). Was null (of type object).]
     expected: FAIL
 
-  [WebGL test #106: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL) should be 0 (of type number). Was null (of type object).]
+  [WebGL test #182: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
-
-  [WebGL test #149: getFramebufferAttachmentParameter did not generate INVALID_ENUM for invalid target enum: NO_ERROR]
-    expected: FAIL
-
-  [WebGL test #51: gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + 7, gl.FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-


### PR DESCRIPTION
Adds support for the `invalidateFramebuffer` and `invalideSubFramebuffer` WebGL2 calls.

See: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4

<!-- Please describe your changes on the following line: -->

Depends on #25785.

cc @jdm @zakorgy


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
