### PR TITLE
Disable running windows binaries on CI.

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -369,8 +369,11 @@ def windows_unit(cached=True):
             "mach fetch",
 
             "mach build --dev",
-            "mach test-unit",
-            "mach smoketest --angle",
+
+            # https://github.com/servo/servo/issues/25961
+            #"mach test-unit",
+            #"mach smoketest --angle",
+
             "mach package --dev",
             "mach build --dev --libsimpleservo",
             # The GStreamer plugin currently doesn't support Windows


### PR DESCRIPTION
In order to get more information out of https://github.com/servo/servo/pull/25745, we're going to temporarily disable the parts of windows CI that don't agree with the updated windows server environment.