### PR TITLE
Automatically enable WebGL 2 for specific domains.

### DIFF
--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -41,7 +41,6 @@ use js::error::throw_type_error;
 use js::rust::HandleValue;
 use profile_traits::ipc;
 use script_layout_interface::{HTMLCanvasData, HTMLCanvasDataSource};
-use servo_config::pref;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 
 const DEFAULT_WIDTH: u32 = 300;
@@ -222,7 +221,8 @@ impl HTMLCanvasElement {
         cx: JSContext,
         options: HandleValue,
     ) -> Option<DomRoot<WebGL2RenderingContext>> {
-        if !pref!(dom.webgl2.enabled) {
+        if !WebGL2RenderingContext::is_webgl2_enabled(cx, self.global().reflector().get_jsobject())
+        {
             return None;
         }
         if let Some(ctx) = self.context() {

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -542,7 +542,7 @@ interface mixin WebGL2RenderingContextBase
   void bindVertexArray(WebGLVertexArrayObject? array);
 };
 
-[Exposed=Window, Pref="dom.webgl2.enabled"]
+[Exposed=Window, Func="WebGL2RenderingContext::is_webgl2_enabled"]
 interface WebGL2RenderingContext
 {
 };


### PR DESCRIPTION
Our WebGL 2 implementation has progressed to the point where some but not all content works well. One particular example of non-working content is Babylon.js; if the WebGL2RenderingContext interface is present, it automatically tries to use it and causes panics in Servo. However, there are demos like http://www.servoexperiments.com/webxr-particles/ that work fine today and would be great to feature on our HoloLens homepage.

This change adds what is effectively an origin trial, where we can identify content that works well, ensure it's running in a list of blessed hosts, and reap the benefits.