### PR TITLE
Delay reftest screenshot while WR frame is rendering

### DIFF
--- a/components/compositing/compositor_thread.rs
+++ b/components/compositing/compositor_thread.rs
@@ -17,6 +17,8 @@ use profile_traits::mem;
 use profile_traits::time;
 use script_traits::{AnimationState, EventResult, MouseButton, MouseEventType};
 use std::fmt::{Debug, Error, Formatter};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use style_traits::viewport::ViewportConstraints;
 use style_traits::CSSPixel;
 use webrender_api;
@@ -167,4 +169,5 @@ pub struct InitialCompositorState {
     pub webrender_api: webrender_api::RenderApi,
     pub webvr_heartbeats: Vec<Box<dyn WebVRMainThreadHeartbeat>>,
     pub webxr_main_thread: webxr::MainThreadRegistry,
+    pub pending_wr_frame: Arc<AtomicBool>,
 }


### PR DESCRIPTION
This PR addresses the theory that #24726 occurs when WR is performing an async frame render and the reftest screenshot decides it's time to synchronously read the framebuffer. If there have not been any completed frames rendered yet, that would yield the page background colour.

The changes in this PR introduce an additional layer of synchronization - the compositor stores an AtomicBool value that indicates whether we know that a WR frame has started rendering, which is set to true when an IPC request from layout that submits a new display list is received. This bool is set to false when WR notifies us that a frame has been rendered. The screenshot code refuses to take a screenshot if the bool is true, causing us to delay taking a screenshot until there is no frame pending.