### PR TITLE
Improve devtools experience when navigating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,6 +1189,7 @@ dependencies = [
  "msg",
  "serde",
  "serde_json",
+ "servo_url",
  "time",
  "uuid",
 ]

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -22,5 +22,6 @@ log = "0.4"
 msg = {path = "../msg"}
 serde = "1.0"
 serde_json = "1.0"
+servo_url = { path = "../url" }
 time = "0.1"
 uuid = {version = "0.8", features = ["v4"]}

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -347,6 +347,13 @@ impl BrowsingContextActor {
             stream.write_json_packet(&msg);
         }
     }
+
+    pub(crate) fn title_changed(&self, pipeline: PipelineId, title: String) {
+        if pipeline != self.active_pipeline.get() {
+            return;
+        }
+        *self.title.borrow_mut() = title;
+    }
 }
 
 #[derive(Serialize)]

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -8,10 +8,22 @@
 //! Supports dynamic attaching and detaching which control notifications of navigation, etc.
 
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
-use crate::actors::console::ConsoleActor;
+use crate::actors::emulation::EmulationActor;
+use crate::actors::inspector::InspectorActor;
+use crate::actors::performance::PerformanceActor;
+use crate::actors::profiler::ProfilerActor;
+use crate::actors::root::RootActor;
+use crate::actors::stylesheets::StyleSheetsActor;
+use crate::actors::thread::ThreadActor;
+use crate::actors::timeline::TimelineActor;
 use crate::protocol::JsonPacketStream;
 use devtools_traits::DevtoolScriptControlMsg::{self, WantsLiveNotifications};
+use devtools_traits::DevtoolsPageInfo;
+use devtools_traits::NavigationState;
+use ipc_channel::ipc::IpcSender;
+use msg::constellation_msg::{BrowsingContextId, PipelineId};
 use serde_json::{Map, Value};
+use std::cell::{Cell, RefCell};
 use std::net::TcpStream;
 
 #[derive(Serialize)]
@@ -118,6 +130,10 @@ pub struct BrowsingContextActor {
     pub performance: String,
     pub styleSheets: String,
     pub thread: String,
+    pub streams: RefCell<Vec<TcpStream>>,
+    pub browsing_context_id: BrowsingContextId,
+    pub active_pipeline: Cell<PipelineId>,
+    pub script_chan: IpcSender<DevtoolScriptControlMsg>,
 }
 
 impl Actor for BrowsingContextActor {
@@ -127,7 +143,7 @@ impl Actor for BrowsingContextActor {
 
     fn handle_message(
         &self,
-        registry: &ActorRegistry,
+        _registry: &ActorRegistry,
         msg_type: &str,
         msg: &Map<String, Value>,
         stream: &mut TcpStream,
@@ -137,10 +153,9 @@ impl Actor for BrowsingContextActor {
                 if let Some(options) = msg.get("options").and_then(|o| o.as_object()) {
                     if let Some(val) = options.get("performReload") {
                         if val.as_bool().unwrap_or(false) {
-                            let console_actor = registry.find::<ConsoleActor>(&self.console);
-                            let _ = console_actor
+                            let _ = self
                                 .script_chan
-                                .send(DevtoolScriptControlMsg::Reload(console_actor.pipeline));
+                                .send(DevtoolScriptControlMsg::Reload(self.active_pipeline.get()));
                         }
                     }
                 }
@@ -165,32 +180,25 @@ impl Actor for BrowsingContextActor {
                         watchpoints: false,
                     },
                 };
-                let console_actor = registry.find::<ConsoleActor>(&self.console);
-                console_actor
-                    .streams
-                    .borrow_mut()
-                    .push(stream.try_clone().unwrap());
+                self.streams.borrow_mut().push(stream.try_clone().unwrap());
                 stream.write_json_packet(&msg);
-                console_actor
-                    .script_chan
-                    .send(WantsLiveNotifications(console_actor.pipeline, true))
+                self.script_chan
+                    .send(WantsLiveNotifications(self.active_pipeline.get(), true))
                     .unwrap();
                 ActorMessageStatus::Processed
             },
 
-            //FIXME: The current implementation won't work for multiple connections. Need to ensure 105
+            //FIXME: The current implementation won't work for multiple connections. Need to ensure
             //       that the correct stream is removed.
             "detach" => {
                 let msg = BrowsingContextDetachedReply {
                     from: self.name(),
                     type_: "detached".to_owned(),
                 };
-                let console_actor = registry.find::<ConsoleActor>(&self.console);
-                console_actor.streams.borrow_mut().pop();
+                self.streams.borrow_mut().pop();
                 stream.write_json_packet(&msg);
-                console_actor
-                    .script_chan
-                    .send(WantsLiveNotifications(console_actor.pipeline, false))
+                self.script_chan
+                    .send(WantsLiveNotifications(self.active_pipeline.get(), false))
                     .unwrap();
                 ActorMessageStatus::Processed
             },
@@ -224,6 +232,70 @@ impl Actor for BrowsingContextActor {
 }
 
 impl BrowsingContextActor {
+    pub(crate) fn new(
+        console: String,
+        id: BrowsingContextId,
+        page_info: DevtoolsPageInfo,
+        pipeline: PipelineId,
+        script_sender: IpcSender<DevtoolScriptControlMsg>,
+        actors: &mut ActorRegistry,
+    ) -> BrowsingContextActor {
+        let emulation = EmulationActor::new(actors.new_name("emulation"));
+
+        let name = actors.new_name("target");
+
+        let inspector = InspectorActor {
+            name: actors.new_name("inspector"),
+            walker: RefCell::new(None),
+            pageStyle: RefCell::new(None),
+            highlighter: RefCell::new(None),
+            script_chan: script_sender.clone(),
+            browsing_context: name.clone(),
+        };
+
+        let timeline =
+            TimelineActor::new(actors.new_name("timeline"), pipeline, script_sender.clone());
+
+        let profiler = ProfilerActor::new(actors.new_name("profiler"));
+        let performance = PerformanceActor::new(actors.new_name("performance"));
+
+        // the strange switch between styleSheets and stylesheets is due
+        // to an inconsistency in devtools. See Bug #1498893 in bugzilla
+        let styleSheets = StyleSheetsActor::new(actors.new_name("stylesheets"));
+        let thread = ThreadActor::new(actors.new_name("context"));
+
+        let DevtoolsPageInfo { title, url } = page_info;
+        let target = BrowsingContextActor {
+            name: name,
+            script_chan: script_sender,
+            title: String::from(title),
+            url: url.into_string(),
+            console: console,
+            emulation: emulation.name(),
+            inspector: inspector.name(),
+            timeline: timeline.name(),
+            profiler: profiler.name(),
+            performance: performance.name(),
+            styleSheets: styleSheets.name(),
+            thread: thread.name(),
+            streams: RefCell::new(Vec::new()),
+            browsing_context_id: id,
+            active_pipeline: Cell::new(pipeline),
+        };
+
+        actors.register(Box::new(emulation));
+        actors.register(Box::new(inspector));
+        actors.register(Box::new(timeline));
+        actors.register(Box::new(profiler));
+        actors.register(Box::new(performance));
+        actors.register(Box::new(styleSheets));
+        actors.register(Box::new(thread));
+
+        let root = actors.find_mut::<RootActor>("root");
+        root.tabs.push(target.name.clone());
+        target
+    }
+
     pub fn encodable(&self) -> BrowsingContextActorMsg {
         BrowsingContextActorMsg {
             actor: self.name(),
@@ -232,8 +304,10 @@ impl BrowsingContextActor {
             },
             title: self.title.clone(),
             url: self.url.clone(),
-            browsingContextId: 0, //FIXME should come from constellation
-            outerWindowID: 0,     //FIXME: this should probably be the pipeline id
+            //FIXME: shouldn't ignore pipeline namespace field
+            browsingContextId: self.browsing_context_id.index.0.get(),
+            //FIXME: shouldn't ignore pipeline namespace field
+            outerWindowID: self.active_pipeline.get().index.0.get(),
             consoleActor: self.console.clone(),
             emulationActor: self.emulation.clone(),
             inspectorActor: self.inspector.clone(),
@@ -243,4 +317,40 @@ impl BrowsingContextActor {
             styleSheetsActor: self.styleSheets.clone(),
         }
     }
+
+    pub(crate) fn navigate(&self, state: NavigationState) {
+        let (pipeline, title, url, state) = match state {
+            NavigationState::Start(url) => (None, None, url, "start"),
+            NavigationState::Stop(pipeline, info) => {
+                (Some(pipeline), Some(info.title), info.url, "stop")
+            },
+        };
+        if let Some(p) = pipeline {
+            self.active_pipeline.set(p);
+        }
+        let msg = TabNavigated {
+            from: self.name(),
+            type_: "tabNavigated".to_owned(),
+            url: url.as_str().to_owned(),
+            title: title,
+            nativeConsoleAPI: true,
+            state: state.to_owned(),
+            isFrameSwitching: false,
+        };
+        for stream in &mut *self.streams.borrow_mut() {
+            stream.write_json_packet(&msg);
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct TabNavigated {
+    from: String,
+    #[serde(rename = "type")]
+    type_: String,
+    url: String,
+    title: Option<String>,
+    nativeConsoleAPI: bool,
+    state: String,
+    isFrameSwitching: bool,
 }

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -443,6 +443,13 @@ impl Actor for ConsoleActor {
                 // Emit an eager reply so that the client starts listening
                 // for an async event with the resultID
                 stream.write_json_packet(&early_reply);
+
+                if msg.get("eager").and_then(|v| v.as_bool()).unwrap_or(false) {
+                    // We don't support the side-effect free evaluation that eager evalaution
+                    // really needs.
+                    return Ok(ActorMessageStatus::Processed);
+                }
+
                 let reply = self.evaluateJS(&registry, &msg).unwrap();
                 let msg = EvaluateJSEvent {
                     from: self.name(),

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -13,8 +13,8 @@ use crate::actors::object::ObjectActor;
 use crate::actors::worker::WorkerActor;
 use crate::protocol::JsonPacketStream;
 use crate::UniqueId;
-use crate::{ConsoleAPICall, ConsoleMessage, ConsoleMsg, PageErrorMsg};
 use devtools_traits::CachedConsoleMessage;
+use devtools_traits::ConsoleMessage;
 use devtools_traits::EvaluateJSReply::{ActorValue, BooleanValue, StringValue};
 use devtools_traits::EvaluateJSReply::{NullValue, NumberValue, VoidValue};
 use devtools_traits::{
@@ -472,4 +472,30 @@ impl Actor for ConsoleActor {
             _ => ActorMessageStatus::Ignored,
         })
     }
+}
+
+#[derive(Serialize)]
+struct ConsoleAPICall {
+    from: String,
+    #[serde(rename = "type")]
+    type_: String,
+    message: ConsoleMsg,
+}
+
+#[derive(Serialize)]
+struct ConsoleMsg {
+    level: String,
+    timeStamp: u64,
+    arguments: Vec<String>,
+    filename: String,
+    lineNumber: usize,
+    columnNumber: usize,
+}
+
+#[derive(Serialize)]
+struct PageErrorMsg {
+    from: String,
+    #[serde(rename = "type")]
+    type_: String,
+    pageError: PageError,
 }

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -277,6 +277,13 @@ impl Actor for ConsoleActor {
         stream: &mut TcpStream,
     ) -> Result<ActorMessageStatus, ()> {
         Ok(match msg_type {
+            "clearMessagesCache" => {
+                let browsing_context =
+                    registry.find::<BrowsingContextActor>(&self.browsing_context);
+                self.cached_events.borrow_mut().remove(&browsing_context.active_pipeline.get());
+                ActorMessageStatus::Processed
+            }
+
             "getCachedMessages" => {
                 let str_types = msg
                     .get("messageTypes")

--- a/components/devtools/actors/worker.rs
+++ b/components/devtools/actors/worker.rs
@@ -3,14 +3,49 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
-use devtools_traits::WorkerId;
+use crate::protocol::JsonPacketStream;
+use devtools_traits::DevtoolScriptControlMsg::WantsLiveNotifications;
+use devtools_traits::{DevtoolScriptControlMsg, WorkerId};
+use ipc_channel::ipc::IpcSender;
+use msg::constellation_msg::TEST_PIPELINE_ID;
 use serde_json::{Map, Value};
+use servo_url::ServoUrl;
+use std::cell::RefCell;
 use std::net::TcpStream;
+
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+pub enum WorkerType {
+    Dedicated = 0,
+    Shared = 1,
+    Service = 2,
+}
 
 pub struct WorkerActor {
     pub name: String,
     pub console: String,
+    pub thread: String,
     pub id: WorkerId,
+    pub url: ServoUrl,
+    pub type_: WorkerType,
+    pub script_chan: IpcSender<DevtoolScriptControlMsg>,
+    pub streams: RefCell<Vec<TcpStream>>,
+}
+
+impl WorkerActor {
+    pub(crate) fn encodable(&self) -> WorkerMsg {
+        WorkerMsg {
+            actor: self.name.clone(),
+            consoleActor: self.console.clone(),
+            threadActor: self.thread.clone(),
+            id: self.id.0.to_string(),
+            url: self.url.to_string(),
+            traits: WorkerTraits {
+                isParentInterceptEnabled: false,
+            },
+            type_: self.type_ as u32,
+        }
+    }
 }
 
 impl Actor for WorkerActor {
@@ -19,11 +54,94 @@ impl Actor for WorkerActor {
     }
     fn handle_message(
         &self,
-        _: &ActorRegistry,
-        _: &str,
-        _: &Map<String, Value>,
-        _: &mut TcpStream,
+        _registry: &ActorRegistry,
+        msg_type: &str,
+        _msg: &Map<String, Value>,
+        stream: &mut TcpStream,
     ) -> Result<ActorMessageStatus, ()> {
-        Ok(ActorMessageStatus::Processed)
+        Ok(match msg_type {
+            "attach" => {
+                let msg = AttachedReply {
+                    from: self.name(),
+                    type_: "attached".to_owned(),
+                    url: self.url.as_str().to_owned(),
+                };
+                self.streams.borrow_mut().push(stream.try_clone().unwrap());
+                stream.write_json_packet(&msg);
+                // FIXME: fix messages to not require forging a pipeline for worker messages
+                self.script_chan
+                    .send(WantsLiveNotifications(TEST_PIPELINE_ID, true))
+                    .unwrap();
+                ActorMessageStatus::Processed
+            },
+
+            "connect" => {
+                let msg = ConnectReply {
+                    from: self.name(),
+                    type_: "connected".to_owned(),
+                    threadActor: self.thread.clone(),
+                    consoleActor: self.console.clone(),
+                };
+                stream.write_json_packet(&msg);
+                ActorMessageStatus::Processed
+            },
+
+            "detach" => {
+                let msg = DetachedReply {
+                    from: self.name(),
+                    type_: "detached".to_string(),
+                };
+                // FIXME: we should ensure we're removing the correct stream.
+                self.streams.borrow_mut().pop();
+                stream.write_json_packet(&msg);
+                self.script_chan
+                    .send(WantsLiveNotifications(TEST_PIPELINE_ID, false))
+                    .unwrap();
+                ActorMessageStatus::Processed
+            },
+
+            _ => ActorMessageStatus::Ignored,
+        })
     }
+}
+
+#[derive(Serialize)]
+struct DetachedReply {
+    from: String,
+    #[serde(rename = "type")]
+    type_: String,
+}
+
+#[derive(Serialize)]
+struct AttachedReply {
+    from: String,
+    #[serde(rename = "type")]
+    type_: String,
+    url: String,
+}
+
+#[derive(Serialize)]
+struct ConnectReply {
+    from: String,
+    #[serde(rename = "type")]
+    type_: String,
+    threadActor: String,
+    consoleActor: String,
+}
+
+#[derive(Serialize)]
+struct WorkerTraits {
+    isParentInterceptEnabled: bool,
+}
+
+#[derive(Serialize)]
+pub(crate) struct WorkerMsg {
+    actor: String,
+    consoleActor: String,
+    threadActor: String,
+    id: String,
+    url: String,
+    traits: WorkerTraits,
+    #[serde(rename = "type")]
+    type_: u32,
 }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -77,32 +77,6 @@ enum UniqueId {
 }
 
 #[derive(Serialize)]
-struct ConsoleAPICall {
-    from: String,
-    #[serde(rename = "type")]
-    type_: String,
-    message: ConsoleMsg,
-}
-
-#[derive(Serialize)]
-struct ConsoleMsg {
-    level: String,
-    timeStamp: u64,
-    arguments: Vec<String>,
-    filename: String,
-    lineNumber: usize,
-    columnNumber: usize,
-}
-
-#[derive(Serialize)]
-struct PageErrorMsg {
-    from: String,
-    #[serde(rename = "type")]
-    type_: String,
-    pageError: PageError,
-}
-
-#[derive(Serialize)]
 struct NetworkEventMsg {
     from: String,
     #[serde(rename = "type")]

--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -80,7 +80,7 @@ pub enum ScriptToDevtoolsControlMsg {
     /// A new global object was created, associated with a particular pipeline.
     /// The means of communicating directly with it are provided.
     NewGlobal(
-        (Option<BrowsingContextId>, PipelineId, Option<WorkerId>),
+        (BrowsingContextId, PipelineId, Option<WorkerId>),
         IpcSender<DevtoolScriptControlMsg>,
         DevtoolsPageInfo,
     ),

--- a/components/devtools_traits/lib.rs
+++ b/components/devtools_traits/lib.rs
@@ -97,6 +97,9 @@ pub enum ScriptToDevtoolsControlMsg {
 
     /// Report a page error for the given pipeline
     ReportPageError(PipelineId, PageError),
+
+    /// Report a page title change
+    TitleChanged(PipelineId, String),
 }
 
 /// Serialized JS return values

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -934,6 +934,14 @@ impl Document {
     pub fn title_changed(&self) {
         if self.browsing_context().is_some() {
             self.send_title_to_embedder();
+            let global = self.window.upcast::<GlobalScope>();
+            if let Some(ref chan) = global.devtools_chan() {
+                let title = String::from(self.Title());
+                let _ = chan.send(ScriptToDevtoolsControlMsg::TitleChanged(
+                    global.pipeline_id(),
+                    title,
+                ));
+            }
         }
     }
 

--- a/components/script/dom/serviceworkerregistration.rs
+++ b/components/script/dom/serviceworkerregistration.rs
@@ -112,7 +112,7 @@ impl ServiceWorkerRegistration {
 
         let worker_id = WorkerId(Uuid::new_v4());
         let devtools_chan = global.devtools_chan().cloned();
-        let init = prepare_workerscope_init(&global, None);
+        let init = prepare_workerscope_init(&global, None, None);
         ScopeThings {
             script_url: script_url,
             init: init,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2008,15 +2008,21 @@ impl Window {
 
         // Step 8
         if doc.prompt_to_unload(false) {
-            if self.window_proxy().parent().is_some() {
+            let window_proxy = self.window_proxy();
+            if window_proxy.parent().is_some() {
                 // Step 10
                 // If browsingContext is a nested browsing context,
                 // then put it in the delaying load events mode.
-                self.window_proxy().start_delaying_load_events_mode();
+                window_proxy.start_delaying_load_events_mode();
             }
             // TODO: step 11, navigationType.
             // Step 12, 13
-            ScriptThread::navigate(pipeline_id, load_data, replace);
+            ScriptThread::navigate(
+                window_proxy.browsing_context_id(),
+                pipeline_id,
+                load_data,
+                replace,
+            );
         };
     }
 

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -105,7 +105,7 @@ impl Worker {
                 url: worker_url.clone(),
             };
             let _ = chan.send(ScriptToDevtoolsControlMsg::NewGlobal(
-                (pipeline_id, Some(worker_id)),
+                (None, pipeline_id, Some(worker_id)),
                 devtools_sender.clone(),
                 page_info,
             ));

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -62,6 +62,7 @@ use uuid::Uuid;
 pub fn prepare_workerscope_init(
     global: &GlobalScope,
     devtools_sender: Option<IpcSender<DevtoolScriptControlMsg>>,
+    worker_id: Option<WorkerId>,
 ) -> WorkerGlobalScopeInit {
     let init = WorkerGlobalScopeInit {
         resource_threads: global.resource_threads().clone(),
@@ -71,7 +72,7 @@ pub fn prepare_workerscope_init(
         from_devtools_sender: devtools_sender,
         script_to_constellation_chan: global.script_to_constellation_chan().clone(),
         scheduler_chan: global.scheduler_chan().clone(),
-        worker_id: WorkerId(Uuid::new_v4()),
+        worker_id: worker_id.unwrap_or_else(|| WorkerId(Uuid::new_v4())),
         pipeline_id: global.pipeline_id(),
         origin: global.origin().immutable().clone(),
         is_headless: global.is_headless(),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3384,7 +3384,7 @@ impl ScriptThread {
                 url: url,
             };
             chan.send(ScriptToDevtoolsControlMsg::NewGlobal(
-                (Some(bc), p, w),
+                (bc, p, w),
                 self.devtools_sender.clone(),
                 page_info.clone(),
             ))

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -87,7 +87,11 @@ impl ServiceWorkerManager {
                     url: scope_things.script_url.clone(),
                 };
                 let _ = chan.send(ScriptToDevtoolsControlMsg::NewGlobal(
-                    (scope_things.init.pipeline_id, Some(scope_things.worker_id)),
+                    (
+                        None,
+                        scope_things.init.pipeline_id,
+                        Some(scope_things.worker_id),
+                    ),
                     devtools_sender,
                     page_info,
                 ));

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -11,7 +11,6 @@ use crate::dom::abstractworker::WorkerScriptMsg;
 use crate::dom::serviceworkerglobalscope::{ServiceWorkerGlobalScope, ServiceWorkerScriptMsg};
 use crate::dom::serviceworkerregistration::longest_prefix_match;
 use crossbeam_channel::{unbounded, Receiver, RecvError, Sender};
-use devtools_traits::{DevtoolsPageInfo, ScriptToDevtoolsControlMsg};
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
 use net_traits::{CoreResourceMsg, CustomResponseMediator};
@@ -79,23 +78,7 @@ impl ServiceWorkerManager {
         let scope_things = self.registered_workers.get(&scope_url);
         if let Some(scope_things) = scope_things {
             let (sender, receiver) = unbounded();
-            let (devtools_sender, devtools_receiver) = ipc::channel().unwrap();
-            if let Some(ref chan) = scope_things.devtools_chan {
-                let title = format!("ServiceWorker for {}", scope_things.script_url);
-                let page_info = DevtoolsPageInfo {
-                    title: title,
-                    url: scope_things.script_url.clone(),
-                };
-                let _ = chan.send(ScriptToDevtoolsControlMsg::NewGlobal(
-                    (
-                        None,
-                        scope_things.init.pipeline_id,
-                        Some(scope_things.worker_id),
-                    ),
-                    devtools_sender,
-                    page_info,
-                ));
-            };
+            let (_devtools_sender, devtools_receiver) = ipc::channel().unwrap();
             ServiceWorkerGlobalScope::run_serviceworker_scope(
                 scope_things.clone(),
                 sender.clone(),


### PR DESCRIPTION
The primary motivation for this work was to fix #15425, and these changes make it possible to use the devtools to meaningfully inspect multiple pages when navigating between them. Navigating through session history is not yet supported.

These changes also include improvements to the dedicated worker support, which broke at some point. We now can observe console messages in workers.