### PR TITLE
Fix failing assertion -- failure to pop reference frame

### DIFF
--- a/components/layout/display_list/items.rs
+++ b/components/layout/display_list/items.rs
@@ -195,7 +195,7 @@ pub struct StackingContext {
     /// The clip and scroll info for this StackingContext.
     pub parent_clipping_and_scrolling: ClippingAndScrolling,
 
-    /// The index of the reference frame that this stacking context estalishes.
+    /// The index of the reference frame that this stacking context establishes.
     pub established_reference_frame: Option<ClipScrollNodeIndex>,
 }
 
@@ -261,6 +261,7 @@ impl StackingContext {
         let pop_item = DisplayItem::PopStackingContext(Box::new(PopStackingContextItem {
             base: base_item.clone(),
             stacking_context_id: self.id,
+            established_reference_frame: self.established_reference_frame.is_some(),
         }));
 
         let push_item = DisplayItem::PushStackingContext(Box::new(PushStackingContextItem {
@@ -657,6 +658,8 @@ pub struct PopStackingContextItem {
     pub base: BaseDisplayItem,
 
     pub stacking_context_id: StackingContextId,
+
+    pub established_reference_frame: bool,
 }
 
 /// Starts a group of items inside a particular scroll root.

--- a/components/layout/display_list/webrender_helpers.rs
+++ b/components/layout/display_list/webrender_helpers.rs
@@ -186,7 +186,7 @@ impl DisplayItem {
                 );
                 IsContentful(false)
             },
-            DisplayItem::PushStackingContext(ref mut item) => {
+            DisplayItem::PushStackingContext(ref item) => {
                 let stacking_context = &item.stacking_context;
                 debug_assert_eq!(stacking_context.context_type, StackingContextType::Real);
 
@@ -252,8 +252,11 @@ impl DisplayItem {
                 builder.push_item(&WrDisplayItem::PushStackingContext(wr_item));
                 IsContentful(false)
             },
-            DisplayItem::PopStackingContext(_) => {
+            DisplayItem::PopStackingContext(ref item) => {
                 builder.pop_stacking_context();
+                if item.established_reference_frame {
+                    builder.pop_reference_frame();
+                }
                 IsContentful(false)
             },
             DisplayItem::DefineClipScrollNode(ref mut item) => {

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-sibling-with-3D-transform.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-sibling-with-3D-transform.html.ini
@@ -1,3 +1,0 @@
-[mix-blend-mode-sibling-with-3D-transform.html]
-  type: reftest
-  expected: FAIL


### PR DESCRIPTION
closes #23438, closes #22901

In-depth description here: https://github.com/servo/servo/issues/23438#issuecomment-605553001

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes fix #23438 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___
