### PR TITLE
Update content-security-policy.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
+name = "base64"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
+
+[[package]]
 name = "binary-space-partition"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,15 +828,17 @@ dependencies = [
 
 [[package]]
 name = "content-security-policy"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30ee9967a875968e66f6690e299f06781ed109cb82d10e0d60a126a38d61947"
+checksum = "e9c6953cf3a032666719b6c432617652532bdeb6015c93473cbbd432d9657600"
 dependencies = [
+ "base64 0.12.0",
  "bitflags",
  "lazy_static",
  "percent-encoding",
  "regex",
  "serde",
+ "sha2",
  "url",
 ]
 

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -29,7 +29,7 @@ servo = [
 [dependencies]
 accountable-refcell = { version = "0.2.0", optional = true }
 app_units = "0.7"
-content-security-policy = {version = "0.3.0", features = ["serde"], optional = true}
+content-security-policy = {version = "0.4.0", features = ["serde"], optional = true}
 crossbeam-channel = { version = "0.4", optional = true }
 cssparser = "0.27"
 euclid = "0.20"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 base64 = "0.10.1"
 brotli = "3"
 bytes = "0.4"
-content-security-policy = {version = "0.3.0", features = ["serde"]}
+content-security-policy = {version = "0.4.0", features = ["serde"]}
 cookie_rs = {package = "cookie", version = "0.11"}
 crossbeam-channel = "0.4"
 data-url = "0.1.0"

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -203,6 +203,7 @@ pub fn main_fetch(
 
     // Step 2.4.
     if should_request_be_blocked_by_csp(request) == csp::CheckResult::Blocked {
+        warn!("Request blocked by CSP");
         response = Some(Response::network_error(NetworkError::Internal(
             "Blocked by Content-Security-Policy".into(),
         )))

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -13,7 +13,7 @@ test = false
 doctest = false
 
 [dependencies]
-content-security-policy = {version = "0.3.0", features = ["serde"]}
+content-security-policy = {version = "0.4.0", features = ["serde"]}
 cookie = "0.11"
 embedder_traits = { path = "../embedder_traits" }
 headers = "0.2"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -39,7 +39,7 @@ bitflags = "1.0"
 bluetooth_traits = {path = "../bluetooth_traits"}
 canvas_traits = {path = "../canvas_traits"}
 caseless = "0.2"
-content-security-policy = {version = "0.3.0", features = ["serde"]}
+content-security-policy = {version = "0.4.0", features = ["serde"]}
 cookie = "0.11"
 chrono = "0.4"
 crossbeam-channel = "0.4"

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -460,6 +460,7 @@ impl HTMLScriptElement {
                 &text,
             ) == csp::CheckResult::Blocked
         {
+            warn!("Blocking inline script due to CSP");
             return;
         }
 


### PR DESCRIPTION
This allows hubs.mozilla.org to load instead of panicking due to unimplemented CSP features.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24702
- [x] These changes do not require tests because we never enabled the CSP testsuite