### PR TITLE
Improved the WebGL2 framebuffer render validation

### DIFF
--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -468,7 +468,7 @@ impl WebGLFramebuffer {
             return CompleteForRendering::Complete;
         }
 
-        if self.colors.iter().any(|att| att.borrow().is_none()) {
+        if self.colors.iter().all(|att| att.borrow().is_none()) {
             return CompleteForRendering::MissingColorAttachment;
         }
 

--- a/tests/wpt/webgl/meta/conformance2/reading/read-pixels-from-rgb8-into-pbo-bug.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/reading/read-pixels-from-rgb8-into-pbo-bug.html.ini
@@ -1,7 +1,0 @@
-[read-pixels-from-rgb8-into-pbo-bug.html]
-  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_OPERATION : Tests should complete without gl errors]
-    expected: FAIL
-
-  [WebGL test #1: Expected in pixel 0: [255,0,0,255\], got: 0,0,0,0]
-    expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance2/rendering/framebuffer-texture-changing-base-level.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/framebuffer-texture-changing-base-level.html.ini
@@ -8,24 +8,9 @@
   [WebGL test #8: getError expected: NO_ERROR. Was INVALID_ENUM : Setup framebuffer with texture should succeed.]
     expected: FAIL
 
-  [WebGL test #3: getError expected: NO_ERROR. Was INVALID_OPERATION : Clearing the texture level 0 to green should succeed.]
-    expected: FAIL
-
-  [WebGL test #9: getError expected: NO_ERROR. Was INVALID_OPERATION : Clearing the texture level 2 to green should succeed.]
-    expected: FAIL
-
-  [WebGL test #6: getError expected: NO_ERROR. Was INVALID_OPERATION : Clearing the texture level 1 to green should succeed.]
-    expected: FAIL
-
-  [WebGL test #14: should be green\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
-    expected: FAIL
-
   [WebGL test #13: getError expected: NO_ERROR. Was INVALID_ENUM : Drawing the texture to default framebuffer with base level 0 should succeed.]
     expected: FAIL
 
   [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : Setup framebuffer with texture should succeed.]
-    expected: FAIL
-
-  [WebGL test #12: getError expected: NO_ERROR. Was INVALID_OPERATION : Clearing the texture level 3 to green should succeed.]
     expected: FAIL
 


### PR DESCRIPTION
It seems `MissingColorAttachment` should be returned only when all of the color attachments are missing.

<!-- Please describe your changes on the following line: -->

cc @jdm @zakorgy 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
