### PR TITLE
Check the BHM option before starting it in multi-process mode.

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1016,8 +1016,11 @@ pub fn run_content_process(token: String) {
         create_sandbox();
     }
 
-    let background_hang_monitor_register =
-        unprivileged_content.register_with_background_hang_monitor();
+    let background_hang_monitor_register = if opts::get().background_hang_monitor {
+        unprivileged_content.register_with_background_hang_monitor()
+    } else {
+        None
+    };
 
     // send the required channels to the service worker manager
     let sw_senders = unprivileged_content.swmanager_senders();


### PR DESCRIPTION
In multi-process mode, if the BHM option is set start with one otherwise don't.

I didn't add a test for this. However if I should I'd be happy to be pointed to where similar tests are done (meaning tests of options yielding the expected state) because I didn't find my way in all those tests.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #26088 

- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they are minor enough to not require one.
