### PR TITLE
Make LayoutNodeHelpers::text_content return a cow

### DIFF
--- a/components/layout/wrapper.rs
+++ b/components/layout/wrapper.rs
@@ -130,7 +130,7 @@ where
             });
         }
 
-        TextContent::Text(self.node_text_content().into_boxed_str())
+        TextContent::Text(self.node_text_content().into_owned().into_boxed_str())
     }
 
     fn restyle_damage(self) -> RestyleDamage {

--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -16,6 +16,7 @@ use crate::style_ext::{ComputedValuesExt, DisplayGeneratingBox, DisplayInside, D
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon_croissant::ParallelIteratorExt;
 use servo_arc::Arc;
+use std::borrow::Cow;
 use std::convert::{TryFrom, TryInto};
 use style::properties::ComputedValues;
 use style::selector_parser::PseudoElement;
@@ -286,7 +287,12 @@ where
         }
     }
 
-    fn handle_text(&mut self, node: Node, input: String, parent_style: &Arc<ComputedValues>) {
+    fn handle_text(
+        &mut self,
+        node: Node,
+        input: Cow<'dom, str>,
+        parent_style: &Arc<ComputedValues>,
+    ) {
         let (leading_whitespace, mut input) = self.handle_leading_whitespace(&input);
         if leading_whitespace || !input.is_empty() {
             // This text node should be pushed either to the next ongoing

--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -67,6 +67,7 @@ use selectors::sink::Push;
 use servo_arc::{Arc, ArcBorrow};
 use servo_atoms::Atom;
 use servo_url::ServoUrl;
+use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
@@ -1110,9 +1111,8 @@ impl<'ln> ThreadSafeLayoutNode<'ln> for ServoThreadSafeLayoutNode<'ln> {
         self.node
     }
 
-    fn node_text_content(&self) -> String {
-        let this = unsafe { self.get_jsmanaged() };
-        return this.text_content();
+    fn node_text_content(self) -> Cow<'ln, str> {
+        unsafe { self.get_jsmanaged().text_content() }
     }
 
     fn selection(&self) -> Option<Range<ByteIndex>> {

--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -828,7 +828,7 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
             .dom_children()
             .all(|node| match node.script_type_id() {
                 NodeTypeId::Element(..) => false,
-                NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::Text)) => unsafe {
+                NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::Text)) => {
                     node.node.downcast().unwrap().data_for_layout().is_empty()
                 },
                 _ => true,

--- a/components/layout_thread_2020/dom_wrapper.rs
+++ b/components/layout_thread_2020/dom_wrapper.rs
@@ -67,6 +67,7 @@ use selectors::sink::Push;
 use servo_arc::{Arc, ArcBorrow};
 use servo_atoms::Atom;
 use servo_url::ServoUrl;
+use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
@@ -1117,9 +1118,8 @@ impl<'ln> ThreadSafeLayoutNode<'ln> for ServoThreadSafeLayoutNode<'ln> {
         self.node
     }
 
-    fn node_text_content(&self) -> String {
-        let this = unsafe { self.get_jsmanaged() };
-        return this.text_content();
+    fn node_text_content(self) -> Cow<'ln, str> {
+        unsafe { self.get_jsmanaged().text_content() }
     }
 
     fn selection(&self) -> Option<Range<ByteIndex>> {

--- a/components/layout_thread_2020/dom_wrapper.rs
+++ b/components/layout_thread_2020/dom_wrapper.rs
@@ -835,7 +835,7 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
             .dom_children()
             .all(|node| match node.script_type_id() {
                 NodeTypeId::Element(..) => false,
-                NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::Text)) => unsafe {
+                NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::Text)) => {
                     node.node.downcast().unwrap().data_for_layout().is_empty()
                 },
                 _ => true,

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -235,9 +235,9 @@ impl Attr {
 #[allow(unsafe_code)]
 pub trait AttrHelpersForLayout<'dom> {
     fn value(self) -> &'dom AttrValue;
-    fn value_ref_forever(self) -> &'dom str;
-    fn value_tokens(self) -> Option<&'dom [Atom]>;
-    fn local_name_atom(self) -> LocalName;
+    fn as_str(self) -> &'dom str;
+    fn as_tokens(self) -> Option<&'dom [Atom]>;
+    fn local_name(self) -> LocalName;
 }
 
 #[allow(unsafe_code)]
@@ -248,12 +248,12 @@ impl<'dom> AttrHelpersForLayout<'dom> for LayoutDom<'dom, Attr> {
     }
 
     #[inline]
-    fn value_ref_forever(self) -> &'dom str {
+    fn as_str(self) -> &'dom str {
         &**self.value()
     }
 
     #[inline]
-    fn value_tokens(self) -> Option<&'dom [Atom]> {
+    fn as_tokens(self) -> Option<&'dom [Atom]> {
         // This transmute is used to cheat the lifetime restriction.
         match *self.value() {
             AttrValue::TokenList(_, ref tokens) => Some(tokens),
@@ -262,7 +262,7 @@ impl<'dom> AttrHelpersForLayout<'dom> for LayoutDom<'dom, Attr> {
     }
 
     #[inline]
-    fn local_name_atom(self) -> LocalName {
+    fn local_name(self) -> LocalName {
         unsafe { self.unsafe_get().identifier.local_name.clone() }
     }
 }

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -238,6 +238,7 @@ pub trait AttrHelpersForLayout<'dom> {
     fn as_str(self) -> &'dom str;
     fn as_tokens(self) -> Option<&'dom [Atom]>;
     fn local_name(self) -> &'dom LocalName;
+    fn namespace(self) -> &'dom Namespace;
 }
 
 #[allow(unsafe_code)]
@@ -264,5 +265,10 @@ impl<'dom> AttrHelpersForLayout<'dom> for LayoutDom<'dom, Attr> {
     #[inline]
     fn local_name(self) -> &'dom LocalName {
         unsafe { &self.unsafe_get().identifier.local_name }
+    }
+
+    #[inline]
+    fn namespace(self) -> &'dom Namespace {
+        unsafe { &self.unsafe_get().identifier.namespace }
     }
 }

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -234,26 +234,26 @@ impl Attr {
 
 #[allow(unsafe_code)]
 pub trait AttrHelpersForLayout<'dom> {
-    unsafe fn value(self) -> &'dom AttrValue;
-    unsafe fn value_ref_forever(self) -> &'dom str;
-    unsafe fn value_tokens(self) -> Option<&'dom [Atom]>;
-    unsafe fn local_name_atom(self) -> LocalName;
+    fn value(self) -> &'dom AttrValue;
+    fn value_ref_forever(self) -> &'dom str;
+    fn value_tokens(self) -> Option<&'dom [Atom]>;
+    fn local_name_atom(self) -> LocalName;
 }
 
 #[allow(unsafe_code)]
 impl<'dom> AttrHelpersForLayout<'dom> for LayoutDom<'dom, Attr> {
     #[inline]
-    unsafe fn value(self) -> &'dom AttrValue {
-        (*self.unsafe_get()).value.borrow_for_layout()
+    fn value(self) -> &'dom AttrValue {
+        unsafe { self.unsafe_get().value.borrow_for_layout() }
     }
 
     #[inline]
-    unsafe fn value_ref_forever(self) -> &'dom str {
+    fn value_ref_forever(self) -> &'dom str {
         &**self.value()
     }
 
     #[inline]
-    unsafe fn value_tokens(self) -> Option<&'dom [Atom]> {
+    fn value_tokens(self) -> Option<&'dom [Atom]> {
         // This transmute is used to cheat the lifetime restriction.
         match *self.value() {
             AttrValue::TokenList(_, ref tokens) => Some(tokens),
@@ -262,7 +262,7 @@ impl<'dom> AttrHelpersForLayout<'dom> for LayoutDom<'dom, Attr> {
     }
 
     #[inline]
-    unsafe fn local_name_atom(self) -> LocalName {
-        (*self.unsafe_get()).identifier.local_name.clone()
+    fn local_name_atom(self) -> LocalName {
+        unsafe { self.unsafe_get().identifier.local_name.clone() }
     }
 }

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -255,7 +255,6 @@ impl<'dom> AttrHelpersForLayout<'dom> for LayoutDom<'dom, Attr> {
 
     #[inline]
     fn as_tokens(self) -> Option<&'dom [Atom]> {
-        // This transmute is used to cheat the lifetime restriction.
         match *self.value() {
             AttrValue::TokenList(_, ref tokens) => Some(tokens),
             _ => None,

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -237,7 +237,7 @@ pub trait AttrHelpersForLayout<'dom> {
     fn value(self) -> &'dom AttrValue;
     fn as_str(self) -> &'dom str;
     fn as_tokens(self) -> Option<&'dom [Atom]>;
-    fn local_name(self) -> LocalName;
+    fn local_name(self) -> &'dom LocalName;
 }
 
 #[allow(unsafe_code)]
@@ -262,7 +262,7 @@ impl<'dom> AttrHelpersForLayout<'dom> for LayoutDom<'dom, Attr> {
     }
 
     #[inline]
-    fn local_name(self) -> LocalName {
-        unsafe { self.unsafe_get().identifier.local_name.clone() }
+    fn local_name(self) -> &'dom LocalName {
+        unsafe { &self.unsafe_get().identifier.local_name }
     }
 }

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -280,16 +280,15 @@ impl CharacterDataMethods for CharacterData {
     }
 }
 
-#[allow(unsafe_code)]
 pub trait LayoutCharacterDataHelpers<'dom> {
-    unsafe fn data_for_layout(self) -> &'dom str;
+    fn data_for_layout(self) -> &'dom str;
 }
 
-#[allow(unsafe_code)]
 impl<'dom> LayoutCharacterDataHelpers<'dom> for LayoutDom<'dom, CharacterData> {
+    #[allow(unsafe_code)]
     #[inline]
-    unsafe fn data_for_layout(self) -> &'dom str {
-        &(*self.unsafe_get()).data.borrow_for_layout()
+    fn data_for_layout(self) -> &'dom str {
+        unsafe { self.unsafe_get().data.borrow_for_layout() }
     }
 }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -578,7 +578,7 @@ pub unsafe fn get_attr_for_layout<'dom>(
         .iter()
         .find(|attr| {
             let attr = attr.to_layout();
-            *name == attr.local_name() && (*attr.unsafe_get()).namespace() == namespace
+            name == attr.local_name() && (*attr.unsafe_get()).namespace() == namespace
         })
         .map(|attr| attr.to_layout())
 }
@@ -610,7 +610,7 @@ impl RawLayoutElementHelpers for Element {
             .iter()
             .filter_map(|attr| {
                 let attr = attr.to_layout();
-                if *name == attr.local_name() {
+                if name == attr.local_name() {
                     Some(attr.value())
                 } else {
                     None

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -578,7 +578,7 @@ pub unsafe fn get_attr_for_layout<'dom>(
         .iter()
         .find(|attr| {
             let attr = attr.to_layout();
-            name == attr.local_name() && (*attr.unsafe_get()).namespace() == namespace
+            name == attr.local_name() && namespace == attr.namespace()
         })
         .map(|attr| attr.to_layout())
 }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -578,7 +578,7 @@ pub unsafe fn get_attr_for_layout<'dom>(
         .iter()
         .find(|attr| {
             let attr = attr.to_layout();
-            *name == attr.local_name_atom() && (*attr.unsafe_get()).namespace() == namespace
+            *name == attr.local_name() && (*attr.unsafe_get()).namespace() == namespace
         })
         .map(|attr| attr.to_layout())
 }
@@ -600,7 +600,7 @@ impl RawLayoutElementHelpers for Element {
         namespace: &Namespace,
         name: &LocalName,
     ) -> Option<&'a str> {
-        get_attr_for_layout(self, namespace, name).map(|attr| attr.value_ref_forever())
+        get_attr_for_layout(self, namespace, name).map(|attr| attr.as_str())
     }
 
     #[inline]
@@ -610,7 +610,7 @@ impl RawLayoutElementHelpers for Element {
             .iter()
             .filter_map(|attr| {
                 let attr = attr.to_layout();
-                if *name == attr.local_name_atom() {
+                if *name == attr.local_name() {
                     Some(attr.value())
                 } else {
                     None
@@ -656,7 +656,7 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
         get_attr_for_layout(&*self.unsafe_get(), &ns!(), &local_name!("class")).map_or(
             false,
             |attr| {
-                attr.value_tokens()
+                attr.as_tokens()
                     .unwrap()
                     .iter()
                     .any(|atom| case_sensitivity.eq_atom(atom, name))
@@ -668,7 +668,7 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
     #[inline]
     unsafe fn get_classes_for_layout(self) -> Option<&'dom [Atom]> {
         get_attr_for_layout(&*self.unsafe_get(), &ns!(), &local_name!("class"))
-            .map(|attr| attr.value_tokens().unwrap())
+            .map(|attr| attr.as_tokens().unwrap())
     }
 
     #[allow(unsafe_code)]

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -56,8 +56,7 @@ pub struct HTMLTextAreaElement {
 }
 
 pub trait LayoutHTMLTextAreaElementHelpers {
-    #[allow(unsafe_code)]
-    unsafe fn value_for_layout(self) -> String;
+    fn value_for_layout(self) -> String;
     #[allow(unsafe_code)]
     unsafe fn selection_for_layout(self) -> Option<Range<usize>>;
     #[allow(unsafe_code)]
@@ -67,19 +66,19 @@ pub trait LayoutHTMLTextAreaElementHelpers {
 }
 
 impl LayoutHTMLTextAreaElementHelpers for LayoutDom<'_, HTMLTextAreaElement> {
-    #[allow(unrooted_must_root)]
     #[allow(unsafe_code)]
-    unsafe fn value_for_layout(self) -> String {
-        let text = (*self.unsafe_get())
-            .textinput
-            .borrow_for_layout()
-            .get_content();
-        if text.is_empty() {
-            (*self.unsafe_get())
-                .placeholder
+    fn value_for_layout(self) -> String {
+        let text = unsafe {
+            self.unsafe_get()
+                .textinput
                 .borrow_for_layout()
-                .replace("\r\n", "\n")
-                .replace("\r", "\n")
+                .get_content()
+        };
+        if text.is_empty() {
+            let placeholder = unsafe { self.unsafe_get().placeholder.borrow_for_layout() };
+            // FIXME(nox): Would be cool to not allocate a new string if the
+            // placeholder is single line, but that's an unimportant detail.
+            placeholder.replace("\r\n", "\n").replace("\r", "\n").into()
         } else {
             text.into()
         }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1463,7 +1463,7 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
         }
 
         if let Some(input) = self.downcast::<HTMLInputElement>() {
-            return unsafe { input.value_for_layout() };
+            return input.value_for_layout().into_owned();
         }
 
         if let Some(area) = self.downcast::<HTMLTextAreaElement>() {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1456,10 +1456,9 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
         val
     }
 
-    #[allow(unsafe_code)]
     fn text_content(self) -> String {
         if let Some(text) = self.downcast::<Text>() {
-            return unsafe { text.upcast().data_for_layout().to_owned() };
+            return text.upcast().data_for_layout().to_owned();
         }
 
         if let Some(input) = self.downcast::<HTMLInputElement>() {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -87,7 +87,7 @@ use servo_arc::Arc;
 use servo_atoms::Atom;
 use servo_url::ServoUrl;
 use smallvec::SmallVec;
-use std::borrow::ToOwned;
+use std::borrow::Cow;
 use std::cell::{Cell, UnsafeCell};
 use std::cmp;
 use std::default::Default;
@@ -1326,7 +1326,7 @@ pub trait LayoutNodeHelpers<'dom> {
     unsafe fn init_style_and_layout_data(self, _: OpaqueStyleAndLayoutData);
     unsafe fn take_style_and_layout_data(self) -> OpaqueStyleAndLayoutData;
 
-    fn text_content(self) -> String;
+    fn text_content(self) -> Cow<'dom, str>;
     fn selection(self) -> Option<Range<usize>>;
     fn image_url(self) -> Option<ServoUrl>;
     fn image_density(self) -> Option<f64>;
@@ -1456,17 +1456,17 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
         val
     }
 
-    fn text_content(self) -> String {
+    fn text_content(self) -> Cow<'dom, str> {
         if let Some(text) = self.downcast::<Text>() {
-            return text.upcast().data_for_layout().to_owned();
+            return text.upcast().data_for_layout().into();
         }
 
         if let Some(input) = self.downcast::<HTMLInputElement>() {
-            return input.value_for_layout().into_owned();
+            return input.value_for_layout();
         }
 
         if let Some(area) = self.downcast::<HTMLTextAreaElement>() {
-            return area.value_for_layout();
+            return area.value_for_layout().into();
         }
 
         panic!("not text!")

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1467,7 +1467,7 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
         }
 
         if let Some(area) = self.downcast::<HTMLTextAreaElement>() {
-            return unsafe { area.value_for_layout() };
+            return area.value_for_layout();
         }
 
         panic!("not text!")

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -17,6 +17,7 @@ use net_traits::image::base::{Image, ImageMetadata};
 use range::Range;
 use servo_arc::Arc;
 use servo_url::ServoUrl;
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::sync::Arc as StdArc;
 use style::attr::AttrValue;
@@ -262,7 +263,7 @@ pub trait ThreadSafeLayoutNode<'dom>:
     /// data flags, and we have this annoying trait separation between script and layout :-(
     unsafe fn unsafe_get(self) -> Self::ConcreteNode;
 
-    fn node_text_content(&self) -> String;
+    fn node_text_content(self) -> Cow<'dom, str>;
 
     /// If the insertion point is within this node, returns it. Otherwise, returns `None`.
     fn selection(&self) -> Option<Range<ByteIndex>>;


### PR DESCRIPTION
What does it mean? It means that layout can process `Text` nodes' contents by just borrowing them, potentially saving us from a lot of unnecessary tempoorary allocations, which is nice.