### PR TITLE
Use new and new_inherited in messagechannel

### DIFF
--- a/components/script/dom/messagechannel.rs
+++ b/components/script/dom/messagechannel.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::codegen::Bindings::MessageChannelBinding::{MessageChannelMethods, Wrap};
-use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::globalscope::GlobalScope;
@@ -20,9 +19,12 @@ pub struct MessageChannel {
 impl MessageChannel {
     /// <https://html.spec.whatwg.org/multipage/#dom-messagechannel>
     #[allow(non_snake_case)]
-    pub fn Constructor(global: &GlobalScope) -> Fallible<DomRoot<MessageChannel>> {
-        let incumbent = GlobalScope::incumbent().ok_or(Error::InvalidState)?;
+    pub fn Constructor(global: &GlobalScope) -> DomRoot<MessageChannel> {
+        MessageChannel::new(global)
+    }
 
+    /// <https://html.spec.whatwg.org/multipage/#dom-messagechannel>
+    pub fn new(incumbent: &GlobalScope) -> DomRoot<MessageChannel> {
         // Step 1
         let port1 = MessagePort::new(&incumbent);
 
@@ -39,18 +41,19 @@ impl MessageChannel {
         );
 
         // Steps 4-6
-        let channel = reflect_dom_object(
-            Box::new(MessageChannel {
-                reflector_: Reflector::new(),
-                port1: Dom::from_ref(&port1),
-                port2: Dom::from_ref(&port2),
-            }),
-            global,
+        reflect_dom_object(
+            Box::new(MessageChannel::new_inherited(&*port1, &*port2)),
+            incumbent,
             Wrap,
-        );
+        )
+    }
 
-        // Step 7
-        Ok(channel)
+    pub fn new_inherited(port1: &MessagePort, port2: &MessagePort) -> MessageChannel {
+        MessageChannel {
+            reflector_: Reflector::new(),
+            port1: Dom::from_ref(port1),
+            port2: Dom::from_ref(port2),
+        }
     }
 }
 

--- a/components/script/dom/webidls/MessageChannel.webidl
+++ b/components/script/dom/webidls/MessageChannel.webidl
@@ -8,7 +8,7 @@
 
 [Exposed=(Window,Worker)]
 interface MessageChannel {
-  [Throws] constructor();
+  constructor();
   readonly attribute MessagePort port1;
   readonly attribute MessagePort port2;
 };


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Use common DOM constructor idioms in `MessageChannel`. Also, remove the falliable from the result, since that seems to match the spec better https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messagechannel

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
