### PR TITLE
Add ipc router shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "ipc-channel"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55162cbe44dacbc0b4a66d1067c885a9d5975f068a432801bba0493e1ece7a51"
+checksum = "3698b8affd5656032a074a7d40b3c2a29b71971f3e1ff6042b9d40724e20d97c"
 dependencies = [
  "bincode",
  "crossbeam-channel",

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2833,6 +2833,9 @@ where
         debug!("Asking compositor to complete shutdown.");
         self.compositor_proxy
             .send(ToCompositorMsg::ShutdownComplete);
+
+        debug!("Shutting-down IPC router thread in constellation.");
+        ROUTER.shutdown();
     }
 
     fn handle_pipeline_exited(&mut self, pipeline_id: PipelineId) {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -145,6 +145,7 @@ use script_traits::{ScriptToConstellationChan, TimerSchedulerMsg};
 use script_traits::{TouchEventType, TouchId, UntrustedNodeAddress, WheelDelta};
 use script_traits::{UpdatePipelineIdReason, WebrenderIpcSender, WindowSizeData, WindowSizeType};
 use servo_atoms::Atom;
+use servo_config::opts;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use std::borrow::Cow;
 use std::cell::Cell;
@@ -2907,6 +2908,12 @@ impl ScriptThread {
         self.background_hang_monitor
             .as_ref()
             .map(|bhm| bhm.unregister());
+
+        // If we're in multiprocess mode, shut-down the IPC router for this process.
+        if opts::multiprocess() {
+            debug!("Exiting IPC router thread in script thread.");
+            ROUTER.shutdown();
+        }
 
         debug!("Exited script thread.");
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Explicitly shutting down IPC router as part of shutdown, for contexts see https://github.com/servo/servo/pull/25685#pullrequestreview-364604068

Note that the call to `shutdown` is idempotent, so it shouldn't matter whether the call in the constellation and the script-thread are actually on the same `ROUTER` in single-process mode...

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
