### PR TITLE
[python/servo/bootstrap.py] Add missing comma

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -100,7 +100,7 @@ def linux(context, force=False):
                 'rpm-build', 'openssl-devel', 'cmake',
                 'libXcursor-devel', 'libXmu-devel', 'mesa-libOSMesa-devel',
                 'dbus-devel', 'ncurses-devel', 'harfbuzz-devel', 'ccache',
-                'clang', 'clang-libs', 'autoconf213', 'python3-devel'
+                'clang', 'clang-libs', 'autoconf213', 'python3-devel',
                 'gstreamer1-devel', 'gstreamer1-plugins-base-devel',
                 'gstreamer1-plugins-bad-free-devel']
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Add a missing comma in `pkgs_dnf` list, so `python3 ./mach bootstrap` works on Fedora.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
Unfortunately I can't actually build Servo right now because of lack of RAM (whoops), but hopefully adding a single comma between elements of a list is small enough of a change for you to overlook that. :sweat_smile: 

- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] (N/A) These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it's in the bootstrap script, which afaik doesn't have tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
