### PR TITLE
 Update backtrace to 0.3.46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,8 +206,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.40"
-source = "git+https://github.com/MeFisto94/backtrace-rs?branch=fix-strtab-freeing-crash#91a0aa4a5d649151878cddd883b92ba7057ca41c"
+version = "0.3.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
 dependencies = [
  "backtrace-sys",
  "cfg-if",
@@ -217,8 +218,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.32"
-source = "git+https://github.com/MeFisto94/backtrace-rs?branch=fix-strtab-freeing-crash#91a0aa4a5d649151878cddd883b92ba7057ca41c"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,3 @@ mio = { git = "https://github.com/servo/mio.git", branch = "servo" }
 # https://github.com/retep998/winapi-rs/pull/816
 winapi = { git = "https://github.com/servo/winapi-rs", branch = "patch-1" }
 spirv_cross = { git = "https://github.com/servo/spirv_cross", branch = "wgpu-servo" }
-backtrace = { git = "https://github.com/MeFisto94/backtrace-rs", branch = "fix-strtab-freeing-crash" }

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -13,7 +13,7 @@ test = false
 doctest = false
 
 [dependencies]
-backtrace = "0.3"
+backtrace = "0.3.46"
 ipc-channel = "0.14"
 libc = "0.2"
 log = "0.4"

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -19,14 +19,14 @@ compositing = {path = "../compositing"}
 crossbeam-channel = "0.4"
 debugger = {path = "../debugger"}
 devtools_traits = {path = "../devtools_traits"}
-euclid = "0.20"
 embedder_traits = { path = "../embedder_traits" }
+euclid = "0.20"
 gfx = {path = "../gfx"}
 gfx_traits = {path = "../gfx_traits"}
 http = "0.1"
 ipc-channel = "0.14"
-layout_traits = {path = "../layout_traits"}
 keyboard-types = "0.4.3"
+layout_traits = {path = "../layout_traits"}
 log = "0.4"
 media = {path = "../media"}
 metrics = {path = "../metrics"}
@@ -36,15 +36,15 @@ net_traits = {path = "../net_traits"}
 profile_traits = {path = "../profile_traits"}
 script_traits = {path = "../script_traits"}
 serde = "1.0"
-style_traits = {path = "../style_traits"}
 servo_config = {path = "../config"}
 servo_geometry = {path = "../geometry"}
 servo_rand = {path = "../rand"}
 servo_remutex = {path = "../remutex"}
 servo_url = {path = "../url"}
+style_traits = {path = "../style_traits"}
 webgpu = {path = "../webgpu"}
-webvr_traits = {path = "../webvr_traits"}
 webrender_api = {git = "https://github.com/servo/webrender"}
+webvr_traits = {path = "../webvr_traits"}
 webxr-api = {git = "https://github.com/servo/webxr", features = ["ipc"]}
 
 [target.'cfg(all(not(target_os = "windows"), not(target_os = "ios"), not(target_os="android"), not(target_arch="arm"), not(target_arch="aarch64")))'.dependencies]

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 
 [dependencies]
 background_hang_monitor = { path = "../background_hang_monitor"}
-backtrace = "0.3"
+backtrace = "0.3.46"
 bluetooth_traits = { path = "../bluetooth_traits" }
 canvas_traits = {path = "../canvas_traits"}
 compositing = {path = "../compositing"}

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0"
 [dependencies]
 accountable-refcell = {version = "0.2.0", optional = true}
 app_units = "0.7"
-backtrace = {version = "0.3", optional = true}
+backtrace = {version = "0.3.46", optional = true}
 base64 = "0.10.1"
 bincode = "1"
 bitflags = "1.0"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -39,9 +39,9 @@ bitflags = "1.0"
 bluetooth_traits = {path = "../bluetooth_traits"}
 canvas_traits = {path = "../canvas_traits"}
 caseless = "0.2"
+chrono = "0.4"
 content-security-policy = {version = "0.3.0", features = ["serde"]}
 cookie = "0.11"
-chrono = "0.4"
 crossbeam-channel = "0.4"
 cssparser = "0.27"
 deny_public_fields = {path = "../deny_public_fields"}
@@ -62,8 +62,8 @@ image = "0.23"
 indexmap = "1.0.2"
 ipc-channel = "0.14"
 itertools = "0.8"
-jstraceable_derive = {path = "../jstraceable_derive"}
 js = {package = "mozjs", git = "https://github.com/servo/rust-mozjs"}
+jstraceable_derive = {path = "../jstraceable_derive"}
 keyboard-types = "0.4.4"
 lazy_static = "1"
 libc = "0.2"
@@ -72,9 +72,9 @@ malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = "0.1"
 media = {path = "../media"}
 metrics = {path = "../metrics"}
-mitochondria = "1.1.2"
 mime = "0.3.13"
 mime_guess = "2.0.0-alpha.6"
+mitochondria = "1.1.2"
 msg = {path = "../msg"}
 net_traits = {path = "../net_traits"}
 num-traits = "0.2"
@@ -97,11 +97,11 @@ servo_arc = {path = "../servo_arc"}
 servo_atoms = {path = "../atoms"}
 servo_config = {path = "../config"}
 servo_geometry = {path = "../geometry" }
-servo-media = {git = "https://github.com/servo/media"}
 servo_rand = {path = "../rand"}
 servo_url = {path = "../url"}
-sparkle = "0.1"
+servo-media = {git = "https://github.com/servo/media"}
 smallvec = { version = "0.6", features = ["std", "union"] }
+sparkle = "0.1"
 style = {path = "../style", features = ["servo"]}
 style_traits = {path = "../style_traits"}
 swapper = "0.1"
@@ -112,12 +112,12 @@ unicode-segmentation = "1.1.0"
 url = "2.0"
 utf-8 = "0.7"
 uuid = {version = "0.8", features = ["v4", "serde"]}
-xml5ever = "0.16"
 webdriver = "0.40"
 webgpu = {path = "../webgpu"}
 webrender_api = {git = "https://github.com/servo/webrender"}
 webvr_traits = {path = "../webvr_traits"}
 webxr-api = {git = "https://github.com/servo/webxr", features = ["ipc"]}
+xml5ever = "0.16"
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]
 mozangle = "0.2"

--- a/ports/glutin/Cargo.toml
+++ b/ports/glutin/Cargo.toml
@@ -48,7 +48,7 @@ vslatestinstalled = ["libservo/vslatestinstalled"]
 xr-profile = ["libservo/xr-profile"]
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
-backtrace = "0.3"
+backtrace = "0.3.46"
 clipboard = "0.5"
 euclid = "0.20"
 getopts = "0.2.11"

--- a/ports/glutin/Cargo.toml
+++ b/ports/glutin/Cargo.toml
@@ -56,15 +56,15 @@ gleam = "0.9"
 glutin = "0.21.0"
 keyboard-types = "0.4.3"
 lazy_static = "1"
-libservo = {path = "../../components/servo"}
 libc = "0.2"
+libservo = {path = "../../components/servo"}
 log = "0.4"
 rust-webvr = { version = "0.19", features = ["glwindow"] }
 servo-media = {git = "https://github.com/servo/media"}
 shellwords = "1.0.0"
 tinyfiledialogs = "3.0"
-webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
 webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless"] }
+webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]
 image = "0.23"

--- a/ports/libsimpleservo/capi/Cargo.toml
+++ b/ports/libsimpleservo/capi/Cargo.toml
@@ -13,11 +13,11 @@ test = false
 bench = false
 
 [dependencies]
-simpleservo = { path = "../api" }
-log = "0.4"
-lazy_static = "1"
-env_logger = "0.7"
 backtrace = "0.3"
+env_logger = "0.7"
+lazy_static = "1"
+log = "0.4"
+simpleservo = { path = "../api" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 libc = "0.2"

--- a/ports/libsimpleservo/capi/Cargo.toml
+++ b/ports/libsimpleservo/capi/Cargo.toml
@@ -13,7 +13,7 @@ test = false
 bench = false
 
 [dependencies]
-backtrace = "0.3"
+backtrace = "0.3.46"
 env_logger = "0.7"
 lazy_static = "1"
 log = "0.4"


### PR DESCRIPTION
https://github.com/rust-lang/backtrace-rs/pull/299 landed so we can stop patching backtrace in our tree.