### PR TITLE
Add initial support for VertexAttribI4* and VertexAttribIPointer

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1297,7 +1297,6 @@ impl WebGLImpl {
             WebGLCommand::GetFragDataLocation(program_id, ref name, ref sender) => {
                 let location =
                     gl.get_frag_data_location(program_id.get(), &to_name_in_compiled_shader(name));
-                assert!(location >= 0);
                 sender.send(location).unwrap();
             },
             WebGLCommand::GetUniformLocation(program_id, ref name, ref chan) => {
@@ -1401,6 +1400,12 @@ impl WebGLImpl {
             WebGLCommand::ValidateProgram(program_id) => gl.validate_program(program_id.get()),
             WebGLCommand::VertexAttrib(attrib_id, x, y, z, w) => {
                 gl.vertex_attrib_4f(attrib_id, x, y, z, w)
+            },
+            WebGLCommand::VertexAttribI(attrib_id, x, y, z, w) => {
+                gl.vertex_attrib_4i(attrib_id, x, y, z, w)
+            },
+            WebGLCommand::VertexAttribU(attrib_id, x, y, z, w) => {
+                gl.vertex_attrib_4ui(attrib_id, x, y, z, w)
             },
             WebGLCommand::VertexAttribPointer2f(attrib_id, size, normalized, stride, offset) => {
                 gl.vertex_attrib_pointer_f32(attrib_id, size, normalized, stride, offset)

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -387,6 +387,8 @@ pub enum WebGLCommand {
     UseProgram(Option<WebGLProgramId>),
     ValidateProgram(WebGLProgramId),
     VertexAttrib(u32, f32, f32, f32, f32),
+    VertexAttribI(u32, i32, i32, i32, i32),
+    VertexAttribU(u32, u32, u32, u32, u32),
     VertexAttribPointer(u32, i32, u32, bool, i32, u32),
     VertexAttribPointer2f(u32, i32, bool, i32, u32),
     SetViewport(i32, i32, i32, i32),

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::dom::bindings::cell::Ref;
+use crate::dom::bindings::cell::{DomRefCell, Ref, RefMut};
 use crate::dom::bindings::codegen::Bindings::ANGLEInstancedArraysBinding::ANGLEInstancedArraysConstants;
 use crate::dom::bindings::codegen::Bindings::EXTBlendMinmaxBinding::EXTBlendMinmaxConstants;
 use crate::dom::bindings::codegen::Bindings::OESVertexArrayObjectBinding::OESVertexArrayObjectConstants;
@@ -148,6 +148,13 @@ bitflags! {
     }
 }
 
+#[derive(Clone, Copy, Debug, JSTraceable, MallocSizeOf)]
+pub enum VertexAttrib {
+    Float(f32, f32, f32, f32),
+    Int(i32, i32, i32, i32),
+    Uint(u32, u32, u32, u32),
+}
+
 #[dom_struct]
 pub struct WebGLRenderingContext {
     reflector_: Reflector,
@@ -173,9 +180,7 @@ pub struct WebGLRenderingContext {
     bound_renderbuffer: MutNullableDom<WebGLRenderbuffer>,
     bound_buffer_array: MutNullableDom<WebGLBuffer>,
     current_program: MutNullableDom<WebGLProgram>,
-    /// https://www.khronos.org/webgl/wiki/WebGL_and_OpenGL_Differences#Vertex_Attribute_0
-    #[ignore_malloc_size_of = "Because it's small"]
-    current_vertex_attrib_0: Cell<(f32, f32, f32, f32)>,
+    current_vertex_attribs: DomRefCell<Box<[VertexAttrib]>>,
     #[ignore_malloc_size_of = "Because it's small"]
     current_scissor: Cell<(i32, i32, u32, u32)>,
     #[ignore_malloc_size_of = "Because it's small"]
@@ -216,6 +221,7 @@ impl WebGLRenderingContext {
 
         result.map(|ctx_data| {
             let max_combined_texture_image_units = ctx_data.limits.max_combined_texture_image_units;
+            let max_vertex_attribs = ctx_data.limits.max_vertex_attribs as usize;
             Self {
                 reflector_: Reflector::new(),
                 webgl_sender: WebGLMessageSender::new(
@@ -236,7 +242,9 @@ impl WebGLRenderingContext {
                 bound_buffer_array: MutNullableDom::new(None),
                 bound_renderbuffer: MutNullableDom::new(None),
                 current_program: MutNullableDom::new(None),
-                current_vertex_attrib_0: Cell::new((0f32, 0f32, 0f32, 1f32)),
+                current_vertex_attribs: DomRefCell::new(
+                    vec![VertexAttrib::Float(0f32, 0f32, 0f32, 1f32); max_vertex_attribs].into(),
+                ),
                 current_scissor: Cell::new((0, 0, size.width, size.height)),
                 // FIXME(#21718) The backend is allowed to choose a size smaller than
                 // what was requested
@@ -303,6 +311,10 @@ impl WebGLRenderingContext {
                     .init_once(|| WebGLVertexArrayObject::new(self, None)),
             )
         })
+    }
+
+    pub fn current_vertex_attribs(&self) -> RefMut<Box<[VertexAttrib]>> {
+        self.current_vertex_attribs.borrow_mut()
     }
 
     pub fn recreate(&self, size: Size2D<u32>) {
@@ -521,9 +533,15 @@ impl WebGLRenderingContext {
             return self.webgl_error(InvalidValue);
         }
 
-        if indx == 0 {
-            self.current_vertex_attrib_0.set((x, y, z, w))
-        }
+        match self.webgl_version() {
+            WebGLVersion::WebGL1 => self
+                .current_vao()
+                .set_vertex_attrib_type(indx, constants::FLOAT),
+            WebGLVersion::WebGL2 => self
+                .current_vao_webgl2()
+                .set_vertex_attrib_type(indx, constants::FLOAT),
+        };
+        self.current_vertex_attribs.borrow_mut()[indx as usize] = VertexAttrib::Float(x, y, z, w);
 
         self.send_command(WebGLCommand::VertexAttrib(indx, x, y, z, w));
     }
@@ -3032,21 +3050,48 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     fn GetVertexAttrib(&self, cx: SafeJSContext, index: u32, param: u32) -> JSVal {
         let get_attrib = |data: Ref<VertexAttribData>| -> JSVal {
             if param == constants::CURRENT_VERTEX_ATTRIB {
-                let value = if index == 0 {
-                    let (x, y, z, w) = self.current_vertex_attrib_0.get();
-                    [x, y, z, w]
-                } else {
-                    let (sender, receiver) = webgl_channel().unwrap();
-                    self.send_command(WebGLCommand::GetCurrentVertexAttrib(index, sender));
-                    receiver.recv().unwrap()
-                };
-                unsafe {
-                    rooted!(in(*cx) let mut result = ptr::null_mut::<JSObject>());
-                    let _ =
-                        Float32Array::create(*cx, CreateWith::Slice(&value), result.handle_mut())
+                let attrib = self.current_vertex_attribs.borrow()[index as usize];
+                match attrib {
+                    VertexAttrib::Float(x, y, z, w) => {
+                        let value = [x, y, z, w];
+                        unsafe {
+                            rooted!(in(*cx) let mut result = ptr::null_mut::<JSObject>());
+                            let _ = Float32Array::create(
+                                *cx,
+                                CreateWith::Slice(&value),
+                                result.handle_mut(),
+                            )
                             .unwrap();
-                    return ObjectValue(result.get());
-                }
+                            return ObjectValue(result.get());
+                        }
+                    },
+                    VertexAttrib::Int(x, y, z, w) => {
+                        let value = [x, y, z, w];
+                        unsafe {
+                            rooted!(in(*cx) let mut result = ptr::null_mut::<JSObject>());
+                            let _ = Int32Array::create(
+                                *cx,
+                                CreateWith::Slice(&value),
+                                result.handle_mut(),
+                            )
+                            .unwrap();
+                            return ObjectValue(result.get());
+                        }
+                    },
+                    VertexAttrib::Uint(x, y, z, w) => {
+                        let value = [x, y, z, w];
+                        unsafe {
+                            rooted!(in(*cx) let mut result = ptr::null_mut::<JSObject>());
+                            let _ = Uint32Array::create(
+                                *cx,
+                                CreateWith::Slice(&value),
+                                result.handle_mut(),
+                            )
+                            .unwrap();
+                            return ObjectValue(result.get());
+                        }
+                    },
+                };
             }
             if !self
                 .extension_manager

--- a/components/script/dom/webglvertexarrayobject.rs
+++ b/components/script/dom/webglvertexarrayobject.rs
@@ -61,6 +61,10 @@ impl WebGLVertexArrayObject {
         self.array_object.get_vertex_attrib(index)
     }
 
+    pub fn set_vertex_attrib_type(&self, index: u32, type_: u32) {
+        self.array_object.set_vertex_attrib_type(index, type_);
+    }
+
     pub fn vertex_attrib_pointer(
         &self,
         index: u32,

--- a/components/script/dom/webglvertexarrayobjectoes.rs
+++ b/components/script/dom/webglvertexarrayobjectoes.rs
@@ -61,6 +61,10 @@ impl WebGLVertexArrayObjectOES {
         self.array_object.get_vertex_attrib(index)
     }
 
+    pub fn set_vertex_attrib_type(&self, index: u32, type_: u32) {
+        self.array_object.set_vertex_attrib_type(index, type_);
+    }
+
     pub fn vertex_attrib_pointer(
         &self,
         index: u32,

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -451,11 +451,11 @@ interface mixin WebGL2RenderingContextBase
                           optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
 
   /* Vertex attribs */
-  // void vertexAttribI4i(GLuint index, GLint x, GLint y, GLint z, GLint w);
-  // void vertexAttribI4iv(GLuint index, Int32List values);
-  // void vertexAttribI4ui(GLuint index, GLuint x, GLuint y, GLuint z, GLuint w);
-  // void vertexAttribI4uiv(GLuint index, Uint32List values);
-  // void vertexAttribIPointer(GLuint index, GLint size, GLenum type, GLsizei stride, GLintptr offset);
+  void vertexAttribI4i(GLuint index, GLint x, GLint y, GLint z, GLint w);
+  void vertexAttribI4iv(GLuint index, Int32List values);
+  void vertexAttribI4ui(GLuint index, GLuint x, GLuint y, GLuint z, GLuint w);
+  void vertexAttribI4uiv(GLuint index, Uint32List values);
+  void vertexAttribIPointer(GLuint index, GLint size, GLenum type, GLsizei stride, GLintptr offset);
 
   /* Writing to the drawing buffer */
   void vertexAttribDivisor(GLuint index, GLuint divisor);

--- a/tests/wpt/webgl/meta/conformance2/attribs/gl-vertex-attrib-i-render.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/attribs/gl-vertex-attrib-i-render.html.ini
@@ -1,5 +1,13 @@
 [gl-vertex-attrib-i-render.html]
-  expected: ERROR
-  [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #1: Attribute of vertexAttribI4ui was not set correctly]
+    expected: FAIL
+
+  [WebGL test #2: Attribute of vertexAttribI4iv was not set correctly]
+    expected: FAIL
+
+  [WebGL test #0: Attribute of vertexAttribI4i was not set correctly]
+    expected: FAIL
+
+  [WebGL test #3: Attribute of vertexAttribI4uiv was not set correctly]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/attribs/gl-vertex-attrib.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/attribs/gl-vertex-attrib.html.ini
@@ -1,5 +1,0 @@
-[gl-vertex-attrib.html]
-  expected: ERROR
-  [WebGL test #61: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance2/attribs/gl-vertexattribipointer-offsets.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/attribs/gl-vertexattribipointer-offsets.html.ini
@@ -1,5 +1,0 @@
-[gl-vertexattribipointer-offsets.html]
-  expected: ERROR
-  [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance2/attribs/gl-vertexattribipointer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/attribs/gl-vertexattribipointer.html.ini
@@ -1,5 +1,0 @@
-[gl-vertexattribipointer.html]
-  expected: ERROR
-  [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
-    expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance2/buffers/get-buffer-sub-data-validity.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/buffers/get-buffer-sub-data-validity.html.ini
@@ -1,5 +1,7 @@
 [get-buffer-sub-data-validity.html]
-  expected: ERROR
-  [Overall test]
-    expected: NOTRUN
+  [WebGL test #17: areArraysEqual(dest, srcData) should be true. Was false.]
+    expected: FAIL
+
+  [WebGL test #16: getError expected: NO_ERROR. Was INVALID_OPERATION : after evaluating: gl.getBufferSubData(gl.COPY_WRITE_BUFFER, 0, dest)]
+    expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/attrib-type-match.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/attrib-type-match.html.ini
@@ -1,5 +1,16 @@
 [attrib-type-match.html]
-  expected: ERROR
-  [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #78: should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #80: should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #82: should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #63: should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #61: should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/element-index-uint.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/element-index-uint.html.ini
@@ -11,3 +11,9 @@
   [WebGL test #18: should be 0,255,0,255\nat (1, 0) expected: 0,255,0,255 was 0,0,255,255]
     expected: FAIL
 
+  [WebGL test #27: getError expected: NO_ERROR. Was INVALID_OPERATION : after drawing]
+    expected: FAIL
+
+  [WebGL test #58: getError expected: NO_ERROR. Was INVALID_OPERATION : after drawing]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/state/gl-object-get-calls.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/state/gl-object-get-calls.html.ini
@@ -1,5 +1,5 @@
 [gl-object-get-calls.html]
-  expected: ERROR
+  expected: TIMEOUT
   [WebGL test #257: getError expected: NO_ERROR. Was INVALID_OPERATION : ]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/vertex_arrays/vertex-array-object.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/vertex_arrays/vertex-array-object.html.ini
@@ -1,0 +1,13 @@
+[vertex-array-object.html]
+  [WebGL test #30: getError expected: NO_ERROR. Was INVALID_OPERATION : Draw call should not fail.]
+    expected: FAIL
+
+  [WebGL test #28: getError expected: NO_ERROR. Was INVALID_OPERATION : Draw call should not fail.]
+    expected: FAIL
+
+  [WebGL test #29: getError expected: NO_ERROR. Was INVALID_OPERATION : Draw call should not fail.]
+    expected: FAIL
+
+  [WebGL test #33: getError expected: NO_ERROR. Was INVALID_OPERATION : there should be no errors]
+    expected: FAIL
+


### PR DESCRIPTION
Add initial support for the WebGL2 `VertexAttribI4i`, `VertexAttribI4iv`, `VertexAttribI4ui`, `VertexAttribI4uiv` and `VertexAttribIPointer` calls.

<!-- Please describe your changes on the following line: -->
I've already updated the test expectations and noticed that I've got a crash on the `conformance2/state/gl-object-get-calls.html` test, which is related to the `GetFragDataLocation`.
The crash comes from here: https://github.com/servo/servo/blob/b4d7ec1c99259f936c9e34de157b652707d308de/components/canvas/webgl_thread.rs#L1292
The assert is invalid here because the `GetFragDataLocation` GL call could return with `-1` also. (https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glGetFragDataLocation.xhtml)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] There are tests for these changes

cc @mmatyas @zakorgy @jdm
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
