### PR TITLE
layout_2020: Fix a documentation comment

### DIFF
--- a/components/layout_2020/fragments.rs
+++ b/components/layout_2020/fragments.rs
@@ -55,7 +55,9 @@ pub(crate) struct BoxFragment {
     /// The scrollable overflow of this box fragment.
     pub scrollable_overflow_from_children: PhysicalRect<Length>,
 
-    /// XXX Add thsi
+    /// If this fragment was laid out from a hoisted box, this id corresponds to the id stored in
+    /// the AbsoluteOrFixedPositionedFragment left as a placeholder in the tree position of the
+    /// box.
     pub hoisted_fragment_id: Option<HoistedFragmentId>,
 }
 


### PR DESCRIPTION
I inadvertently failed to complete this doc comment.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they don't change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
