### PR TITLE
Context menu API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5386,6 +5386,7 @@ dependencies = [
  "core-foundation 0.6.4",
  "getopts",
  "gl_generator 0.11.0",
+ "ipc-channel",
  "libc",
  "libloading",
  "libservo",

--- a/components/embedder_traits/lib.rs
+++ b/components/embedder_traits/lib.rs
@@ -107,6 +107,13 @@ impl EmbedderReceiver {
 }
 
 #[derive(Deserialize, Serialize)]
+pub enum ContextMenuResult {
+    Dismissed,
+    Ignored,
+    Selected(usize),
+}
+
+#[derive(Deserialize, Serialize)]
 pub enum PromptDefinition {
     /// Show a message.
     Alert(String, IpcSender<()>),
@@ -149,6 +156,8 @@ pub enum EmbedderMsg {
     ResizeTo(DeviceIntSize),
     /// Show dialog to user
     Prompt(PromptDefinition, PromptOrigin),
+    /// Show a context menu to the user
+    ShowContextMenu(IpcSender<ContextMenuResult>, Vec<String>),
     /// Whether or not to allow a pipeline to load a url.
     AllowNavigationRequest(PipelineId, ServoUrl),
     /// Whether or not to allow script to open a new tab/browser
@@ -235,6 +244,7 @@ impl Debug for EmbedderMsg {
             EmbedderMsg::ReportProfile(..) => write!(f, "ReportProfile"),
             EmbedderMsg::MediaSessionEvent(..) => write!(f, "MediaSessionEvent"),
             EmbedderMsg::OnDevtoolsStarted(..) => write!(f, "OnDevtoolsStarted"),
+            EmbedderMsg::ShowContextMenu(..) => write!(f, "ShowContextMenu"),
         }
     }
 }

--- a/ports/glutin/browser.rs
+++ b/ports/glutin/browser.rs
@@ -8,7 +8,7 @@ use euclid::{Point2D, Vector2D};
 use keyboard_types::{Key, KeyboardEvent, Modifiers, ShortcutMatcher};
 use servo::compositing::windowing::{WebRenderDebugOption, WindowEvent};
 use servo::embedder_traits::{
-    EmbedderMsg, FilterPattern, PermissionRequest, PromptDefinition, PromptOrigin, PromptResult,
+    ContextMenuResult, EmbedderMsg, FilterPattern, PermissionRequest, PromptDefinition, PromptOrigin, PromptResult,
     PermissionPrompt,
 };
 use servo::msg::constellation_msg::TopLevelBrowsingContextId as BrowserId;
@@ -521,6 +521,9 @@ where
                         Err(()) => error!("Error running devtools server"),
                     }
                 },
+                EmbedderMsg::ShowContextMenu(sender, _) => {
+                    let _ = sender.send(ContextMenuResult::Ignored);
+                }
             }
         }
     }

--- a/ports/libsimpleservo/api/Cargo.toml
+++ b/ports/libsimpleservo/api/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 getopts = "0.2.11"
+ipc-channel = "0.14"
 libservo = { path = "../../../components/servo" }
 log = "0.4"
 servo-media = { git = "https://github.com/servo/media" }

--- a/support/hololens/ServoApp/ServoControl/Servo.cpp
+++ b/support/hololens/ServoApp/ServoControl/Servo.cpp
@@ -43,7 +43,7 @@ void on_ime_state_changed(bool aShow) {
   sServo->Delegate().OnServoIMEStateChanged(aShow);
 }
 
-void set_clipboard_contents(const char *content) {
+void set_clipboard_contents(const char *) {
   // FIXME
 }
 
@@ -65,6 +65,14 @@ void on_media_session_playback_state_change(
 
 void prompt_alert(const char *message, bool trusted) {
   sServo->Delegate().OnServoPromptAlert(char2hstring(message), trusted);
+}
+
+void show_context_menu(const char *const *items_list, uint32_t items_size) {
+  std::vector<winrt::hstring> items;
+  for (uint32_t i = 0; i < items_size; i++) {
+    items.push_back(char2hstring(items_list[i]));
+  }
+  sServo->Delegate().OnServoShowContextMenu(items);
 }
 
 void on_devtools_started(Servo::DevtoolsServerState result,
@@ -154,6 +162,7 @@ Servo::Servo(hstring url, hstring args, GLsizei width, GLsizei height,
   c.prompt_yes_no = &prompt_yes_no;
   c.prompt_input = &prompt_input;
   c.on_devtools_started = &on_devtools_started;
+  c.show_context_menu = &show_context_menu;
 
   capi::register_panic_handler(&on_panic);
 

--- a/support/hololens/ServoApp/ServoControl/Servo.h
+++ b/support/hololens/ServoApp/ServoControl/Servo.h
@@ -29,6 +29,7 @@ public:
 
   typedef capi::CMouseButton MouseButton;
   typedef capi::CPromptResult PromptResult;
+  typedef capi::CContextMenuResult ContextMenuResult;
   typedef capi::CMediaSessionActionType MediaSessionActionType;
   typedef capi::CMediaSessionPlaybackState MediaSessionPlaybackState;
   typedef capi::CDevtoolsServerState DevtoolsServerState;
@@ -74,6 +75,9 @@ public:
   void SendMediaSessionAction(capi::CMediaSessionActionType action) {
     capi::media_session_action(action);
   }
+  void ContextMenuClosed(capi::CContextMenuResult res, unsigned int idx) {
+    capi::on_context_menu_closed(res, idx);
+  }
 
 private:
   ServoDelegate &mDelegate;
@@ -95,12 +99,13 @@ public:
   virtual bool OnServoAllowNavigation(hstring) = 0;
   virtual void OnServoAnimatingChanged(bool) = 0;
   virtual void OnServoIMEStateChanged(bool) = 0;
-  virtual void OnServoDevtoolsStarted(bool, unsigned int) = 0;
+  virtual void OnServoDevtoolsStarted(bool, const unsigned int) = 0;
   virtual void Flush() = 0;
   virtual void MakeCurrent() = 0;
   virtual void OnServoMediaSessionMetadata(hstring, hstring, hstring) = 0;
   virtual void OnServoMediaSessionPlaybackStateChange(int) = 0;
   virtual void OnServoPromptAlert(hstring, bool) = 0;
+  virtual void OnServoShowContextMenu(std::vector<hstring>) = 0;
   virtual Servo::PromptResult OnServoPromptOkCancel(hstring, bool) = 0;
   virtual Servo::PromptResult OnServoPromptYesNo(hstring, bool) = 0;
   virtual std::optional<hstring> OnServoPromptInput(hstring, hstring, bool) = 0;

--- a/support/hololens/ServoApp/ServoControl/ServoControl.h
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.h
@@ -109,12 +109,13 @@ struct ServoControl : ServoControlT<ServoControl>, public servo::ServoDelegate {
                                            winrt::hstring);
   virtual void OnServoMediaSessionPlaybackStateChange(int);
   virtual void OnServoPromptAlert(winrt::hstring, bool);
+  virtual void OnServoShowContextMenu(std::vector<winrt::hstring>);
   virtual servo::Servo::PromptResult OnServoPromptOkCancel(winrt::hstring,
                                                            bool);
   virtual servo::Servo::PromptResult OnServoPromptYesNo(winrt::hstring, bool);
   virtual std::optional<hstring> OnServoPromptInput(winrt::hstring,
                                                     winrt::hstring, bool);
-  virtual void OnServoDevtoolsStarted(bool success, const unsigned int port);
+  virtual void OnServoDevtoolsStarted(bool, const unsigned int);
 
 private:
   winrt::event<Windows::Foundation::EventHandler<hstring>> mOnURLChangedEvent;


### PR DESCRIPTION
This adds an API for Servo internals to request a context menu to the embedder, along an implement for the UWP port.