### PR TITLE
Ensure reference frame is popped in layout 2020

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -522,6 +522,10 @@ impl BoxFragment {
                 StackingContextBuildMode::SkipHoisted,
             );
         }
+
+        if established_reference_frame {
+            builder.wr.pop_reference_frame();
+        }
     }
 
     fn adjust_spatial_id_for_positioning(&self, builder: &mut StackingContextBuilder) {


### PR DESCRIPTION
closes: #26066

Should be equivalent to https://github.com/servo/servo/pull/26063 for layout2020

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes fix #26066 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___