### PR TITLE
Make Background Hang Monitor Optional

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -136,6 +136,9 @@ pub struct Opts {
     /// Whether we're running in multiprocess mode.
     pub multiprocess: bool,
 
+    /// Whether we want background hang monitor enabled or not
+    pub background_hang_monitor: bool,
+
     /// Whether we're running inside the sandbox.
     pub sandbox: bool,
 
@@ -545,6 +548,7 @@ pub fn default_opts() -> Opts {
         initial_window_size: Size2D::new(1024, 740),
         user_agent: default_user_agent_string(DEFAULT_USER_AGENT).into(),
         multiprocess: false,
+        background_hang_monitor: false,
         random_pipeline_closure_probability: None,
         random_pipeline_closure_seed: None,
         sandbox: false,
@@ -669,6 +673,7 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         "NCSA Mosaic/1.0 (X11;SunOS 4.1.4 sun4m)",
     );
     opts.optflag("M", "multiprocess", "Run in multiprocess mode");
+    opts.optflag("B", "bhm", "Background Hang Monitor enabled");
     opts.optflag("S", "sandbox", "Run in a sandbox if multiprocess");
     opts.optopt(
         "",
@@ -965,6 +970,7 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         initial_window_size: initial_window_size,
         user_agent: user_agent,
         multiprocess: opt_match.opt_present("M"),
+        background_hang_monitor: opt_match.opt_present("B"),
         sandbox: opt_match.opt_present("S"),
         random_pipeline_closure_probability: random_pipeline_closure_probability,
         random_pipeline_closure_seed: random_pipeline_closure_seed,

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -159,7 +159,7 @@ pub struct LayoutThread {
     font_cache_sender: IpcSender<()>,
 
     /// A means of communication with the background hang monitor.
-    background_hang_monitor: Box<dyn BackgroundHangMonitor>,
+    background_hang_monitor: Option<Box<dyn BackgroundHangMonitor>>,
 
     /// The channel on which messages can be sent to the constellation.
     constellation_chan: IpcSender<ConstellationMsg>,
@@ -292,7 +292,7 @@ impl LayoutThreadFactory for LayoutThread {
         is_iframe: bool,
         chan: (Sender<Msg>, Receiver<Msg>),
         pipeline_port: IpcReceiver<LayoutControlMsg>,
-        background_hang_monitor_register: Box<dyn BackgroundHangMonitorRegister>,
+        background_hang_monitor_register: Option<Box<dyn BackgroundHangMonitorRegister>>,
         constellation_chan: IpcSender<ConstellationMsg>,
         script_chan: IpcSender<ConstellationControlMsg>,
         image_cache: Arc<dyn ImageCache>,
@@ -326,12 +326,13 @@ impl LayoutThreadFactory for LayoutThread {
                     // Ensures layout thread is destroyed before we send shutdown message
                     let sender = chan.0;
 
-                    let background_hang_monitor = background_hang_monitor_register
-                        .register_component(
+                    let background_hang_monitor = background_hang_monitor_register.map(|bhm| {
+                        bhm.register_component(
                             MonitoredComponentId(id, MonitoredComponentType::Layout),
                             Duration::from_millis(1000),
                             Duration::from_millis(5000),
-                        );
+                        )
+                    });
 
                     let layout = LayoutThread::new(
                         id,
@@ -510,7 +511,7 @@ impl LayoutThread {
         is_iframe: bool,
         port: Receiver<Msg>,
         pipeline_port: IpcReceiver<LayoutControlMsg>,
-        background_hang_monitor: Box<dyn BackgroundHangMonitor>,
+        background_hang_monitor: Option<Box<dyn BackgroundHangMonitor>>,
         constellation_chan: IpcSender<ConstellationMsg>,
         script_chan: IpcSender<ConstellationControlMsg>,
         image_cache: Arc<dyn ImageCache>,
@@ -708,7 +709,8 @@ impl LayoutThread {
             Msg::GetRunningAnimations(..) => LayoutHangAnnotation::GetRunningAnimations,
         };
         self.background_hang_monitor
-            .notify_activity(HangAnnotation::Layout(hang_annotation));
+            .as_ref()
+            .map(|bhm| bhm.notify_activity(HangAnnotation::Layout(hang_annotation)));
     }
 
     /// Receives and dispatches messages from the script and constellation threads
@@ -720,7 +722,9 @@ impl LayoutThread {
         }
 
         // Notify the background-hang-monitor we are waiting for an event.
-        self.background_hang_monitor.notify_wait();
+        self.background_hang_monitor
+            .as_ref()
+            .map(|bhm| bhm.notify_wait());
 
         let request = select! {
             recv(self.pipeline_port) -> msg => Request::FromPipeline(msg.unwrap()),
@@ -995,7 +999,9 @@ impl LayoutThread {
         );
 
         self.root_flow.borrow_mut().take();
-        self.background_hang_monitor.unregister();
+        self.background_hang_monitor
+            .as_ref()
+            .map(|bhm| bhm.unregister());
     }
 
     fn handle_add_stylesheet(&self, stylesheet: &Stylesheet, guard: &SharedRwLockReadGuard) {

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -36,7 +36,7 @@ pub trait LayoutThreadFactory {
         is_iframe: bool,
         chan: (Sender<Self::Message>, Receiver<Self::Message>),
         pipeline_port: IpcReceiver<LayoutControlMsg>,
-        background_hang_monitor: Box<dyn BackgroundHangMonitorRegister>,
+        background_hang_monitor: Option<Box<dyn BackgroundHangMonitorRegister>>,
         constellation_chan: IpcSender<ConstellationMsg>,
         script_chan: IpcSender<ConstellationControlMsg>,
         image_cache: Arc<dyn ImageCache>,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -545,9 +545,9 @@ pub struct ScriptThread {
     task_queue: TaskQueue<MainThreadScriptMsg>,
 
     /// A handle to register associated layout threads for hang-monitoring.
-    background_hang_monitor_register: Box<dyn BackgroundHangMonitorRegister>,
+    background_hang_monitor_register: Option<Box<dyn BackgroundHangMonitorRegister>>,
     /// The dedicated means of communication with the background-hang-monitor for this script-thread.
-    background_hang_monitor: Box<dyn BackgroundHangMonitor>,
+    background_hang_monitor: Option<Box<dyn BackgroundHangMonitor>>,
 
     /// A channel to hand out to script thread-based entities that need to be able to enqueue
     /// events in the event queue.
@@ -1262,18 +1262,20 @@ impl ScriptThread {
         let devtools_port =
             ROUTER.route_ipc_receiver_to_new_crossbeam_receiver(ipc_devtools_receiver);
 
-        // Ask the router to proxy IPC messages from the control port to us.
-        let control_port = ROUTER.route_ipc_receiver_to_new_crossbeam_receiver(state.control_port);
-
         let (image_cache_channel, image_cache_port) = unbounded();
 
         let task_queue = TaskQueue::new(port, chan.clone());
 
-        let background_hang_monitor = state.background_hang_monitor_register.register_component(
-            MonitoredComponentId(state.id, MonitoredComponentType::Script),
-            Duration::from_millis(1000),
-            Duration::from_millis(5000),
-        );
+        let background_hang_monitor = state.background_hang_monitor_register.clone().map(|bhm| {
+            bhm.register_component(
+                MonitoredComponentId(state.id.clone(), MonitoredComponentType::Script),
+                Duration::from_millis(1000),
+                Duration::from_millis(5000),
+            )
+        });
+
+        // Ask the router to proxy IPC messages from the control port to us.
+        let control_port = ROUTER.route_ipc_receiver_to_new_crossbeam_receiver(state.control_port);
 
         ScriptThread {
             documents: DomRefCell::new(Documents::new()),
@@ -1408,7 +1410,9 @@ impl ScriptThread {
         let mut sequential = vec![];
 
         // Notify the background-hang-monitor we are waiting for an event.
-        self.background_hang_monitor.notify_wait();
+        self.background_hang_monitor
+            .as_ref()
+            .map(|bhm| bhm.notify_wait());
 
         // Receive at least one message so we don't spinloop.
         debug!("Waiting for event.");
@@ -1662,7 +1666,8 @@ impl ScriptThread {
             ScriptThreadEventCategory::PortMessage => ScriptHangAnnotation::PortMessage,
         };
         self.background_hang_monitor
-            .notify_activity(HangAnnotation::Script(hang_annotation));
+            .as_ref()
+            .map(|bhm| bhm.notify_activity(HangAnnotation::Script(hang_annotation)));
     }
 
     fn message_to_pipeline(&self, msg: &MixedMessage) -> Option<PipelineId> {
@@ -2882,7 +2887,9 @@ impl ScriptThread {
             self.handle_exit_pipeline_msg(pipeline_id, DiscardBrowsingContext::Yes);
         }
 
-        self.background_hang_monitor.unregister();
+        self.background_hang_monitor
+            .as_ref()
+            .map(|bhm| bhm.unregister());
 
         debug!("Exited script thread.");
     }

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -226,7 +226,7 @@ pub struct LayoutThreadInit {
     pub is_parent: bool,
     pub layout_pair: (Sender<Msg>, Receiver<Msg>),
     pub pipeline_port: IpcReceiver<LayoutControlMsg>,
-    pub background_hang_monitor_register: Box<dyn BackgroundHangMonitorRegister>,
+    pub background_hang_monitor_register: Option<Box<dyn BackgroundHangMonitorRegister>>,
     pub constellation_chan: IpcSender<ConstellationMsg>,
     pub script_chan: IpcSender<ConstellationControlMsg>,
     pub image_cache: Arc<dyn ImageCache>,

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -644,7 +644,7 @@ pub struct InitialScriptState {
     /// A channel on which messages can be sent to the constellation from script.
     pub script_to_constellation_chan: ScriptToConstellationChan,
     /// A handle to register script-(and associated layout-)threads for hang monitoring.
-    pub background_hang_monitor_register: Box<dyn BackgroundHangMonitorRegister>,
+    pub background_hang_monitor_register: Option<Box<dyn BackgroundHangMonitorRegister>>,
     /// A sender for the layout thread to communicate to the constellation.
     pub layout_to_constellation_chan: IpcSender<LayoutMsg>,
     /// A channel to schedule timer events.


### PR DESCRIPTION
This is done by wrapping all channels of communication and related objects inside Option which are configured using flag inside servo_config.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25647  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
