### PR TITLE
layout_2020: Paint hoisted positioned fragments in tree order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,6 +2919,7 @@ dependencies = [
  "html5ever",
  "ipc-channel",
  "libc",
+ "log",
  "mitochondria",
  "msg",
  "net_traits",

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -25,6 +25,7 @@ gfx_traits = {path = "../gfx_traits"}
 html5ever = "0.25"
 ipc-channel = "0.14"
 libc = "0.2"
+log = "0.4"
 msg = {path = "../msg"}
 mitochondria = "1.1.2"
 net_traits = {path = "../net_traits"}

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -6,6 +6,8 @@
 #![feature(exact_size_is_empty)]
 
 #[macro_use]
+extern crate log;
+#[macro_use]
 extern crate serde;
 
 pub mod context;

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -56,6 +56,7 @@ pub(crate) trait ComputedValuesExt {
     fn has_transform_or_perspective(&self) -> bool;
     fn effective_z_index(&self) -> i32;
     fn establishes_stacking_context(&self) -> bool;
+    fn establishes_containing_block(&self) -> bool;
     fn establishes_containing_block_for_all_descendants(&self) -> bool;
 }
 
@@ -231,6 +232,14 @@ impl ComputedValuesExt for ComputedValues {
         // context if there is a z-index set.
         // See https://www.w3.org/TR/CSS2/visuren.html#z-index
         !self.get_position().z_index.is_auto()
+    }
+
+    fn establishes_containing_block(&self) -> bool {
+        if self.establishes_containing_block_for_all_descendants() {
+            return true;
+        }
+
+        self.clone_position() != ComputedPosition::Static
     }
 
     /// Returns true if this style establishes a containing block for all descendants

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-intrinsic-010.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-intrinsic-010.xht.ini
@@ -1,2 +1,0 @@
-[background-intrinsic-010.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/borders/border-005.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/borders/border-005.xht.ini
@@ -1,2 +1,0 @@
-[border-005.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/borders/border-006.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/borders/border-006.xht.ini
@@ -1,2 +1,0 @@
-[border-006.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/borders/border-008.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/borders/border-008.xht.ini
@@ -1,2 +1,0 @@
-[border-008.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/csswg-issues/submitted/css2.1/anonymous-boxes-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/csswg-issues/submitted/css2.1/anonymous-boxes-001.xht.ini
@@ -1,2 +1,0 @@
-[anonymous-boxes-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats/hit-test-floats-005.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats/hit-test-floats-005.html.ini
@@ -1,4 +1,0 @@
-[hit-test-floats-005.html]
-  [Miss clipped float]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-bottom-103.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-bottom-103.xht.ini
@@ -1,2 +1,0 @@
-[margin-bottom-103.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-bottom-104.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-bottom-104.xht.ini
@@ -1,2 +1,0 @@
-[margin-bottom-104.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/abspos-028.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/abspos-028.xht.ini
@@ -1,2 +1,0 @@
-[abspos-028.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-019.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-019.xht.ini
@@ -1,2 +1,0 @@
-[top-019.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-020.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-020.xht.ini
@@ -1,2 +1,0 @@
-[top-020.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-031.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-031.xht.ini
@@ -1,2 +1,0 @@
-[top-031.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-032.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-032.xht.ini
@@ -1,2 +1,0 @@
-[top-032.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-043.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-043.xht.ini
@@ -1,2 +1,0 @@
-[top-043.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-044.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-044.xht.ini
@@ -1,2 +1,0 @@
-[top-044.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-055.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-055.xht.ini
@@ -1,2 +1,0 @@
-[top-055.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-056.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-056.xht.ini
@@ -1,2 +1,0 @@
-[top-056.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-067.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-067.xht.ini
@@ -1,2 +1,0 @@
-[top-067.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-068.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-068.xht.ini
@@ -1,2 +1,0 @@
-[top-068.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-079.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-079.xht.ini
@@ -1,2 +1,0 @@
-[top-079.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-080.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-080.xht.ini
@@ -1,2 +1,0 @@
-[top-080.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-103.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-103.xht.ini
@@ -1,2 +1,0 @@
-[top-103.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-104.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-104.xht.ini
@@ -1,2 +1,0 @@
-[top-104.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-113.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-113.xht.ini
@@ -1,2 +1,0 @@
-[top-113.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/visudet/line-height-202.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/visudet/line-height-202.html.ini
@@ -1,0 +1,2 @@
+[line-height-202.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/visudet/line-height-203.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/visudet/line-height-203.html.ini
@@ -1,2 +1,0 @@
-[line-height-203.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/visudet/line-height-204.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/visudet/line-height-204.html.ini
@@ -1,0 +1,2 @@
+[line-height-204.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/preserve3d-button.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/preserve3d-button.html.ini
@@ -1,0 +1,2 @@
+[preserve3d-button.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/absolute_z_index_auto_paint_order_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/absolute_z_index_auto_paint_order_a.html.ini
@@ -1,2 +1,0 @@
-[absolute_z_index_auto_paint_order_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/opacity_stacking_context_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/opacity_stacking_context_a.html.ini
@@ -1,2 +1,0 @@
-[opacity_stacking_context_a.html]
-  expected: FAIL


### PR DESCRIPTION
Instead of painting hoisted position fragments in the order to which
they are hoisted, paint them in tree order and properly incorporate them
into the stacking context.

We do this by creating a placeholder fragment in the original tree position
of hoisted fragments. The ghost fragment contains an atomic id which
links back to the hoisted fragment in the containing block.

While building the stacking context, we keep track of containing blocks
and their children. When encountering a placeholder fragment we look at
the containing block's hoisted children in order to properly paint the
hoisted fragment.

One notable design modification in this change is that hoisted fragments
no longer need an AnonymousFragment as their parent. Instead they are
now direct children of the fragment that establishes their containing block.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
