### PR TITLE
Remove GL->d3d blit in HoloLens immersive mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,8 +496,8 @@ dependencies = [
  "raqote",
  "servo_config",
  "sparkle",
- "surfman 0.1.3",
- "surfman-chains 0.2.1",
+ "surfman 0.1.4",
+ "surfman-chains 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "surfman-chains-api",
  "time",
  "webrender",
@@ -742,6 +742,7 @@ dependencies = [
 name = "compositing"
 version = "0.0.1"
 dependencies = [
+ "canvas",
  "crossbeam-channel",
  "embedder_traits",
  "euclid",
@@ -3184,7 +3185,7 @@ dependencies = [
  "sparkle",
  "style",
  "style_traits",
- "surfman 0.1.3",
+ "surfman 0.1.4",
  "webdriver_server",
  "webgpu",
  "webrender",
@@ -5046,7 +5047,7 @@ dependencies = [
  "servo-media",
  "sparkle",
  "surfman 0.2.0",
- "surfman-chains 0.3.0",
+ "surfman-chains 0.3.0 (git+https://github.com/asajeffrey/surfman-chains?branch=multi)",
  "surfman-chains-api",
 ]
 
@@ -5697,9 +5698,9 @@ dependencies = [
 
 [[package]]
 name = "surfman"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10248da202c1c8d8798783bbc4ba08e81ff225c6e2a394d64748d2a62acb198c"
+checksum = "43bf043642ad98aaa51956091c4f829a400bad5f023b5f0095ecda61f925c63d"
 dependencies = [
  "bitflags",
  "cgl 0.3.2",
@@ -5726,7 +5727,7 @@ dependencies = [
 [[package]]
 name = "surfman"
 version = "0.2.0"
-source = "git+https://github.com/pcwalton/surfman?branch=multi#808e5c5906dbcc6707536c8bac8bcc9389b4e1eb"
+source = "git+https://github.com/pcwalton/surfman?branch=multi#fb782262617e7ca839a4e487b116a5199afaf963"
 dependencies = [
  "bitflags",
  "cgl 0.3.2",
@@ -5752,20 +5753,6 @@ dependencies = [
 
 [[package]]
 name = "surfman-chains"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1b5976b229a807a9e79b3b5248da577948b9882c77f2afce27cf562f80e22"
-dependencies = [
- "euclid",
- "fnv",
- "log",
- "sparkle",
- "surfman 0.1.3",
- "surfman-chains-api",
-]
-
-[[package]]
-name = "surfman-chains"
 version = "0.3.0"
 source = "git+https://github.com/asajeffrey/surfman-chains?branch=multi#80a71b1a2df71ae70c3c194d0af40b8ebf72968a"
 dependencies = [
@@ -5774,6 +5761,20 @@ dependencies = [
  "log",
  "sparkle",
  "surfman 0.2.0",
+ "surfman-chains-api",
+]
+
+[[package]]
+name = "surfman-chains"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a679f5be9644bbf93662f3b1a704cc6b81c147d4b7d6d5c8d8b6f453176f01"
+dependencies = [
+ "euclid",
+ "fnv",
+ "log",
+ "sparkle",
+ "surfman 0.1.4",
  "surfman-chains-api",
 ]
 
@@ -6649,9 +6650,10 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#a1afba096c9797c3663727de58f54eae898f3050"
+source = "git+https://github.com/servo/webxr#3ac3e83f37ff64c74c847a610a8cefba9b907a9c"
 dependencies = [
  "bindgen",
+ "crossbeam-channel",
  "euclid",
  "gl_generator 0.13.1",
  "gleam 0.9.2",
@@ -6659,8 +6661,8 @@ dependencies = [
  "log",
  "openxr",
  "serde",
- "surfman 0.1.3",
- "surfman-chains 0.2.1",
+ "surfman 0.1.4",
+ "surfman-chains 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time",
  "webxr-api",
  "winapi",
@@ -6670,7 +6672,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#a1afba096c9797c3663727de58f54eae898f3050"
+source = "git+https://github.com/servo/webxr#3ac3e83f37ff64c74c847a610a8cefba9b907a9c"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -42,5 +42,5 @@ webrender_traits = {path = "../webrender_traits"}
 webxr-api = {git = "https://github.com/servo/webxr", features = ["ipc"]}
 # NOTE: the sm-angle feature only enables angle on windows, not other platforms!
 surfman = { version = "0.1", features = ["sm-angle", "sm-osmesa"] }
-surfman-chains = "0.2"
+surfman-chains = "0.3"
 surfman-chains-api = "0.2"

--- a/components/canvas/lib.rs
+++ b/components/canvas/lib.rs
@@ -12,6 +12,9 @@ extern crate log;
 mod raqote_backend;
 
 pub use webgl_mode::WebGLComm;
+pub use webgl_thread::SurfaceProvider;
+pub use webgl_thread::SurfaceProviders;
+pub use webgl_thread::WebGlExecutor;
 
 pub mod canvas_data;
 pub mod canvas_paint_thread;

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -14,6 +14,7 @@ use std::num::{NonZeroU32, NonZeroU64};
 use std::ops::Deref;
 use webrender_api::{DocumentId, ImageKey, PipelineId};
 use webvr_traits::WebVRPoseInformation;
+use webxr_api::SessionId;
 use webxr_api::SwapChainId as WebXRSwapChainId;
 
 /// Helper function that creates a WebGL channel (WebGLSender, WebGLReceiver) to be used in WebGLCommands.
@@ -80,6 +81,7 @@ pub enum WebGLMsg {
         WebGLContextId,
         Size2D<i32>,
         WebGLSender<Option<WebXRSwapChainId>>,
+        SessionId,
     ),
     /// Performs a buffer swap.
     ///
@@ -188,9 +190,14 @@ impl WebGLMsgSender {
         &self,
         size: Size2D<i32>,
         sender: WebGLSender<Option<WebXRSwapChainId>>,
+        id: SessionId,
     ) -> WebGLSendResult {
-        self.sender
-            .send(WebGLMsg::CreateWebXRSwapChain(self.ctx_id, size, sender))
+        self.sender.send(WebGLMsg::CreateWebXRSwapChain(
+            self.ctx_id,
+            size,
+            sender,
+            id,
+        ))
     }
 
     #[inline]

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -16,6 +16,7 @@ default = []
 gl = ["gleam", "pixels"]
 
 [dependencies]
+canvas = { path = "../canvas" }
 crossbeam-channel = "0.4"
 embedder_traits = {path = "../embedder_traits"}
 euclid = "0.20"

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -4,6 +4,7 @@
 
 //! Abstract windowing methods. The concrete implementations of these can be found in `platform/`.
 
+use canvas::{SurfaceProviders, WebGlExecutor};
 use embedder_traits::EventLoopWaker;
 use euclid::Scale;
 #[cfg(feature = "gl")]
@@ -184,7 +185,13 @@ pub trait EmbedderMethods {
     }
 
     /// Register services with a WebXR Registry.
-    fn register_webxr(&mut self, _: &mut webxr::MainThreadRegistry) {}
+    fn register_webxr(
+        &mut self,
+        _: &mut webxr::MainThreadRegistry,
+        _: WebGlExecutor,
+        _: SurfaceProviders,
+    ) {
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -142,9 +142,11 @@ impl WebGLFramebuffer {
         size: Size2D<i32, Viewport>,
     ) -> Option<(WebXRSwapChainId, DomRoot<Self>)> {
         let (sender, receiver) = webgl_channel().unwrap();
-        let _ = context
-            .webgl_sender()
-            .send_create_webxr_swap_chain(size.to_untyped(), sender);
+        let _ = context.webgl_sender().send_create_webxr_swap_chain(
+            size.to_untyped(),
+            sender,
+            session.session_id(),
+        );
         let swap_chain_id = receiver.recv().unwrap()?;
         let framebuffer_id =
             WebGLFramebufferId::Opaque(WebGLOpaqueFramebufferId::WebXR(swap_chain_id));

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -81,6 +81,7 @@ use std::cell::Cell;
 use std::cmp;
 use std::ptr::{self, NonNull};
 use std::rc::Rc;
+use webxr_api::SessionId;
 use webxr_api::SwapChainId as WebXRSwapChainId;
 
 // From the GLES 2.0.25 spec, page 85:
@@ -4576,8 +4577,9 @@ impl WebGLMessageSender {
         &self,
         size: Size2D<i32>,
         sender: WebGLSender<Option<WebXRSwapChainId>>,
+        id: SessionId,
     ) -> WebGLSendResult {
-        self.wake_after_send(|| self.sender.send_create_webxr_swap_chain(size, sender))
+        self.wake_after_send(|| self.sender.send_create_webxr_swap_chain(size, sender, id))
     }
 
     pub fn send_resize(

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -51,7 +51,7 @@ use std::mem;
 use std::rc::Rc;
 use webxr_api::{
     self, util, Display, EnvironmentBlendMode, Event as XREvent, Frame, SelectEvent, SelectKind,
-    Session, View, Viewer, Visibility,
+    Session, SessionId, View, Viewer, Visibility,
 };
 
 #[dom_struct]
@@ -461,6 +461,10 @@ impl XRSession {
             projection: *self.inline_projection_matrix.borrow(),
             viewport: Rect::from_size(size.to_i32()),
         }
+    }
+
+    pub fn session_id(&self) -> SessionId {
+        self.session.borrow().id()
     }
 }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -65,7 +65,7 @@ fn webdriver(_port: u16, _constellation: Sender<ConstellationMsg>) {}
 
 use bluetooth::BluetoothThreadFactory;
 use bluetooth_traits::BluetoothRequest;
-use canvas::WebGLComm;
+use canvas::{SurfaceProviders, WebGLComm, WebGlExecutor};
 use canvas_traits::webgl::WebGLThreads;
 use compositing::compositor_thread::{
     CompositorProxy, CompositorReceiver, InitialCompositorState, Msg,
@@ -432,14 +432,6 @@ where
             panic!("We don't currently support running both WebVR and WebXR");
         }
 
-        // For the moment, we enable use both the webxr crate and the rust-webvr crate,
-        // but we are migrating over to just using webxr.
-        let mut webxr_main_thread = webxr::MainThreadRegistry::new(event_loop_waker)
-            .expect("Failed to create WebXR device registry");
-        if pref!(dom.webxr.enabled) {
-            embedder.register_webxr(&mut webxr_main_thread);
-        }
-
         let mut webvr_heartbeats = Vec::new();
         let webvr_services = if pref!(dom.webvr.enabled) {
             let mut services = VRServiceManager::new();
@@ -468,7 +460,12 @@ where
         let (external_image_handlers, external_images) = WebrenderExternalImageHandlers::new();
         let mut external_image_handlers = Box::new(external_image_handlers);
 
-        let webgl_threads = create_webgl_threads(
+        // For the moment, we enable use both the webxr crate and the rust-webvr crate,
+        // but we are migrating over to just using webxr.
+        let mut webxr_main_thread = webxr::MainThreadRegistry::new(event_loop_waker)
+            .expect("Failed to create WebXR device registry");
+
+        let (webgl_threads, webgl_extras) = create_webgl_threads(
             &*window,
             &mut webrender,
             webrender_api_sender.clone(),
@@ -477,6 +474,16 @@ where
             &mut external_image_handlers,
             external_images.clone(),
         );
+
+        if pref!(dom.webxr.enabled) {
+            if let Some((webxr_surface_providers, webgl_executor)) = webgl_extras {
+                embedder.register_webxr(
+                    &mut webxr_main_thread,
+                    webgl_executor,
+                    webxr_surface_providers,
+                );
+            }
+        }
 
         let glplayer_threads = match window.get_gl_context() {
             GlContext::Unknown => None,
@@ -1060,7 +1067,10 @@ fn create_webgl_threads<W>(
     webxr_main_thread: &mut webxr::MainThreadRegistry,
     external_image_handlers: &mut WebrenderExternalImageHandlers,
     external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
-) -> Option<WebGLThreads>
+) -> (
+    Option<WebGLThreads>,
+    Option<(SurfaceProviders, WebGlExecutor)>,
+)
 where
     W: WindowMethods + 'static + ?Sized,
 {
@@ -1074,7 +1084,7 @@ where
                 Ok(a) => a,
                 Err(e) => {
                     warn!("Failed to create software graphics context: {:?}", e);
-                    return None;
+                    return (None, None);
                 },
             };
             (Device::Software(device), Context::Software(context))
@@ -1083,7 +1093,7 @@ where
                 Ok(a) => a,
                 Err(e) => {
                     warn!("Failed to create hardware graphics context: {:?}", e);
-                    return None;
+                    return (None, None);
                 },
             };
             (Device::Hardware(device), Context::Hardware(context))
@@ -1094,7 +1104,7 @@ where
         Ok(a) => a,
         Err(e) => {
             warn!("Failed to create graphics context: {:?}", e);
-            return None;
+            return (None, None);
         },
     };
 
@@ -1106,8 +1116,10 @@ where
     let WebGLComm {
         webgl_threads,
         webxr_swap_chains,
+        webxr_surface_providers,
         image_handler,
         output_handler,
+        webgl_executor,
     } = WebGLComm::new(
         device,
         context,
@@ -1129,5 +1141,8 @@ where
         webrender.set_output_image_handler(output_handler);
     }
 
-    Some(webgl_threads)
+    (
+        Some(webgl_threads),
+        Some((webxr_surface_providers, webgl_executor)),
+    )
 }

--- a/ports/glutin/embedder.rs
+++ b/ports/glutin/embedder.rs
@@ -12,6 +12,7 @@ use glutin;
 use glutin::dpi::LogicalSize;
 use glutin::EventsLoopClosed;
 use rust_webvr::GlWindowVRService;
+use servo::canvas::{SurfaceProviders, WebGlExecutor};
 use servo::compositing::windowing::EmbedderMethods;
 use servo::embedder_traits::EventLoopWaker;
 use servo::servo_config::{opts, pref};
@@ -89,7 +90,12 @@ impl EmbedderMethods for EmbedderCallbacks {
         }
     }
 
-    fn register_webxr(&mut self, xr: &mut webxr::MainThreadRegistry) {
+    fn register_webxr(
+        &mut self,
+        xr: &mut webxr::MainThreadRegistry,
+        _executor: WebGlExecutor,
+        _surface_provider_registration: SurfaceProviders
+    ) {
         if pref!(dom.webxr.test) {
             xr.register_mock(webxr::headless::HeadlessMockDiscovery::new());
         } else if !opts::get().headless && pref!(dom.webxr.glwindow) {

--- a/tests/wpt/webgl/meta/conformance2/uniforms/incompatible-texture-type-for-sampler.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/uniforms/incompatible-texture-type-for-sampler.html.ini
@@ -1,2 +1,2 @@
 [incompatible-texture-type-for-sampler.html]
-  expected: CRASH
+  expected: TIMEOUT


### PR DESCRIPTION
Depends on:
* https://github.com/servo/surfman/pull/151
* https://github.com/asajeffrey/surfman-chains/pull/7
* https://github.com/servo/webxr/pull/133

These changes add two extra APIs for embedders to use when registering a WebXR device - one to allow running any closure as a task in the webgl thread, and one to register an arbitrary surface provider for a particular webxr session. When an openxr session is started, it can then obtain the webgl thread's d3d device from that thread's surfman device and ensure that openxr uses it.

Surface providers are traits that have their methods invoked by the webgl thread as part of the the normal swapchain operations. This allows the openxr surface provider to return surfaces that wrap the underlying openxr textures, which are valid in the webgl thread and can be used as the target of an opaque framebuffer.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25735
- [x] These changes do not require tests because there are no windows immersive mode tests