### PR TITLE
Don't run 2dcontext tests in layout-2020.

### DIFF
--- a/tests/wpt/include-layout-2020.ini
+++ b/tests/wpt/include-layout-2020.ini
@@ -5,8 +5,6 @@ skip: true
     skip: false
   [mozilla]
     skip: false
-[2dcontext]
-  skip: false
 [css]
   skip: true
   [CSS2]


### PR DESCRIPTION
The vast majority of these tests only test the DOM APIs, not the actual layout via reftests. That means we just duplicate the results and have to update them every time we change the canvas behaviour.