### PR TITLE
Don't send empty canvases to WebRender

### DIFF
--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -1875,6 +1875,12 @@ impl Fragment {
                 }
             },
             SpecificFragmentInfo::Canvas(ref canvas_fragment_info) => {
+                if canvas_fragment_info.dom_width == Au(0) ||
+                    canvas_fragment_info.dom_height == Au(0)
+                {
+                    return;
+                }
+
                 let image_key = match canvas_fragment_info.source {
                     CanvasFragmentSource::WebGL(image_key) => image_key,
                     CanvasFragmentSource::Image(ref ipc_renderer) => match *ipc_renderer {

--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -87,6 +87,7 @@ impl Fragment {
                     .rect
                     .to_physical(i.style.writing_mode, containing_block)
                     .translate(containing_block.origin.to_vector());
+
                 let common = builder.common_properties(rect.clone().to_webrender());
                 builder.wr.push_image(
                     &common,

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -102,6 +102,7 @@ impl ReplacedContent {
 
         let width = (intrinsic_size_in_dots.width as CSSFloat) / dppx;
         let height = (intrinsic_size_in_dots.height as CSSFloat) / dppx;
+
         return Some(Self {
             kind,
             intrinsic: IntrinsicSizes {
@@ -201,6 +202,12 @@ impl ReplacedContent {
                 .into_iter()
                 .collect(),
             ReplacedContentKind::Canvas(canvas_info) => {
+                if self.intrinsic.width == Some(Length::zero()) ||
+                    self.intrinsic.height == Some(Length::zero())
+                {
+                    return vec![];
+                }
+
                 let image_key = match canvas_info.source {
                     CanvasSource::WebGL(image_key) => image_key,
                     CanvasSource::Image(ref ipc_renderer) => match *ipc_renderer {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14591,6 +14591,13 @@
       null,
       {}
      ]
+    ],
+    "zero_size_canvas_crash.html": [
+     "45eb9b559e8d6105baca5ab4d336de520d33b36b",
+     [
+      null,
+      {}
+     ]
     ]
    },
    "webxr": {

--- a/tests/wpt/mozilla/tests/mozilla/zero_size_canvas_crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/zero_size_canvas_crash.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Test for #21411: Panic when putting a zero-sized canvas on the display list.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<canvas id="myCanvas" width="0" height="0" style="width:10px; height:10px;"></canvas>
+<script>
+    test(function () {
+        var c = document.getElementById("myCanvas");
+        var ctx = c.getContext("2d");
+        ctx.clearRect(0, 0, c.width, c.height);
+    }, "Doesn't crash when the page has a canvas with a zero-dimension");
+</script>


### PR DESCRIPTION
If any dimension of a canvas is 0, don't try to display it as it causes
problems inside webrender.

Minimal test case available here: https://github.com/servo/servo/issues/21411#issuecomment-605226547

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
