### PR TITLE
Dirty canvas when exiting immersive sessions

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -503,7 +503,7 @@ impl WebGLRenderingContext {
         }
     }
 
-    fn mark_as_dirty(&self) {
+    pub fn mark_as_dirty(&self) {
         // If we have a bound framebuffer, then don't mark the canvas as dirty.
         if self.bound_draw_framebuffer.get().is_some() {
             return;

--- a/components/script/dom/xrsession.rs
+++ b/components/script/dom/xrsession.rs
@@ -14,6 +14,9 @@ use crate::dom::bindings::codegen::Bindings::XRSessionBinding::XRFrameRequestCal
 use crate::dom::bindings::codegen::Bindings::XRSessionBinding::XRSessionMethods;
 use crate::dom::bindings::codegen::Bindings::XRSessionBinding::XRVisibilityState;
 use crate::dom::bindings::codegen::Bindings::XRSystemBinding::XRSessionMode;
+use crate::dom::bindings::codegen::Bindings::XRWebGLLayerBinding::{
+    XRWebGLLayerMethods, XRWebGLRenderingContext,
+};
 use crate::dom::bindings::error::{Error, ErrorResult};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
@@ -322,6 +325,9 @@ impl XRSession {
                     self,
                 );
                 event.upcast::<Event>().fire(self.upcast());
+                // The page may be visible again, dirty the layers
+                // This also wakes up the event loop if necessary
+                self.dirty_layers();
             },
             XREvent::AddInput(info) => {
                 self.input_sources.add_input_sources(self, &[info]);
@@ -451,6 +457,17 @@ impl XRSession {
 
     pub fn session_id(&self) -> SessionId {
         self.session.borrow().id()
+    }
+
+    pub fn dirty_layers(&self) {
+        if let Some(layer) = self.RenderState().GetBaseLayer() {
+            match layer.Context() {
+                XRWebGLRenderingContext::WebGLRenderingContext(c) => c.mark_as_dirty(),
+                XRWebGLRenderingContext::WebGL2RenderingContext(c) => {
+                    c.base_context().mark_as_dirty()
+                },
+            }
+        }
     }
 }
 

--- a/components/script/dom/xrsystem.rs
+++ b/components/script/dom/xrsystem.rs
@@ -3,13 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::cell::DomRefCell;
-use crate::dom::bindings::codegen::Bindings::XRRenderStateBinding::XRRenderStateMethods;
-use crate::dom::bindings::codegen::Bindings::XRSessionBinding::XRSessionMethods;
 use crate::dom::bindings::codegen::Bindings::XRSystemBinding::XRSessionInit;
 use crate::dom::bindings::codegen::Bindings::XRSystemBinding::{XRSessionMode, XRSystemMethods};
-use crate::dom::bindings::codegen::Bindings::XRWebGLLayerBinding::{
-    XRWebGLLayerMethods, XRWebGLRenderingContext,
-};
 use crate::dom::bindings::conversions::{ConversionResult, FromJSValConvertible};
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
@@ -86,17 +81,9 @@ impl XRSystem {
         if let Some(active) = self.active_immersive_session.get() {
             if Dom::from_ref(&*active) == Dom::from_ref(session) {
                 self.active_immersive_session.set(None);
-
                 // Dirty the canvas, since it has been skipping this step whilst in immersive
                 // mode
-                if let Some(layer) = session.RenderState().GetBaseLayer() {
-                    match layer.Context() {
-                        XRWebGLRenderingContext::WebGLRenderingContext(c) => c.mark_as_dirty(),
-                        XRWebGLRenderingContext::WebGL2RenderingContext(c) => {
-                            c.base_context().mark_as_dirty()
-                        },
-                    }
-                }
+                session.dirty_layers();
             }
         }
         self.active_inline_sessions

--- a/components/script/dom/xrsystem.rs
+++ b/components/script/dom/xrsystem.rs
@@ -3,8 +3,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::XRRenderStateBinding::XRRenderStateMethods;
+use crate::dom::bindings::codegen::Bindings::XRSessionBinding::XRSessionMethods;
 use crate::dom::bindings::codegen::Bindings::XRSystemBinding::XRSessionInit;
 use crate::dom::bindings::codegen::Bindings::XRSystemBinding::{XRSessionMode, XRSystemMethods};
+use crate::dom::bindings::codegen::Bindings::XRWebGLLayerBinding::{
+    XRWebGLLayerMethods, XRWebGLRenderingContext,
+};
 use crate::dom::bindings::conversions::{ConversionResult, FromJSValConvertible};
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
@@ -81,6 +86,17 @@ impl XRSystem {
         if let Some(active) = self.active_immersive_session.get() {
             if Dom::from_ref(&*active) == Dom::from_ref(session) {
                 self.active_immersive_session.set(None);
+
+                // Dirty the canvas, since it has been skipping this step whilst in immersive
+                // mode
+                if let Some(layer) = session.RenderState().GetBaseLayer() {
+                    match layer.Context() {
+                        XRWebGLRenderingContext::WebGLRenderingContext(c) => c.mark_as_dirty(),
+                        XRWebGLRenderingContext::WebGL2RenderingContext(c) => {
+                            c.base_context().mark_as_dirty()
+                        },
+                    }
+                }
             }
         }
         self.active_inline_sessions


### PR DESCRIPTION
Fixes https://github.com/servo/servo/issues/26162, fixes servo/webxr#155

We basically end up in a situation where the main thread is asleep. It's unclear to me why it doesn't wake up after attempts to interact with the screen, but we stopped dirtying the canvas during the immersive session (https://github.com/servo/servo/pull/26077) so the main thread wasn't awake initially.

This is probably not the cleanest fix -- we really should not be ending up in situations where the main thread is perma-asleep -- however, we should be dirtying the canvas after exiting immersive mode _anyway_ since the contents need to be shown to the user, so this fix is still valid, even if it's not fixing the root cause.