### PR TITLE
Properly position atomic inline level boxes

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -567,7 +567,10 @@ fn layout_atomic<'box_tree>(
         },
     };
 
-    ifc.inline_position += pbm.inline_end;
+    ifc.inline_position += pbm.inline_end + fragment.content_rect.size.inline;
+    ifc.current_nesting_level
+        .max_block_size_of_fragments_so_far
+        .max_assign(pbm.block_sum() + fragment.content_rect.size.block);
     ifc.current_nesting_level
         .fragments_so_far
         .push(Fragment::Box(fragment));

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-087.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-087.xht.ini
@@ -1,2 +1,0 @@
-[background-087.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-182.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-182.xht.ini
@@ -1,2 +1,0 @@
-[background-182.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-328.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-328.xht.ini
@@ -1,2 +1,0 @@
-[background-328.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-329.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-329.xht.ini
@@ -1,2 +1,0 @@
-[background-329.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-002.xht.ini
@@ -1,2 +1,0 @@
-[background-color-002.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-003.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-003.xht.ini
@@ -1,2 +1,0 @@
-[background-color-003.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-004.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-004.xht.ini
@@ -1,2 +1,0 @@
-[background-color-004.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-005.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-005.xht.ini
@@ -1,2 +1,0 @@
-[background-color-005.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-006.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-006.xht.ini
@@ -1,2 +1,0 @@
-[background-color-006.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-009.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-009.xht.ini
@@ -1,2 +1,0 @@
-[background-color-009.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-010.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-010.xht.ini
@@ -1,2 +1,0 @@
-[background-color-010.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-011.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-011.xht.ini
@@ -1,2 +1,0 @@
-[background-color-011.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-012.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-012.xht.ini
@@ -1,2 +1,0 @@
-[background-color-012.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-014.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-014.xht.ini
@@ -1,2 +1,0 @@
-[background-color-014.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-015.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-015.xht.ini
@@ -1,2 +1,0 @@
-[background-color-015.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-016.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-016.xht.ini
@@ -1,2 +1,0 @@
-[background-color-016.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-017.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-017.xht.ini
@@ -1,2 +1,0 @@
-[background-color-017.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-019.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-019.xht.ini
@@ -1,2 +1,0 @@
-[background-color-019.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-020.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-020.xht.ini
@@ -1,2 +1,0 @@
-[background-color-020.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-021.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-021.xht.ini
@@ -1,2 +1,0 @@
-[background-color-021.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-022.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-022.xht.ini
@@ -1,2 +1,0 @@
-[background-color-022.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-025.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-025.xht.ini
@@ -1,2 +1,0 @@
-[background-color-025.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-026.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-026.xht.ini
@@ -1,2 +1,0 @@
-[background-color-026.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-027.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-027.xht.ini
@@ -1,2 +1,0 @@
-[background-color-027.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-028.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-028.xht.ini
@@ -1,2 +1,0 @@
-[background-color-028.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-029.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-029.xht.ini
@@ -1,2 +1,0 @@
-[background-color-029.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-032.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-032.xht.ini
@@ -1,2 +1,0 @@
-[background-color-032.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-033.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-033.xht.ini
@@ -1,2 +1,0 @@
-[background-color-033.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-034.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-034.xht.ini
@@ -1,2 +1,0 @@
-[background-color-034.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-035.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-035.xht.ini
@@ -1,2 +1,0 @@
-[background-color-035.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-037.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-037.xht.ini
@@ -1,2 +1,0 @@
-[background-color-037.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-038.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-038.xht.ini
@@ -1,2 +1,0 @@
-[background-color-038.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-039.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-039.xht.ini
@@ -1,2 +1,0 @@
-[background-color-039.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-040.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-040.xht.ini
@@ -1,2 +1,0 @@
-[background-color-040.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-042.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-042.xht.ini
@@ -1,2 +1,0 @@
-[background-color-042.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-043.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-043.xht.ini
@@ -1,2 +1,0 @@
-[background-color-043.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-044.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-044.xht.ini
@@ -1,2 +1,0 @@
-[background-color-044.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-045.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-045.xht.ini
@@ -1,2 +1,0 @@
-[background-color-045.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-047.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-047.xht.ini
@@ -1,2 +1,0 @@
-[background-color-047.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-048.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-048.xht.ini
@@ -1,2 +1,0 @@
-[background-color-048.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-049.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-049.xht.ini
@@ -1,2 +1,0 @@
-[background-color-049.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-050.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-050.xht.ini
@@ -1,2 +1,0 @@
-[background-color-050.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-051.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-051.xht.ini
@@ -1,2 +1,0 @@
-[background-color-051.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-052.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-052.xht.ini
@@ -1,2 +1,0 @@
-[background-color-052.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-053.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-053.xht.ini
@@ -1,2 +1,0 @@
-[background-color-053.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-054.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-054.xht.ini
@@ -1,2 +1,0 @@
-[background-color-054.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-055.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-055.xht.ini
@@ -1,2 +1,0 @@
-[background-color-055.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-056.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-056.xht.ini
@@ -1,2 +1,0 @@
-[background-color-056.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-057.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-057.xht.ini
@@ -1,2 +1,0 @@
-[background-color-057.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-058.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-058.xht.ini
@@ -1,2 +1,0 @@
-[background-color-058.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-059.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-059.xht.ini
@@ -1,2 +1,0 @@
-[background-color-059.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-060.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-060.xht.ini
@@ -1,2 +1,0 @@
-[background-color-060.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-061.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-061.xht.ini
@@ -1,2 +1,0 @@
-[background-color-061.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-062.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-062.xht.ini
@@ -1,2 +1,0 @@
-[background-color-062.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-063.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-063.xht.ini
@@ -1,2 +1,0 @@
-[background-color-063.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-064.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-064.xht.ini
@@ -1,2 +1,0 @@
-[background-color-064.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-065.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-065.xht.ini
@@ -1,2 +1,0 @@
-[background-color-065.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-066.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-066.xht.ini
@@ -1,2 +1,0 @@
-[background-color-066.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-067.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-067.xht.ini
@@ -1,2 +1,0 @@
-[background-color-067.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-068.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-068.xht.ini
@@ -1,2 +1,0 @@
-[background-color-068.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-069.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-069.xht.ini
@@ -1,2 +1,0 @@
-[background-color-069.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-070.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-070.xht.ini
@@ -1,2 +1,0 @@
-[background-color-070.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-071.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-071.xht.ini
@@ -1,2 +1,0 @@
-[background-color-071.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-072.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-072.xht.ini
@@ -1,2 +1,0 @@
-[background-color-072.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-073.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-073.xht.ini
@@ -1,2 +1,0 @@
-[background-color-073.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-074.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-074.xht.ini
@@ -1,2 +1,0 @@
-[background-color-074.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-075.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-075.xht.ini
@@ -1,2 +1,0 @@
-[background-color-075.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-076.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-076.xht.ini
@@ -1,2 +1,0 @@
-[background-color-076.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-077.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-077.xht.ini
@@ -1,2 +1,0 @@
-[background-color-077.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-078.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-078.xht.ini
@@ -1,2 +1,0 @@
-[background-color-078.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-079.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-079.xht.ini
@@ -1,2 +1,0 @@
-[background-color-079.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-080.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-080.xht.ini
@@ -1,2 +1,0 @@
-[background-color-080.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-081.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-081.xht.ini
@@ -1,2 +1,0 @@
-[background-color-081.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-082.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-082.xht.ini
@@ -1,2 +1,0 @@
-[background-color-082.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-083.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-083.xht.ini
@@ -1,2 +1,0 @@
-[background-color-083.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-084.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-084.xht.ini
@@ -1,2 +1,0 @@
-[background-color-084.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-085.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-085.xht.ini
@@ -1,2 +1,0 @@
-[background-color-085.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-086.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-086.xht.ini
@@ -1,2 +1,0 @@
-[background-color-086.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-087.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-087.xht.ini
@@ -1,2 +1,0 @@
-[background-color-087.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-088.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-088.xht.ini
@@ -1,2 +1,0 @@
-[background-color-088.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-089.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-089.xht.ini
@@ -1,2 +1,0 @@
-[background-color-089.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-090.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-090.xht.ini
@@ -1,2 +1,0 @@
-[background-color-090.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-091.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-091.xht.ini
@@ -1,2 +1,0 @@
-[background-color-091.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-092.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-092.xht.ini
@@ -1,2 +1,0 @@
-[background-color-092.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-093.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-093.xht.ini
@@ -1,2 +1,0 @@
-[background-color-093.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-094.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-094.xht.ini
@@ -1,2 +1,0 @@
-[background-color-094.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-095.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-095.xht.ini
@@ -1,2 +1,0 @@
-[background-color-095.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-096.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-096.xht.ini
@@ -1,2 +1,0 @@
-[background-color-096.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-097.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-097.xht.ini
@@ -1,2 +1,0 @@
-[background-color-097.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-098.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-098.xht.ini
@@ -1,2 +1,0 @@
-[background-color-098.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-099.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-099.xht.ini
@@ -1,2 +1,0 @@
-[background-color-099.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-100.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-100.xht.ini
@@ -1,2 +1,0 @@
-[background-color-100.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-101.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-101.xht.ini
@@ -1,2 +1,0 @@
-[background-color-101.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-102.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-102.xht.ini
@@ -1,2 +1,0 @@
-[background-color-102.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-103.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-103.xht.ini
@@ -1,2 +1,0 @@
-[background-color-103.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-104.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-104.xht.ini
@@ -1,2 +1,0 @@
-[background-color-104.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-105.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-105.xht.ini
@@ -1,2 +1,0 @@
-[background-color-105.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-106.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-106.xht.ini
@@ -1,2 +1,0 @@
-[background-color-106.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-107.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-107.xht.ini
@@ -1,2 +1,0 @@
-[background-color-107.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-108.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-108.xht.ini
@@ -1,2 +1,0 @@
-[background-color-108.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-109.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-109.xht.ini
@@ -1,2 +1,0 @@
-[background-color-109.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-110.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-110.xht.ini
@@ -1,2 +1,0 @@
-[background-color-110.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-111.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-111.xht.ini
@@ -1,2 +1,0 @@
-[background-color-111.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-112.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-112.xht.ini
@@ -1,2 +1,0 @@
-[background-color-112.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-113.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-113.xht.ini
@@ -1,2 +1,0 @@
-[background-color-113.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-114.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-114.xht.ini
@@ -1,2 +1,0 @@
-[background-color-114.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-115.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-115.xht.ini
@@ -1,2 +1,0 @@
-[background-color-115.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-116.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-116.xht.ini
@@ -1,2 +1,0 @@
-[background-color-116.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-117.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-117.xht.ini
@@ -1,2 +1,0 @@
-[background-color-117.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-118.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-118.xht.ini
@@ -1,2 +1,0 @@
-[background-color-118.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-119.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-119.xht.ini
@@ -1,2 +1,0 @@
-[background-color-119.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-120.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-120.xht.ini
@@ -1,2 +1,0 @@
-[background-color-120.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-121.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-121.xht.ini
@@ -1,2 +1,0 @@
-[background-color-121.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-122.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-122.xht.ini
@@ -1,2 +1,0 @@
-[background-color-122.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-123.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-123.xht.ini
@@ -1,2 +1,0 @@
-[background-color-123.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-124.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-124.xht.ini
@@ -1,2 +1,0 @@
-[background-color-124.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-125.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-125.xht.ini
@@ -1,2 +1,0 @@
-[background-color-125.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-126.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-126.xht.ini
@@ -1,2 +1,0 @@
-[background-color-126.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-127.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-127.xht.ini
@@ -1,2 +1,0 @@
-[background-color-127.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-128.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-128.xht.ini
@@ -1,2 +1,0 @@
-[background-color-128.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-129.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-129.xht.ini
@@ -1,2 +1,0 @@
-[background-color-129.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-130.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-130.xht.ini
@@ -1,2 +1,0 @@
-[background-color-130.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-131.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-131.xht.ini
@@ -1,2 +1,0 @@
-[background-color-131.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-132.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-132.xht.ini
@@ -1,2 +1,0 @@
-[background-color-132.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-133.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-133.xht.ini
@@ -1,2 +1,0 @@
-[background-color-133.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-134.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-134.xht.ini
@@ -1,2 +1,0 @@
-[background-color-134.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-135.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-135.xht.ini
@@ -1,2 +1,0 @@
-[background-color-135.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-136.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-136.xht.ini
@@ -1,2 +1,0 @@
-[background-color-136.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-137.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-137.xht.ini
@@ -1,2 +1,0 @@
-[background-color-137.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-138.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-138.xht.ini
@@ -1,2 +1,0 @@
-[background-color-138.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-139.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-139.xht.ini
@@ -1,2 +1,0 @@
-[background-color-139.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-140.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-140.xht.ini
@@ -1,2 +1,0 @@
-[background-color-140.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-141.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-141.xht.ini
@@ -1,2 +1,0 @@
-[background-color-141.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-142.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-142.xht.ini
@@ -1,2 +1,0 @@
-[background-color-142.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-143.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-143.xht.ini
@@ -1,2 +1,0 @@
-[background-color-143.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-144.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-144.xht.ini
@@ -1,2 +1,0 @@
-[background-color-144.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-145.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-145.xht.ini
@@ -1,2 +1,0 @@
-[background-color-145.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-175.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-color-175.xht.ini
@@ -1,2 +1,0 @@
-[background-color-175.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-repeat-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-repeat-001.xht.ini
@@ -1,2 +1,0 @@
-[background-repeat-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/box-display/containing-block-009.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/box-display/containing-block-009.xht.ini
@@ -1,2 +1,0 @@
-[containing-block-009.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/box-display/containing-block-030.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/box-display/containing-block-030.xht.ini
@@ -1,2 +1,0 @@
-[containing-block-030.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/generated-content/before-content-display-005.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/generated-content/before-content-display-005.xht.ini
@@ -1,2 +1,0 @@
-[before-content-display-005.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-334.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-334.html.ini
@@ -1,2 +1,0 @@
-[background-334.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPoint-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPoint-001.html.ini
@@ -1,0 +1,4 @@
+[elementFromPoint-001.html]
+  [CSSOM View - 5 - extensions to the Document interface]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/acid2_ref.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/acid2_ref.html.ini
@@ -1,0 +1,2 @@
+[acid2_ref.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/alpha_gif_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/alpha_gif_a.html.ini
@@ -1,2 +1,0 @@
-[alpha_gif_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/alpha_png_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/alpha_png_a.html.ini
@@ -1,2 +1,0 @@
-[alpha_png_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/block_replaced_content_b.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/block_replaced_content_b.html.ini
@@ -1,2 +1,0 @@
-[block_replaced_content_b.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-right.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-right.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-right.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-top.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/css-position-3/position-sticky-top.html.ini
@@ -1,0 +1,2 @@
+[position-sticky-top.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_absolute_hypothetical_line_metrics_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_absolute_hypothetical_line_metrics_a.html.ini
@@ -1,2 +1,0 @@
-[inline_absolute_hypothetical_line_metrics_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_block_explicit_height_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_block_explicit_height_a.html.ini
@@ -1,2 +1,0 @@
-[inline_block_explicit_height_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_block_with_margin_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_block_with_margin_a.html.ini
@@ -1,2 +1,0 @@
-[inline_block_with_margin_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/inline_hypothetical_box_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/inline_hypothetical_box_a.html.ini
@@ -1,2 +1,0 @@
-[inline_hypothetical_box_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/list_item_marker_around_float.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/list_item_marker_around_float.html.ini
@@ -1,2 +1,0 @@
-[list_item_marker_around_float.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/margin_padding_inline_block_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/margin_padding_inline_block_a.html.ini
@@ -1,2 +1,0 @@
-[margin_padding_inline_block_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_inline_block_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/vertical_align_inline_block_a.html.ini
@@ -1,2 +1,0 @@
-[vertical_align_inline_block_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/mozilla/fetch_cannot_overwhelm_system.window.js.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/mozilla/fetch_cannot_overwhelm_system.window.js.ini
@@ -1,2 +1,0 @@
-[fetch_cannot_overwhelm_system.window.html]
-  expected: CRASH

--- a/tests/wpt/mozilla/meta-layout-2020/mozilla/hit_test_pos_fixed.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/mozilla/hit_test_pos_fixed.html.ini
@@ -1,4 +1,0 @@
-[hit_test_pos_fixed.html]
-  [Hit-test of an element with position: fixed should discard scroll offset]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta-layout-2020/mozilla/htmllabel-activation.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/mozilla/htmllabel-activation.html.ini
@@ -1,4 +1,0 @@
-[htmllabel-activation.html]
-  [If label's 1st child (submit) is disabled, click should have no impact]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta-layout-2020/mozilla/paint_timing.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/mozilla/paint_timing.html.ini
@@ -1,0 +1,5 @@
+[paint_timing.html]
+  expected: ERROR
+  [Performance entries observer]
+    expected: NOTRUN
+

--- a/tests/wpt/mozilla/meta-layout-2020/mozilla/svg/svg.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/mozilla/svg/svg.html.ini
@@ -1,0 +1,2 @@
+[svg.html]
+  expected: FAIL


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25709

