### PR TITLE
Add support for WebGL2 GetFragDataLocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5490,9 +5490,9 @@ dependencies = [
 
 [[package]]
 name = "sparkle"
-version = "0.1.20"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc89be71cc02b59fdb05edd5589aac8e7542356f815adf84851f8142938f6534"
+checksum = "34a99c8f866b15ebf845b1957a244e033f434346f648620c645d95a05b00c0af"
 dependencies = [
  "gl_generator 0.13.1",
 ]

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -35,7 +35,7 @@ raqote = {git = "https://github.com/jrmuizel/raqote"}
 time = { version = "0.1.0", optional = true }
 pixels = {path = "../pixels"}
 servo_config = {path = "../config"}
-sparkle = "0.1.20"
+sparkle = "0.1.22"
 webrender = {git = "https://github.com/servo/webrender"}
 webrender_api = {git = "https://github.com/servo/webrender"}
 webrender_traits = {path = "../webrender_traits"}

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1287,6 +1287,12 @@ impl WebGLImpl {
                 Self::shader_precision_format(gl, shader_type, precision_type, chan)
             },
             WebGLCommand::GetExtensions(ref chan) => Self::get_extensions(gl, chan),
+            WebGLCommand::GetFragDataLocation(program_id, ref name, ref sender) => {
+                let location =
+                    gl.get_frag_data_location(program_id.get(), &to_name_in_compiled_shader(name));
+                assert!(location >= 0);
+                sender.send(location).unwrap();
+            },
             WebGLCommand::GetUniformLocation(program_id, ref name, ref chan) => {
                 Self::uniform_location(gl, program_id, &name, chan)
             },

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -305,6 +305,7 @@ pub enum WebGLCommand {
     FramebufferTexture2D(u32, u32, u32, Option<WebGLTextureId>, i32),
     GetExtensions(WebGLSender<String>),
     GetShaderPrecisionFormat(u32, u32, WebGLSender<(i32, i32, i32)>),
+    GetFragDataLocation(WebGLProgramId, String, WebGLSender<i32>),
     GetUniformLocation(WebGLProgramId, String, WebGLSender<i32>),
     GetShaderInfoLog(WebGLShaderId, WebGLSender<String>),
     GetProgramInfoLog(WebGLProgramId, WebGLSender<String>),

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -1467,6 +1467,12 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.GetAttribLocation(program, name)
     }
 
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.7
+    fn GetFragDataLocation(&self, program: &WebGLProgram, name: DOMString) -> i32 {
+        handle_potential_webgl_error!(self.base, self.base.validate_ownership(program), return -1);
+        handle_potential_webgl_error!(self.base, program.get_frag_data_location(name), -1)
+    }
+
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.9
     fn GetProgramInfoLog(&self, program: &WebGLProgram) -> Option<DOMString> {
         self.base.GetProgramInfoLog(program)

--- a/components/script/dom/webglprogram.rs
+++ b/components/script/dom/webglprogram.rs
@@ -365,6 +365,30 @@ impl WebGLProgram {
         Ok(location)
     }
 
+    /// glGetFragDataLocation
+    pub fn get_frag_data_location(&self, name: DOMString) -> WebGLResult<i32> {
+        if !self.is_linked() || self.is_deleted() {
+            return Err(WebGLError::InvalidOperation);
+        }
+
+        if !validate_glsl_name(&name)? {
+            return Ok(-1);
+        }
+        if name.starts_with("gl_") {
+            return Ok(-1);
+        }
+
+        let (sender, receiver) = webgl_channel().unwrap();
+        self.upcast::<WebGLObject>()
+            .context()
+            .send_command(WebGLCommand::GetFragDataLocation(
+                self.id,
+                name.into(),
+                sender,
+            ));
+        Ok(receiver.recv().unwrap())
+    }
+
     /// glGetUniformLocation
     pub fn get_uniform_location(
         &self,

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -422,7 +422,7 @@ interface mixin WebGL2RenderingContextBase
   //                              optional GLuint srcLengthOverride = 0);
 
   /* Programs and shaders */
-  // [WebGLHandlesContextLoss] GLint getFragDataLocation(WebGLProgram program, DOMString name);
+  [WebGLHandlesContextLoss] GLint getFragDataLocation(WebGLProgram program, DOMString name);
 
   /* Uniforms */
   void uniform1ui(WebGLUniformLocation? location, GLuint v0);

--- a/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
@@ -1,17 +1,20 @@
 [methods-2.html]
+  [WebGL test #19: Property either does not exist or is not a function: getIndexedParameter]
+    expected: FAIL
+
   [WebGL test #11: Property either does not exist or is not a function: compressedTexSubImage3D]
     expected: FAIL
 
   [WebGL test #8: Property either does not exist or is not a function: texSubImage3D]
     expected: FAIL
 
-  [WebGL test #14: Property either does not exist or is not a function: vertexAttribI4iv]
+  [WebGL test #14: Property either does not exist or is not a function: vertexAttribI4ui]
     expected: FAIL
 
-  [WebGL test #15: Property either does not exist or is not a function: vertexAttribI4ui]
+  [WebGL test #18: Property either does not exist or is not a function: drawBuffers]
     expected: FAIL
 
-  [WebGL test #22: Property either does not exist or is not a function: deleteVertexArray]
+  [WebGL test #12: Property either does not exist or is not a function: vertexAttribI4i]
     expected: FAIL
 
   [WebGL test #6: Property either does not exist or is not a function: texStorage2D]
@@ -20,19 +23,13 @@
   [WebGL test #1: Property either does not exist or is not a function: blitFramebuffer]
     expected: FAIL
 
-  [WebGL test #13: Property either does not exist or is not a function: vertexAttribI4i]
-    expected: FAIL
-
   [WebGL test #5: Property either does not exist or is not a function: texImage3D]
     expected: FAIL
 
-  [WebGL test #4: Property either does not exist or is not a function: renderbufferStorageMultisample]
+  [WebGL test #17: Property either does not exist or is not a function: drawRangeElements]
     expected: FAIL
 
-  [WebGL test #20: Property either does not exist or is not a function: getIndexedParameter]
-    expected: FAIL
-
-  [WebGL test #19: Property either does not exist or is not a function: drawBuffers]
+  [WebGL test #21: Property either does not exist or is not a function: deleteVertexArray]
     expected: FAIL
 
   [WebGL test #10: Property either does not exist or is not a function: compressedTexImage3D]
@@ -41,10 +38,10 @@
   [WebGL test #7: Property either does not exist or is not a function: texStorage3D]
     expected: FAIL
 
-  [WebGL test #16: Property either does not exist or is not a function: vertexAttribI4uiv]
+  [WebGL test #22: Property either does not exist or is not a function: isVertexArray]
     expected: FAIL
 
-  [WebGL test #18: Property either does not exist or is not a function: drawRangeElements]
+  [WebGL test #4: Property either does not exist or is not a function: renderbufferStorageMultisample]
     expected: FAIL
 
   [WebGL test #9: Property either does not exist or is not a function: copyTexSubImage3D]
@@ -53,7 +50,16 @@
   [WebGL test #0: Property either does not exist or is not a function: isContextLost]
     expected: FAIL
 
-  [WebGL test #17: Property either does not exist or is not a function: vertexAttribIPointer]
+  [WebGL test #20: Property either does not exist or is not a function: createVertexArray]
+    expected: FAIL
+
+  [WebGL test #23: Property either does not exist or is not a function: bindVertexArray]
+    expected: FAIL
+
+  [WebGL test #16: Property either does not exist or is not a function: vertexAttribIPointer]
+    expected: FAIL
+
+  [WebGL test #15: Property either does not exist or is not a function: vertexAttribI4uiv]
     expected: FAIL
 
   [WebGL test #2: Property either does not exist or is not a function: getInternalformatParameter]
@@ -62,15 +68,6 @@
   [WebGL test #3: Property either does not exist or is not a function: readBuffer]
     expected: FAIL
 
-  [WebGL test #21: Property either does not exist or is not a function: createVertexArray]
-    expected: FAIL
-
-  [WebGL test #12: Property either does not exist or is not a function: getFragDataLocation]
-    expected: FAIL
-
-  [WebGL test #24: Property either does not exist or is not a function: bindVertexArray]
-    expected: FAIL
-
-  [WebGL test #23: Property either does not exist or is not a function: isVertexArray]
+  [WebGL test #13: Property either does not exist or is not a function: vertexAttribI4iv]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/programs/gl-get-frag-data-location.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/programs/gl-get-frag-data-location.html.ini
@@ -1,4 +1,0 @@
-[gl-get-frag-data-location.html]
-  expected: ERROR
-  [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL


### PR DESCRIPTION
Adds support for the `GetFragDataLocation` WebGL2 call.

See: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.7

<!-- Please describe your changes on the following line: -->

Depends on https://github.com/servo/sparkle/pull/25
No test updates yet due to #25908.

cc @jdm @zakorgy 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
