### PR TITLE
webgl: Avoid IPC for drawingBufferWidth/Height APIs

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1528,21 +1528,13 @@ impl WebGLImpl {
                     &*data,
                 );
             },
-            WebGLCommand::DrawingBufferWidth(ref sender) => {
+            WebGLCommand::DrawingBufferSize(ref sender) => {
                 let size = device
                     .context_surface_info(&ctx)
                     .unwrap()
                     .expect("Where's the front buffer?")
                     .size;
-                sender.send(size.width).unwrap()
-            },
-            WebGLCommand::DrawingBufferHeight(ref sender) => {
-                let size = device
-                    .context_surface_info(&ctx)
-                    .unwrap()
-                    .expect("Where's the front buffer?")
-                    .size;
-                sender.send(size.height).unwrap()
+                sender.send(size).unwrap()
             },
             WebGLCommand::Finish(ref sender) => Self::finish(gl, sender),
             WebGLCommand::Flush => gl.flush(),

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -438,8 +438,7 @@ pub enum WebGLCommand {
         format: u32,
         data: TruncatedDebug<IpcSharedMemory>,
     },
-    DrawingBufferWidth(WebGLSender<i32>),
-    DrawingBufferHeight(WebGLSender<i32>),
+    DrawingBufferSize(WebGLSender<Size2D<i32>>),
     Finish(WebGLSender<()>),
     Flush,
     GenerateMipmap(u32),
@@ -674,6 +673,15 @@ pub enum WebGLOpaqueFramebufferId {
 pub enum WebGLFramebufferId {
     Transparent(WebGLTransparentFramebufferId),
     Opaque(WebGLOpaqueFramebufferId),
+}
+
+impl WebGLFramebufferId {
+    pub fn is_opaque(&self) -> bool {
+        match self {
+            WebGLFramebufferId::Opaque(_) => true,
+            WebGLFramebufferId::Transparent(_) => false,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
In the common case, there is no need to fetch the current webgl context's surface size every time these APIs are used. We only expect the values to change when the canvas is resized, or when an opaque framebuffer is bound, or the default framebuffer is bound when an opaque framebuffer was previously bound. We can store any previously determined surface size otherwise, and report it without any IPC.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #20530
- [x] There are tests for these changes