### PR TITLE
Add support for some more WebGL2 renderbuffer functions

### DIFF
--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -330,6 +330,7 @@ pub enum WebGLCommand {
     TransformFeedbackVaryings(WebGLProgramId, Vec<String>, u32),
     PolygonOffset(f32, f32),
     RenderbufferStorage(u32, u32, i32, i32),
+    RenderbufferStorageMultisample(u32, i32, u32, i32, i32),
     ReadPixels(Rect<u32>, u32, u32, IpcBytesSender),
     ReadPixelsPP(Rect<i32>, u32, u32, usize),
     SampleCoverage(f32, bool),
@@ -458,6 +459,7 @@ pub enum WebGLCommand {
     GetCurrentVertexAttrib(u32, WebGLSender<[f32; 4]>),
     GetTexParameterFloat(u32, TexParameterFloat, WebGLSender<f32>),
     GetTexParameterInt(u32, TexParameterInt, WebGLSender<i32>),
+    GetInternalFormatIntVec(u32, u32, InternalFormatIntVec, WebGLSender<Vec<i32>>),
     TexParameteri(u32, u32, i32),
     TexParameterf(u32, u32, f32),
     DrawArrays {
@@ -909,6 +911,14 @@ parameters! {
         Int(TexParameterInt {
             TextureWrapS = gl::TEXTURE_WRAP_S,
             TextureWrapT = gl::TEXTURE_WRAP_T,
+        }),
+    }
+}
+
+parameters! {
+    InternalFormatParameter {
+        IntVec(InternalFormatIntVec {
+            Samples = gl::SAMPLES,
         }),
     }
 }

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -2460,6 +2460,9 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
                     &uniform_get(triple, WebGLCommand::GetUniformFloat4x3),
                 )
             },
+            constants::SAMPLER_3D | constants::SAMPLER_2D_ARRAY => {
+                Int32Value(uniform_get(triple, WebGLCommand::GetUniformInt))
+            },
             _ => self.base.GetUniform(cx, program, location),
         }
     }

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -316,9 +316,9 @@ interface mixin WebGL2RenderingContextBase
   // void readBuffer(GLenum src);
 
   /* Renderbuffer objects */
-  // any getInternalformatParameter(GLenum target, GLenum internalformat, GLenum pname);
-  // void renderbufferStorageMultisample(GLenum target, GLsizei samples, GLenum internalformat,
-  //                                     GLsizei width, GLsizei height);
+  any getInternalformatParameter(GLenum target, GLenum internalformat, GLenum pname);
+  void renderbufferStorageMultisample(GLenum target, GLsizei samples, GLenum internalformat,
+                                      GLsizei width, GLsizei height);
 
   /* Texture objects */
   // void texStorage2D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width,

--- a/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
@@ -1,58 +1,52 @@
 [methods-2.html]
-  [WebGL test #11: Property either does not exist or is not a function: compressedTexSubImage3D]
-    expected: FAIL
-
-  [WebGL test #8: Property either does not exist or is not a function: texSubImage3D]
-    expected: FAIL
-
-  [WebGL test #14: Property either does not exist or is not a function: vertexAttribI4ui]
-    expected: FAIL
-
-  [WebGL test #18: Property either does not exist or is not a function: drawBuffers]
-    expected: FAIL
-
-  [WebGL test #12: Property either does not exist or is not a function: vertexAttribI4i]
-    expected: FAIL
-
-  [WebGL test #6: Property either does not exist or is not a function: texStorage2D]
+  [WebGL test #2: Property either does not exist or is not a function: readBuffer]
     expected: FAIL
 
   [WebGL test #1: Property either does not exist or is not a function: blitFramebuffer]
     expected: FAIL
 
-  [WebGL test #5: Property either does not exist or is not a function: texImage3D]
+  [WebGL test #11: Property either does not exist or is not a function: vertexAttribI4iv]
     expected: FAIL
 
-  [WebGL test #17: Property either does not exist or is not a function: drawRangeElements]
+  [WebGL test #8: Property either does not exist or is not a function: compressedTexImage3D]
     expected: FAIL
 
-  [WebGL test #10: Property either does not exist or is not a function: compressedTexImage3D]
+  [WebGL test #13: Property either does not exist or is not a function: vertexAttribI4uiv]
     expected: FAIL
 
-  [WebGL test #7: Property either does not exist or is not a function: texStorage3D]
+  [WebGL test #16: Property either does not exist or is not a function: drawBuffers]
     expected: FAIL
 
-  [WebGL test #4: Property either does not exist or is not a function: renderbufferStorageMultisample]
+  [WebGL test #3: Property either does not exist or is not a function: texImage3D]
     expected: FAIL
 
-  [WebGL test #9: Property either does not exist or is not a function: copyTexSubImage3D]
+  [WebGL test #10: Property either does not exist or is not a function: vertexAttribI4i]
+    expected: FAIL
+
+  [WebGL test #9: Property either does not exist or is not a function: compressedTexSubImage3D]
+    expected: FAIL
+
+  [WebGL test #12: Property either does not exist or is not a function: vertexAttribI4ui]
     expected: FAIL
 
   [WebGL test #0: Property either does not exist or is not a function: isContextLost]
     expected: FAIL
 
-  [WebGL test #16: Property either does not exist or is not a function: vertexAttribIPointer]
+  [WebGL test #7: Property either does not exist or is not a function: copyTexSubImage3D]
     expected: FAIL
 
-  [WebGL test #15: Property either does not exist or is not a function: vertexAttribI4uiv]
+  [WebGL test #14: Property either does not exist or is not a function: vertexAttribIPointer]
     expected: FAIL
 
-  [WebGL test #2: Property either does not exist or is not a function: getInternalformatParameter]
+  [WebGL test #4: Property either does not exist or is not a function: texStorage2D]
     expected: FAIL
 
-  [WebGL test #3: Property either does not exist or is not a function: readBuffer]
+  [WebGL test #15: Property either does not exist or is not a function: drawRangeElements]
     expected: FAIL
 
-  [WebGL test #13: Property either does not exist or is not a function: vertexAttribI4iv]
+  [WebGL test #6: Property either does not exist or is not a function: texSubImage3D]
+    expected: FAIL
+
+  [WebGL test #5: Property either does not exist or is not a function: texStorage3D]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/invalidate-framebuffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/invalidate-framebuffer.html.ini
@@ -1,5 +1,8 @@
 [invalidate-framebuffer.html]
   expected: ERROR
-  [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #17: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL
+
+  [WebGL test #11: getError expected: INVALID_VALUE. Was NO_ERROR : calling invalidateSubFramebuffer should generate INVALID_VALUE if width < 0 or height < 0.]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html.ini
@@ -1,5 +1,5 @@
 [multisampled-depth-renderbuffer-initialization.html]
   expected: ERROR
-  [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #5: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-renderbuffer-initialization.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-renderbuffer-initialization.html.ini
@@ -1,5 +1,5 @@
 [multisampled-renderbuffer-initialization.html]
   expected: ERROR
-  [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #9: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-stencil-renderbuffer-initialization.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-stencil-renderbuffer-initialization.html.ini
@@ -1,5 +1,5 @@
 [multisampled-stencil-renderbuffer-initialization.html]
   expected: ERROR
-  [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #5: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-multisampled-readbuffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-multisampled-readbuffer.html.ini
@@ -1,5 +1,7 @@
 [blitframebuffer-multisampled-readbuffer.html]
-  expected: ERROR
-  [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #2: Framebuffer incomplete.]
+    expected: FAIL
+
+  [WebGL test #1: Framebuffer incomplete.]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-resolve-to-back-buffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-resolve-to-back-buffer.html.ini
@@ -1,5 +1,5 @@
 [blitframebuffer-resolve-to-back-buffer.html]
   expected: ERROR
-  [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/line-rendering-quality.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/line-rendering-quality.html.ini
@@ -1,5 +1,5 @@
 [line-rendering-quality.html]
   expected: ERROR
-  [WebGL test #6: successfullyParsed should be true. Threw exception ReferenceError: can't access lexical declaration `successfullyParsed' before initialization]
+  [WebGL test #10: successfullyParsed should be true. Threw exception ReferenceError: can't access lexical declaration `successfullyParsed' before initialization]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/rgb-format-support.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/rgb-format-support.html.ini
@@ -1,5 +1,10 @@
 [rgb-format-support.html]
-  expected: ERROR
-  [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #15: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : should be no errors from clear()]
+    expected: FAIL
+
+  [WebGL test #14: framebuffer with texture is incomplete]
+    expected: FAIL
+
+  [WebGL test #13: getError expected: NO_ERROR. Was INVALID_ENUM : should be no errors from texture setup]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/state/gl-object-get-calls.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/state/gl-object-get-calls.html.ini
@@ -1,9 +1,21 @@
 [gl-object-get-calls.html]
   expected: ERROR
+  [WebGL test #257: getError expected: NO_ERROR. Was INVALID_OPERATION : ]
+    expected: FAIL
+
   [WebGL test #10: gl.getBufferParameter(gl.COPY_WRITE_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #18: gl.getBufferParameter(gl.TRANSFORM_FEEDBACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #182: gl.getRenderbufferParameter(gl.RENDERBUFFER, gl.RENDERBUFFER_SAMPLES) should be 4 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #204: getTexParameter returned 1 instead of null for invalid parameter enum: 0x84fe]
+    expected: FAIL
+
+  [WebGL test #199: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_MAX_LOD) should be 10 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #19: gl.getBufferParameter(gl.TRANSFORM_FEEDBACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
@@ -15,6 +27,9 @@
   [WebGL test #15: gl.getBufferParameter(gl.PIXEL_UNPACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
     expected: FAIL
 
+  [WebGL test #202: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_IMMUTABLE_FORMAT) should be false (of type boolean). Was null (of type object).]
+    expected: FAIL
+
   [WebGL test #7: gl.getBufferParameter(gl.COPY_READ_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
     expected: FAIL
 
@@ -24,7 +39,13 @@
   [WebGL test #16: gl.getBufferParameter(gl.PIXEL_UNPACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
     expected: FAIL
 
+  [WebGL test #201: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_WRAP_R) should be 33071 (of type number). Was null (of type object).]
+    expected: FAIL
+
   [WebGL test #6: gl.getBufferParameter(gl.COPY_READ_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #203: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_IMMUTABLE_LEVELS) should be 0 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #22: gl.getBufferParameter(gl.UNIFORM_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
@@ -33,13 +54,37 @@
   [WebGL test #12: gl.getBufferParameter(gl.PIXEL_PACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
     expected: FAIL
 
+  [WebGL test #196: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_COMPARE_FUNC) should be 515 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #195: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_BASE_LEVEL) should be 0 (of type number). Was null (of type object).]
+    expected: FAIL
+
   [WebGL test #13: gl.getBufferParameter(gl.PIXEL_PACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #197: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_COMPARE_MODE) should be 34894 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #167: gl.getProgramParameter(uniformBlockProgram, gl.ACTIVE_UNIFORM_BLOCKS) should be 1 (of type number). Was null (of type object).]
     expected: FAIL
 
-  [WebGL test #182: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #268: gl.getVertexAttrib(1, gl.VERTEX_ATTRIB_ARRAY_INTEGER) should be false (of type boolean). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #259: gl.getUniform(samplerForWebGL2Program, s2DArrayValLoc) should be 1. Was 0.]
+    expected: FAIL
+
+  [WebGL test #198: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_MAX_LEVEL) should be 10 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #200: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_MIN_LOD) should be 0 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #183: getRenderbufferParameter did not generate INVALID_ENUM for invalid parameter enum: NO_ERROR]
+    expected: FAIL
+
+  [WebGL test #274: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
   [WebGL test #3: gl.getBufferParameter(gl.ELEMENT_ARRAY_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]


### PR DESCRIPTION
Adds support for the following WebGL2 calls:

- `RenderbufferStorageMultisample`
- `GetInternalFormativ`

See: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.5

<!-- Please describe your changes on the following line: -->

The test results depend on #25903.

cc @jdm @zakorgy 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
