### PR TITLE
Avoid infinitely looping CSS transitions.

### DIFF
--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -110,6 +110,7 @@ pub fn update_animation_state<E>(
                     .unwrap();
             }
 
+            debug!("expiring animation for {:?}", running_animation);
             expired_animations
                 .entry(*key)
                 .or_insert_with(Vec::new)

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -607,7 +607,12 @@ trait PrivateMatchMethods: TElement {
 
         // Finish any expired transitions.
         let this_opaque = self.as_node().opaque();
-        animation::complete_expired_transitions(this_opaque, style, context);
+        animation::complete_expired_transitions(
+            this_opaque,
+            style,
+            context,
+            possibly_expired_animations,
+        );
 
         // Merge any running animations into the current style, and cancel them.
         let had_running_animations = context

--- a/tests/wpt/mozilla/meta-layout-2020/css/transitionend_event.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/transitionend_event.html.ini
@@ -1,0 +1,4 @@
+[transitionend_event.html]
+  expected: TIMEOUT
+  [transitionend_event]
+    expected: TIMEOUT

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13031,6 +13031,13 @@
       {}
      ]
     ],
+    "transitionend_event.html": [
+     "71b88117a0280fbffcf3ab77105c0460317c66c8",
+     [
+      null,
+      {}
+     ]
+    ],
     "white-space-pre-line-long-line.html": [
      "bf0d0085fef0f1639637b2e652a7fb857cd51bf6",
      [

--- a/tests/wpt/mozilla/tests/css/transitionend_event.html
+++ b/tests/wpt/mozilla/tests/css/transitionend_event.html
@@ -1,0 +1,27 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #test {
+    width: 10px;
+    height: 10px;
+    background: black;
+    transition: 1ms linear transform;
+  }
+  .transform {
+    transform:scale(1.2);
+  }
+</style>
+<div id="test" class="transform"></div>
+<script>
+  async_test(function(t) {
+      let d = document.querySelector('div');
+      // Verify that we only receive a single transitionend event once the transition is complete.
+      d.ontransitionend = t.step_func(() => {
+          d.ontransitionend = t.unreached_func();
+          t.step_timeout(() => t.done(), 100);
+      });
+      t.step_timeout(() => d.className = "", 10);
+  });
+</script>


### PR DESCRIPTION
This change addresses the long-standing issue of CSS transitions not ending appropriately. It does not fundamentally change the way we process transitions/animations.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #20379
- [x] There are tests for these changes