### PR TITLE
Remove assertion for negative value from get_uniform_location

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -2280,7 +2280,6 @@ impl WebGLImpl {
 
     fn uniform_location(gl: &Gl, program_id: WebGLProgramId, name: &str, chan: &WebGLSender<i32>) {
         let location = gl.get_uniform_location(program_id.get(), &to_name_in_compiled_shader(name));
-        assert!(location >= 0);
         chan.send(location).unwrap();
     }
 


### PR DESCRIPTION
closes #26150

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #26150 (GitHub issue number if applicable)
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___