### PR TITLE
Accept only connected attributes for checkbox and radio activation behavior

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2488,6 +2488,9 @@ impl Activatable for HTMLInputElement {
                 // https://html.spec.whatwg.org/multipage/#checkbox-state-(type=checkbox):activation-behavior
                 // https://html.spec.whatwg.org/multipage/#radio-button-state-(type=radio):activation-behavior
                 // Check if document owner is fully active
+                if !self.upcast::<Node>().is_connected() {
+                    return ();
+                }
                 let target = self.upcast::<EventTarget>();
                 target.fire_bubbling_event(atom!("input"));
                 target.fire_bubbling_event(atom!("change"));

--- a/tests/wpt/metadata/dom/events/Event-dispatch-detached-input-and-change.html.ini
+++ b/tests/wpt/metadata/dom/events/Event-dispatch-detached-input-and-change.html.ini
@@ -2,19 +2,7 @@
   [attached to shadow dom radio should emit input and change events on click().]
     expected: FAIL
 
-  [detached checkbox should not emit input or change events on click().]
-    expected: FAIL
-
   [attached to shadow dom checkbox should emit input and change events on click().]
-    expected: FAIL
-
-  [detached radio should not emit input or change events on click().]
-    expected: FAIL
-
-  [detached radio should not emit input or change events on dispatchEvent(new MouseEvent('click')).]
-    expected: FAIL
-
-  [detached checkbox should not emit input or change events on dispatchEvent(new MouseEvent('click')).]
     expected: FAIL
 
   [attached to shadow dom checkbox should emit input and change events on dispatchEvent(new MouseEvent('click')).]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Accept only connected attributes for checkbox and radio activation behavior

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25906 
- [x] WPT tests were already here