### PR TITLE
Generate ::before and ::after content from url() for layout2020

### DIFF
--- a/components/layout_2020/dom_traversal.rs
+++ b/components/layout_2020/dom_traversal.rs
@@ -271,10 +271,11 @@ where
     })
 }
 
+/// https://www.w3.org/TR/CSS2/generate.html#propdef-content
 fn generate_pseudo_element_content<'dom, Node>(
     pseudo_element_style: &ComputedValues,
     element: Node,
-    _context: &LayoutContext,
+    context: &LayoutContext,
 ) -> Vec<PseudoElementContentItem>
 where
     Node: NodeExt<'dom>,
@@ -297,6 +298,13 @@ where
                         vec.push(PseudoElementContentItem::Text(
                             attr_val.map_or("".to_string(), |s| s.to_string()),
                         ));
+                    },
+                    ContentItem::Url(image_url) => {
+                        if let Some(replaced_content) =
+                            ReplacedContent::from_image_url(element, context, image_url)
+                        {
+                            vec.push(PseudoElementContentItem::Replaced(replaced_content));
+                        }
                     },
                     _ => (),
                 }

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::context::LayoutContext;
 use crate::dom_traversal::NodeExt;
 use crate::fragments::{DebugId, Fragment, ImageFragment};
 use crate::geom::flow_relative::{Rect, Vec2};
@@ -10,9 +11,11 @@ use crate::sizing::ContentSizes;
 use crate::style_ext::ComputedValuesExt;
 use crate::ContainingBlock;
 use net_traits::image::base::Image;
+use net_traits::image_cache::{ImageOrMetadataAvailable, UsePlaceholder};
 use servo_arc::Arc as ServoArc;
 use std::sync::Arc;
 use style::properties::ComputedValues;
+use style::servo::url::ComputedUrl;
 use style::values::computed::{Length, LengthOrAuto};
 use style::values::CSSFloat;
 use style::Zero;
@@ -57,6 +60,39 @@ impl ReplacedContent {
 
             let width = (intrinsic_size_in_dots.width as CSSFloat) / dppx;
             let height = (intrinsic_size_in_dots.height as CSSFloat) / dppx;
+            return Some(Self {
+                kind: ReplacedContentKind::Image(image),
+                intrinsic: IntrinsicSizes {
+                    width: Some(Length::new(width)),
+                    height: Some(Length::new(height)),
+                    // FIXME https://github.com/w3c/csswg-drafts/issues/4572
+                    ratio: Some(width / height),
+                },
+            });
+        }
+        None
+    }
+
+    pub fn from_image_url<'dom>(
+        element: impl NodeExt<'dom>,
+        context: &LayoutContext,
+        image_url: &ComputedUrl,
+    ) -> Option<Self> {
+        if let ComputedUrl::Valid(image_url) = image_url {
+            let (image, width, height) = match context.get_or_request_image_or_meta(
+                element.as_opaque(),
+                image_url.clone(),
+                UsePlaceholder::No,
+            ) {
+                Some(ImageOrMetadataAvailable::ImageAvailable(image, _)) => {
+                    (Some(image.clone()), image.width as f32, image.height as f32)
+                },
+                Some(ImageOrMetadataAvailable::MetadataAvailable(metadata)) => {
+                    (None, metadata.width as f32, metadata.height as f32)
+                },
+                None => return None,
+            };
+
             return Some(Self {
                 kind: ReplacedContentKind::Image(image),
                 intrinsic: IntrinsicSizes {

--- a/components/style/values/specified/counters.rs
+++ b/components/style/values/specified/counters.rs
@@ -134,7 +134,7 @@ impl Parse for Content {
         let mut content = vec![];
         let mut has_alt_content = false;
         loop {
-            #[cfg(feature = "gecko")]
+            #[cfg(any(feature = "gecko", feature = "servo-layout-2020"))]
             {
                 if let Ok(url) = input.try(|i| SpecifiedImageUrl::parse(context, i)) {
                     content.push(generics::ContentItem::Url(url));

--- a/tests/wpt/metadata-layout-2020/css/CSS2/generated-content/content-004.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/generated-content/content-004.xht.ini
@@ -1,2 +1,0 @@
-[content-004.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-content/pseudo-element-inline-box.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-content/pseudo-element-inline-box.html.ini
@@ -1,2 +1,0 @@
-[pseudo-element-inline-box.html]
-  expected: FAIL


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes