### PR TITLE
Stop embedder calls and fake rAF when window not visible

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -483,9 +483,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 ShutdownState::NotShuttingDown,
             ) => {
                 self.pipeline_details(pipeline_id).visible = visible;
-                if visible {
-                    self.process_animations();
-                }
+                self.process_animations();
             },
 
             (Msg::PipelineExited(pipeline_id, sender), _) => {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1636,11 +1636,10 @@ impl Document {
             .borrow_mut()
             .push((ident, Some(callback)));
 
-        // TODO: Should tick animation only when document is visible
-
         // If we are running 'fake' animation frames, we unconditionally
         // set up a one-shot timer for script to execute the rAF callbacks.
-        if self.is_faking_animation_frames() {
+        if self.is_faking_animation_frames() && self.window().visible() {
+            warn!("Scheduling fake animation frame. Animation frames tick too fast.");
             let callback = FakeRequestAnimationFrameCallback {
                 document: Trusted::new(self),
             };

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -332,6 +332,8 @@ pub struct Window {
     /// A mechanism to force the compositor to process events.
     #[ignore_malloc_size_of = "traits are cumbersome"]
     event_loop_waker: Option<Box<dyn EventLoopWaker>>,
+
+    visible: Cell<bool>,
 }
 
 impl Window {
@@ -2185,11 +2187,16 @@ impl Window {
 
     /// Slow down/speed up timers based on visibility.
     pub fn alter_resource_utilization(&self, visible: bool) {
+        self.visible.set(visible);
         if visible {
             self.upcast::<GlobalScope>().speed_up_timers();
         } else {
             self.upcast::<GlobalScope>().slow_down_timers();
         }
+    }
+
+    pub fn visible(&self) -> bool {
+        self.visible.get()
     }
 
     pub fn unminified_js_dir(&self) -> Option<String> {
@@ -2339,6 +2346,7 @@ impl Window {
             replace_surrogates,
             player_context,
             event_loop_waker,
+            visible: Cell::new(true),
         });
 
         unsafe { WindowBinding::Wrap(JSContext::from_ptr(runtime.cx()), win) }


### PR DESCRIPTION
This addresses 2 issues:

- a rAF loop might still be ongoing when the window is invisible if script decided that the rAF were going too fast (spurious rAF)
- a hidden window does not run the rAF loop, but the embedder would still be in animating mode

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
