### PR TITLE
Report error when vcvarsall fails

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -315,11 +315,15 @@ class MachCommands(CommandBase):
             process = subprocess.Popen('("%s" %s > nul) && "python" -c "import os; print(repr(os.environ))"' %
                                        (os.path.join(vs_dirs['vcdir'], "Auxiliary", "Build", "vcvarsall.bat"), "x64"),
                                        stdout=subprocess.PIPE, shell=True)
-            stdout, _ = process.communicate()
+            stdout, stderr = process.communicate()
             exitcode = process.wait()
             encoding = locale.getpreferredencoding()  # See https://stackoverflow.com/a/9228117
             if exitcode == 0:
                 os.environ.update(eval(stdout.decode(encoding)))
+            else:
+                print("Failed to run vcvarsall. stderr:")
+                print(stderr.decode(encoding))
+                exit(1)
 
         # Ensure that GStreamer libraries are accessible when linking.
         if 'windows' in target_triple:


### PR DESCRIPTION
In trying to get my Windows cross build working on my desktop, I ended up spending a lot of time trying to replicate a failure within servo's build system that ultimately turned out to be vcvarsall silently failing (I was missing a trailing slash in my `VSINSTALLDIR` env var, which vcvarsall does not handle well at all)

We should report an error when this happens.

r? @jdm