### PR TITLE
Replace IRC channel with Matrix link

### DIFF
--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -295,9 +295,9 @@ See the [debugging guide](./debugging.md) to get started in how to debug Servo.
 
 ## Ask questions
 
-### IRC channels (irc.mozilla.org)
+### [Matrix](https://wiki.mozilla.org/Matrix)
 
-- #servo
+- [Servo room](https://chat.mozilla.org/#/room/#servo:mozilla.org)
 
 ### Discord servers
 


### PR DESCRIPTION
This PR updates the `HACKING_QUICKSTART.md` file to mention the Matrix Servo channel instead of the now-defunct `#servo` IRC channel.