### PR TITLE
Reduce unnecessary layout queries in babylon.js content

### DIFF
--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -9,6 +9,8 @@ use crate::dom::customelementregistry::{
 use crate::dom::mutationobserver::RegisteredObserver;
 use crate::dom::node::UniqueId;
 use crate::dom::shadowroot::ShadowRoot;
+use crate::dom::window::LayoutValue;
+use euclid::default::Rect;
 use servo_atoms::Atom;
 use std::rc::Rc;
 
@@ -46,4 +48,6 @@ pub struct ElementRareData {
     /// The "name" content attribute; not used as frequently as id, but used
     /// in named getter loops so it's worth looking up quickly when present
     pub name_attribute: Option<Atom>,
+    /// The client rect reported by layout.
+    pub client_rect: Option<LayoutValue<Rect<i32>>>,
 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3709,7 +3709,7 @@ impl ScriptThread {
             new_size
         );
         window.set_window_size(new_size);
-        window.force_reflow(ReflowGoal::Full, ReflowReason::WindowResize);
+        window.force_reflow(ReflowGoal::Full, ReflowReason::WindowResize, None);
 
         // http://dev.w3.org/csswg/cssom-view/#resizing-viewports
         if size_type == WindowSizeType::Resize {


### PR DESCRIPTION
Every frame, Babylon.js compares the width property of the webgl canvas element to its clientWidth. This incurs two layout operations every frame - one to get the dimensions of the element, and at the end of the frame to construct a display list and send that to webrender.

These changes introduce the concept of cached layout values which are constructed from the result of layout queries. These cached values are automatically invalidated when a new layout operation takes place, but as long as only the query operations that stored a cached value are used and the DOM is not otherwise dirtied, the cached values will remain valid and no further layout operations will take place. 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix (part of) #26019
- [x] These changes do not require tests because we have no infrastructure to test whether or not reflow occurred.