### PR TITLE
Dump all UWP logging output to a file

### DIFF
--- a/ports/libsimpleservo/capi/src/vslogger.rs
+++ b/ports/libsimpleservo/capi/src/vslogger.rs
@@ -2,15 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::OUTPUT_LOG_HANDLER;
 use log::{self, Metadata, Record};
 use std::sync::{Arc, Mutex};
 
 lazy_static! {
     pub static ref LOG_MODULE_FILTERS: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(vec![]));
-}
-
-extern "C" {
-    fn OutputDebugStringA(s: *const u8);
 }
 
 pub struct VSLogger;
@@ -33,9 +30,9 @@ impl log::Log for VSLogger {
                 record.target(),
                 record.args()
             );
-            unsafe {
-                OutputDebugStringA(log.as_ptr());
-            };
+            if let Some(handler) = OUTPUT_LOG_HANDLER.lock().unwrap().as_ref() {
+                (handler)(log.as_ptr() as _, log.len() as u32);
+            }
         }
     }
 

--- a/support/hololens/ServoApp/ServoControl/Servo.h
+++ b/support/hololens/ServoApp/ServoControl/Servo.h
@@ -119,5 +119,6 @@ protected:
 // pointer as callback in Servo, and these functions need a way to get
 // the Servo instance. See https://github.com/servo/servo/issues/22967
 static Servo *sServo = nullptr;
+static HANDLE sLogHandle = INVALID_HANDLE_VALUE;
 
 } // namespace winrt::servo


### PR DESCRIPTION
These changes ensure that we keep getting debug output in the VS output window, but we also write each message to a file in the app's local data directory. These changes also extend the C API a bit to support more generic logging facilities, removing some of the Windows-specific nature of the VSLogger. Fixes part of #23813.