### PR TITLE
layout_2020: Use ArcRefCell to track hoisted fragments

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -304,12 +304,15 @@ impl InlineFormattingContext {
                                 },
                             };
                         let hoisted_box = box_.clone().to_hoisted(initial_start_corner, tree_rank);
-                        let hoisted_fragment_id = hoisted_box.fragment_id;
+                        let hoisted_fragment = hoisted_box.fragment.clone();
                         ifc.push_hoisted_box_to_positioning_context(hoisted_box);
                         ifc.current_nesting_level.fragments_so_far.push(
-                            Fragment::AbsoluteOrFixedPositioned(AbsoluteOrFixedPositionedFragment(
-                                hoisted_fragment_id,
-                            )),
+                            Fragment::AbsoluteOrFixedPositioned(
+                                AbsoluteOrFixedPositionedFragment {
+                                    hoisted_fragment,
+                                    position: box_.contents.style.clone_position(),
+                                },
+                            ),
                         );
                     },
                     InlineLevelBox::OutOfFlowFloatBox(_box_) => {
@@ -492,7 +495,6 @@ impl<'box_tree> PartialInlineBoxFragment<'box_tree> {
             self.border.clone(),
             self.margin.clone(),
             CollapsedBlockMargins::zero(),
-            None, // hoisted_fragment_id
         );
         let last_fragment = self.last_box_tree_fragment && !at_line_break;
         if last_fragment {
@@ -560,7 +562,6 @@ fn layout_atomic(
                 border,
                 margin,
                 CollapsedBlockMargins::zero(),
-                None, // hoisted_fragment_id
             )
         },
         Err(non_replaced) => {
@@ -636,7 +637,6 @@ fn layout_atomic(
                 border,
                 margin,
                 CollapsedBlockMargins::zero(),
-                None, // hoisted_fragment_id
             )
         },
     };

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -315,12 +315,13 @@ impl BlockLevelBox {
                 ))
             },
             BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(box_) => {
-                let hoisted_fragment = box_.clone().to_hoisted(Vec2::zero(), tree_rank);
-                let hoisted_fragment_id = hoisted_fragment.fragment_id.clone();
-                positioning_context.push(hoisted_fragment);
-                Fragment::AbsoluteOrFixedPositioned(AbsoluteOrFixedPositionedFragment(
-                    hoisted_fragment_id,
-                ))
+                let hoisted_box = box_.clone().to_hoisted(Vec2::zero(), tree_rank);
+                let hoisted_fragment = hoisted_box.fragment.clone();
+                positioning_context.push(hoisted_box);
+                Fragment::AbsoluteOrFixedPositioned(AbsoluteOrFixedPositionedFragment {
+                    hoisted_fragment,
+                    position: box_.contents.style.clone_position(),
+                })
             },
             BlockLevelBox::OutOfFlowFloatBox(_box_) => {
                 // FIXME: call layout_maybe_position_relative_fragment here
@@ -501,7 +502,6 @@ fn layout_in_flow_non_replaced_block_level(
         border,
         margin,
         block_margins_collapsed_with_children,
-        None, // hoisted_fragment_id
     )
 }
 
@@ -553,7 +553,6 @@ fn layout_in_flow_replaced_block_level<'a>(
         border,
         margin,
         block_margins_collapsed_with_children,
-        None, // hoisted_fragment_id
     )
 }
 

--- a/tests/wpt/mozilla/meta-layout-2020/css/absolute_hypothetical_with_intervening_inline_block_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/absolute_hypothetical_with_intervening_inline_block_a.html.ini
@@ -1,2 +1,0 @@
-[absolute_hypothetical_with_intervening_inline_block_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/list_item_marker_around_float.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/list_item_marker_around_float.html.ini
@@ -1,0 +1,2 @@
+[list_item_marker_around_float.html]
+  expected: FAIL


### PR DESCRIPTION
This avoids the use of lookup tables for containing blocks when
constructing the stacking context tree.

This seems to catch some laid-out hoisted fragments that were otherwise
dropped in the previous design. The changes cause one new test to pass
and one to fail. Visual examination of the failing tests reveals that
it's a progression (list markers are appearing when they were previously
not rendered).

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
