### PR TITLE
Add support for Debian in mach bootstrap

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -64,7 +64,7 @@ def run_as_root(command, force=False):
 def install_linux_deps(context, pkgs_ubuntu, pkgs_fedora, force):
     install = False
     pkgs = []
-    if context.distro == 'Ubuntu':
+    if context.distro in ['Ubuntu', 'Debian GNU/Linux']:
         command = ['apt-get', 'install']
         pkgs = pkgs_ubuntu
         if subprocess.call(['dpkg', '-s'] + pkgs, stdout=PIPE, stderr=PIPE) != 0:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Run apt-get commands (as written for Ubuntu), when `context.distro` is 'Debian GNU/Linux'.

This makes `./mach bootstrap` install dependencies on Debian.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #26080 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

No test is included, I'm unsure how I would add one, since the changes are distro-dependant.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
