### PR TITLE
Extract user_agent from global opts and allow embedder to provide user agent string

### DIFF
--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -193,6 +193,11 @@ pub trait EmbedderMethods {
         _: EmbedderProxy,
     ) {
     }
+
+    /// Returns the user agent string to report in network requests.
+    fn get_user_agent_string(&self) -> Option<String> {
+        None
+    }
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -166,7 +166,7 @@ use servo_config::{opts, pref};
 use servo_rand::{random, Rng, ServoRng, SliceRandom};
 use servo_remutex::ReentrantMutex;
 use servo_url::{Host, ImmutableOrigin, ServoUrl};
-use std::borrow::ToOwned;
+use std::borrow::{Cow, ToOwned};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::marker::PhantomData;
@@ -503,6 +503,9 @@ pub struct Constellation<Message, LTF, STF, SWF> {
 
     /// Pipeline ID of the active media session.
     active_media_session: Option<PipelineId>,
+
+    /// User agent string to report in network requests.
+    user_agent: Cow<'static, str>,
 }
 
 /// State needed to construct a constellation.
@@ -562,6 +565,9 @@ pub struct InitialConstellationState {
 
     /// A flag share with the compositor to indicate that a WR frame is in progress.
     pub pending_wr_frame: Arc<AtomicBool>,
+
+    /// User agent string to report in network requests.
+    pub user_agent: Cow<'static, str>,
 }
 
 /// Data needed for webdriver
@@ -1021,6 +1027,7 @@ where
                     player_context: state.player_context,
                     event_loop_waker: state.event_loop_waker,
                     active_media_session: None,
+                    user_agent: state.user_agent,
                 };
 
                 constellation.run();
@@ -1268,6 +1275,7 @@ where
             webxr_registry: self.webxr_registry.clone(),
             player_context: self.player_context.clone(),
             event_loop_waker: self.event_loop_waker.as_ref().map(|w| (*w).clone_box()),
+            user_agent: self.user_agent.clone(),
         });
 
         let pipeline = match result {

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -41,6 +41,7 @@ use script_traits::{ScriptThreadFactory, TimerSchedulerMsg, WindowSizeData};
 use servo_config::opts::{self, Opts};
 use servo_config::{prefs, prefs::PrefValue};
 use servo_url::ServoUrl;
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::atomic::AtomicBool;
@@ -201,6 +202,9 @@ pub struct InitialPipelineState {
 
     /// Mechanism to force the compositor to process events.
     pub event_loop_waker: Option<Box<dyn EventLoopWaker>>,
+
+    /// User agent string to report in network requests.
+    pub user_agent: Cow<'static, str>,
 }
 
 pub struct NewPipeline {
@@ -304,6 +308,7 @@ impl Pipeline {
                     webvr_chan: state.webvr_chan,
                     webxr_registry: state.webxr_registry,
                     player_context: state.player_context,
+                    user_agent: state.user_agent,
                 };
 
                 // Spawn the child process.
@@ -520,6 +525,7 @@ pub struct UnprivilegedPipelineContent {
     webvr_chan: Option<IpcSender<WebVRMsg>>,
     webxr_registry: webxr_api::Registry,
     player_context: WindowGLContext,
+    user_agent: Cow<'static, str>,
 }
 
 impl UnprivilegedPipelineContent {
@@ -588,7 +594,7 @@ impl UnprivilegedPipelineContent {
             self.opts.userscripts,
             self.opts.headless,
             self.opts.replace_surrogates,
-            self.opts.user_agent,
+            self.user_agent,
         );
 
         LTF::create(

--- a/ports/glutin/app.rs
+++ b/ports/glutin/app.rs
@@ -40,6 +40,7 @@ impl App {
         use_msaa: bool,
         no_native_titlebar: bool,
         device_pixels_per_px: Option<f32>,
+        user_agent: Option<String>,
     ) {
         let events_loop = EventsLoop::new(opts::get().headless);
 
@@ -70,7 +71,7 @@ impl App {
         // Handle browser state.
         let browser = Browser::new(window.clone());
 
-        let mut servo = Servo::new(embedder, window.clone());
+        let mut servo = Servo::new(embedder, window.clone(), user_agent);
         let browser_id = BrowserId::new();
         servo.handle_events(vec![WindowEvent::NewBrowser(get_default_url(), browser_id)]);
         servo.setup_logging();

--- a/ports/glutin/main2.rs
+++ b/ports/glutin/main2.rs
@@ -104,6 +104,12 @@ pub fn main() {
     opts.optflag("", "msaa", "Use multisample antialiasing in WebRender.");
     opts.optflag("b", "no-native-titlebar", "Do not use native titlebar");
     opts.optopt("", "device-pixel-ratio", "Device pixels per px", "");
+    opts.optopt(
+        "u",
+        "user-agent",
+        "Set custom user agent string (or ios / android / desktop for platform default)",
+        "NCSA Mosaic/1.0 (X11;SunOS 4.1.4 sun4m)",
+    );
 
     let opts_matches;
     let content_process_token;
@@ -173,12 +179,20 @@ pub fn main() {
     let use_msaa = opts_matches.opt_present("msaa");
     let device_pixels_per_px = opts_matches.opt_str("device-pixel-ratio").map(|dppx_str| {
         dppx_str.parse().unwrap_or_else(|err| {
-            error!( "Error parsing option: --device-pixel-ratio ({})", err);
+            error!("Error parsing option: --device-pixel-ratio ({})", err);
             process::exit(1);
         })
     });
+    let user_agent = opts_matches.opt_str("u");
 
-    App::run(angle, enable_vsync, use_msaa, do_not_use_native_titlebar, device_pixels_per_px);
+    App::run(
+        angle,
+        enable_vsync,
+        use_msaa,
+        do_not_use_native_titlebar,
+        device_pixels_per_px,
+        user_agent,
+    );
 
     platform::deinit(clean_shutdown)
 }

--- a/ports/gstplugin/servowebsrc.rs
+++ b/ports/gstplugin/servowebsrc.rs
@@ -205,7 +205,7 @@ impl ServoThread {
         let window = Rc::new(ServoWebSrcWindow::new(connection, version));
         let swap_chain = window.swap_chain.clone();
         let gfx = window.gfx.clone();
-        let mut servo = Servo::new(embedder, window);
+        let mut servo = Servo::new(embedder, window, None);
         let id = TopLevelBrowsingContextId::new();
         servo.handle_events(vec![WindowEvent::NewBrowser(url, id)]);
 

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -235,7 +235,7 @@ pub fn init(
         gl: gl.clone(),
     });
 
-    let servo = Servo::new(embedder_callbacks, window_callbacks.clone());
+    let servo = Servo::new(embedder_callbacks, window_callbacks.clone(), None);
 
     SERVO.with(|s| {
         let mut servo_glue = ServoGlue {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25646
- [x] These changes do not require tests because these are refactoring changes and I'm assuming that existing tests cover these changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
