### PR TITLE
Reuse layout-2013 WPT results with layout-2020 when syncing.

### DIFF
--- a/etc/ci/update-wpt-checkout
+++ b/etc/ci/update-wpt-checkout
@@ -83,8 +83,10 @@ function unsafe_run_tests() {
 # last commit with the new results.
 function unsafe_update_metadata() {
     ./mach update-wpt "${1}" "${2}" "${3}" || return 1
+    # Hope that any test result changes from layout-2013 are also applicable to layout-2020.
+    ./mach update-wpt --layout-2020 "${1}" "${2}" "${3}" || return 2
     # Ensure any new directories or ini files are included in these changes.
-    git add tests/wpt/metadata tests/wpt/mozilla/meta || return 2
+    git add tests/wpt/metadata tests/wpt/metadata-layout-2020 tests/wpt/mozilla/meta || return 3
     # Merge all changes with the existing commit.
     git commit -a --amend --no-edit || return 3
 }


### PR DESCRIPTION
This should fix #25666, or at least the most common failure case. If new test results actually have different behaviour between the layout-2013 and layout-2020 engines there's not much we can do without a proper build with 2020 enabled.