### PR TITLE
Expect dom syntax error in window postmessage sameorigin test

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14500,7 +14500,7 @@
      ]
     ],
     "window-postmessage-sameorigin.html": [
-     "6a1d00fd1c37fcf1492ecb48a02fe358ac2cbacf",
+     "cb3bc26e8821b73bcee0455c765362ab731bf3fa",
      [
       null,
       {}

--- a/tests/wpt/mozilla/meta/mozilla/window-postmessage-sameorigin.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/window-postmessage-sameorigin.html.ini
@@ -1,7 +1,0 @@
-[window-postmessage-sameorigin.html]
-  [explicit invalid url, cloneable string message (handler)]
-    expected: FAIL
-
-  [explicit invalid url, cloneable string message (listener)]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/tests/mozilla/window-postmessage-sameorigin.html
+++ b/tests/wpt/mozilla/tests/mozilla/window-postmessage-sameorigin.html
@@ -56,7 +56,7 @@ var base_tests = [
   function() { return expect_message('basic', '/', 'same origin, cloneable string message') },
   function() { return expect_message('basic', HTTP_ORIGIN, 'explicit same origin, cloneable string message') },
   function() { return expect_no_message('basic', HTTPS_ORIGIN, 'explicit cross origin, cloneable string message') },
-  function() { return expect_error_js(SyntaxError, 'basic', 'not-a-url', 'explicit invalid url, cloneable string message') },
+  function() { return expect_error_dom('SyntaxError', 'basic', 'not-a-url', 'explicit invalid url, cloneable string message') },
   function() { return expect_error_dom('DATA_CLONE_ERR', window, '*', 'any origin, non-cloneable message') },
 ];
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

FIX #25808

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
