### PR TITLE
Publish new UWP package

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -301,15 +301,14 @@ def with_rust_nightly():
     )
 
 
-def appx_artifact(debug):
-    return '/'.join([
-        'repo',
-        'support',
-        'hololens',
-        'AppPackages',
-        'ServoApp',
-        'ServoApp_1.0.0.0_%sTest.zip' % ('Debug_' if debug else ''),
-    ])
+appx_artifact = '/'.join([
+    'repo',
+    'support',
+    'hololens',
+    'AppPackages',
+    'ServoApp',
+    'FirefoxReality.zip',
+])
 
 
 def windows_arm64(rdp=False):
@@ -322,7 +321,7 @@ def windows_arm64(rdp=False):
             "python mach build --dev --target=aarch64-uwp-windows-msvc",
             "python mach package --dev --target aarch64-uwp-windows-msvc --uwp=arm64",
         )
-        .with_artifacts(appx_artifact(debug=True))
+        .with_artifacts(appx_artifact)
         .find_or_create("build.windows_uwp_arm64_dev." + CONFIG.tree_hash())
     )
 
@@ -338,7 +337,7 @@ def windows_uwp_x64(rdp=False):
             "python mach package --dev --target=x86_64-uwp-windows-msvc --uwp=x64",
             "python mach test-tidy --force-cpp --no-wpt",
         )
-        .with_artifacts(appx_artifact(debug=True))
+        .with_artifacts(appx_artifact)
         .find_or_create("build.windows_uwp_x64_dev." + CONFIG.tree_hash())
     )
 
@@ -358,7 +357,7 @@ def uwp_nightly(rdp=False):
             "mach package --release --target=x86_64-uwp-windows-msvc --uwp=x64 --uwp=arm64",
             "mach upload-nightly uwp --secret-from-taskcluster",
         )
-        .with_artifacts(appx_artifact(debug=False))
+        .with_artifacts(appx_artifact)
         .with_max_run_time_minutes(3 * 60)
         .find_or_create("build.windows_uwp_nightlies." + CONFIG.tree_hash())
     )

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -827,10 +827,12 @@ def build_uwp(platforms, dev, msbuild_dir, ms_app_store):
         subprocess.check_call([msbuild, "/m", build_file.name] + msbuild_args)
         os.unlink(build_file.name)
 
-    print("Creating ZIP")
-    out_dir = path.join(os.getcwd(), 'support', 'hololens', 'AppPackages', 'ServoApp')
-    name = 'ServoApp_%s_%sTest' % (version, 'Debug_' if dev else '')
-    artifacts_dir = path.join(out_dir, name)
-    zip_path = path.join(out_dir, "FirefoxReality.zip")
-    archive_deterministically(artifacts_dir, zip_path, prepend_path='servo/')
-    print("Packaged Servo into " + zip_path)
+    # Don't bother creating an archive that contains unsigned app packages.
+    if not ms_app_store:
+        print("Creating ZIP")
+        out_dir = path.join(os.getcwd(), 'support', 'hololens', 'AppPackages', 'ServoApp')
+        name = 'ServoApp_%s_%sTest' % (version, 'Debug_' if dev else '')
+        artifacts_dir = path.join(out_dir, name)
+        zip_path = path.join(out_dir, "FirefoxReality.zip")
+        archive_deterministically(artifacts_dir, zip_path, prepend_path='servo/')
+        print("Packaged Servo into " + zip_path)

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -627,8 +627,8 @@ class PackageCommands(CommandBase):
             nightly_dir = 'nightly/{}'.format(platform)
             filename = nightly_filename(package, timestamp)
             package_upload_key = '{}/{}'.format(nightly_dir, filename)
-            extension = path.basename(package).partition('.')[2]
-            latest_upload_key = '{}/servo-latest.{}'.format(nightly_dir, extension)
+            extension = path.splitext(path.basename(package))[1]
+            latest_upload_key = '{}/servo-latest{}'.format(nightly_dir, extension)
 
             s3.upload_file(package, BUCKET, package_upload_key)
             copy_source = {

--- a/support/hololens/ServoApp/Package.appxmanifest
+++ b/support/hololens/ServoApp/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" IgnorableNamespaces="uap mp uap5">
-  <Identity Name="MozillaFoundation.FirefoxReality" Publisher="CN=Allizom" Version="1.0.0.0" />
+  <Identity Name="MozillaFoundation.FirefoxReality" Publisher="CN=Allizom" Version="1.1.0.0" />
   <mp:PhoneIdentity PhoneProductId="1d265729-8836-4bd3-9992-4cb111d1068b" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Firefox Reality</DisplayName>


### PR DESCRIPTION
This fixes an issue where the latest UWP package is published at http://download.servo.org/nightly/uwp/servo-latest.0.0.0_Test.zip because the full filename contains "1.0.0.0" and we don't detect file extensions correctly.