### PR TITLE
Force alert message to its own line.

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -615,7 +615,7 @@ impl WindowMethods for Window {
             let mut stderr = stderr.lock();
             let stdout = stdout();
             let mut stdout = stdout.lock();
-            writeln!(&mut stdout, "ALERT: {}", s).unwrap();
+            writeln!(&mut stdout, "\nALERT: {}", s).unwrap();
             stdout.flush().unwrap();
             stderr.flush().unwrap();
         }


### PR DESCRIPTION
This should avoid timeouts in WPT caused by output that looks like:
```
 │ 0:00:00.542631465 10817 0x7f9ccc161630 WARN                 playbin gstplaybin2.c:4663:autoplug_select_cb:<playbin> Could not activate sink oss4sink
  │ ALSA lib confmisc.c:767:(parse_card) ALERT: RESULT: ["/html/semantics/embedded-content/media-elements/event_pause_noautoplay.html",0,null,null,[["audio events - pause",0,null,null],["video events - pause",0,null,null],["calling play() then pause() on non-autoplay audio should trigger pause event",0,null,null],["calling play() then pause() on non-autoplay video should trigger pause event",0,null,null]]]
  │ cannot find card '0'
```