### PR TITLE
Use rust-mozjs exposed function to generate SourceText

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -36,7 +36,8 @@ use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::realms::{enter_realm, InRealm};
 use dom_struct::dom_struct;
 use fnv::FnvHasher;
-use js::jsapi::{JS_GetFunctionObject, SourceText};
+use js::jsapi::JS_GetFunctionObject;
+use js::rust::transform_u16_to_source_text;
 use js::rust::wrappers::CompileFunction;
 use js::rust::{CompileOptionsWrapper, RootedObjectVectorWrapper};
 use libc::c_char;
@@ -47,7 +48,6 @@ use std::collections::HashMap;
 use std::default::Default;
 use std::ffi::CString;
 use std::hash::BuildHasherDefault;
-use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
@@ -539,12 +539,7 @@ impl EventTarget {
                 name.as_ptr(),
                 args.len() as u32,
                 args.as_ptr(),
-                &mut SourceText {
-                    units_: body.as_ptr() as *const _,
-                    length_: body.len() as u32,
-                    ownsUnits_: false,
-                    _phantom_0: PhantomData,
-                },
+                &mut transform_u16_to_source_text(&body),
             )
         });
         if handler.get().is_null() {

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -67,9 +67,10 @@ use ipc_channel::router::ROUTER;
 use js::glue::{IsWrapper, UnwrapObjectDynamic};
 use js::jsapi::{CurrentGlobalOrNull, GetNonCCWObjectGlobal};
 use js::jsapi::{HandleObject, Heap};
-use js::jsapi::{JSContext, JSObject, SourceText};
+use js::jsapi::{JSContext, JSObject};
 use js::jsval::{JSVal, UndefinedValue};
 use js::panic::maybe_resume_unwind;
+use js::rust::transform_str_to_source_text;
 use js::rust::wrappers::Evaluate2;
 use js::rust::{get_object_class, CompileOptionsWrapper, ParentRuntime, Runtime};
 use js::rust::{HandleValue, MutableHandleValue};
@@ -97,7 +98,6 @@ use std::cell::{Cell, RefCell, RefMut};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
 use std::ffi::CString;
-use std::marker::PhantomData;
 use std::mem;
 use std::ops::Index;
 use std::rc::Rc;
@@ -2166,12 +2166,7 @@ impl GlobalScope {
                     Evaluate2(
                         *cx,
                         options.ptr,
-                        &mut SourceText {
-                            units_: code.as_ptr() as *const _,
-                            length_: code.len() as u32,
-                            ownsUnits_: false,
-                            _phantom_0: PhantomData,
-                        },
+                        &mut transform_str_to_source_text(code),
                         rval,
                     )
                 };


### PR DESCRIPTION
With the exposed functions from mozjs, we can get rid of the `get_source_text` in `script_module`.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it just tries to use exposed functions from mozjs to create `SourceText`

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
