### PR TITLE
Do not try to read pixels from an FBO without read buffer

### DIFF
--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -349,7 +349,11 @@ impl WebGL2RenderingContext {
         }
 
         let fb_slot = self.base.get_draw_framebuffer_slot();
-        if fb_slot.get().is_none() && self.default_fb_readbuffer.get() == constants::NONE {
+        let fb_readbuffer_valid = match fb_slot.get() {
+            Some(fb) => fb.attachment(fb.read_buffer()).is_some(),
+            None => self.default_fb_readbuffer.get() != constants::NONE,
+        };
+        if !fb_readbuffer_valid {
             return self.base.webgl_error(InvalidOperation);
         }
 

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/readbuffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/readbuffer.html.ini
@@ -1,8 +1,2 @@
 [readbuffer.html]
   expected: TIMEOUT
-  [WebGL test #3: gl.getParameter(gl.READ_BUFFER) should be 1029 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #4: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-


### PR DESCRIPTION
A follow up to #25905, this adds another check to the WebGL2 ReadPixels implementation to fix
an OpenGL invalid operation crash when the method is called on a bound framebuffer that has no read buffer.

<!-- Please describe your changes on the following line: -->

cc @jdm @zakorgy 

However, it seems there's an issue with the headless mode: when ReadBuffer is called on the default framebuffer with the value `GL_BACK`, like [here](https://github.com/servo/servo/blob/e1103176e3de8a8c0996d1d60c092cfd8f60e805/tests/wpt/webgl/tests/conformance2/renderbuffers/readbuffer.html#L77), in headless mode an invalid operation is generated. In non-headless mode the whole test completes successfully: 
![sshot](https://user-images.githubusercontent.com/4354863/76845770-b0ffbd80-683f-11ea-8103-a81512188808.png)


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
