### PR TITLE
Hook up new openxr context menu gesture to embedder context menu machinery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6680,7 +6680,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#72b30f2b70ff7b40dc0ffdeefce1116b24041f3d"
+source = "git+https://github.com/servo/webxr#412f385483ad502320f94d98fe5beabf53d14de7"
 dependencies = [
  "bindgen",
  "crossbeam-channel",
@@ -6702,7 +6702,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#72b30f2b70ff7b40dc0ffdeefce1116b24041f3d"
+source = "git+https://github.com/servo/webxr#412f385483ad502320f94d98fe5beabf53d14de7"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -5,7 +5,7 @@
 //! Abstract windowing methods. The concrete implementations of these can be found in `platform/`.
 
 use canvas::{SurfaceProviders, WebGlExecutor};
-use embedder_traits::EventLoopWaker;
+use embedder_traits::{EmbedderProxy, EventLoopWaker};
 use euclid::Scale;
 #[cfg(feature = "gl")]
 use gleam::gl;
@@ -190,6 +190,7 @@ pub trait EmbedderMethods {
         _: &mut webxr::MainThreadRegistry,
         _: WebGlExecutor,
         _: SurfaceProviders,
+        _: EmbedderProxy,
     ) {
     }
 }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -481,6 +481,7 @@ where
                     &mut webxr_main_thread,
                     webgl_executor,
                     webxr_surface_providers,
+                    embedder_proxy.clone(),
                 );
             }
         }
@@ -521,7 +522,7 @@ where
         let (constellation_chan, sw_senders) = create_constellation(
             opts.user_agent.clone(),
             opts.config_dir.clone(),
-            embedder_proxy.clone(),
+            embedder_proxy,
             compositor_proxy.clone(),
             time_profiler_chan.clone(),
             mem_profiler_chan.clone(),

--- a/ports/glutin/embedder.rs
+++ b/ports/glutin/embedder.rs
@@ -14,7 +14,7 @@ use glutin::EventsLoopClosed;
 use rust_webvr::GlWindowVRService;
 use servo::canvas::{SurfaceProviders, WebGlExecutor};
 use servo::compositing::windowing::EmbedderMethods;
-use servo::embedder_traits::EventLoopWaker;
+use servo::embedder_traits::{EmbedderProxy, EventLoopWaker};
 use servo::servo_config::{opts, pref};
 use servo::webvr::VRServiceManager;
 use servo::webvr_traits::WebVRMainThreadHeartbeat;
@@ -94,7 +94,8 @@ impl EmbedderMethods for EmbedderCallbacks {
         &mut self,
         xr: &mut webxr::MainThreadRegistry,
         _executor: WebGlExecutor,
-        _surface_provider_registration: SurfaceProviders
+        _surface_provider_registration: SurfaceProviders,
+        _embedder_proxy: EmbedderProxy,
     ) {
         if pref!(dom.webxr.test) {
             xr.register_mock(webxr::headless::HeadlessMockDiscovery::new());


### PR DESCRIPTION
Based on https://github.com/servo/servo/pull/26043/

Fixes https://github.com/servo/servo/issues/25797, #26057

https://github.com/servo/webxr/pull/144 needs to land first

Currently when exited the Servo window is blurred, apparently we need to call `Window.Activate` on it.


r? @jdm

cc @paulrouget