### PR TITLE
Add support for WebGL2 FramebufferTextureLayer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5486,9 +5486,9 @@ dependencies = [
 
 [[package]]
 name = "sparkle"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f334407d95c9450dc10f8ca90ba2555f3739052848feedb4c60cb83e1dc94b29"
+checksum = "dc89be71cc02b59fdb05edd5589aac8e7542356f815adf84851f8142938f6534"
 dependencies = [
  "gl_generator 0.13.1",
 ]

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -35,7 +35,7 @@ raqote = {git = "https://github.com/jrmuizel/raqote"}
 time = { version = "0.1.0", optional = true }
 pixels = {path = "../pixels"}
 servo_config = {path = "../config"}
-sparkle = "0.1.19"
+sparkle = "0.1.20"
 webrender = {git = "https://github.com/servo/webrender"}
 webrender_api = {git = "https://github.com/servo/webrender"}
 webrender_traits = {path = "../webrender_traits"}

--- a/components/canvas/webgl_limits.rs
+++ b/components/canvas/webgl_limits.rs
@@ -79,6 +79,8 @@ impl GLLimitsDetect for GLLimits {
             max_vertex_uniform_components,
             max_fragment_uniform_blocks,
             max_fragment_uniform_components,
+            max_3d_texture_size,
+            max_array_texture_layers,
             uniform_buffer_offset_alignment,
         );
         if webgl_version == WebGLVersion::WebGL2 {
@@ -102,6 +104,8 @@ impl GLLimitsDetect for GLLimits {
             max_fragment_uniform_blocks = gl.get_integer(gl::MAX_FRAGMENT_UNIFORM_BLOCKS);
             max_fragment_uniform_components = gl.get_integer(gl::MAX_FRAGMENT_UNIFORM_COMPONENTS);
             uniform_buffer_offset_alignment = gl.get_integer(gl::UNIFORM_BUFFER_OFFSET_ALIGNMENT);
+            max_3d_texture_size = gl.get_integer(gl::MAX_3D_TEXTURE_SIZE);
+            max_array_texture_layers = gl.get_integer(gl::MAX_ARRAY_TEXTURE_LAYERS)
         } else {
             max_uniform_block_size = 0;
             max_uniform_buffer_bindings = 0;
@@ -118,6 +122,8 @@ impl GLLimitsDetect for GLLimits {
             max_fragment_uniform_blocks = 0;
             max_fragment_uniform_components = 0;
             uniform_buffer_offset_alignment = 0;
+            max_3d_texture_size = 0;
+            max_array_texture_layers = 0;
         }
 
         GLLimits {
@@ -148,6 +154,8 @@ impl GLLimitsDetect for GLLimits {
             max_vertex_uniform_components,
             max_fragment_uniform_blocks,
             max_fragment_uniform_components,
+            max_3d_texture_size,
+            max_array_texture_layers,
             uniform_buffer_offset_alignment,
         }
     }

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1974,6 +1974,19 @@ impl WebGLImpl {
             WebGLCommand::InvalidateSubFramebuffer(target, ref attachments, x, y, w, h) => {
                 gl.invalidate_sub_framebuffer(target, attachments, x, y, w, h)
             },
+            WebGLCommand::FramebufferTextureLayer(target, attachment, tex_id, level, layer) => {
+                let tex_id = tex_id.map_or(0, WebGLTextureId::get);
+                let attach = |attachment| {
+                    gl.framebuffer_texture_layer(target, attachment, tex_id, level, layer)
+                };
+
+                if attachment == gl::DEPTH_STENCIL_ATTACHMENT {
+                    attach(gl::DEPTH_ATTACHMENT);
+                    attach(gl::STENCIL_ATTACHMENT);
+                } else {
+                    attach(attachment)
+                }
+            },
         }
 
         // If debug asertions are enabled, then check the error state.

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -535,6 +535,7 @@ pub enum WebGLCommand {
     ClearBufferfi(u32, i32, f32, i32),
     InvalidateFramebuffer(u32, Vec<u32>),
     InvalidateSubFramebuffer(u32, Vec<u32>, i32, i32, i32, i32),
+    FramebufferTextureLayer(u32, u32, Option<WebGLTextureId>, i32, i32),
 }
 
 macro_rules! nonzero_type {
@@ -1074,5 +1075,7 @@ pub struct GLLimits {
     pub max_vertex_uniform_components: u32,
     pub max_fragment_uniform_blocks: u32,
     pub max_fragment_uniform_components: u32,
+    pub max_3d_texture_size: u32,
+    pub max_array_texture_layers: u32,
     pub uniform_buffer_offset_alignment: u32,
 }

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -3581,6 +3581,36 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
                 height,
             ))
     }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4
+    fn FramebufferTextureLayer(
+        &self,
+        target: u32,
+        attachment: u32,
+        texture: Option<&WebGLTexture>,
+        level: i32,
+        layer: i32,
+    ) {
+        if let Some(tex) = texture {
+            handle_potential_webgl_error!(self.base, self.base.validate_ownership(tex), return);
+        }
+
+        let fb_slot = match target {
+            constants::FRAMEBUFFER | constants::DRAW_FRAMEBUFFER => {
+                self.base.get_draw_framebuffer_slot()
+            },
+            constants::READ_FRAMEBUFFER => self.base.get_read_framebuffer_slot(),
+            _ => return self.base.webgl_error(InvalidEnum),
+        };
+
+        match fb_slot.get() {
+            Some(fb) => handle_potential_webgl_error!(
+                self.base,
+                fb.texture_layer(attachment, texture, level, layer)
+            ),
+            None => self.base.webgl_error(InvalidOperation),
+        }
+    }
 }
 
 impl LayoutCanvasWebGLRenderingContextHelpers for LayoutDom<WebGL2RenderingContext> {

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -312,8 +312,8 @@ interface mixin WebGL2RenderingContextBase
   /* Framebuffer objects */
   // void blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0,
   //                      GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
-  // void framebufferTextureLayer(GLenum target, GLenum attachment, WebGLTexture? texture, GLint level,
-  //                              GLint layer);
+  void framebufferTextureLayer(GLenum target, GLenum attachment, WebGLTexture? texture, GLint level,
+                               GLint layer);
   void invalidateFramebuffer(GLenum target, sequence<GLenum> attachments);
   void invalidateSubFramebuffer(GLenum target, sequence<GLenum> attachments,
                                 GLint x, GLint y, GLsizei width, GLsizei height);

--- a/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
@@ -1,79 +1,76 @@
 [methods-2.html]
-  [WebGL test #20: Property either does not exist or is not a function: drawBuffers]
+  [WebGL test #11: Property either does not exist or is not a function: compressedTexSubImage3D]
     expected: FAIL
 
-  [WebGL test #9: Property either does not exist or is not a function: texSubImage3D]
+  [WebGL test #8: Property either does not exist or is not a function: texSubImage3D]
     expected: FAIL
 
-  [WebGL test #2: Property either does not exist or is not a function: framebufferTextureLayer]
+  [WebGL test #14: Property either does not exist or is not a function: vertexAttribI4iv]
     expected: FAIL
 
-  [WebGL test #7: Property either does not exist or is not a function: texStorage2D]
+  [WebGL test #15: Property either does not exist or is not a function: vertexAttribI4ui]
     expected: FAIL
 
-  [WebGL test #8: Property either does not exist or is not a function: texStorage3D]
+  [WebGL test #22: Property either does not exist or is not a function: deleteVertexArray]
     expected: FAIL
 
-  [WebGL test #15: Property either does not exist or is not a function: vertexAttribI4iv]
-    expected: FAIL
-
-  [WebGL test #5: Property either does not exist or is not a function: renderbufferStorageMultisample]
-    expected: FAIL
-
-  [WebGL test #16: Property either does not exist or is not a function: vertexAttribI4ui]
-    expected: FAIL
-
-  [WebGL test #22: Property either does not exist or is not a function: createVertexArray]
-    expected: FAIL
-
-  [WebGL test #4: Property either does not exist or is not a function: readBuffer]
-    expected: FAIL
-
-  [WebGL test #11: Property either does not exist or is not a function: compressedTexImage3D]
+  [WebGL test #6: Property either does not exist or is not a function: texStorage2D]
     expected: FAIL
 
   [WebGL test #1: Property either does not exist or is not a function: blitFramebuffer]
     expected: FAIL
 
-  [WebGL test #24: Property either does not exist or is not a function: isVertexArray]
+  [WebGL test #13: Property either does not exist or is not a function: vertexAttribI4i]
     expected: FAIL
 
-  [WebGL test #12: Property either does not exist or is not a function: compressedTexSubImage3D]
+  [WebGL test #5: Property either does not exist or is not a function: texImage3D]
     expected: FAIL
 
-  [WebGL test #18: Property either does not exist or is not a function: vertexAttribIPointer]
+  [WebGL test #4: Property either does not exist or is not a function: renderbufferStorageMultisample]
     expected: FAIL
 
-  [WebGL test #6: Property either does not exist or is not a function: texImage3D]
+  [WebGL test #20: Property either does not exist or is not a function: getIndexedParameter]
     expected: FAIL
 
-  [WebGL test #3: Property either does not exist or is not a function: getInternalformatParameter]
+  [WebGL test #19: Property either does not exist or is not a function: drawBuffers]
     expected: FAIL
 
-  [WebGL test #21: Property either does not exist or is not a function: getIndexedParameter]
+  [WebGL test #10: Property either does not exist or is not a function: compressedTexImage3D]
     expected: FAIL
 
-  [WebGL test #13: Property either does not exist or is not a function: getFragDataLocation]
+  [WebGL test #7: Property either does not exist or is not a function: texStorage3D]
+    expected: FAIL
+
+  [WebGL test #16: Property either does not exist or is not a function: vertexAttribI4uiv]
+    expected: FAIL
+
+  [WebGL test #18: Property either does not exist or is not a function: drawRangeElements]
+    expected: FAIL
+
+  [WebGL test #9: Property either does not exist or is not a function: copyTexSubImage3D]
     expected: FAIL
 
   [WebGL test #0: Property either does not exist or is not a function: isContextLost]
     expected: FAIL
 
-  [WebGL test #10: Property either does not exist or is not a function: copyTexSubImage3D]
+  [WebGL test #17: Property either does not exist or is not a function: vertexAttribIPointer]
     expected: FAIL
 
-  [WebGL test #25: Property either does not exist or is not a function: bindVertexArray]
+  [WebGL test #2: Property either does not exist or is not a function: getInternalformatParameter]
     expected: FAIL
 
-  [WebGL test #17: Property either does not exist or is not a function: vertexAttribI4uiv]
+  [WebGL test #3: Property either does not exist or is not a function: readBuffer]
     expected: FAIL
 
-  [WebGL test #19: Property either does not exist or is not a function: drawRangeElements]
+  [WebGL test #21: Property either does not exist or is not a function: createVertexArray]
     expected: FAIL
 
-  [WebGL test #14: Property either does not exist or is not a function: vertexAttribI4i]
+  [WebGL test #12: Property either does not exist or is not a function: getFragDataLocation]
     expected: FAIL
 
-  [WebGL test #23: Property either does not exist or is not a function: deleteVertexArray]
+  [WebGL test #24: Property either does not exist or is not a function: bindVertexArray]
+    expected: FAIL
+
+  [WebGL test #23: Property either does not exist or is not a function: isVertexArray]
     expected: FAIL
 


### PR DESCRIPTION
Adds support for `FramebufferTextureLayer` WebGL2 call.

See: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4

<!-- Please describe your changes on the following line: -->

Depends on #25798.

cc @jdm @zakorgy 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
