### PR TITLE
Do not filter out platform objects when doing dictionary conversions in overload resolution

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -429,8 +429,8 @@ class CGMethodCall(CGThing):
 
             # Check for vanilla JS objects
             # XXXbz Do we need to worry about security wrappers?
-            pickFirstSignature("%s.get().is_object() && !is_platform_object(%s.get().to_object(), *cx)" %
-                               (distinguishingArg, distinguishingArg),
+            pickFirstSignature("%s.get().is_object()" %
+                               distinguishingArg,
                                lambda s: (s[1][distinguishingIndex].type.isCallback() or
                                           s[1][distinguishingIndex].type.isCallbackInterface() or
                                           s[1][distinguishingIndex].type.isDictionary() or

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -12,7 +12,7 @@ use crate::dom::bindings::codegen::Bindings::TestBindingBinding::{
     TestBindingMethods, TestDictionary,
 };
 use crate::dom::bindings::codegen::Bindings::TestBindingBinding::{
-    TestDictionaryDefaults, TestEnum,
+    TestDictionaryDefaults, TestEnum, TestURLLike,
 };
 use crate::dom::bindings::codegen::UnionTypes;
 use crate::dom::bindings::codegen::UnionTypes::{
@@ -45,6 +45,7 @@ use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::bindings::weakref::MutableWeakRef;
 use crate::dom::blob::Blob;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::node::Node;
 use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::url::URL;
@@ -678,6 +679,14 @@ impl TestBindingMethods for TestBinding {
 
     fn PassOverloaded(&self, _: CustomAutoRooterGuard<typedarray::ArrayBuffer>) {}
     fn PassOverloaded_(&self, _: DOMString) {}
+
+    fn PassOverloadedDict(&self, _: &Node) -> DOMString {
+        "node".into()
+    }
+
+    fn PassOverloadedDict_(&self, u: &TestURLLike) -> DOMString {
+        u.href.clone()
+    }
 
     fn PassNullableBoolean(&self, _: Option<bool>) {}
     fn PassNullableByte(&self, _: Option<i8>) {}

--- a/components/script/dom/webidls/TestBinding.webidl
+++ b/components/script/dom/webidls/TestBinding.webidl
@@ -86,6 +86,10 @@ dictionary TestDictionaryDefaults {
   object? nullableObjectValue = null;
 };
 
+dictionary TestURLLike {
+  required DOMString href;
+};
+
 [Pref="dom.testbinding.enabled",
  Exposed=(Window,Worker)
 ]
@@ -278,6 +282,10 @@ interface TestBinding {
 
   void passOverloaded(ArrayBuffer arg);
   void passOverloaded(DOMString arg);
+
+  // https://github.com/servo/servo/pull/26154
+  DOMString passOverloadedDict(Node arg);
+  DOMString passOverloadedDict(TestURLLike arg);
 
   void passNullableBoolean(boolean? arg);
   void passNullableByte(byte? arg);

--- a/tests/wpt/mozilla/meta-layout-2020/mozilla/overload_dict.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/mozilla/overload_dict.html.ini
@@ -1,0 +1,3 @@
+[overload_dict.html]
+  type: testharness
+  prefs: [dom.testbinding.enabled:true]

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14088,6 +14088,13 @@
       {}
      ]
     ],
+    "overload_dict.html": [
+     "cd42fd97331753fc0580a47a39814cff57911638",
+     [
+      null,
+      {}
+     ]
+    ],
     "paint_timing.html": [
      "0c1798ec565a77d20d9550b5cec352a0b286c415",
      [

--- a/tests/wpt/mozilla/meta/mozilla/overload_dict.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/overload_dict.html.ini
@@ -1,0 +1,3 @@
+[overload_dict.html]
+  type: testharness
+  prefs: [dom.testbinding.enabled:true]

--- a/tests/wpt/mozilla/tests/mozilla/overload_dict.html
+++ b/tests/wpt/mozilla/tests/mozilla/overload_dict.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Test for overload with dictionary object</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  var t = new TestBinding();
+
+  assert_equals(t.passOverloadedDict({href: "a"}), "a");
+  assert_equals(t.passOverloadedDict(document.documentElement), "node");
+  // interface objects should be converted to the dictionary if
+  // they're incompatible with the interface
+  // See https://github.com/servo/servo/pull/26154
+  assert_equals(t.passOverloadedDict(new URL("https://example.org/foo")), "https://example.org/foo");
+
+}, "Overload of dictionary and interface item works")
+</script>


### PR DESCRIPTION
https://heycam.github.io/webidl/#es-overloads

In step 12, the platform object check is for substep 4, but importantly it only matters if `V` implements the matching interface. If not, it should be able to fall back to substep 10 and attempt conversion to a dictionary.