### PR TITLE
Remove DomRefCell wrapper for CanvasState

### DIFF
--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -175,14 +175,6 @@ impl CanvasState {
         &self.missing_image_urls
     }
 
-    pub fn get_state(&self) -> &DomRefCell<CanvasContextState> {
-        &self.state
-    }
-
-    pub fn get_saved_state(&self) -> &DomRefCell<Vec<CanvasContextState>> {
-        &self.saved_states
-    }
-
     pub fn get_canvas_id(&self) -> CanvasId {
         self.canvas_id.clone()
     }

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::canvas_state::{CanvasContextState, CanvasState};
-use crate::dom::bindings::cell::DomRefCell;
+use crate::canvas_state::CanvasState;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasFillRule;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasImageSource;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasLineCap;
@@ -80,17 +79,10 @@ impl CanvasRenderingContext2D {
             .unwrap();
     }
 
-    //  TODO: This duplicates functionality in canvas state
     // https://html.spec.whatwg.org/multipage/#reset-the-rendering-context-to-its-default-state
     fn reset_to_initial_state(&self) {
-        self.canvas_state.get_saved_state().borrow_mut().clear();
-        *self.canvas_state.get_state().borrow_mut() = CanvasContextState::new();
+        self.canvas_state.reset_to_initial_state();
     }
-    /*
-        pub fn get_canvas_state(&self) -> Ref<CanvasState> {
-            self.canvas_state.borrow()
-        }
-    */
 
     pub fn set_canvas_bitmap_dimensions(&self, size: Size2D<u64>) {
         self.canvas_state.set_bitmap_dimensions(size);

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -33,7 +33,7 @@ use ipc_channel::ipc::IpcSender;
 pub struct OffscreenCanvasRenderingContext2D {
     reflector_: Reflector,
     canvas: Dom<OffscreenCanvas>,
-    canvas_state: DomRefCell<CanvasState>,
+    canvas_state: CanvasState,
     htmlcanvas: Option<Dom<HTMLCanvasElement>>,
 }
 
@@ -47,7 +47,7 @@ impl OffscreenCanvasRenderingContext2D {
             reflector_: Reflector::new(),
             canvas: Dom::from_ref(canvas),
             htmlcanvas: htmlcanvas.map(Dom::from_ref),
-            canvas_state: DomRefCell::new(CanvasState::new(global, canvas.get_size())),
+            canvas_state: CanvasState::new(global, canvas.get_size()),
         }
     }
 
@@ -68,23 +68,23 @@ impl OffscreenCanvasRenderingContext2D {
     */
 
     pub fn set_canvas_bitmap_dimensions(&self, size: Size2D<u64>) {
-        self.canvas_state.borrow().set_bitmap_dimensions(size);
+        self.canvas_state.set_bitmap_dimensions(size);
     }
 
     pub fn send_canvas_2d_msg(&self, msg: Canvas2dMsg) {
-        self.canvas_state.borrow().send_canvas_2d_msg(msg)
+        self.canvas_state.send_canvas_2d_msg(msg)
     }
 
     pub fn origin_is_clean(&self) -> bool {
-        self.canvas_state.borrow().origin_is_clean()
+        self.canvas_state.origin_is_clean()
     }
 
     pub fn get_canvas_id(&self) -> CanvasId {
-        self.canvas_state.borrow().get_canvas_id()
+        self.canvas_state.get_canvas_id()
     }
 
     pub fn get_ipc_renderer(&self) -> IpcSender<CanvasMsg> {
-        self.canvas_state.borrow().get_ipc_renderer().clone()
+        self.canvas_state.get_ipc_renderer().clone()
     }
 }
 
@@ -96,80 +96,78 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-fillrect
     fn FillRect(&self, x: f64, y: f64, width: f64, height: f64) {
-        self.canvas_state.borrow().fill_rect(x, y, width, height);
+        self.canvas_state.fill_rect(x, y, width, height);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-clearrect
     fn ClearRect(&self, x: f64, y: f64, width: f64, height: f64) {
-        self.canvas_state.borrow().clear_rect(x, y, width, height);
+        self.canvas_state.clear_rect(x, y, width, height);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokerect
     fn StrokeRect(&self, x: f64, y: f64, width: f64, height: f64) {
-        self.canvas_state.borrow().stroke_rect(x, y, width, height);
+        self.canvas_state.stroke_rect(x, y, width, height);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowoffsetx
     fn ShadowOffsetX(&self) -> f64 {
-        self.canvas_state.borrow().shadow_offset_x()
+        self.canvas_state.shadow_offset_x()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowoffsetx
     fn SetShadowOffsetX(&self, value: f64) {
-        self.canvas_state.borrow().set_shadow_offset_x(value)
+        self.canvas_state.set_shadow_offset_x(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowoffsety
     fn ShadowOffsetY(&self) -> f64 {
-        self.canvas_state.borrow().shadow_offset_y()
+        self.canvas_state.shadow_offset_y()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowoffsety
     fn SetShadowOffsetY(&self, value: f64) {
-        self.canvas_state.borrow().set_shadow_offset_y(value)
+        self.canvas_state.set_shadow_offset_y(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowblur
     fn ShadowBlur(&self) -> f64 {
-        self.canvas_state.borrow().shadow_blur()
+        self.canvas_state.shadow_blur()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowblur
     fn SetShadowBlur(&self, value: f64) {
-        self.canvas_state.borrow().set_shadow_blur(value)
+        self.canvas_state.set_shadow_blur(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor
     fn ShadowColor(&self) -> DOMString {
-        self.canvas_state.borrow().shadow_color()
+        self.canvas_state.shadow_color()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor
     fn SetShadowColor(&self, value: DOMString) {
-        self.canvas_state.borrow().set_shadow_color(value)
+        self.canvas_state.set_shadow_color(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
     fn StrokeStyle(&self) -> StringOrCanvasGradientOrCanvasPattern {
-        self.canvas_state.borrow().stroke_style()
+        self.canvas_state.stroke_style()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
     fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
         self.canvas_state
-            .borrow()
             .set_stroke_style(self.htmlcanvas.as_ref().map(|c| &**c), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
     fn FillStyle(&self) -> StringOrCanvasGradientOrCanvasPattern {
-        self.canvas_state.borrow().fill_style()
+        self.canvas_state.fill_style()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
     fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
         self.canvas_state
-            .borrow()
             .set_fill_style(self.htmlcanvas.as_ref().map(|c| &**c), value)
     }
 
@@ -182,7 +180,6 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
         y1: Finite<f64>,
     ) -> DomRoot<CanvasGradient> {
         self.canvas_state
-            .borrow()
             .create_linear_gradient(&self.global(), x0, y0, x1, y1)
     }
 
@@ -197,7 +194,6 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
         r1: Finite<f64>,
     ) -> Fallible<DomRoot<CanvasGradient>> {
         self.canvas_state
-            .borrow()
             .create_radial_gradient(&self.global(), x0, y0, r0, x1, y1, r1)
     }
 
@@ -208,137 +204,120 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
         repetition: DOMString,
     ) -> Fallible<Option<DomRoot<CanvasPattern>>> {
         self.canvas_state
-            .borrow()
             .create_pattern(&self.global(), image, repetition)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-save
     fn Save(&self) {
-        self.canvas_state.borrow().save()
+        self.canvas_state.save()
     }
 
     #[allow(unrooted_must_root)]
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-restore
     fn Restore(&self) {
-        self.canvas_state.borrow().restore()
+        self.canvas_state.restore()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-globalalpha
     fn GlobalAlpha(&self) -> f64 {
-        self.canvas_state.borrow().global_alpha()
+        self.canvas_state.global_alpha()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-globalalpha
     fn SetGlobalAlpha(&self, alpha: f64) {
-        self.canvas_state.borrow().set_global_alpha(alpha)
+        self.canvas_state.set_global_alpha(alpha)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-globalcompositeoperation
     fn GlobalCompositeOperation(&self) -> DOMString {
-        self.canvas_state.borrow().global_composite_operation()
+        self.canvas_state.global_composite_operation()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-globalcompositeoperation
     fn SetGlobalCompositeOperation(&self, op_str: DOMString) {
-        self.canvas_state
-            .borrow()
-            .set_global_composite_operation(op_str)
+        self.canvas_state.set_global_composite_operation(op_str)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-imagesmoothingenabled
     fn ImageSmoothingEnabled(&self) -> bool {
-        self.canvas_state.borrow().image_smoothing_enabled()
+        self.canvas_state.image_smoothing_enabled()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-imagesmoothingenabled
     fn SetImageSmoothingEnabled(&self, value: bool) {
-        self.canvas_state
-            .borrow()
-            .set_image_smoothing_enabled(value)
+        self.canvas_state.set_image_smoothing_enabled(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-filltext
     fn FillText(&self, text: DOMString, x: f64, y: f64, max_width: Option<f64>) {
-        self.canvas_state.borrow().fill_text(text, x, y, max_width)
+        self.canvas_state.fill_text(text, x, y, max_width)
     }
 
     // https://html.spec.whatwg.org/multipage/#textmetrics
     fn MeasureText(&self, text: DOMString) -> DomRoot<TextMetrics> {
-        self.canvas_state
-            .borrow()
-            .measure_text(&self.global(), text)
+        self.canvas_state.measure_text(&self.global(), text)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linewidth
     fn LineWidth(&self) -> f64 {
-        self.canvas_state.borrow().line_width()
+        self.canvas_state.line_width()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linewidth
     fn SetLineWidth(&self, width: f64) {
-        self.canvas_state.borrow().set_line_width(width)
+        self.canvas_state.set_line_width(width)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linecap
     fn LineCap(&self) -> CanvasLineCap {
-        self.canvas_state.borrow().line_cap()
+        self.canvas_state.line_cap()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linecap
     fn SetLineCap(&self, cap: CanvasLineCap) {
-        self.canvas_state.borrow().set_line_cap(cap)
+        self.canvas_state.set_line_cap(cap)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linejoin
     fn LineJoin(&self) -> CanvasLineJoin {
-        self.canvas_state.borrow().line_join()
+        self.canvas_state.line_join()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linejoin
     fn SetLineJoin(&self, join: CanvasLineJoin) {
-        self.canvas_state.borrow().set_line_join(join)
+        self.canvas_state.set_line_join(join)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-miterlimit
     fn MiterLimit(&self) -> f64 {
-        self.canvas_state.borrow().miter_limit()
+        self.canvas_state.miter_limit()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-miterlimit
     fn SetMiterLimit(&self, limit: f64) {
-        self.canvas_state.borrow().set_miter_limit(limit)
+        self.canvas_state.set_miter_limit(limit)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata
     fn CreateImageData(&self, sw: i32, sh: i32) -> Fallible<DomRoot<ImageData>> {
-        self.canvas_state
-            .borrow()
-            .create_image_data(&self.global(), sw, sh)
+        self.canvas_state.create_image_data(&self.global(), sw, sh)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata
     fn CreateImageData_(&self, imagedata: &ImageData) -> Fallible<DomRoot<ImageData>> {
         self.canvas_state
-            .borrow()
             .create_image_data_(&self.global(), imagedata)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-getimagedata
     fn GetImageData(&self, sx: i32, sy: i32, sw: i32, sh: i32) -> Fallible<DomRoot<ImageData>> {
-        self.canvas_state.borrow().get_image_data(
-            self.canvas.get_size(),
-            &self.global(),
-            sx,
-            sy,
-            sw,
-            sh,
-        )
+        self.canvas_state
+            .get_image_data(self.canvas.get_size(), &self.global(), sx, sy, sw, sh)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata
     fn PutImageData(&self, imagedata: &ImageData, dx: i32, dy: i32) {
         self.canvas_state
-            .borrow()
             .put_image_data(self.canvas.get_size(), imagedata, dx, dy)
     }
 
@@ -354,7 +333,7 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
         dirty_width: i32,
         dirty_height: i32,
     ) {
-        self.canvas_state.borrow().put_image_data_(
+        self.canvas_state.put_image_data_(
             self.canvas.get_size(),
             imagedata,
             dx,
@@ -369,7 +348,6 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage
     fn DrawImage(&self, image: CanvasImageSource, dx: f64, dy: f64) -> ErrorResult {
         self.canvas_state
-            .borrow()
             .draw_image(self.htmlcanvas.as_ref().map(|c| &**c), image, dx, dy)
     }
 
@@ -382,7 +360,7 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
         dw: f64,
         dh: f64,
     ) -> ErrorResult {
-        self.canvas_state.borrow().draw_image_(
+        self.canvas_state.draw_image_(
             self.htmlcanvas.as_ref().map(|c| &**c),
             image,
             dx,
@@ -405,7 +383,7 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
         dw: f64,
         dh: f64,
     ) -> ErrorResult {
-        self.canvas_state.borrow().draw_image__(
+        self.canvas_state.draw_image__(
             self.htmlcanvas.as_ref().map(|c| &**c),
             image,
             sx,
@@ -421,108 +399,104 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-beginpath
     fn BeginPath(&self) {
-        self.canvas_state.borrow().begin_path()
+        self.canvas_state.begin_path()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-fill
     fn Fill(&self, fill_rule: CanvasFillRule) {
-        self.canvas_state.borrow().fill(fill_rule)
+        self.canvas_state.fill(fill_rule)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-stroke
     fn Stroke(&self) {
-        self.canvas_state.borrow().stroke()
+        self.canvas_state.stroke()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-clip
     fn Clip(&self, fill_rule: CanvasFillRule) {
-        self.canvas_state.borrow().clip(fill_rule)
+        self.canvas_state.clip(fill_rule)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-ispointinpath
     fn IsPointInPath(&self, x: f64, y: f64, fill_rule: CanvasFillRule) -> bool {
         self.canvas_state
-            .borrow()
             .is_point_in_path(&self.global(), x, y, fill_rule)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-scale
     fn Scale(&self, x: f64, y: f64) {
-        self.canvas_state.borrow().scale(x, y)
+        self.canvas_state.scale(x, y)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-rotate
     fn Rotate(&self, angle: f64) {
-        self.canvas_state.borrow().rotate(angle)
+        self.canvas_state.rotate(angle)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-translate
     fn Translate(&self, x: f64, y: f64) {
-        self.canvas_state.borrow().translate(x, y)
+        self.canvas_state.translate(x, y)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-transform
     fn Transform(&self, a: f64, b: f64, c: f64, d: f64, e: f64, f: f64) {
-        self.canvas_state.borrow().transform(a, b, c, d, e, f)
+        self.canvas_state.transform(a, b, c, d, e, f)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-gettransform
     fn GetTransform(&self) -> DomRoot<DOMMatrix> {
-        self.canvas_state.borrow().get_transform(&self.global())
+        self.canvas_state.get_transform(&self.global())
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-settransform
     fn SetTransform(&self, a: f64, b: f64, c: f64, d: f64, e: f64, f: f64) {
-        self.canvas_state.borrow().set_transform(a, b, c, d, e, f)
+        self.canvas_state.set_transform(a, b, c, d, e, f)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-resettransform
     fn ResetTransform(&self) {
-        self.canvas_state.borrow().reset_transform()
+        self.canvas_state.reset_transform()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-closepath
     fn ClosePath(&self) {
-        self.canvas_state.borrow().close_path()
+        self.canvas_state.close_path()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-moveto
     fn MoveTo(&self, x: f64, y: f64) {
-        self.canvas_state.borrow().move_to(x, y)
+        self.canvas_state.move_to(x, y)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-lineto
     fn LineTo(&self, x: f64, y: f64) {
-        self.canvas_state.borrow().line_to(x, y)
+        self.canvas_state.line_to(x, y)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-rect
     fn Rect(&self, x: f64, y: f64, width: f64, height: f64) {
-        self.canvas_state.borrow().rect(x, y, width, height)
+        self.canvas_state.rect(x, y, width, height)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-quadraticcurveto
     fn QuadraticCurveTo(&self, cpx: f64, cpy: f64, x: f64, y: f64) {
-        self.canvas_state
-            .borrow()
-            .quadratic_curve_to(cpx, cpy, x, y)
+        self.canvas_state.quadratic_curve_to(cpx, cpy, x, y)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-beziercurveto
     fn BezierCurveTo(&self, cp1x: f64, cp1y: f64, cp2x: f64, cp2y: f64, x: f64, y: f64) {
         self.canvas_state
-            .borrow()
             .bezier_curve_to(cp1x, cp1y, cp2x, cp2y, x, y)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-arc
     fn Arc(&self, x: f64, y: f64, r: f64, start: f64, end: f64, ccw: bool) -> ErrorResult {
-        self.canvas_state.borrow().arc(x, y, r, start, end, ccw)
+        self.canvas_state.arc(x, y, r, start, end, ccw)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-arcto
     fn ArcTo(&self, cp1x: f64, cp1y: f64, cp2x: f64, cp2y: f64, r: f64) -> ErrorResult {
-        self.canvas_state.borrow().arc_to(cp1x, cp1y, cp2x, cp2y, r)
+        self.canvas_state.arc_to(cp1x, cp1y, cp2x, cp2y, r)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-ellipse
@@ -538,7 +512,6 @@ impl OffscreenCanvasRenderingContext2DMethods for OffscreenCanvasRenderingContex
         ccw: bool,
     ) -> ErrorResult {
         self.canvas_state
-            .borrow()
             .ellipse(x, y, rx, ry, rotation, start, end, ccw)
     }
 }

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::canvas_state::CanvasState;
-use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasFillRule;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasImageSource;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasLineCap;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23436
- [x] There are tests for these changes

The PR removes the DomRefCell wrapper for CanvasState from `CanvasRenderingContext2D` and `OffscreenCanvasRenderingContext2D`. The reason for keeping member wrappers in CanvasState instead of overall CanvasState wrapper itself is because I believe that removing member wrappers would make it rather difficult to refactor the internal CanvasState methods in order to cover certain edge cases. 

[For example](https://github.com/servo/servo/issues/23436#issuecomment-611089157): Drawing a canvas inside of itself would require getting and providing certain parameters for source canvas such as `canvas_id` and `is_origin_clean` that are currently accessed through source canvas context. Also, we might run into similar issue when creating patterns using canvas.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
