### PR TITLE
Add initial support for BlitFramebuffer

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1473,6 +1473,20 @@ impl WebGLImpl {
             WebGLCommand::BindTexture(target, id) => {
                 gl.bind_texture(target, id.map_or(0, WebGLTextureId::get))
             },
+            WebGLCommand::BlitFrameBuffer(
+                src_x0,
+                src_y0,
+                src_x1,
+                src_y1,
+                dst_x0,
+                dst_y0,
+                dst_x1,
+                dst_y1,
+                mask,
+                filter,
+            ) => gl.blit_framebuffer(
+                src_x0, src_y0, src_x1, src_y1, dst_x0, dst_y0, dst_x1, dst_y1, mask, filter,
+            ),
             WebGLCommand::Uniform1f(uniform_id, v) => gl.uniform_1f(uniform_id, v),
             WebGLCommand::Uniform1fv(uniform_id, ref v) => gl.uniform_1fv(uniform_id, v),
             WebGLCommand::Uniform1i(uniform_id, v) => gl.uniform_1i(uniform_id, v),

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -295,6 +295,7 @@ pub enum WebGLCommand {
     BindFramebuffer(u32, WebGLFramebufferBindingRequest),
     BindRenderbuffer(u32, Option<WebGLRenderbufferId>),
     BindTexture(u32, Option<WebGLTextureId>),
+    BlitFrameBuffer(i32, i32, i32, i32, i32, i32, i32, i32, u32, u32),
     DisableVertexAttribArray(u32),
     EnableVertexAttribArray(u32),
     FramebufferRenderbuffer(u32, u32, u32, Option<WebGLRenderbufferId>),

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -227,6 +227,25 @@ impl WebGLFramebuffer {
         self.size.get()
     }
 
+    pub fn get_attachment_formats(&self) -> WebGLResult<(Option<u32>, Option<u32>, Option<u32>)> {
+        if self.check_status() != constants::FRAMEBUFFER_COMPLETE {
+            return Err(WebGLError::InvalidFramebufferOperation);
+        }
+        let color = match self.attachment(constants::COLOR_ATTACHMENT0) {
+            Some(WebGLFramebufferAttachmentRoot::Renderbuffer(rb)) => Some(rb.internal_format()),
+            _ => None,
+        };
+        let depth = match self.attachment(constants::DEPTH_ATTACHMENT) {
+            Some(WebGLFramebufferAttachmentRoot::Renderbuffer(rb)) => Some(rb.internal_format()),
+            _ => None,
+        };
+        let stencil = match self.attachment(constants::STENCIL_ATTACHMENT) {
+            Some(WebGLFramebufferAttachmentRoot::Renderbuffer(rb)) => Some(rb.internal_format()),
+            _ => None,
+        };
+        Ok((color, depth, stencil))
+    }
+
     fn check_attachment_constraints<'a>(
         &self,
         attachment: &Option<WebGLFramebufferAttachment>,

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -295,8 +295,8 @@ interface mixin WebGL2RenderingContextBase
                         optional GLuint dstOffset = 0, optional GLuint length = 0);
 
   /* Framebuffer objects */
-  // void blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0,
-  //                      GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
+  void blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0,
+                       GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
   void framebufferTextureLayer(GLenum target, GLenum attachment, WebGLTexture? texture, GLint level,
                                GLint layer);
   void invalidateFramebuffer(GLenum target, sequence<GLenum> attachments);

--- a/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
@@ -44,3 +44,24 @@
   [WebGL test #6: Property either does not exist or is not a function: copyTexSubImage3D]
     expected: FAIL
 
+  [WebGL test #7: Property either does not exist or is not a function: compressedTexSubImage3D]
+    expected: FAIL
+
+  [WebGL test #5: Property either does not exist or is not a function: copyTexSubImage3D]
+    expected: FAIL
+
+  [WebGL test #6: Property either does not exist or is not a function: compressedTexImage3D]
+    expected: FAIL
+
+  [WebGL test #3: Property either does not exist or is not a function: texStorage3D]
+    expected: FAIL
+
+  [WebGL test #1: Property either does not exist or is not a function: texImage3D]
+    expected: FAIL
+
+  [WebGL test #2: Property either does not exist or is not a function: texStorage2D]
+    expected: FAIL
+
+  [WebGL test #4: Property either does not exist or is not a function: texSubImage3D]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/invalidate-framebuffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/invalidate-framebuffer.html.ini
@@ -1,7 +1,7 @@
 [invalidate-framebuffer.html]
   bug: https://github.com/servo/servo/issues/20529
   expected:
-    if os == "linux": ERROR
+    if os == "linux": TIMEOUT
     if os == "mac": TIMEOUT
   [WebGL test #17: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/multisample-with-full-sample-counts.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/multisample-with-full-sample-counts.html.ini
@@ -1,5 +1,66 @@
 [multisample-with-full-sample-counts.html]
-  expected: ERROR
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
+
+  [WebGL test #0: User buffer has been rendered to red with sample = 1, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #1: User buffer has been rendered to red with sample = 1, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #10: User buffer has been rendered to red with sample = 6, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #2: User buffer has been rendered to red with sample = 2, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #5: User buffer has been rendered to red with sample = 3, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #6: User buffer has been rendered to red with sample = 4, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #13: User buffer has been rendered to red with sample = 7, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #11: User buffer has been rendered to red with sample = 6, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #3: User buffer has been rendered to red with sample = 2, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #15: User buffer has been rendered to red with sample = 8, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #12: User buffer has been rendered to red with sample = 7, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #4: User buffer has been rendered to red with sample = 3, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #14: User buffer has been rendered to red with sample = 8, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #8: User buffer has been rendered to red with sample = 5, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #7: User buffer has been rendered to red with sample = 4, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #9: User buffer has been rendered to red with sample = 5, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html.ini
@@ -1,5 +1,44 @@
 [multisampled-depth-renderbuffer-initialization.html]
-  expected: ERROR
   [WebGL test #5: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
+
+  [WebGL test #36: getError expected: NO_ERROR. Was INVALID_OPERATION : should be no error after renderbufferStorageMultisample(DEPTH_COMPONENT16).]
+    expected: FAIL
+
+  [WebGL test #63: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #14: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #30: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #77: getError expected: NO_ERROR. Was INVALID_OPERATION : should be no error after renderbufferStorageMultisample(DEPTH_COMPONENT16).]
+    expected: FAIL
+
+  [WebGL test #47: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #22: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #39: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #80: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #6: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #55: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #71: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #14: should be 0,0,255,255\nat (35, 6) expected: 0,0,255,255 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-renderbuffer-initialization.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-renderbuffer-initialization.html.ini
@@ -1,5 +1,64 @@
 [multisampled-renderbuffer-initialization.html]
-  expected: ERROR
   [WebGL test #9: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
+
+  [WebGL test #35: user buffer has been initialized to 0\nat (8, 0) expected: 0,0,0,0 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #85: user buffer has been initialized to 0\nat (8, 0) expected: 0,0,0,0 was 255,255,255,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #48: user buffer has been initialized to 0\nat (3, 0) expected: 0,0,0,0 was 0,0,224,207]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #61: user buffer has been initialized to 0\nat (8, 0) expected: 0,0,0,0 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #124: user buffer has been initialized to 0\nat (1, 0) expected: 0,0,0,0 was 248,3,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #111: user buffer has been initialized to 0\nat (3, 0) expected: 0,0,0,0 was 0,0,224,207]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #22: user buffer has been initialized to 0\nat (1, 0) expected: 0,0,0,0 was 248,3,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #73: user buffer has been initialized to 0\nat (1, 0) expected: 0,0,0,0 was 248,3,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #98: user buffer has been initialized to 0\nat (1, 0) expected: 0,0,0,0 was 248,3,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #22: user buffer has been initialized to 0\nat (8, 0) expected: 0,0,0,0 was 32,32,32,32]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #35: user buffer has been initialized to 0\nat (1, 0) expected: 0,0,0,0 was 124,1,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #10: user buffer has been initialized to 0\nat (0, 0) expected: 0,0,0,0 was 144,2,144,33]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #48: user buffer has been initialized to 0\nat (8, 0) expected: 0,0,0,0 was 255,255,255,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #73: user buffer has been initialized to 0\nat (41, 28) expected: 0,0,0,0 was 0,0,0,33]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #85: user buffer has been initialized to 0\nat (0, 0) expected: 0,0,0,0 was 0,128,0,128]
+    expected:
+      if os == "mac": FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-stencil-renderbuffer-initialization.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-stencil-renderbuffer-initialization.html.ini
@@ -1,5 +1,58 @@
 [multisampled-stencil-renderbuffer-initialization.html]
-  expected: ERROR
   [WebGL test #5: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
+
+  [WebGL test #77: getError expected: NO_ERROR. Was INVALID_OPERATION : should be no error after renderbufferStorageMultisample(STENCIL_INDEX8).]
+    expected: FAIL
+
+  [WebGL test #36: getError expected: NO_ERROR. Was INVALID_OPERATION : should be no error after renderbufferStorageMultisample(STENCIL_INDEX8).]
+    expected: FAIL
+
+  [WebGL test #22: should be 0,0,255,255\nat (5, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #47: should be 0,0,255,255\nat (8, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #14: should be 0,0,255,255\nat (8, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #6: should be 0,0,255,255\nat (8, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #39: should be 0,0,255,255\nat (1, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #63: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #30: should be 0,0,255,255\nat (1, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #47: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #22: should be 0,0,255,255\nat (1, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #80: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #55: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #71: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected:
+      if os == "mac": FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-filter-srgb.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-filter-srgb.html.ini
@@ -1,5 +1,1342 @@
 [blitframebuffer-filter-srgb.html]
-  expected: ERROR
-  [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #390: pixel at [5, 5\] should be (128,128,255,144), but the actual color is (0,0,0,0)]
     expected: FAIL
+
+  [WebGL test #154: pixel at [5, 1\] should be (28,28,255,34), but the actual color is (3,3,255,0)]
+    expected: FAIL
+
+  [WebGL test #126: pixel at [5, 6\] should be (119,119,255,132), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #403: pixel at [2, 7\] should be (192,255,192,192), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #294: pixel at [1, 2\] should be (13,13,255,13), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #369: pixel at [0, 3\] should be (64,64,64,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #386: pixel at [1, 5\] should be (128,128,255,128), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #250: pixel at [1, 5\] should be (188,188,255,188), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #408: pixel at [7, 7\] should be (255,208,208,208), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #232: pixel at [7, 2\] should be (255,152,152,152), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #318: pixel at [1, 5\] should be (55,55,255,55), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #204: pixel at [7, 7\] should be (255,204,204,204), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #96: pixel at [7, 2\] should be (255,13,13,13), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #198: pixel at [1, 7\] should be (192,192,255,196), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #385: pixel at [0, 5\] should be (128,128,128,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #359: pixel at [6, 1\] should be (0,255,13,13), but the actual color is (0,255,0,0)]
+    expected: FAIL
+
+  [WebGL test #59: pixel at [6, 6\] should be (219,255,223,223), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #363: pixel at [2, 2\] should be (64,255,64,64), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #249: pixel at [0, 5\] should be (188,188,188,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #31: pixel at [2, 3\] should be (152,255,155,155), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #251: pixel at [2, 5\] should be (188,255,188,188), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #130: pixel at [1, 7\] should be (134,134,255,140), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #275: pixel at [0, 1\] should be (161,161,161,255), but the actual color is (208,208,208,255)]
+    expected: FAIL
+
+  [WebGL test #243: pixel at [2, 4\] should be (188,255,188,188), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #254: pixel at [5, 5\] should be (188,188,255,198), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #13: pixel at [0, 1\] should be (71,71,71,255), but the actual color is (16,16,16,255)]
+    expected: FAIL
+
+  [WebGL test #167: pixel at [2, 3\] should be (85,255,88,88), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #307: pixel at [6, 3\] should be (13,255,20,20), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #115: pixel at [2, 5\] should be (74,255,79,79), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #7: pixel at [2, 0\] should be (0,255,34,34), but the actual color is (0,255,4,4)]
+    expected: FAIL
+
+  [WebGL test #203: pixel at [6, 7\] should be (196,255,204,204), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #334: pixel at [1, 7\] should be (134,134,255,134), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #351: pixel at [6, 0\] should be (0,255,13,13), but the actual color is (0,255,0,0)]
+    expected: FAIL
+
+  [WebGL test #26: pixel at [5, 2\] should be (125,125,255,133), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #398: pixel at [5, 6\] should be (192,192,255,208), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #319: pixel at [2, 5\] should be (55,255,55,55), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #129: pixel at [0, 7\] should be (134,134,134,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #158: pixel at [1, 2\] should be (53,53,255,56), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #32: pixel at [3, 3\] should be (255,155,155,155), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #57: pixel at [4, 6\] should be (219,219,219,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #27: pixel at [6, 2\] should be (125,255,133,133), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #1: pixel at [0, 0\] should be (110,110,110,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #71: pixel at [0, 1\] should be (105,105,105,255), but the actual color is (168,168,168,255)]
+    expected: FAIL
+
+  [WebGL test #150: pixel at [1, 1\] should be (28,28,255,28), but the actual color is (3,3,255,3)]
+    expected: FAIL
+
+  [WebGL test #242: pixel at [1, 4\] should be (188,188,255,188), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #379: pixel at [2, 4\] should be (128,255,128,128), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #124: pixel at [3, 6\] should be (255,119,119,119), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #271: pixel at [6, 7\] should be (225,255,233,233), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #106: pixel at [1, 4\] should be (44,44,255,47), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #3: pixel at [0, 1\] should be (212,212,212,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #135: pixel at [6, 7\] should be (140,255,154,154), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #24: pixel at [3, 2\] should be (255,125,125,125), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #15: pixel at [2, 1\] should be (71,255,79,79), but the actual color is (16,255,20,20)]
+    expected: FAIL
+
+  [WebGL test #8: pixel at [3, 0\] should be (255,34,34,34), but the actual color is (255,4,4,4)]
+    expected: FAIL
+
+  [WebGL test #64: pixel at [3, 7\] should be (255,227,227,227), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #63: pixel at [2, 7\] should be (225,255,227,227), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #108: pixel at [3, 4\] should be (255,47,47,47), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #263: pixel at [6, 6\] should be (225,255,233,233), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #314: pixel at [5, 4\] should be (55,55,255,71), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #235: pixel at [2, 3\] should be (137,255,137,137), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #296: pixel at [3, 2\] should be (255,13,13,13), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #368: pixel at [7, 2\] should be (255,79,79,79), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #308: pixel at [7, 3\] should be (255,20,20,20), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #160: pixel at [3, 2\] should be (255,56,56,56), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #370: pixel at [1, 3\] should be (64,64,255,64), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #227: pixel at [2, 2\] should be (137,255,137,137), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #320: pixel at [3, 5\] should be (255,55,55,55), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #272: pixel at [7, 7\] should be (255,233,233,233), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #187: pixel at [6, 5\] should be (151,255,159,159), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #60: pixel at [7, 6\] should be (255,223,223,223), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #99: pixel at [2, 3\] should be (23,255,25,25), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #139: pixel at [0, 1\] should be (172,172,172,255), but the actual color is (105,105,105,255)]
+    expected: FAIL
+
+  [WebGL test #166: pixel at [1, 3\] should be (85,85,255,88), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #172: pixel at [7, 3\] should be (255,96,96,96), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #366: pixel at [5, 2\] should be (64,64,255,79), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #375: pixel at [6, 3\] should be (64,255,79,79), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #14: pixel at [1, 1\] should be (71,71,255,79), but the actual color is (16,16,255,20)]
+    expected: FAIL
+
+  [WebGL test #343: pixel at [0, 1\] should be (208,208,208,255), but the actual color is (161,161,161,255)]
+    expected: FAIL
+
+  [WebGL test #201: pixel at [4, 7\] should be (196,196,196,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #65: pixel at [4, 7\] should be (227,227,227,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #377: pixel at [0, 4\] should be (128,128,128,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #200: pixel at [3, 7\] should be (255,196,196,196), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #152: pixel at [3, 1\] should be (255,28,28,28), but the actual color is (255,3,3,3)]
+    expected: FAIL
+
+  [WebGL test #404: pixel at [3, 7\] should be (255,192,192,192), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #109: pixel at [4, 4\] should be (47,47,47,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #10: pixel at [5, 0\] should be (34,34,255,61), but the actual color is (4,4,255,0)]
+    expected: FAIL
+
+  [WebGL test #270: pixel at [5, 7\] should be (225,225,255,233), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #35: pixel at [6, 3\] should be (155,255,162,162), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #267: pixel at [2, 7\] should be (225,255,225,225), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #226: pixel at [1, 2\] should be (137,137,255,137), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #295: pixel at [2, 2\] should be (13,255,13,13), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #341: pixel at [0, 0\] should be (79,79,79,255), but the actual color is (20,20,20,255)]
+    expected: FAIL
+
+  [WebGL test #400: pixel at [7, 6\] should be (255,208,208,208), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #174: pixel at [1, 4\] should be (115,115,255,119), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #301: pixel at [0, 3\] should be (13,13,13,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #72: pixel at [1, 1\] should be (105,105,255,153), but the actual color is (168,168,255,200)]
+    expected: FAIL
+
+  [WebGL test #309: pixel at [0, 4\] should be (55,55,55,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #95: pixel at [6, 2\] should be (10,255,13,13), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #392: pixel at [7, 5\] should be (255,144,144,144), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #151: pixel at [2, 1\] should be (28,255,28,28), but the actual color is (3,255,3,3)]
+    expected: FAIL
+
+  [WebGL test #374: pixel at [5, 3\] should be (64,64,255,79), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #157: pixel at [0, 2\] should be (53,53,53,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #236: pixel at [3, 3\] should be (255,137,137,137), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #327: pixel at [2, 6\] should be (134,255,134,134), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #101: pixel at [4, 3\] should be (25,25,25,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #233: pixel at [0, 3\] should be (137,137,137,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #382: pixel at [5, 4\] should be (128,128,255,144), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #194: pixel at [5, 6\] should be (182,182,255,190), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #246: pixel at [5, 4\] should be (188,188,255,198), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #164: pixel at [7, 2\] should be (255,64,64,64), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #360: pixel at [7, 1\] should be (255,13,13,13), but the actual color is (255,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #23: pixel at [2, 2\] should be (120,255,125,125), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #223: pixel at [6, 1\] should be (0,255,71,71), but the actual color is (0,255,0,0)]
+    expected: FAIL
+
+  [WebGL test #239: pixel at [6, 3\] should be (137,255,152,152), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #352: pixel at [7, 0\] should be (255,13,13,13), but the actual color is (255,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #299: pixel at [6, 2\] should be (13,255,20,20), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #405: pixel at [4, 7\] should be (192,192,192,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #230: pixel at [5, 2\] should be (137,137,255,152), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #256: pixel at [7, 5\] should be (255,198,198,198), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #112: pixel at [7, 4\] should be (255,54,54,54), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #257: pixel at [0, 6\] should be (225,225,225,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #133: pixel at [4, 7\] should be (140,140,140,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #50: pixel at [5, 5\] should be (200,200,255,205), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #394: pixel at [1, 6\] should be (192,192,255,192), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #269: pixel at [4, 7\] should be (225,225,225,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #169: pixel at [4, 3\] should be (88,88,88,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #25: pixel at [4, 2\] should be (125,125,125,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #34: pixel at [5, 3\] should be (155,155,255,162), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #324: pixel at [7, 5\] should be (255,71,71,71), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #388: pixel at [3, 5\] should be (255,128,128,128), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #12: pixel at [7, 0\] should be (255,61,61,61), but the actual color is (255,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #208: pixel at [1, 1\] should be (233,233,255,248), but the actual color is (161,161,255,222)]
+    expected: FAIL
+
+  [WebGL test #182: pixel at [1, 5\] should be (147,147,255,151), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #206: pixel at [1, 0\] should be (152,152,255,177), but the actual color is (20,20,255,41)]
+    expected: FAIL
+
+  [WebGL test #231: pixel at [6, 2\] should be (137,255,152,152), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #387: pixel at [2, 5\] should be (128,255,128,128), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #202: pixel at [5, 7\] should be (196,196,255,204), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #381: pixel at [4, 4\] should be (128,128,128,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #237: pixel at [4, 3\] should be (137,137,137,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #337: pixel at [4, 7\] should be (134,134,134,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #39: pixel at [2, 4\] should be (177,255,180,180), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #274: pixel at [1, 0\] should be (20,20,255,41), but the actual color is (80,80,255,112)]
+    expected: FAIL
+
+  [WebGL test #234: pixel at [1, 3\] should be (137,137,255,137), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #47: pixel at [2, 5\] should be (198,255,200,200), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #224: pixel at [7, 1\] should be (255,71,71,71), but the actual color is (255,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #62: pixel at [1, 7\] should be (225,225,255,227), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #259: pixel at [2, 6\] should be (225,255,225,225), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #92: pixel at [3, 2\] should be (255,10,10,10), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #225: pixel at [0, 2\] should be (137,137,137,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #89: pixel at [0, 2\] should be (9,9,9,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #28: pixel at [7, 2\] should be (255,133,133,133), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #331: pixel at [6, 6\] should be (134,255,161,161), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #11: pixel at [6, 0\] should be (34,255,61,61), but the actual color is (4,255,0,0)]
+    expected: FAIL
+
+  [WebGL test #229: pixel at [4, 2\] should be (137,137,137,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #66: pixel at [5, 7\] should be (227,227,255,231), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #380: pixel at [3, 4\] should be (255,128,128,128), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #261: pixel at [4, 6\] should be (225,225,225,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #195: pixel at [6, 6\] should be (182,255,190,190), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #118: pixel at [5, 5\] should be (79,79,255,88), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #244: pixel at [3, 4\] should be (255,188,188,188), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #70: pixel at [1, 0\] should be (8,8,255,20), but the actual color is (40,40,255,72)]
+    expected: FAIL
+
+  [WebGL test #364: pixel at [3, 2\] should be (255,64,64,64), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #313: pixel at [4, 4\] should be (55,55,55,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #43: pixel at [6, 4\] should be (180,255,185,185), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #247: pixel at [6, 4\] should be (188,255,198,198), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #297: pixel at [4, 2\] should be (13,13,13,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #156: pixel at [7, 1\] should be (255,34,34,34), but the actual color is (255,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #238: pixel at [5, 3\] should be (137,137,255,152), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #42: pixel at [5, 4\] should be (180,180,255,185), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #391: pixel at [6, 5\] should be (128,255,144,144), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #131: pixel at [2, 7\] should be (134,255,140,140), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #105: pixel at [0, 4\] should be (44,44,44,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #402: pixel at [1, 7\] should be (192,192,255,192), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #192: pixel at [3, 6\] should be (255,182,182,182), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #113: pixel at [0, 5\] should be (74,74,74,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #163: pixel at [6, 2\] should be (56,255,64,64), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #128: pixel at [7, 6\] should be (255,132,132,132), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #100: pixel at [3, 3\] should be (255,25,25,25), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #21: pixel at [0, 2\] should be (120,120,120,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #303: pixel at [2, 3\] should be (13,255,13,13), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #41: pixel at [4, 4\] should be (180,180,180,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #191: pixel at [2, 6\] should be (178,255,182,182), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #260: pixel at [3, 6\] should be (255,225,225,225), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #264: pixel at [7, 6\] should be (255,233,233,233), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #30: pixel at [1, 3\] should be (152,152,255,155), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #300: pixel at [7, 2\] should be (255,20,20,20), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #177: pixel at [4, 4\] should be (119,119,119,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #315: pixel at [6, 4\] should be (55,255,71,71), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #9: pixel at [4, 0\] should be (34,34,34,255), but the actual color is (4,4,4,255)]
+    expected: FAIL
+
+  [WebGL test #266: pixel at [1, 7\] should be (225,225,255,225), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #56: pixel at [3, 6\] should be (255,219,219,219), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #104: pixel at [7, 3\] should be (255,30,30,30), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #340: pixel at [7, 7\] should be (255,161,161,161), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #401: pixel at [0, 7\] should be (192,192,192,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #48: pixel at [3, 5\] should be (255,200,200,200), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #98: pixel at [1, 3\] should be (23,23,255,25), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #321: pixel at [4, 5\] should be (55,55,55,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #137: pixel at [0, 0\] should be (50,50,50,255), but the actual color is (8,8,8,255)]
+    expected: FAIL
+
+  [WebGL test #372: pixel at [3, 3\] should be (255,64,64,64), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #36: pixel at [7, 3\] should be (255,162,162,162), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #138: pixel at [1, 0\] should be (50,50,255,79), but the actual color is (8,8,255,20)]
+    expected: FAIL
+
+  [WebGL test #94: pixel at [5, 2\] should be (10,10,255,13), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #90: pixel at [1, 2\] should be (9,9,255,10), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #268: pixel at [3, 7\] should be (255,225,225,225), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #52: pixel at [7, 5\] should be (255,205,205,205), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #365: pixel at [4, 2\] should be (64,64,64,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #273: pixel at [0, 0\] should be (20,20,20,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #389: pixel at [4, 5\] should be (128,128,128,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #306: pixel at [5, 3\] should be (13,13,255,20), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #199: pixel at [2, 7\] should be (192,255,196,196), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #367: pixel at [6, 2\] should be (64,255,79,79), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #262: pixel at [5, 6\] should be (225,225,255,233), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #252: pixel at [3, 5\] should be (255,188,188,188), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #40: pixel at [3, 4\] should be (255,180,180,180), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #46: pixel at [1, 5\] should be (198,198,255,200), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #16: pixel at [3, 1\] should be (255,79,79,79), but the actual color is (255,20,20,20)]
+    expected: FAIL
+
+  [WebGL test #102: pixel at [5, 3\] should be (25,25,255,30), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #61: pixel at [0, 7\] should be (225,225,225,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #325: pixel at [0, 6\] should be (134,134,134,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #37: pixel at [0, 4\] should be (177,177,177,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #196: pixel at [7, 6\] should be (255,190,190,190), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #205: pixel at [0, 0\] should be (152,152,152,255), but the actual color is (20,20,20,255)]
+    expected: FAIL
+
+  [WebGL test #373: pixel at [4, 3\] should be (64,64,64,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #332: pixel at [7, 6\] should be (255,161,161,161), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #333: pixel at [0, 7\] should be (134,134,134,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #215: pixel at [6, 0\] should be (0,255,71,71), but the actual color is (0,255,0,0)]
+    expected: FAIL
+
+  [WebGL test #2: pixel at [1, 0\] should be (110,110,255,145), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #310: pixel at [1, 4\] should be (55,55,255,55), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #68: pixel at [7, 7\] should be (255,231,231,231), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #122: pixel at [1, 6\] should be (114,114,255,119), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #335: pixel at [2, 7\] should be (134,255,134,134), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #153: pixel at [4, 1\] should be (28,28,28,255), but the actual color is (3,3,3,255)]
+    expected: FAIL
+
+  [WebGL test #53: pixel at [0, 6\] should be (216,216,216,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #371: pixel at [2, 3\] should be (64,255,64,64), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #175: pixel at [2, 4\] should be (115,255,119,119), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #322: pixel at [5, 5\] should be (55,55,255,71), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #168: pixel at [3, 3\] should be (255,88,88,88), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #55: pixel at [2, 6\] should be (216,255,219,219), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #176: pixel at [3, 4\] should be (255,119,119,119), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #33: pixel at [4, 3\] should be (155,155,155,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #20: pixel at [7, 1\] should be (255,93,93,93), but the actual color is (255,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #316: pixel at [7, 4\] should be (255,71,71,71), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #222: pixel at [5, 1\] should be (0,0,255,71), but the actual color is (0,0,255,0)]
+    expected: FAIL
+
+  [WebGL test #258: pixel at [1, 6\] should be (225,225,255,225), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #399: pixel at [6, 6\] should be (192,255,208,208), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #120: pixel at [7, 5\] should be (255,88,88,88), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #178: pixel at [5, 4\] should be (119,119,255,127), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #383: pixel at [6, 4\] should be (128,255,144,144), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #121: pixel at [0, 6\] should be (114,114,114,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #328: pixel at [3, 6\] should be (255,134,134,134), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #45: pixel at [0, 5\] should be (198,198,198,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #155: pixel at [6, 1\] should be (28,255,34,34), but the actual color is (3,255,0,0)]
+    expected: FAIL
+
+  [WebGL test #117: pixel at [4, 5\] should be (79,79,79,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #302: pixel at [1, 3\] should be (13,13,255,13), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #393: pixel at [0, 6\] should be (192,192,192,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #276: pixel at [1, 1\] should be (161,161,255,222), but the actual color is (208,208,255,240)]
+    expected: FAIL
+
+  [WebGL test #188: pixel at [7, 5\] should be (255,159,159,159), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #123: pixel at [2, 6\] should be (114,255,119,119), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #93: pixel at [4, 2\] should be (10,10,10,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #38: pixel at [1, 4\] should be (177,177,255,180), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #116: pixel at [3, 5\] should be (255,79,79,79), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #376: pixel at [7, 3\] should be (255,79,79,79), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #185: pixel at [4, 5\] should be (151,151,151,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #190: pixel at [1, 6\] should be (178,178,255,182), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #173: pixel at [0, 4\] should be (115,115,115,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #111: pixel at [6, 4\] should be (47,255,54,54), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #344: pixel at [1, 1\] should be (208,208,255,240), but the actual color is (161,161,255,222)]
+    expected: FAIL
+
+  [WebGL test #51: pixel at [6, 5\] should be (200,255,205,205), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #326: pixel at [1, 6\] should be (134,134,255,134), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #6: pixel at [1, 0\] should be (0,0,255,34), but the actual color is (0,0,255,4)]
+    expected: FAIL
+
+  [WebGL test #248: pixel at [7, 4\] should be (255,198,198,198), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #170: pixel at [5, 3\] should be (88,88,255,96), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #162: pixel at [5, 2\] should be (56,56,255,64), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #305: pixel at [4, 3\] should be (13,13,13,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #397: pixel at [4, 6\] should be (192,192,192,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #406: pixel at [5, 7\] should be (192,192,255,208), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #293: pixel at [0, 2\] should be (13,13,13,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #114: pixel at [1, 5\] should be (74,74,255,79), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #165: pixel at [0, 3\] should be (85,85,85,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #136: pixel at [7, 7\] should be (255,154,154,154), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #69: pixel at [0, 0\] should be (8,8,8,255), but the actual color is (40,40,40,255)]
+    expected: FAIL
+
+  [WebGL test #329: pixel at [4, 6\] should be (134,134,134,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #214: pixel at [5, 0\] should be (0,0,255,71), but the actual color is (0,0,255,0)]
+    expected: FAIL
+
+  [WebGL test #186: pixel at [5, 5\] should be (151,151,255,159), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #58: pixel at [5, 6\] should be (219,219,255,223), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #127: pixel at [6, 6\] should be (119,255,132,132), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #179: pixel at [6, 4\] should be (119,255,127,127), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #110: pixel at [5, 4\] should be (47,47,255,54), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #361: pixel at [0, 2\] should be (64,64,64,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #103: pixel at [6, 3\] should be (25,255,30,30), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #54: pixel at [1, 6\] should be (216,216,255,219), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #338: pixel at [5, 7\] should be (134,134,255,161), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #342: pixel at [1, 0\] should be (79,79,255,112), but the actual color is (20,20,255,41)]
+    expected: FAIL
+
+  [WebGL test #159: pixel at [2, 2\] should be (53,255,56,56), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #4: pixel at [1, 1\] should be (212,212,255,229), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #184: pixel at [3, 5\] should be (255,151,151,151), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #207: pixel at [0, 1\] should be (233,233,233,255), but the actual color is (161,161,161,255)]
+    expected: FAIL
+
+  [WebGL test #396: pixel at [3, 6\] should be (255,192,192,192), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #44: pixel at [7, 4\] should be (255,185,185,185), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #253: pixel at [4, 5\] should be (188,188,188,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #180: pixel at [7, 4\] should be (255,127,127,127), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #67: pixel at [6, 7\] should be (227,255,231,231), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #19: pixel at [6, 1\] should be (79,255,93,93), but the actual color is (20,255,0,0)]
+    expected: FAIL
+
+  [WebGL test #330: pixel at [5, 6\] should be (134,134,255,161), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #339: pixel at [6, 7\] should be (134,255,161,161), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #336: pixel at [3, 7\] should be (255,134,134,134), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #107: pixel at [2, 4\] should be (44,255,47,47), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #197: pixel at [0, 7\] should be (192,192,192,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #119: pixel at [6, 5\] should be (79,255,88,88), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #149: pixel at [0, 1\] should be (28,28,28,255), but the actual color is (3,3,3,255)]
+    expected: FAIL
+
+  [WebGL test #49: pixel at [4, 5\] should be (200,200,200,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #134: pixel at [5, 7\] should be (140,140,255,154), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #265: pixel at [0, 7\] should be (225,225,225,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #304: pixel at [3, 3\] should be (255,13,13,13), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #171: pixel at [6, 3\] should be (88,255,96,96), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #317: pixel at [0, 5\] should be (55,55,55,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #189: pixel at [0, 6\] should be (178,178,178,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #17: pixel at [4, 1\] should be (79,79,79,255), but the actual color is (20,20,20,255)]
+    expected: FAIL
+
+  [WebGL test #312: pixel at [3, 4\] should be (255,55,55,55), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #395: pixel at [2, 6\] should be (192,255,192,192), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #181: pixel at [0, 5\] should be (147,147,147,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #298: pixel at [5, 2\] should be (13,13,255,20), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #255: pixel at [6, 5\] should be (188,255,198,198), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #91: pixel at [2, 2\] should be (9,255,10,10), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #18: pixel at [5, 1\] should be (79,79,255,93), but the actual color is (20,20,255,0)]
+    expected: FAIL
+
+  [WebGL test #228: pixel at [3, 2\] should be (255,137,137,137), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #358: pixel at [5, 1\] should be (0,0,255,13), but the actual color is (0,0,255,0)]
+    expected: FAIL
+
+  [WebGL test #311: pixel at [2, 4\] should be (55,255,55,55), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #216: pixel at [7, 0\] should be (255,71,71,71), but the actual color is (255,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #161: pixel at [4, 2\] should be (56,56,56,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #240: pixel at [7, 3\] should be (255,152,152,152), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #241: pixel at [0, 4\] should be (188,188,188,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #125: pixel at [4, 6\] should be (119,119,119,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #22: pixel at [1, 2\] should be (120,120,255,125), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #29: pixel at [0, 3\] should be (152,152,152,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #132: pixel at [3, 7\] should be (255,140,140,140), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #350: pixel at [5, 0\] should be (0,0,255,13), but the actual color is (0,0,255,0)]
+    expected: FAIL
+
+  [WebGL test #323: pixel at [6, 5\] should be (55,255,71,71), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #183: pixel at [2, 5\] should be (147,255,151,151), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #97: pixel at [0, 3\] should be (23,23,23,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #140: pixel at [1, 1\] should be (172,172,255,203), but the actual color is (105,105,255,153)]
+    expected: FAIL
+
+  [WebGL test #245: pixel at [4, 4\] should be (188,188,188,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #193: pixel at [4, 6\] should be (182,182,182,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #362: pixel at [1, 2\] should be (64,64,255,64), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #378: pixel at [1, 4\] should be (128,128,255,128), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #407: pixel at [6, 7\] should be (192,255,208,208), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #384: pixel at [7, 4\] should be (255,144,144,144), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #146: pixel at [5, 0\] should be (0,0,255,13), but the actual color is (0,0,255,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #147: pixel at [6, 0\] should be (0,255,13,13), but the actual color is (0,255,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #148: pixel at [7, 0\] should be (255,13,13,13), but the actual color is (255,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #112: pixel at [7, 4\] should be (255,55,55,55), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #125: pixel at [4, 6\] should be (120,120,120,255), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #94: pixel at [5, 2\] should be (11,11,255,14), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #96: pixel at [7, 2\] should be (255,14,14,14), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #171: pixel at [6, 3\] should be (90,255,96,96), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #134: pixel at [5, 7\] should be (141,141,255,154), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #131: pixel at [2, 7\] should be (134,255,141,141), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #132: pixel at [3, 7\] should be (255,141,141,141), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #169: pixel at [4, 3\] should be (90,90,90,255), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #90: pixel at [1, 2\] should be (10,10,255,11), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #159: pixel at [2, 2\] should be (56,255,59,59), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #107: pixel at [2, 4\] should be (44,255,48,48), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #98: pixel at [1, 3\] should be (23,23,255,26), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #164: pixel at [7, 2\] should be (255,66,66,66), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #166: pixel at [1, 3\] should be (85,85,255,90), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #178: pixel at [5, 4\] should be (120,120,255,128), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #111: pixel at [6, 4\] should be (48,255,55,55), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #158: pixel at [1, 2\] should be (56,56,255,59), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #174: pixel at [1, 4\] should be (115,115,255,120), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #157: pixel at [0, 2\] should be (56,56,56,255), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #110: pixel at [5, 4\] should be (48,48,255,55), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #150: pixel at [1, 1\] should be (28,28,255,34), but the actual color is (3,3,255,4)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #115: pixel at [2, 5\] should be (75,255,79,79), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #95: pixel at [6, 2\] should be (11,255,14,14), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #182: pixel at [1, 5\] should be (148,148,255,151), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #162: pixel at [5, 2\] should be (59,59,255,66), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #91: pixel at [2, 2\] should be (10,255,11,11), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #167: pixel at [2, 3\] should be (85,255,90,90), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #119: pixel at [6, 5\] should be (79,255,89,89), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #118: pixel at [5, 5\] should be (79,79,255,89), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #127: pixel at [6, 6\] should be (120,255,132,132), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #180: pixel at [7, 4\] should be (255,128,128,128), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #135: pixel at [6, 7\] should be (141,255,154,154), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #93: pixel at [4, 2\] should be (11,11,11,255), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #103: pixel at [6, 3\] should be (26,255,30,30), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #176: pixel at [3, 4\] should be (255,120,120,120), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #133: pixel at [4, 7\] should be (141,141,141,255), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #181: pixel at [0, 5\] should be (148,148,148,255), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #123: pixel at [2, 6\] should be (114,255,120,120), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #130: pixel at [1, 7\] should be (134,134,255,141), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #101: pixel at [4, 3\] should be (26,26,26,255), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #124: pixel at [3, 6\] should be (255,120,120,120), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #161: pixel at [4, 2\] should be (59,59,59,255), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #126: pixel at [5, 6\] should be (120,120,255,132), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #70: pixel at [1, 0\] should be (8,8,255,21), but the actual color is (40,40,255,72)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #92: pixel at [3, 2\] should be (255,11,11,11), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #160: pixel at [3, 2\] should be (255,59,59,59), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #168: pixel at [3, 3\] should be (255,90,90,90), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #120: pixel at [7, 5\] should be (255,89,89,89), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #109: pixel at [4, 4\] should be (48,48,48,255), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #108: pixel at [3, 4\] should be (255,48,48,48), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #170: pixel at [5, 3\] should be (90,90,255,96), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #152: pixel at [3, 1\] should be (255,34,34,34), but the actual color is (255,4,4,4)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #175: pixel at [2, 4\] should be (115,255,120,120), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #99: pixel at [2, 3\] should be (23,255,26,26), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #100: pixel at [3, 3\] should be (255,26,26,26), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #177: pixel at [4, 4\] should be (120,120,120,255), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #102: pixel at [5, 3\] should be (26,26,255,30), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #106: pixel at [1, 4\] should be (44,44,255,48), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #183: pixel at [2, 5\] should be (148,255,151,151), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #113: pixel at [0, 5\] should be (75,75,75,255), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #154: pixel at [5, 1\] should be (34,34,255,38), but the actual color is (4,4,255,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #163: pixel at [6, 2\] should be (59,255,66,66), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #122: pixel at [1, 6\] should be (114,114,255,120), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #114: pixel at [1, 5\] should be (75,75,255,79), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #155: pixel at [6, 1\] should be (34,255,38,38), but the actual color is (4,255,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #138: pixel at [1, 0\] should be (50,50,255,81), but the actual color is (8,8,255,21)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #156: pixel at [7, 1\] should be (255,38,38,38), but the actual color is (255,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #89: pixel at [0, 2\] should be (10,10,10,255), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #179: pixel at [6, 4\] should be (120,255,128,128), but the actual color is (0,0,0,0)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #153: pixel at [4, 1\] should be (34,34,34,255), but the actual color is (4,4,4,255)]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #151: pixel at [2, 1\] should be (28,255,34,34), but the actual color is (3,255,4,4)]
+    expected:
+      if os == "mac": FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-multisampled-readbuffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-multisampled-readbuffer.html.ini
@@ -1,7 +1,4 @@
 [blitframebuffer-multisampled-readbuffer.html]
-  expected:
-    if os =="mac": ERROR
-
   [WebGL test #1: Framebuffer incomplete.]
     expected:
       if os == "linux": FAIL
@@ -14,7 +11,23 @@
     expected:
       if os == "mac": FAIL
 
-  [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : blitframebuffer should succeed]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #4: should be 254,184,69,255\nat (0, 0) expected: 254,184,69,255 was 0,0,0,0]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #5: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : setup draw framebuffer should succeed]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #6: getError expected: NO_ERROR. Was INVALID_FRAMEBUFFER_OPERATION : blitframebuffer should succeed]
+    expected:
+      if os == "mac": FAIL
+
+  [WebGL test #8: should be 254,184,69,255\nat (0, 0) expected: 254,184,69,255 was 0,0,0,0]
     expected:
       if os == "mac": FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-resolve-to-back-buffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-resolve-to-back-buffer.html.ini
@@ -1,5 +1,6 @@
 [blitframebuffer-resolve-to-back-buffer.html]
-  expected: ERROR
+  expected: 
+    if os == "mac": TIMEOUT
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/draw-buffers-driver-hang.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/draw-buffers-driver-hang.html.ini
@@ -1,2 +1,4 @@
 [draw-buffers-driver-hang.html]
-  expected: ERROR
+  expected:
+    if os =="linux": TIMEOUT
+

--- a/tests/wpt/webgl/meta/conformance2/rendering/draw-buffers.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/draw-buffers.html.ini
@@ -113,3 +113,6 @@
   [WebGL test #44: attachment 7 should be 0,255,0,255\nat (4, 0) expected: 0,255,0,255 was 255,255,0,4]
     expected: FAIL
 
+  [WebGL test #44: attachment 7 should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,255]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/rendering/line-rendering-quality.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/line-rendering-quality.html.ini
@@ -1,9 +1,12 @@
 [line-rendering-quality.html]
-  expected: ERROR
   bug: https://github.com/servo/servo/issues/25937
   [WebGL test #5: Found 0 lines, looking in the vertical direction, expected 2]
     expected:
       if os == "linux": FAIL
+
   [WebGL test #10: successfullyParsed should be true. Threw exception ReferenceError: can't access lexical declaration `successfullyParsed' before initialization]
+    expected: FAIL
+
+  [WebGL test #11: Found 0 lines, looking in the vertical direction, expected 2]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/rendering/multisampling-fragment-evaluation.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/multisampling-fragment-evaluation.html.ini
@@ -1,5 +1,4 @@
 [multisampling-fragment-evaluation.html]
-  expected: ERROR
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 


### PR DESCRIPTION
Add initial support for the WebGL2 `BlitFramebuffer` call.

---
Note:
After I've rebased my patch to the latest master (`5504d9259d59bb80e019ed1563b213dcf56fc86a`) I realized some unexpected crash on running the `conformance2 wpt tests`. I've talked with @mmatyas and the crashes did not appear on him side, maybe it could be driver related.

Running the `./mach test-wpt tests/wpt/webgl/tests/conformance2/` on the `00ac44796667d93806b79f79e23dcd4dcee58652` commit (before the https://github.com/servo/servo/pull/25853 Pull Request) the results: https://gist.github.com/imiklos/315078ddff683d74c5981258b2752aa7
```
Ran 1110 tests finished in 123.0 seconds.
  • 1107 ran as expected. 921 tests skipped.
  • 3 tests timed out unexpectedly
```
Running the `./mach test-wpt tests/wpt/webgl/tests/conformance2/` on the `5504d9259d59bb80e019ed1563b213dcf56fc86a` commit (latest master) the results: https://gist.github.com/imiklos/6d8901975101d3a1720b911bfdc26e23
```
Ran 1110 tests finished in 136.0 seconds.
  • 1098 ran as expected. 921 tests skipped.
  • 1 tests crashed unexpectedly
  • 1 tests had errors unexpectedly
  • 6 tests timed out unexpectedly
  • 1 tests unexpectedly okay
  • 5 tests had unexpected subtest results
```
Additional information about my config:
```
OS: Manjaro Linux x86_64 
Kernel: 5.4.34-1-MANJARO 
DE: Plasma 
CPU: AMD Ryzen 7 1800X (16) @ 3.600GHz 
GPU: NVIDIA GeForce GTX 1050 Ti 
```
glxinfo | grep "OpenGL" :
```
OpenGL vendor string: NVIDIA Corporation
OpenGL renderer string: GeForce GTX 1050 Ti/PCIe/SSE2
OpenGL core profile version string: 4.6.0 NVIDIA 440.82
OpenGL core profile shading language version string: 4.60 NVIDIA
OpenGL core profile context flags: (none)
OpenGL core profile profile mask: core profile
OpenGL core profile extensions:
OpenGL version string: 4.6.0 NVIDIA 440.82
OpenGL shading language version string: 4.60 NVIDIA
OpenGL context flags: (none)
OpenGL profile mask: (none)
OpenGL extensions:
OpenGL ES profile version string: OpenGL ES 3.2 NVIDIA 440.82
OpenGL ES profile shading language version string: OpenGL ES GLSL ES 3.20
```

Mesa version: `20.0.4-2` https://www.archlinux.org/packages/extra/x86_64/mesa/

Could the mesa or video driver downgrade/upgrade help on matching the results?

---

Should I update the test expectations on an earlier commit or try on the master?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
cc @mmatyas @zakorgy @jdm