### PR TITLE
Add VCINSTALLDIR to the 'do not run within vcvarsall' check

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -256,10 +256,11 @@ class MachCommands(CommandBase):
             vs_dirs = self.vs_dirs()
 
         if host != target_triple and 'windows' in target_triple:
-            if os.environ.get('VisualStudioVersion'):
+            if os.environ.get('VisualStudioVersion') or os.environ.get('VCINSTALLDIR'):
                 print("Can't cross-compile for Windows inside of a Visual Studio shell.\n"
                       "Please run `python mach build [arguments]` to bypass automatic "
-                      "Visual Studio shell.")
+                      "Visual Studio shell, and make sure the VisualStudioVersion and "
+                      "VCINSTALLDIR environment variables are not set.")
                 sys.exit(1)
             vcinstalldir = vs_dirs['vcdir']
             if not os.path.exists(vcinstalldir):


### PR DESCRIPTION
Servo is able to run with VSINSTALLDIR set, but not VCINSTALLDIR, since cc-rs takes it to mean vcvarsall has been called.

As far as I can tell servo is able to build with a custom VS install without needing help finding it (aside from perhaps VSINSTALLDIR), since many tools use a non-env var method of finding VS.

r? @jdm