### PR TITLE
Upgrade clang to 9.0 on Windows.

### DIFF
--- a/python/servo/packages.py
+++ b/python/servo/packages.py
@@ -4,7 +4,7 @@
 
 WINDOWS_MSVC = {
     "cmake": "3.14.3",
-    "llvm": "8.0.1",
+    "llvm": "9.0.0",
     "moztools": "3.2",
     "ninja": "1.7.1",
     "nuget": "08-08-2019",

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -49,7 +49,7 @@ WEB_PLATFORM_TESTS_PATH = os.path.join("tests", "wpt", "web-platform-tests")
 SERVO_TESTS_PATH = os.path.join("tests", "wpt", "mozilla", "tests")
 
 CLANGFMT_CPP_DIRS = ["support/hololens/"]
-CLANGFMT_VERSION = "8"
+CLANGFMT_VERSION = "9"
 
 TEST_SUITES = OrderedDict([
     ("tidy", {"kwargs": {"all_files": False, "no_progress": False, "self_test": False,


### PR DESCRIPTION
This is required for building with the latest versions of Visual Studio 2019.