### PR TITLE
Avoid a panic when closing webgl pages using VAOs

### DIFF
--- a/components/script/dom/vertexarrayobject.rs
+++ b/components/script/dom/vertexarrayobject.rs
@@ -59,11 +59,11 @@ impl VertexArrayObject {
 
         for attrib_data in &**self.vertex_attribs.borrow() {
             if let Some(buffer) = attrib_data.buffer() {
-                buffer.decrement_attached_counter();
+                buffer.decrement_attached_counter(fallible);
             }
         }
         if let Some(buffer) = self.element_array_buffer.get() {
-            buffer.decrement_attached_counter();
+            buffer.decrement_attached_counter(fallible);
         }
     }
 
@@ -136,7 +136,7 @@ impl VertexArrayObject {
             offset as u32,
         ));
         if let Some(old) = data.buffer() {
-            old.decrement_attached_counter();
+            old.decrement_attached_counter(false);
         }
 
         *data = VertexAttribData {
@@ -168,7 +168,7 @@ impl VertexArrayObject {
                 if b.id() != buffer.id() {
                     continue;
                 }
-                b.decrement_attached_counter();
+                b.decrement_attached_counter(false);
             }
             attrib.buffer = None;
         }
@@ -177,7 +177,7 @@ impl VertexArrayObject {
             .get()
             .map_or(false, |b| buffer == &*b)
         {
-            buffer.decrement_attached_counter();
+            buffer.decrement_attached_counter(false);
             self.element_array_buffer.set(None);
         }
     }

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -222,7 +222,7 @@ impl WebGL2RenderingContext {
 
     fn unbind_from(&self, slot: &MutNullableDom<WebGLBuffer>, buffer: &WebGLBuffer) {
         if slot.get().map_or(false, |b| buffer == &*b) {
-            buffer.decrement_attached_counter();
+            buffer.decrement_attached_counter(false);
             slot.set(None);
         }
     }
@@ -3405,7 +3405,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
 
         for slot in &[&generic_slot, &indexed_binding.buffer] {
             if let Some(old) = slot.get() {
-                old.decrement_attached_counter();
+                old.decrement_attached_counter(false);
             }
             slot.set(buffer);
         }
@@ -3483,7 +3483,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
 
         for slot in &[&generic_slot, &indexed_binding.buffer] {
             if let Some(old) = slot.get() {
-                old.decrement_attached_counter();
+                old.decrement_attached_counter(false);
             }
             slot.set(buffer);
         }

--- a/components/script/dom/webglbuffer.rs
+++ b/components/script/dom/webglbuffer.rs
@@ -166,7 +166,7 @@ impl WebGLBuffer {
         );
     }
 
-    pub fn decrement_attached_counter(&self) {
+    pub fn decrement_attached_counter(&self, fallible: bool) {
         self.attached_counter.set(
             self.attached_counter
                 .get()
@@ -174,7 +174,7 @@ impl WebGLBuffer {
                 .expect("refcount underflowed"),
         );
         if self.is_deleted() {
-            self.delete(false);
+            self.delete(fallible);
         }
     }
 

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1317,7 +1317,7 @@ impl WebGLRenderingContext {
 
         self.send_command(WebGLCommand::BindBuffer(target, buffer.map(|b| b.id())));
         if let Some(old) = slot.get() {
-            old.decrement_attached_counter();
+            old.decrement_attached_counter(false);
         }
 
         slot.set(buffer);
@@ -2565,7 +2565,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             .map_or(false, |b| buffer == &*b)
         {
             self.bound_buffer_array.set(None);
-            buffer.decrement_attached_counter();
+            buffer.decrement_attached_counter(false);
         }
         buffer.mark_for_deletion(false);
     }


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25891
- [x] These changes do not require tests because GC behaviour at shutdown is nondeterministic and difficult to test