### PR TITLE
Update x11-dl to pickup the fix for x11 startup crash (recurrence of #21530)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,6 +3400,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "media"
 version = "0.0.1"
 dependencies = [
@@ -6847,12 +6853,13 @@ dependencies = [
 
 [[package]]
 name = "x11-dl"
-version = "2.18.3"
+version = "2.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940586acb859ea05c53971ac231685799a7ec1dee66ac0bccc0e6ad96e06b4e3"
+checksum = "2bf981e3a5b3301209754218f962052d4d9ee97e478f4d26d4a6eced34c1fef8"
 dependencies = [
  "lazy_static",
  "libc",
+ "maybe-uninit",
  "pkg-config",
 ]
 


### PR DESCRIPTION
This branch updates x11-dl to 2.18.5 to get erlepereira/x11-rs#99

```
% ./mach run --release https://duckduckgo.com                             
attempted to leave type `std::mem::ManuallyDrop<xlib_xcb::Xlib_xcb>` uninitialized, which is invalid (thread main, at /rustc/45ebd5808afd3df7ba842797c0fcd4447ddf30fb/src/libcore/mem/mod.rs:536)     
stack backtrace:                                                                                   
   0: servo::backtrace::print                   
   1: servo::main::{{closure}}        
   2: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:513                                                        
   3: rust_begin_unwind                       
             at src/libstd/panicking.rs:417                                                        
   4: core::panicking::panic_fmt
             at src/libcore/panicking.rs:111                                                       
   5: core::panicking::panic                     
             at src/libcore/panicking.rs:54 
   6: x11_dl::xlib_xcb::Xlib_xcb::open                                                                                                                                                                
   7: winit::platform::platform::x11::xdisplay::XConnection::new                                   
   8: std::sync::once::Once::call_once::{{closure}}                 
   9: std::sync::once::Once::call_inner          
             at src/libstd/sync/once.rs:416
  10: winit::platform::platform::EventsLoop::new_x11
  11: winit::platform::platform::EventsLoop::new
  12: winit::EventsLoop::new
  13: servo::events_loop::EventsLoop::new
  14: servo::app::App::run
  15: servo::main
  16: std::rt::lang_start::{{closure}}
  17: std::rt::lang_start_internal::{{closure}}
             at src/libstd/rt.rs:52
      std::panicking::try::do_call
             at src/libstd/panicking.rs:329
      std::panicking::try::do_try
             at src/libstd/panicking.rs:285
      std::panicking::try
             at src/libstd/panicking.rs:274
      std::panic::catch_unwind
             at src/libstd/panic.rs:394
      std::rt::lang_start_internal
             at src/libstd/rt.rs:51
  18: main
  19: __libc_start_main
  20: _start
Servo exited with return value 101
```

This patch is created by `cargo update -p x11-dl`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it fixes a startup crash

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
