### PR TITLE
Fix resize event is not fired for window in headless mode

### DIFF
--- a/ports/servoshell/window_trait.rs
+++ b/ports/servoshell/window_trait.rs
@@ -38,7 +38,7 @@ pub trait WindowPortsMethods: WindowMethods {
     fn queue_embedder_events_for_winit_event(&self, event: winit::event::WindowEvent<'_>);
     fn is_animating(&self) -> bool;
     fn set_title(&self, _title: &str) {}
-    fn set_inner_size(&self, _size: DeviceIntSize) {}
+    fn set_inner_size(&self, _size: DeviceIntSize);
     fn set_position(&self, _point: DeviceIntPoint) {}
     fn set_fullscreen(&self, _state: bool) {}
     fn set_cursor(&self, _cursor: Cursor) {}

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14142,6 +14142,13 @@
       {}
      ]
     ],
+    "window_resizeTo.html": [
+     "87d60498e80bcd01b5790feb3f9e104410cb6e1b",
+     [
+      null,
+      {}
+     ]
+    ],
     "window_resize_not_triggered_on_load.html": [
      "f551f67ee91f25c7e05c868dbbcad5cb11c93645",
      [

--- a/tests/wpt/mozilla/tests/mozilla/window_resizeTo.html
+++ b/tests/wpt/mozilla/tests/mozilla/window_resizeTo.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Verify that the resize event is fired when the window is resized (particularly in headless mode)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    async_test(function (t) {
+        window.onresize = t.step_func(function () {
+            assert_equals(window.innerWidth, 200);
+            assert_equals(window.innerHeight, 200);
+            t.done();
+        });
+
+        window.resizeTo(200, 200);
+    }, "onresize");
+</script>


### PR DESCRIPTION

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15621
- [x] There are tests for these changes
