### PR TITLE
Refactor CanvasRenderingContext2D.arc() and .ellipse()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,7 @@ dependencies = [
  "half",
  "ipc-channel",
  "log",
+ "lyon_geom 0.14.0",
  "num-traits",
  "pixels",
  "raqote",

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -30,6 +30,7 @@ gleam = "0.6.7"
 half = "1"
 ipc-channel = "0.12"
 log = "0.4"
+lyon_geom = "0.14"
 num-traits = "0.2"
 raqote = {git = "https://github.com/jrmuizel/raqote", optional = true}
 pixels = {path = "../pixels"}

--- a/tests/wpt/metadata/2dcontext/line-styles/2d.line.cap.round.html.ini
+++ b/tests/wpt/metadata/2dcontext/line-styles/2d.line.cap.round.html.ini
@@ -1,4 +1,0 @@
-[2d.line.cap.round.html]
-  [lineCap 'round' is rendered correctly]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.twopie.1.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.twopie.1.html.ini
@@ -1,4 +1,0 @@
-[2d.path.arc.twopie.1.html]
-  [arc() draws nothing when end = start + 2pi-e and anticlockwise]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.twopie.3.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arc.twopie.3.html.ini
@@ -1,4 +1,0 @@
-[2d.path.arc.twopie.3.html]
-  [arc() draws a full circle when end = start + 2pi+e and anticlockwise]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.scale.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.scale.html.ini
@@ -1,4 +1,0 @@
-[2d.path.arcTo.scale.html]
-  [arcTo scales the curve, not just the control points]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.shape.curve2.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.shape.curve2.html.ini
@@ -1,5 +1,0 @@
-[2d.path.arcTo.shape.curve2.html]
-  type: testharness
-  [arcTo() curves in the right kind of shape]
-    expected: FAIL
-

--- a/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.transformation.html.ini
+++ b/tests/wpt/metadata/2dcontext/path-objects/2d.path.arcTo.transformation.html.ini
@@ -1,4 +1,0 @@
-[2d.path.arcTo.transformation.html]
-  [arcTo joins up to the last subpath point correctly]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cap.round.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cap.round.html.ini
@@ -1,4 +1,0 @@
-[2d.line.cap.round.html]
-  [lineCap 'round' is rendered correctly]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cap.round.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/line-styles/2d.line.cap.round.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.line.cap.round.worker.html]
-  [lineCap 'round' is rendered correctly]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arc.twopie.1.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arc.twopie.1.html.ini
@@ -1,4 +1,0 @@
-[2d.path.arc.twopie.1.html]
-  [arc() draws nothing when end = start + 2pi-e and anticlockwise]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arc.twopie.1.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arc.twopie.1.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.path.arc.twopie.1.worker.html]
-  [arc() draws nothing when end = start + 2pi-e and anticlockwise]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arc.twopie.3.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arc.twopie.3.html.ini
@@ -1,4 +1,0 @@
-[2d.path.arc.twopie.3.html]
-  [arc() draws a full circle when end = start + 2pi+e and anticlockwise]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arc.twopie.3.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arc.twopie.3.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.path.arc.twopie.3.worker.html]
-  [arc() draws a full circle when end = start + 2pi+e and anticlockwise]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arcTo.scale.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arcTo.scale.html.ini
@@ -1,4 +1,0 @@
-[2d.path.arcTo.scale.html]
-  [arcTo scales the curve, not just the control points]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arcTo.scale.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arcTo.scale.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.path.arcTo.scale.worker.html]
-  [arcTo scales the curve, not just the control points]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arcTo.shape.curve2.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arcTo.shape.curve2.html.ini
@@ -1,4 +1,0 @@
-[2d.path.arcTo.shape.curve2.html]
-  [arcTo() curves in the right kind of shape]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arcTo.shape.curve2.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arcTo.shape.curve2.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.path.arcTo.shape.curve2.worker.html]
-  [arcTo() curves in the right kind of shape]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arcTo.transformation.html.ini
+++ b/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arcTo.transformation.html.ini
@@ -1,4 +1,0 @@
-[2d.path.arcTo.transformation.html]
-  [arcTo joins up to the last subpath point correctly]
-    expected: FAIL
-

--- a/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arcTo.transformation.worker.js.ini
+++ b/tests/wpt/metadata/offscreen-canvas/path-objects/2d.path.arcTo.transformation.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.path.arcTo.transformation.worker.html]
-  [arcTo joins up to the last subpath point correctly]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Refactor `arc()` and `ellipse()` to make use of `lyon_geom::Arc` for approximating an arc with quadratic bezier curves.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix part of #25331

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
