### PR TITLE
Add support for canceling CSS transitions

### DIFF
--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -129,6 +129,7 @@ time
 timeupdate
 toggle
 track
+transitioncancel
 transitionend
 unhandledrejection
 unload

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -207,6 +207,9 @@ pub struct LayoutThread {
     /// The list of animations that have expired since the last style recalculation.
     expired_animations: ServoArc<RwLock<FxHashMap<OpaqueNode, Vec<Animation>>>>,
 
+    /// The list of animations that have been cancelled during the last style recalculation.
+    cancelled_animations: ServoArc<RwLock<FxHashMap<OpaqueNode, Vec<Animation>>>>,
+
     /// A counter for epoch messages
     epoch: Cell<Epoch>,
 
@@ -576,6 +579,7 @@ impl LayoutThread {
             document_shared_lock: None,
             running_animations: ServoArc::new(RwLock::new(Default::default())),
             expired_animations: ServoArc::new(RwLock::new(Default::default())),
+            cancelled_animations: ServoArc::new(RwLock::new(Default::default())),
             // Epoch starts at 1 because of the initial display list for epoch 0 that we send to WR
             epoch: Cell::new(Epoch(1)),
             viewport_size: Size2D::new(Au(0), Au(0)),
@@ -655,6 +659,7 @@ impl LayoutThread {
                 visited_styles_enabled: false,
                 running_animations: self.running_animations.clone(),
                 expired_animations: self.expired_animations.clone(),
+                cancelled_animations: self.cancelled_animations.clone(),
                 registered_speculative_painters: &self.registered_painters,
                 local_context_creation_data: Mutex::new(thread_local_style_context_creation_data),
                 timer: self.timer.clone(),
@@ -1785,6 +1790,7 @@ impl LayoutThread {
                 &self.script_chan,
                 &mut *self.running_animations.write(),
                 &mut *self.expired_animations.write(),
+                &mut *self.cancelled_animations.write(),
                 invalid_nodes,
                 newly_transitioning_nodes,
                 &self.new_animations_receiver,

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -609,6 +609,7 @@ impl LayoutThread {
                 visited_styles_enabled: false,
                 running_animations: Default::default(),
                 expired_animations: Default::default(),
+                cancelled_animations: Default::default(),
                 registered_speculative_painters: &self.registered_painters,
                 local_context_creation_data: Mutex::new(thread_local_style_context_creation_data),
                 timer: self.timer.clone(),

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -496,6 +496,7 @@ macro_rules! global_event_handlers(
         event_handler!(suspend, GetOnsuspend, SetOnsuspend);
         event_handler!(timeupdate, GetOntimeupdate, SetOntimeupdate);
         event_handler!(toggle, GetOntoggle, SetOntoggle);
+        event_handler!(transitioncancel, GetOntransitioncancel, SetOntransitioncancel);
         event_handler!(transitionend, GetOntransitionend, SetOntransitionend);
         event_handler!(volumechange, GetOnvolumechange, SetOnvolumechange);
         event_handler!(waiting, GetOnwaiting, SetOnwaiting);

--- a/components/script/dom/webidls/EventHandler.webidl
+++ b/components/script/dom/webidls/EventHandler.webidl
@@ -93,6 +93,7 @@ interface mixin GlobalEventHandlers {
 // https://drafts.csswg.org/css-transitions/#interface-globaleventhandlers-idl
 partial interface mixin GlobalEventHandlers {
            attribute EventHandler ontransitionend;
+           attribute EventHandler ontransitioncancel;
 };
 
 // https://w3c.github.io/selection-api/#extensions-to-globaleventhandlers-interface

--- a/components/style/context.rs
+++ b/components/style/context.rs
@@ -194,6 +194,10 @@ pub struct SharedStyleContext<'a> {
     #[cfg(feature = "servo")]
     pub expired_animations: Arc<RwLock<FxHashMap<OpaqueNode, Vec<Animation>>>>,
 
+    /// The list of animations that have expired since the last style recalculation.
+    #[cfg(feature = "servo")]
+    pub cancelled_animations: Arc<RwLock<FxHashMap<OpaqueNode, Vec<Animation>>>>,
+
     /// Paint worklets
     #[cfg(feature = "servo")]
     pub registered_speculative_painters: &'a dyn RegisteredSpeculativePainters,

--- a/tests/wpt/metadata/css/css-transitions/idlharness.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/idlharness.html.ini
@@ -5,40 +5,22 @@
   [HTMLElement interface: attribute ontransitionstart]
     expected: FAIL
 
-  [Document interface: attribute ontransitioncancel]
-    expected: FAIL
-
   [Document interface: document must inherit property "ontransitionstart" with the proper type]
-    expected: FAIL
-
-  [Document interface: document must inherit property "ontransitioncancel" with the proper type]
     expected: FAIL
 
   [HTMLElement interface: attribute ontransitionrun]
     expected: FAIL
 
-  [HTMLElement interface: document must inherit property "ontransitioncancel" with the proper type]
-    expected: FAIL
-
   [Window interface: attribute ontransitionrun]
     expected: FAIL
 
-  [Window interface: attribute ontransitioncancel]
-    expected: FAIL
-
   [HTMLElement interface: document must inherit property "ontransitionstart" with the proper type]
-    expected: FAIL
-
-  [HTMLElement interface: attribute ontransitioncancel]
     expected: FAIL
 
   [HTMLElement interface: document must inherit property "ontransitionrun" with the proper type]
     expected: FAIL
 
   [Window interface: window must inherit property "ontransitionrun" with the proper type]
-    expected: FAIL
-
-  [Window interface: window must inherit property "ontransitioncancel" with the proper type]
     expected: FAIL
 
   [Document interface: attribute ontransitionstart]

--- a/tests/wpt/metadata/css/css-transitions/transitioncancel-001.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/transitioncancel-001.html.ini
@@ -1,4 +1,0 @@
-[transitioncancel-001.html]
-  [transitioncancel should be fired if the element is made display:none during the transition]
-    expected: FAIL
-

--- a/tests/wpt/web-platform-tests/css/css-transitions/transitioncancel-002.html
+++ b/tests/wpt/web-platform-tests/css/css-transitions/transitioncancel-002.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transitions Test: Removing transitioning property from transition-property triggers transitioncancel</title>
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<meta name="assert" content="Removing transitioning property from transition-property
+causes transitioncancel.">
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/#event-dispatch">
+
+<script src="/resources/testharness.js" type="text/javascript"></script>
+<script src="/resources/testharnessreport.js" type="text/javascript"></script>
+<script src="./support/helper.js" type="text/javascript"></script>
+
+</head>
+<body>
+<div id="log"></div>
+
+<script>
+promise_test(async t => {
+  // Create element and prepare to trigger a transition on it.
+  const div = addDiv(t, {
+    style: 'transition: background-color 0.25s; background-color: red;',
+  });
+
+  // Attach event listeners
+  const eventWatcher = new EventWatcher(t, div, ['transitioncancel']);
+  div.addEventListener('transitionend', t.step_func((event) => {
+    assert_unreached('transitionend event should not be fired');
+  }));
+
+  // Trigger transition
+  getComputedStyle(div).backgroundColor;
+  div.style.backgroundColor = 'green';
+  getComputedStyle(div).backgroundColor;
+
+  // Remove the transitioning property from transition-property asynchronously.
+  await waitForFrame();
+  div.style.transitionProperty = 'none';
+
+  await eventWatcher.wait_for('transitioncancel');
+}, 'Removing a transitioning property from transition-property should trigger transitioncancel');
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This change adds support for canceling CSS transitions when a property is
no longer transitionable. Support for canceling and replacing CSS
transitions when the end value changes is still pending. This change
also takes advantage of updating the constellation message to fix a bug
where transition events could be sent for closed pipelines.

Fixes #15079.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #15079.

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
