### PR TITLE
layout_2020: Properly handle HTML element background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2931,6 +2931,7 @@ version = "0.0.1"
 dependencies = [
  "app_units",
  "atomic_refcell",
+ "bitflags",
  "canvas_traits",
  "cssparser",
  "embedder_traits",

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 [dependencies]
 app_units = "0.7"
 atomic_refcell = "0.1.6"
+bitflags = "1.0"
 canvas_traits = {path = "../canvas_traits"}
 cssparser = "0.27"
 embedder_traits = {path = "../embedder_traits"}

--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -432,6 +432,7 @@ where
                 first_fragment: true,
                 last_fragment: false,
                 children: vec![],
+                flags: node.get_node_flags(),
             });
 
             // `unwrap` doesn’t panic here because `is_replaced` returned `false`.
@@ -492,6 +493,7 @@ where
                         // are obviously not the last fragment.
                         last_fragment: false,
                         children: std::mem::take(&mut ongoing.children),
+                        flags: ongoing.flags,
                     };
                     ongoing.first_fragment = false;
                     fragmented
@@ -699,6 +701,7 @@ where
                     tag: node.as_opaque(),
                     contents,
                     style,
+                    flags: node.get_node_flags(),
                 });
                 (block_level_box, contains_floats)
             },

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -4,6 +4,7 @@
 
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
+use crate::dom_traversal::NodeFlags;
 use crate::flow::float::FloatBox;
 use crate::flow::FlowLayout;
 use crate::formatting_contexts::IndependentFormattingContext;
@@ -53,6 +54,7 @@ pub(crate) struct InlineBox {
     pub first_fragment: bool,
     pub last_fragment: bool,
     pub children: Vec<ArcRefCell<InlineLevelBox>>,
+    pub flags: NodeFlags,
 }
 
 /// https://www.w3.org/TR/css-display-3/#css-text-run
@@ -85,6 +87,7 @@ struct PartialInlineBoxFragment<'box_tree> {
     border: Sides<Length>,
     margin: Sides<Length>,
     last_box_tree_fragment: bool,
+    flags: NodeFlags,
     parent_nesting_level: InlineNestingLevelState<'box_tree>,
 }
 
@@ -451,6 +454,7 @@ impl InlineBox {
             border,
             margin,
             last_box_tree_fragment: self.last_fragment,
+            flags: self.flags,
             parent_nesting_level: std::mem::replace(
                 &mut ifc.current_nesting_level,
                 InlineNestingLevelState {
@@ -493,6 +497,7 @@ impl<'box_tree> PartialInlineBoxFragment<'box_tree> {
             self.border.clone(),
             self.margin.clone(),
             CollapsedBlockMargins::zero(),
+            self.flags,
         );
         let last_fragment = self.last_box_tree_fragment && !at_line_break;
         if last_fragment {
@@ -555,6 +560,7 @@ fn layout_atomic(
                 pbm.border,
                 margin,
                 CollapsedBlockMargins::zero(),
+                atomic.flags,
             )
         },
         Err(non_replaced) => {
@@ -626,6 +632,7 @@ fn layout_atomic(
                 pbm.border,
                 margin,
                 CollapsedBlockMargins::zero(),
+                atomic.flags,
             )
         },
     };

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -197,6 +197,7 @@ impl BoxTreeRoot {
 impl FragmentTreeRoot {
     pub fn build_display_list(&self, builder: &mut crate::display_list::DisplayListBuilder) {
         let mut stacking_context = StackingContext::create_root();
+
         {
             let mut stacking_context_builder = StackingContextBuilder::new(&mut builder.wr);
             let containing_block_info = ContainingBlockInfo {
@@ -217,6 +218,8 @@ impl FragmentTreeRoot {
                     StackingContextBuildMode::SkipHoisted,
                 );
             }
+
+            builder.root_canvas_style = stacking_context_builder.root_canvas_style.take();
         }
 
         stacking_context.sort();

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::context::LayoutContext;
-use crate::dom_traversal::{Contents, NodeExt};
+use crate::dom_traversal::{Contents, NodeExt, NodeFlags};
 use crate::flow::BlockFormattingContext;
 use crate::fragments::Fragment;
 use crate::positioned::PositioningContext;
@@ -29,6 +29,8 @@ pub(crate) struct IndependentFormattingContext {
     pub content_sizes: BoxContentSizes,
 
     contents: IndependentFormattingContextContents,
+
+    pub flags: NodeFlags,
 }
 
 pub(crate) struct IndependentLayout {
@@ -81,6 +83,7 @@ impl IndependentFormattingContext {
                         style,
                         content_sizes,
                         contents: IndependentFormattingContextContents::Flow(bfc),
+                        flags: node.get_node_flags(),
                     }
                 },
             },
@@ -91,6 +94,7 @@ impl IndependentFormattingContext {
                     style,
                     content_sizes,
                     contents: IndependentFormattingContextContents::Replaced(replaced),
+                    flags: node.get_node_flags(),
                 }
             },
         }

--- a/components/layout_2020/fragments.rs
+++ b/components/layout_2020/fragments.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::cell::ArcRefCell;
+use crate::dom_traversal::NodeFlags;
 use crate::geom::flow_relative::{Rect, Sides};
 use crate::geom::{PhysicalPoint, PhysicalRect};
 #[cfg(debug_assertions)]
@@ -60,6 +61,9 @@ pub(crate) struct BoxFragment {
 
     /// The scrollable overflow of this box fragment.
     pub scrollable_overflow_from_children: PhysicalRect<Length>,
+
+    /// Node flags of the node that this fragment belongs to.
+    pub flags: NodeFlags,
 }
 
 #[derive(Serialize)]
@@ -276,6 +280,7 @@ impl BoxFragment {
         border: Sides<Length>,
         margin: Sides<Length>,
         block_margins_collapsed_with_children: CollapsedBlockMargins,
+        flags: NodeFlags,
     ) -> BoxFragment {
         // FIXME(mrobinson, bug 25564): We should be using the containing block
         // here to properly convert scrollable overflow to physical geometry.
@@ -298,6 +303,7 @@ impl BoxFragment {
             margin,
             block_margins_collapsed_with_children,
             scrollable_overflow_from_children,
+            flags,
         }
     }
 

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -7,6 +7,8 @@
 #![feature(exact_size_is_empty)]
 
 #[macro_use]
+extern crate bitflags;
+#[macro_use]
 extern crate serde;
 
 mod cell;

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -554,6 +554,7 @@ impl HoistedAbsolutelyPositionedBox {
                     pbm.border,
                     margin,
                     CollapsedBlockMargins::zero(),
+                    self.absolutely_positioned_box.contents.flags,
                 )
             },
         )

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -10,6 +10,7 @@ use style::computed_values::position::T as ComputedPosition;
 use style::computed_values::transform_style::T as ComputedTransformStyle;
 use style::properties::longhands::box_sizing::computed_value::T as BoxSizing;
 use style::properties::ComputedValues;
+use style::values::computed::image::ImageLayer as ComputedImageLayer;
 use style::values::computed::{Length, LengthPercentage};
 use style::values::computed::{NonNegativeLengthPercentage, Size};
 use style::values::generics::box_::Perspective;
@@ -88,6 +89,7 @@ pub(crate) trait ComputedValuesExt {
     fn establishes_stacking_context(&self) -> bool;
     fn establishes_containing_block(&self) -> bool;
     fn establishes_containing_block_for_all_descendants(&self) -> bool;
+    fn has_nontransparent_background(&self) -> bool;
 }
 
 impl ComputedValuesExt for ComputedValues {
@@ -360,6 +362,24 @@ impl ComputedValuesExt for ComputedValues {
 
         // TODO: We need to handle CSS Contain here.
         false
+    }
+
+    /// Whether or not this style specifies a non-transparent background.
+    fn has_nontransparent_background(&self) -> bool {
+        let background = self.get_background();
+        let color = self.resolve_color(background.background_color);
+        if color.alpha > 0 {
+            return true;
+        }
+
+        background
+            .background_image
+            .0
+            .iter()
+            .any(|layer| match layer {
+                ComputedImageLayer::None => false,
+                _ => true,
+            })
     }
 }
 

--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -1074,6 +1074,24 @@ impl<'ln> ThreadSafeLayoutNode<'ln> for ServoThreadSafeLayoutNode<'ln> {
         }
     }
 
+    fn is_body_element_for_layout(&self) -> bool {
+        unsafe {
+            self.get_jsmanaged()
+                .downcast::<Element>()
+                .map(|element| element.is_body_element_for_layout())
+                .unwrap_or(false)
+        }
+    }
+
+    fn is_html_element_for_layout(&self) -> bool {
+        unsafe {
+            self.get_jsmanaged()
+                .downcast::<Element>()
+                .map(|element| element.is_html_element_for_layout())
+                .unwrap_or(false)
+        }
+    }
+
     unsafe fn unsafe_get(self) -> Self::ConcreteNode {
         self.node
     }

--- a/components/layout_thread_2020/dom_wrapper.rs
+++ b/components/layout_thread_2020/dom_wrapper.rs
@@ -1082,6 +1082,24 @@ impl<'ln> ThreadSafeLayoutNode<'ln> for ServoThreadSafeLayoutNode<'ln> {
         }
     }
 
+    fn is_body_element_for_layout(&self) -> bool {
+        unsafe {
+            self.get_jsmanaged()
+                .downcast::<Element>()
+                .map(|element| element.is_body_element_for_layout())
+                .unwrap_or(false)
+        }
+    }
+
+    fn is_html_element_for_layout(&self) -> bool {
+        unsafe {
+            self.get_jsmanaged()
+                .downcast::<Element>()
+                .map(|element| element.is_html_element_for_layout())
+                .unwrap_or(false)
+        }
+    }
+
     unsafe fn unsafe_get(self) -> Self::ConcreteNode {
         self.node
     }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1273,6 +1273,8 @@ pub trait LayoutNodeHelpers<'dom> {
     fn prev_sibling_ref(self) -> Option<LayoutDom<'dom, Node>>;
     fn next_sibling_ref(self) -> Option<LayoutDom<'dom, Node>>;
 
+    fn is_root(self) -> bool;
+
     fn owner_doc_for_layout(self) -> LayoutDom<'dom, Document>;
     fn containing_shadow_root_for_layout(self) -> Option<LayoutDom<'dom, ShadowRoot>>;
 
@@ -1352,6 +1354,12 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
     #[allow(unsafe_code)]
     fn next_sibling_ref(self) -> Option<LayoutDom<'dom, Node>> {
         unsafe { self.unsafe_get().next_sibling.get_inner_as_layout() }
+    }
+
+    #[inline]
+    fn is_root(self) -> bool {
+        self.parent_node_ref()
+            .map_or(false, |parent| parent.downcast::<Document>().is_some())
     }
 
     #[inline]

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -249,6 +249,10 @@ pub trait ThreadSafeLayoutNode<'dom>:
 
     fn is_ignorable_whitespace(&self, context: &SharedStyleContext) -> bool;
 
+    fn is_body_element_for_layout(&self) -> bool;
+
+    fn is_html_element_for_layout(&self) -> bool;
+
     /// Returns true if this node contributes content. This is used in the implementation of
     /// `empty_cells` per CSS 2.1 § 17.6.1.1.
     fn is_content(&self) -> bool {

--- a/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-004a.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-004a.xht.ini
@@ -1,2 +1,0 @@
-[abspos-containing-block-initial-004a.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-004b.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-004b.xht.ini
@@ -1,2 +1,0 @@
-[abspos-containing-block-initial-004b.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-004c.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-004c.xht.ini
@@ -1,2 +1,0 @@
-[abspos-containing-block-initial-004c.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-004d.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-004d.xht.ini
@@ -1,2 +1,0 @@
-[abspos-containing-block-initial-004d.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-004e.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-004e.xht.ini
@@ -1,2 +1,0 @@
-[abspos-containing-block-initial-004e.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-004f.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-004f.xht.ini
@@ -1,2 +1,0 @@
-[abspos-containing-block-initial-004f.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-005a.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-005a.xht.ini
@@ -1,2 +1,0 @@
-[abspos-containing-block-initial-005a.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-005b.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-005b.xht.ini
@@ -1,2 +1,0 @@
-[abspos-containing-block-initial-005b.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-005c.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-005c.xht.ini
@@ -1,2 +1,0 @@
-[abspos-containing-block-initial-005c.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-005d.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/abspos/abspos-containing-block-initial-005d.xht.ini
@@ -1,2 +1,0 @@
-[abspos-containing-block-initial-005d.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-body-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-body-001.xht.ini
@@ -1,2 +1,0 @@
-[background-body-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-001.xht.ini
@@ -1,2 +1,0 @@
-[background-root-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-002.xht.ini
@@ -1,2 +1,0 @@
-[background-root-002.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-005.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-005.xht.ini
@@ -1,2 +1,0 @@
-[background-root-005.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-007.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-007.xht.ini
@@ -1,2 +1,0 @@
-[background-root-007.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-008.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-008.xht.ini
@@ -1,2 +1,0 @@
-[background-root-008.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-009.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-009.xht.ini
@@ -1,2 +1,0 @@
-[background-root-009.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-010.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-010.xht.ini
@@ -1,2 +1,0 @@
-[background-root-010.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-012b.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-012b.xht.ini
@@ -1,2 +1,0 @@
-[background-root-012b.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-015.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-015.xht.ini
@@ -1,2 +1,0 @@
-[background-root-015.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-016.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-016.xht.ini
@@ -1,2 +1,0 @@
-[background-root-016.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-018.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-018.xht.ini
@@ -1,2 +1,0 @@
-[background-root-018.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-019.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-019.xht.ini
@@ -1,2 +1,0 @@
-[background-root-019.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-024.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-root-024.xht.ini
@@ -1,2 +1,0 @@
-[background-root-024.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/box-display/root-box-003.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/box-display/root-box-003.xht.ini
@@ -1,0 +1,2 @@
+[root-box-003.xht]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/css1/c45-bg-canvas-000.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/css1/c45-bg-canvas-000.xht.ini
@@ -1,2 +1,0 @@
-[c45-bg-canvas-000.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-021.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-021.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-021.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/visudet/height-percentage-003a.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/visudet/height-percentage-003a.xht.ini
@@ -1,2 +1,0 @@
-[height-percentage-003a.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-color-body-propagation-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-color-body-propagation-001.html.ini
@@ -1,2 +1,0 @@
-[background-color-body-propagation-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-color-body-propagation-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-color-body-propagation-003.html.ini
@@ -1,2 +1,0 @@
-[background-color-body-propagation-003.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-color/t421-rgb-func-whitespace-b.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-color/t421-rgb-func-whitespace-b.xht.ini
@@ -1,2 +1,0 @@
-[t421-rgb-func-whitespace-b.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-color/t422-rgba-func-whitespace-b.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-color/t422-rgba-func-whitespace-b.xht.ini
@@ -1,2 +1,0 @@
-[t422-rgba-func-whitespace-b.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-color/t423-transparent-2-a.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-color/t423-transparent-2-a.xht.ini
@@ -1,2 +1,0 @@
-[t423-transparent-2-a.xht]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/root_height_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/root_height_a.html.ini
@@ -1,2 +1,0 @@
-[root_height_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -8057,7 +8057,7 @@
      ]
     ],
     "scroll_root.html": [
-     "5896eb3957da1eb85a26680053823d3f3bf9af49",
+     "b1a9cb590b0fcce9c883f99e17fa029a999b699b",
      [
       null,
       [
@@ -11085,7 +11085,7 @@
      []
     ],
     "scroll_root_ref.html": [
-     "c7d4cfec7b9d9b5daf32841172721ddac3e4d071",
+     "6503ad5d5265c0698f61fc607e2e4e017b31cb6f",
      []
     ],
     "scrolling_div_background_borders_background.png": [

--- a/tests/wpt/mozilla/tests/mozilla/scroll_root.html
+++ b/tests/wpt/mozilla/tests/mozilla/scroll_root.html
@@ -7,9 +7,6 @@
         <style>
             body {
                 background: green;
-
-                /* FIXME(mrobinson): Remove this workaround when #25559 is fixed. */
-                margin: 0;
             }
         </style>
     </head>

--- a/tests/wpt/mozilla/tests/mozilla/scroll_root_ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/scroll_root_ref.html
@@ -5,14 +5,7 @@
         <style>
             body {
                 background: green;
-
-                /* FIXME(mrobinson): Remove this workaround when #25559 is fixed. */
-                margin: 0;
             }
         </style>
     </head>
-    <body>
-        <!-- FIXME(mrobinson): Remove this workaround div when #25559 is fixed. -->
-        <div style="height: 10000px;"></div>
-    </body>
 </html>


### PR DESCRIPTION
The CSS Backgrounds and Borders specification describes the
circumstances under which the HTML element's used style for backgrounds
is determined by the BODY element. This change properly implements that
behavior, fixing a variety of tests that expect the background specified
on the BODY cover the entire page.

Fixes: #25559

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25559

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
