### PR TITLE
Add support for WebGL2 read and draw buffer settings

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -2024,6 +2024,8 @@ impl WebGLImpl {
                     attach(attachment)
                 }
             },
+            WebGLCommand::ReadBuffer(buffer) => gl.read_buffer(buffer),
+            WebGLCommand::DrawBuffers(ref buffers) => gl.draw_buffers(buffers),
         }
 
         // If debug asertions are enabled, then check the error state.

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -546,6 +546,8 @@ pub enum WebGLCommand {
     InvalidateFramebuffer(u32, Vec<u32>),
     InvalidateSubFramebuffer(u32, Vec<u32>, i32, i32, i32, i32),
     FramebufferTextureLayer(u32, u32, Option<WebGLTextureId>, i32, i32),
+    ReadBuffer(u32),
+    DrawBuffers(Vec<u32>),
 }
 
 macro_rules! nonzero_type {

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1510,6 +1510,11 @@ impl WebGLRenderingContext {
 
         // FIXME: https://github.com/servo/servo/issues/13710
     }
+
+    pub fn valid_color_attachment_enum(&self, attachment: u32) -> bool {
+        let last_slot = constants::COLOR_ATTACHMENT0 + self.limits().max_color_attachments - 1;
+        constants::COLOR_ATTACHMENT0 <= attachment && attachment <= last_slot
+    }
 }
 
 #[cfg(not(feature = "webgl_backtrace"))]

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -313,7 +313,7 @@ interface mixin WebGL2RenderingContextBase
   void invalidateFramebuffer(GLenum target, sequence<GLenum> attachments);
   void invalidateSubFramebuffer(GLenum target, sequence<GLenum> attachments,
                                 GLint x, GLint y, GLsizei width, GLsizei height);
-  // void readBuffer(GLenum src);
+  void readBuffer(GLenum src);
 
   /* Renderbuffer objects */
   any getInternalformatParameter(GLenum target, GLenum internalformat, GLenum pname);
@@ -475,7 +475,7 @@ interface mixin WebGL2RenderingContextBase
                   /*[AllowShared]*/ ArrayBufferView dstData, GLuint dstOffset);
 
   /* Multiple Render Targets */
-  // void drawBuffers(sequence<GLenum> buffers);
+  void drawBuffers(sequence<GLenum> buffers);
 
   void clearBufferfv(GLenum buffer, GLint drawbuffer, Float32List values,
                      optional GLuint srcOffset = 0);

--- a/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
@@ -1,52 +1,46 @@
 [methods-2.html]
-  [WebGL test #2: Property either does not exist or is not a function: readBuffer]
-    expected: FAIL
-
   [WebGL test #1: Property either does not exist or is not a function: blitFramebuffer]
     expected: FAIL
 
-  [WebGL test #11: Property either does not exist or is not a function: vertexAttribI4iv]
+  [WebGL test #7: Property either does not exist or is not a function: compressedTexImage3D]
     expected: FAIL
 
-  [WebGL test #8: Property either does not exist or is not a function: compressedTexImage3D]
+  [WebGL test #4: Property either does not exist or is not a function: texStorage3D]
     expected: FAIL
 
-  [WebGL test #13: Property either does not exist or is not a function: vertexAttribI4uiv]
+  [WebGL test #11: Property either does not exist or is not a function: vertexAttribI4ui]
     expected: FAIL
 
-  [WebGL test #16: Property either does not exist or is not a function: drawBuffers]
+  [WebGL test #2: Property either does not exist or is not a function: texImage3D]
     expected: FAIL
 
-  [WebGL test #3: Property either does not exist or is not a function: texImage3D]
+  [WebGL test #12: Property either does not exist or is not a function: vertexAttribI4uiv]
     expected: FAIL
 
-  [WebGL test #10: Property either does not exist or is not a function: vertexAttribI4i]
+  [WebGL test #3: Property either does not exist or is not a function: texStorage2D]
     expected: FAIL
 
-  [WebGL test #9: Property either does not exist or is not a function: compressedTexSubImage3D]
-    expected: FAIL
-
-  [WebGL test #12: Property either does not exist or is not a function: vertexAttribI4ui]
+  [WebGL test #8: Property either does not exist or is not a function: compressedTexSubImage3D]
     expected: FAIL
 
   [WebGL test #0: Property either does not exist or is not a function: isContextLost]
     expected: FAIL
 
-  [WebGL test #7: Property either does not exist or is not a function: copyTexSubImage3D]
+  [WebGL test #9: Property either does not exist or is not a function: vertexAttribI4i]
     expected: FAIL
 
-  [WebGL test #14: Property either does not exist or is not a function: vertexAttribIPointer]
+  [WebGL test #13: Property either does not exist or is not a function: vertexAttribIPointer]
     expected: FAIL
 
-  [WebGL test #4: Property either does not exist or is not a function: texStorage2D]
+  [WebGL test #14: Property either does not exist or is not a function: drawRangeElements]
     expected: FAIL
 
-  [WebGL test #15: Property either does not exist or is not a function: drawRangeElements]
+  [WebGL test #5: Property either does not exist or is not a function: texSubImage3D]
     expected: FAIL
 
-  [WebGL test #6: Property either does not exist or is not a function: texSubImage3D]
+  [WebGL test #10: Property either does not exist or is not a function: vertexAttribI4iv]
     expected: FAIL
 
-  [WebGL test #5: Property either does not exist or is not a function: texStorage3D]
+  [WebGL test #6: Property either does not exist or is not a function: copyTexSubImage3D]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/readbuffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/readbuffer.html.ini
@@ -1,5 +1,5 @@
 [readbuffer.html]
-  expected: ERROR
+  expected: TIMEOUT
   [WebGL test #3: gl.getParameter(gl.READ_BUFFER) should be 1029 (of type number). Was null (of type object).]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-srgb-and-linear-drawbuffers.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-srgb-and-linear-drawbuffers.html.ini
@@ -1,8 +1,109 @@
 [blitframebuffer-srgb-and-linear-drawbuffers.html]
-  expected: ERROR
+  [WebGL test #10: getError expected: NO_ERROR. Was INVALID_ENUM : setup read framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #31: getError expected: NO_ERROR. Was INVALID_ENUM : setup read framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #7: getError expected: NO_ERROR. Was INVALID_ENUM : setup read framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #35: getError expected: NO_ERROR. Was INVALID_ENUM : setup draw framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #3: Framebuffer incomplete when setup draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #4: getError expected: NO_ERROR. Was INVALID_ENUM : setup read framebuffer should succeed]
+    expected: FAIL
+
   [WebGL test #1: getError expected: NO_ERROR. Was INVALID_ENUM : setup read framebuffer should succeed]
     expected: FAIL
 
-  [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #21: Framebuffer incomplete when setup draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #14: getError expected: NO_ERROR. Was INVALID_ENUM : setup draw framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #30: Framebuffer incomplete when setup draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #6: Framebuffer incomplete when setup draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #11: getError expected: NO_ERROR. Was INVALID_ENUM : setup draw framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #9: Framebuffer incomplete when setup draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : setup draw framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #22: getError expected: NO_ERROR. Was INVALID_ENUM : setup read framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #20: getError expected: NO_ERROR. Was INVALID_ENUM : setup draw framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #27: Framebuffer incomplete when setup draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #13: getError expected: NO_ERROR. Was INVALID_ENUM : setup read framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #12: Framebuffer incomplete when setup draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #19: getError expected: NO_ERROR. Was INVALID_ENUM : setup read framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #34: getError expected: NO_ERROR. Was INVALID_ENUM : setup read framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #24: Framebuffer incomplete when setup draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #25: getError expected: NO_ERROR. Was INVALID_ENUM : setup read framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #17: getError expected: NO_ERROR. Was INVALID_ENUM : setup draw framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #16: getError expected: NO_ERROR. Was INVALID_ENUM : setup read framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #15: Framebuffer incomplete when setup draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #18: Framebuffer incomplete when setup draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #33: Framebuffer incomplete when setup draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #28: getError expected: NO_ERROR. Was INVALID_ENUM : setup read framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #8: getError expected: NO_ERROR. Was INVALID_ENUM : setup draw framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #26: getError expected: NO_ERROR. Was INVALID_ENUM : setup draw framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #32: getError expected: NO_ERROR. Was INVALID_ENUM : setup draw framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #23: getError expected: NO_ERROR. Was INVALID_ENUM : setup draw framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #36: Framebuffer incomplete when setup draw framebuffer.]
+    expected: FAIL
+
+  [WebGL test #5: getError expected: NO_ERROR. Was INVALID_ENUM : setup draw framebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #29: getError expected: NO_ERROR. Was INVALID_ENUM : setup draw framebuffer should succeed]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/clear-func-buffer-type-match.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/clear-func-buffer-type-match.html.ini
@@ -1,5 +1,5 @@
 [clear-func-buffer-type-match.html]
-  expected: ERROR
+  expected: TIMEOUT
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/draw-buffers.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/draw-buffers.html.ini
@@ -1,5 +1,43 @@
 [draw-buffers.html]
-  expected: ERROR
-  [WebGL test #5: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #44: attachment 7 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #49: attachment 4 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #43: attachment 6 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #38: attachment 1 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #51: attachment 6 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #50: attachment 5 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #48: attachment 3 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #42: attachment 5 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #40: attachment 3 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #39: attachment 2 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #46: attachment 1 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #47: attachment 2 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #52: attachment 7 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #41: attachment 4 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/framebuffer-completeness-unaffected.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/framebuffer-completeness-unaffected.html.ini
@@ -1,5 +1,0 @@
-[framebuffer-completeness-unaffected.html]
-  expected: ERROR
-  [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance2/rendering/fs-color-type-mismatch-color-buffer-type.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/fs-color-type-mismatch-color-buffer-type.html.ini
@@ -1,5 +1,5 @@
 [fs-color-type-mismatch-color-buffer-type.html]
-  expected: ERROR
+  expected: TIMEOUT
   [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/read-draw-when-missing-image.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/read-draw-when-missing-image.html.ini
@@ -1,8 +1,17 @@
 [read-draw-when-missing-image.html]
   expected: ERROR
+  [WebGL test #3: getError expected: INVALID_OPERATION. Was INVALID_FRAMEBUFFER_OPERATION : Should generate INVALID_OPERATION when reading from a color buffer without image.]
+    expected: FAIL
+
   [WebGL test #1: Framebuffer incomplete.]
     expected: FAIL
 
-  [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #4: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Should generate INVALID_OPERATION when reading from a color buffer without image.]
+    expected: FAIL
+
+  [WebGL test #2: getError expected: INVALID_OPERATION. Was INVALID_ENUM : Should generate INVALID_OPERATION when reading from a color buffer without image.]
+    expected: FAIL
+
+  [WebGL test #5: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/rendering-sampling-feedback-loop.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/rendering-sampling-feedback-loop.html.ini
@@ -1,5 +1,7 @@
 [rendering-sampling-feedback-loop.html]
-  expected: ERROR
-  [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #2: getError expected: INVALID_OPERATION. Was NO_ERROR : Rendering to a texture where it samples from should geneates INVALID_OPERATION. Otherwise, it should be NO_ERROR]
+    expected: FAIL
+
+  [WebGL test #3: getError expected: INVALID_OPERATION. Was NO_ERROR : Rendering to a texture where it samples from should geneates INVALID_OPERATION. Otherwise, it should be NO_ERROR]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/state/gl-get-calls.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/state/gl-get-calls.html.ini
@@ -1,7 +1,4 @@
 [gl-get-calls.html]
-  [WebGL test #13: context.getParameter(context.READ_BUFFER) should be 1029 (of type number). Was null (of type object).]
-    expected: FAIL
-
   [WebGL test #47: context.getParameter(context.MAX_FRAGMENT_INPUT_COMPONENTS) should be >= 60. Was null (of type object).]
     expected: FAIL
 
@@ -21,9 +18,6 @@
     expected: FAIL
 
   [WebGL test #56: context.getParameter(context.MAX_PROGRAM_TEXEL_OFFSET) is not an instance of Number]
-    expected: FAIL
-
-  [WebGL test #4: context.getParameter(context.DRAW_BUFFER0) should be 1029 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #45: context.getParameter(context.MAX_ELEMENTS_INDICES) is not an instance of Number]

--- a/tests/wpt/webgl/meta/conformance2/state/gl-object-get-calls.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/state/gl-object-get-calls.html.ini
@@ -24,6 +24,9 @@
   [WebGL test #21: gl.getBufferParameter(gl.UNIFORM_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
     expected: FAIL
 
+  [WebGL test #3: gl.getBufferParameter(gl.ELEMENT_ARRAY_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
+    expected: FAIL
+
   [WebGL test #15: gl.getBufferParameter(gl.PIXEL_UNPACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
     expected: FAIL
 
@@ -45,7 +48,13 @@
   [WebGL test #6: gl.getBufferParameter(gl.COPY_READ_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
     expected: FAIL
 
+  [WebGL test #4: gl.getBufferParameter(gl.ELEMENT_ARRAY_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
+    expected: FAIL
+
   [WebGL test #203: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_IMMUTABLE_LEVELS) should be 0 (of type number). Was null (of type object).]
+    expected: FAIL
+
+  [WebGL test #5: getBufferParameter did not generate INVALID_ENUM for invalid parameter enum: NO_ERROR]
     expected: FAIL
 
   [WebGL test #22: gl.getBufferParameter(gl.UNIFORM_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
@@ -85,14 +94,5 @@
     expected: FAIL
 
   [WebGL test #274: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-
-  [WebGL test #3: gl.getBufferParameter(gl.ELEMENT_ARRAY_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #4: gl.getBufferParameter(gl.ELEMENT_ARRAY_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #5: getBufferParameter did not generate INVALID_ENUM for invalid parameter enum: NO_ERROR]
     expected: FAIL
 


### PR DESCRIPTION
Adds support for the `ReadBuffer` and `DrawBuffers` WebGL2 calls and the related parameter getters.

See:

- https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2
- https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4
- https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.11

<!-- Please describe your changes on the following line: -->

This is marked as WIP because with these functions added (but apparently not directly related to them), some tests now run into states that produces crash.

cc @jdm @zakorgy 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
