### PR TITLE
layout_2020: Stop throwing away hoisted boxes in nested absolutes

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -736,10 +736,7 @@ impl AbsoluteOrFixedPositionedFragment {
         let hoisted_fragment = self.hoisted_fragment.borrow();
         let fragment_ref = match hoisted_fragment.as_ref() {
             Some(fragment_ref) => fragment_ref,
-            None => {
-                warn!("Found hoisted box with missing fragment.");
-                return;
-            },
+            None => unreachable!("Found hoisted box with missing fragment."),
         };
 
         let containing_block = match self.position {

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -7,8 +7,6 @@
 #![feature(exact_size_is_empty)]
 
 #[macro_use]
-extern crate log;
-#[macro_use]
 extern crate serde;
 
 mod cell;

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -226,8 +226,8 @@ impl PositioningContext {
 
         let mut new_fragment = fragment_layout_fn(&mut new_context);
         new_context.layout_collected_children(layout_context, &mut new_fragment);
-        *for_nearest_containing_block_for_all_descendants =
-            new_context.for_nearest_containing_block_for_all_descendants;
+        for_nearest_containing_block_for_all_descendants
+            .extend(new_context.for_nearest_containing_block_for_all_descendants);
         new_fragment
     }
 


### PR DESCRIPTION
We were previously throwing away some boxes hoisted to containing blocks
for all descendants when they were contained by absolutes. This prevents
panics in existing web platform tests that would otherwise be triggered
by the addition of the `unreachable!` statement.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
