### PR TITLE
Disable devtools for HoloLens.

### DIFF
--- a/support/hololens/ServoApp/ServoControl/Servo.cpp
+++ b/support/hololens/ServoApp/ServoControl/Servo.cpp
@@ -92,7 +92,7 @@ Servo::Servo(hstring url, hstring args, GLsizei width, GLsizei height,
     : mWindowHeight(height), mWindowWidth(width), mDelegate(aDelegate) {
 
   capi::CInitOptions o;
-  hstring defaultPrefs = L" --pref dom.webxr.enabled  --devtools=6000";
+  hstring defaultPrefs = L" --pref dom.webxr.enabled";
   o.args = *hstring2char(args + defaultPrefs);
   o.url = *hstring2char(url);
   o.width = mWindowWidth;


### PR DESCRIPTION
Apparently new pre-release OS images have something using port 6000 and this makes it impossible to start our app. Let's disable it for the short term.