### PR TITLE
Download usable macOS SDK during bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3594,7 +3594,6 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.13.0"
-source = "git+https://github.com/servo/rust-mozjs?branch=smup#a09ebb19ee0f1b7d20716b60b19c590fa28a9e1b"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3607,7 +3606,6 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.68.0"
-source = "git+https://github.com/servo/mozjs?rev=aabcc9ba889b2755f1e4e83f28323a60415a790f#aabcc9ba889b2755f1e4e83f28323a60415a790f"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,9 @@ mio = { git = "https://github.com/servo/mio.git", branch = "servo" }
 winapi = { git = "https://github.com/servo/winapi-rs", branch = "patch-1" }
 spirv_cross = { git = "https://github.com/servo/spirv_cross", branch = "wgpu-servo" }
 backtrace = { git = "https://github.com/MeFisto94/backtrace-rs", branch = "fix-strtab-freeing-crash" }
+
+[patch."https://github.com/servo/mozjs"]
+mozjs_sys = { path = "../mozjs" }
+
+[patch."https://github.com/servo/rust-mozjs"]
+mozjs = { path = "../rust-mozjs" }

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -28,22 +28,19 @@ from mach.decorators import (
 )
 
 import servo.bootstrap as bootstrap
-from servo.command_base import CommandBase, cd, check_call
-from servo.util import delete, download_bytes, download_file, extract, check_hash
+from servo.command_base import CommandBase, cd
+from servo.util import delete, download_bytes, download_file, extract, check_hash, check_call
 
 
 @CommandProvider
 class MachCommands(CommandBase):
-    @Command('bootstrap',
+    @Command('bootstrap-build',
              description='Install required packages for building.',
              category='bootstrap')
     @CommandArgument('--force', '-f',
                      action='store_true',
                      help='Boostrap without confirmation')
-    def bootstrap(self, force=False):
-        # This entry point isn't actually invoked, ./mach bootstrap is directly
-        # called by mach (see mach_bootstrap.bootstrap_command_only) so that
-        # it can install dependencies without needing mach's dependencies
+    def bootstrap_build(self, force=False):
         return bootstrap.bootstrap(self.context, force=force)
 
     @Command('bootstrap-salt',

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -30,8 +30,8 @@ from mach.decorators import (
 from mach.registrar import Registrar
 
 from mach_bootstrap import _get_exec_path
-from servo.command_base import CommandBase, cd, call, check_call, append_to_path_env, gstreamer_root
-from servo.util import host_triple
+from servo.command_base import CommandBase, cd, call, append_to_path_env, gstreamer_root
+from servo.util import host_triple, check_call
 
 
 def format_duration(seconds):

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -23,9 +23,10 @@ from mach.decorators import (
 
 from servo.command_base import (
     CommandBase,
-    check_call, check_output, BIN_SUFFIX,
+    check_output, BIN_SUFFIX,
     is_linux, set_osmesa_env,
 )
+from servo.util import check_call
 
 
 def read_file(filename, if_exists=False):


### PR DESCRIPTION
This renames the `bootstrap` mach command to `bootstrap-build` because the bootstrap name is hardcoded into mach in a way that interferes with the actual command execution (#25224). These changes also support automatically setting up a 10.14 SDK on macOS 10.15, which is needed to build spidermonkey since #25678 merged.

Depends on https://github.com/servo/mozjs/pull/233.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25919
- [x] These changes do not require tests because there are no 10.15 test machines