### PR TITLE
Replaced failible boolean with an enum

### DIFF
--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -26,7 +26,7 @@ use crate::dom::webglprogram::WebGLProgram;
 use crate::dom::webglquery::WebGLQuery;
 use crate::dom::webglrenderbuffer::WebGLRenderbuffer;
 use crate::dom::webglrenderingcontext::{
-    uniform_get, uniform_typed, LayoutCanvasWebGLRenderingContextHelpers, VertexAttrib,
+    uniform_get, uniform_typed, LayoutCanvasWebGLRenderingContextHelpers, Operation, VertexAttrib,
     WebGLRenderingContext,
 };
 use crate::dom::webglsampler::{WebGLSampler, WebGLSamplerValue};
@@ -339,7 +339,7 @@ impl WebGL2RenderingContext {
 
     fn unbind_from(&self, slot: &MutNullableDom<WebGLBuffer>, buffer: &WebGLBuffer) {
         if slot.get().map_or(false, |b| buffer == &*b) {
-            buffer.decrement_attached_counter(false);
+            buffer.decrement_attached_counter(Operation::Infallible);
             slot.set(None);
         }
     }
@@ -1633,7 +1633,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             self.unbind_from(&binding.buffer, &buffer);
         }
 
-        buffer.mark_for_deletion(false);
+        buffer.mark_for_deletion(Operation::Infallible);
     }
 
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
@@ -3054,7 +3054,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
                 }
             }
 
-            query.delete(false);
+            query.delete(Operation::Infallible);
         }
     }
 
@@ -3080,7 +3080,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
                     slot.set(None);
                 }
             }
-            sampler.delete(false);
+            sampler.delete(Operation::Infallible);
         }
     }
 
@@ -3311,7 +3311,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     fn DeleteSync(&self, sync: Option<&WebGLSync>) {
         if let Some(sync) = sync {
             handle_potential_webgl_error!(self.base, self.base.validate_ownership(sync), return);
-            sync.delete(false);
+            sync.delete(Operation::Infallible);
         }
     }
 
@@ -3390,7 +3390,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
                 self.base.webgl_error(InvalidOperation);
                 return;
             }
-            tf.delete(false);
+            tf.delete(Operation::Infallible);
             self.current_transform_feedback.set(None);
         }
     }
@@ -3624,7 +3624,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
 
         for slot in &[&generic_slot, &indexed_binding.buffer] {
             if let Some(old) = slot.get() {
-                old.decrement_attached_counter(false);
+                old.decrement_attached_counter(Operation::Infallible);
             }
             slot.set(buffer);
         }
@@ -3702,7 +3702,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
 
         for slot in &[&generic_slot, &indexed_binding.buffer] {
             if let Some(old) = slot.get() {
-                old.decrement_attached_counter(false);
+                old.decrement_attached_counter(Operation::Infallible);
             }
             slot.set(buffer);
         }

--- a/components/script/dom/webglrenderbuffer.rs
+++ b/components/script/dom/webglrenderbuffer.rs
@@ -11,7 +11,7 @@ use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::webglframebuffer::WebGLFramebuffer;
 use crate::dom::webglobject::WebGLObject;
-use crate::dom::webglrenderingcontext::WebGLRenderingContext;
+use crate::dom::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use canvas_traits::webgl::{
     webgl_channel, GlType, InternalFormatIntVec, WebGLCommand, WebGLError, WebGLRenderbufferId,
     WebGLResult, WebGLVersion,
@@ -90,7 +90,7 @@ impl WebGLRenderbuffer {
             .send_command(WebGLCommand::BindRenderbuffer(target, Some(self.id)));
     }
 
-    pub fn delete(&self, fallible: bool) {
+    pub fn delete(&self, operation_fallibility: Operation) {
         if !self.is_deleted.get() {
             self.is_deleted.set(true);
 
@@ -113,10 +113,9 @@ impl WebGLRenderbuffer {
             }
 
             let cmd = WebGLCommand::DeleteRenderbuffer(self.id);
-            if fallible {
-                context.send_command_ignored(cmd);
-            } else {
-                context.send_command(cmd);
+            match operation_fallibility {
+                Operation::Fallible => context.send_command_ignored(cmd),
+                Operation::Infallible => context.send_command(cmd),
             }
         }
     }
@@ -277,6 +276,6 @@ impl WebGLRenderbuffer {
 
 impl Drop for WebGLRenderbuffer {
     fn drop(&mut self) {
-        self.delete(true);
+        self.delete(Operation::Fallible);
     }
 }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -155,6 +155,12 @@ pub enum VertexAttrib {
     Uint(u32, u32, u32, u32),
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum Operation {
+    Fallible,
+    Infallible,
+}
+
 #[dom_struct]
 pub struct WebGLRenderingContext {
     reflector_: Reflector,
@@ -1142,7 +1148,7 @@ impl WebGLRenderingContext {
                 self.current_vao.set(None);
                 self.send_command(WebGLCommand::BindVertexArray(None));
             }
-            vao.delete(false);
+            vao.delete(Operation::Infallible);
         }
     }
 
@@ -1160,7 +1166,7 @@ impl WebGLRenderingContext {
                 self.current_vao_webgl2.set(None);
                 self.send_command(WebGLCommand::BindVertexArray(None));
             }
-            vao.delete(false);
+            vao.delete(Operation::Infallible);
         }
     }
 
@@ -1335,7 +1341,7 @@ impl WebGLRenderingContext {
 
         self.send_command(WebGLCommand::BindBuffer(target, buffer.map(|b| b.id())));
         if let Some(old) = slot.get() {
-            old.decrement_attached_counter(false);
+            old.decrement_attached_counter(Operation::Infallible);
         }
 
         slot.set(buffer);
@@ -2583,9 +2589,9 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
             .map_or(false, |b| buffer == &*b)
         {
             self.bound_buffer_array.set(None);
-            buffer.decrement_attached_counter(false);
+            buffer.decrement_attached_counter(Operation::Infallible);
         }
-        buffer.mark_for_deletion(false);
+        buffer.mark_for_deletion(Operation::Infallible);
     }
 
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
@@ -2605,7 +2611,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
                     WebGLFramebufferBindingRequest::Default
                 ))
             );
-            framebuffer.delete(false)
+            framebuffer.delete(Operation::Infallible)
         }
     }
 
@@ -2622,7 +2628,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
                     None
                 ))
             );
-            renderbuffer.delete(false)
+            renderbuffer.delete(Operation::Infallible)
         }
     }
 
@@ -2657,7 +2663,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
                 ));
             }
 
-            texture.delete(false)
+            texture.delete(Operation::Infallible)
         }
     }
 
@@ -2665,7 +2671,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     fn DeleteProgram(&self, program: Option<&WebGLProgram>) {
         if let Some(program) = program {
             handle_potential_webgl_error!(self, self.validate_ownership(program), return);
-            program.mark_for_deletion(false)
+            program.mark_for_deletion(Operation::Infallible)
         }
     }
 
@@ -2673,7 +2679,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     fn DeleteShader(&self, shader: Option<&WebGLShader>) {
         if let Some(shader) = shader {
             handle_potential_webgl_error!(self, self.validate_ownership(shader), return);
-            shader.mark_for_deletion(false)
+            shader.mark_for_deletion(Operation::Infallible)
         }
     }
 

--- a/components/script/dom/webglvertexarrayobject.rs
+++ b/components/script/dom/webglvertexarrayobject.rs
@@ -8,7 +8,7 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::vertexarrayobject::{VertexArrayObject, VertexAttribData};
 use crate::dom::webglbuffer::WebGLBuffer;
 use crate::dom::webglobject::WebGLObject;
-use crate::dom::webglrenderingcontext::WebGLRenderingContext;
+use crate::dom::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use canvas_traits::webgl::{ActiveAttribInfo, WebGLResult, WebGLVertexArrayId};
 use dom_struct::dom_struct;
 
@@ -41,8 +41,8 @@ impl WebGLVertexArrayObject {
         self.array_object.is_deleted()
     }
 
-    pub fn delete(&self, fallible: bool) {
-        self.array_object.delete(fallible);
+    pub fn delete(&self, operation_fallibility: Operation) {
+        self.array_object.delete(operation_fallibility);
     }
 
     pub fn ever_bound(&self) -> bool {

--- a/components/script/dom/webglvertexarrayobjectoes.rs
+++ b/components/script/dom/webglvertexarrayobjectoes.rs
@@ -8,7 +8,7 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::vertexarrayobject::{VertexArrayObject, VertexAttribData};
 use crate::dom::webglbuffer::WebGLBuffer;
 use crate::dom::webglobject::WebGLObject;
-use crate::dom::webglrenderingcontext::WebGLRenderingContext;
+use crate::dom::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use canvas_traits::webgl::{ActiveAttribInfo, WebGLResult, WebGLVertexArrayId};
 use dom_struct::dom_struct;
 
@@ -41,8 +41,8 @@ impl WebGLVertexArrayObjectOES {
         self.array_object.is_deleted()
     }
 
-    pub fn delete(&self, fallible: bool) {
-        self.array_object.delete(fallible);
+    pub fn delete(&self, operation_fallibility: Operation) {
+        self.array_object.delete(operation_fallibility);
     }
 
     pub fn ever_bound(&self) -> bool {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Replaced the boolean `fallible` argument of some WebGL object methods with the new `enum Operation { Fallible, Infallible }` that was added to the `webglrenderingcontext`. This improves the readability of that methods.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #26047 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because the issue says so

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
