### PR TITLE
Upgrade mime crate to use the essence function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3465,12 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.13"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
-dependencies = [
- "unicase",
-]
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mime_guess"


### PR DESCRIPTION
While implementing module script, the `essence` function is not supported in mime crate yet so Manish filed the issue.

So, as that issue is fixed and shipped, we can upgrade mime crate to use the `essence_str` function.

I've tried to run https://threejs.org/examples/webgl_animation_cloth.html locally. Other than a bunch of `Unimplemented canvas2d.fillText`, I can see the animated cloth.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
