### PR TITLE
Remove XR canvas dirtying step.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6650,7 +6650,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#3ac3e83f37ff64c74c847a610a8cefba9b907a9c"
+source = "git+https://github.com/servo/webxr#bf3d92b744a3e48d9addb76f0eef45320ac33960"
 dependencies = [
  "bindgen",
  "crossbeam-channel",
@@ -6672,7 +6672,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#3ac3e83f37ff64c74c847a610a8cefba9b907a9c"
+source = "git+https://github.com/servo/webxr#bf3d92b744a3e48d9addb76f0eef45320ac33960"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -5,7 +5,6 @@
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorBinding::NavigatorMethods;
-use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowBinding::WindowMethods;
 use crate::dom::bindings::codegen::Bindings::XRReferenceSpaceBinding::XRReferenceSpaceType;
 use crate::dom::bindings::codegen::Bindings::XRRenderStateBinding::XRRenderStateInit;
@@ -16,7 +15,6 @@ use crate::dom::bindings::codegen::Bindings::XRSessionBinding::XRFrameRequestCal
 use crate::dom::bindings::codegen::Bindings::XRSessionBinding::XRSessionMethods;
 use crate::dom::bindings::codegen::Bindings::XRSessionBinding::XRVisibilityState;
 use crate::dom::bindings::codegen::Bindings::XRSystemBinding::XRSessionMode;
-use crate::dom::bindings::codegen::Bindings::XRWebGLLayerBinding::XRWebGLLayerMethods;
 use crate::dom::bindings::error::{Error, ErrorResult};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
@@ -25,8 +23,6 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutDom, MutNullableDom};
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::node::Node;
-use crate::dom::node::NodeDamage;
 use crate::dom::performance::reduce_timing_resolution;
 use crate::dom::promise::Promise;
 use crate::dom::xrframe::XRFrame;

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -412,14 +412,6 @@ impl XRSession {
             "WEBXR PROFILING [raf execute]:\t{}ms",
             (time::precise_time_ns() - raf_start) as f64 / 1_000_000.
         );
-
-        // If the canvas element is attached to the DOM, it is now dirty,
-        // and we need to trigger a reflow.
-        base_layer
-            .Context()
-            .Canvas()
-            .upcast::<Node>()
-            .dirty(NodeDamage::OtherNodeDamage);
     }
 
     fn update_inline_projection_matrix(&self) {


### PR DESCRIPTION
Alan tells me that this is no longer necessary, and it causes layout operations to appear in immersive mode profiles when there should not be any.