### PR TITLE
Add support for launching devtools server on random port

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -653,12 +653,7 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
         "Start remote debugger server on port",
         "2794",
     );
-    opts.optflagopt(
-        "",
-        "devtools",
-        "Start remote devtools server on port",
-        "6000",
-    );
+    opts.optflagopt("", "devtools", "Start remote devtools server on port", "0");
     opts.optflagopt(
         "",
         "webdriver",
@@ -886,7 +881,8 @@ pub fn from_cmdline_args(mut opts: Options, args: &[String]) -> ArgumentParsingR
             })
         });
 
-    let devtools_port = opt_match.opt_default("devtools", "6000").map(|port| {
+    // Set default port 0 for a random port to be selected.
+    let devtools_port = opt_match.opt_default("devtools", "0").map(|port| {
         port.parse()
             .unwrap_or_else(|err| args_fail(&format!("Error parsing option: --devtools ({})", err)))
     });

--- a/components/embedder_traits/lib.rs
+++ b/components/embedder_traits/lib.rs
@@ -198,6 +198,8 @@ pub enum EmbedderMsg {
     /// Notifies the embedder about media session events
     /// (i.e. when there is metadata for the active media session, playback state changes...).
     MediaSessionEvent(MediaSessionEvent),
+    /// Report the status of Devtools Server
+    OnDevtoolsStarted(Result<u16, ()>),
 }
 
 impl Debug for EmbedderMsg {
@@ -232,6 +234,7 @@ impl Debug for EmbedderMsg {
             EmbedderMsg::BrowserCreated(..) => write!(f, "BrowserCreated"),
             EmbedderMsg::ReportProfile(..) => write!(f, "ReportProfile"),
             EmbedderMsg::MediaSessionEvent(..) => write!(f, "MediaSessionEvent"),
+            EmbedderMsg::OnDevtoolsStarted(..) => write!(f, "OnDevtoolsStarted"),
         }
     }
 }

--- a/ports/glutin/browser.rs
+++ b/ports/glutin/browser.rs
@@ -515,6 +515,12 @@ where
                     debug!("MediaSessionEvent received");
                     // TODO(ferjm): MediaSession support for Glutin based browsers.
                 },
+                EmbedderMsg::OnDevtoolsStarted(port) => {
+                    match port {
+                        Ok(p) => info!("Devtools Server running on port {}", p),
+                        Err(()) => error!("Error running devtools server"),
+                    }
+                },
             }
         }
     }

--- a/ports/libmlservo/src/lib.rs
+++ b/ports/libmlservo/src/lib.rs
@@ -423,6 +423,13 @@ impl HostTrait for HostCallbacks {
     }
 
     fn set_clipboard_contents(&self, _contents: String) {}
+
+    fn on_devtools_started(&self, port: Result<u16, ()>) {
+        match port {
+            Ok(p) => info!("Devtools Server running on port {}", p),
+            Err(()) => error!("Error running Devtools server"),
+        }
+    }
 }
 
 pub struct ServoInstance {

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -146,6 +146,8 @@ pub trait HostTrait {
     fn on_media_session_playback_state_change(&self, state: MediaSessionPlaybackState);
     /// Called when the media session position state is set.
     fn on_media_session_set_position_state(&self, duration: f64, position: f64, playback_rate: f64);
+    /// Called when devtools server is started
+    fn on_devtools_started(&self, port: Result<u16, ()>);
 }
 
 pub struct ServoGlue {
@@ -669,6 +671,9 @@ impl ServoGlue {
                                 position_state.playback_rate,
                             ),
                     };
+                },
+                EmbedderMsg::OnDevtoolsStarted(port) => {
+                    self.callbacks.host_callbacks.on_devtools_started(port);
                 },
                 EmbedderMsg::Status(..) |
                 EmbedderMsg::SelectFiles(..) |

--- a/ports/libsimpleservo/jniapi/src/lib.rs
+++ b/ports/libsimpleservo/jniapi/src/lib.rs
@@ -603,6 +603,13 @@ impl HostTrait for HostCallbacks {
         )
         .unwrap();
     }
+
+    fn on_devtools_started(&self, port: Result<u16, ()>) {
+        match port {
+            Ok(p) => info!("Devtools Server running on port {}", p),
+            Err(()) => error!("Error running devtools server"),
+        }
+    }
 }
 
 fn initialize_android_glue(env: &JNIEnv, activity: JObject) {

--- a/support/hololens/ServoApp/ServoControl/Servo.cpp
+++ b/support/hololens/ServoApp/ServoControl/Servo.cpp
@@ -87,6 +87,11 @@ const char *prompt_input(const char *message, const char *default,
   }
 }
 
+void on_devtools_started(Servo::DevtoolsServerState result,
+                         const unsigned int port) {
+  // FIXME
+}
+
 Servo::Servo(hstring url, hstring args, GLsizei width, GLsizei height,
              float dpi, ServoDelegate &aDelegate)
     : mWindowHeight(height), mWindowWidth(width), mDelegate(aDelegate) {
@@ -147,6 +152,7 @@ Servo::Servo(hstring url, hstring args, GLsizei width, GLsizei height,
   c.prompt_ok_cancel = &prompt_ok_cancel;
   c.prompt_yes_no = &prompt_yes_no;
   c.prompt_input = &prompt_input;
+  c.on_devtools_started = &on_devtools_started;
 
   capi::register_panic_handler(&on_panic);
 

--- a/support/hololens/ServoApp/ServoControl/Servo.h
+++ b/support/hololens/ServoApp/ServoControl/Servo.h
@@ -31,6 +31,7 @@ public:
   typedef capi::CPromptResult PromptResult;
   typedef capi::CMediaSessionActionType MediaSessionActionType;
   typedef capi::CMediaSessionPlaybackState MediaSessionPlaybackState;
+  typedef capi::CDevtoolsServerState DevtoolsServerState;
 
   void PerformUpdates() { capi::perform_updates(); }
   void DeInit() { capi::deinit(); }


### PR DESCRIPTION
In case the default port(6000) or the port specified by user for
devtools server is already taken, random port will be assigned to
it which is reported to the embedding layer for display to user.

r?@jdm @paulrouget 

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25907  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
