### PR TITLE
layout_2020: Use the containing block more when calculating scrolling overflow

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -580,7 +580,8 @@ impl BoxFragment {
             builder.current_space_and_clip = builder.wr.define_scroll_frame(
                 &original_scroll_and_clip_info,
                 Some(external_id),
-                self.scrollable_overflow().to_webrender(),
+                self.scrollable_overflow(&containing_block_info.rect)
+                    .to_webrender(),
                 padding_rect,
                 vec![], // complex_clips
                 None,   // image_mask

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -163,7 +163,7 @@ impl BoxTreeRoot {
                 .fragments
                 .iter()
                 .fold(PhysicalRect::zero(), |acc, child| {
-                    let child_overflow = child.scrollable_overflow();
+                    let child_overflow = child.scrollable_overflow(&physical_containing_block);
 
                     // https://drafts.csswg.org/css-overflow/#scrolling-direction
                     // We want to clip scrollable overflow on box-start and inline-start


### PR DESCRIPTION
When calculating scrolling overflow calculation we cannot currently use
the actual containing block in all cases. This change increases the
amount that we do use the containing block.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
