### PR TITLE
Fix InvalidateSubFramebuffer error handling

### DIFF
--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -3966,7 +3966,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         }
 
         if width < 0 || height < 0 {
-            return;
+            return self.base.webgl_error(InvalidValue);
         }
 
         self.base

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/invalidate-framebuffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/invalidate-framebuffer.html.ini
@@ -6,6 +6,3 @@
   [WebGL test #17: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
-  [WebGL test #11: getError expected: INVALID_VALUE. Was NO_ERROR : calling invalidateSubFramebuffer should generate INVALID_VALUE if width < 0 or height < 0.]
-    expected: FAIL
-


### PR DESCRIPTION
The WebGL2 InvalidateSubFramebuffer function should generate INVALID_VALUE when width or height is negative.

See [OpenGL ES 3.0.4 §4.5](https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section-4.5)

The remaining test cases depend on BlitFramebuffer, which is not implemented yet.

<!-- Please describe your changes on the following line: -->

cc @jdm @zakorgy

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes may fix #20529 *
- [x] There are tests for these changes

\* InvalidateSubFramebuffer was added earlier, it just wasn't closed back then. There seems to be a Mac specific issue there too.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
