### PR TITLE
webgl: Don't dirty canvas element while in immersive mode.

### DIFF
--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -59,6 +59,10 @@ impl Navigator {
     pub fn new(window: &Window) -> DomRoot<Navigator> {
         reflect_dom_object(Box::new(Navigator::new_inherited()), window)
     }
+
+    pub fn xr(&self) -> Option<DomRoot<XRSystem>> {
+        self.xr.get()
+    }
 }
 
 impl NavigatorMethods for Navigator {

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -502,6 +502,12 @@ impl WebGLRenderingContext {
             return;
         }
 
+        // Dirtying the canvas is unnecessary if we're actively displaying immersive
+        // XR content right now.
+        if self.global().as_window().in_immersive_xr_session() {
+            return;
+        }
+
         self.canvas
             .upcast::<Node>()
             .dirty(NodeDamage::OtherNodeDamage);

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2225,6 +2225,14 @@ impl Window {
     pub fn webrender_document(&self) -> DocumentId {
         self.webrender_document
     }
+
+    pub fn in_immersive_xr_session(&self) -> bool {
+        self.navigator
+            .get()
+            .as_ref()
+            .and_then(|nav| nav.xr())
+            .map_or(false, |xr| xr.pending_or_active_session())
+    }
 }
 
 impl Window {


### PR DESCRIPTION
There are various WebGL APIs that are supposed to trigger a frame composite at the end of the event loop when they're used. We enforce this via dirtying the canvas element and ensuring that reflow occurs for normal content. This is redundant when we're using immersive mode and incurs extra work by the layout thread and compositor that inhibits the immersive rendering performance.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix (part of) #26019
- [x] These changes do not require tests because we do not have infrastructure to test immersive mode on CI.