### PR TITLE
Update checking origin trustworthy align to spec

### DIFF
--- a/components/script/dom/urlhelper.rs
+++ b/components/script/dom/urlhelper.rs
@@ -74,14 +74,19 @@ impl UrlHelper {
     }
     // https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy
     pub fn is_origin_trustworthy(url: &ServoUrl) -> bool {
+        // Step 1
+        if !url.origin().is_tuple() {
+            return false;
+        }
+
         // Step 3
-        if url.scheme() == "http" || url.scheme() == "wss" {
+        if url.scheme() == "https" || url.scheme() == "wss" {
             true
         // Step 4
         } else if url.host().is_some() {
             let host = url.host_str().unwrap();
             host == "127.0.0.0/8" || host == "::1/128"
-        // Step 5
+        // Step 6
         } else {
             url.scheme() == "file"
         }

--- a/tests/wpt/mozilla/meta-layout-2020/mozilla/service-workers/service-worker-registration.https.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/mozilla/service-workers/service-worker-registration.https.html.ini
@@ -1,4 +1,4 @@
-[service-worker-registration.html]
+[service-worker-registration.https.html]
   [Test: Throws Error when Invalid Scope]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14273,8 +14273,8 @@
      ]
     ],
     "service-workers": {
-     "service-worker-registration.html": [
-      "da46088ca92d8706c40a48fdb3805aaf28bbddd5",
+     "service-worker-registration.https.html": [
+      "949992e45de6858c336936b4f1ea4bca76db1d91",
       [
        null,
        {}

--- a/tests/wpt/mozilla/tests/mozilla/service-workers/service-worker-registration.https.html
+++ b/tests/wpt/mozilla/tests/mozilla/service-workers/service-worker-registration.https.html
@@ -16,7 +16,7 @@ test(function (){
 
 promise_test(function() {
   return register_sw('resources/sw.js').then(function(sw_reg) {
-    assert_equals(sw_reg.active.scriptURL, location.href.replace("service-worker-registration.html", "resources/sw.js"));
+    assert_equals(sw_reg.active.scriptURL, location.href.replace("service-worker-registration.https.html", "resources/sw.js"));
   });
 }, "Test: Active Service Worker ScriptURL property");
 
@@ -30,7 +30,7 @@ promise_test(function() {
 
 promise_test(function() {
   return register_sw('resources/sw.js', './').then(function(sw_reg) {
-    assert_equals(sw_reg.scope, location.href.replace("service-worker-registration.html", ""));
+    assert_equals(sw_reg.scope, location.href.replace("service-worker-registration.https.html", ""));
   });
 }, "Test: Service Worker Registration property scope Url when no scope");
 


### PR DESCRIPTION
While reading the [spec of ` Is origin potentially trustworthy? `](https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy), I found our second step is wrong; then, I found Josh said we didn't check it with `https` because we didn't support https in tests yet (https://github.com/servo/servo/pull/13574#discussion_r89346191).

IIRC, we've supported https wpt tests now so it might be fine to change it to align with spec.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
