### PR TITLE
Use python binary to run multiprocess tests.

### DIFF
--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -614,7 +614,7 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
         # https://github.com/servo/servo/issues/22438
         if this_chunk == 0:
             task.with_script("""
-                time python2 ./mach test-wpt --release --binary-arg=--multiprocess \
+                time python ./mach test-wpt --release --binary-arg=--multiprocess \
                     --processes $PROCESSES \
                     --log-raw test-wpt-mp.log \
                     --log-errorsummary wpt-mp-errorsummary.log \

--- a/etc/taskcluster/decisionlib.py
+++ b/etc/taskcluster/decisionlib.py
@@ -685,7 +685,7 @@ class MacOsGenericWorkerTask(UnixTaskMixin, GenericWorkerTask):
         # So concatenate scripts and use a single `bash` command instead.
         return [
             [
-                "/bin/bash", "--login", "-x", "-e", "-c",
+                "/bin/bash", "--login", "-x", "-e", "-o", "pipefail", "-c",
                 deindent("\n".join(self.scripts))
             ]
         ]
@@ -749,7 +749,7 @@ class DockerWorkerTask(UnixTaskMixin, Task):
             "image": self.docker_image,
             "maxRunTime": self.max_run_time_minutes * 60,
             "command": [
-                "/bin/bash", "--login", "-x", "-e", "-c",
+                "/bin/bash", "--login", "-x", "-e", "-o", "pipefail", "-c",
                 deindent("\n".join(self.scripts))
             ],
         }

--- a/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -277,7 +277,7 @@ class ServoWebDriverRefTestExecutor(RefTestExecutor):
 
         return ServoWebDriverRun(self.logger,
                                  self._screenshot,
-                                 self.protocol.session,
+                                 self.protocol,
                                  self.test_url(test),
                                  timeout,
                                  self.extra_timeout).run()


### PR DESCRIPTION
The python2 binary doesn't exist in the path on macOS. This change uses an existing python2 on macOS and whatever the default python version is on linux.