### PR TITLE
Allow more WebGL2 FBO attachment formats

### DIFF
--- a/components/script/dom/webglrenderbuffer.rs
+++ b/components/script/dom/webglrenderbuffer.rs
@@ -145,6 +145,31 @@ impl WebGLRenderbuffer {
             constants::RGBA4 | constants::DEPTH_COMPONENT16 | constants::STENCIL_INDEX8 => {
                 internal_format
             },
+            constants::R8 |
+            constants::R8UI |
+            constants::R8I |
+            constants::R16UI |
+            constants::R16I |
+            constants::R32UI |
+            constants::R32I |
+            constants::RG8 |
+            constants::RG8UI |
+            constants::RG8I |
+            constants::RG16UI |
+            constants::RG16I |
+            constants::RG32UI |
+            constants::RG32I |
+            constants::RGB8 |
+            constants::RGBA8 |
+            constants::SRGB8_ALPHA8 |
+            constants::RGB10_A2 |
+            constants::RGBA8UI |
+            constants::RGBA8I |
+            constants::RGB10_A2UI |
+            constants::RGBA16UI |
+            constants::RGBA16I |
+            constants::RGBA32I |
+            constants::RGBA32UI |
             constants::DEPTH_COMPONENT24 |
             constants::DEPTH_COMPONENT32F |
             constants::DEPTH24_STENCIL8 |

--- a/tests/wpt/webgl/meta/conformance2/extensions/webgl_multiview.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/extensions/webgl_multiview.html.ini
@@ -1,7 +1,0 @@
-[webgl_multiview.html]
-  [WebGL test #3: getError expected: INVALID_ENUM. Was INVALID_OPERATION : Can't query FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR without enabling WEBGL_multiview]
-    expected: FAIL
-
-  [WebGL test #2: getError expected: INVALID_ENUM. Was INVALID_OPERATION : Can't query FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR without enabling WEBGL_multiview]
-    expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance2/reading/read-pixels-from-rgb8-into-pbo-bug.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/reading/read-pixels-from-rgb8-into-pbo-bug.html.ini
@@ -1,7 +1,7 @@
 [read-pixels-from-rgb8-into-pbo-bug.html]
-  [WebGL test #1: framebuffer with RGB8 color buffer is incomplete]
+  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_OPERATION : Tests should complete without gl errors]
     expected: FAIL
 
-  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : Tests should complete without gl errors]
+  [WebGL test #1: Expected in pixel 0: [255,0,0,255\], got: 0,0,0,0]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/framebuffer-object-attachment.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/framebuffer-object-attachment.html.ini
@@ -1,34 +1,7 @@
 [framebuffer-object-attachment.html]
-  [WebGL test #13: gl.getParameter(gl.RED_BITS) + gl.getParameter(gl.GREEN_BITS) + gl.getParameter(gl.BLUE_BITS) + gl.getParameter(gl.ALPHA_BITS) >= 16 should be true. Was false.]
+  [WebGL test #45: getError expected: NO_ERROR. Was INVALID_ENUM : ]
     expected: FAIL
 
-  [WebGL test #10: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
-    expected: FAIL
-
-  [WebGL test #20: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
-    expected: FAIL
-
-  [WebGL test #21: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
-    expected: FAIL
-
-  [WebGL test #17: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
-    expected: FAIL
-
-  [WebGL test #9: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
-    expected: FAIL
-
-  [WebGL test #11: getError expected: NO_ERROR. Was INVALID_ENUM : ]
-    expected: FAIL
-
-  [WebGL test #19: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
-    expected: FAIL
-
-  [WebGL test #22: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
-    expected: FAIL
-
-  [WebGL test #18: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
-    expected: FAIL
-
-  [WebGL test #27: getError expected: NO_ERROR. Was INVALID_ENUM : ]
+  [WebGL test #28: checkFramebufferStatus expects [FRAMEBUFFER_COMPLETE\], was FRAMEBUFFER_INCOMPLETE_ATTACHMENT]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/clearbuffer-sub-source.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/clearbuffer-sub-source.html.ini
@@ -1,11 +1,5 @@
 [clearbuffer-sub-source.html]
-  [WebGL test #14: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : clearBuffer with srcOffset = 2 should succeed]
-    expected: FAIL
-
   [WebGL test #5: clearBuffer fails to work. Expected: 1,2,3,4, got: 0,0,0,0]
-    expected: FAIL
-
-  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : clearBuffer with no srcOffset should succeed]
     expected: FAIL
 
   [WebGL test #11: clearBuffer fails to work. Expected: 1,2,3,4, got: 0,0,0,0]
@@ -14,34 +8,28 @@
   [WebGL test #13: clearBuffer fails to work. Expected: 1,2,3,4, got: 0,0,0,0]
     expected: FAIL
 
-  [WebGL test #9: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+  [WebGL test #12: getError expected: NO_ERROR. Was INVALID_OPERATION : clearBuffer with srcOffset = 0 should succeed]
     expected: FAIL
 
-  [WebGL test #10: getError expected: NO_ERROR. Was INVALID_ENUM : clearBuffer with no srcOffset should succeed]
+  [WebGL test #6: getError expected: NO_ERROR. Was INVALID_OPERATION : clearBuffer with srcOffset = 2 should succeed]
     expected: FAIL
 
-  [WebGL test #16: getError expected: INVALID_VALUE. Was INVALID_FRAMEBUFFER_OPERATION : clearBuffer with srcOffset = 4 should fail: out of bounds]
+  [WebGL test #4: getError expected: NO_ERROR. Was INVALID_OPERATION : clearBuffer with srcOffset = 0 should succeed]
     expected: FAIL
 
-  [WebGL test #4: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : clearBuffer with srcOffset = 0 should succeed]
+  [WebGL test #14: getError expected: NO_ERROR. Was INVALID_OPERATION : clearBuffer with srcOffset = 2 should succeed]
     expected: FAIL
 
   [WebGL test #15: clearBuffer fails to work. Expected: 3,4,5,6, got: 0,0,0,0]
     expected: FAIL
 
-  [WebGL test #8: getError expected: INVALID_VALUE. Was INVALID_FRAMEBUFFER_OPERATION : clearBuffer with srcOffset = 4 should fail: out of bounds]
-    expected: FAIL
-
-  [WebGL test #6: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : clearBuffer with srcOffset = 2 should succeed]
+  [WebGL test #8: getError expected: INVALID_VALUE. Was INVALID_OPERATION : clearBuffer with srcOffset = 4 should fail: out of bounds]
     expected: FAIL
 
   [WebGL test #7: clearBuffer fails to work. Expected: 3,4,5,6, got: 0,0,0,0]
     expected: FAIL
 
-  [WebGL test #12: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : clearBuffer with srcOffset = 0 should succeed]
-    expected: FAIL
-
-  [WebGL test #1: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
+  [WebGL test #16: getError expected: INVALID_VALUE. Was INVALID_OPERATION : clearBuffer with srcOffset = 4 should fail: out of bounds]
     expected: FAIL
 
   [WebGL test #3: clearBuffer fails to work. Expected: 1,2,3,4, got: 0,0,0,0]

--- a/tests/wpt/webgl/meta/conformance2/rendering/framebuffer-completeness-unaffected.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/framebuffer-completeness-unaffected.html.ini
@@ -3,6 +3,3 @@
   [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
-  [WebGL test #1: gl.checkFramebufferStatus(gl.FRAMEBUFFER) should be 36053. Was 36054.]
-    expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance2/state/gl-get-calls.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/state/gl-get-calls.html.ini
@@ -8,9 +8,6 @@
   [WebGL test #80: context.getParameter(context.MIN_PROGRAM_TEXEL_OFFSET) is not an instance of Number]
     expected: FAIL
 
-  [WebGL test #41: context.getParameter(context.MAX_DRAW_BUFFERS) should be >= 4. Was null (of type object).]
-    expected: FAIL
-
   [WebGL test #33: context.getParameter(context.MAX_ARRAY_TEXTURE_LAYERS) should be >= 256. Was null (of type object).]
     expected: FAIL
 
@@ -89,13 +86,7 @@
   [WebGL test #48: context.getParameter(context.MAX_FRAGMENT_INPUT_COMPONENTS) is not an instance of Number]
     expected: FAIL
 
-  [WebGL test #37: context.getParameter(context.MAX_COLOR_ATTACHMENTS) should be >= 4. Was null (of type object).]
-    expected: FAIL
-
   [WebGL test #9: context.getParameter(context.PACK_SKIP_ROWS) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #42: context.getParameter(context.MAX_DRAW_BUFFERS) is not an instance of Number]
     expected: FAIL
 
   [WebGL test #34: context.getParameter(context.MAX_ARRAY_TEXTURE_LAYERS) is not an instance of Number]
@@ -105,9 +96,6 @@
     expected: FAIL
 
   [WebGL test #12: context.getParameter(context.RASTERIZER_DISCARD) should be false (of type boolean). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #38: context.getParameter(context.MAX_COLOR_ATTACHMENTS) is not an instance of Number]
     expected: FAIL
 
   [WebGL test #44: context.getParameter(context.MAX_ELEMENT_INDEX) is not an instance of Number]


### PR DESCRIPTION
Add support for most of the framebuffer attachment formats introduced in WebGL2 for textures and renderbuffers.

Related format tables:

- https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glTexImage2D.xhtml
- https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glRenderbufferStorage.xhtml

<!-- Please describe your changes on the following line: -->

cc @jdm @zakorgy


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
