### PR TITLE
layout_2020: Add support for hoisting positioned fragments in inline boxes

### DIFF
--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -172,7 +172,7 @@ impl PositioningContext {
         self.for_nearest_positioned_ancestor.is_some()
     }
 
-    fn new_for_style(style: &ComputedValues) -> Option<Self> {
+    pub(crate) fn new_for_style(style: &ComputedValues) -> Option<Self> {
         if style.establishes_containing_block_for_all_descendants() {
             Some(Self::new_for_containing_block_for_all_descendants())
         } else if style.establishes_containing_block() {
@@ -243,7 +243,7 @@ impl PositioningContext {
 
     // Lay out the hoisted boxes collected into this `PositioningContext` and add them
     // to the given `BoxFragment`.
-    fn layout_collected_children(
+    pub fn layout_collected_children(
         &mut self,
         layout_context: &LayoutContext,
         new_fragment: &mut BoxFragment,

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -245,7 +245,9 @@ impl ComputedValuesExt for ComputedValues {
     /// Returns true if this style establishes a containing block for all descendants
     /// including fixed and absolutely positioned ones.
     fn establishes_containing_block_for_all_descendants(&self) -> bool {
-        if self.has_transform_or_perspective() {
+        if self.get_box().display.outside() != stylo::DisplayOutside::Inline &&
+            self.has_transform_or_perspective()
+        {
             return true;
         }
 

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/abspos-inline-008.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/abspos-inline-008.xht.ini
@@ -1,2 +1,0 @@
-[abspos-inline-008.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/toogle-abspos-on-relpos-inline-child.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/toogle-abspos-on-relpos-inline-child.html.ini
@@ -1,2 +1,0 @@
-[toogle-abspos-on-relpos-inline-child.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/preserve3d-button.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/preserve3d-button.html.ini
@@ -1,2 +1,0 @@
-[preserve3d-button.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/filter-effects/filtered-inline-is-container.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/filter-effects/filtered-inline-is-container.html.ini
@@ -1,2 +1,0 @@
-[filtered-inline-is-container.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/absolute_inline_containing_block_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/absolute_inline_containing_block_a.html.ini
@@ -1,2 +1,0 @@
-[absolute_inline_containing_block_a.html]
-  expected: FAIL


### PR DESCRIPTION
Add support for tracking containing blocks when doing inline layout.
This requires setting up a PositioningContext for inline boxes when
necessary. Instead of using the PositioningContext helper methods
and we reuse the contexts between line breaks.

Fixes #25279.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25279

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
