### PR TITLE
Have transforms and filters be CBs for all descendants in layout_2020

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -37,7 +37,12 @@ type ItemTag = (u64, u16);
 type HitInfo = Option<ItemTag>;
 
 pub struct DisplayListBuilder<'a> {
+    /// The current SpatialId and ClipId information for this `DisplayListBuilder`.
     current_space_and_clip: wr::SpaceAndClipInfo,
+
+    /// The id of the nearest ancestor reference frame for this `DisplayListBuilder`.
+    nearest_reference_frame: wr::SpatialId,
+
     pub context: &'a LayoutContext<'a>,
     pub wr: wr::DisplayListBuilder,
 
@@ -56,6 +61,7 @@ impl<'a> DisplayListBuilder<'a> {
     ) -> Self {
         Self {
             current_space_and_clip: wr::SpaceAndClipInfo::root_scroll(pipeline_id),
+            nearest_reference_frame: wr::SpatialId::root_reference_frame(pipeline_id),
             is_contentful: false,
             context,
             wr: wr::DisplayListBuilder::new(pipeline_id, viewport_size),
@@ -68,9 +74,14 @@ impl<'a> DisplayListBuilder<'a> {
     }
 
     fn clipping_and_scrolling_scope<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
-        let previous = self.current_space_and_clip;
+        let previous_space_and_clip = self.current_space_and_clip;
+        let previous_nearest_reference_frame = self.nearest_reference_frame;
+
         let result = f(self);
-        self.current_space_and_clip = previous;
+
+        self.current_space_and_clip = previous_space_and_clip;
+        self.nearest_reference_frame = previous_nearest_reference_frame;
+
         result
     }
 }

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -223,7 +223,8 @@ fn layout_block_level_children<'a>(
                 })
                 .collect()
         } else {
-            let has_positioned_ancestor = positioning_context.has_positioned_ancestor();
+            let collects_for_nearest_positioned_ancestor =
+                positioning_context.collects_for_nearest_positioned_ancestor();
             let mut fragments = child_boxes
                 .par_iter()
                 .enumerate()
@@ -238,7 +239,7 @@ fn layout_block_level_children<'a>(
                             /* float_context = */ None,
                         )
                     },
-                    || PositioningContext::new_for_rayon(has_positioned_ancestor),
+                    || PositioningContext::new_for_rayon(collects_for_nearest_positioned_ancestor),
                     PositioningContext::append,
                 )
                 .collect();
@@ -275,7 +276,7 @@ impl BlockLevelBox {
                 tag,
                 style,
                 contents,
-            } => Fragment::Box(positioning_context.for_maybe_position_relative(
+            } => Fragment::Box(positioning_context.layout_maybe_position_relative_fragment(
                 layout_context,
                 containing_block,
                 style,
@@ -293,7 +294,7 @@ impl BlockLevelBox {
                 },
             )),
             BlockLevelBox::Independent(contents) => {
-                Fragment::Box(positioning_context.for_maybe_position_relative(
+                Fragment::Box(positioning_context.layout_maybe_position_relative_fragment(
                     layout_context,
                     containing_block,
                     &contents.style,
@@ -326,8 +327,7 @@ impl BlockLevelBox {
                 ))
             },
             BlockLevelBox::OutOfFlowFloatBox(_box_) => {
-                // FIXME: call for_maybe_position_relative here
-                // TODO
+                // FIXME: call layout_maybe_position_relative_fragment here
                 Fragment::Anonymous(AnonymousFragment::no_op(
                     containing_block.style.writing_mode,
                 ))

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -137,7 +137,8 @@ impl BoxTreeRoot {
         };
 
         let dummy_tree_rank = 0;
-        let mut positioning_context = PositioningContext::new_for_initial_containing_block();
+        let mut positioning_context =
+            PositioningContext::new_for_containing_block_for_all_descendants();
         let mut independent_layout = self.0.layout(
             layout_context,
             &mut positioning_context,
@@ -145,7 +146,7 @@ impl BoxTreeRoot {
             dummy_tree_rank,
         );
 
-        positioning_context.layout_in_initial_containing_block(
+        positioning_context.layout_initial_containing_block_children(
             layout_context,
             &initial_containing_block,
             &mut independent_layout.fragments,

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/preserve3d-button.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/preserve3d-button.html.ini
@@ -1,2 +1,0 @@
-[preserve3d-button.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/transform-abspos-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/transform-abspos-001.html.ini
@@ -1,2 +1,0 @@
-[transform-abspos-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/transform-abspos-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/transform-abspos-002.html.ini
@@ -1,2 +1,0 @@
-[transform-abspos-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/transform-abspos-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/transform-abspos-003.html.ini
@@ -1,2 +1,0 @@
-[transform-abspos-003.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/transform-abspos-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/transform-abspos-004.html.ini
@@ -1,2 +1,0 @@
-[transform-abspos-004.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/transform-abspos-006.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/transform-abspos-006.html.ini
@@ -1,2 +1,0 @@
-[transform-abspos-006.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/transform-abspos-007.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/transform-abspos-007.html.ini
@@ -1,2 +1,0 @@
-[transform-abspos-007.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/filter-effects/filtered-inline-is-container.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/filter-effects/filtered-inline-is-container.html.ini
@@ -1,0 +1,2 @@
+[filtered-inline-is-container.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/transform_stacking_context_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/transform_stacking_context_a.html.ini
@@ -1,2 +1,0 @@
-[transform_stacking_context_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/translate_clip_nested.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/translate_clip_nested.html.ini
@@ -1,2 +1,0 @@
-[translate_clip_nested.html]
-  expected: FAIL


### PR DESCRIPTION
This is a feature that was never properly implemented in the previous
layout system. We still need to preserve their in-tree order in the
display list though.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
