### PR TITLE
Restyle should reflect animations and transitions

### DIFF
--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -15,6 +15,7 @@ use script_traits::UntrustedNodeAddress;
 use script_traits::{
     AnimationState, ConstellationControlMsg, LayoutMsg as ConstellationMsg, TransitionEventType,
 };
+use servo_arc::Arc;
 use style::animation::{
     update_style_for_animation, Animation, ElementAnimationState, PropertyAnimation,
 };
@@ -223,7 +224,7 @@ fn do_recalc_style_for_animations<E>(
             update_style_for_animation::<E>(
                 &context.style_context,
                 animation,
-                &mut fragment.style,
+                Arc::make_mut(&mut fragment.style),
                 &ServoMetricsProvider,
             );
             let difference = RestyleDamage::compute_style_difference(&old_style, &fragment.style);

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -445,7 +445,10 @@ trait PrivateMatchMethods: TElement {
         let mut animation_state = animation_states.remove(&this_opaque).unwrap_or_default();
 
         if let Some(ref mut old_values) = *old_values {
-            animation_state.compute_before_change_style::<Self>(
+            // We convert old values into `before-change-style` here.
+            // https://drafts.csswg.org/css-transitions/#starting
+            animation_state.apply_completed_animations(old_values);
+            animation_state.apply_running_animations::<Self>(
                 shared_context,
                 old_values,
                 &context.thread_local.font_metrics_provider,
@@ -475,10 +478,20 @@ trait PrivateMatchMethods: TElement {
                 .cancel_transitions_with_nontransitioning_properties(&transitioning_properties);
         }
 
-        animation_state.finished_animations.clear();
+        animation_state.apply_running_animations::<Self>(
+            shared_context,
+            new_values,
+            &context.thread_local.font_metrics_provider,
+        );
+        animation_state.apply_new_animations::<Self>(
+            shared_context,
+            new_values,
+            &context.thread_local.font_metrics_provider,
+        );
 
-        // If the ElementAnimationState is empty, don't push it to save
-        // memory and to avoid extra processing later.
+        // If the ElementAnimationState is empty, and don't store it in order to
+        // save memory and to avoid extra processing later.
+        animation_state.finished_animations.clear();
         if !animation_state.is_empty() {
             animation_states.insert(this_opaque, animation_state);
         }

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -19,20 +19,34 @@ skip: true
     skip: false
   [CSS2]
     skip: false
+    [linebox]
+      skip:false
+      [animations]
+        skip: true
   [css-align]
     skip: false
+    [animation]
+      skip: true
   [css-animations]
     skip: false
   [css-backgrounds]
     skip: false
+    [animations]
+      skip: true
   [css-color]
     skip: false
+    [animation]
+      skip: true
   [css-conditional]
     skip: false
   [css-flexbox]
     skip: false
+    [animation]
+      skip: true
   [css-fonts]
     skip: false
+    [animations]
+      skip: true
   [css-images]
     skip: false
   [css-paint-api]
@@ -41,18 +55,28 @@ skip: true
     skip: false
   [css-text]
     skip: false
+    [animations]
+      skip: true
     [i18n]
       skip: true
   [css-text-decor]
     skip: false
   [css-transforms]
     skip: false
+    [animation]
+      skip: true
   [css-transitions]
     skip: false
+    [animations]
+      skip: true
   [css-ui]
     skip: false
+    [animation]
+      skip: true
   [css-values]
     skip: false
+    [animations]
+      skip: true
   [css-variables]
     skip: false
   [cssom]
@@ -61,6 +85,8 @@ skip: true
     skip: false
   [filter-effects]
     skip: false
+    [animation]
+      skip: true
   [geometry]
     skip: false
   [mediaqueries]

--- a/tests/wpt/metadata/css/CSS2/linebox/animations/line-height-interpolation.html.ini
+++ b/tests/wpt/metadata/css/CSS2/linebox/animations/line-height-interpolation.html.ini
@@ -1,11 +1,5 @@
 [line-height-interpolation.html]
-  [CSS Transitions with transition: all: property <line-height> from [4px\] to [14px\] at (-1) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [14px\] to [normal\] at (0.5) should be [normal\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [4q\] to [14q\] at (1.5) should be [19q\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [inherit\] to [20px\] at (0) should be [30px\]]
@@ -17,16 +11,7 @@
   [Web Animations: property <line-height> from [14px\] to [4\] at (1) should be [4\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <line-height> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [14q\] to [normal\] at (1.5) should be [normal\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from [4\] to [14\] at (0) should be [4\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [14px\] to [normal\] at (0.5) should be [normal\]]
@@ -36,12 +21,6 @@
     expected: FAIL
 
   [CSS Animations: property <line-height> from [4\] to [normal\] at (1.5) should be [normal\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [4px\] to [14px\] at (-1) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [4\] to [14\] at (1.5) should be [19\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [normal\] to [14px\] at (0.3) should be [normal\]]
@@ -59,31 +38,16 @@
   [CSS Animations: property <line-height> from [14px\] to [4\] at (1.5) should be [4\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <line-height> from [4q\] to [14q\] at (-1) should be [0q\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [4px\] to [14px\] at (1) should be [14px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <line-height> from [4q\] to [14q\] at (0.6) should be [10q\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [initial\] to [20px\] at (0) should be [initial\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from neutral to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [14q\] to [normal\] at (0) should be [14q\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [normal\] to [normal\] at (0.3) should be [normal\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [4px\] to [14px\] at (0.3) should be [7px\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [normal\] to [4\] at (0) should be [normal\]]
@@ -119,9 +83,6 @@
   [CSS Animations: property <line-height> from [4\] to [14q\] at (0) should be [4\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <line-height> from [inherit\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [4\] to [14px\] at (1.5) should be [14px\]]
     expected: FAIL
 
@@ -137,25 +98,10 @@
   [Web Animations: property <line-height> from [normal\] to [14px\] at (-0.3) should be [normal\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [4px\] to [14px\] at (1) should be [14px\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [14px\] to [4\] at (-0.3) should be [14px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <line-height> from [inherit\] to [20px\] at (-1) should be [40px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from [4\] to [14\] at (0.3) should be [7\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [4\] to [normal\] at (0) should be [4\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [unset\] to [20px\] at (0.3) should be [27px\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from neutral to [20px\] at (-0.3) should be [7px\]]
@@ -164,13 +110,7 @@
   [Web Animations: property <line-height> from [14q\] to [normal\] at (0.3) should be [14q\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [4\] to [14\] at (1.5) should be [19\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [14px\] to [normal\] at (-0.3) should be [14px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from [4px\] to [14px\] at (0.6) should be [10px\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [initial\] to [20px\] at (0.3) should be [initial\]]
@@ -203,9 +143,6 @@
   [Web Animations: property <line-height> from [4\] to [14px\] at (0.5) should be [14px\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [4q\] to [14q\] at (0.6) should be [10q\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [4\] to [14q\] at (0.5) should be [14q\]]
     expected: FAIL
 
@@ -230,9 +167,6 @@
   [Web Animations: property <line-height> from [normal\] to [normal\] at (0) should be [normal\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [4\] to [14\] at (-0.3) should be [1\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [normal\] to [normal\] at (0.3) should be [normal\]]
     expected: FAIL
 
@@ -251,12 +185,6 @@
   [Web Animations: property <line-height> from [normal\] to [14px\] at (1) should be [14px\]]
     expected: FAIL
 
-  [CSS Transitions: property <line-height> from [4q\] to [14q\] at (0.6) should be [10q\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [inherit\] to [20px\] at (-1) should be [40px\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [normal\] to [14px\] at (0.6) should be [14px\]]
     expected: FAIL
 
@@ -264,9 +192,6 @@
     expected: FAIL
 
   [Web Animations: property <line-height> from [14px\] to [4\] at (0.3) should be [14px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from [unset\] to [20px\] at (0.3) should be [27px\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [4\] to [14q\] at (0.6) should be [14q\]]
@@ -278,19 +203,10 @@
   [Web Animations: property <line-height> from [initial\] to [20px\] at (1.5) should be [20px\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [4q\] to [14q\] at (0.3) should be [7q\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [14px\] to [4\] at (0.6) should be [4\]]
     expected: FAIL
 
   [CSS Transitions: property <line-height> from [4q\] to [14q\] at (-0.3) should be [1q\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [unset\] to [20px\] at (-1) should be [40px\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from [4px\] to [14px\] at (0) should be [4px\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from neutral to [20px\] at (1) should be [20px\]]
@@ -300,12 +216,6 @@
     expected: FAIL
 
   [Web Animations: property <line-height> from [4px\] to [14px\] at (1.5) should be [19px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from [inherit\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from neutral to [20px\] at (-1) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [14px\] to [normal\] at (1) should be [normal\]]
@@ -320,12 +230,6 @@
   [Web Animations: property <line-height> from [normal\] to [14px\] at (0) should be [normal\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [4\] to [14\] at (0.3) should be [7\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from neutral to [20px\] at (-1) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [normal\] to [normal\] at (-0.3) should be [normal\]]
     expected: FAIL
 
@@ -338,25 +242,10 @@
   [Web Animations: property <line-height> from [4\] to [14q\] at (0.6) should be [14q\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <line-height> from [4px\] to [14px\] at (0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from [4\] to [14\] at (0.6) should be [10\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [unset\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from [4q\] to [14q\] at (1.5) should be [19q\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [14px\] to [4\] at (0.5) should be [4\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [unset\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from [inherit\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [14px\] to [4\] at (0) should be [14px\]]
@@ -365,22 +254,10 @@
   [CSS Animations: property <line-height> from [4\] to [14px\] at (-0.3) should be [4\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [normal\] to [4\] at (0.3) should be [normal\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [14px\] to [normal\] at (0.6) should be [normal\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from [4\] to [14\] at (1.5) should be [19\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from [4\] to [14\] at (-1) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [4px\] to [14px\] at (-0.3) should be [1px\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [4\] to [14q\] at (1) should be [14q\]]
@@ -389,19 +266,10 @@
   [CSS Animations: property <line-height> from [inherit\] to [20px\] at (0.6) should be [24px\]]
     expected: FAIL
 
-  [CSS Transitions: property <line-height> from [unset\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [4\] to [14px\] at (0.3) should be [4\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [4px\] to [14px\] at (0.6) should be [10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from [4\] to [14\] at (-0.3) should be [1\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [14px\] to [normal\] at (0.3) should be [14px\]]
@@ -410,22 +278,10 @@
   [Web Animations: property <line-height> from [initial\] to [20px\] at (-0.3) should be [initial\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <line-height> from [4px\] to [14px\] at (1.5) should be [19px\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [normal\] to [4\] at (1.5) should be [4\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [14px\] to [4\] at (0.5) should be [4\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from [4q\] to [14q\] at (1.5) should be [19q\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from [4px\] to [14px\] at (-1) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [4\] to [normal\] at (0.3) should be [4\]]
@@ -440,12 +296,6 @@
   [CSS Animations: property <line-height> from [4\] to [14px\] at (0.6) should be [14px\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [4px\] to [14px\] at (1.5) should be [19px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [14px\] to [normal\] at (1.5) should be [normal\]]
     expected: FAIL
 
@@ -458,31 +308,13 @@
   [CSS Animations: property <line-height> from [4\] to [14q\] at (1.5) should be [14q\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [4px\] to [14px\] at (0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from neutral to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [normal\] to [14px\] at (1.5) should be [14px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [4q\] to [14q\] at (-1) should be [0q\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [14q\] to [normal\] at (1.5) should be [normal\]]
     expected: FAIL
 
-  [CSS Transitions: property <line-height> from [4\] to [14\] at (0.3) should be [7\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [4\] to [14\] at (-1) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [4px\] to [14px\] at (1.5) should be [19px\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [14px\] to [4\] at (1.5) should be [4\]]
@@ -500,9 +332,6 @@
   [CSS Animations: property <line-height> from [14q\] to [normal\] at (0.3) should be [14q\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [unset\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [normal\] to [normal\] at (0.6) should be [normal\]]
     expected: FAIL
 
@@ -515,9 +344,6 @@
   [Web Animations: property <line-height> from neutral to [20px\] at (0.6) should be [16px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <line-height> from [4\] to [14\] at (-1) should be [0\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [4\] to [14\] at (1) should be [14\]]
     expected: FAIL
 
@@ -528,9 +354,6 @@
     expected: FAIL
 
   [CSS Animations: property <line-height> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [4\] to [14\] at (0.6) should be [10\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [normal\] to [normal\] at (-0.3) should be [normal\]]
@@ -551,16 +374,7 @@
   [CSS Transitions: property <line-height> from [4\] to [14\] at (-0.3) should be [1\]]
     expected: FAIL
 
-  [CSS Transitions: property <line-height> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [14px\] to [normal\] at (-0.3) should be [14px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from [4px\] to [14px\] at (-0.3) should be [1px\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [unset\] to [20px\] at (-1) should be [40px\]]
@@ -570,9 +384,6 @@
     expected: FAIL
 
   [CSS Animations: property <line-height> from [unset\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from [unset\] to [20px\] at (1.5) should be [15px\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [4px\] to [14px\] at (-0.3) should be [1px\]]
@@ -596,13 +407,7 @@
   [CSS Animations: property <line-height> from [4\] to [14px\] at (0) should be [4\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [4q\] to [14q\] at (1) should be [14q\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [14px\] to [normal\] at (1.5) should be [normal\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from [unset\] to [20px\] at (0.6) should be [24px\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [inherit\] to [20px\] at (0.3) should be [27px\]]
@@ -641,9 +446,6 @@
   [Web Animations: property <line-height> from [14px\] to [normal\] at (0) should be [14px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <line-height> from [4px\] to [14px\] at (-0.3) should be [1px\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [4q\] to [14q\] at (0.3) should be [7q\]]
     expected: FAIL
 
@@ -659,16 +461,7 @@
   [Web Animations: property <line-height> from [initial\] to [20px\] at (0.5) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <line-height> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [4\] to [14q\] at (0.3) should be [4\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [inherit\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from neutral to [20px\] at (-1) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <line-height> from [14q\] to [normal\] at (0.5) should be [normal\]]
@@ -683,25 +476,13 @@
   [CSS Animations: property <line-height> from [initial\] to [20px\] at (0.5) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <line-height> from [4\] to [14\] at (-1) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from [unset\] to [20px\] at (-1) should be [40px\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [4px\] to [14px\] at (0.6) should be [10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [4\] to [14q\] at (-0.3) should be [4\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [unset\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from neutral to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [unset\] to [20px\] at (0.3) should be [27px\]]
@@ -737,9 +518,6 @@
   [Web Animations: property <line-height> from [initial\] to [20px\] at (0) should be [initial\]]
     expected: FAIL
 
-  [CSS Transitions: property <line-height> from [unset\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [14px\] to [4\] at (0.6) should be [4\]]
     expected: FAIL
 
@@ -749,9 +527,6 @@
   [Web Animations: property <line-height> from [unset\] to [20px\] at (0) should be [30px\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [4\] to [14\] at (1) should be [14\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from neutral to [20px\] at (0) should be [10px\]]
     expected: FAIL
 
@@ -759,15 +534,6 @@
     expected: FAIL
 
   [CSS Animations: property <line-height> from [normal\] to [14px\] at (-0.3) should be [normal\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from [4\] to [14\] at (0.6) should be [10\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <line-height> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <line-height> from [inherit\] to [20px\] at (0.6) should be [24px\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [unset\] to [20px\] at (1.5) should be [15px\]]
@@ -794,9 +560,6 @@
   [Web Animations: property <line-height> from [4\] to [14px\] at (1) should be [14px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <line-height> from [unset\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [initial\] to [20px\] at (-0.3) should be [initial\]]
     expected: FAIL
 
@@ -809,19 +572,10 @@
   [Web Animations: property <line-height> from [4q\] to [14q\] at (-1) should be [0q\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [4q\] to [14q\] at (0) should be [4q\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [4\] to [14\] at (0.6) should be [10\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [4q\] to [14q\] at (-1) should be [0q\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [unset\] to [20px\] at (-1) should be [40px\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from neutral to [20px\] at (-0.3) should be [7px\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [4px\] to [14px\] at (-1) should be [0px\]]
@@ -836,6 +590,12 @@
   [Web Animations: property <line-height> from [normal\] to [14px\] at (0.5) should be [14px\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [4q\] to [14q\] at (-0.3) should be [1q\]]
+  [CSS Transitions: property <line-height> from [4q\] to [14q\] at (1.5) should be [19q\]]
+    expected: FAIL
+
+  [CSS Transitions: property <line-height> from [unset\] to [20px\] at (-1) should be [40px\]]
+    expected: FAIL
+
+  [CSS Transitions: property <line-height> from [unset\] to [20px\] at (-0.3) should be [33px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/CSS2/visufx/animation/visibility-interpolation.html.ini
+++ b/tests/wpt/metadata/css/CSS2/visufx/animation/visibility-interpolation.html.ini
@@ -14,9 +14,6 @@
   [CSS Animations: property <visibility> from [collapse\] to [hidden\] at (-0.3) should be [collapse\]]
     expected: FAIL
 
-  [CSS Transitions: property <visibility> from [hidden\] to [visible\] at (1.5) should be [visible\]]
-    expected: FAIL
-
   [Web Animations: property <visibility> from [visible\] to [hidden\] at (0) should be [visible\]]
     expected: FAIL
 
@@ -24,9 +21,6 @@
     expected: FAIL
 
   [Web Animations: property <visibility> from [visible\] to [hidden\] at (1.5) should be [hidden\]]
-    expected: FAIL
-
-  [CSS Animations: property <visibility> from [hidden\] to [visible\] at (0) should be [hidden\]]
     expected: FAIL
 
   [CSS Animations: property <visibility> from [collapse\] to [hidden\] at (1.5) should be [hidden\]]
@@ -44,9 +38,6 @@
   [CSS Animations: property <visibility> from [collapse\] to [hidden\] at (0.3) should be [collapse\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <visibility> from [hidden\] to [visible\] at (0.1) should be [visible\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <visibility> from [collapse\] to [hidden\] at (0) should be [hidden\]]
     expected: FAIL
 
@@ -60,9 +51,6 @@
     expected: FAIL
 
   [CSS Animations: property <visibility> from [collapse\] to [visible\] at (1.5) should be [visible\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <visibility> from [visible\] to [hidden\] at (1.5) should be [hidden\]]
     expected: FAIL
 
   [Web Animations: property <visibility> from [hidden\] to [visible\] at (1) should be [visible\]]
@@ -83,13 +71,7 @@
   [CSS Animations: property <visibility> from [collapse\] to [hidden\] at (0.5) should be [hidden\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <visibility> from [hidden\] to [visible\] at (1.5) should be [visible\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <visibility> from [collapse\] to [hidden\] at (0.3) should be [hidden\]]
-    expected: FAIL
-
-  [CSS Animations: property <visibility> from [visible\] to [hidden\] at (1) should be [hidden\]]
     expected: FAIL
 
   [Web Animations: property <visibility> from [collapse\] to [visible\] at (0.1) should be [visible\]]
@@ -105,9 +87,6 @@
     expected: FAIL
 
   [CSS Animations: property <visibility> from [collapse\] to [hidden\] at (0.6) should be [hidden\]]
-    expected: FAIL
-
-  [CSS Transitions: property <visibility> from [visible\] to [hidden\] at (1.5) should be [hidden\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <visibility> from [collapse\] to [hidden\] at (0.6) should be [hidden\]]
@@ -143,9 +122,6 @@
   [CSS Animations: property <visibility> from [collapse\] to [visible\] at (-1) should be [collapse\]]
     expected: FAIL
 
-  [CSS Animations: property <visibility> from [visible\] to [hidden\] at (1.5) should be [hidden\]]
-    expected: FAIL
-
   [CSS Transitions: property <visibility> from [collapse\] to [visible\] at (0.9) should be [visible\]]
     expected: FAIL
 
@@ -167,16 +143,7 @@
   [CSS Transitions with transition: all: property <visibility> from [collapse\] to [hidden\] at (-0.3) should be [hidden\]]
     expected: FAIL
 
-  [CSS Transitions: property <visibility> from [hidden\] to [visible\] at (0.1) should be [visible\]]
-    expected: FAIL
-
-  [CSS Animations: property <visibility> from [hidden\] to [visible\] at (-1) should be [hidden\]]
-    expected: FAIL
-
   [Web Animations: property <visibility> from [hidden\] to [visible\] at (1.5) should be [visible\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <visibility> from [hidden\] to [visible\] at (0.9) should be [visible\]]
     expected: FAIL
 
   [Web Animations: property <visibility> from [visible\] to [hidden\] at (0.1) should be [visible\]]
@@ -237,9 +204,6 @@
     expected: FAIL
 
   [CSS Transitions: property <visibility> from [collapse\] to [hidden\] at (0.5) should be [hidden\]]
-    expected: FAIL
-
-  [CSS Transitions: property <visibility> from [hidden\] to [visible\] at (0.9) should be [visible\]]
     expected: FAIL
 
   [Web Animations: property <visibility> from [collapse\] to [hidden\] at (-0.3) should be [collapse\]]

--- a/tests/wpt/metadata/css/css-backgrounds/animations/background-color-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/animations/background-color-interpolation.html.ini
@@ -2,13 +2,7 @@
   [background-color-interpolation]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-color> from neutral to [green\] at (0.3) should be [rgb(0, 38, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (1.5) should be [rgba(0, 255, 0, 0.88)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [white\] to [orange\] at (1.5) should be [rgb(255, 120, 0)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (1) should be [rgba(0, 255, 0, 0.75)\]]
@@ -23,91 +17,28 @@
   [Web Animations: property <background-color> from [white\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-color> from [transparent\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from [inherit\] to [green\] at (0.6) should be [rgb(95, 172, 95)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (-0.5) should be [rgba(0, 0, 255, 0.38)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (0.5) should be [rgba(0, 153, 102, 0.63)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from neutral to [green\] at (1) should be [rgb(0, 128, 0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (0.25) should be [rgba(0, 85, 170, 0.56)\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from [transparent\] to [green\] at (0.6) should be [rgba(0, 128, 0, 0.6)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [initial\] to [green\] at (0.6) should be [rgba(0, 128, 0, 0.6)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [white\] to [orange\] at (-0.3) should be [white\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from neutral to [green\] at (0.6) should be [rgb(0, 77, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (1.5) should be [rgba(0, 255, 0, 0.88)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from [initial\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-color> from [inherit\] to [green\] at (-0.3) should be [rgb(255, 255, 255)\]]
-    expected: FAIL
-
   [CSS Animations: property <background-color> from [inherit\] to [green\] at (0.3) should be [rgb(167, 205, 167)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [white\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from [inherit\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-color> from neutral to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [inherit\] to [green\] at (1.5) should be [rgb(0, 73, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [inherit\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [white\] to [orange\] at (1.5) should be [rgb(255, 120, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [unset\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
   [CSS Animations: property <background-color> from [inherit\] to [green\] at (-0.3) should be [rgb(255, 255, 255)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-color> from neutral to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [white\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [unset\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [transparent\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [initial\] to [green\] at (0.3) should be [rgba(0, 128, 0, 0.3)\]]
-    expected: FAIL
-
   [CSS Animations: property <background-color> from [inherit\] to [green\] at (0) should be [rgb(238, 238, 238)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [transparent\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from [unset\] to [green\] at (0) should be [rgba(0, 0, 0, 0)\]]
@@ -119,64 +50,19 @@
   [Web Animations: property <background-color> from [unset\] to [green\] at (0.6) should be [rgba(0, 128, 0, 0.6)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-color> from [initial\] to [green\] at (0.6) should be [rgba(0, 128, 0, 0.6)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (0.5) should be [rgba(0, 153, 102, 0.63)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [transparent\] to [green\] at (0.3) should be [rgba(0, 128, 0, 0.3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (1) should be [rgba(0, 255, 0, 0.75)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [white\] to [orange\] at (0) should be [white\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from [white\] to [orange\] at (1) should be [orange\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [inherit\] to [green\] at (0.6) should be [rgb(95, 172, 95)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from neutral to [green\] at (0.3) should be [rgb(0, 38, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (-0.5) should be [rgba(0, 0, 255, 0.38)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [inherit\] to [green\] at (1.5) should be [rgb(0, 73, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [inherit\] to [green\] at (-0.3) should be [rgb(255, 255, 255)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [initial\] to [green\] at (0.6) should be [rgba(0, 128, 0, 0.6)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from [unset\] to [green\] at (-0.3) should be [rgba(0, 0, 0, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-color> from [initial\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (0.5) should be [rgba(0, 153, 102, 0.63)\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from [initial\] to [green\] at (0) should be [rgba(0, 0, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [initial\] to [green\] at (0.3) should be [rgba(0, 128, 0, 0.3)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (0.75) should be [rgba(0, 208, 47, 0.69)\]]
     expected: FAIL
 
   [CSS Animations: property <background-color> from [white\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [white\] to [orange\] at (1) should be [orange\]]
     expected: FAIL
 
   [CSS Animations: property <background-color> from [inherit\] to [green\] at (0.6) should be [rgb(95, 172, 95)\]]
@@ -191,25 +77,10 @@
   [Web Animations: property <background-color> from [transparent\] to [green\] at (-0.3) should be [rgba(0, 0, 0, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-color> from [transparent\] to [green\] at (0.3) should be [rgba(0, 128, 0, 0.3)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [transparent\] to [green\] at (0.6) should be [rgba(0, 128, 0, 0.6)\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from [unset\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-color> from [unset\] to [green\] at (0.3) should be [rgba(0, 128, 0, 0.3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [unset\] to [green\] at (0) should be [rgba(0, 0, 0, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from [transparent\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [transparent\] to [green\] at (0.6) should be [rgba(0, 128, 0, 0.6)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from [initial\] to [green\] at (0.6) should be [rgba(0, 128, 0, 0.6)\]]
@@ -218,49 +89,22 @@
   [Web Animations: property <background-color> from [initial\] to [green\] at (-0.3) should be [rgba(0, 0, 0, 0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-color> from [transparent\] to [green\] at (0.3) should be [rgba(0, 128, 0, 0.3)\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from [unset\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (-0.5) should be [rgba(0, 0, 255, 0.38)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (0) should be [rgba(0, 0, 255, 0.5)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-color> from [initial\] to [green\] at (-0.3) should be [rgba(0, 0, 0, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from neutral to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (0) should be [rgba(0, 0, 255, 0.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (0.75) should be [rgba(0, 208, 47, 0.69)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from neutral to [green\] at (0.6) should be [rgb(0, 77, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from neutral to [green\] at (0) should be [rgb(0, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [transparent\] to [green\] at (-0.3) should be [rgba(0, 0, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [inherit\] to [green\] at (0.3) should be [rgb(167, 205, 167)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from [white\] to [orange\] at (-0.3) should be [white\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (0.25) should be [rgba(0, 85, 170, 0.56)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [unset\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from [inherit\] to [green\] at (0) should be [rgb(238, 238, 238)\]]
@@ -272,31 +116,7 @@
   [Web Animations: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (-0.5) should be [rgba(0, 0, 255, 0.38)\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-color> from [unset\] to [green\] at (0.6) should be [rgba(0, 128, 0, 0.6)\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from [white\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [initial\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [white\] to [orange\] at (1.5) should be [rgb(255, 120, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [initial\] to [green\] at (0.3) should be [rgba(0, 128, 0, 0.3)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from neutral to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from neutral to [green\] at (0.3) should be [rgb(0, 38, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (0.75) should be [rgba(0, 208, 47, 0.69)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (1.5) should be [rgba(0, 255, 0, 0.88)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from neutral to [green\] at (0.6) should be [rgb(0, 77, 0)\]]
@@ -308,76 +128,22 @@
   [CSS Transitions with transition: all: property <background-color> from [white\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-color> from [transparent\] to [green\] at (0.6) should be [rgba(0, 128, 0, 0.6)\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from [inherit\] to [green\] at (-0.3) should be [rgb(255, 255, 255)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from neutral to [green\] at (0.6) should be [rgb(0, 77, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (1.5) should be [rgba(0, 255, 0, 0.88)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [initial\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (0.5) should be [rgba(0, 153, 102, 0.63)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-color> from [unset\] to [green\] at (0.6) should be [rgba(0, 128, 0, 0.6)\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from [unset\] to [green\] at (0.3) should be [rgba(0, 128, 0, 0.3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [unset\] to [green\] at (-0.3) should be [rgba(0, 0, 0, 0)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from [inherit\] to [green\] at (0.3) should be [rgb(167, 205, 167)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-color> from [unset\] to [green\] at (0.3) should be [rgba(0, 128, 0, 0.3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (0.75) should be [rgba(0, 208, 47, 0.69)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [initial\] to [green\] at (0) should be [rgba(0, 0, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [unset\] to [green\] at (0.3) should be [rgba(0, 128, 0, 0.3)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (0.25) should be [rgba(0, 85, 170, 0.56)\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from [transparent\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-color> from [inherit\] to [green\] at (0.6) should be [rgb(95, 172, 95)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [white\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [initial\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [transparent\] to [green\] at (0) should be [rgba(0, 0, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from neutral to [green\] at (1) should be [rgb(0, 128, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-color> from [unset\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <background-color> from [initial\] to [green\] at (0.3) should be [rgba(0, 128, 0, 0.3)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [inherit\] to [green\] at (0.3) should be [rgb(167, 205, 167)\]]
     expected: FAIL
 
   [Web Animations: property <background-color> from [white\] to [orange\] at (0) should be [white\]]
@@ -386,15 +152,6 @@
   [Web Animations: property <background-color> from neutral to [green\] at (-0.3) should be [rgb(0, 0, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-color> from [currentcolor\] to [rgba(0, 255, 0, 0.75)\] at (0.25) should be [rgba(0, 85, 170, 0.56)\]]
-    expected: FAIL
-
   [CSS Transitions: property <background-color> from [white\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-color> from [unset\] to [green\] at (0.6) should be [rgba(0, 128, 0, 0.6)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-color> from [transparent\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-backgrounds/animations/background-image-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/animations/background-image-interpolation.html.ini
@@ -1,14 +1,5 @@
 [background-image-interpolation.html]
-  [CSS Animations: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (1) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (1.5) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [url(../resources/stripes-100.png), url(../resources/blue-100.png)\] to [url(../resources/blue-100.png), url(../resources/stripes-100.png)\] at (0.6) should be [url(../resources/blue-100.png), url(../resources/stripes-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png), none\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (1.5) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (0) should be [url(../resources/blue-100.png)\]]
@@ -26,25 +17,7 @@
   [Web Animations: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (1) should be [url(../resources/green-100.png)\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-image> from [inherit\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [inherit\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [linear-gradient(45deg, blue, orange)\] at (0) should be [url(../resources/blue-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [unset\] to [url(../resources/green-100.png)\] at (0) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (0.3) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [unset\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [inherit\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
@@ -53,25 +26,10 @@
   [CSS Transitions: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (1.5) should be [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (0) should be [none\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/green-100.png)\] at (0.3) should be [url(../resources/blue-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/stripes-100.png), url(../resources/blue-100.png)\] to [url(../resources/blue-100.png), url(../resources/stripes-100.png)\] at (1) should be [url(../resources/blue-100.png), url(../resources/stripes-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [unset\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
@@ -83,31 +41,10 @@
   [Web Animations: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (0.3) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <background-image> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (1) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from neutral to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (-0.3) should be [none\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-image> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from [url(../resources/stripes-100.png), url(../resources/blue-100.png)\] to [url(../resources/blue-100.png), url(../resources/stripes-100.png)\] at (0.6) should be [url(../resources/blue-100.png), url(../resources/stripes-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0) should be [linear-gradient(-45deg, red, yellow)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from neutral to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)\] at (-0.3) should be [url(../resources/blue-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/stripes-100.png), url(../resources/blue-100.png)\] to [url(../resources/blue-100.png), url(../resources/stripes-100.png)\] at (0.6) should be [url(../resources/blue-100.png), url(../resources/stripes-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)\] at (0) should be [url(../resources/blue-100.png)\]]
@@ -116,16 +53,7 @@
   [CSS Transitions with transition: all: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (1) should be [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-image> from [url(../resources/blue-100.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [unset\] to [url(../resources/green-100.png)\] at (-0.3) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [inherit\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (1.5) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [url(../resources/stripes-100.png), url(../resources/blue-100.png)\] to [url(../resources/blue-100.png), url(../resources/stripes-100.png)\] at (-0.3) should be [url(../resources/stripes-100.png), url(../resources/blue-100.png)\]]
@@ -134,40 +62,13 @@
   [Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)\] at (0.3) should be [url(../resources/blue-100.png)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [url(../resources/stripes-100.png), url(../resources/blue-100.png)\] to [url(../resources/blue-100.png), url(../resources/stripes-100.png)\] at (0.6) should be [url(../resources/blue-100.png), url(../resources/stripes-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (0.6) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [unset\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png)\] to [linear-gradient(45deg, blue, orange)\] at (1) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [inherit\] to [url(../resources/green-100.png)\] at (-0.3) should be [url(../resources/blue-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-image> from [unset\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
   [CSS Transitions: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (0.6) should be [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (0.3) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from [url(../resources/blue-100.png), none\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (1.5) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (0.6) should be [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\]]
@@ -179,25 +80,10 @@
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [linear-gradient(45deg, blue, orange)\] at (1) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/stripes-100.png), url(../resources/blue-100.png)\] to [url(../resources/blue-100.png), url(../resources/stripes-100.png)\] at (0) should be [url(../resources/stripes-100.png), url(../resources/blue-100.png)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [url(../resources/blue-100.png), none\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (-0.3) should be [url(../resources/blue-100.png), none\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)\] at (1) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from [inherit\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (1.5) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
     expected: FAIL
 
   [CSS Animations: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (0.6) should be [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\]]
@@ -206,22 +92,7 @@
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (1) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-image> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (-0.3) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.3) should be [linear-gradient(-45deg, red, yellow)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [url(../resources/blue-100.png), none\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (0) should be [url(../resources/blue-100.png), none\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (-0.3) should be [linear-gradient(-45deg, red, yellow)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from neutral to [url(../resources/green-100.png)\] at (1) should be [url(../resources/green-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [url(../resources/blue-100.png), none\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (0.6) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
@@ -239,19 +110,10 @@
   [Web Animations: property <background-image> from [unset\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (0) should be [none\]]
-    expected: FAIL
-
   [CSS Animations: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (0) should be [url(../resources/blue-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.3) should be [url(../resources/blue-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from [url(../resources/blue-100.png), none\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (0.6) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (-0.3) should be [url(../resources/blue-100.png)\]]
@@ -260,31 +122,7 @@
   [Web Animations: property <background-image> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (1.5) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-image> from neutral to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (1.5) should be [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (1) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [url(../resources/blue-100.png), none\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (0.6) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [url(../resources/blue-100.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (1.5) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from neutral to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [unset\] to [url(../resources/green-100.png)\] at (1) should be [url(../resources/green-100.png)\]]
@@ -308,25 +146,13 @@
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (0.6) should be [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-image> from [url(../resources/stripes-100.png), url(../resources/blue-100.png)\] to [url(../resources/blue-100.png), url(../resources/stripes-100.png)\] at (0.3) should be [url(../resources/stripes-100.png), url(../resources/blue-100.png)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [url(../resources/stripes-100.png), url(../resources/blue-100.png)\] to [url(../resources/blue-100.png), url(../resources/stripes-100.png)\] at (0.3) should be [url(../resources/stripes-100.png), url(../resources/blue-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [unset\] to [url(../resources/green-100.png)\] at (1) should be [url(../resources/green-100.png)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (-0.3) should be [url(../resources/blue-100.png)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png), none\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (1) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (0.6) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
     expected: FAIL
 
   [CSS Animations: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (-0.3) should be [url(../resources/blue-100.png)\]]
@@ -338,46 +164,16 @@
   [Web Animations: property <background-image> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (1) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-image> from [unset\] to [url(../resources/green-100.png)\] at (-0.3) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png), none\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (0.6) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/green-100.png)\] at (1) should be [url(../resources/green-100.png)\]]
     expected: FAIL
 
   [CSS Animations: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (1) should be [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [url(../resources/blue-100.png)\] to [linear-gradient(45deg, blue, orange)\] at (1.5) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png), none\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (0.3) should be [url(../resources/blue-100.png), none\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [unset\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [unset\] to [url(../resources/green-100.png)\] at (0.3) should be [none\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [inherit\] to [url(../resources/green-100.png)\] at (0.3) should be [url(../resources/blue-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [url(../resources/stripes-100.png), url(../resources/blue-100.png)\] to [url(../resources/blue-100.png), url(../resources/stripes-100.png)\] at (0) should be [url(../resources/stripes-100.png), url(../resources/blue-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (1.5) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/green-100.png)\] at (1) should be [url(../resources/green-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (0.3) should be [none\]]
@@ -390,15 +186,6 @@
     expected: FAIL
 
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (0.6) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from [unset\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [url(../resources/stripes-100.png), url(../resources/blue-100.png)\] to [url(../resources/blue-100.png), url(../resources/stripes-100.png)\] at (1.5) should be [url(../resources/blue-100.png), url(../resources/stripes-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
@@ -422,40 +209,19 @@
   [Web Animations: property <background-image> from [url(../resources/blue-100.png), none\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (0.3) should be [url(../resources/blue-100.png), none\]]
     expected: FAIL
 
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (0.6) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/green-100.png)\] at (-0.3) should be [url(../resources/blue-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from neutral to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (1) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from neutral to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
   [CSS Transitions: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (0.3) should be [url(../resources/blue-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png), none\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (0) should be [url(../resources/blue-100.png), none\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (0.3) should be [url(../resources/blue-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/green-100.png)\] at (0) should be [url(../resources/blue-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [inherit\] to [url(../resources/green-100.png)\] at (1) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (1) should be [url(../resources/green-100.png)\]]
@@ -467,9 +233,6 @@
   [Web Animations: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (0) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
     expected: FAIL
 
@@ -479,22 +242,10 @@
   [Web Animations: property <background-image> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0) should be [linear-gradient(-45deg, red, yellow)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-image> from [url(../resources/blue-100.png), none\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (1.5) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (1.5) should be [url(../resources/stripes-100.png), url(../resources/green-100.png)\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png)\] to [linear-gradient(45deg, blue, orange)\] at (1.5) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [url(../resources/green-100.png)\] at (0.6) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from [url(../resources/stripes-100.png), url(../resources/blue-100.png)\] to [url(../resources/blue-100.png), url(../resources/stripes-100.png)\] at (1.5) should be [url(../resources/blue-100.png), url(../resources/stripes-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.3) should be [linear-gradient(-45deg, red, yellow)\]]
@@ -503,31 +254,7 @@
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (0.3) should be [url(../resources/blue-100.png)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-image> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (1.5) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from neutral to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/blue-100.png), none\] to [url(../resources/stripes-100.png), url(../resources/green-100.png)\] at (-0.3) should be [url(../resources/blue-100.png), none\]]
-    expected: FAIL
-
   [Web Animations: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (1) should be [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [inherit\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (-0.3) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-image> from [url(../resources/stripes-100.png), url(../resources/blue-100.png)\] to [url(../resources/blue-100.png), url(../resources/stripes-100.png)\] at (-0.3) should be [url(../resources/stripes-100.png), url(../resources/blue-100.png)\]]
     expected: FAIL
 
   [Web Animations: property <background-image> from [inherit\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
@@ -536,21 +263,9 @@
   [CSS Transitions with transition: all: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (0) should be [url(../resources/blue-100.png)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-image> from [none\] to [url(../resources/green-100.png)\] at (0) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-image> from [initial\] to [url(../resources/green-100.png)\] at (1.5) should be [url(../resources/green-100.png)\]]
-    expected: FAIL
-
   [CSS Transitions: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (-0.3) should be [url(../resources/blue-100.png)\]]
     expected: FAIL
 
-  [CSS Animations: property <background-image> from [url(../resources/stripes-100.png), url(../resources/blue-100.png)\] to [url(../resources/blue-100.png), url(../resources/stripes-100.png)\] at (1.5) should be [url(../resources/blue-100.png), url(../resources/stripes-100.png)\]]
-    expected: FAIL
-
   [CSS Animations: property <background-image> from [url(../resources/blue-100.png)\] to [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\] at (1.5) should be [cross-fade(url(../resources/green-100.png), url(../resources/stripes-100.png), 0.5)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-image> from [url(../resources/blue-100.png)\] to [linear-gradient(45deg, blue, orange)\] at (1.5) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-backgrounds/animations/background-position-x-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/animations/background-position-x-interpolation.html.ini
@@ -2,64 +2,16 @@
   [background-position-x-interpolation]
     expected: FAIL
 
-  [CSS Transitions: property <background-position-x> from [inherit\] to [80px\] at (0.75) should be [75px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-position-x> from neutral to [80px\] at (0.75) should be [70px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-position-x> from neutral to [80px\] at (-0.25) should be [30px\]]
-    expected: FAIL
-
   [CSS Animations: property <background-position-x> from [inherit\] to [80px\] at (-0.25) should be [55px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (0.25) should be [350px, 450px, 400px, 425px, 375px, 475px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (1.25) should be [550px, 650px, 800px, 525px, 675px, 775px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from [initial\] to [right\] at (0.5) should be [50%\]]
     expected: FAIL
 
   [Web Animations: property <background-position-x> from [inherit\] to [80px\] at (0.75) should be [75px\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-position-x> from [inherit\] to [80px\] at (-0.25) should be [55px\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-x> from [inherit\] to [80px\] at (-0.25) should be [55px\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-position-x> from [inherit\] to [80px\] at (0.5) should be [70px\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-x> from neutral to [80px\] at (0.25) should be [50px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from neutral to [80px\] at (-0.25) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from neutral to [80px\] at (0.75) should be [70px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (1.25) should be [550px, 650px, 800px, 525px, 675px, 775px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from neutral to [80px\] at (1) should be [80px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from [initial\] to [right\] at (1) should be [100%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-x> from [inherit\] to [80px\] at (1.25) should be [85px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-position-x> from [inherit\] to [80px\] at (1.25) should be [85px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-x> from [inherit\] to [80px\] at (-0.25) should be [55px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (-0.25) should be [250px, 350px, 200px, 375px, 225px, 325px\]]
@@ -74,13 +26,7 @@
   [CSS Transitions with transition: all: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (0.75) should be [450px, 550px, 600px, 475px, 525px, 625px\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-position-x> from neutral to [80px\] at (0.25) should be [50px\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (1.25) should be [550px, 650px, 800px, 525px, 675px, 775px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (-0.25) should be [250px, 350px, 200px, 375px, 225px, 325px\]]
     expected: FAIL
 
   [Web Animations: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (1) should be [500px, 600px, 700px, 500px, 600px, 700px\]]
@@ -92,37 +38,16 @@
   [CSS Animations: property <background-position-x> from [inherit\] to [80px\] at (0.75) should be [75px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-position-x> from neutral to [80px\] at (-0.25) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from neutral to [80px\] at (0.5) should be [60px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <background-position-x> from [initial\] to [right\] at (0.5) should be [50%\]]
     expected: FAIL
 
   [CSS Transitions: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (-0.25) should be [250px, 350px, 200px, 375px, 225px, 325px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-position-x> from neutral to [80px\] at (0.75) should be [70px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-x> from [inherit\] to [80px\] at (0.25) should be [65px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-x> from neutral to [80px\] at (1.25) should be [90px\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-x> from neutral to [80px\] at (1) should be [80px\]]
     expected: FAIL
 
   [Web Animations: property <background-position-x> from [inherit\] to [80px\] at (1) should be [80px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-x> from [inherit\] to [80px\] at (0.5) should be [70px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (0.5) should be [400px, 500px, 500px, 450px, 450px, 550px\]]
     expected: FAIL
 
   [Web Animations: property <background-position-x> from [initial\] to [right\] at (0.5) should be [50%\]]
@@ -134,40 +59,13 @@
   [Web Animations: property <background-position-x> from neutral to [80px\] at (0) should be [40px\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-position-x> from [initial\] to [right\] at (0.75) should be [75%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-x> from neutral to [80px\] at (0.5) should be [60px\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-x> from [initial\] to [right\] at (1) should be [100%\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (0) should be [300px, 400px, 300px, 400px, 300px, 400px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-x> from neutral to [80px\] at (0.25) should be [50px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from [initial\] to [right\] at (-0.25) should be [-25%\]]
     expected: FAIL
 
   [CSS Animations: property <background-position-x> from [inherit\] to [80px\] at (1.25) should be [85px\]]
     expected: FAIL
 
   [CSS Transitions: property <background-position-x> from [initial\] to [right\] at (0.5) should be [50%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-x> from [initial\] to [right\] at (1.25) should be [125%\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from [inherit\] to [80px\] at (1) should be [80px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-position-x> from [initial\] to [right\] at (1.25) should be [125%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-x> from [inherit\] to [80px\] at (0.75) should be [75px\]]
     expected: FAIL
 
   [CSS Transitions: property <background-position-x> from [initial\] to [right\] at (-0.25) should be [-25%\]]
@@ -182,34 +80,13 @@
   [Web Animations: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (-0.25) should be [250px, 350px, 200px, 375px, 225px, 325px\]]
     expected: FAIL
 
-  [CSS Animations: property <background-position-x> from [initial\] to [right\] at (1.25) should be [125%\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (0.5) should be [400px, 500px, 500px, 450px, 450px, 550px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from [initial\] to [right\] at (0) should be [0%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-x> from [initial\] to [right\] at (0.75) should be [75%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-x> from [initial\] to [right\] at (-0.25) should be [-25%\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from neutral to [80px\] at (1.25) should be [90px\]]
     expected: FAIL
 
   [Web Animations: property <background-position-x> from [initial\] to [right\] at (0) should be [0%\]]
     expected: FAIL
 
   [Web Animations: property <background-position-x> from [initial\] to [right\] at (1.25) should be [125%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-position-x> from neutral to [80px\] at (0.5) should be [60px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (0.75) should be [450px, 550px, 600px, 475px, 525px, 625px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (0.25) should be [350px, 450px, 400px, 425px, 375px, 475px\]]
@@ -227,25 +104,10 @@
   [CSS Animations: property <background-position-x> from [inherit\] to [80px\] at (0.25) should be [65px\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-position-x> from neutral to [80px\] at (1.25) should be [90px\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-x> from [initial\] to [right\] at (0.25) should be [25%\]]
     expected: FAIL
 
-  [CSS Animations: property <background-position-x> from [initial\] to [right\] at (0.25) should be [25%\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-x> from neutral to [80px\] at (0.5) should be [60px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from neutral to [80px\] at (0.25) should be [50px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (1) should be [500px, 600px, 700px, 500px, 600px, 700px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-x> from [initial\] to [right\] at (0.75) should be [75%\]]
     expected: FAIL
 
   [Web Animations: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (0) should be [300px, 400px, 300px, 400px, 300px, 400px\]]
@@ -258,9 +120,6 @@
     expected: FAIL
 
   [CSS Transitions: property <background-position-x> from [300px, 400px\] to [500px, 600px, 700px\] at (0.75) should be [450px, 550px, 600px, 475px, 525px, 625px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-x> from [initial\] to [right\] at (0.25) should be [25%\]]
     expected: FAIL
 
   [Web Animations: property <background-position-x> from [inherit\] to [80px\] at (1.25) should be [85px\]]
@@ -284,6 +143,21 @@
   [Web Animations: property <background-position-x> from [inherit\] to [80px\] at (0.25) should be [65px\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-position-x> from [inherit\] to [80px\] at (0.25) should be [65px\]]
+  [CSS Transitions: property <background-position-x> from [initial\] to [right\] at (0.75) should be [75%\]]
+    expected: FAIL
+
+  [CSS Transitions: property <background-position-x> from [initial\] to [right\] at (1.25) should be [125%\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <background-position-x> from [initial\] to [right\] at (0.75) should be [75%\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <background-position-x> from [initial\] to [right\] at (-0.25) should be [-25%\]]
+    expected: FAIL
+
+  [CSS Transitions: property <background-position-x> from neutral to [80px\] at (0.5) should be [60px\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <background-position-x> from [initial\] to [right\] at (0.25) should be [25%\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-backgrounds/animations/background-position-y-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/animations/background-position-y-interpolation.html.ini
@@ -2,13 +2,7 @@
   [background-position-y-interpolation]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-position-y> from [inherit\] to [80px\] at (0.25) should be [65px\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (1.25) should be [550px, 650px, 800px, 525px, 675px, 775px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-y> from [initial\] to [bottom\] at (0) should be [0%\]]
     expected: FAIL
 
   [CSS Transitions: property <background-position-y> from [initial\] to [bottom\] at (-0.25) should be [-25%\]]
@@ -20,31 +14,13 @@
   [Web Animations: property <background-position-y> from [inherit\] to [80px\] at (0) should be [60px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-position-y> from neutral to [80px\] at (0.75) should be [70px\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-y> from neutral to [80px\] at (0.5) should be [60px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-y> from [inherit\] to [80px\] at (1.25) should be [85px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (0.25) should be [350px, 450px, 400px, 425px, 375px, 475px\]]
     expected: FAIL
 
-  [CSS Animations: property <background-position-y> from [initial\] to [bottom\] at (1.25) should be [125%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-y> from [inherit\] to [80px\] at (0.75) should be [75px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-y> from neutral to [80px\] at (1) should be [80px\]]
-    expected: FAIL
-
   [CSS Animations: property <background-position-y> from [inherit\] to [80px\] at (0) should be [60px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-y> from [initial\] to [bottom\] at (0.25) should be [25%\]]
     expected: FAIL
 
   [CSS Animations: property <background-position-y> from [inherit\] to [80px\] at (-0.25) should be [55px\]]
@@ -53,64 +29,19 @@
   [Web Animations: property <background-position-y> from [inherit\] to [80px\] at (0.25) should be [65px\]]
     expected: FAIL
 
-  [CSS Animations: property <background-position-y> from neutral to [80px\] at (1.25) should be [90px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-y> from neutral to [80px\] at (1.25) should be [90px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-y> from [initial\] to [bottom\] at (0.75) should be [75%\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-y> from neutral to [80px\] at (0.25) should be [50px\]]
-    expected: FAIL
-
   [CSS Animations: property <background-position-y> from [inherit\] to [80px\] at (1.25) should be [85px\]]
     expected: FAIL
 
   [CSS Transitions: property <background-position-y> from [initial\] to [bottom\] at (1.25) should be [125%\]]
     expected: FAIL
 
-  [CSS Animations: property <background-position-y> from neutral to [80px\] at (0.5) should be [60px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (1.25) should be [550px, 650px, 800px, 525px, 675px, 775px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-y> from neutral to [80px\] at (0.5) should be [60px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-y> from [initial\] to [bottom\] at (1) should be [100%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-position-y> from neutral to [80px\] at (-0.25) should be [30px\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-y> from [initial\] to [bottom\] at (0.5) should be [50%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-position-y> from [inherit\] to [80px\] at (-0.25) should be [55px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (0.5) should be [400px, 500px, 500px, 450px, 450px, 550px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-y> from neutral to [80px\] at (0.75) should be [70px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-position-y> from [inherit\] to [80px\] at (0.75) should be [75px\]]
     expected: FAIL
 
   [Web Animations: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (-0.25) should be [250px, 350px, 200px, 375px, 225px, 325px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-position-y> from [inherit\] to [80px\] at (0.5) should be [70px\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-y> from neutral to [80px\] at (0) should be [40px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-position-y> from neutral to [80px\] at (0.5) should be [60px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (-0.25) should be [250px, 350px, 200px, 375px, 225px, 325px\]]
@@ -119,31 +50,16 @@
   [Web Animations: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (0.5) should be [400px, 500px, 500px, 450px, 450px, 550px\]]
     expected: FAIL
 
-  [CSS Animations: property <background-position-y> from [initial\] to [bottom\] at (-0.25) should be [-25%\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-y> from [inherit\] to [80px\] at (1) should be [80px\]]
     expected: FAIL
 
   [CSS Transitions: property <background-position-y> from [initial\] to [bottom\] at (0.75) should be [75%\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-position-y> from neutral to [80px\] at (1.25) should be [90px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (0.25) should be [350px, 450px, 400px, 425px, 375px, 475px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (0.5) should be [400px, 500px, 500px, 450px, 450px, 550px\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-position-y> from neutral to [80px\] at (0.75) should be [70px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <background-position-y> from [initial\] to [bottom\] at (0.25) should be [25%\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-y> from neutral to [80px\] at (-0.25) should be [30px\]]
     expected: FAIL
 
   [Web Animations: property <background-position-y> from [initial\] to [bottom\] at (0.75) should be [75%\]]
@@ -155,9 +71,6 @@
   [Web Animations: property <background-position-y> from [initial\] to [bottom\] at (0) should be [0%\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-position-y> from [inherit\] to [80px\] at (0.5) should be [70px\]]
-    expected: FAIL
-
   [CSS Transitions: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (0.75) should be [450px, 550px, 600px, 475px, 525px, 625px\]]
     expected: FAIL
 
@@ -167,37 +80,19 @@
   [CSS Transitions with transition: all: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (0.75) should be [450px, 550px, 600px, 475px, 525px, 625px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (1.25) should be [550px, 650px, 800px, 525px, 675px, 775px\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (0) should be [300px, 400px, 300px, 400px, 300px, 400px\]]
     expected: FAIL
 
   [CSS Transitions: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (-0.25) should be [250px, 350px, 200px, 375px, 225px, 325px\]]
     expected: FAIL
 
-  [CSS Animations: property <background-position-y> from [initial\] to [bottom\] at (0.5) should be [50%\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-y> from [initial\] to [bottom\] at (1.25) should be [125%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-y> from [initial\] to [bottom\] at (1.25) should be [125%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <background-position-y> from [inherit\] to [80px\] at (0.25) should be [65px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-y> from [initial\] to [bottom\] at (0.75) should be [75%\]]
     expected: FAIL
 
   [Web Animations: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (0.25) should be [350px, 450px, 400px, 425px, 375px, 475px\]]
     expected: FAIL
 
   [Web Animations: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (1) should be [500px, 600px, 700px, 500px, 600px, 700px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (1) should be [500px, 600px, 700px, 500px, 600px, 700px\]]
     expected: FAIL
 
   [CSS Animations: property <background-position-y> from [inherit\] to [80px\] at (0.75) should be [75px\]]
@@ -221,9 +116,6 @@
   [Web Animations: property <background-position-y> from neutral to [80px\] at (1) should be [80px\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-position-y> from neutral to [80px\] at (0.25) should be [50px\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-y> from [initial\] to [bottom\] at (-0.25) should be [-25%\]]
     expected: FAIL
 
@@ -233,19 +125,10 @@
   [Web Animations: property <background-position-y> from [inherit\] to [80px\] at (0.75) should be [75px\]]
     expected: FAIL
 
-  [CSS Transitions: property <background-position-y> from [inherit\] to [80px\] at (1.25) should be [85px\]]
-    expected: FAIL
-
   [Web Animations: property <background-position-y> from [initial\] to [bottom\] at (0.25) should be [25%\]]
     expected: FAIL
 
   [CSS Transitions: property <background-position-y> from [initial\] to [bottom\] at (0.5) should be [50%\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (0.75) should be [450px, 550px, 600px, 475px, 525px, 625px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-y> from neutral to [80px\] at (0.25) should be [50px\]]
     expected: FAIL
 
   [Web Animations: property <background-position-y> from neutral to [80px\] at (-0.25) should be [30px\]]
@@ -263,27 +146,24 @@
   [CSS Animations: property <background-position-y> from [inherit\] to [80px\] at (0.25) should be [65px\]]
     expected: FAIL
 
-  [CSS Animations: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (0) should be [300px, 400px, 300px, 400px, 300px, 400px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <background-position-y> from [initial\] to [bottom\] at (-0.25) should be [-25%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-y> from neutral to [80px\] at (-0.25) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <background-position-y> from [inherit\] to [80px\] at (-0.25) should be [55px\]]
     expected: FAIL
 
   [Web Animations: property <background-position-y> from neutral to [80px\] at (0.25) should be [50px\]]
     expected: FAIL
 
-  [CSS Animations: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (-0.25) should be [250px, 350px, 200px, 375px, 225px, 325px\]]
-    expected: FAIL
-
   [CSS Transitions: property <background-position-y> from [300px, 400px\] to [500px, 600px, 700px\] at (0.25) should be [350px, 450px, 400px, 425px, 375px, 475px\]]
     expected: FAIL
 
-  [CSS Animations: property <background-position-y> from [inherit\] to [80px\] at (1) should be [80px\]]
+  [CSS Transitions: property <background-position-y> from neutral to [80px\] at (-0.25) should be [30px\]]
+    expected: FAIL
+
+  [CSS Transitions: property <background-position-y> from neutral to [80px\] at (0.5) should be [60px\]]
+    expected: FAIL
+
+  [CSS Transitions: property <background-position-y> from neutral to [80px\] at (0.75) should be [70px\]]
+    expected: FAIL
+
+  [CSS Transitions: property <background-position-y> from neutral to [80px\] at (0.25) should be [50px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-backgrounds/animations/background-size-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/animations/background-size-interpolation.html.ini
@@ -53,9 +53,6 @@
   [CSS Transitions: property <background-size> from [0px 0px, 80px 0px\] to [40px 40px, 80px 80px, 0px 80px\] at (0.5) should be [20px 20px, 80px  40px, 0px  40px, 60px 20px\]]
     expected: FAIL
 
-  [CSS Animations: property <background-size> from [0px 0px, 0px 0px, 0px 0px, 0px 0px\] to [20px 20px, 40px 40px, 60px 60px, 100px 100px\] at (-0.25) should be [ 0px  0px,  0px  0px,  0px  0px,   0px   0px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <background-size> from [0px\] to [80px\] at (1.25) should be [100px, 100px, 100px, 100px\]]
     expected: FAIL
 
@@ -338,9 +335,6 @@
   [Web Animations: property <background-size> from [initial\] to [20px 20px, 0px 0px\] at (0.5) should be [20px 20px, 0px 0px\]]
     expected: FAIL
 
-  [CSS Animations: property <background-size> from [0px 0px, 0px 0px, 0px 0px, 0px 0px\] to [20px 20px, 40px 40px, 60px 60px, 100px 100px\] at (0.25) should be [ 5px  5px, 10px 10px, 15px 15px,  25px  25px\]]
-    expected: FAIL
-
   [CSS Animations: property <background-size> from [0px 0px\] to [80px 80px\] at (-0.25) should be [  0px   0px,   0px   0px,   0px   0px,   0px   0px\]]
     expected: FAIL
 
@@ -368,9 +362,6 @@
   [CSS Animations: property <background-size> from [0px 0px, 80px 0px\] to [40px 40px, 80px 80px, 0px 80px\] at (0.25) should be [10px 10px, 80px  20px, 0px  20px, 70px 10px\]]
     expected: FAIL
 
-  [CSS Animations: property <background-size> from [0px 0px, 0px 0px, 0px 0px, 0px 0px\] to [20px 20px, 40px 40px, 60px 60px, 100px 100px\] at (0.75) should be [15px 15px, 30px 30px, 45px 45px,  75px  75px\]]
-    expected: FAIL
-
   [CSS Transitions: property <background-size> from [0px\] to [80px\] at (1.25) should be [100px, 100px, 100px, 100px\]]
     expected: FAIL
 
@@ -393,9 +384,6 @@
     expected: FAIL
 
   [Web Animations: property <background-size> from [inherit\] to [20px 20px, 0px 0px\] at (1.25) should be [  0px   0px,   0px   0px,   0px   0px,   0px   0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-size> from [0px 0px, 0px 0px, 0px 0px, 0px 0px\] to [20px 20px, 40px 40px, 60px 60px, 100px 100px\] at (1.25) should be [25px 25px, 50px 50px, 75px 75px, 125px 125px\]]
     expected: FAIL
 
   [CSS Animations: property <background-size> from [0px\] to [80px\] at (-0.25) should be [  0px,   0px,   0px,   0px\]]
@@ -467,13 +455,7 @@
   [Web Animations: property <background-size> from [0px 0px, 80px 0px\] to [40px 40px, 80px 80px, 0px 80px\] at (0.5) should be [20px 20px, 80px  40px, 0px  40px, 60px 20px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <background-size> from [0px 0px, 0px 0px, 0px 0px, 0px 0px\] to [20px 20px, 40px 40px, 60px 60px, 100px 100px\] at (1.25) should be [25px 25px, 50px 50px, 75px 75px, 125px 125px\]]
-    expected: FAIL
-
   [Web Animations: property <background-size> from [0px auto, 0px 0px, contain, cover\] to [40px auto, 40px 40px, contain, cover\] at (0.25) should be [10px auto, 10px 10px, contain, cover\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-size> from [0px 0px, 0px 0px, 0px 0px, 0px 0px\] to [20px 20px, 40px 40px, 60px 60px, 100px 100px\] at (1) should be [20px 20px, 40px 40px, 60px 60px, 100px 100px\]]
     expected: FAIL
 
   [Web Animations: property <background-size> from [0px 0px\] to [80px 80px\] at (1.25) should be [100px 100px, 100px 100px, 100px 100px, 100px 100px\]]
@@ -618,12 +600,6 @@
     expected: FAIL
 
   [Web Animations: property <background-size> from [0px 0px\] to [80px 80px\] at (0.5) should be [ 40px  40px,  40px  40px,  40px  40px,  40px  40px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-size> from [0px 0px, 0px 0px, 0px 0px, 0px 0px\] to [20px 20px, 40px 40px, 60px 60px, 100px 100px\] at (0) should be [ 0px  0px,  0px  0px,  0px  0px,   0px   0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <background-size> from [0px 0px, 0px 0px, 0px 0px, 0px 0px\] to [20px 20px, 40px 40px, 60px 60px, 100px 100px\] at (0.5) should be [10px 10px, 20px 20px, 30px 30px,  50px  50px\]]
     expected: FAIL
 
   [CSS Animations: property <background-size> from [unset\] to [20px 20px, 0px 0px\] at (1) should be [20px 20px, 0px 0px\]]

--- a/tests/wpt/metadata/css/css-backgrounds/animations/border-color-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/animations/border-color-interpolation.html.ini
@@ -2,12 +2,6 @@
   [border-color interpolation]
     expected: FAIL
 
-  [CSS Animations: property <border-top-color> from [white\] to [orange\] at (1.5) should be [rgb(255, 120, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-color> from [unset\] to [orange\] at (0.3) should be [rgb(77, 50, 0)\]]
-    expected: FAIL
-
   [CSS Animations: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (-0.3) should be [rgb(23, 33, 43) rgb(40, 50, 60) rgb(17, 27, 37) rgb(37, 47, 57)\]]
     expected: FAIL
 
@@ -17,19 +11,7 @@
   [CSS Animations: property <border-top-color> from [inherit\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-color> from [unset\] to [orange\] at (1) should be [rgb(255, 165, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-color> from neutral to [orange\] at (0.6) should be [rgb(153, 99, 56)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (0.3) should be [rgb(17, 27, 37) rgb(40, 50, 60) rgb(23, 33, 43) rgb(43, 53, 63)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-color> from [initial\] to [orange\] at (0) should be [rgb(0, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-color> from neutral to [orange\] at (-0.3) should be [rgb(0, 0, 181)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-top-color> from [inherit\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]
@@ -38,49 +20,16 @@
   [Web Animations: property <border-top-color> from [white\] to [orange\] at (-0.3) should be [white\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-top-color> from [unset\] to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-color> from [unset\] to [orange\] at (0.6) should be [rgb(153, 99, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-color> from [inherit\] to [orange\] at (1.5) should be [rgb(255, 120, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-color> from [initial\] to [orange\] at (0.6) should be [rgb(153, 99, 0)\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-top-color> from [inherit\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-color> from [initial\] to [orange\] at (0.6) should be [rgb(153, 99, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-color> from [white\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
     expected: FAIL
 
   [Web Animations: property <border-top-color> from [white\] to [orange\] at (1) should be [orange\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-color> from neutral to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-color> from [inherit\] to [orange\] at (0) should be [rgb(255, 255, 255)\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-top-color> from [inherit\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-color> from [unset\] to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
-    expected: FAIL
-
   [CSS Animations: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (0.6) should be [rgb(14, 24, 34) rgb(40, 50, 60) rgb(26, 36, 46) rgb(46, 56, 66)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-color> from [white\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-color> from neutral to [orange\] at (0.3) should be [rgb(77, 50, 97)\]]
     expected: FAIL
 
   [Web Animations: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (1) should be [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\]]
@@ -92,12 +41,6 @@
   [CSS Animations: property <border-top-color> from [white\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-color> from [initial\] to [orange\] at (-0.3) should be [rgb(0, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-color> from neutral to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (1) should be [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\]]
     expected: FAIL
 
@@ -105,9 +48,6 @@
     expected: FAIL
 
   [CSS Transitions: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (0) should be [rgb(20, 30, 40) rgb(40, 50, 60)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-color> from [initial\] to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
     expected: FAIL
 
   [Web Animations: property <border-top-color> from [inherit\] to [orange\] at (1.5) should be [rgb(255, 120, 0)\]]
@@ -119,13 +59,7 @@
   [Web Animations: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (1.5) should be [rgb(5, 15, 25) rgb(40, 50, 60) rgb(35, 45, 55) rgb(55, 65, 75)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-color> from [white\] to [orange\] at (-0.3) should be [white\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-color> from neutral to [orange\] at (0) should be [rgb(0, 0, 139)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-color> from neutral to [orange\] at (-0.3) should be [rgb(0, 0, 181)\]]
     expected: FAIL
 
   [Web Animations: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (0.6) should be [rgb(14, 24, 34) rgb(40, 50, 60) rgb(26, 36, 46) rgb(46, 56, 66)\]]
@@ -155,9 +89,6 @@
   [Web Animations: property <border-top-color> from [unset\] to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-color> from neutral to [orange\] at (0.3) should be [rgb(77, 50, 97)\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-top-color> from [white\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]
     expected: FAIL
 
@@ -165,18 +96,6 @@
     expected: FAIL
 
   [CSS Animations: property <border-top-color> from [inherit\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-color> from [unset\] to [orange\] at (0.3) should be [rgb(77, 50, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-color> from [white\] to [orange\] at (0) should be [white\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-color> from [initial\] to [orange\] at (0.3) should be [rgb(77, 50, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-color> from [unset\] to [orange\] at (0.6) should be [rgb(153, 99, 0)\]]
     expected: FAIL
 
   [Web Animations: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (0.3) should be [rgb(17, 27, 37) rgb(40, 50, 60) rgb(23, 33, 43) rgb(43, 53, 63)\]]
@@ -188,19 +107,10 @@
   [Web Animations: property <border-top-color> from [unset\] to [orange\] at (1) should be [rgb(255, 165, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-color> from [unset\] to [orange\] at (0.6) should be [rgb(153, 99, 0)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (0.6) should be [rgb(14, 24, 34) rgb(40, 50, 60) rgb(26, 36, 46) rgb(46, 56, 66)\]]
     expected: FAIL
 
   [CSS Animations: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (0) should be [rgb(20, 30, 40) rgb(40, 50, 60)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-color> from neutral to [orange\] at (1) should be [rgb(255, 165, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-color> from [initial\] to [orange\] at (0.3) should be [rgb(77, 50, 0)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-top-color> from [white\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]
@@ -212,19 +122,7 @@
   [Web Animations: property <border-top-color> from neutral to [orange\] at (1) should be [rgb(255, 165, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-color> from [white\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-color> from neutral to [orange\] at (0.3) should be [rgb(77, 50, 97)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-color> from [inherit\] to [orange\] at (1.5) should be [rgb(255, 120, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-color> from [unset\] to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-color> from [white\] to [orange\] at (1.5) should be [rgb(255, 120, 0)\]]
     expected: FAIL
 
   [Web Animations: property <border-top-color> from [initial\] to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
@@ -245,9 +143,6 @@
   [CSS Transitions with transition: all: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (0) should be [rgb(20, 30, 40) rgb(40, 50, 60)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-top-color> from neutral to [orange\] at (0.3) should be [rgb(77, 50, 97)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (1.5) should be [rgb(5, 15, 25) rgb(40, 50, 60) rgb(35, 45, 55) rgb(55, 65, 75)\]]
     expected: FAIL
 
@@ -257,43 +152,13 @@
   [Web Animations: property <border-top-color> from neutral to [orange\] at (0.6) should be [rgb(153, 99, 56)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-color> from [inherit\] to [orange\] at (1) should be [rgb(255, 165, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-color> from neutral to [orange\] at (0.6) should be [rgb(153, 99, 56)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-color> from neutral to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-color> from [initial\] to [orange\] at (1) should be [rgb(255, 165, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-color> from [initial\] to [orange\] at (0.6) should be [rgb(153, 99, 0)\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (0.6) should be [rgb(14, 24, 34) rgb(40, 50, 60) rgb(26, 36, 46) rgb(46, 56, 66)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-color> from [unset\] to [orange\] at (0) should be [rgb(0, 0, 0)\]]
     expected: FAIL
 
   [Web Animations: property <border-top-color> from neutral to [orange\] at (-0.3) should be [rgb(0, 0, 181)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-color> from [initial\] to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
-    expected: FAIL
-
   [CSS Animations: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (1) should be [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-color> from [unset\] to [orange\] at (-0.3) should be [rgb(0, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-color> from [white\] to [orange\] at (1) should be [orange\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-color> from neutral to [orange\] at (0.6) should be [rgb(153, 99, 56)\]]
     expected: FAIL
 
   [CSS Animations: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (1.5) should be [rgb(5, 15, 25) rgb(40, 50, 60) rgb(35, 45, 55) rgb(55, 65, 75)\]]
@@ -302,13 +167,7 @@
   [Web Animations: property <border-top-color> from [white\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-top-color> from [white\] to [orange\] at (1.5) should be [rgb(255, 120, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-color> from [white\] to [orange\] at (1.5) should be [rgb(255, 120, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-color> from [initial\] to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (1) should be [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\]]
@@ -317,31 +176,19 @@
   [CSS Animations: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (0.3) should be [rgb(17, 27, 37) rgb(40, 50, 60) rgb(23, 33, 43) rgb(43, 53, 63)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-color> from [initial\] to [orange\] at (0.3) should be [rgb(77, 50, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-color> from [unset\] to [orange\] at (0.3) should be [rgb(77, 50, 0)\]]
     expected: FAIL
 
   [Web Animations: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (-0.3) should be [rgb(23, 33, 43) rgb(40, 50, 60) rgb(17, 27, 37) rgb(37, 47, 57)\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-top-color> from [unset\] to [orange\] at (0.3) should be [rgb(77, 50, 0)\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (0.3) should be [rgb(17, 27, 37) rgb(40, 50, 60) rgb(23, 33, 43) rgb(43, 53, 63)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-color> from neutral to [orange\] at (-0.3) should be [rgb(0, 0, 181)\]]
     expected: FAIL
 
   [Web Animations: property <border-top-color> from [initial\] to [orange\] at (0) should be [rgb(0, 0, 0)\]]
     expected: FAIL
 
   [CSS Transitions: property <border-color> from [rgb(20, 30, 40) rgb(40, 50, 60)\] to [rgb(10, 20, 30) rgb(40, 50, 60) rgb(30, 40, 50) rgb(50, 60, 70)\] at (-0.3) should be [rgb(23, 33, 43) rgb(40, 50, 60) rgb(17, 27, 37) rgb(37, 47, 57)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-color> from [inherit\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
     expected: FAIL
 
   [Web Animations: property <border-top-color> from [white\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]

--- a/tests/wpt/metadata/css/css-backgrounds/animations/border-image-outset-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/animations/border-image-outset-interpolation.html.ini
@@ -2,16 +2,7 @@
   [border-image-outset interpolation]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-outset> from neutral to [2px\] at (1.5) should be [2.5px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [initial\] to [2\] at (0) should be [0\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from [0px\] to [5px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [0\] to [1\] at (0.3) should be [0.3\]]
     expected: FAIL
 
   [Web Animations: property <border-image-outset> from [0px\] to [5px\] at (1.5) should be [7.5px\]]
@@ -20,28 +11,16 @@
   [Web Animations: property <border-image-outset> from [0\] to [1\] at (1) should be [1\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (-0.3) should be [0 0 0px 0px\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (0.3) should be [31 32 33px 34px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-outset> from [unset\] to [2\] at (0.3) should be [0.6\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-outset> from [initial\] to [2\] at (1.5) should be [3\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from [unset\] to [2\] at (0) should be [0\]]
     expected: FAIL
 
   [Web Animations: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (0.3) should be [31 32 33px 34px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [inherit\] to [2px\] at (0.3) should be [7.6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [0\] to [1\] at (0) should be [0\]]
     expected: FAIL
 
   [Web Animations: property <border-image-outset> from [0\] to [1\] at (1.5) should be [1.5\]]
@@ -53,34 +32,13 @@
   [Web Animations: property <border-image-outset> from [initial\] to [2\] at (-0.3) should be [0\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-outset> from [initial\] to [2\] at (-0.3) should be [0\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [0\] to [1\] at (0.3) should be [0.3\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (1.5) should be [151 152 153px 154px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [unset\] to [2\] at (0.3) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [0\] to [1\] at (0.6) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [0px\] to [5px\] at (1.5) should be [7.5px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-outset> from [0px\] to [5px\] at (0.3) should be [1.5px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-outset> from [initial\] to [2\] at (0.6) should be [1.2\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-outset> from [inherit\] to [2px\] at (0.6) should be [5.2px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from neutral to [2px\] at (0.3) should be [1.3px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-outset> from [unset\] to [2\] at (1.5) should be [3\]]
@@ -89,73 +47,16 @@
   [Web Animations: property <border-image-outset> from [0\] to [1\] at (0.3) should be [0.3\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-outset> from [initial\] to [2\] at (0.6) should be [1.2\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [unset\] to [2\] at (1.5) should be [3\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [0px\] to [5px\] at (0.3) should be [1.5px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [initial\] to [2\] at (0.3) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [unset\] to [2\] at (0.3) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [0\] to [1\] at (-0.3) should be [0\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [0px\] to [5px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from [0px\] to [5px\] at (1) should be [5px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (0.3) should be [31 32 33px 34px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [inherit\] to [2px\] at (-0.3) should be [12.4px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [initial\] to [2\] at (0.3) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [initial\] to [2\] at (1) should be [2\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [unset\] to [2\] at (0.6) should be [1.2\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from neutral to [2px\] at (0.6) should be [1.6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [unset\] to [2\] at (1.5) should be [3\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [initial\] to [2\] at (1.5) should be [3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [inherit\] to [2px\] at (0.3) should be [7.6px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-outset> from [unset\] to [2\] at (-0.3) should be [0\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-outset> from neutral to [2px\] at (1.5) should be [2.5px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from [inherit\] to [2px\] at (0.6) should be [5.2px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-outset> from neutral to [2px\] at (0.3) should be [1.3px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from [initial\] to [2\] at (1) should be [2\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [0px\] to [5px\] at (0.6) should be [3px\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-outset> from [inherit\] to [2px\] at (0.3) should be [7.6px\]]
@@ -164,28 +65,10 @@
   [Web Animations: property <border-image-outset> from [initial\] to [2\] at (1.5) should be [3\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (0.6) should be [61 62 63px 64px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from neutral to [2px\] at (1) should be [2px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [unset\] to [2\] at (1.5) should be [3\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (0) should be [1 2 3px 4px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-outset> from [inherit\] to [2px\] at (1.5) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (1) should be [101 102 103px 104px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [unset\] to [2\] at (1) should be [2\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [0px\] to [5px\] at (1.5) should be [7.5px\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (0.6) should be [61 62 63px 64px\]]
@@ -203,55 +86,19 @@
   [CSS Animations: property <border-image-outset> from [inherit\] to [2px\] at (1.5) should be [0px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-outset> from [initial\] to [2\] at (0.3) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [0px\] to [5px\] at (0.6) should be [3px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (-0.3) should be [0 0 0px 0px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from neutral to [2px\] at (0.3) should be [1.3px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-outset> from neutral to [2px\] at (1) should be [2px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-outset> from [0\] to [1\] at (1) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (-0.3) should be [0 0 0px 0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [0px\] to [5px\] at (0.3) should be [1.5px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [initial\] to [2\] at (0.6) should be [1.2\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [0\] to [1\] at (1.5) should be [1.5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [0px\] to [5px\] at (0.3) should be [1.5px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [0px\] to [5px\] at (0.6) should be [3px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from [0\] to [1\] at (0.6) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from neutral to [2px\] at (0.3) should be [1.3px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-outset> from [inherit\] to [2px\] at (0) should be [10px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (-0.3) should be [0 0 0px 0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [inherit\] to [2px\] at (-0.3) should be [12.4px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-outset> from [unset\] to [2\] at (0.6) should be [1.2\]]
@@ -263,12 +110,6 @@
   [Web Animations: property <border-image-outset> from [inherit\] to [2px\] at (0.3) should be [7.6px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-outset> from [inherit\] to [2px\] at (1) should be [2px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [unset\] to [2\] at (0.6) should be [1.2\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from [initial\] to [2\] at (0) should be [0\]]
     expected: FAIL
 
@@ -278,31 +119,10 @@
   [Web Animations: property <border-image-outset> from [inherit\] to [2px\] at (1.5) should be [0px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-outset> from neutral to [2px\] at (-0.3) should be [0.7px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from [0px\] to [5px\] at (0.6) should be [3px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-outset> from neutral to [2px\] at (-0.3) should be [0.7px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from neutral to [2px\] at (1.5) should be [2.5px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [inherit\] to [2px\] at (1.5) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (0.6) should be [61 62 63px 64px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from neutral to [2px\] at (-0.3) should be [0.7px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from [0\] to [1\] at (0) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [initial\] to [2\] at (1.5) should be [3\]]
     expected: FAIL
 
   [Web Animations: property <border-image-outset> from neutral to [2px\] at (-0.3) should be [0.7px\]]
@@ -311,73 +131,13 @@
   [CSS Animations: property <border-image-outset> from [inherit\] to [2px\] at (-0.3) should be [12.4px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-outset> from [0\] to [1\] at (0.3) should be [0.3\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [unset\] to [2\] at (0) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (1.5) should be [151 152 153px 154px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [unset\] to [2\] at (0.6) should be [1.2\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (1.5) should be [151 152 153px 154px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-outset> from [inherit\] to [2px\] at (0) should be [10px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-outset> from neutral to [2px\] at (0.6) should be [1.6px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (0) should be [1 2 3px 4px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [0\] to [1\] at (0.6) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [0\] to [1\] at (0.6) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (1.5) should be [151 152 153px 154px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [0\] to [1\] at (1.5) should be [1.5\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (0.6) should be [61 62 63px 64px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [unset\] to [2\] at (-0.3) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from neutral to [2px\] at (0.6) should be [1.6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [0px\] to [5px\] at (1.5) should be [7.5px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [unset\] to [2\] at (0.3) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (1) should be [101 102 103px 104px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (0.3) should be [31 32 33px 34px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [0px\] to [5px\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from neutral to [2px\] at (0.6) should be [1.6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-outset> from [0px\] to [5px\] at (1) should be [5px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-outset> from [inherit\] to [2px\] at (0.6) should be [5.2px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-outset> from [initial\] to [2\] at (0.3) should be [0.6\]]
@@ -386,12 +146,15 @@
   [Web Animations: property <border-image-outset> from [inherit\] to [2px\] at (1) should be [2px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-outset> from [0\] to [1\] at (1.5) should be [1.5\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-outset> from [inherit\] to [2px\] at (0.6) should be [5.2px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-outset> from [0\] to [1\] at (-0.3) should be [0\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (0.3) should be [31 32 33px 34px\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (0.6) should be [61 62 63px 64px\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-outset> from [1 2 3px 4px\] to [101 102 103px 104px\] at (1.5) should be [151 152 153px 154px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-backgrounds/animations/border-image-slice-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/animations/border-image-slice-interpolation.html.ini
@@ -5,9 +5,6 @@
   [CSS Animations: property <border-image-slice> from [50%\] to [100\] at (1.5) should be [100\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (-0.5) should be [0% 0 0% 10 fill\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (1) should be [40% 50% 60% 70%\]]
     expected: FAIL
 
@@ -15,9 +12,6 @@
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70\] at (0.6) should be [40% 50 60% 70\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (-0.5) should be [0% 0 0% 10 fill\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [initial\] to [10%\] at (0.6) should be [46%\]]
@@ -35,25 +29,10 @@
   [CSS Transitions: property <border-image-slice> from [initial\] to [10%\] at (-0.3) should be [127%\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-slice> from [unset\] to [10%\] at (1) should be [10%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0.5) should be [20 30 40 50 fill\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-slice> from [unset\] to [10%\] at (0.6) should be [46%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0.6) should be [24 34 44 54 fill\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0.3) should be [12 22 32 42 fill\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (1) should be [40% 50% 60% 70%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [inherit\] to [10%\] at (-0.3) should be [62%\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-slice> from [0% 10 20 30 fill\] to [40 50 60% 70\] at (0.5) should be [40 50 60% 70\]]
@@ -62,31 +41,16 @@
   [CSS Transitions: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (-0.5) should be [0% 0 0% 10 fill\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-slice> from [initial\] to [10%\] at (-0.3) should be [127%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [0%\] to [50%\] at (0.6) should be [30%\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0) should be [0% 10% 20% 30%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [0% 10 20 30 fill\] to [40 50 60% 70\] at (0.6) should be [40 50 60% 70\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from neutral to [10%\] at (0.3) should be [17%\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-slice> from [50% fill\] to [100 fill\] at (0.6) should be [100 fill\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from neutral to [10%\] at (1.5) should be [5%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0) should be [0 10 20 30 fill\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0.5) should be [20% 30 40% 50 fill\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-slice> from [50%\] to [100\] at (0.3) should be [50%\]]
@@ -107,31 +71,13 @@
   [CSS Animations: property <border-image-slice> from [0% 10 20 30 fill\] to [40 50 60% 70\] at (1.5) should be [40 50 60% 70\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (1) should be [40 50 60 70 fill\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70\] at (-0.3) should be [0% 10 20% 30 fill\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-slice> from [unset\] to [10%\] at (-0.3) should be [127%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [initial\] to [10%\] at (1) should be [10%\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.3) should be [12% 22% 32% 42%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [initial\] to [10%\] at (0.5) should be [55%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from neutral to [10%\] at (0.6) should be [14%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [unset\] to [10%\] at (1.5) should be [0%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [unset\] to [10%\] at (0.6) should be [46%\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-slice> from [0% fill\] to [50%\] at (1.5) should be [50%\]]
@@ -140,13 +86,7 @@
   [Web Animations: property <border-image-slice> from [50% fill\] to [100 fill\] at (0.5) should be [100 fill\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0.3) should be [12% 22 32% 42 fill\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [unset\] to [10%\] at (-0.3) should be [127%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0.5) should be [20 30 40 50 fill\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [inherit\] to [10%\] at (-0.3) should be [62%\]]
@@ -164,12 +104,6 @@
   [Web Animations: property <border-image-slice> from [0% 10 20 30 fill\] to [40 50 60% 70\] at (1) should be [40 50 60% 70\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-slice> from neutral to [10%\] at (0.3) should be [17%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from neutral to [10%\] at (0.5) should be [15%\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-slice> from [0% fill\] to [50%\] at (0.3) should be [0% fill\]]
     expected: FAIL
 
@@ -179,25 +113,13 @@
   [CSS Animations: property <border-image-slice> from [inherit\] to [10%\] at (0) should be [50%\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0.5) should be [20% 30 40% 50 fill\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-slice> from [50% fill\] to [100 fill\] at (1.5) should be [100 fill\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [inherit\] to [10%\] at (1) should be [10%\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-slice> from neutral to [10%\] at (0.5) should be [15%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from neutral to [10%\] at (0.5) should be [15%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0) should be [0 10 20 30 fill\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [inherit\] to [10%\] at (1.5) should be [0%\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-slice> from [initial\] to [10%\] at (0.5) should be [55%\]]
@@ -207,12 +129,6 @@
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [unset\] to [10%\] at (0.3) should be [73%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [initial\] to [10%\] at (0) should be [100%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0%\] to [50%\] at (0.5) should be [25%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [50%\] to [100\] at (0.3) should be [50%\]]
@@ -230,12 +146,6 @@
   [CSS Animations: property <border-image-slice> from [50%\] to [100\] at (0.6) should be [100\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-slice> from [inherit\] to [10%\] at (-0.3) should be [62%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (-0.5) should be [0% 0% 0% 10%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [50%\] to [100\] at (0) should be [50%\]]
     expected: FAIL
 
@@ -243,15 +153,6 @@
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [0% fill\] to [50%\] at (1.5) should be [50%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [unset\] to [10%\] at (0.3) should be [73%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.5) should be [20% 30% 40% 50%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0.6) should be [24 34 44 54 fill\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from neutral to [10%\] at (0.5) should be [15%\]]
@@ -272,25 +173,10 @@
   [CSS Animations: property <border-image-slice> from [inherit\] to [10%\] at (0.5) should be [30%\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0.6) should be [24% 34 44% 54 fill\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (1.5) should be [60 70 80 90 fill\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [50% fill\] to [100 fill\] at (-0.3) should be [50% fill\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-slice> from [0%\] to [50%\] at (0.3) should be [15%\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-slice> from [inherit\] to [10%\] at (-0.3) should be [62%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0%\] to [50%\] at (1.5) should be [75%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [initial\] to [10%\] at (1.5) should be [0%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [initial\] to [10%\] at (0) should be [100%\]]
@@ -299,13 +185,7 @@
   [Web Animations: property <border-image-slice> from [0% fill\] to [50%\] at (0.5) should be [50%\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (1.5) should be [60% 70% 80% 90%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [0% fill\] to [50%\] at (0.6) should be [50%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from neutral to [10%\] at (1.5) should be [5%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [0%\] to [50%\] at (0.3) should be [15%\]]
@@ -326,25 +206,7 @@
   [CSS Animations: property <border-image-slice> from [0% 10 20 30 fill\] to [40 50 60% 70\] at (1) should be [40 50 60% 70\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-slice> from [initial\] to [10%\] at (1.5) should be [0%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (1.5) should be [60 70 80 90 fill\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-slice> from [0%\] to [50%\] at (1.5) should be [75%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [unset\] to [10%\] at (-0.3) should be [127%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [50%\] to [100\] at (0.5) should be [100\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [inherit\] to [10%\] at (0.3) should be [38%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0.6) should be [24% 34 44% 54 fill\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from neutral to [10%\] at (0) should be [20%\]]
@@ -353,31 +215,13 @@
   [Web Animations: property <border-image-slice> from [0% 10 20 30 fill\] to [40 50 60% 70\] at (1.5) should be [40 50 60% 70\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-slice> from [0%\] to [50%\] at (-0.3) should be [0%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [0%\] to [50%\] at (1.5) should be [75%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [0% 10 20 30 fill\] to [40 50 60% 70\] at (0.3) should be [0% 10 20 30 fill\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [0% fill\] to [50%\] at (0.3) should be [0% fill\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-slice> from [inherit\] to [10%\] at (0.3) should be [38%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-slice> from [inherit\] to [10%\] at (0.6) should be [26%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [unset\] to [10%\] at (0) should be [100%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [unset\] to [10%\] at (0.5) should be [55%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [unset\] to [10%\] at (0.6) should be [46%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70\] at (0) should be [0% 10 20% 30 fill\]]
@@ -401,9 +245,6 @@
   [Web Animations: property <border-image-slice> from [50% fill\] to [100 fill\] at (0.3) should be [50% fill\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-slice> from [initial\] to [10%\] at (1.5) should be [0%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [inherit\] to [10%\] at (0.6) should be [26%\]]
     expected: FAIL
 
@@ -414,9 +255,6 @@
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [initial\] to [10%\] at (0.3) should be [73%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0.3) should be [12% 22 32% 42 fill\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [initial\] to [10%\] at (0.5) should be [55%\]]
@@ -440,31 +278,13 @@
   [CSS Animations: property <border-image-slice> from [0% 10 20 30 fill\] to [40 50 60% 70\] at (0.6) should be [40 50 60% 70\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-slice> from neutral to [10%\] at (0.6) should be [14%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [inherit\] to [10%\] at (1.5) should be [0%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0%\] to [50%\] at (0.6) should be [30%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0.6) should be [24% 34 44% 54 fill\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (1.5) should be [60% 70% 80% 90%\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.5) should be [20% 30% 40% 50%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [unset\] to [10%\] at (-0.3) should be [127%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from neutral to [10%\] at (0.3) should be [17%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from neutral to [10%\] at (1) should be [10%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.5) should be [20% 30% 40% 50%\]]
@@ -479,16 +299,10 @@
   [CSS Transitions: property <border-image-slice> from [0%\] to [50%\] at (0.3) should be [15%\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (1.5) should be [60% 70% 80% 90%\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0.5) should be [20 30 40 50 fill\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [0% fill\] to [50%\] at (-0.3) should be [0% fill\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-slice> from neutral to [10%\] at (0.6) should be [14%\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-slice> from [0% 10 20 30 fill\] to [40 50 60% 70\] at (0) should be [0% 10 20 30 fill\]]
@@ -497,37 +311,10 @@
   [CSS Animations: property <border-image-slice> from [inherit\] to [10%\] at (1.5) should be [0%\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-slice> from neutral to [10%\] at (0.3) should be [17%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from neutral to [10%\] at (0.6) should be [14%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.5) should be [20% 30% 40% 50%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.6) should be [24% 34% 44% 54%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [initial\] to [10%\] at (0.6) should be [46%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [unset\] to [10%\] at (0.3) should be [73%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (-0.5) should be [0% 0 0% 10 fill\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-slice> from neutral to [10%\] at (-0.3) should be [23%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0.3) should be [12 22 32 42 fill\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0.3) should be [12% 22 32% 42 fill\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from neutral to [10%\] at (-0.3) should be [23%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [0% 10 20 30 fill\] to [40 50 60% 70\] at (0.5) should be [40 50 60% 70\]]
@@ -539,13 +326,7 @@
   [Web Animations: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0) should be [0% 10% 20% 30%\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0.3) should be [12% 22 32% 42 fill\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-image-slice> from [initial\] to [10%\] at (0.3) should be [73%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (-0.5) should be [0 0 0 10 fill\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0) should be [0% 10 20% 30 fill\]]
@@ -554,16 +335,10 @@
   [Web Animations: property <border-image-slice> from [0% fill\] to [50%\] at (0) should be [0% fill\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-slice> from neutral to [10%\] at (1.5) should be [5%\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-slice> from [0% fill\] to [50%\] at (0) should be [0% fill\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0.3) should be [12 22 32 42 fill\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0%\] to [50%\] at (0) should be [0%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [unset\] to [10%\] at (0.6) should be [46%\]]
@@ -584,55 +359,19 @@
   [CSS Transitions: property <border-image-slice> from [0%\] to [50%\] at (0.5) should be [25%\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (-0.5) should be [0% 0% 0% 10%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (1) should be [40 50 60 70 fill\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.3) should be [12% 22% 32% 42%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-slice> from neutral to [10%\] at (-0.3) should be [23%\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70\] at (0.5) should be [40% 50 60% 70\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (1.5) should be [60% 70 80% 90 fill\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [initial\] to [10%\] at (0.3) should be [73%\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70\] at (0.3) should be [0% 10 20% 30 fill\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [unset\] to [10%\] at (0) should be [100%\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-image-slice> from [inherit\] to [10%\] at (0.5) should be [30%\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-slice> from [inherit\] to [10%\] at (0.6) should be [26%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [initial\] to [10%\] at (1) should be [10%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from neutral to [10%\] at (1.5) should be [5%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [unset\] to [10%\] at (1.5) should be [0%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0.5) should be [20% 30 40% 50 fill\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (-0.5) should be [0% 0% 0% 10%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.6) should be [24% 34% 44% 54%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0.6) should be [24% 34 44% 54 fill\]]
@@ -641,22 +380,7 @@
   [Web Animations: property <border-image-slice> from [unset\] to [10%\] at (1) should be [10%\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (1.5) should be [60% 70 80% 90 fill\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [50% fill\] to [100 fill\] at (1.5) should be [100 fill\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [initial\] to [10%\] at (-0.3) should be [127%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (1.5) should be [60 70 80 90 fill\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [initial\] to [10%\] at (0.6) should be [46%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (1.5) should be [60% 70% 80% 90%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [0%\] to [50%\] at (1) should be [50%\]]
@@ -666,9 +390,6 @@
     expected: FAIL
 
   [CSS Animations: property <border-image-slice> from [0% fill\] to [50%\] at (0.5) should be [50%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0%\] to [50%\] at (1) should be [50%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (-0.5) should be [0 0 0 10 fill\]]
@@ -686,9 +407,6 @@
   [Web Animations: property <border-image-slice> from [50%\] to [100\] at (0.6) should be [100\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-slice> from [inherit\] to [10%\] at (1.5) should be [0%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [50%\] to [100\] at (1.5) should be [100\]]
     expected: FAIL
 
@@ -696,12 +414,6 @@
     expected: FAIL
 
   [CSS Transitions: property <border-image-slice> from [unset\] to [10%\] at (0.3) should be [73%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.3) should be [12% 22% 32% 42%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.6) should be [24% 34% 44% 54%\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-slice> from [50%\] to [100\] at (-0.3) should be [50%\]]
@@ -713,16 +425,7 @@
   [CSS Transitions with transition: all: property <border-image-slice> from [0%\] to [50%\] at (0.5) should be [25%\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-slice> from [inherit\] to [10%\] at (1) should be [10%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [50% fill\] to [100 fill\] at (0.6) should be [100 fill\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (1) should be [40% 50 60% 70 fill\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0%\] to [50%\] at (0.3) should be [15%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0.6) should be [24 34 44 54 fill\]]
@@ -743,18 +446,6 @@
   [Web Animations: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.3) should be [12% 22% 32% 42%\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-slice> from [unset\] to [10%\] at (1.5) should be [0%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (-0.5) should be [0 0 0 10 fill\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0.6) should be [24 34 44 54 fill\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0) should be [0% 10 20% 30 fill\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (1.5) should be [60 70 80 90 fill\]]
     expected: FAIL
 
@@ -764,12 +455,6 @@
   [Web Animations: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0.3) should be [12 22 32 42 fill\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (1.5) should be [60% 70 80% 90 fill\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-slice> from [0%\] to [50%\] at (0.6) should be [30%\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (-0.5) should be [0 0 0 10 fill\]]
     expected: FAIL
 
@@ -777,5 +462,74 @@
     expected: FAIL
 
   [CSS Animations: property <border-image-slice> from [0% fill\] to [50%\] at (0.6) should be [50%\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-slice> from [unset\] to [10%\] at (-0.3) should be [127%\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-slice> from [unset\] to [10%\] at (0.3) should be [73%\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-slice> from [unset\] to [10%\] at (-0.3) should be [127%\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0.3) should be [12% 22 32% 42 fill\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.5) should be [20% 30% 40% 50%\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (-0.5) should be [0% 0 0% 10 fill\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-slice> from [initial\] to [10%\] at (-0.3) should be [127%\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0.5) should be [20% 30 40% 50 fill\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.3) should be [12% 22% 32% 42%\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-slice> from [inherit\] to [10%\] at (-0.3) should be [62%\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.5) should be [20% 30% 40% 50%\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0.6) should be [24 34 44 54 fill\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (0.6) should be [24% 34 44% 54 fill\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-slice> from [inherit\] to [10%\] at (0.3) should be [38%\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-slice> from [unset\] to [10%\] at (0.6) should be [46%\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0.3) should be [12 22 32 42 fill\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (-0.5) should be [0 0 0 10 fill\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (-0.5) should be [0% 0% 0% 10%\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-slice> from [0% 10 20% 30 fill\] to [40% 50 60% 70 fill\] at (1.5) should be [60% 70 80% 90 fill\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (1.5) should be [60 70 80 90 fill\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-slice> from [initial\] to [10%\] at (0.6) should be [46%\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-slice> from [0% 10% 20% 30%\] to [40% 50% 60% 70%\] at (0.6) should be [24% 34% 44% 54%\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-slice> from [0 10 20 30 fill\] to [40 50 60 70 fill\] at (0.6) should be [24 34 44 54 fill\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-backgrounds/animations/border-image-source-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/animations/border-image-source-interpolation.html.ini
@@ -5,40 +5,13 @@
   [Web Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (-0.3) should be [url(../support/aqua_color.png)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (-0.3) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
   [Web Animations: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (1.5) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (0.3) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.5) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (1.5) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (0.3) should be [url(../support/orange_color.png)\]]
@@ -47,28 +20,13 @@
   [Web Animations: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (0) should be [none\]]
     expected: FAIL
 
   [Web Animations: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (1) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (-0.3) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (1) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (0) should be [initial\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0) should be [linear-gradient(45deg, blue, orange)\]]
@@ -83,16 +41,10 @@
   [Web Animations: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (-0.3) should be [inherit\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (0.3) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (-0.3) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (-0.3) should be [url(../support/orange_color.png)\]]
@@ -110,25 +62,10 @@
   [Web Animations: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (1) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (-0.3) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (0.3) should be [url(../support/orange_color.png)\]]
@@ -143,28 +80,10 @@
   [Web Animations: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (1) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0) should be [linear-gradient(-45deg, red, yellow)\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (0) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (0) should be [unset\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (0) should be [url(../support/orange_color.png)\]]
@@ -185,13 +104,7 @@
   [Web Animations: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (-0.3) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (-0.3) should be [url(../support/aqua_color.png)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (1) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (1) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.3) should be [linear-gradient(45deg, blue, orange)\]]
@@ -200,16 +113,10 @@
   [Web Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.3) should be [url(../support/aqua_color.png)\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (1.5) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.3) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
   [Web Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (0) should be [url(../support/aqua_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (0.3) should be [unset\]]
     expected: FAIL
 
   [Web Animations: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.5) should be [linear-gradient(45deg, blue, orange)\]]
@@ -221,12 +128,6 @@
   [CSS Transitions with transition: all: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (-0.3) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.5) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
@@ -236,19 +137,7 @@
   [CSS Animations: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (-0.3) should be [inherit\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.5) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (1) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
   [Web Animations: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (0) should be [inherit\]]
@@ -263,25 +152,13 @@
   [Web Animations: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (1) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.5) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (-0.3) should be [linear-gradient(-45deg, red, yellow)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (0.3) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (0) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (1.5) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
   [Web Animations: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (0.3) should be [inherit\]]
@@ -302,22 +179,13 @@
   [Web Animations: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (0) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
   [Web Animations: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (0.3) should be [unset\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.3) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (-0.3) should be [url(../support/orange_color.png)\]]
@@ -332,88 +200,28 @@
   [CSS Transitions: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (0) should be [url(../support/aqua_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (-0.3) should be [url(../support/aqua_color.png)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (-0.3) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (1) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (0.3) should be [initial\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (1.5) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
   [Web Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0) should be [url(../support/aqua_color.png)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (-0.3) should be [initial\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (1) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.3) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0) should be [linear-gradient(-45deg, red, yellow)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (0.3) should be [none\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (-0.3) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.3) should be [url(../support/aqua_color.png)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (0.3) should be [url(../support/orange_color.png)\]]
@@ -422,19 +230,7 @@
   [Web Animations: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.5) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (0.3) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (1) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
   [Web Animations: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
@@ -449,25 +245,10 @@
   [CSS Transitions: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (0.3) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (0) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.3) should be [linear-gradient(-45deg, red, yellow)\]]
     expected: FAIL
 
   [Web Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0.5) should be [linear-gradient(45deg, blue, orange)\]]
@@ -476,43 +257,13 @@
   [Web Animations: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (1) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (0) should be [url(../support/aqua_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [url(../support/orange_color.png)\] at (0.3) should be [url(../support/aqua_color.png)\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (0) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (1.5) should be [linear-gradient(45deg, blue, orange)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (-0.3) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (0) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (1.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (-0.3) should be [unset\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [initial\] to [url(../support/orange_color.png)\] at (0.3) should be [initial\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.6) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 
   [Web Animations: property <border-image-source> from [url(../support/aqua_color.png)\] to [linear-gradient(45deg, blue, orange)\] at (1) should be [linear-gradient(45deg, blue, orange)\]]
@@ -531,20 +282,5 @@
     expected: FAIL
 
   [Web Animations: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (-0.3) should be [linear-gradient(-45deg, red, yellow)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [none\] to [url(../support/orange_color.png)\] at (-0.3) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [unset\] to [url(../support/orange_color.png)\] at (-0.3) should be [unset\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (0.5) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-source> from [inherit\] to [url(../support/orange_color.png)\] at (0.6) should be [url(../support/orange_color.png)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-source> from [linear-gradient(-45deg, red, yellow)\] to [linear-gradient(45deg, blue, orange)\] at (0.5) should be [linear-gradient(45deg, blue, orange)\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-backgrounds/animations/border-image-width-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/animations/border-image-width-interpolation.html.ini
@@ -2,12 +2,6 @@
   [border-image-width interpolation]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-width> from [0\] to [20\] at (1.5) should be [30\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (1.5) should be [115px  95%  75  55px\]]
     expected: FAIL
 
@@ -18,9 +12,6 @@
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [10\] to [20%\] at (1) should be [20%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [0\] to [20\] at (-0.3) should be [0\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [unset\] to [20px\] at (0.6) should be [20px\]]
@@ -35,16 +26,7 @@
   [Web Animations: property <border-image-width> from [initial\] to [20px\] at (0.3) should be [initial\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-width> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [0px\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-width> from [10px\] to [20\] at (0.6) should be [20\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from neutral to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto 120 auto\] at (0.5) should be [110px auto 120 auto\]]
@@ -59,16 +41,10 @@
   [Web Animations: property <border-image-width> from [10%\] to [20\] at (1) should be [20\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-width> from [0px\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (0) should be [ 10px auto auto  20\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10\] to [20px\] at (1.5) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [0px\] to [20px\] at (0.6) should be [12px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (0.3) should be [ 40px auto auto  50\]]
@@ -80,37 +56,19 @@
   [Web Animations: property <border-image-width> from [10%\] to [20px\] at (0.6) should be [calc(4% + 12px)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [10px\] to [20%\] at (0.6) should be [calc(4px + 12%)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (0) should be [10px  20%  30  40px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [10px\] to [20%\] at (-0.3) should be [calc(13px + -6%)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [10%\] to [20px\] at (0.3) should be [calc(7% + 6px)\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10\] to [20px\] at (0.6) should be [20px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [10\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [0px\] to [20px\] at (5) should be [100px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (0.6) should be [ 70px auto auto  80\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto 120 auto\] at (0) should be [10px auto auto 20\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [inherit\] to [20px\] at (0.3) should be [76px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10\] to [20%\] at (1.5) should be [20%\]]
@@ -125,22 +83,10 @@
   [Web Animations: property <border-image-width> from [10%\] to [20px\] at (0) should be [10%\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-width> from [0%\] to [20%\] at (1.5) should be [30%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10%\] to [20px\] at (1.5) should be [calc(-5% + 30px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [inherit\] to [20px\] at (1.5) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [0\] to [20\] at (10) should be [200\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [0px\] to [20px\] at (10) should be [200px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [0px\] to [20px\] at (0) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [10\] to [20%\] at (1.5) should be [20%\]]
@@ -149,25 +95,7 @@
   [Web Animations: property <border-image-width> from neutral to [20px\] at (0) should be [10px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-width> from [inherit\] to [20px\] at (1.5) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [0%\] to [20%\] at (1) should be [20%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [0px\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [0%\] to [20%\] at (0.6) should be [12%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [0px\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [0%\] to [20%\] at (1.5) should be [30%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (0.3) should be [31px  35%  39  43px\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (10) should be [710px 520% 330 140px\]]
@@ -179,49 +107,16 @@
   [Web Animations: property <border-image-width> from [10px\] to [20\] at (0.5) should be [20\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-width> from [10px\] to [20%\] at (1.5) should be [calc(-5px + 30%)\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-width> from [initial\] to [20px\] at (0.5) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [10%\] to [20px\] at (0.3) should be [calc(7% + 6px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (1) should be [80px  70%  60  50px\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (1.5) should be [115px  95%  75  55px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [10%\] to [20px\] at (1.5) should be [calc(-5% + 30px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [0px\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [10%\] to [20\] at (-0.3) should be [10%\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-width> from [10px\] to [20%\] at (1.5) should be [calc(-5px + 30%)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [0\] to [20\] at (1.5) should be [30\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (-0.3) should be [  0px auto auto   0\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto 120 auto\] at (0.3) should be [10px auto auto 20\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from neutral to [20px\] at (10) should be [110px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [0px\] to [20px\] at (10) should be [200px\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [10%\] to [20\] at (1.5) should be [20\]]
@@ -230,22 +125,13 @@
   [Web Animations: property <border-image-width> from [inherit\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (1.5) should be [160px auto auto 170\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [initial\] to [20px\] at (-0.3) should be [initial\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from neutral to [20px\] at (10) should be [110px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto 120 auto\] at (1.5) should be [110px auto 120 auto\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [10\] to [20px\] at (-0.3) should be [10\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (-0.3) should be [0px   5%  21  37px\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [10\] to [20%\] at (0.3) should be [10\]]
@@ -257,25 +143,10 @@
   [Web Animations: property <border-image-width> from [10px\] to [20\] at (1.5) should be [20\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [0%\] to [20%\] at (0.3) should be [6%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [0%\] to [20%\] at (0.6) should be [12%\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-width> from [inherit\] to [20px\] at (10) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [unset\] to [20px\] at (-0.3) should be [unset\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [10%\] to [20px\] at (-0.3) should be [calc(13% + -6px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [inherit\] to [20px\] at (10) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [0px\] to [20px\] at (10) should be [200px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10\] to [20%\] at (1) should be [20%\]]
@@ -293,13 +164,7 @@
   [Web Animations: property <border-image-width> from [inherit\] to [20px\] at (1.5) should be [0px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [0px\] to [20px\] at (10) should be [200px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto 120 auto\] at (0.3) should be [10px auto auto 20\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [0\] to [20\] at (0.6) should be [12\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [inherit\] to [20px\] at (0.6) should be [52px\]]
@@ -320,28 +185,13 @@
   [CSS Animations: property <border-image-width> from [unset\] to [20px\] at (0.6) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-width> from [10%\] to [20px\] at (0.6) should be [calc(4% + 12px)\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-width> from [10%\] to [20\] at (-0.3) should be [10%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [0%\] to [20%\] at (-0.3) should be [0%\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [10\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-width> from [0\] to [20\] at (10) should be [200\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px\] to [20%\] at (1.5) should be [calc(-5px + 30%)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [10px\] to [20\] at (0) should be [10px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [0\] to [20\] at (5) should be [100\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [initial\] to [20px\] at (0) should be [initial\]]
@@ -365,22 +215,10 @@
   [CSS Transitions: property <border-image-width> from [inherit\] to [20px\] at (0.3) should be [76px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [0\] to [20\] at (1.5) should be [30\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [unset\] to [20px\] at (0) should be [unset\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto 120 auto\] at (1) should be [110px auto 120 auto\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [10%\] to [20px\] at (0.6) should be [calc(4% + 12px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [10px\] to [20%\] at (0.6) should be [calc(4px + 12%)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [10px\] to [20%\] at (-0.3) should be [calc(13px + -6%)\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [0\] to [20\] at (5) should be [100\]]
@@ -392,9 +230,6 @@
   [CSS Animations: property <border-image-width> from [10\] to [20px\] at (0.5) should be [20px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [10%\] to [20px\] at (0.6) should be [calc(4% + 12px)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [inherit\] to [20px\] at (-0.3) should be [124px\]]
     expected: FAIL
 
@@ -404,13 +239,7 @@
   [CSS Animations: property <border-image-width> from [10\] to [20%\] at (0.5) should be [20%\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-width> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [10%\] to [20px\] at (1) should be [calc(0% + 20px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [10px\] to [20%\] at (0.3) should be [calc(7px + 6%)\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (1) should be [110px auto auto 120\]]
@@ -419,16 +248,7 @@
   [CSS Animations: property <border-image-width> from [inherit\] to [20px\] at (0.3) should be [76px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [0px\] to [20px\] at (5) should be [100px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [0px\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-width> from [inherit\] to [20px\] at (-0.3) should be [124px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (0.6) should be [52px  50%  48  46px\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [unset\] to [20px\] at (0.3) should be [unset\]]
@@ -437,22 +257,10 @@
   [CSS Animations: property <border-image-width> from [initial\] to [20px\] at (-0.3) should be [initial\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-width> from [10%\] to [20px\] at (1.5) should be [calc(-5% + 30px)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [0px\] to [20px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [0\] to [20\] at (0.6) should be [12\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10%\] to [20px\] at (-0.3) should be [calc(13% + -6px)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [10px\] to [20\] at (-0.3) should be [10px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from neutral to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [0\] to [20\] at (1) should be [20\]]
@@ -470,31 +278,13 @@
   [Web Animations: property <border-image-width> from neutral to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-width> from [10px\] to [20%\] at (0.6) should be [calc(4px + 12%)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [inherit\] to [20px\] at (10) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [10\] to [20px\] at (0) should be [10\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [10\] to [20%\] at (0) should be [10\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [0%\] to [20%\] at (1.5) should be [30%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [0%\] to [20%\] at (1) should be [20%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [0%\] to [20%\] at (10) should be [200%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px\] to [20%\] at (1) should be [20%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [0px\] to [20px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [10%\] to [20\] at (1) should be [20\]]
@@ -512,12 +302,6 @@
   [Web Animations: property <border-image-width> from [10px\] to [20\] at (0.6) should be [20\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [10%\] to [20px\] at (0) should be [10%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [0%\] to [20%\] at (5) should be [100%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [0%\] to [20%\] at (0.6) should be [12%\]]
     expected: FAIL
 
@@ -530,22 +314,13 @@
   [CSS Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto 120 auto\] at (0.6) should be [110px auto 120 auto\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [0\] to [20\] at (0) should be [0\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (-0.3) should be [0px   5%  21  37px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [0\] to [20\] at (5) should be [100\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [0%\] to [20%\] at (0) should be [0%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (5) should be [360px 270% 180  90px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [0%\] to [20%\] at (10) should be [200%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (0.3) should be [31px  35%  39  43px\]]
@@ -557,31 +332,10 @@
   [CSS Animations: property <border-image-width> from [10\] to [20px\] at (0.6) should be [20px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [0\] to [20\] at (10) should be [200\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (0.6) should be [ 70px auto auto  80\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [inherit\] to [20px\] at (-0.3) should be [124px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [inherit\] to [20px\] at (0.3) should be [76px\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [unset\] to [20px\] at (0.5) should be [20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10%\] to [20px\] at (0.3) should be [calc(7% + 6px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from neutral to [20px\] at (5) should be [60px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (0.3) should be [ 40px auto auto  50\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [0px\] to [20px\] at (1.5) should be [30px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [inherit\] to [20px\] at (0) should be [100px\]]
@@ -590,22 +344,7 @@
   [Web Animations: property <border-image-width> from neutral to [20px\] at (0.6) should be [16px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [0%\] to [20%\] at (0) should be [0%\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [10%\] to [20\] at (0.5) should be [20\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [0\] to [20\] at (10) should be [200\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from neutral to [20px\] at (5) should be [60px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (5) should be [360px 270% 180  90px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px\] to [20%\] at (-0.3) should be [calc(13px + -6%)\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10%\] to [20px\] at (-0.3) should be [calc(13% + -6px)\]]
@@ -615,9 +354,6 @@
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [0\] to [20\] at (-0.3) should be [0\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [inherit\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10%\] to [20px\] at (0.3) should be [calc(7% + 6px)\]]
@@ -630,9 +366,6 @@
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (0.3) should be [31px  35%  39  43px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [0%\] to [20%\] at (0.3) should be [6%\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [10%\] to [20\] at (0.6) should be [20\]]
@@ -653,25 +386,10 @@
   [Web Animations: property <border-image-width> from [10\] to [20%\] at (0) should be [10\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-width> from [0\] to [20\] at (0.3) should be [6\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (0.6) should be [52px  50%  48  46px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (1.5) should be [115px  95%  75  55px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from neutral to [20px\] at (10) should be [110px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [inherit\] to [20px\] at (5) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-width> from [unset\] to [20px\] at (1.5) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from neutral to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 
   [CSS Transitions: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (-0.3) should be [0px   5%  21  37px\]]
@@ -683,16 +401,7 @@
   [Web Animations: property <border-image-width> from [10px\] to [20%\] at (0) should be [calc(0% + 10px)\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (10) should be [710px 520% 330 140px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from neutral to [20px\] at (10) should be [110px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [0\] to [20\] at (0.6) should be [12\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from neutral to [20px\] at (-0.3) should be [7px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto 120 auto\] at (1) should be [110px auto 120 auto\]]
@@ -701,22 +410,7 @@
   [Web Animations: property <border-image-width> from [10px\] to [20%\] at (0.6) should be [calc(4px + 12%)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (1.5) should be [115px  95%  75  55px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (0) should be [ 10px auto auto  20\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [0px\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [10%\] to [20\] at (0.3) should be [10%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [10%\] to [20px\] at (-0.3) should be [calc(13% + -6px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (1) should be [110px auto auto 120\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [initial\] to [20px\] at (1.5) should be [20px\]]
@@ -731,28 +425,10 @@
   [Web Animations: property <border-image-width> from [10px\] to [20%\] at (1.5) should be [calc(-5px + 30%)\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-width> from [0px\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [initial\] to [20px\] at (0.6) should be [20px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (0.3) should be [ 40px auto auto  50\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (1.5) should be [160px auto auto 170\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [0%\] to [20%\] at (0.6) should be [12%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (-0.3) should be [  0px auto auto   0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [0%\] to [20%\] at (0.3) should be [6%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [unset\] to [20px\] at (0.5) should be [20px\]]
@@ -761,16 +437,10 @@
   [CSS Transitions with transition: all: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (-0.3) should be [0px   5%  21  37px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [10px\] to [20%\] at (0) should be [calc(0% + 10px)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from neutral to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto 120 auto\] at (-0.3) should be [10px auto auto 20\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (5) should be [360px 270% 180  90px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [0px\] to [20px\] at (0) should be [0px\]]
@@ -783,12 +453,6 @@
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [0%\] to [20%\] at (10) should be [200%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [0%\] to [20%\] at (5) should be [100%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from neutral to [20px\] at (5) should be [60px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [0%\] to [20%\] at (5) should be [100%\]]
@@ -812,25 +476,13 @@
   [Web Animations: property <border-image-width> from [unset\] to [20px\] at (0.3) should be [unset\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [10%\] to [20px\] at (1) should be [calc(0% + 20px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [0\] to [20\] at (0.3) should be [6\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-width> from [unset\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [0px\] to [20px\] at (5) should be [100px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto 120 auto\] at (-0.3) should be [10px auto auto 20\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from neutral to [20px\] at (5) should be [60px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from neutral to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [inherit\] to [20px\] at (0.6) should be [52px\]]
@@ -848,18 +500,6 @@
   [Web Animations: property <border-image-width> from [10\] to [20%\] at (0.3) should be [10\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-width> from [10px\] to [20%\] at (0.3) should be [calc(7px + 6%)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [0%\] to [20%\] at (5) should be [100%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [0\] to [20\] at (5) should be [100\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (0) should be [10px  20%  30  40px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-width> from [10\] to [20px\] at (0.3) should be [10\]]
     expected: FAIL
 
@@ -872,9 +512,6 @@
   [CSS Animations: property <border-image-width> from [10px\] to [20\] at (0.5) should be [20\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-image-width> from [0px\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from neutral to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 
@@ -882,9 +519,6 @@
     expected: FAIL
 
   [CSS Transitions: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (0.6) should be [ 70px auto auto  80\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from neutral to [20px\] at (0.6) should be [16px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10%\] to [20\] at (0.6) should be [20\]]
@@ -896,37 +530,13 @@
   [Web Animations: property <border-image-width> from [10px\] to [20\] at (1) should be [20\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [0\] to [20\] at (1) should be [20\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [inherit\] to [20px\] at (5) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [inherit\] to [20px\] at (0.6) should be [52px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (-0.3) should be [  0px auto auto   0\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [initial\] to [20px\] at (0.5) should be [20px\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [0\] to [20\] at (0) should be [0\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [10px\] to [20%\] at (0.3) should be [calc(7px + 6%)\]]
-    expected: FAIL
-
   [Web Animations: property <border-image-width> from [0px\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (1.5) should be [160px auto auto 170\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (10) should be [710px 520% 330 140px\]]
     expected: FAIL
 
   [CSS Animations: property <border-image-width> from [10\] to [20px\] at (0) should be [10\]]
@@ -938,15 +548,42 @@
   [Web Animations: property <border-image-width> from [10px\] to [20%\] at (1) should be [20%\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-image-width> from [0%\] to [20%\] at (10) should be [200%\]]
-    expected: FAIL
-
   [CSS Animations: property <border-image-width> from [10%\] to [20\] at (0.3) should be [10%\]]
     expected: FAIL
 
   [Web Animations: property <border-image-width> from [10px\] to [20\] at (0.3) should be [10px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-image-width> from [0\] to [20\] at (0.3) should be [6\]]
+  [CSS Transitions with transition: all: property <border-image-width> from [inherit\] to [20px\] at (0.3) should be [76px\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-width> from [inherit\] to [20px\] at (-0.3) should be [124px\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-width> from [0%\] to [20%\] at (1.5) should be [30%\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-width> from [10px auto auto 20\] to [110px auto auto 120\] at (1.5) should be [160px auto auto 170\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-width> from [0%\] to [20%\] at (0.6) should be [12%\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-width> from [0%\] to [20%\] at (10) should be [200%\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-width> from [0%\] to [20%\] at (0.3) should be [6%\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (1.5) should be [115px  95%  75  55px\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-width> from [10px 20% 30 40px\] to [80px 70% 60 50px\] at (5) should be [360px 270% 180  90px\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-image-width> from [0%\] to [20%\] at (5) should be [100%\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <border-image-width> from [inherit\] to [20px\] at (0.6) should be [52px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-backgrounds/animations/border-radius-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/animations/border-radius-interpolation.html.ini
@@ -5,28 +5,7 @@
   [Web Animations: property <border-top-left-radius> from [20px\] to [10px 30px\] at (-0.3) should be [23px 17px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-left-radius> from [10px\] to [100%\] at (1) should be [100%\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [10px\] to [50px\] at (0.6) should be [34px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (-0.3) should be [17px 37px 57px 77px / 117px 137px 157px 177px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [10px\] to [50px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [10px\] to [50px\] at (0.3) should be [22px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from neutral to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
   [Web Animations: property <border-top-left-radius> from neutral to [20px\] at (0.3) should be [13px\]]
@@ -35,31 +14,10 @@
   [Web Animations: property <border-top-left-radius> from [20px\] to [10px 30px\] at (0) should be [20px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-left-radius> from [initial\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [10px\] to [50px\] at (0.6) should be [34px\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-left-radius> from [10px\] to [50px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-left-radius> from [20px\] to [10px 30px\] at (1.5) should be [5px 35px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [20px\] to [10px 30px\] at (0) should be [20px\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-left-radius> from [unset\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [10px\] to [50px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [unset\] to [20px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [Web Animations: property <border-top-left-radius> from [10px\] to [50px\] at (1) should be [50px\]]
@@ -68,19 +26,7 @@
   [Web Animations: property <border-top-left-radius> from [inherit\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-top-left-radius> from [10px\] to [50px\] at (1.5) should be [70px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (0.3) should be [23px 43px 63px 83px / 123px 143px 163px 183px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [10px\] to [100%\] at (0) should be [calc(10px + 0%)\]]
     expected: FAIL
 
   [CSS Animations: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (0.6) should be [26px 46px 66px 86px / 126px 146px 166px 186px\]]
@@ -89,46 +35,16 @@
   [CSS Transitions with transition: all: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (1.5) should be [35px 55px 75px 95px / 135px 155px 175px 195px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-left-radius> from [20px\] to [10px 30px\] at (-0.3) should be [23px 17px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [20px\] to [10px 30px\] at (-2) should be [40px 0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from [unset\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [10px\] to [100%\] at (0.6) should be [calc(4px + 60%)\]]
-    expected: FAIL
-
   [CSS Animations: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (1) should be [30px 50px 70px 90px / 130px 150px 170px 190px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from neutral to [20px\] at (-0.3) should be [7px\]]
     expected: FAIL
 
   [CSS Transitions: property <border-top-left-radius> from [10px\] to [100%\] at (0.6) should be [calc(4px + 60%)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-left-radius> from [10px\] to [50px\] at (0.6) should be [34px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-top-left-radius> from [10px\] to [50px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-left-radius> from [inherit\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [inherit\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [unset\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [unset\] to [20px\] at (0.3) should be [6px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (0.6) should be [26px 46px 66px 86px / 126px 146px 166px 186px\]]
@@ -155,9 +71,6 @@
   [Web Animations: property <border-top-left-radius> from [initial\] to [20px\] at (1.5) should be [30px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-left-radius> from [10px\] to [50px\] at (1) should be [50px\]]
-    expected: FAIL
-
   [Web Animations: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (1) should be [30px 50px 70px 90px / 130px 150px 170px 190px\]]
     expected: FAIL
 
@@ -167,19 +80,7 @@
   [Web Animations: property <border-top-left-radius> from [10px\] to [50px\] at (1.5) should be [70px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-top-left-radius> from [unset\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-left-radius> from [20px\] to [10px 30px\] at (0.6) should be [14px 26px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from [10px\] to [50px\] at (0.6) should be [34px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [20px\] to [10px 30px\] at (1) should be [10px 30px\]]
     expected: FAIL
 
   [Web Animations: property <border-top-left-radius> from [10px\] to [50px\] at (0.3) should be [22px\]]
@@ -191,28 +92,7 @@
   [Web Animations: property <border-top-left-radius> from [unset\] to [20px\] at (1.5) should be [30px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-left-radius> from [initial\] to [20px\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [unset\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from [inherit\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from [20px\] to [10px 30px\] at (-2) should be [40px 0px\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (-0.3) should be [17px 37px 57px 77px / 117px 137px 157px 177px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from [initial\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [unset\] to [20px\] at (1.5) should be [30px\]]
     expected: FAIL
 
   [Web Animations: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (0) should be [20px 40px 60px 80px / 120px 140px 160px 180px\]]
@@ -227,31 +107,16 @@
   [CSS Animations: property <border-top-left-radius> from [inherit\] to [20px\] at (0.3) should be [27px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-left-radius> from [unset\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-left-radius> from neutral to [20px\] at (0) should be [10px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-left-radius> from [initial\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [10px\] to [100%\] at (1.5) should be [calc(-5px + 150%)\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-left-radius> from [10px\] to [100%\] at (0) should be [calc(10px + 0%)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [initial\] to [20px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [CSS Transitions: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (0) should be [20px 40px 60px 80px / 120px 140px 160px 180px\]]
     expected: FAIL
 
   [Web Animations: property <border-top-left-radius> from [10px\] to [100%\] at (0.3) should be [calc(7px + 30%)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [unset\] to [20px\] at (0.3) should be [6px\]]
     expected: FAIL
 
   [Web Animations: property <border-top-left-radius> from neutral to [20px\] at (1.5) should be [25px\]]
@@ -263,37 +128,10 @@
   [Web Animations: property <border-top-left-radius> from [20px\] to [10px 30px\] at (1.5) should be [5px 35px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [20px\] to [10px 30px\] at (-2) should be [40px 0px\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-left-radius> from [initial\] to [20px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [10px\] to [100%\] at (1.5) should be [calc(-5px + 150%)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (1) should be [30px 50px 70px 90px / 130px 150px 170px 190px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from [20px\] to [10px 30px\] at (0.3) should be [17px 23px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [20px\] to [10px 30px\] at (1.5) should be [5px 35px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [initial\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [10px\] to [50px\] at (1.5) should be [70px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from [unset\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [10px\] to [100%\] at (0.3) should be [calc(7px + 30%)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [unset\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
   [CSS Transitions: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (0.3) should be [23px 43px 63px 83px / 123px 143px 163px 183px\]]
@@ -305,25 +143,7 @@
   [CSS Animations: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (1.5) should be [35px 55px 75px 95px / 135px 155px 175px 195px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [inherit\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from [initial\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (1.5) should be [35px 55px 75px 95px / 135px 155px 175px 195px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [10px\] to [100%\] at (-0.3) should be [calc(13px + -30%)\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [20px\] to [10px 30px\] at (0.6) should be [14px 26px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from neutral to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (0) should be [20px 40px 60px 80px / 120px 140px 160px 180px\]]
@@ -336,12 +156,6 @@
     expected: FAIL
 
   [Web Animations: property <border-top-left-radius> from [20px\] to [10px 30px\] at (-2) should be [40px 0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [inherit\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [initial\] to [20px\] at (0.6) should be [12px\]]
     expected: FAIL
 
   [CSS Transitions: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (1) should be [30px 50px 70px 90px / 130px 150px 170px 190px\]]
@@ -362,31 +176,13 @@
   [CSS Transitions: property <border-radius> from [20px 40px 60px 80px / 120px 140px 160px 180px\] to [30px 50px 70px 90px / 130px 150px 170px 190px\] at (0.6) should be [26px 46px 66px 86px / 126px 146px 166px 186px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [10px\] to [50px\] at (1.5) should be [70px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from [inherit\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-left-radius> from [10px\] to [100%\] at (1) should be [100%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [10px\] to [50px\] at (0.3) should be [22px\]]
     expected: FAIL
 
   [CSS Animations: property <border-top-left-radius> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
     expected: FAIL
 
   [Web Animations: property <border-top-left-radius> from [initial\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [initial\] to [20px\] at (0.6) should be [12px\]]
     expected: FAIL
 
   [Web Animations: property <border-top-left-radius> from [initial\] to [20px\] at (0.6) should be [12px\]]
@@ -398,43 +194,10 @@
   [Web Animations: property <border-top-left-radius> from [initial\] to [20px\] at (0) should be [0px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-top-left-radius> from [20px\] to [10px 30px\] at (0.6) should be [14px 26px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from [20px\] to [10px 30px\] at (-0.3) should be [23px 17px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [20px\] to [10px 30px\] at (0.3) should be [17px 23px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [20px\] to [10px 30px\] at (-0.3) should be [23px 17px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-left-radius> from [unset\] to [20px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-top-left-radius> from [10px\] to [50px\] at (0.3) should be [22px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from neutral to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from [10px\] to [100%\] at (1.5) should be [calc(-5px + 150%)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-left-radius> from [unset\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-left-radius> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [unset\] to [20px\] at (0) should be [0px\]]
     expected: FAIL
 
   [Web Animations: property <border-top-left-radius> from [10px\] to [100%\] at (1.5) should be [calc(-5px + 150%)\]]
@@ -446,9 +209,6 @@
   [CSS Transitions: property <border-top-left-radius> from [10px\] to [100%\] at (0.3) should be [calc(7px + 30%)\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-top-left-radius> from [20px\] to [10px 30px\] at (1.5) should be [5px 35px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-top-left-radius> from [inherit\] to [20px\] at (0) should be [30px\]]
     expected: FAIL
 
@@ -458,13 +218,7 @@
   [Web Animations: property <border-top-left-radius> from neutral to [20px\] at (0.6) should be [16px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-top-left-radius> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-left-radius> from [inherit\] to [20px\] at (0) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-top-left-radius> from [20px\] to [10px 30px\] at (0.3) should be [17px 23px\]]
     expected: FAIL
 
   [Web Animations: property <border-top-left-radius> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
@@ -473,18 +227,24 @@
   [CSS Transitions with transition: all: property <border-top-left-radius> from [10px\] to [100%\] at (0.3) should be [calc(7px + 30%)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-top-left-radius> from [20px\] to [10px 30px\] at (0.6) should be [14px 26px\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-left-radius> from [unset\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-left-radius> from [initial\] to [20px\] at (1.5) should be [30px\]]
     expected: FAIL
 
   [CSS Animations: property <border-top-left-radius> from [inherit\] to [20px\] at (1.5) should be [15px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-top-left-radius> from [10px\] to [100%\] at (0.6) should be [calc(4px + 60%)\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-top-left-radius> from [10px\] to [100%\] at (1.5) should be [calc(-5px + 150%)\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-top-left-radius> from [10px\] to [50px\] at (1.5) should be [70px\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-top-left-radius> from [10px\] to [50px\] at (0.6) should be [34px\]]
+    expected: FAIL
+
+  [CSS Transitions: property <border-top-left-radius> from [10px\] to [50px\] at (0.3) should be [22px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-backgrounds/animations/border-width-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/animations/border-width-interpolation.html.ini
@@ -8,9 +8,6 @@
   [CSS Animations: property <border-bottom-width> from [thick\] to [15px\] at (1) should be [15px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-top-width> from [15px\] to [thick\] at (-0.3) should be [18px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-left-width> from [unset\] to [20px\] at (1.5) should be [28.5px\]]
     expected: FAIL
 
@@ -23,16 +20,7 @@
   [CSS Animations: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (0.3) should be [23px 43px 63px 83px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-top-width> from [15px\] to [thick\] at (-2) should be [35px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-left-width> from [medium\] to [13px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-bottom-width> from [thick\] to [15px\] at (0.3) should be [8px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from [initial\] to [20px\] at (0.6) should be [13.2px\]]
     expected: FAIL
 
   [CSS Animations: property <border-top-width> from [15px\] to [thick\] at (-2) should be [35px\]]
@@ -41,25 +29,10 @@
   [CSS Animations: property <border-top-width> from [15px\] to [thick\] at (1.5) should be [0px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-left-width> from [initial\] to [20px\] at (0.3) should be [8.1px\]]
-    expected: FAIL
-
   [Web Animations: property <border-right-width> from [thin\] to [11px\] at (0.6) should be [7px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-left-width> from [0px\] to [10px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (0.6) should be [26px 46px 66px 86px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-width> from [15px\] to [thick\] at (0.6) should be [9px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-width> from [15px\] to [thick\] at (0.6) should be [9px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from [medium\] to [13px\] at (-0.25) should be [0.5px\]]
     expected: FAIL
 
   [CSS Animations: property <border-right-width> from [thin\] to [11px\] at (0) should be [1px\]]
@@ -83,13 +56,7 @@
   [Web Animations: property <border-bottom-width> from [thick\] to [15px\] at (0.3) should be [8px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-right-width> from [thin\] to [11px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-left-width> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-left-width> from [medium\] to [13px\] at (-0.25) should be [0.5px\]]
     expected: FAIL
 
   [Web Animations: property <border-bottom-width> from [thick\] to [15px\] at (1) should be [15px\]]
@@ -104,16 +71,10 @@
   [Web Animations: property <border-left-width> from neutral to [20px\] at (0) should be [10px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-left-width> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
   [Web Animations: property <border-right-width> from [thin\] to [11px\] at (-2) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <border-left-width> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from [unset\] to [20px\] at (0.3) should be [8.1px\]]
     expected: FAIL
 
   [Web Animations: property <border-left-width> from [initial\] to [20px\] at (1.5) should be [28.5px\]]
@@ -149,9 +110,6 @@
   [CSS Transitions with transition: all: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (0.3) should be [23px 43px 63px 83px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-left-width> from [inherit\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-top-width> from [15px\] to [thick\] at (0.3) should be [12px\]]
     expected: FAIL
 
@@ -161,37 +119,19 @@
   [CSS Transitions: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (1) should be [30px 50px 70px 90px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-right-width> from [thin\] to [11px\] at (-2) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-left-width> from [0px\] to [10px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from [initial\] to [20px\] at (1.5) should be [28.5px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-bottom-width> from [thick\] to [15px\] at (0.3) should be [8px\]]
     expected: FAIL
 
   [CSS Animations: property <border-left-width> from [initial\] to [20px\] at (1.5) should be [28.5px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-left-width> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-left-width> from [unset\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-left-width> from [0px\] to [10px\] at (0.3) should be [3px\]]
     expected: FAIL
 
   [Web Animations: property <border-right-width> from [thin\] to [11px\] at (1.5) should be [16px\]]
     expected: FAIL
 
   [Web Animations: property <border-left-width> from [inherit\] to [20px\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-bottom-width> from [thick\] to [15px\] at (0.6) should be [11px\]]
     expected: FAIL
 
   [Web Animations: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (0.6) should be [26px 46px 66px 86px\]]
@@ -212,12 +152,6 @@
   [CSS Animations: property <border-right-width> from [thin\] to [11px\] at (0.3) should be [4px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-top-width> from [15px\] to [thick\] at (0.3) should be [12px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-right-width> from [thin\] to [11px\] at (0.3) should be [4px\]]
-    expected: FAIL
-
   [Web Animations: property <border-right-width> from [thin\] to [11px\] at (0) should be [1px\]]
     expected: FAIL
 
@@ -230,16 +164,7 @@
   [Web Animations: property <border-left-width> from [medium\] to [13px\] at (-0.25) should be [0.5px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-left-width> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
   [Web Animations: property <border-bottom-width> from [thick\] to [15px\] at (0) should be [5px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-width> from [15px\] to [thick\] at (1.5) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-left-width> from [initial\] to [20px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [Web Animations: property <border-left-width> from [unset\] to [20px\] at (-0.3) should be [0px\]]
@@ -248,19 +173,10 @@
   [CSS Transitions: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (1.5) should be [35px 55px 75px 95px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-left-width> from [medium\] to [13px\] at (-2) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <border-left-width> from [initial\] to [20px\] at (0.3) should be [8.1px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-left-width> from [medium\] to [13px\] at (-2) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-left-width> from [0px\] to [10px\] at (0.6) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-left-width> from [medium\] to [13px\] at (0.3) should be [6px\]]
     expected: FAIL
 
   [CSS Animations: property <border-left-width> from [unset\] to [20px\] at (0) should be [3px\]]
@@ -269,16 +185,10 @@
   [Web Animations: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (0.3) should be [23px 43px 63px 83px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-bottom-width> from [thick\] to [15px\] at (1.5) should be [20px\]]
-    expected: FAIL
-
   [CSS Transitions: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (0.3) should be [23px 43px 63px 83px\]]
     expected: FAIL
 
   [Web Animations: property <border-left-width> from [inherit\] to [20px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-width> from [15px\] to [thick\] at (-2) should be [35px\]]
     expected: FAIL
 
   [Web Animations: property <border-bottom-width> from [thick\] to [15px\] at (-2) should be [0px\]]
@@ -293,9 +203,6 @@
   [Web Animations: property <border-top-width> from [15px\] to [thick\] at (1.5) should be [0px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-left-width> from [unset\] to [20px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <border-top-width> from [15px\] to [thick\] at (0.3) should be [12px\]]
     expected: FAIL
 
@@ -305,46 +212,22 @@
   [CSS Animations: property <border-left-width> from [inherit\] to [20px\] at (0.6) should be [12px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-left-width> from [unset\] to [20px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from [0px\] to [10px\] at (0.6) should be [6px\]]
-    expected: FAIL
-
   [Web Animations: property <border-left-width> from neutral to [20px\] at (-0.3) should be [7px\]]
     expected: FAIL
 
   [CSS Animations: property <border-left-width> from [medium\] to [13px\] at (1.5) should be [18px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-left-width> from [medium\] to [13px\] at (1.5) should be [18px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-right-width> from [thin\] to [11px\] at (-2) should be [0px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-bottom-width> from [thick\] to [15px\] at (0.6) should be [11px\]]
-    expected: FAIL
-
   [Web Animations: property <border-bottom-width> from [thick\] to [15px\] at (1.5) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from [unset\] to [20px\] at (0.6) should be [13.2px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-left-width> from [0px\] to [10px\] at (0.6) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-right-width> from [thin\] to [11px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <border-left-width> from [medium\] to [13px\] at (0) should be [3px\]]
     expected: FAIL
 
   [CSS Animations: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (-0.3) should be [17px 37px 57px 77px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from neutral to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
   [Web Animations: property <border-left-width> from [inherit\] to [20px\] at (1) should be [20px\]]
@@ -356,19 +239,10 @@
   [CSS Animations: property <border-left-width> from [initial\] to [20px\] at (0) should be [3px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-left-width> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-left-width> from [inherit\] to [20px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [Web Animations: property <border-bottom-width> from [thick\] to [15px\] at (-0.3) should be [2px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from [unset\] to [20px\] at (1.5) should be [28.5px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-left-width> from [inherit\] to [20px\] at (1.5) should be [30px\]]
     expected: FAIL
 
   [CSS Animations: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (0.6) should be [26px 46px 66px 86px\]]
@@ -378,9 +252,6 @@
     expected: FAIL
 
   [CSS Animations: property <border-left-width> from [inherit\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from [medium\] to [13px\] at (0.6) should be [9px\]]
     expected: FAIL
 
   [Web Animations: property <border-left-width> from [0px\] to [10px\] at (1.5) should be [15px\]]
@@ -398,22 +269,7 @@
   [Web Animations: property <border-right-width> from [thin\] to [11px\] at (0.3) should be [4px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-left-width> from [medium\] to [13px\] at (0.6) should be [9px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-left-width> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
   [Web Animations: property <border-left-width> from [initial\] to [20px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from [inherit\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-right-width> from [thin\] to [11px\] at (0.6) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-top-width> from [15px\] to [thick\] at (1.5) should be [0px\]]
     expected: FAIL
 
   [Web Animations: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (0) should be [20px 40px 60px 80px\]]
@@ -428,19 +284,10 @@
   [Web Animations: property <border-top-width> from [15px\] to [thick\] at (-2) should be [35px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-bottom-width> from [thick\] to [15px\] at (-2) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-left-width> from [unset\] to [20px\] at (0.3) should be [8.1px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-bottom-width> from [thick\] to [15px\] at (1.5) should be [20px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (0) should be [20px 40px 60px 80px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from [initial\] to [20px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <border-top-width> from [15px\] to [thick\] at (0.6) should be [9px\]]
@@ -461,12 +308,6 @@
   [CSS Animations: property <border-left-width> from [medium\] to [13px\] at (-0.25) should be [0.5px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-left-width> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from [inherit\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-top-width> from [15px\] to [thick\] at (-0.3) should be [18px\]]
     expected: FAIL
 
@@ -476,34 +317,13 @@
   [Web Animations: property <border-right-width> from [thin\] to [11px\] at (1) should be [11px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-right-width> from [thin\] to [11px\] at (0.6) should be [7px\]]
-    expected: FAIL
-
   [Web Animations: property <border-left-width> from [initial\] to [20px\] at (0) should be [3px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-bottom-width> from [thick\] to [15px\] at (-2) should be [0px\]]
     expected: FAIL
 
   [Web Animations: property <border-left-width> from [medium\] to [13px\] at (0.3) should be [6px\]]
     expected: FAIL
 
   [CSS Animations: property <border-left-width> from [inherit\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-bottom-width> from [thick\] to [15px\] at (-0.3) should be [2px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-width> from [15px\] to [thick\] at (0.3) should be [12px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-left-width> from [initial\] to [20px\] at (0.3) should be [8.1px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-left-width> from [inherit\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-left-width> from [medium\] to [13px\] at (1.5) should be [18px\]]
     expected: FAIL
 
   [Web Animations: property <border-left-width> from [0px\] to [10px\] at (0) should be [0px\]]
@@ -515,16 +335,7 @@
   [Web Animations: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (1.5) should be [35px 55px 75px 95px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-left-width> from [unset\] to [20px\] at (0.6) should be [13.2px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-left-width> from [inherit\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-left-width> from [initial\] to [20px\] at (1.5) should be [28.5px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-top-width> from [15px\] to [thick\] at (-0.3) should be [18px\]]
     expected: FAIL
 
   [Web Animations: property <border-left-width> from [inherit\] to [20px\] at (0.6) should be [12px\]]
@@ -533,16 +344,10 @@
   [Web Animations: property <border-left-width> from [unset\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-left-width> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
   [Web Animations: property <border-right-width> from [thin\] to [11px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <border-left-width> from [0px\] to [10px\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from [0px\] to [10px\] at (1.5) should be [15px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (0) should be [20px 40px 60px 80px\]]
@@ -551,34 +356,13 @@
   [Web Animations: property <border-left-width> from [medium\] to [13px\] at (0.6) should be [9px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-left-width> from [inherit\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-left-width> from [initial\] to [20px\] at (0.6) should be [13.2px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from [medium\] to [13px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-left-width> from [unset\] to [20px\] at (1.5) should be [28.5px\]]
-    expected: FAIL
-
   [Web Animations: property <border-left-width> from [0px\] to [10px\] at (0.6) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-left-width> from [0px\] to [10px\] at (0.3) should be [3px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-right-width> from [thin\] to [11px\] at (0.3) should be [4px\]]
     expected: FAIL
 
   [Web Animations: property <border-left-width> from [inherit\] to [20px\] at (1.5) should be [30px\]]
     expected: FAIL
 
   [CSS Animations: property <border-top-width> from [15px\] to [thick\] at (0) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <border-right-width> from [thin\] to [11px\] at (-2) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <border-right-width> from [thin\] to [11px\] at (0.6) should be [7px\]]
@@ -605,9 +389,6 @@
   [CSS Animations: property <border-left-width> from neutral to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
-  [CSS Transitions: property <border-right-width> from [thin\] to [11px\] at (1.5) should be [16px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-left-width> from neutral to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 
@@ -617,16 +398,10 @@
   [Web Animations: property <border-left-width> from [initial\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <border-bottom-width> from [thick\] to [15px\] at (-0.3) should be [2px\]]
-    expected: FAIL
-
   [Web Animations: property <border-left-width> from [0px\] to [10px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [Web Animations: property <border-top-width> from [15px\] to [thick\] at (1) should be [5px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-right-width> from [thin\] to [11px\] at (1.5) should be [16px\]]
     expected: FAIL
 
   [CSS Animations: property <border-bottom-width> from [thick\] to [15px\] at (0.6) should be [11px\]]
@@ -639,8 +414,5 @@
     expected: FAIL
 
   [Web Animations: property <border-left-width> from [0px\] to [10px\] at (1) should be [10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <border-left-width> from [unset\] to [20px\] at (0.3) should be [8.1px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-backgrounds/animations/box-shadow-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/animations/box-shadow-interpolation.html.ini
@@ -2,73 +2,16 @@
   [box-shadow-interpolation]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (-0.3) should be [rgb(0, 0, 0) 7px 33px 7px 33px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (0.3) should be [rgb(0, 0, 0) 13px 27px 13px 27px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (1.5) should be [rgba(0, 0, 0, 0) -5px -10px 0px 0px, rgba(0, 0, 0, 0) -2.5px -15px 0px 0px inset\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 25px 15px 25px 15px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 25px 15px 25px 15px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px 3px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (0.3) should be [rgba(255, 255, 0, 0.353) 7px 14px 0px 0px, rgba(0, 128, 0, 0.7) 3.5px 21px 0px 0px inset\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 30px 30px 30px 30px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px 0px\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (1) should be [rgb(0, 128, 0) -15px -10px 25px -4px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (1.5) should be [rgb(0, 192, 0) 10px 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (0) should be [rgba(0, 0, 0, 0) 0px 0px 0px 0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px -9px inset\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (0.3) should be [rgb(0, 38, 0) 6px 4px 11px 3px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (0.3) should be [rgba(255, 255, 0, 0.353) 7px 14px 0px 0px, rgba(0, 128, 0, 0.7) 3.5px 21px 0px 0px inset\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (0) should be [rgb(0, 0, 0) 10px 30px 10px 30px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (1.5) should be [rgb(0, 192, 0) 10px 10px 10px 10px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (0.6) should be [rgb(0, 0, 0) 16px 24px 16px 24px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px -9px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px -9px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (0.6) should be [rgba(0, 0, 0, 0.6) 12px 12px 12px 12px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (-0.3) should be [rgba(0, 0, 0, 0) -6px -6px 0px -6px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (0) should be [rgb(0, 0, 0) 15px 10px 5px 6px inset\]]
@@ -80,55 +23,22 @@
   [CSS Animations: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 15px 25px 15px 25px\]]
     expected: FAIL
 
-  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px 3px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (0.3) should be [rgb(0, 0, 0) 13px 27px 13px 27px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px 3px\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (0.6) should be [rgb(0, 0, 0) 16px 24px 16px 24px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (1) should be [rgb(0, 0, 0) 20px 20px 20px 20px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (0) should be [rgba(0, 0, 0, 0) 0px 0px 0px 0px\]]
     expected: FAIL
 
-  [CSS Transitions: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (0.3) should be [rgb(0, 38, 0) 10px 10px 10px 10px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [10px 20px yellow, 5px 10px green\] to [inset 5px 10px green, 15px 20px blue\] at (0) should be [10px 20px yellow, 5px 10px green\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (-0.3) should be [rgba(255, 255, 0, 0.65) 13px 26px 0px 0px, rgb(0, 166, 0) 6.5px 39px 0px 0px inset\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (-0.3) should be [rgba(0, 0, 0, 0) -6px -6px 0px -6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (0.6) should be [rgba(255, 255, 0, 0.2) 4px 8px 0px 0px, rgba(0, 128, 0, 0.4) 2px 12px 0px 0px inset\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (0) should be [rgb(0, 0, 0) 15px 10px 5px 6px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (0.3) should be [rgba(255, 255, 0, 0.353) 7px 14px 0px 0px, rgba(0, 128, 0, 0.7) 3.5px 21px 0px 0px inset\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (0.6) should be [rgba(255, 255, 0, 0.2) 4px 8px 0px 0px, rgba(0, 128, 0, 0.4) 2px 12px 0px 0px inset\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px 0px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px 3px inset\]]
@@ -143,109 +53,34 @@
   [CSS Animations: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (0) should be [rgb(0, 0, 0) 30px 10px 30px 10px\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (0.3) should be [rgb(0, 38, 0) 10px 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px 0px inset\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [10px 20px yellow, 5px 10px green\] to [inset 5px 10px green, 15px 20px blue\] at (0.3) should be [10px 20px yellow, 5px 10px green\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (0.3) should be [rgba(0, 0, 0, 0.3) 6px 6px 6px 6px\]]
     expected: FAIL
 
   [CSS Animations: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (-0.3) should be [rgb(0, 0, 0) 33px 7px 33px 7px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (0.6) should be [rgba(0, 0, 0, 0.6) 12px 12px 12px 12px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [10px 20px yellow, 5px 10px green\] to [inset 5px 10px green, 15px 20px blue\] at (1) should be [inset 5px 10px green, 15px 20px blue\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (0.6) should be [rgba(255, 255, 0, 0.2) 4px 8px 0px 0px, rgba(0, 128, 0, 0.4) 2px 12px 0px 0px inset\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px -9px inset\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (0.6) should be [rgba(0, 0, 0, 0.6) 12px 12px 12px 12px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px -9px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (0.3) should be [rgba(255, 255, 0, 0.353) 7px 14px 0px 0px, rgba(0, 128, 0, 0.7) 3.5px 21px 0px 0px inset\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (1.5) should be [rgba(0, 0, 0, 0) -5px -10px 0px 0px, rgba(0, 0, 0, 0) -2.5px -15px 0px 0px inset\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (-0.3) should be [rgba(255, 255, 0, 0.65) 13px 26px 0px 0px, rgb(0, 166, 0) 6.5px 39px 0px 0px inset\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (-0.3) should be [rgb(0, 0, 0) 33px 7px 33px 7px\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (0) should be [rgb(0, 0, 0) 15px 10px 5px 6px inset\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px -9px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (0) should be [rgb(0, 0, 0) 15px 10px 5px 6px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px 0px inset\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (1) should be [rgb(0, 128, 0) -15px -10px 25px -4px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (0) should be [rgb(0, 0, 0) 10px 10px 10px 10px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 30px 30px 30px 30px\]]
     expected: FAIL
 
-  [CSS Transitions: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 30px 30px 30px 30px\]]
-    expected: FAIL
-
   [CSS Animations: property <box-shadow> from [10px 20px yellow, 5px 10px green\] to [inset 5px 10px green, 15px 20px blue\] at (1) should be [inset 5px 10px green, 15px 20px blue\]]
     expected: FAIL
 
-  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px 3px inset\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (1) should be [rgb(0, 0, 0) 20px 20px 20px 20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (-0.3) should be [rgba(255, 255, 0, 0.65) 13px 26px 0px 0px, rgb(0, 166, 0) 6.5px 39px 0px 0px inset\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (0.3) should be [rgba(0, 0, 0, 0.3) 6px 6px 6px 6px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (0.6) should be [rgb(0, 77, 0) -3px -2px 17px 0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 15px 25px 15px 25px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px inset\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (0.6) should be [rgba(0, 0, 0, 0.6) 12px 12px 12px 12px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (-0.3) should be [rgba(0, 0, 0, 0) -6px -6px 0px -6px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (0.6) should be [rgba(255, 255, 0, 0.2) 4px 8px 0px 0px, rgba(0, 128, 0, 0.4) 2px 12px 0px 0px inset\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (1) should be [rgb(0, 0, 0) 20px 20px 20px 20px\]]
@@ -254,58 +89,16 @@
   [Web Animations: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (1.5) should be [rgb(0, 192, 0) 10px 10px 10px 10px\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px 3px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px -9px inset\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px 3px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px 3px inset\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (0) should be [rgb(0, 0, 0) 15px 10px 5px 6px\]]
     expected: FAIL
 
   [CSS Animations: property <box-shadow> from [10px 20px yellow, 5px 10px green\] to [inset 5px 10px green, 15px 20px blue\] at (0.6) should be [inset 5px 10px green, 15px 20px blue\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (1) should be [rgb(0, 0, 0) 20px 20px 20px 20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (0.6) should be [rgba(0, 0, 0, 0.6) 12px 12px 12px 12px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (-0.3) should be [rgb(0, 0, 0) 33px 7px 33px 7px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 30px 30px 30px 30px\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 30px 30px 30px 30px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (-0.3) should be [rgb(0, 0, 0) 7px 33px 7px 33px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (-0.3) should be [rgb(0, 0, 0) 33px 7px 33px 7px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (1) should be [rgb(255, 165, 0) -15px -10px 25px -4px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [10px 20px yellow, 5px 10px green\] to [inset 5px 10px green, 15px 20px blue\] at (0.6) should be [inset 5px 10px green, 15px 20px blue\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (0.6) should be [rgba(0, 0, 0, 0.6) 12px 12px 12px 12px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (0.6) should be [rgb(0, 77, 0) 10px 10px 10px 10px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (1) should be [rgb(255, 165, 0) -15px -10px 25px -4px inset\]]
@@ -314,16 +107,7 @@
   [Web Animations: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (-0.3) should be [rgba(0, 0, 0, 0) -6px -6px 0px -6px\]]
     expected: FAIL
 
-  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (1.5) should be [rgb(0, 192, 0) -30px -20px 35px -9px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (0.3) should be [rgb(0, 38, 0) 6px 4px 11px 3px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px 0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (1) should be [rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px inset\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px\]]
@@ -332,55 +116,25 @@
   [Web Animations: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (1) should be [rgb(0, 0, 0) 20px 20px 20px 20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (0.6) should be [rgb(0, 0, 0) 16px 24px 16px 24px\]]
-    expected: FAIL
-
   [CSS Animations: property <box-shadow> from [10px 20px yellow, 5px 10px green\] to [inset 5px 10px green, 15px 20px blue\] at (0) should be [10px 20px yellow, 5px 10px green\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (0.6) should be [rgb(0, 77, 0) 10px 10px 10px 10px\]]
     expected: FAIL
 
-  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (0.6) should be [rgb(0, 77, 0) -3px -2px 17px 0px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (0) should be [rgb(0, 0, 0) 15px 10px 5px 6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (0.3) should be [rgb(0, 0, 0) 27px 13px 27px 13px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [10px 20px yellow, 5px 10px green\] to [inset 5px 10px green, 15px 20px blue\] at (1.5) should be [inset 5px 10px green, 15px 20px blue\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (1.5) should be [rgb(0, 192, 0) -30px -20px 35px -9px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px 0px inset\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (0.6) should be [rgb(0, 0, 0) 16px 24px 16px 24px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (1) should be [rgb(0, 128, 0) 10px 10px 10px 10px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [10px 20px yellow, 5px 10px green\] to [inset 5px 10px green, 15px 20px blue\] at (-0.3) should be [10px 20px yellow, 5px 10px green\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (1.5) should be [rgba(0, 0, 0, 0) -5px -10px 0px 0px, rgba(0, 0, 0, 0) -2.5px -15px 0px 0px inset\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (0.3) should be [rgba(0, 0, 0, 0.3) 6px 6px 6px 6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 25px 15px 25px 15px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [10px 20px yellow, 5px 10px green\] to [inset 5px 10px green, 15px 20px blue\] at (0.5) should be [inset 5px 10px green, 15px 20px blue\]]
@@ -398,34 +152,10 @@
   [Web Animations: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (1) should be [rgb(0, 0, 0) 20px 20px 20px 20px\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (1.5) should be [rgb(0, 192, 0) 10px 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (0.3) should be [rgb(0, 0, 0) 27px 13px 27px 13px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (0.3) should be [rgb(0, 0, 0) 27px 13px 27px 13px\]]
     expected: FAIL
 
-  [CSS Transitions: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (0.6) should be [rgb(0, 0, 0) 24px 16px 24px 16px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (-0.3) should be [rgb(0, 0, 0) 7px 33px 7px 33px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (0.3) should be [rgb(0, 0, 0) 13px 27px 13px 27px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (0.6) should be [rgb(0, 0, 0) 24px 16px 24px 16px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (1) should be [rgb(255, 165, 0) -15px -10px 25px -4px inset\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px -9px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (1) should be [rgb(0, 0, 0) 20px 20px 20px 20px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (0) should be [rgba(0, 0, 0, 0) 0px 0px 0px 0px\]]
@@ -443,46 +173,13 @@
   [Web Animations: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (1) should be [rgb(255, 165, 0) -15px -10px 25px -4px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (-0.3) should be [rgba(0, 0, 0, 0) -6px -6px 0px -6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (-0.3) should be [rgba(0, 0, 0, 0) -6px -6px 0px -6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (0) should be [rgb(0, 0, 0) 15px 10px 5px 6px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px 3px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (-0.3) should be [rgb(0, 0, 0) 10px 10px 10px 10px\]]
     expected: FAIL
 
-  [CSS Transitions: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px 3px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 25px 15px 25px 15px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 30px 30px 30px 30px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px 3px inset\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (0) should be [rgba(0, 0, 0, 0) 0px 0px 0px 0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px 0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (0.3) should be [rgb(0, 38, 0) 6px 4px 11px 3px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (0.3) should be [rgba(0, 0, 0, 0.3) 6px 6px 6px 6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (0.3) should be [rgb(0, 38, 0) 10px 10px 10px 10px\]]
     expected: FAIL
 
   [CSS Animations: property <box-shadow> from [10px 20px yellow, 5px 10px green\] to [inset 5px 10px green, 15px 20px blue\] at (0.5) should be [inset 5px 10px green, 15px 20px blue\]]
@@ -491,73 +188,22 @@
   [CSS Animations: property <box-shadow> from [10px 20px yellow, 5px 10px green\] to [inset 5px 10px green, 15px 20px blue\] at (-0.3) should be [10px 20px yellow, 5px 10px green\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (0.6) should be [rgb(0, 77, 0) -3px -2px 17px 0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px 0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (0.3) should be [rgb(0, 38, 0) 6px 4px 11px 3px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (0.3) should be [rgba(0, 0, 0, 0.3) 6px 6px 6px 6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px 0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px 0px inset\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 30px 30px 30px 30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (0.6) should be [rgb(0, 77, 0) -3px -2px 17px 0px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (1) should be [rgb(255, 165, 0) -15px -10px 25px -4px\]]
     expected: FAIL
 
-  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px inset\]]
-    expected: FAIL
-
   [CSS Animations: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (0.6) should be [rgb(0, 0, 0) 24px 16px 24px 16px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px 0px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (0) should be [rgb(0, 0, 0) 10px 10px 10px 10px\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (1) should be [rgb(0, 128, 0) 10px 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (0.6) should be [rgb(0, 77, 0) 10px 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px 3px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (1.5) should be [rgb(0, 192, 0) -30px -20px 35px -9px\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (1) should be [rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px inset\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (0.3) should be [rgba(0, 0, 0, 0.3) 6px 6px 6px 6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 30px 30px 30px 30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px -9px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (1.5) should be [rgba(0, 0, 0, 0) -5px -10px 0px 0px, rgba(0, 0, 0, 0) -2.5px -15px 0px 0px inset\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [initial\] to [20px 20px 20px 20px black\] at (1) should be [rgb(0, 0, 0) 20px 20px 20px 20px\]]
@@ -566,37 +212,16 @@
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px -9px\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from [10px 20px rgba(255, 255, 0, 0.5), inset 5px 10em #008000\] to [none\] at (0) should be [rgba(255, 255, 0, 0.5) 10px 20px 0px 0px, rgb(0, 128, 0) 5px 30px 0px 0px inset\]]
-    expected: FAIL
-
   [CSS Animations: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (0.3) should be [rgb(0, 0, 0) 27px 13px 27px 13px\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px inset\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px\] at (1.5) should be [rgb(0, 192, 0) -30px -20px 35px -9px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (-0.3) should be [rgb(0, 0, 0) 7px 33px 7px 33px\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (0.3) should be [rgba(0, 0, 0, 0.3) 6px 6px 6px 6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (-0.3) should be [rgb(0, 0, 0) 10px 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [unset\] to [20px 20px 20px 20px black\] at (-0.3) should be [rgba(0, 0, 0, 0) -6px -6px 0px -6px\]]
-    expected: FAIL
-
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (1) should be [rgb(255, 165, 0) -15px -10px 25px -4px\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px -9px inset\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (0) should be [rgb(0, 0, 0) 30px 10px 30px 10px\]]
@@ -605,33 +230,24 @@
   [Web Animations: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (0.3) should be [rgb(0, 38, 0) 10px 10px 10px 10px\]]
     expected: FAIL
 
-  [CSS Animations: property <box-shadow> from neutral to [20px 20px 20px 20px black\] at (0.3) should be [rgb(0, 0, 0) 13px 27px 13px 27px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (0.6) should be [rgb(0, 0, 0) 24px 16px 24px 16px\]]
-    expected: FAIL
-
   [CSS Animations: property <box-shadow> from [10px 20px yellow, 5px 10px green\] to [inset 5px 10px green, 15px 20px blue\] at (1.5) should be [inset 5px 10px green, 15px 20px blue\]]
-    expected: FAIL
-
-  [CSS Animations: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [inherit\] to [20px 20px 20px 20px black\] at (1.5) should be [rgb(0, 0, 0) 15px 25px 15px 25px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [black 15px 10px 5px 6px\] to [orange -15px -10px 25px -4px\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px -9px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <box-shadow> from [10px 10px 10px 10px black\] to [10px 10px 10px 10px currentColor\] at (0.6) should be [rgb(0, 77, 0) 10px 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px inset\]]
     expected: FAIL
 
   [CSS Animations: property <box-shadow> from [10px 20px yellow, 5px 10px green\] to [inset 5px 10px green, 15px 20px blue\] at (0.3) should be [10px 20px yellow, 5px 10px green\]]
     expected: FAIL
 
   [Web Animations: property <box-shadow> from [15px 10px 5px 6px black\] to [-15px -10px 25px -4px orange\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px 0px\]]
+    expected: FAIL
+
+  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px -9px inset\]]
+    expected: FAIL
+
+  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px 0px inset\]]
+    expected: FAIL
+
+  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px 3px inset\]]
+    expected: FAIL
+
+  [CSS Transitions: property <box-shadow> from [15px 10px 5px 6px black inset\] to [-15px -10px 25px -4px orange inset\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px 9px inset\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-color/animation/color-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-color/animation/color-interpolation.html.ini
@@ -2,30 +2,6 @@
   [color interpolation]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <color> from [initial\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <color> from [initial\] to [green\] at (0.6) should be [rgb(0, 77, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <color> from [initial\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <color> from [black\] to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <color> from [black\] to [orange\] at (1) should be [rgb(255, 165, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <color> from [black\] to [orange\] at (-0.3) should be [rgb(0, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <color> from [black\] to [orange\] at (0.3) should be [rgb(77, 50, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <color> from [black\] to [orange\] at (0.3) should be [rgb(77, 50, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <color> from [inherit\] to [green\] at (-0.3) should be [rgb(0, 0, 255)\]]
     expected: FAIL
 
@@ -38,22 +14,13 @@
   [Web Animations: property <color> from [initial\] to [green\] at (0) should be [rgb(0, 0, 0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <color> from [initial\] to [green\] at (0.6) should be [rgb(0, 77, 0)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <color> from [inherit\] to [green\] at (0.3) should be [rgb(0, 38, 179)\]]
     expected: FAIL
 
   [CSS Transitions: property <color> from neutral to [green\] at (1.5) should be [rgb(0, 65, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <color> from [initial\] to [green\] at (0) should be [rgb(0, 0, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <color> from neutral to [green\] at (-0.3) should be [rgb(255, 255, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <color> from [initial\] to [green\] at (-0.3) should be [rgb(0, 0, 0)\]]
     expected: FAIL
 
   [Web Animations: property <color> from [black\] to [orange\] at (0.3) should be [rgb(77, 50, 0)\]]
@@ -68,12 +35,6 @@
   [Web Animations: property <color> from neutral to [green\] at (0.6) should be [rgb(102, 179, 0)\]]
     expected: FAIL
 
-  [CSS Transitions: property <color> from [initial\] to [green\] at (0.6) should be [rgb(0, 77, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <color> from [unset\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <color> from [initial\] to [green\] at (-0.3) should be [rgb(0, 0, 0)\]]
     expected: FAIL
 
@@ -86,25 +47,13 @@
   [CSS Animations: property <color> from [unset\] to [green\] at (-0.3) should be [rgb(0, 0, 255)\]]
     expected: FAIL
 
-  [CSS Animations: property <color> from [black\] to [orange\] at (0) should be [rgb(0, 0, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <color> from neutral to [green\] at (1.5) should be [rgb(0, 65, 0)\]]
     expected: FAIL
 
   [Web Animations: property <color> from neutral to [green\] at (0.3) should be [rgb(179, 217, 0)\]]
     expected: FAIL
 
-  [CSS Transitions: property <color> from [black\] to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
-    expected: FAIL
-
   [CSS Animations: property <color> from neutral to [green\] at (1.5) should be [rgb(0, 65, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <color> from [inherit\] to [green\] at (0.6) should be [rgb(0, 77, 102)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <color> from [unset\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
     expected: FAIL
 
   [Web Animations: property <color> from [inherit\] to [green\] at (0) should be [rgb(0, 0, 255)\]]
@@ -116,25 +65,13 @@
   [CSS Animations: property <color> from neutral to [green\] at (0.3) should be [rgb(179, 217, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <color> from [black\] to [orange\] at (0.3) should be [rgb(77, 50, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <color> from [black\] to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
     expected: FAIL
 
   [Web Animations: property <color> from neutral to [green\] at (1) should be [rgb(0, 128, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <color> from neutral to [green\] at (1) should be [rgb(0, 128, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <color> from [black\] to [orange\] at (1.5) should be [rgb(255, 248, 0)\]]
-    expected: FAIL
-
   [CSS Transitions: property <color> from [unset\] to [green\] at (0.3) should be [rgb(0, 38, 179)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <color> from [inherit\] to [green\] at (0.6) should be [rgb(0, 77, 102)\]]
     expected: FAIL
 
   [Web Animations: property <color> from [initial\] to [green\] at (0.6) should be [rgb(0, 77, 0)\]]
@@ -146,19 +83,7 @@
   [Web Animations: property <color> from [unset\] to [green\] at (0.3) should be [rgb(0, 38, 179)\]]
     expected: FAIL
 
-  [CSS Animations: property <color> from neutral to [green\] at (0.6) should be [rgb(102, 179, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <color> from [black\] to [orange\] at (0.6) should be [rgb(153, 99, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <color> from [inherit\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
   [CSS Animations: property <color> from [inherit\] to [green\] at (-0.3) should be [rgb(0, 0, 255)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <color> from [unset\] to [green\] at (0.6) should be [rgb(0, 77, 102)\]]
     expected: FAIL
 
   [Web Animations: property <color> from [initial\] to [green\] at (0.3) should be [rgb(0, 38, 0)\]]
@@ -182,15 +107,6 @@
   [CSS Animations: property <color> from [inherit\] to [green\] at (0) should be [rgb(0, 0, 255)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <color> from [initial\] to [green\] at (0.3) should be [rgb(0, 38, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <color> from [black\] to [orange\] at (0.6) should be [rgb(153, 99, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <color> from [initial\] to [green\] at (0.3) should be [rgb(0, 38, 0)\]]
-    expected: FAIL
-
   [CSS Animations: property <color> from [unset\] to [green\] at (0) should be [rgb(0, 0, 255)\]]
     expected: FAIL
 
@@ -198,12 +114,6 @@
     expected: FAIL
 
   [Web Animations: property <color> from [initial\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <color> from neutral to [green\] at (0.6) should be [rgb(102, 179, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <color> from [unset\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
     expected: FAIL
 
   [Web Animations: property <color> from neutral to [green\] at (0) should be [rgb(255, 255, 0)\]]
@@ -221,9 +131,6 @@
   [CSS Animations: property <color> from [unset\] to [green\] at (0.6) should be [rgb(0, 77, 102)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <color> from [black\] to [orange\] at (0.6) should be [rgb(153, 99, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <color> from [unset\] to [green\] at (0.6) should be [rgb(0, 77, 102)\]]
     expected: FAIL
 
@@ -233,36 +140,15 @@
   [CSS Transitions with transition: all: property <color> from neutral to [green\] at (0.3) should be [rgb(179, 217, 0)\]]
     expected: FAIL
 
-  [CSS Transitions: property <color> from [inherit\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <color> from neutral to [green\] at (0.6) should be [rgb(102, 179, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <color> from [inherit\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
-    expected: FAIL
-
   [CSS Animations: property <color> from [inherit\] to [green\] at (0.3) should be [rgb(0, 38, 179)\]]
     expected: FAIL
 
   [Web Animations: property <color> from [unset\] to [green\] at (0) should be [rgb(0, 0, 255)\]]
     expected: FAIL
 
-  [CSS Animations: property <color> from [initial\] to [green\] at (0.3) should be [rgb(0, 38, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <color> from [inherit\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
     expected: FAIL
 
-  [CSS Transitions: property <color> from [unset\] to [green\] at (0.6) should be [rgb(0, 77, 102)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <color> from neutral to [green\] at (1.5) should be [rgb(0, 65, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <color> from [initial\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <color> from [initial\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-color/animation/opacity-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-color/animation/opacity-interpolation.html.ini
@@ -5,28 +5,13 @@
   [Web Animations: property <opacity> from [0\] to [1\] at (0) should be [0\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <opacity> from neutral to [0.2\] at (0.3) should be [0.13\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <opacity> from [inherit\] to [0.2\] at (1.5) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <opacity> from [unset\] to [0.2\] at (0.3) should be [0.76\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <opacity> from [initial\] to [0.2\] at (1.5) should be [0\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <opacity> from [initial\] to [0.2\] at (0.6) should be [0.52\]]
-    expected: FAIL
-
   [CSS Transitions: property <opacity> from [inherit\] to [0.2\] at (1.5) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <opacity> from [unset\] to [0.2\] at (0.3) should be [0.76\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <opacity> from neutral to [0.2\] at (0.6) should be [0.16\]]
     expected: FAIL
 
   [Web Animations: property <opacity> from [inherit\] to [0.2\] at (0.3) should be [0.62\]]
@@ -35,16 +20,7 @@
   [CSS Transitions: property <opacity> from [0\] to [1\] at (1.5) should be [1\]]
     expected: FAIL
 
-  [CSS Animations: property <opacity> from [unset\] to [0.2\] at (1) should be [0.2\]]
-    expected: FAIL
-
-  [CSS Animations: property <opacity> from neutral to [0.2\] at (-0.3) should be [0.07\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <opacity> from [unset\] to [0.2\] at (1.5) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <opacity> from [unset\] to [0.2\] at (0.6) should be [0.52\]]
     expected: FAIL
 
   [Web Animations: property <opacity> from [initial\] to [0.2\] at (0.6) should be [0.52\]]
@@ -62,16 +38,7 @@
   [Web Animations: property <opacity> from [initial\] to [0.2\] at (1) should be [0.2\]]
     expected: FAIL
 
-  [CSS Transitions: property <opacity> from [0\] to [1\] at (0.6) should be [0.6\]]
-    expected: FAIL
-
   [Web Animations: property <opacity> from [0\] to [1\] at (1.5) should be [1\]]
-    expected: FAIL
-
-  [CSS Animations: property <opacity> from neutral to [0.2\] at (0.3) should be [0.13\]]
-    expected: FAIL
-
-  [CSS Transitions: property <opacity> from [inherit\] to [0.2\] at (-0.3) should be [0.98\]]
     expected: FAIL
 
   [Web Animations: property <opacity> from [inherit\] to [0.2\] at (-0.3) should be [0.98\]]
@@ -81,9 +48,6 @@
     expected: FAIL
 
   [Web Animations: property <opacity> from [initial\] to [0.2\] at (-0.3) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions: property <opacity> from [initial\] to [0.2\] at (0.6) should be [0.52\]]
     expected: FAIL
 
   [Web Animations: property <opacity> from [unset\] to [0.2\] at (0.6) should be [0.52\]]
@@ -98,19 +62,7 @@
   [CSS Animations: property <opacity> from [unset\] to [0.2\] at (-0.3) should be [1\]]
     expected: FAIL
 
-  [CSS Transitions: property <opacity> from neutral to [0.2\] at (1.5) should be [0.25\]]
-    expected: FAIL
-
-  [CSS Transitions: property <opacity> from [inherit\] to [0.2\] at (0.3) should be [0.62\]]
-    expected: FAIL
-
-  [CSS Transitions: property <opacity> from neutral to [0.2\] at (-0.3) should be [0.07\]]
-    expected: FAIL
-
   [CSS Transitions: property <opacity> from [unset\] to [0.2\] at (1.5) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <opacity> from [inherit\] to [0.2\] at (-0.3) should be [0.98\]]
     expected: FAIL
 
   [Web Animations: property <opacity> from [0\] to [1\] at (0.3) should be [0.3\]]
@@ -119,16 +71,7 @@
   [Web Animations: property <opacity> from [initial\] to [0.2\] at (1.5) should be [0\]]
     expected: FAIL
 
-  [CSS Animations: property <opacity> from neutral to [0.2\] at (1) should be [0.2\]]
-    expected: FAIL
-
-  [CSS Animations: property <opacity> from neutral to [0.2\] at (0.6) should be [0.16\]]
-    expected: FAIL
-
   [Web Animations: property <opacity> from [inherit\] to [0.2\] at (1.5) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <opacity> from neutral to [0.2\] at (0.6) should be [0.16\]]
     expected: FAIL
 
   [CSS Animations: property <opacity> from [0\] to [1\] at (1.5) should be [1\]]
@@ -137,49 +80,19 @@
   [Web Animations: property <opacity> from [unset\] to [0.2\] at (1) should be [0.2\]]
     expected: FAIL
 
-  [CSS Animations: property <opacity> from [0\] to [1\] at (0) should be [0\]]
-    expected: FAIL
-
   [Web Animations: property <opacity> from [unset\] to [0.2\] at (0) should be [1\]]
-    expected: FAIL
-
-  [CSS Animations: property <opacity> from [inherit\] to [0.2\] at (1) should be [0.2\]]
-    expected: FAIL
-
-  [CSS Animations: property <opacity> from [0\] to [1\] at (1) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <opacity> from neutral to [0.2\] at (-0.3) should be [0.07\]]
     expected: FAIL
 
   [Web Animations: property <opacity> from [inherit\] to [0.2\] at (0.6) should be [0.44\]]
     expected: FAIL
 
-  [CSS Animations: property <opacity> from [initial\] to [0.2\] at (0) should be [1\]]
-    expected: FAIL
-
   [CSS Animations: property <opacity> from [initial\] to [0.2\] at (1.5) should be [0\]]
-    expected: FAIL
-
-  [CSS Animations: property <opacity> from [initial\] to [0.2\] at (1) should be [0.2\]]
     expected: FAIL
 
   [CSS Animations: property <opacity> from [0\] to [1\] at (-0.3) should be [0\]]
     expected: FAIL
 
   [Web Animations: property <opacity> from [unset\] to [0.2\] at (-0.3) should be [1\]]
-    expected: FAIL
-
-  [CSS Animations: property <opacity> from [unset\] to [0.2\] at (0.3) should be [0.76\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <opacity> from [unset\] to [0.2\] at (0.6) should be [0.52\]]
-    expected: FAIL
-
-  [CSS Transitions: property <opacity> from neutral to [0.2\] at (0.3) should be [0.13\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <opacity> from [0\] to [1\] at (0.6) should be [0.6\]]
     expected: FAIL
 
   [Web Animations: property <opacity> from [0\] to [1\] at (1) should be [1\]]
@@ -194,43 +107,16 @@
   [CSS Transitions with transition: all: property <opacity> from [0\] to [1\] at (1.5) should be [1\]]
     expected: FAIL
 
-  [CSS Animations: property <opacity> from neutral to [0.2\] at (1.5) should be [0.25\]]
-    expected: FAIL
-
   [Web Animations: property <opacity> from [0\] to [1\] at (-0.3) should be [0\]]
     expected: FAIL
 
   [Web Animations: property <opacity> from [inherit\] to [0.2\] at (1) should be [0.2\]]
     expected: FAIL
 
-  [CSS Animations: property <opacity> from [unset\] to [0.2\] at (0) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <opacity> from [0\] to [1\] at (0.3) should be [0.3\]]
-    expected: FAIL
-
-  [CSS Transitions: property <opacity> from [0\] to [1\] at (0.3) should be [0.3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <opacity> from [initial\] to [0.2\] at (0.3) should be [0.76\]]
-    expected: FAIL
-
   [CSS Animations: property <opacity> from [inherit\] to [0.2\] at (0.6) should be [0.44\]]
     expected: FAIL
 
   [Web Animations: property <opacity> from [0\] to [1\] at (0.6) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <opacity> from [unset\] to [0.2\] at (0.6) should be [0.52\]]
-    expected: FAIL
-
-  [CSS Transitions: property <opacity> from [inherit\] to [0.2\] at (0.6) should be [0.44\]]
-    expected: FAIL
-
-  [CSS Animations: property <opacity> from [0\] to [1\] at (0.6) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <opacity> from neutral to [0.2\] at (1.5) should be [0.25\]]
     expected: FAIL
 
   [Web Animations: property <opacity> from neutral to [0.2\] at (0.6) should be [0.16\]]
@@ -245,19 +131,10 @@
   [Web Animations: property <opacity> from neutral to [0.2\] at (1.5) should be [0.25\]]
     expected: FAIL
 
-  [CSS Animations: property <opacity> from [0\] to [1\] at (0.3) should be [0.3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <opacity> from [inherit\] to [0.2\] at (0.3) should be [0.62\]]
-    expected: FAIL
-
   [Web Animations: property <opacity> from neutral to [0.2\] at (0) should be [0.1\]]
     expected: FAIL
 
   [Web Animations: property <opacity> from neutral to [0.2\] at (-0.3) should be [0.07\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <opacity> from [inherit\] to [0.2\] at (0.6) should be [0.44\]]
     expected: FAIL
 
   [CSS Animations: property <opacity> from [initial\] to [0.2\] at (-0.3) should be [1\]]
@@ -266,18 +143,27 @@
   [Web Animations: property <opacity> from [initial\] to [0.2\] at (0.3) should be [0.76\]]
     expected: FAIL
 
-  [CSS Transitions: property <opacity> from [initial\] to [0.2\] at (0.3) should be [0.76\]]
-    expected: FAIL
-
-  [CSS Animations: property <opacity> from [initial\] to [0.2\] at (0.3) should be [0.76\]]
-    expected: FAIL
-
   [CSS Animations: property <opacity> from [inherit\] to [0.2\] at (-0.3) should be [0.98\]]
     expected: FAIL
 
-  [CSS Animations: property <opacity> from [initial\] to [0.2\] at (0.6) should be [0.52\]]
+  [CSS Animations: property <opacity> from [inherit\] to [0.2\] at (0.3) should be [0.62\]]
     expected: FAIL
 
-  [CSS Animations: property <opacity> from [inherit\] to [0.2\] at (0.3) should be [0.62\]]
+  [CSS Transitions with transition: all: property <opacity> from [0\] to [1\] at (-0.3) should be [0\]]
+    expected: FAIL
+
+  [CSS Transitions: property <opacity> from [initial\] to [0.2\] at (-0.3) should be [1\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <opacity> from [initial\] to [0.2\] at (-0.3) should be [1\]]
+    expected: FAIL
+
+  [CSS Transitions: property <opacity> from [0\] to [1\] at (-0.3) should be [0\]]
+    expected: FAIL
+
+  [CSS Transitions: property <opacity> from [unset\] to [0.2\] at (-0.3) should be [1\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <opacity> from [unset\] to [0.2\] at (-0.3) should be [1\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-flexbox/animation/flex-basis-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-flexbox/animation/flex-basis-interpolation.html.ini
@@ -8,25 +8,7 @@
   [CSS Animations: property <flex-basis> from [unset\] to [2%\] at (0.6) should be [2%\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <flex-basis> from neutral to [2%\] at (-0.3) should be [0.7%\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from [0px\] to [100px\] at (1.5) should be [150px\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from [inherit\] to [2%\] at (1) should be [2%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-basis> from neutral to [2%\] at (0.3) should be [1.3%\]]
-    expected: FAIL
-
   [CSS Transitions: property <flex-basis> from [0px\] to [100px\] at (0.4) should be [40px\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from [0px\] to [100px\] at (1) should be [100px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-basis> from [inherit\] to [2%\] at (-0.3) should be [3.3%\]]
     expected: FAIL
 
   [Web Animations: property <flex-basis> from neutral to [2%\] at (0) should be [1%\]]
@@ -56,16 +38,7 @@
   [CSS Animations: property <flex-basis> from [unset\] to [2%\] at (1.5) should be [2%\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-basis> from [0%\] to [100%\] at (-0.3) should be [0%\]]
-    expected: FAIL
-
   [Web Animations: property <flex-basis> from [initial\] to [2%\] at (-0.3) should be [initial\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-basis> from [inherit\] to [2%\] at (0.3) should be [2.7%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-basis> from [0%\] to [100%\] at (1.5) should be [150%\]]
     expected: FAIL
 
   [Web Animations: property <flex-basis> from [inherit\] to [2%\] at (0) should be [3%\]]
@@ -80,34 +53,13 @@
   [Web Animations: property <flex-basis> from neutral to [2%\] at (0.3) should be [1.3%\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-basis> from neutral to [2%\] at (-0.3) should be [0.7%\]]
-    expected: FAIL
-
   [Web Animations: property <flex-basis> from [initial\] to [2%\] at (0.6) should be [2%\]]
     expected: FAIL
 
   [CSS Animations: property <flex-basis> from [initial\] to [2%\] at (1.5) should be [2%\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <flex-basis> from neutral to [2%\] at (1.5) should be [2.5%\]]
-    expected: FAIL
-
   [Web Animations: property <flex-basis> from [initial\] to [2%\] at (0.3) should be [initial\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-basis> from [inherit\] to [2%\] at (0.6) should be [2.4%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-basis> from [0px\] to [100px\] at (0.4) should be [40px\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from neutral to [2%\] at (0.3) should be [1.3%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-basis> from [inherit\] to [2%\] at (0.3) should be [2.7%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-basis> from neutral to [2%\] at (0.3) should be [1.3%\]]
     expected: FAIL
 
   [Web Animations: property <flex-basis> from [unset\] to [2%\] at (-0.3) should be [unset\]]
@@ -116,16 +68,7 @@
   [Web Animations: property <flex-basis> from neutral to [2%\] at (0.6) should be [1.6%\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-basis> from neutral to [2%\] at (1.5) should be [2.5%\]]
-    expected: FAIL
-
   [Web Animations: property <flex-basis> from [inherit\] to [2%\] at (-0.3) should be [3.3%\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from neutral to [2%\] at (1.5) should be [2.5%\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from neutral to [2%\] at (0.6) should be [1.6%\]]
     expected: FAIL
 
   [Web Animations: property <flex-basis> from [initial\] to [2%\] at (0.5) should be [2%\]]
@@ -140,25 +83,16 @@
   [Web Animations: property <flex-basis> from [initial\] to [2%\] at (0) should be [initial\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-basis> from [inherit\] to [2%\] at (0.6) should be [2.4%\]]
-    expected: FAIL
-
   [Web Animations: property <flex-basis> from [unset\] to [2%\] at (0.3) should be [unset\]]
     expected: FAIL
 
   [CSS Transitions: property <flex-basis> from [0%\] to [100%\] at (0.6) should be [60%\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-basis> from [0%\] to [100%\] at (1.5) should be [150%\]]
-    expected: FAIL
-
   [Web Animations: property <flex-basis> from [unset\] to [2%\] at (1.5) should be [2%\]]
     expected: FAIL
 
   [Web Animations: property <flex-basis> from [unset\] to [2%\] at (0.5) should be [2%\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from [0px\] to [100px\] at (0.4) should be [40px\]]
     expected: FAIL
 
   [CSS Animations: property <flex-basis> from [unset\] to [2%\] at (0) should be [unset\]]
@@ -173,15 +107,6 @@
   [Web Animations: property <flex-basis> from [0%\] to [100%\] at (1) should be [100%\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <flex-basis> from [0px\] to [100px\] at (0.6) should be [60px\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from [0%\] to [100%\] at (1.5) should be [150%\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from [0%\] to [100%\] at (0.6) should be [60%\]]
-    expected: FAIL
-
   [Web Animations: property <flex-basis> from [0%\] to [100%\] at (0) should be [0%\]]
     expected: FAIL
 
@@ -194,13 +119,7 @@
   [CSS Transitions: property <flex-basis> from [0%\] to [100%\] at (0.4) should be [40%\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-basis> from [0px\] to [100px\] at (1.5) should be [150px\]]
-    expected: FAIL
-
   [CSS Animations: property <flex-basis> from [initial\] to [2%\] at (1) should be [2%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-basis> from [0%\] to [100%\] at (0.4) should be [40%\]]
     expected: FAIL
 
   [Web Animations: property <flex-basis> from [0%\] to [100%\] at (0.6) should be [60%\]]
@@ -212,12 +131,6 @@
   [CSS Animations: property <flex-basis> from [initial\] to [2%\] at (0.3) should be [initial\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-basis> from [inherit\] to [2%\] at (1.5) should be [1.5%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-basis> from neutral to [2%\] at (0.6) should be [1.6%\]]
-    expected: FAIL
-
   [Web Animations: property <flex-basis> from [0px\] to [100px\] at (0.6) should be [60px\]]
     expected: FAIL
 
@@ -225,18 +138,6 @@
     expected: FAIL
 
   [CSS Animations: property <flex-basis> from [unset\] to [2%\] at (1) should be [2%\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from [0px\] to [100px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from [0%\] to [100%\] at (0) should be [0%\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from neutral to [2%\] at (-0.3) should be [0.7%\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from neutral to [2%\] at (1) should be [2%\]]
     expected: FAIL
 
   [Web Animations: property <flex-basis> from [unset\] to [2%\] at (0) should be [unset\]]
@@ -248,16 +149,10 @@
   [Web Animations: property <flex-basis> from neutral to [2%\] at (1.5) should be [2.5%\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <flex-basis> from [0px\] to [100px\] at (1.5) should be [150px\]]
-    expected: FAIL
-
   [Web Animations: property <flex-basis> from [0%\] to [100%\] at (1.5) should be [150%\]]
     expected: FAIL
 
   [Web Animations: property <flex-basis> from [inherit\] to [2%\] at (0.3) should be [2.7%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-basis> from [0%\] to [100%\] at (0.6) should be [60%\]]
     expected: FAIL
 
   [Web Animations: property <flex-basis> from [unset\] to [2%\] at (1) should be [2%\]]
@@ -266,22 +161,7 @@
   [CSS Animations: property <flex-basis> from [inherit\] to [2%\] at (0) should be [3%\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-basis> from neutral to [2%\] at (0.6) should be [1.6%\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from [0px\] to [100px\] at (0.6) should be [60px\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from [0%\] to [100%\] at (0.4) should be [40%\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-basis> from [0px\] to [100px\] at (0) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <flex-basis> from [inherit\] to [2%\] at (-0.3) should be [3.3%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-basis> from [inherit\] to [2%\] at (-0.3) should be [3.3%\]]
     expected: FAIL
 
   [Web Animations: property <flex-basis> from [0px\] to [100px\] at (-0.3) should be [0px\]]
@@ -305,9 +185,21 @@
   [Web Animations: property <flex-basis> from [inherit\] to [2%\] at (0.6) should be [2.4%\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-basis> from [0%\] to [100%\] at (1) should be [100%\]]
+  [CSS Transitions with transition: all: property <flex-basis> from [0px\] to [100px\] at (0.4) should be [40px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <flex-basis> from [inherit\] to [2%\] at (1.5) should be [1.5%\]]
+  [CSS Transitions: property <flex-basis> from [0%\] to [100%\] at (1.5) should be [150%\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <flex-basis> from [0px\] to [100px\] at (0.6) should be [60px\]]
+    expected: FAIL
+
+  [CSS Transitions: property <flex-basis> from [0px\] to [100px\] at (1.5) should be [150px\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <flex-basis> from [0%\] to [100%\] at (0.4) should be [40%\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <flex-basis> from [0%\] to [100%\] at (0.6) should be [60%\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-flexbox/animation/flex-grow-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-flexbox/animation/flex-grow-interpolation.html.ini
@@ -2,22 +2,10 @@
   [flex-grow interpolation]
     expected: FAIL
 
-  [CSS Animations: property <flex-grow> from [1\] to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
   [Web Animations: property <flex-grow> from neutral to [2\] at (0.3) should be [1.3\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-grow> from [1\] to [2\] at (-5) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [unset\] to [2\] at (0.3) should be [0.6\]]
-    expected: FAIL
-
   [Web Animations: property <flex-grow> from [0\] to [1\] at (-0.3) should be [0\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [unset\] to [2\] at (0.6) should be [1.2\]]
     expected: FAIL
 
   [Web Animations: property <flex-grow> from [0\] to [1\] at (-5) should be [0\]]
@@ -29,67 +17,19 @@
   [Web Animations: property <flex-grow> from neutral to [2\] at (0.6) should be [1.6\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-grow> from [inherit\] to [2\] at (1) should be [2\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from [1\] to [2\] at (-0.3) should be [0.7\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from [unset\] to [2\] at (1.5) should be [3\]]
-    expected: FAIL
-
   [Web Animations: property <flex-grow> from [unset\] to [2\] at (1) should be [2\]]
     expected: FAIL
 
   [Web Animations: property <flex-grow> from [1\] to [2\] at (-5) should be [0\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-grow> from [inherit\] to [2\] at (-0.3) should be [3.3\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from neutral to [2\] at (0.3) should be [1.3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from neutral to [2\] at (-0.3) should be [0.7\]]
-    expected: FAIL
-
   [Web Animations: property <flex-grow> from neutral to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from [inherit\] to [2\] at (0.3) should be [2.7\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [1\] to [2\] at (0.6) should be [1.6\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from neutral to [2\] at (0.3) should be [1.3\]]
     expected: FAIL
 
   [Web Animations: property <flex-grow> from [1\] to [2\] at (0.6) should be [1.6\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-grow> from [unset\] to [2\] at (1.5) should be [3\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [0\] to [1\] at (1.5) should be [1.5\]]
-    expected: FAIL
-
   [Web Animations: property <flex-grow> from [0\] to [1\] at (0.3) should be [0.3\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [initial\] to [2\] at (-0.3) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from [unset\] to [2\] at (0.3) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from neutral to [2\] at (0.6) should be [1.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [1\] to [2\] at (0.3) should be [1.3\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from [inherit\] to [2\] at (0.6) should be [2.4\]]
     expected: FAIL
 
   [Web Animations: property <flex-grow> from [inherit\] to [2\] at (-0.3) should be [3.3\]]
@@ -113,31 +53,13 @@
   [CSS Animations: property <flex-grow> from [inherit\] to [2\] at (1.5) should be [1.5\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <flex-grow> from [initial\] to [2\] at (0.3) should be [0.6\]]
-    expected: FAIL
-
   [Web Animations: property <flex-grow> from [unset\] to [2\] at (0) should be [0\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [1\] to [2\] at (-5) should be [0\]]
     expected: FAIL
 
   [Web Animations: property <flex-grow> from neutral to [2\] at (1) should be [2\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-grow> from neutral to [2\] at (-0.3) should be [0.7\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from neutral to [2\] at (1) should be [2\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from [1\] to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
   [Web Animations: property <flex-grow> from [initial\] to [2\] at (0.3) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [1\] to [2\] at (1.5) should be [2.5\]]
     expected: FAIL
 
   [Web Animations: property <flex-grow> from [initial\] to [2\] at (1) should be [2\]]
@@ -149,73 +71,13 @@
   [Web Animations: property <flex-grow> from neutral to [2\] at (0) should be [1\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-grow> from [1\] to [2\] at (0.3) should be [1.3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [0\] to [1\] at (0.3) should be [0.3\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from [initial\] to [2\] at (0.3) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from neutral to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from neutral to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [inherit\] to [2\] at (-0.3) should be [3.3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [1\] to [2\] at (0.6) should be [1.6\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [1\] to [2\] at (0.3) should be [1.3\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from [initial\] to [2\] at (1.5) should be [3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [1\] to [2\] at (-5) should be [0\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [0\] to [1\] at (-5) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [initial\] to [2\] at (1.5) should be [3\]]
-    expected: FAIL
-
   [Web Animations: property <flex-grow> from [unset\] to [2\] at (0.6) should be [1.2\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from neutral to [2\] at (-0.3) should be [0.7\]]
     expected: FAIL
 
   [Web Animations: property <flex-grow> from [0\] to [1\] at (1.5) should be [1.5\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <flex-grow> from neutral to [2\] at (0.6) should be [1.6\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from [initial\] to [2\] at (0.6) should be [1.2\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from [inherit\] to [2\] at (1.5) should be [1.5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [initial\] to [2\] at (0.6) should be [1.2\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from neutral to [2\] at (0.3) should be [1.3\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [unset\] to [2\] at (-0.3) should be [0\]]
-    expected: FAIL
-
   [Web Animations: property <flex-grow> from [inherit\] to [2\] at (1.5) should be [1.5\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [0\] to [1\] at (-0.3) should be [0\]]
     expected: FAIL
 
   [Web Animations: property <flex-grow> from [initial\] to [2\] at (0.6) should be [1.2\]]
@@ -224,31 +86,10 @@
   [CSS Animations: property <flex-grow> from [inherit\] to [2\] at (0) should be [3\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-grow> from [0\] to [1\] at (0.6) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [initial\] to [2\] at (0.3) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [initial\] to [2\] at (1.5) should be [3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [inherit\] to [2\] at (0.6) should be [2.4\]]
-    expected: FAIL
-
   [CSS Animations: property <flex-grow> from [inherit\] to [2\] at (0.3) should be [2.7\]]
     expected: FAIL
 
   [Web Animations: property <flex-grow> from [inherit\] to [2\] at (1) should be [2\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [unset\] to [2\] at (1) should be [2\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [unset\] to [2\] at (0.3) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from [0\] to [1\] at (0.3) should be [0.3\]]
     expected: FAIL
 
   [Web Animations: property <flex-grow> from [inherit\] to [2\] at (0) should be [3\]]
@@ -257,34 +98,10 @@
   [Web Animations: property <flex-grow> from [initial\] to [2\] at (1.5) should be [3\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-grow> from [1\] to [2\] at (-0.3) should be [0.7\]]
-    expected: FAIL
-
   [Web Animations: property <flex-grow> from [unset\] to [2\] at (0.3) should be [0.6\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-grow> from [1\] to [2\] at (0.6) should be [1.6\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [1\] to [2\] at (-0.3) should be [0.7\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from [unset\] to [2\] at (0.6) should be [1.2\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [unset\] to [2\] at (1.5) should be [3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [inherit\] to [2\] at (0.3) should be [2.7\]]
-    expected: FAIL
-
   [CSS Animations: property <flex-grow> from [inherit\] to [2\] at (-0.3) should be [3.3\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [initial\] to [2\] at (0.6) should be [1.2\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [unset\] to [2\] at (0.6) should be [1.2\]]
     expected: FAIL
 
   [Web Animations: property <flex-grow> from [1\] to [2\] at (-0.3) should be [0.7\]]
@@ -293,31 +110,10 @@
   [Web Animations: property <flex-grow> from [0\] to [1\] at (0.6) should be [0.6\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-grow> from [0\] to [1\] at (0.6) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [initial\] to [2\] at (0) should be [0\]]
-    expected: FAIL
-
   [Web Animations: property <flex-grow> from [1\] to [2\] at (1) should be [2\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-grow> from [0\] to [1\] at (0.3) should be [0.3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [0\] to [1\] at (1.5) should be [1.5\]]
-    expected: FAIL
-
   [Web Animations: property <flex-grow> from neutral to [2\] at (-0.3) should be [0.7\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-grow> from [0\] to [1\] at (1.5) should be [1.5\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [0\] to [1\] at (0) should be [0\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from neutral to [2\] at (0.6) should be [1.6\]]
     expected: FAIL
 
   [Web Animations: property <flex-grow> from [1\] to [2\] at (0) should be [1\]]
@@ -326,28 +122,10 @@
   [Web Animations: property <flex-grow> from [initial\] to [2\] at (-0.3) should be [0\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-grow> from [1\] to [2\] at (1) should be [2\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from neutral to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [0\] to [1\] at (0.6) should be [0.6\]]
-    expected: FAIL
-
   [Web Animations: property <flex-grow> from [unset\] to [2\] at (1.5) should be [3\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-grow> from [unset\] to [2\] at (0) should be [0\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-grow> from [initial\] to [2\] at (1) should be [2\]]
-    expected: FAIL
-
   [Web Animations: property <flex-grow> from [inherit\] to [2\] at (0.3) should be [2.7\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-grow> from [inherit\] to [2\] at (1.5) should be [1.5\]]
     expected: FAIL
 
   [CSS Animations: property <flex-grow> from [inherit\] to [2\] at (0.6) should be [2.4\]]

--- a/tests/wpt/metadata/css/css-flexbox/animation/flex-shrink-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-flexbox/animation/flex-shrink-interpolation.html.ini
@@ -8,25 +8,10 @@
   [Web Animations: property <flex-shrink> from neutral to [2\] at (-0.3) should be [1.35\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <flex-shrink> from [unset\] to [2\] at (0.6) should be [1.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [initial\] to [2\] at (0) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [unset\] to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
   [CSS Animations: property <flex-shrink> from [inherit\] to [2\] at (0) should be [3\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-shrink> from [initial\] to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
   [CSS Animations: property <flex-shrink> from [inherit\] to [2\] at (0.6) should be [2.4\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from neutral to [2\] at (0.3) should be [1.65\]]
     expected: FAIL
 
   [Web Animations: property <flex-shrink> from [1\] to [2\] at (1.5) should be [2.5\]]
@@ -38,34 +23,10 @@
   [Web Animations: property <flex-shrink> from [0\] to [1\] at (1) should be [1\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <flex-shrink> from [1\] to [2\] at (-5) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [inherit\] to [2\] at (1.5) should be [1.5\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from neutral to [2\] at (1) should be [2\]]
-    expected: FAIL
-
   [Web Animations: property <flex-shrink> from [0\] to [1\] at (0.6) should be [0.6\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-shrink> from neutral to [2\] at (0.6) should be [1.8\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [unset\] to [2\] at (0.6) should be [1.6\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [1\] to [2\] at (-0.3) should be [0.7\]]
-    expected: FAIL
-
   [Web Animations: property <flex-shrink> from [unset\] to [2\] at (0.3) should be [1.3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [inherit\] to [2\] at (-0.3) should be [3.3\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from neutral to [2\] at (1.5) should be [2.25\]]
     expected: FAIL
 
   [Web Animations: property <flex-shrink> from [unset\] to [2\] at (0) should be [1\]]
@@ -74,31 +35,7 @@
   [Web Animations: property <flex-shrink> from [unset\] to [2\] at (-0.3) should be [0.7\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-shrink> from [1\] to [2\] at (0.6) should be [1.6\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [initial\] to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [unset\] to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [unset\] to [2\] at (0.3) should be [1.3\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from neutral to [2\] at (1.5) should be [2.25\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from neutral to [2\] at (0.3) should be [1.65\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [1\] to [2\] at (0.6) should be [1.6\]]
-    expected: FAIL
-
   [Web Animations: property <flex-shrink> from [inherit\] to [2\] at (1.5) should be [1.5\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [1\] to [2\] at (-5) should be [0\]]
     expected: FAIL
 
   [Web Animations: property <flex-shrink> from [initial\] to [2\] at (0.6) should be [1.6\]]
@@ -107,46 +44,10 @@
   [Web Animations: property <flex-shrink> from [0\] to [1\] at (1.5) should be [1.5\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-shrink> from [initial\] to [2\] at (0.6) should be [1.6\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [inherit\] to [2\] at (0.6) should be [2.4\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [unset\] to [2\] at (-0.3) should be [0.7\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from neutral to [2\] at (-0.3) should be [1.35\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [inherit\] to [2\] at (0.6) should be [2.4\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [1\] to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [0\] to [1\] at (1.5) should be [1.5\]]
-    expected: FAIL
-
   [Web Animations: property <flex-shrink> from neutral to [2\] at (0.6) should be [1.8\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-shrink> from [0\] to [1\] at (-5) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [1\] to [2\] at (0.6) should be [1.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [0\] to [1\] at (0.6) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [1\] to [2\] at (1) should be [2\]]
-    expected: FAIL
-
   [Web Animations: property <flex-shrink> from [0\] to [1\] at (-5) should be [0\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [initial\] to [2\] at (1) should be [2\]]
     expected: FAIL
 
   [Web Animations: property <flex-shrink> from [initial\] to [2\] at (-0.3) should be [0.7\]]
@@ -155,100 +56,19 @@
   [CSS Animations: property <flex-shrink> from [inherit\] to [2\] at (0.3) should be [2.7\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-shrink> from [unset\] to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from neutral to [2\] at (-0.3) should be [1.35\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [unset\] to [2\] at (1) should be [2\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [0\] to [1\] at (-0.3) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [initial\] to [2\] at (-0.3) should be [0.7\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [0\] to [1\] at (0.6) should be [0.6\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [inherit\] to [2\] at (-0.3) should be [3.3\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [0\] to [1\] at (1.5) should be [1.5\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [1\] to [2\] at (-0.3) should be [0.7\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [unset\] to [2\] at (0.3) should be [1.3\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [1\] to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [0\] to [1\] at (0.3) should be [0.3\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [1\] to [2\] at (0.3) should be [1.3\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [initial\] to [2\] at (0.3) should be [1.3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [1\] to [2\] at (0.3) should be [1.3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from neutral to [2\] at (0.3) should be [1.65\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [inherit\] to [2\] at (1.5) should be [1.5\]]
-    expected: FAIL
-
   [Web Animations: property <flex-shrink> from [0\] to [1\] at (0) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [0\] to [1\] at (0.3) should be [0.3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [initial\] to [2\] at (0.6) should be [1.6\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [unset\] to [2\] at (0) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [1\] to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [unset\] to [2\] at (-0.3) should be [0.7\]]
     expected: FAIL
 
   [Web Animations: property <flex-shrink> from [1\] to [2\] at (0) should be [1\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-shrink> from neutral to [2\] at (0.6) should be [1.8\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [initial\] to [2\] at (0.6) should be [1.6\]]
-    expected: FAIL
-
   [Web Animations: property <flex-shrink> from [inherit\] to [2\] at (0.6) should be [2.4\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [initial\] to [2\] at (0.3) should be [1.3\]]
     expected: FAIL
 
   [Web Animations: property <flex-shrink> from [initial\] to [2\] at (1) should be [2\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-shrink> from [1\] to [2\] at (-5) should be [0\]]
-    expected: FAIL
-
   [Web Animations: property <flex-shrink> from [1\] to [2\] at (-5) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [1\] to [2\] at (0.3) should be [1.3\]]
     expected: FAIL
 
   [Web Animations: property <flex-shrink> from [initial\] to [2\] at (0.3) should be [1.3\]]
@@ -260,22 +80,10 @@
   [Web Animations: property <flex-shrink> from [initial\] to [2\] at (1.5) should be [2.5\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-shrink> from neutral to [2\] at (-0.3) should be [1.35\]]
-    expected: FAIL
-
   [Web Animations: property <flex-shrink> from [inherit\] to [2\] at (1) should be [2\]]
     expected: FAIL
 
   [Web Animations: property <flex-shrink> from neutral to [2\] at (0) should be [1.5\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [inherit\] to [2\] at (1) should be [2\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [0\] to [1\] at (0) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [unset\] to [2\] at (0.6) should be [1.6\]]
     expected: FAIL
 
   [Web Animations: property <flex-shrink> from [1\] to [2\] at (-0.3) should be [0.7\]]
@@ -287,31 +95,10 @@
   [Web Animations: property <flex-shrink> from neutral to [2\] at (1.5) should be [2.25\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <flex-shrink> from [inherit\] to [2\] at (0.3) should be [2.7\]]
-    expected: FAIL
-
   [Web Animations: property <flex-shrink> from [1\] to [2\] at (1) should be [2\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-shrink> from [initial\] to [2\] at (1.5) should be [2.5\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [1\] to [2\] at (0) should be [1\]]
-    expected: FAIL
-
   [Web Animations: property <flex-shrink> from [unset\] to [2\] at (1) should be [2\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [0\] to [1\] at (0.3) should be [0.3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from neutral to [2\] at (0.6) should be [1.8\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [inherit\] to [2\] at (0.3) should be [2.7\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [0\] to [1\] at (0.6) should be [0.6\]]
     expected: FAIL
 
   [Web Animations: property <flex-shrink> from [1\] to [2\] at (0.6) should be [1.6\]]
@@ -320,28 +107,13 @@
   [Web Animations: property <flex-shrink> from neutral to [2\] at (1) should be [2\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-shrink> from [0\] to [1\] at (1) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions: property <flex-shrink> from [unset\] to [2\] at (0.3) should be [1.3\]]
-    expected: FAIL
-
   [Web Animations: property <flex-shrink> from neutral to [2\] at (0.3) should be [1.65\]]
     expected: FAIL
 
   [Web Animations: property <flex-shrink> from [0\] to [1\] at (0.3) should be [0.3\]]
     expected: FAIL
 
-  [CSS Transitions: property <flex-shrink> from [initial\] to [2\] at (-0.3) should be [0.7\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [1\] to [2\] at (-0.3) should be [0.7\]]
-    expected: FAIL
-
   [CSS Animations: property <flex-shrink> from [inherit\] to [2\] at (-0.3) should be [3.3\]]
-    expected: FAIL
-
-  [CSS Animations: property <flex-shrink> from [initial\] to [2\] at (-0.3) should be [0.7\]]
     expected: FAIL
 
   [Web Animations: property <flex-shrink> from [1\] to [2\] at (0.3) should be [1.3\]]
@@ -350,18 +122,12 @@
   [Web Animations: property <flex-shrink> from [inherit\] to [2\] at (0.3) should be [2.7\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <flex-shrink> from neutral to [2\] at (1.5) should be [2.25\]]
-    expected: FAIL
-
   [Web Animations: property <flex-shrink> from [unset\] to [2\] at (1.5) should be [2.5\]]
     expected: FAIL
 
   [Web Animations: property <flex-shrink> from [inherit\] to [2\] at (0) should be [3\]]
     expected: FAIL
 
-  [CSS Animations: property <flex-shrink> from [initial\] to [2\] at (0.3) should be [1.3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <flex-shrink> from [unset\] to [2\] at (-0.3) should be [0.7\]]
+  [CSS Animations: property <flex-shrink> from [inherit\] to [2\] at (1.5) should be [1.5\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-flexbox/animation/order-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-flexbox/animation/order-interpolation.html.ini
@@ -2,19 +2,7 @@
   [order interpolation]
     expected: FAIL
 
-  [CSS Transitions: property <order> from neutral to [20\] at (0.6) should be [16\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [initial\] to [20\] at (0.3) should be [6\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [initial\] to [20\] at (1.5) should be [30\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [unset\] to [20\] at (0.3) should be [6\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [initial\] to [20\] at (0) should be [0\]]
     expected: FAIL
 
   [Web Animations: property <order> from [inherit\] to [20\] at (0.6) should be [24\]]
@@ -29,136 +17,37 @@
   [Web Animations: property <order> from [inherit\] to [20\] at (-0.5) should be [35\]]
     expected: FAIL
 
-  [CSS Animations: property <order> from [10\] to [20\] at (0.3) should be [13\]]
-    expected: FAIL
-
   [CSS Animations: property <order> from [inherit\] to [20\] at (-3) should be [60\]]
     expected: FAIL
 
   [Web Animations: property <order> from neutral to [20\] at (-3) should be [-20\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <order> from neutral to [20\] at (1.5) should be [25\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [initial\] to [20\] at (-3) should be [-60\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [2\] to [4\] at (1.5) should be [5\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [2\] to [4\] at (0.6) should be [3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [unset\] to [20\] at (-0.5) should be [-10\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [10\] to [20\] at (-3) should be [-20\]]
     expected: FAIL
 
   [Web Animations: property <order> from [10\] to [20\] at (1) should be [20\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <order> from [2\] to [4\] at (0.3) should be [3\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [unset\] to [20\] at (-0.5) should be [-10\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [10\] to [20\] at (-0.5) should be [5\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [10\] to [20\] at (1.5) should be [25\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [initial\] to [20\] at (0.3) should be [6\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [unset\] to [20\] at (0.6) should be [12\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [inherit\] to [20\] at (0) should be [30\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from neutral to [20\] at (0.3) should be [13\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from neutral to [20\] at (0.6) should be [16\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [unset\] to [20\] at (1.5) should be [30\]]
     expected: FAIL
 
   [Web Animations: property <order> from [inherit\] to [20\] at (1.5) should be [15\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <order> from neutral to [20\] at (0.3) should be [13\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from neutral to [20\] at (-0.5) should be [5\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [unset\] to [20\] at (0.6) should be [12\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from neutral to [20\] at (0.6) should be [16\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [10\] to [20\] at (0.6) should be [16\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [unset\] to [20\] at (0.3) should be [6\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [inherit\] to [20\] at (0.6) should be [24\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [initial\] to [20\] at (0.6) should be [12\]]
     expected: FAIL
 
   [Web Animations: property <order> from [2\] to [4\] at (1) should be [4\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <order> from [10\] to [20\] at (1.5) should be [25\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from neutral to [20\] at (1.5) should be [25\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [initial\] to [20\] at (0.3) should be [6\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [2\] to [4\] at (-0.5) should be [1\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [10\] to [20\] at (1.5) should be [25\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [inherit\] to [20\] at (-3) should be [60\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [10\] to [20\] at (1.5) should be [25\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from neutral to [20\] at (1) should be [20\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [2\] to [4\] at (0) should be [2\]]
     expected: FAIL
 
   [CSS Animations: property <order> from [inherit\] to [20\] at (1.5) should be [15\]]
     expected: FAIL
 
-  [CSS Transitions: property <order> from [10\] to [20\] at (0.3) should be [13\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [2\] to [4\] at (-0.5) should be [1\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [unset\] to [20\] at (-3) should be [-60\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [initial\] to [20\] at (0.6) should be [12\]]
     expected: FAIL
 
   [CSS Animations: property <order> from [inherit\] to [20\] at (0.3) should be [27\]]
@@ -173,91 +62,28 @@
   [Web Animations: property <order> from [initial\] to [20\] at (-3) should be [-60\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <order> from [initial\] to [20\] at (1.5) should be [30\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [inherit\] to [20\] at (0.3) should be [27\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [10\] to [20\] at (-3) should be [-20\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [initial\] to [20\] at (-3) should be [-60\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [unset\] to [20\] at (0) should be [0\]]
     expected: FAIL
 
   [Web Animations: property <order> from [initial\] to [20\] at (1) should be [20\]]
     expected: FAIL
 
-  [CSS Animations: property <order> from [2\] to [4\] at (-3) should be [-4\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [inherit\] to [20\] at (-3) should be [60\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [2\] to [4\] at (-0.5) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [inherit\] to [20\] at (-0.5) should be [35\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [2\] to [4\] at (1.5) should be [5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [initial\] to [20\] at (0.3) should be [6\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [initial\] to [20\] at (1.5) should be [30\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [2\] to [4\] at (1.5) should be [5\]]
     expected: FAIL
 
   [Web Animations: property <order> from neutral to [20\] at (0.3) should be [13\]]
     expected: FAIL
 
-  [CSS Animations: property <order> from [unset\] to [20\] at (-0.5) should be [-10\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [10\] to [20\] at (0.3) should be [13\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [unset\] to [20\] at (0.6) should be [12\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [unset\] to [20\] at (1.5) should be [30\]]
     expected: FAIL
 
   [Web Animations: property <order> from [unset\] to [20\] at (0) should be [0\]]
     expected: FAIL
 
-  [CSS Transitions: property <order> from [2\] to [4\] at (-0.5) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [2\] to [4\] at (0.6) should be [3\]]
-    expected: FAIL
-
   [CSS Animations: property <order> from [inherit\] to [20\] at (0) should be [30\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <order> from [initial\] to [20\] at (-0.5) should be [-10\]]
-    expected: FAIL
-
   [Web Animations: property <order> from neutral to [20\] at (0) should be [10\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [2\] to [4\] at (0.3) should be [3\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [2\] to [4\] at (-3) should be [-4\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from neutral to [20\] at (-3) should be [-20\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [10\] to [20\] at (-0.5) should be [5\]]
     expected: FAIL
 
   [CSS Animations: property <order> from [inherit\] to [20\] at (-0.5) should be [35\]]
@@ -266,88 +92,16 @@
   [Web Animations: property <order> from neutral to [20\] at (0.6) should be [16\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <order> from neutral to [20\] at (-0.5) should be [5\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [inherit\] to [20\] at (0.3) should be [27\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from neutral to [20\] at (0.3) should be [13\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [10\] to [20\] at (1) should be [20\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [2\] to [4\] at (0.3) should be [3\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [inherit\] to [20\] at (1) should be [20\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [unset\] to [20\] at (1) should be [20\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [initial\] to [20\] at (1) should be [20\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [unset\] to [20\] at (0.6) should be [12\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [2\] to [4\] at (1.5) should be [5\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from neutral to [20\] at (-3) should be [-20\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [inherit\] to [20\] at (0.6) should be [24\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [10\] to [20\] at (0.3) should be [13\]]
-    expected: FAIL
-
   [CSS Animations: property <order> from [inherit\] to [20\] at (0.6) should be [24\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [initial\] to [20\] at (0.6) should be [12\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [10\] to [20\] at (-3) should be [-20\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [2\] to [4\] at (1) should be [4\]]
     expected: FAIL
 
   [Web Animations: property <order> from [2\] to [4\] at (0) should be [2\]]
     expected: FAIL
 
-  [CSS Transitions: property <order> from [inherit\] to [20\] at (1.5) should be [15\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [10\] to [20\] at (-3) should be [-20\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [initial\] to [20\] at (0) should be [0\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <order> from [inherit\] to [20\] at (1.5) should be [15\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [2\] to [4\] at (0.6) should be [3\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [inherit\] to [20\] at (-0.5) should be [35\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [unset\] to [20\] at (-3) should be [-60\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [initial\] to [20\] at (-0.5) should be [-10\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from neutral to [20\] at (1.5) should be [25\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [initial\] to [20\] at (-0.5) should be [-10\]]
     expected: FAIL
 
   [Web Animations: property <order> from [inherit\] to [20\] at (0.3) should be [27\]]
@@ -356,22 +110,10 @@
   [Web Animations: property <order> from [initial\] to [20\] at (1.5) should be [30\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <order> from neutral to [20\] at (-3) should be [-20\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [2\] to [4\] at (0.6) should be [3\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <order> from [unset\] to [20\] at (0.3) should be [6\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [10\] to [20\] at (0.6) should be [16\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [2\] to [4\] at (0.3) should be [3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [10\] to [20\] at (-0.5) should be [5\]]
     expected: FAIL
 
   [Web Animations: property <order> from neutral to [20\] at (1.5) should be [25\]]
@@ -380,19 +122,7 @@
   [Web Animations: property <order> from [inherit\] to [20\] at (1) should be [20\]]
     expected: FAIL
 
-  [CSS Transitions: property <order> from [unset\] to [20\] at (-3) should be [-60\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [inherit\] to [20\] at (-3) should be [60\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [2\] to [4\] at (-3) should be [-4\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [initial\] to [20\] at (-0.5) should be [-10\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [10\] to [20\] at (0.6) should be [16\]]
     expected: FAIL
 
   [Web Animations: property <order> from [unset\] to [20\] at (0.3) should be [6\]]
@@ -401,25 +131,13 @@
   [Web Animations: property <order> from neutral to [20\] at (-0.5) should be [5\]]
     expected: FAIL
 
-  [CSS Animations: property <order> from neutral to [20\] at (-0.5) should be [5\]]
-    expected: FAIL
-
   [Web Animations: property <order> from [unset\] to [20\] at (-0.5) should be [-10\]]
-    expected: FAIL
-
-  [CSS Animations: property <order> from [unset\] to [20\] at (1.5) should be [30\]]
-    expected: FAIL
-
-  [CSS Transitions: property <order> from [initial\] to [20\] at (-3) should be [-60\]]
     expected: FAIL
 
   [Web Animations: property <order> from [unset\] to [20\] at (1) should be [20\]]
     expected: FAIL
 
   [Web Animations: property <order> from [unset\] to [20\] at (1.5) should be [30\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <order> from [unset\] to [20\] at (-3) should be [-60\]]
     expected: FAIL
 
   [Web Animations: property <order> from [10\] to [20\] at (0) should be [10\]]

--- a/tests/wpt/metadata/css/css-fonts/animations/font-size-interpolation-001.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/animations/font-size-interpolation-001.html.ini
@@ -11,22 +11,10 @@
   [Web Animations: property <font-size> from [4px\] to [14px\] at (0.6) should be [10px\]]
     expected: FAIL
 
-  [CSS Animations: property <font-size> from [4px\] to [14px\] at (0.3) should be [7px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [unset\] to [20px\] at (-2) should be [50px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <font-size> from [4px\] to [14px\] at (-0.3) should be [1px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [4px\] to [14px\] at (-0.3) should be [1px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [unset\] to [20px\] at (0) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [4px\] to [14px\] at (1.5) should be [19px\]]
     expected: FAIL
 
   [CSS Animations: property <font-size> from [inherit\] to [20px\] at (-2) should be [50px\]]
@@ -35,46 +23,13 @@
   [Web Animations: property <font-size> from [unset\] to [20px\] at (-0.3) should be [33px\]]
     expected: FAIL
 
-  [CSS Animations: property <font-size> from neutral to [20px\] at (-2) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [inherit\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [initial\] to [20px\] at (0.3) should be [17.2px\]]
     expected: FAIL
 
   [Web Animations: property <font-size> from [4px\] to [14px\] at (0) should be [4px\]]
     expected: FAIL
 
-  [CSS Animations: property <font-size> from [4px\] to [14px\] at (-0.3) should be [1px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [4px\] to [14px\] at (0) should be [4px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [inherit\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [4px\] to [14px\] at (0.6) should be [10px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from neutral to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [4px\] to [14px\] at (0.6) should be [10px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [unset\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [inherit\] to [20px\] at (0.3) should be [27px\]]
     expected: FAIL
 
   [Web Animations: property <font-size> from [inherit\] to [20px\] at (0) should be [30px\]]
@@ -83,34 +38,13 @@
   [CSS Animations: property <font-size> from [inherit\] to [20px\] at (0.6) should be [24px\]]
     expected: FAIL
 
-  [CSS Transitions: property <font-size> from neutral to [20px\] at (-2) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [inherit\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [initial\] to [20px\] at (-0.3) should be [14.8px\]]
     expected: FAIL
 
   [CSS Animations: property <font-size> from [unset\] to [20px\] at (0.3) should be [27px\]]
     expected: FAIL
 
-  [CSS Transitions: property <font-size> from [unset\] to [20px\] at (-2) should be [50px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [initial\] to [20px\] at (-2) should be [8px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [4px\] to [14px\] at (1.5) should be [19px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [unset\] to [20px\] at (-0.3) should be [33px\]]
     expected: FAIL
 
   [CSS Animations: property <font-size> from [inherit\] to [20px\] at (0.3) should be [27px\]]
@@ -119,115 +53,28 @@
   [CSS Animations: property <font-size> from [unset\] to [20px\] at (-0.3) should be [33px\]]
     expected: FAIL
 
-  [CSS Animations: property <font-size> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [initial\] to [20px\] at (0.6) should be [18.4px\]]
-    expected: FAIL
-
   [CSS Animations: property <font-size> from [unset\] to [20px\] at (0) should be [30px\]]
     expected: FAIL
 
   [Web Animations: property <font-size> from [initial\] to [20px\] at (0.3) should be [17.2px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <font-size> from [unset\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [initial\] to [20px\] at (1.5) should be [22px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [4px\] to [14px\] at (-2) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [4px\] to [14px\] at (-2) should be [0px\]]
     expected: FAIL
 
   [Web Animations: property <font-size> from [unset\] to [20px\] at (0.6) should be [24px\]]
     expected: FAIL
 
-  [CSS Transitions: property <font-size> from [initial\] to [20px\] at (0.6) should be [18.4px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from neutral to [20px\] at (-2) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [unset\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [unset\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [initial\] to [20px\] at (0.6) should be [18.4px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [initial\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [initial\] to [20px\] at (0.3) should be [17.2px\]]
     expected: FAIL
 
   [CSS Animations: property <font-size> from [inherit\] to [20px\] at (1.5) should be [15px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <font-size> from [initial\] to [20px\] at (-0.3) should be [14.8px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [4px\] to [14px\] at (1) should be [14px\]]
     expected: FAIL
 
-  [CSS Transitions: property <font-size> from [initial\] to [20px\] at (1.5) should be [22px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [initial\] to [20px\] at (1.5) should be [22px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [4px\] to [14px\] at (0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [4px\] to [14px\] at (1.5) should be [19px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [4px\] to [14px\] at (1) should be [14px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [unset\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [unset\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [4px\] to [14px\] at (-2) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [inherit\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from neutral to [20px\] at (-0.3) should be [7px\]]
     expected: FAIL
 
   [CSS Animations: property <font-size> from [unset\] to [20px\] at (0.6) should be [24px\]]
@@ -236,49 +83,16 @@
   [Web Animations: property <font-size> from [initial\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <font-size> from [unset\] to [20px\] at (-2) should be [50px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [initial\] to [20px\] at (0.6) should be [18.4px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [initial\] to [20px\] at (-2) should be [8px\]]
-    expected: FAIL
-
   [CSS Animations: property <font-size> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
     expected: FAIL
 
   [Web Animations: property <font-size> from neutral to [20px\] at (-2) should be [0px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <font-size> from [initial\] to [20px\] at (-2) should be [8px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [unset\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [inherit\] to [20px\] at (-2) should be [50px\]]
     expected: FAIL
 
-  [CSS Transitions: property <font-size> from [inherit\] to [20px\] at (-2) should be [50px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [inherit\] to [20px\] at (-2) should be [50px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [4px\] to [14px\] at (0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [initial\] to [20px\] at (0) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [initial\] to [20px\] at (0.3) should be [17.2px\]]
     expected: FAIL
 
   [Web Animations: property <font-size> from neutral to [20px\] at (-0.3) should be [7px\]]
@@ -296,15 +110,6 @@
   [Web Animations: property <font-size> from [inherit\] to [20px\] at (0.6) should be [24px\]]
     expected: FAIL
 
-  [CSS Animations: property <font-size> from [initial\] to [20px\] at (-0.3) should be [14.8px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [unset\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [inherit\] to [20px\] at (1.5) should be [15px\]]
     expected: FAIL
 
@@ -317,22 +122,10 @@
   [Web Animations: property <font-size> from neutral to [20px\] at (0) should be [10px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <font-size> from [initial\] to [20px\] at (1.5) should be [22px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [initial\] to [20px\] at (0) should be [16px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from neutral to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
   [Web Animations: property <font-size> from [4px\] to [14px\] at (-2) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [inherit\] to [20px\] at (0.6) should be [24px\]]
     expected: FAIL
 
   [Web Animations: property <font-size> from [4px\] to [14px\] at (-0.3) should be [1px\]]
@@ -347,12 +140,6 @@
   [Web Animations: property <font-size> from [unset\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <font-size> from [unset\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
   [CSS Animations: property <font-size> from [unset\] to [20px\] at (-2) should be [50px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [4px\] to [14px\] at (1.5) should be [19px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-fonts/animations/font-size-interpolation-002.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/animations/font-size-interpolation-002.html.ini
@@ -5,9 +5,6 @@
   [CSS Animations: property <font-size> from [unset\] to [20px\] at (-0.3) should be [7px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <font-size> from [unset\] to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [unset\] to [20px\] at (0.6) should be [16px\]]
     expected: FAIL
 
@@ -17,22 +14,7 @@
   [CSS Animations: property <font-size> from [unset\] to [20px\] at (-2) should be [0px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <font-size> from [unset\] to [20px\] at (-2) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [unset\] to [20px\] at (0) should be [10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [unset\] to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [unset\] to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [unset\] to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [unset\] to [20px\] at (0.6) should be [16px\]]
     expected: FAIL
 
   [CSS Animations: property <font-size> from [unset\] to [20px\] at (0.3) should be [13px\]]
@@ -41,28 +23,16 @@
   [Web Animations: property <font-size> from [unset\] to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
-  [CSS Transitions: property <font-size> from [unset\] to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [unset\] to [20px\] at (-0.3) should be [7px\]]
     expected: FAIL
 
   [CSS Animations: property <font-size> from [unset\] to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
-  [CSS Transitions: property <font-size> from [unset\] to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [unset\] to [20px\] at (-2) should be [0px\]]
     expected: FAIL
 
-  [CSS Transitions: property <font-size> from [unset\] to [20px\] at (-2) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <font-size> from [unset\] to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [unset\] to [20px\] at (0.6) should be [16px\]]
     expected: FAIL
 
   [Web Animations: property <font-size> from [unset\] to [20px\] at (0.3) should be [13px\]]

--- a/tests/wpt/metadata/css/css-fonts/animations/font-size-interpolation-003.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/animations/font-size-interpolation-003.html.ini
@@ -5,43 +5,13 @@
   [Web Animations: property <font-size> from [10px\] to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 
-  [CSS Animations: property <font-size> from [10px\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [10px\] to [20px\] at (-2) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [10px\] to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [10px\] to [20px\] at (0.6) should be [16px\]]
     expected: FAIL
 
   [Web Animations: property <font-size> from [10px\] to [20px\] at (-2) should be [0px\]]
     expected: FAIL
 
-  [CSS Transitions: property <font-size> from [10px\] to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [10px\] to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [10px\] to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [10px\] to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [10px\] to [20px\] at (0) should be [10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [10px\] to [20px\] at (-2) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [10px\] to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [10px\] to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 
   [Web Animations: property <font-size> from [10px\] to [20px\] at (0.6) should be [16px\]]
@@ -50,24 +20,6 @@
   [Web Animations: property <font-size> from [10px\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Animations: property <font-size> from [10px\] to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [10px\] to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <font-size> from [10px\] to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [10px\] to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Animations: property <font-size> from [10px\] to [20px\] at (-2) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <font-size> from [10px\] to [20px\] at (0) should be [10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <font-size> from [10px\] to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-fonts/variations/font-style-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/variations/font-style-interpolation.html.ini
@@ -1,8 +1,0 @@
-[font-style-interpolation.html]
-  bug: https://github.com/servo/servo/issues/21570
-  expected: TIMEOUT
-  [font-style transition]
-    expected: TIMEOUT
-  [font-style animation]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata/css/css-fonts/variations/font-weight-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/variations/font-weight-interpolation.html.ini
@@ -1,9 +1,6 @@
 [font-weight-interpolation.html]
   bug: https://github.com/servo/servo/issues/21570
   expected: TIMEOUT
-  [font-weight animation]
-    expected: TIMEOUT
-
   [font-weight transition]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/css/css-text/animations/letter-spacing-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-text/animations/letter-spacing-interpolation.html.ini
@@ -11,16 +11,7 @@
   [Web Animations: property <letter-spacing> from [normal\] to [10px\] at (0.3) should be [3px\]]
     expected: FAIL
 
-  [CSS Transitions: property <letter-spacing> from [unset\] to [20px\] at (-0.3) should be [-3.4px\]]
-    expected: FAIL
-
   [Web Animations: property <letter-spacing> from [inherit\] to [20px\] at (1.5) should be [29px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from neutral to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [unset\] to [20px\] at (0.3) should be [7.4px\]]
     expected: FAIL
 
   [Web Animations: property <letter-spacing> from [-10px\] to [10px\] at (0.6) should be [2px\]]
@@ -29,28 +20,7 @@
   [Web Animations: property <letter-spacing> from neutral to [20px\] at (0.6) should be [24px\]]
     expected: FAIL
 
-  [CSS Animations: property <letter-spacing> from neutral to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
   [Web Animations: property <letter-spacing> from [-10px\] to [10px\] at (1) should be [10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [unset\] to [20px\] at (0.3) should be [7.4px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [inherit\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [unset\] to [20px\] at (0.6) should be [12.8px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from neutral to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [-10px\] to [10px\] at (0.3) should be [-4px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [initial\] to [20px\] at (0.3) should be [6px\]]
     expected: FAIL
 
   [Web Animations: property <letter-spacing> from [unset\] to [20px\] at (-0.3) should be [-3.4px\]]
@@ -59,52 +29,10 @@
   [Web Animations: property <letter-spacing> from neutral to [20px\] at (0) should be [30px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <letter-spacing> from [normal\] to [10px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [inherit\] to [20px\] at (0.6) should be [12.8px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [inherit\] to [20px\] at (0.6) should be [12.8px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [normal\] to [10px\] at (0.6) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [unset\] to [20px\] at (-0.3) should be [-3.4px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from neutral to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from neutral to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
   [Web Animations: property <letter-spacing> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
     expected: FAIL
 
-  [CSS Animations: property <letter-spacing> from [normal\] to [10px\] at (0.3) should be [3px\]]
-    expected: FAIL
-
   [Web Animations: property <letter-spacing> from [normal\] to [10px\] at (0) should be [normal\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [inherit\] to [20px\] at (-0.3) should be [-3.4px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [normal\] to [10px\] at (0.3) should be [3px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [-10px\] to [10px\] at (-0.3) should be [-16px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [initial\] to [20px\] at (0.3) should be [6px\]]
     expected: FAIL
 
   [Web Animations: property <letter-spacing> from [normal\] to [10px\] at (1.5) should be [15px\]]
@@ -113,31 +41,13 @@
   [Web Animations: property <letter-spacing> from [normal\] to [10px\] at (-0.3) should be [-3px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <letter-spacing> from [-10px\] to [10px\] at (0.3) should be [-4px\]]
-    expected: FAIL
-
   [Web Animations: property <letter-spacing> from neutral to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [-10px\] to [10px\] at (1) should be [10px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [-10px\] to [10px\] at (0.3) should be [-4px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [-10px\] to [10px\] at (1.5) should be [20px\]]
     expected: FAIL
 
   [Web Animations: property <letter-spacing> from [inherit\] to [20px\] at (0.6) should be [12.8px\]]
     expected: FAIL
 
   [Web Animations: property <letter-spacing> from [-10px\] to [10px\] at (1.5) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [normal\] to [10px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [normal\] to [10px\] at (0.6) should be [6px\]]
     expected: FAIL
 
   [CSS Animations: property <letter-spacing> from [inherit\] to [20px\] at (1.5) should be [29px\]]
@@ -152,40 +62,19 @@
   [Web Animations: property <letter-spacing> from [unset\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <letter-spacing> from neutral to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
   [CSS Animations: property <letter-spacing> from [unset\] to [20px\] at (0) should be [2px\]]
     expected: FAIL
 
   [Web Animations: property <letter-spacing> from neutral to [20px\] at (1.5) should be [15px\]]
     expected: FAIL
 
-  [CSS Transitions: property <letter-spacing> from [normal\] to [10px\] at (-0.3) should be [-3px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [initial\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
   [Web Animations: property <letter-spacing> from neutral to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [-10px\] to [10px\] at (0.6) should be [2px\]]
     expected: FAIL
 
   [Web Animations: property <letter-spacing> from [normal\] to [10px\] at (0.6) should be [6px\]]
     expected: FAIL
 
   [CSS Animations: property <letter-spacing> from [inherit\] to [20px\] at (-0.3) should be [-3.4px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [normal\] to [10px\] at (-0.3) should be [-3px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [unset\] to [20px\] at (0.6) should be [12.8px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
     expected: FAIL
 
   [Web Animations: property <letter-spacing> from [-10px\] to [10px\] at (0) should be [-10px\]]
@@ -197,52 +86,16 @@
   [Web Animations: property <letter-spacing> from [inherit\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Animations: property <letter-spacing> from [normal\] to [10px\] at (0) should be [normal\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from neutral to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [normal\] to [10px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
   [Web Animations: property <letter-spacing> from neutral to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <letter-spacing> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
   [Web Animations: property <letter-spacing> from [initial\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from neutral to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [unset\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from neutral to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [-10px\] to [10px\] at (0) should be [-10px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [initial\] to [20px\] at (0.3) should be [6px\]]
     expected: FAIL
 
   [Web Animations: property <letter-spacing> from [initial\] to [20px\] at (0) should be [normal\]]
     expected: FAIL
 
   [Web Animations: property <letter-spacing> from [initial\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [initial\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [normal\] to [10px\] at (0.3) should be [3px\]]
     expected: FAIL
 
   [Web Animations: property <letter-spacing> from [-10px\] to [10px\] at (-0.3) should be [-16px\]]
@@ -254,34 +107,13 @@
   [CSS Animations: property <letter-spacing> from [unset\] to [20px\] at (1.5) should be [29px\]]
     expected: FAIL
 
-  [CSS Transitions: property <letter-spacing> from [normal\] to [10px\] at (0.6) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [-10px\] to [10px\] at (0.6) should be [2px\]]
-    expected: FAIL
-
   [Web Animations: property <letter-spacing> from [inherit\] to [20px\] at (-0.3) should be [-3.4px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [unset\] to [20px\] at (1.5) should be [29px\]]
     expected: FAIL
 
   [CSS Animations: property <letter-spacing> from [unset\] to [20px\] at (0.6) should be [12.8px\]]
     expected: FAIL
 
   [Web Animations: property <letter-spacing> from [inherit\] to [20px\] at (0.3) should be [7.4px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [initial\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [unset\] to [20px\] at (1.5) should be [29px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [-10px\] to [10px\] at (-0.3) should be [-16px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from neutral to [20px\] at (1.5) should be [15px\]]
     expected: FAIL
 
   [Web Animations: property <letter-spacing> from [initial\] to [20px\] at (1) should be [20px\]]
@@ -293,66 +125,18 @@
   [CSS Animations: property <letter-spacing> from [unset\] to [20px\] at (0.3) should be [7.4px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <letter-spacing> from neutral to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
   [Web Animations: property <letter-spacing> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [-10px\] to [10px\] at (1.5) should be [20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [initial\] to [20px\] at (0) should be [normal\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [initial\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [inherit\] to [20px\] at (0.3) should be [7.4px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from neutral to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <letter-spacing> from [inherit\] to [20px\] at (1.5) should be [29px\]]
     expected: FAIL
 
   [CSS Animations: property <letter-spacing> from [inherit\] to [20px\] at (0) should be [2px\]]
     expected: FAIL
 
-  [CSS Transitions: property <letter-spacing> from [-10px\] to [10px\] at (-0.3) should be [-16px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [-10px\] to [10px\] at (1.5) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [inherit\] to [20px\] at (0.3) should be [7.4px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [inherit\] to [20px\] at (-0.3) should be [-3.4px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from [inherit\] to [20px\] at (1.5) should be [29px\]]
-    expected: FAIL
-
   [Web Animations: property <letter-spacing> from [normal\] to [10px\] at (1) should be [10px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [normal\] to [10px\] at (-0.3) should be [-3px\]]
     expected: FAIL
 
   [Web Animations: property <letter-spacing> from [unset\] to [20px\] at (1.5) should be [29px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <letter-spacing> from [-10px\] to [10px\] at (0.6) should be [2px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <letter-spacing> from neutral to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
   [CSS Animations: property <letter-spacing> from [inherit\] to [20px\] at (0.6) should be [12.8px\]]
-    expected: FAIL
-
-  [CSS Animations: property <letter-spacing> from [normal\] to [10px\] at (1) should be [10px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-text/animations/text-indent-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-text/animations/text-indent-interpolation.html.ini
@@ -5,9 +5,6 @@
   [CSS Transitions: property <text-indent> from [0px hanging each-line\] to [50px each-line hanging\] at (0) should be [0 hanging each-line\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-indent> from [inherit\] to [20px\] at (-0.3) should be [85px\]]
-    expected: FAIL
-
   [Web Animations: property <text-indent> from [0px hanging each-line\] to [50px each-line hanging\] at (0.3) should be [15px hanging each-line\]]
     expected: FAIL
 
@@ -15,9 +12,6 @@
     expected: FAIL
 
   [CSS Animations: property <text-indent> from [0px\] to [50px each-line hanging\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-indent> from [unset\] to [20px\] at (1.5) should be [-5px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <text-indent> from [0px hanging\] to [50px hanging\] at (0.3) should be [15px hanging\]]
@@ -32,9 +26,6 @@
   [CSS Transitions with transition: all: property <text-indent> from [0px hanging\] to [50px hanging\] at (0) should be [0 hanging\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-indent> from neutral to [40px\] at (0.3) should be [19px\]]
-    expected: FAIL
-
   [CSS Animations: property <text-indent> from [inherit\] to [20px\] at (0.6) should be [40px\]]
     expected: FAIL
 
@@ -44,19 +35,10 @@
   [CSS Animations: property <text-indent> from [0px hanging\] to [50px hanging\] at (0.6) should be [30px hanging\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from neutral to [40px\] at (1) should be [40px\]]
-    expected: FAIL
-
   [Web Animations: property <text-indent> from [0px hanging\] to [50px hanging\] at (0.3) should be [15px hanging\]]
     expected: FAIL
 
   [Web Animations: property <text-indent> from [inherit\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from neutral to [40px\] at (0.6) should be [28px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-indent> from [inherit\] to [20px\] at (0.6) should be [40px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <text-indent> from [0px\] to [50px each-line hanging\] at (1) should be [50px each-line hanging\]]
@@ -74,12 +56,6 @@
   [Web Animations: property <text-indent> from [unset\] to [20px\] at (0) should be [70px\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [initial\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
   [CSS Animations: property <text-indent> from [unset\] to [20px\] at (-0.3) should be [85px\]]
     expected: FAIL
 
@@ -87,18 +63,6 @@
     expected: FAIL
 
   [CSS Transitions with transition: all: property <text-indent> from [0px\] to [50px each-line hanging\] at (0) should be [50px each-line hanging\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [inherit\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from [0px\] to [50px\] at (1.5) should be [75px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from [unset\] to [20px\] at (-0.3) should be [85px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-indent> from neutral to [40px\] at (1.5) should be [55px\]]
     expected: FAIL
 
   [CSS Animations: property <text-indent> from [inherit\] to [20px\] at (-0.3) should be [85px\]]
@@ -116,15 +80,6 @@
   [CSS Animations: property <text-indent> from [0px hanging\] to [50px hanging\] at (0.3) should be [15px hanging\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from [0px\] to [50px\] at (1.5) should be [75px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-indent> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from neutral to [40px\] at (-0.3) should be [1px\]]
-    expected: FAIL
-
   [Web Animations: property <text-indent> from [0px\] to [50px\] at (0) should be [0\]]
     expected: FAIL
 
@@ -134,16 +89,10 @@
   [Web Animations: property <text-indent> from [unset\] to [20px\] at (0.3) should be [55px\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from neutral to [40px\] at (0.6) should be [28px\]]
-    expected: FAIL
-
   [Web Animations: property <text-indent> from [0px\] to [50px each-line hanging\] at (1.5) should be [50px each-line hanging\]]
     expected: FAIL
 
   [CSS Animations: property <text-indent> from [0px\] to [50px each-line hanging\] at (0.3) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-indent> from [initial\] to [20px\] at (0.3) should be [6px\]]
     expected: FAIL
 
   [Web Animations: property <text-indent> from [0px each-line\] to [50px hanging\] at (1) should be [50px hanging\]]
@@ -155,12 +104,6 @@
   [Web Animations: property <text-indent> from [unset\] to [20px\] at (1.5) should be [-5px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-indent> from neutral to [40px\] at (-0.3) should be [1px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from neutral to [40px\] at (1.5) should be [55px\]]
-    expected: FAIL
-
   [CSS Transitions: property <text-indent> from [0px\] to [50px each-line hanging\] at (0.3) should be [50px each-line hanging\]]
     expected: FAIL
 
@@ -168,9 +111,6 @@
     expected: FAIL
 
   [CSS Animations: property <text-indent> from [0px each-line\] to [50px hanging\] at (0.5) should be [50px hanging\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from neutral to [40px\] at (0.3) should be [19px\]]
     expected: FAIL
 
   [CSS Animations: property <text-indent> from [0px hanging each-line\] to [50px each-line hanging\] at (1.5) should be [75px hanging each-line\]]
@@ -185,25 +125,7 @@
   [CSS Transitions with transition: all: property <text-indent> from [0px hanging\] to [50px hanging\] at (1.5) should be [75px hanging\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from neutral to [40px\] at (-0.3) should be [1px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from [0px\] to [50px\] at (-0.3) should be [-15px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [initial\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from [inherit\] to [20px\] at (1.5) should be [-5px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from [inherit\] to [20px\] at (-0.3) should be [85px\]]
-    expected: FAIL
-
   [Web Animations: property <text-indent> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from [unset\] to [20px\] at (0.6) should be [40px\]]
     expected: FAIL
 
   [Web Animations: property <text-indent> from [0px hanging\] to [50px hanging\] at (0.6) should be [30px hanging\]]
@@ -213,12 +135,6 @@
     expected: FAIL
 
   [CSS Transitions: property <text-indent> from [0px\] to [50px each-line hanging\] at (1.5) should be [50px each-line hanging\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-indent> from [initial\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [0px\] to [50px\] at (-0.3) should be [-15px\]]
     expected: FAIL
 
   [CSS Transitions: property <text-indent> from [0px hanging each-line\] to [50px each-line hanging\] at (-0.3) should be [-15px hanging each-line\]]
@@ -248,9 +164,6 @@
   [CSS Transitions with transition: all: property <text-indent> from [0px hanging\] to [50px hanging\] at (-0.3) should be [-15px hanging\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-indent> from [inherit\] to [20px\] at (0.3) should be [55px\]]
-    expected: FAIL
-
   [Web Animations: property <text-indent> from [0px hanging each-line\] to [50px each-line hanging\] at (0.6) should be [30px hanging each-line\]]
     expected: FAIL
 
@@ -278,15 +191,6 @@
   [Web Animations: property <text-indent> from [initial\] to [20px\] at (0.6) should be [12px\]]
     expected: FAIL
 
-  [CSS Transitions: property <text-indent> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-indent> from [unset\] to [20px\] at (-0.3) should be [85px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-indent> from neutral to [40px\] at (0.6) should be [28px\]]
-    expected: FAIL
-
   [CSS Animations: property <text-indent> from [0px\] to [50px each-line hanging\] at (1) should be [50px each-line hanging\]]
     expected: FAIL
 
@@ -305,9 +209,6 @@
   [CSS Transitions with transition: all: property <text-indent> from [0px hanging each-line\] to [50px each-line hanging\] at (0.6) should be [30px hanging each-line\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
   [CSS Transitions: property <text-indent> from [0px each-line\] to [50px hanging\] at (-0.3) should be [50px hanging\]]
     expected: FAIL
 
@@ -317,16 +218,10 @@
   [CSS Animations: property <text-indent> from [unset\] to [20px\] at (1.5) should be [-5px\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from [0px\] to [50px\] at (0.6) should be [30px\]]
-    expected: FAIL
-
   [CSS Animations: property <text-indent> from [0px\] to [50px each-line hanging\] at (0.5) should be [50px each-line hanging\]]
     expected: FAIL
 
   [Web Animations: property <text-indent> from [0px hanging\] to [50px hanging\] at (0) should be [0 hanging\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from [0px\] to [50px\] at (0.3) should be [15px\]]
     expected: FAIL
 
   [Web Animations: property <text-indent> from [0px\] to [50px each-line hanging\] at (-0.3) should be [0px\]]
@@ -341,16 +236,10 @@
   [Web Animations: property <text-indent> from [0px hanging each-line\] to [50px each-line hanging\] at (1.5) should be [75px hanging each-line\]]
     expected: FAIL
 
-  [CSS Transitions: property <text-indent> from [initial\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
   [Web Animations: property <text-indent> from [initial\] to [20px\] at (0.3) should be [6px\]]
     expected: FAIL
 
   [Web Animations: property <text-indent> from neutral to [40px\] at (0.6) should be [28px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from [unset\] to [20px\] at (1.5) should be [-5px\]]
     expected: FAIL
 
   [CSS Transitions: property <text-indent> from [0px\] to [50px each-line hanging\] at (1) should be [50px each-line hanging\]]
@@ -362,31 +251,19 @@
   [CSS Animations: property <text-indent> from [0px each-line\] to [50px hanging\] at (1.5) should be [50px hanging\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-indent> from [unset\] to [20px\] at (0.3) should be [55px\]]
-    expected: FAIL
-
   [CSS Transitions: property <text-indent> from [0px hanging\] to [50px hanging\] at (0.3) should be [15px hanging\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <text-indent> from [0px hanging\] to [50px hanging\] at (0.6) should be [30px hanging\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-indent> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
-    expected: FAIL
-
   [CSS Animations: property <text-indent> from [0px hanging\] to [50px hanging\] at (-0.3) should be [-15px hanging\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-indent> from [0px\] to [50px\] at (0.3) should be [15px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <text-indent> from [0px hanging each-line\] to [50px each-line hanging\] at (1) should be [50px hanging each-line\]]
     expected: FAIL
 
   [CSS Animations: property <text-indent> from [0px hanging each-line\] to [50px each-line hanging\] at (1) should be [50px hanging each-line\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from neutral to [40px\] at (0.3) should be [19px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <text-indent> from [0px\] to [50px each-line hanging\] at (0.6) should be [50px each-line hanging\]]
@@ -422,13 +299,7 @@
   [Web Animations: property <text-indent> from neutral to [40px\] at (0) should be [10px\]]
     expected: FAIL
 
-  [CSS Transitions: property <text-indent> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
-    expected: FAIL
-
   [Web Animations: property <text-indent> from [0px each-line\] to [50px hanging\] at (-0.3) should be [0px each-line\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-indent> from [0px\] to [50px\] at (-0.3) should be [-15px\]]
     expected: FAIL
 
   [Web Animations: property <text-indent> from [0px hanging each-line\] to [50px each-line hanging\] at (1) should be [50px hanging each-line\]]
@@ -458,25 +329,7 @@
   [Web Animations: property <text-indent> from [0px\] to [50px\] at (0.6) should be [30px\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from neutral to [40px\] at (1.5) should be [55px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-indent> from [inherit\] to [20px\] at (1.5) should be [-5px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from [inherit\] to [20px\] at (0.6) should be [40px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [0px\] to [50px\] at (0.3) should be [15px\]]
-    expected: FAIL
-
   [CSS Animations: property <text-indent> from [0px\] to [50px each-line hanging\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from [unset\] to [20px\] at (0.3) should be [55px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from [inherit\] to [20px\] at (0.3) should be [55px\]]
     expected: FAIL
 
   [CSS Animations: property <text-indent> from [0px hanging\] to [50px hanging\] at (0) should be [0 hanging\]]
@@ -488,9 +341,6 @@
   [CSS Transitions with transition: all: property <text-indent> from [0px each-line\] to [50px hanging\] at (1) should be [50px hanging\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from [unset\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
   [CSS Transitions: property <text-indent> from [0px\] to [50px each-line hanging\] at (0.6) should be [50px each-line hanging\]]
     expected: FAIL
 
@@ -498,9 +348,6 @@
     expected: FAIL
 
   [CSS Transitions with transition: all: property <text-indent> from [0px hanging each-line\] to [50px each-line hanging\] at (1.5) should be [75px hanging each-line\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-indent> from [0px\] to [50px\] at (0.6) should be [30px\]]
     expected: FAIL
 
   [CSS Transitions: property <text-indent> from [0px hanging each-line\] to [50px each-line hanging\] at (0.6) should be [30px hanging each-line\]]
@@ -530,9 +377,6 @@
   [Web Animations: property <text-indent> from [0px hanging\] to [50px hanging\] at (1.5) should be [75px hanging\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from [0px\] to [50px\] at (0) should be [0\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <text-indent> from [0px each-line\] to [50px hanging\] at (1.5) should be [50px hanging\]]
     expected: FAIL
 
@@ -542,31 +386,10 @@
   [CSS Transitions: property <text-indent> from [0px each-line\] to [50px hanging\] at (0.5) should be [50px hanging\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-indent> from [unset\] to [20px\] at (0.6) should be [40px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [0px\] to [50px\] at (1) should be [50px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [initial\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
   [Web Animations: property <text-indent> from [0px\] to [50px each-line hanging\] at (0) should be [0px\]]
     expected: FAIL
 
   [Web Animations: property <text-indent> from [0px\] to [50px\] at (1.5) should be [75px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-indent> from [0px\] to [50px\] at (1.5) should be [75px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from [0px\] to [50px\] at (0.6) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [initial\] to [20px\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-indent> from [initial\] to [20px\] at (0.6) should be [12px\]]
     expected: FAIL
 
   [CSS Animations: property <text-indent> from [0px hanging\] to [50px hanging\] at (1.5) should be [75px hanging\]]
@@ -609,5 +432,8 @@
     expected: FAIL
 
   [CSS Animations: property <text-indent> from [0px each-line\] to [50px hanging\] at (-0.3) should be [0px each-line\]]
+    expected: FAIL
+
+  [CSS Transitions: property <text-indent> from [0px\] to [50px\] at (-0.3) should be [-15px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-text/animations/word-spacing-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-text/animations/word-spacing-interpolation.html.ini
@@ -2,46 +2,13 @@
   [word-spacing-interpolation]
     expected: FAIL
 
-  [CSS Transitions: property <word-spacing> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
   [Web Animations: property <word-spacing> from [normal\] to [10px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [-10px\] to [40px\] at (-0.3) should be [-25px\]]
     expected: FAIL
 
   [Web Animations: property <word-spacing> from neutral to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <word-spacing> from [-10px\] to [40px\] at (0.6) should be [20px\]]
-    expected: FAIL
-
   [Web Animations: property <word-spacing> from [-10px\] to [40px\] at (0.3) should be [5px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [inherit\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [-10px\] to [40px\] at (1.5) should be [65px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [initial\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [initial\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [unset\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [-10px\] to [40px\] at (0) should be [-10px\]]
     expected: FAIL
 
   [Web Animations: property <word-spacing> from [normal\] to [10px\] at (0) should be [0px\]]
@@ -53,37 +20,10 @@
   [Web Animations: property <word-spacing> from [inherit\] to [20px\] at (1.5) should be [15px\]]
     expected: FAIL
 
-  [CSS Animations: property <word-spacing> from [initial\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [-10px\] to [40px\] at (1) should be [40px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [inherit\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
   [CSS Animations: property <word-spacing> from [inherit\] to [20px\] at (0.6) should be [24px\]]
     expected: FAIL
 
   [Web Animations: property <word-spacing> from [unset\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [initial\] to [20px\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [normal\] to [10px\] at (-0.3) should be [-3px\]]
     expected: FAIL
 
   [Web Animations: property <word-spacing> from [inherit\] to [20px\] at (0.3) should be [27px\]]
@@ -95,31 +35,7 @@
   [Web Animations: property <word-spacing> from [-10px\] to [40px\] at (1) should be [40px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <word-spacing> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [normal\] to [10px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
   [Web Animations: property <word-spacing> from [unset\] to [20px\] at (0) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [-10px\] to [40px\] at (0.6) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [-10px\] to [40px\] at (1.5) should be [65px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [normal\] to [10px\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [inherit\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [normal\] to [10px\] at (0.6) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [initial\] to [20px\] at (0.3) should be [6px\]]
     expected: FAIL
 
   [Web Animations: property <word-spacing> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
@@ -128,64 +44,22 @@
   [Web Animations: property <word-spacing> from [inherit\] to [20px\] at (0.6) should be [24px\]]
     expected: FAIL
 
-  [CSS Animations: property <word-spacing> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
   [Web Animations: property <word-spacing> from [normal\] to [10px\] at (0.6) should be [6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [-10px\] to [40px\] at (0.6) should be [20px\]]
     expected: FAIL
 
   [CSS Animations: property <word-spacing> from [inherit\] to [20px\] at (0.3) should be [27px\]]
     expected: FAIL
 
-  [CSS Transitions: property <word-spacing> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [normal\] to [10px\] at (0.3) should be [3px\]]
-    expected: FAIL
-
   [CSS Animations: property <word-spacing> from [unset\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
     expected: FAIL
 
   [Web Animations: property <word-spacing> from [-10px\] to [40px\] at (0.6) should be [20px\]]
     expected: FAIL
 
-  [CSS Animations: property <word-spacing> from neutral to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [-10px\] to [40px\] at (0.3) should be [5px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [normal\] to [10px\] at (0.3) should be [3px\]]
-    expected: FAIL
-
   [CSS Animations: property <word-spacing> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <word-spacing> from [normal\] to [10px\] at (-0.3) should be [-3px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
   [Web Animations: property <word-spacing> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from neutral to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 
   [Web Animations: property <word-spacing> from [unset\] to [20px\] at (0.6) should be [24px\]]
@@ -198,12 +72,6 @@
     expected: FAIL
 
   [Web Animations: property <word-spacing> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [inherit\] to [20px\] at (0.6) should be [24px\]]
     expected: FAIL
 
   [Web Animations: property <word-spacing> from [initial\] to [20px\] at (1) should be [20px\]]
@@ -221,19 +89,10 @@
   [Web Animations: property <word-spacing> from [initial\] to [20px\] at (0.3) should be [6px\]]
     expected: FAIL
 
-  [CSS Transitions: property <word-spacing> from [unset\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [normal\] to [10px\] at (-0.3) should be [-3px\]]
-    expected: FAIL
-
   [Web Animations: property <word-spacing> from neutral to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
   [CSS Animations: property <word-spacing> from [unset\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [-10px\] to [40px\] at (-0.3) should be [-25px\]]
     expected: FAIL
 
   [Web Animations: property <word-spacing> from [initial\] to [20px\] at (0) should be [0px\]]
@@ -248,22 +107,7 @@
   [Web Animations: property <word-spacing> from [-10px\] to [40px\] at (1.5) should be [65px\]]
     expected: FAIL
 
-  [CSS Animations: property <word-spacing> from [-10px\] to [40px\] at (0.3) should be [5px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [unset\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [unset\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [initial\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
   [Web Animations: property <word-spacing> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [initial\] to [20px\] at (0.6) should be [12px\]]
     expected: FAIL
 
   [Web Animations: property <word-spacing> from [unset\] to [20px\] at (-0.3) should be [33px\]]
@@ -278,34 +122,7 @@
   [Web Animations: property <word-spacing> from [inherit\] to [20px\] at (0) should be [30px\]]
     expected: FAIL
 
-  [CSS Animations: property <word-spacing> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [normal\] to [10px\] at (0.3) should be [3px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
-    expected: FAIL
-
   [Web Animations: property <word-spacing> from [normal\] to [10px\] at (1) should be [10px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [normal\] to [10px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [unset\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [inherit\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [unset\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
   [CSS Animations: property <word-spacing> from [unset\] to [20px\] at (1.5) should be [15px\]]
@@ -317,42 +134,9 @@
   [Web Animations: property <word-spacing> from [normal\] to [10px\] at (-0.3) should be [-3px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <word-spacing> from [normal\] to [10px\] at (0.6) should be [6px\]]
-    expected: FAIL
-
   [Web Animations: property <word-spacing> from [initial\] to [20px\] at (0.6) should be [12px\]]
     expected: FAIL
 
-  [CSS Animations: property <word-spacing> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [initial\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [-10px\] to [40px\] at (0.3) should be [5px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [unset\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
   [Web Animations: property <word-spacing> from [inherit\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [-10px\] to [40px\] at (1.5) should be [65px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [normal\] to [10px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <word-spacing> from [unset\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [normal\] to [10px\] at (0.6) should be [6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <word-spacing> from [-10px\] to [40px\] at (-0.3) should be [-25px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <word-spacing> from [unset\] to [20px\] at (-0.3) should be [33px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transforms/animation/list-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/list-interpolation.html.ini
@@ -89,9 +89,6 @@
   [Transform list interpolation]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [none\] to [translate(200px) rotate(720deg)\] at (0.25) should be [translate(50px) rotate(180deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [none\] to [none\] at (0.25) should be [none\]]
     expected: FAIL
 
@@ -105,9 +102,6 @@
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [scaleX(-3) scaleY(2)\] to [scaleY(-3) translateX(0px) scaleX(2)\] at (0.25) should be [scale(-2, 0) matrix(1.25, 0, 0, 1.75, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translate(100px) rotate(720deg)\] to [translate(200px)\] at (0.25) should be [translate(125px) rotate(540deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotate(0deg) scaleX(1)\] to [rotate(720deg) translateX(0px) scaleX(2)\] at (0.25) should be [rotate(180deg) matrix(1.25, 0, 0, 1, 0, 0)\]]
@@ -128,9 +122,6 @@
   [Web Animations: property <transform> from [scaleY(-3) translateX(0px) scaleX(2)\] to [scaleX(-3) scaleY(2)\] at (0.25) should be [scale(0, -2) matrix(1.75, 0, 0, 1.25, 0, 0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [none\] to [translate(200px) rotate(720deg)\] at (0.25) should be [translate(50px) rotate(180deg)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [translateX(100px) scaleX(3) translate(500px) scale(2)\] to [translateY(200px) scale(5) translateX(100px) scaleY(3)\] at (0.25) should be [translate(75px, 50px) scale(3.5, 2) translate(400px, 0px) scale(1.75, 2.25)\]]
     expected: FAIL
 
@@ -140,19 +131,10 @@
   [CSS Transitions with transition: all: property <transform> from [rotateX(90deg) translateX(100px)\] to [rotate3d(50, 0, 0, 180deg) translateY(200px)\] at (0.25) should be [rotateX(112.5deg) translate(75px, 50px)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translate(200px) rotate(720deg)\] to [none\] at (0.25) should be [translate(150px) rotate(540deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translate(200px) rotate(720deg)\] to [none\] at (0.25) should be [translate(150px) rotate(540deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [rotate(0deg) translate(100px)\] to [rotate(720deg) scale(2) translate(200px)\] at (0.25) should be [rotate(180deg) matrix(1.25, 0, 0, 1.25, 175, 0)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [scale(2) rotate(360deg) translate(100px) matrix(1, 0, 0, 1, 100, 0) skew(0deg)\] to [scale(3) rotate(1080deg) translate(200px) matrix(1, 0, 0, 1, 0, 200) skew(720deg)\] at (0.25) should be [scale(2.25) rotate(540deg) translate(125px) matrix(1, 0, 0, 1, 75, 50) skew(180deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translate(100px) rotate(720deg)\] to [translate(200px)\] at (0.25) should be [translate(125px) rotate(540deg)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [rotate(0deg) translate(100px)\] to [rotate(720deg) scale(2) translate(200px)\] at (0.25) should be [rotate(180deg) matrix(1.25, 0, 0, 1.25, 175, 0)\]]
@@ -194,9 +176,6 @@
   [Web Animations: property <transform> from [rotate3d(1, 0, 0, 360deg) translateX(100px)\] to [rotate3d(0, 1, 0, -720deg) translateY(200px)\] at (0.25) should be [rotate3d(0, 0, 1, 0deg) translate(75px, 50px)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [none\] to [translate(200px) rotate(720deg)\] at (0.25) should be [translate(50px) rotate(180deg)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [rotateX(90deg) translateX(100px)\] to [rotateY(0deg) translateY(200px)\] at (0.25) should be [rotateX(67.5deg) translate(75px, 50px)\]]
     expected: FAIL
 
@@ -221,9 +200,6 @@
   [Web Animations: property <transform> from [rotate(720deg) translateX(0px) scaleX(2)\] to [rotate(0deg) scaleX(1)\] at (0.25) should be [rotate(540deg) matrix(1.75, 0, 0, 1, 0, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [scale(2) rotate(360deg) translate(100px) matrix(1, 0, 0, 1, 100, 0) skew(0deg)\] to [scale(3) rotate(1080deg) translate(200px) matrix(1, 0, 0, 1, 0, 200) skew(720deg)\] at (0.25) should be [scale(2.25) rotate(540deg) translate(125px) matrix(1, 0, 0, 1, 75, 50) skew(180deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [rotateX(90deg) translateX(100px)\] to [rotateY(0deg) translateY(200px)\] at (0.25) should be [rotateX(67.5deg) translate(75px, 50px)\]]
     expected: FAIL
 
@@ -233,9 +209,6 @@
   [CSS Transitions with transition: all: property <transform> from [scale(2) rotate(0deg) translate(100px)\] to [rotate(720deg) scale(2) translate(200px)\] at (0.25) should be [matrix(2, 0, 0, 2, 250, 0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [scale(2) rotate(360deg) translate(100px) matrix(1, 0, 0, 1, 100, 0) skew(0deg)\] to [scale(3) rotate(1080deg) translate(200px) matrix(1, 0, 0, 1, 0, 200) skew(720deg)\] at (0.25) should be [scale(2.25) rotate(540deg) translate(125px) matrix(1, 0, 0, 1, 75, 50) skew(180deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scale(2) rotate(0deg)\] to [rotate(720deg) scale(2) translate(200px)\] at (0.25) should be [matrix(2, 0, 0, 2, 100, 0)\]]
     expected: FAIL
 
@@ -243,9 +216,6 @@
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [rotate(720deg) translateX(0px) scaleX(2)\] to [rotate(0deg) scaleX(1)\] at (0.25) should be [rotate(540deg) matrix(1.75, 0, 0, 1, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translate(100px)\] to [translate(200px) rotate(720deg)\] at (0.25) should be [translate(125px) rotate(180deg)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [scale(2) rotate(0deg) translate(100px)\] to [rotate(720deg) scale(2) translate(200px)\] at (0.25) should be [matrix(2, 0, 0, 2, 250, 0)\]]
@@ -284,9 +254,6 @@
   [CSS Transitions: property <transform> from [translate(100px)\] to [translate(200px) rotate(720deg)\] at (0.25) should be [translate(125px) rotate(180deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translate(100px)\] to [translate(200px) rotate(720deg)\] at (0.25) should be [translate(125px) rotate(180deg)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [scaleY(-3) translateX(0px) scaleX(2)\] to [scaleX(-3) scaleY(2)\] at (0.25) should be [scale(0, -2) matrix(1.75, 0, 0, 1.25, 0, 0)\]]
     expected: FAIL
 
@@ -306,5 +273,8 @@
     expected: FAIL
 
   [Web Animations: property <transform> from [none\] to [translate(200px) rotate(720deg)\] at (0.25) should be [translate(50px) rotate(180deg)\]]
+    expected: FAIL
+
+  [CSS Transitions: property <transform> from [none\] to [translate(200px) rotate(720deg)\] at (0.25) should be [translate(50px) rotate(180deg)\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transforms/animation/perspective-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/perspective-interpolation.html.ini
@@ -2,9 +2,6 @@
   [ perspective interpolation]
     expected: FAIL
 
-  [CSS Transitions: property <perspective> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
   [CSS Transitions: property <perspective> from [50px\] to [100px\] at (1.5) should be [125px\]]
     expected: FAIL
 
@@ -17,9 +14,6 @@
   [CSS Animations: property <perspective> from [50px\] to [none\] at (0.3) should be [50px\]]
     expected: FAIL
 
-  [CSS Animations: property <perspective> from [inherit\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
   [Web Animations: property <perspective> from [unset\] to [20px\] at (0.5) should be [20px\]]
     expected: FAIL
 
@@ -30,9 +24,6 @@
     expected: FAIL
 
   [CSS Animations: property <perspective> from [inherit\] to [20px\] at (0) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <perspective> from neutral to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
   [Web Animations: property <perspective> from [inherit\] to [20px\] at (-1) should be [40px\]]
@@ -50,22 +41,10 @@
   [CSS Transitions with transition: all: property <perspective> from [50px\] to [100px\] at (-1) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <perspective> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
   [Web Animations: property <perspective> from [50px\] to [100px\] at (1) should be [100px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <perspective> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
   [Web Animations: property <perspective> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <perspective> from [50px\] to [100px\] at (1.5) should be [125px\]]
-    expected: FAIL
-
-  [CSS Animations: property <perspective> from [50px\] to [100px\] at (1.5) should be [125px\]]
     expected: FAIL
 
   [Web Animations: property <perspective> from [inherit\] to [20px\] at (0) should be [30px\]]
@@ -84,9 +63,6 @@
     expected: FAIL
 
   [Web Animations: property <perspective> from [unset\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <perspective> from [50px\] to [100px\] at (-0.3) should be [35px\]]
     expected: FAIL
 
   [CSS Animations: property <perspective> from [initial\] to [20px\] at (-0.3) should be [initial\]]
@@ -125,9 +101,6 @@
   [Web Animations: property <perspective> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <perspective> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
   [Web Animations: property <perspective> from [50px\] to [none\] at (0.3) should be [50px\]]
     expected: FAIL
 
@@ -143,43 +116,10 @@
   [Web Animations: property <perspective> from [unset\] to [20px\] at (0.6) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <perspective> from [50px\] to [100px\] at (0.3) should be [65px\]]
-    expected: FAIL
-
   [CSS Animations: property <perspective> from [initial\] to [20px\] at (0) should be [initial\]]
     expected: FAIL
 
-  [CSS Transitions: property <perspective> from [inherit\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <perspective> from [inherit\] to [20px\] at (-1) should be [40px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <perspective> from [50px\] to [100px\] at (0.6) should be [80px\]]
-    expected: FAIL
-
-  [CSS Animations: property <perspective> from [50px\] to [100px\] at (1) should be [100px\]]
-    expected: FAIL
-
-  [CSS Animations: property <perspective> from [50px\] to [100px\] at (0.3) should be [65px\]]
-    expected: FAIL
-
   [CSS Animations: property <perspective> from [inherit\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <perspective> from [inherit\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <perspective> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <perspective> from [inherit\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <perspective> from [inherit\] to [20px\] at (-20) should be [230px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <perspective> from [inherit\] to [20px\] at (1.5) should be [15px\]]
     expected: FAIL
 
   [Web Animations: property <perspective> from [50px\] to [none\] at (0.6) should be [none\]]
@@ -195,12 +135,6 @@
     expected: FAIL
 
   [CSS Animations: property <perspective> from [50px\] to [none\] at (0.5) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <perspective> from [50px\] to [100px\] at (0.6) should be [80px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <perspective> from [inherit\] to [20px\] at (0.3) should be [27px\]]
     expected: FAIL
 
   [Web Animations: property <perspective> from [initial\] to [20px\] at (1.5) should be [20px\]]
@@ -227,9 +161,6 @@
   [CSS Animations: property <perspective> from [50px\] to [100px\] at (-20) should be [none\]]
     expected: FAIL
 
-  [CSS Transitions: property <perspective> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
   [Web Animations: property <perspective> from [50px\] to [100px\] at (0.6) should be [80px\]]
     expected: FAIL
 
@@ -240,9 +171,6 @@
     expected: FAIL
 
   [Web Animations: property <perspective> from [50px\] to [none\] at (-0.3) should be [50px\]]
-    expected: FAIL
-
-  [CSS Animations: property <perspective> from neutral to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 
   [Web Animations: property <perspective> from [unset\] to [20px\] at (0) should be [unset\]]
@@ -272,9 +200,6 @@
   [Web Animations: property <perspective> from neutral to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 
-  [CSS Transitions: property <perspective> from [inherit\] to [20px\] at (-20) should be [230px\]]
-    expected: FAIL
-
   [Web Animations: property <perspective> from [50px\] to [none\] at (0.5) should be [none\]]
     expected: FAIL
 
@@ -296,25 +221,10 @@
   [CSS Transitions: property <perspective> from neutral to [20px\] at (-20) should be [none\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <perspective> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
-  [CSS Animations: property <perspective> from neutral to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
   [CSS Transitions: property <perspective> from [50px\] to [100px\] at (-0.3) should be [35px\]]
     expected: FAIL
 
-  [CSS Animations: property <perspective> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <perspective> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
   [CSS Transitions: property <perspective> from [50px\] to [100px\] at (0.3) should be [65px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <perspective> from [inherit\] to [20px\] at (1.5) should be [15px\]]
     expected: FAIL
 
   [CSS Animations: property <perspective> from [initial\] to [20px\] at (1) should be [20px\]]
@@ -323,19 +233,7 @@
   [Web Animations: property <perspective> from neutral to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Animations: property <perspective> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
   [CSS Animations: property <perspective> from [unset\] to [20px\] at (0.6) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <perspective> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Animations: property <perspective> from [50px\] to [100px\] at (0) should be [50px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <perspective> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
     expected: FAIL
 
   [Web Animations: property <perspective> from [initial\] to [20px\] at (-0.3) should be [initial\]]
@@ -356,9 +254,6 @@
   [CSS Animations: property <perspective> from [inherit\] to [20px\] at (-1) should be [40px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <perspective> from [inherit\] to [20px\] at (-1) should be [40px\]]
-    expected: FAIL
-
   [CSS Animations: property <perspective> from [initial\] to [20px\] at (1.5) should be [20px\]]
     expected: FAIL
 
@@ -375,5 +270,11 @@
     expected: FAIL
 
   [Web Animations: property <perspective> from [inherit\] to [20px\] at (0.3) should be [27px\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <perspective> from [50px\] to [100px\] at (0.3) should be [65px\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <perspective> from [50px\] to [100px\] at (0.6) should be [80px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transforms/animation/perspective-origin-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/perspective-origin-interpolation.html.ini
@@ -11,16 +11,10 @@
   [CSS Transitions: property <perspective-origin> from [unset\] to [20px 20px\] at (1.5) should be [17.5px 17.5px\]]
     expected: FAIL
 
-  [CSS Animations: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (0.6) should be [60% 110%\]]
-    expected: FAIL
-
   [CSS Animations: property <perspective-origin> from [unset\] to [20px 20px\] at (0) should be [25px 25px\]]
     expected: FAIL
 
   [Web Animations: property <perspective-origin> from [initial\] to [20px 20px\] at (0.3) should be [23.5px 23.5px\]]
-    expected: FAIL
-
-  [CSS Animations: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (1) should be [100% 150%\]]
     expected: FAIL
 
   [CSS Animations: property <perspective-origin> from [initial\] to [20px 20px\] at (0.6) should be [22px 22px\]]
@@ -29,22 +23,10 @@
   [Web Animations: property <perspective-origin> from neutral to [20px 20px\] at (1) should be [20px 20px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <perspective-origin> from [inherit\] to [20px 20px\] at (0.6) should be [24px 16px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <perspective-origin> from [initial\] to [20px 20px\] at (0.3) should be [23.5px 23.5px\]]
     expected: FAIL
 
-  [CSS Animations: property <perspective-origin> from neutral to [20px 20px\] at (0.6) should be [16px 24px\]]
-    expected: FAIL
-
   [Web Animations: property <perspective-origin> from [inherit\] to [20px 20px\] at (0.6) should be [24px 16px\]]
-    expected: FAIL
-
-  [CSS Animations: property <perspective-origin> from [inherit\] to [20px 20px\] at (1) should be [20px 20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <perspective-origin> from [inherit\] to [20px 20px\] at (0.3) should be [27px 13px\]]
     expected: FAIL
 
   [Web Animations: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (0.6) should be [60% 110%\]]
@@ -56,31 +38,13 @@
   [CSS Transitions with transition: all: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (-0.3) should be [-30% 20%\]]
     expected: FAIL
 
-  [CSS Animations: property <perspective-origin> from neutral to [20px 20px\] at (1) should be [20px 20px\]]
-    expected: FAIL
-
   [CSS Transitions: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (0.3) should be [30% 80%\]]
-    expected: FAIL
-
-  [CSS Transitions: property <perspective-origin> from neutral to [20px 20px\] at (0.3) should be [13px 27px\]]
     expected: FAIL
 
   [Web Animations: property <perspective-origin> from [unset\] to [20px 20px\] at (-0.3) should be [26.5px 26.5px\]]
     expected: FAIL
 
-  [CSS Animations: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (1.5) should be [150% 200%\]]
-    expected: FAIL
-
   [CSS Transitions: property <perspective-origin> from [unset\] to [20px 20px\] at (-0.3) should be [26.5px 26.5px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <perspective-origin> from [inherit\] to [20px 20px\] at (-0.3) should be [33px 7px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <perspective-origin> from [inherit\] to [20px 20px\] at (0.3) should be [27px 13px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <perspective-origin> from neutral to [20px 20px\] at (0.6) should be [16px 24px\]]
     expected: FAIL
 
   [CSS Animations: property <perspective-origin> from [inherit\] to [20px 20px\] at (0.3) should be [27px 13px\]]
@@ -96,9 +60,6 @@
     expected: FAIL
 
   [CSS Transitions: property <perspective-origin> from [unset\] to [20px 20px\] at (0) should be [25px 25px\]]
-    expected: FAIL
-
-  [CSS Animations: property <perspective-origin> from neutral to [20px 20px\] at (0.3) should be [13px 27px\]]
     expected: FAIL
 
   [CSS Animations: property <perspective-origin> from [inherit\] to [20px 20px\] at (0.6) should be [24px 16px\]]
@@ -125,9 +86,6 @@
   [CSS Transitions: property <perspective-origin> from [unset\] to [20px 20px\] at (0.3) should be [23.5px 23.5px\]]
     expected: FAIL
 
-  [CSS Transitions: property <perspective-origin> from neutral to [20px 20px\] at (0.6) should be [16px 24px\]]
-    expected: FAIL
-
   [CSS Animations: property <perspective-origin> from [unset\] to [20px 20px\] at (1.5) should be [17.5px 17.5px\]]
     expected: FAIL
 
@@ -140,16 +98,10 @@
   [CSS Transitions: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (1.5) should be [150% 200%\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <perspective-origin> from neutral to [20px 20px\] at (-0.3) should be [7px 33px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (0.3) should be [30% 80%\]]
     expected: FAIL
 
   [Web Animations: property <perspective-origin> from neutral to [20px 20px\] at (0.6) should be [16px 24px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <perspective-origin> from [inherit\] to [20px 20px\] at (-0.3) should be [33px 7px\]]
     expected: FAIL
 
   [Web Animations: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (0) should be [0% 50%\]]
@@ -170,9 +122,6 @@
   [Web Animations: property <perspective-origin> from [unset\] to [20px 20px\] at (0.6) should be [22px 22px\]]
     expected: FAIL
 
-  [CSS Transitions: property <perspective-origin> from [inherit\] to [20px 20px\] at (0.6) should be [24px 16px\]]
-    expected: FAIL
-
   [Web Animations: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (0.3) should be [30% 80%\]]
     expected: FAIL
 
@@ -189,9 +138,6 @@
     expected: FAIL
 
   [Web Animations: property <perspective-origin> from [unset\] to [20px 20px\] at (0) should be [25px 25px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <perspective-origin> from [inherit\] to [20px 20px\] at (1.5) should be [15px 25px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <perspective-origin> from [initial\] to [20px 20px\] at (1) should be [20px 20px\]]
@@ -218,15 +164,6 @@
   [Web Animations: property <perspective-origin> from [initial\] to [20px 20px\] at (0.6) should be [22px 22px\]]
     expected: FAIL
 
-  [CSS Animations: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (-0.3) should be [-30% 20%\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <perspective-origin> from neutral to [20px 20px\] at (0.3) should be [13px 27px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <perspective-origin> from [inherit\] to [20px 20px\] at (1.5) should be [15px 25px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <perspective-origin> from [unset\] to [20px 20px\] at (1.5) should be [17.5px 17.5px\]]
     expected: FAIL
 
@@ -245,13 +182,7 @@
   [CSS Transitions: property <perspective-origin> from [initial\] to [20px 20px\] at (-0.3) should be [26.5px 26.5px\]]
     expected: FAIL
 
-  [CSS Animations: property <perspective-origin> from neutral to [20px 20px\] at (1.5) should be [25px 15px\]]
-    expected: FAIL
-
   [CSS Transitions: property <perspective-origin> from [unset\] to [20px 20px\] at (1) should be [20px 20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <perspective-origin> from neutral to [20px 20px\] at (1.5) should be [25px 15px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (0.6) should be [60% 110%\]]
@@ -281,9 +212,6 @@
   [Web Animations: property <perspective-origin> from [unset\] to [20px 20px\] at (0.3) should be [23.5px 23.5px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (1.5) should be [150% 200%\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <perspective-origin> from [unset\] to [20px 20px\] at (1) should be [20px 20px\]]
     expected: FAIL
 
@@ -296,28 +224,13 @@
   [CSS Transitions: property <perspective-origin> from [initial\] to [20px 20px\] at (1) should be [20px 20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <perspective-origin> from neutral to [20px 20px\] at (-0.3) should be [7px 33px\]]
-    expected: FAIL
-
-  [CSS Animations: property <perspective-origin> from neutral to [20px 20px\] at (-0.3) should be [7px 33px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <perspective-origin> from [unset\] to [20px 20px\] at (0) should be [25px 25px\]]
     expected: FAIL
 
   [Web Animations: property <perspective-origin> from neutral to [20px 20px\] at (-0.3) should be [7px 33px\]]
     expected: FAIL
 
-  [CSS Animations: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (0.3) should be [30% 80%\]]
-    expected: FAIL
-
-  [CSS Animations: property <perspective-origin> from [0% 50%\] to [100% 150%\] at (0) should be [0% 50%\]]
-    expected: FAIL
-
   [Web Animations: property <perspective-origin> from neutral to [20px 20px\] at (0) should be [10px 30px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <perspective-origin> from neutral to [20px 20px\] at (1.5) should be [25px 15px\]]
     expected: FAIL
 
   [CSS Transitions: property <perspective-origin> from [initial\] to [20px 20px\] at (0.3) should be [23.5px 23.5px\]]

--- a/tests/wpt/metadata/css/css-transforms/animation/rotate-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/rotate-interpolation.html.ini
@@ -80,43 +80,19 @@
   [Web Animations: property <rotate> from [0 1 0 0deg\] to [1 0 0 450deg\] at (2) should be [1 0 0 900deg\]]
     expected: FAIL
 
-  [CSS Transitions: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (-1) should be [0.67 -0.06 -0.74 124.97deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [0 1 0 100deg\] to [0 1 0 -100deg\] at (0.25) should be [0 1 0 50deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (2) should be [1 0 0 -450deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [100deg\] to [180deg\] at (2) should be [260deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (-1) should be [0 1 0 -10deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [0 1 0 100deg\] to [0 1 0 -100deg\] at (0.25) should be [0 1 0 50deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [none\] to [30deg\] at (0.25) should be [7.5deg\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <rotate> from [none\] to [7 -8 9 400grad\] at (0.125) should be [0.5 -0.57 0.65 50grad\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (1) should be [1 0 0 0deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [inherit\] to [270deg\] at (-1) should be [-90deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [100deg\] to [180deg\] at (-1) should be [20deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (0.875) should be [-0.70246 0.70246 0.114452 53.1994deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (0.75) should be [0.17 0.78 0.61 118.68deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (-1) should be [0.22 -0.55 0.8 300deg\]]
@@ -128,13 +104,7 @@
   [CSS Transitions with transition: all: property <rotate> from [0 1 0 100deg\] to [0 1 0 -100deg\] at (0.25) should be [0 1 0 50deg\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <rotate> from [0 1 0 100deg\] to [0 1 0 -100deg\] at (2) should be [0 1 0 -300deg\]]
-    expected: FAIL
-
   [CSS Animations: property <rotate> from [none\] to [none\] at (0) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [0 1 0 0deg\] to [1 0 0 450deg\] at (0) should be [1 0 0 0deg\]]
     expected: FAIL
 
   [CSS Animations: property <rotate> from [none\] to [none\] at (2) should be [none\]]
@@ -143,16 +113,7 @@
   [CSS Transitions: property <rotate> from [none\] to [7 -8 9 400grad\] at (-1) should be [0.5 -0.57 0.65 -400grad\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (-1) should be [0.447214 -0.447214 0.774597 104.478deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [none\] to [7 -8 9 400grad\] at (0) should be [0.5 -0.57 0.65 0deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from neutral to [30deg\] at (1) should be [30deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (0) should be [0 1 0 0deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [inherit\] to [270deg\] at (0) should be [90deg\]]
@@ -176,21 +137,6 @@
   [Web Animations: property <rotate> from [inherit\] to [270deg\] at (0.25) should be [135deg\]]
     expected: FAIL
 
-  [CSS Transitions: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (0.875) should be [-0.70246 0.70246 0.114452 53.1994deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [0 1 0 100deg\] to [0 1 0 -100deg\] at (-1) should be [0 1 0 300deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from neutral to [30deg\] at (0.75) should be [25deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [100deg\] to [180deg\] at (0.875) should be [170deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (2) should be [-0.52 0.29 0.81 208.96deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [inherit\] to [270deg\] at (0.75) should be [225deg\]]
     expected: FAIL
 
@@ -209,25 +155,7 @@
   [CSS Transitions with transition: all: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (0.75) should be [0.22 -0.55 0.8 -50deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [100deg\] to [180deg\] at (1) should be [180deg\]]
-    expected: FAIL
-
   [CSS Transitions: property <rotate> from [none\] to [7 -8 9 400grad\] at (0.125) should be [0.5 -0.57 0.65 50grad\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [unset\] to [30deg\] at (0.25) should be [7.5deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (0.125) should be [-0.136456 0.136456 0.981203 40.6037deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [100deg\] to [-100deg\] at (2) should be [-300deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [none\] to [7 -8 9 400grad\] at (0.125) should be [0.5 -0.57 0.65 50grad\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (0.875) should be [-0.70246 0.70246 0.114452 53.1994deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (0.75) should be [0.22 -0.55 0.8 -50deg\]]
@@ -248,22 +176,10 @@
   [CSS Transitions with transition: all: property <rotate> from [0 1 0 0deg\] to [1 0 0 450deg\] at (-1) should be [1 0 0 -450deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (2) should be [-0.52 0.29 0.81 208.96deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from neutral to [30deg\] at (-1) should be [-10deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [100deg\] to [180deg\] at (0.875) should be [170deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (0) should be [0.22 -0.55 0.8 100deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [100deg\] to [-100deg\] at (0.25) should be [50deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (0.75) should be [0 1 0 7.5deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from neutral to [30deg\] at (-1) should be [-10deg\]]
@@ -275,43 +191,16 @@
   [CSS Transitions with transition: all: property <rotate> from [100deg\] to [180deg\] at (-1) should be [20deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [unset\] to [30deg\] at (0.25) should be [7.5deg\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (0.25) should be [0.54 0.8 0.26 94.83deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (2) should be [1 0 0 -450deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from neutral to [30deg\] at (2) should be [50deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [0 1 0 0deg\] to [1 0 0 450deg\] at (-1) should be [1 0 0 -450deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (0.75) should be [0 1 0 7.5deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [100deg\] to [180deg\] at (0) should be [100deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [100deg\] to [180deg\] at (0) should be [100deg\]]
-    expected: FAIL
-
   [CSS Animations: property <rotate> from [none\] to [none\] at (0.125) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (0.875) should be [-0.70246 0.70246 0.114452 53.1994deg\]]
-    expected: FAIL
-
   [CSS Animations: property <rotate> from [none\] to [none\] at (1) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (1) should be [-0.71 0.71 0 60deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (2) should be [0.22 -0.55 0.8 -300deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [none\] to [7 -8 9 400grad\] at (-1) should be [0.5 -0.57 0.65 -400grad\]]
@@ -320,28 +209,10 @@
   [CSS Transitions: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (0.25) should be [0.54 0.8 0.26 94.83deg\]]
     expected: FAIL
 
-  [CSS Transitions: property <rotate> from [unset\] to [30deg\] at (2) should be [60deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [100deg\] to [180deg\] at (2) should be [260deg\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (-1) should be [0.447214 -0.447214 0.774597 104.478deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [0 1 0 0deg\] to [1 0 0 450deg\] at (0.25) should be [1 0 0 112.5deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [unset\] to [30deg\] at (2) should be [60deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (2) should be [-0.637897 0.637897 -0.431479 124.975deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (0) should be [0.71 0.71 0 90deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (0.25) should be [0.22 -0.55 0.8 50deg\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <rotate> from [0 1 0 100deg\] to [0 1 0 -100deg\] at (-1) should be [0 1 0 300deg\]]
@@ -371,9 +242,6 @@
   [Web Animations: property <rotate> from [100deg\] to [-100deg\] at (1) should be [-100deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [none\] to [7 -8 9 400grad\] at (-1) should be [0.5 -0.57 0.65 -400grad\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [none\] to [30deg\] at (0.75) should be [22.5deg\]]
     expected: FAIL
 
@@ -383,13 +251,7 @@
   [Web Animations: property <rotate> from [none\] to [7 -8 9 400grad\] at (0) should be [0.5 -0.57 0.65 0deg\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <rotate> from [unset\] to [30deg\] at (-1) should be [-30deg\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (-1) should be [0.22 -0.55 0.8 300deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (-1) should be [0.67 -0.06 -0.74 124.97deg\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <rotate> from [inherit\] to [270deg\] at (-1) should be [-90deg\]]
@@ -401,9 +263,6 @@
   [Web Animations: property <rotate> from [0 1 0 100deg\] to [0 1 0 -100deg\] at (0) should be [0 1 0 100deg\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (2) should be [1 0 0 -450deg\]]
-    expected: FAIL
-
   [CSS Transitions: property <rotate> from [100deg\] to [180deg\] at (-1) should be [20deg\]]
     expected: FAIL
 
@@ -411,9 +270,6 @@
     expected: FAIL
 
   [Web Animations: property <rotate> from [0 1 0 0deg\] to [1 0 0 450deg\] at (0) should be [1 0 0 0deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from neutral to [30deg\] at (2) should be [50deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (0.25) should be [0.54 0.8 0.26 94.83deg\]]
@@ -452,16 +308,7 @@
   [Web Animations: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (0.25) should be [0.22 -0.55 0.8 50deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (0) should be [z 45deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [none\] to [none\] at (2) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [none\] to [30deg\] at (1) should be [30deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [none\] to [7 -8 9 400grad\] at (0.875) should be [0.5 -0.57 0.65 350grad\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (1) should be [0 1 0 10deg\]]
@@ -473,52 +320,16 @@
   [CSS Transitions with transition: all: property <rotate> from [inherit\] to [270deg\] at (0.25) should be [135deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [none\] to [30deg\] at (2) should be [60deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (0.125) should be [-0.136456 0.136456 0.981203 40.6037deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [none\] to [none\] at (1) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [100deg\] to [-100deg\] at (-1) should be [300deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from [unset\] to [30deg\] at (0.25) should be [7.5deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from neutral to [30deg\] at (0.25) should be [15deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (0) should be [0.22 -0.55 0.8 100deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (0.125) should be [-0.136456 0.136456 0.981203 40.6037deg\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <rotate> from neutral to [30deg\] at (0.75) should be [25deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [none\] to [30deg\] at (2) should be [60deg\]]
-    expected: FAIL
-
   [CSS Transitions: property <rotate> from [none\] to [7 -8 9 400grad\] at (0.875) should be [0.5 -0.57 0.65 350grad\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [0 1 0 0deg\] to [1 0 0 450deg\] at (2) should be [1 0 0 900deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (0.75) should be [0.17 0.78 0.61 118.68deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from neutral to [30deg\] at (-1) should be [-10deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [none\] to [none\] at (0.875) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [none\] to [30deg\] at (0) should be [0deg\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <rotate> from [100deg\] to [-100deg\] at (0.25) should be [50deg\]]
@@ -542,19 +353,7 @@
   [CSS Animations: property <rotate> from [none\] to [none\] at (0.875) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [unset\] to [30deg\] at (0.75) should be [22.5deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (0.25) should be [1 0 0 337.5deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [unset\] to [30deg\] at (2) should be [60deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from [none\] to [30deg\] at (0.25) should be [7.5deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [100deg\] to [180deg\] at (0.125) should be [110deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [none\] to [7 -8 9 400grad\] at (1) should be [0.5 -0.57 0.65 400grad\]]
@@ -563,43 +362,16 @@
   [CSS Transitions: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (0.25) should be [1 0 0 337.5deg\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (0.125) should be [-0.136456 0.136456 0.981203 40.6037deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [100deg\] to [-100deg\] at (1) should be [-100deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (2) should be [0.22 -0.55 0.8 -300deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (0.75) should be [1 0 0 112.5deg\]]
     expected: FAIL
 
-  [CSS Transitions: property <rotate> from [none\] to [30deg\] at (2) should be [60deg\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <rotate> from [inherit\] to [270deg\] at (0.75) should be [225deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from neutral to [30deg\] at (0.25) should be [15deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (0.25) should be [0 1 0 2.5deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [unset\] to [30deg\] at (1) should be [30deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (0.25) should be [0 1 0 2.5deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [100deg\] to [180deg\] at (0.125) should be [110deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [none\] to [none\] at (-1) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [unset\] to [30deg\] at (-1) should be [-30deg\]]
     expected: FAIL
 
   [CSS Transitions: property <rotate> from [inherit\] to [270deg\] at (0.25) should be [135deg\]]
@@ -617,34 +389,13 @@
   [Web Animations: property <rotate> from [none\] to [7 -8 9 400grad\] at (0.125) should be [0.5 -0.57 0.65 50grad\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (2) should be [0 1 0 20deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [unset\] to [30deg\] at (0.75) should be [22.5deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [0 1 0 100deg\] to [0 1 0 -100deg\] at (1) should be [0 1 0 -100deg\]]
     expected: FAIL
 
   [CSS Transitions: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (0.25) should be [0.22 -0.55 0.8 50deg\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <rotate> from [100deg\] to [-100deg\] at (0.75) should be [-50deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from [unset\] to [30deg\] at (-1) should be [-30deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [0 1 0 100deg\] to [0 1 0 -100deg\] at (2) should be [0 1 0 -300deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from [100deg\] to [180deg\] at (2) should be [260deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [none\] to [30deg\] at (-1) should be [-30deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [unset\] to [30deg\] at (0) should be [0deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (0.75) should be [0 1 0 7.5deg\]]
@@ -660,18 +411,6 @@
     expected: FAIL
 
   [Web Animations: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (0) should be [1 0 0 450deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from [100deg\] to [180deg\] at (0.125) should be [110deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (-1) should be [0 1 0 -10deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [none\] to [7 -8 9 400grad\] at (2) should be [0.5 -0.57 0.65 800grad\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from neutral to [30deg\] at (0.75) should be [25deg\]]
     expected: FAIL
 
   [CSS Transitions: property <rotate> from [inherit\] to [270deg\] at (0.75) should be [225deg\]]
@@ -695,28 +434,16 @@
   [Web Animations: property <rotate> from [100deg\] to [-100deg\] at (-1) should be [300deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [inherit\] to [270deg\] at (1) should be [270deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [inherit\] to [270deg\] at (1) should be [270deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [unset\] to [30deg\] at (-1) should be [-30deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (2) should be [0 1 0 20deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (0) should be [1 0 0 450deg\]]
-    expected: FAIL
-
   [CSS Transitions: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (-1) should be [0.22 -0.55 0.8 300deg\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (0.25) should be [1 0 0 337.5deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (-1) should be [0.67 -0.06 -0.74 124.97deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (2) should be [0.22 -0.55 0.8 -300deg\]]
@@ -737,97 +464,28 @@
   [Web Animations: property <rotate> from [0 1 0 100deg\] to [0 1 0 -100deg\] at (-1) should be [0 1 0 300deg\]]
     expected: FAIL
 
-  [CSS Transitions: property <rotate> from [none\] to [30deg\] at (0.75) should be [22.5deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (1) should be [0 0.71 0.71 135deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [unset\] to [30deg\] at (0.25) should be [7.5deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (1) should be [0 0.71 0.71 135deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from [none\] to [30deg\] at (-1) should be [-30deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [100deg\] to [180deg\] at (-1) should be [20deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from neutral to [30deg\] at (-1) should be [-10deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from [unset\] to [30deg\] at (0.75) should be [22.5deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from neutral to [30deg\] at (0.25) should be [15deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [0 1 0 0deg\] to [1 0 0 450deg\] at (0.75) should be [1 0 0 337.5deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [none\] to [7 -8 9 400grad\] at (1) should be [0.5 -0.57 0.65 400grad\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (-1) should be [0 1 0 -10deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from neutral to [30deg\] at (0.75) should be [25deg\]]
     expected: FAIL
 
-  [CSS Transitions: property <rotate> from [100deg\] to [180deg\] at (0.875) should be [170deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [0 1 0 0deg\] to [1 0 0 450deg\] at (1) should be [1 0 0 450deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (1) should be [1 0 0 0deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (2) should be [-0.637897 0.637897 -0.431479 124.975deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [100deg\] to [180deg\] at (0.125) should be [110deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from neutral to [30deg\] at (0) should be [10deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [100deg\] to [-100deg\] at (0.25) should be [50deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (0.75) should be [0.22 -0.55 0.8 -50deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from neutral to [30deg\] at (1) should be [30deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (2) should be [0 1 0 20deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [0 1 0 0deg\] to [1 0 0 450deg\] at (2) should be [1 0 0 900deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [none\] to [30deg\] at (0.75) should be [22.5deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [unset\] to [30deg\] at (0.75) should be [22.5deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [100deg\] to [-100deg\] at (0) should be [100deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (1) should be [0 1 0 10deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [0 1 0 0deg\] to [1 0 0 450deg\] at (-1) should be [1 0 0 -450deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [0 1 0 100deg\] to [0 1 0 -100deg\] at (2) should be [0 1 0 -300deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [100deg\] to [-100deg\] at (2) should be [-300deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from neutral to [30deg\] at (2) should be [50deg\]]
@@ -839,16 +497,10 @@
   [Web Animations: property <rotate> from [none\] to [none\] at (0.125) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [0 1 0 100deg\] to [0 1 0 -100deg\] at (0.75) should be [0 1 0 -50deg\]]
-    expected: FAIL
-
   [CSS Transitions: property <rotate> from [none\] to [7 -8 9 400grad\] at (2) should be [0.5 -0.57 0.65 800grad\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (0) should be [0.71 0.71 0 90deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [none\] to [30deg\] at (-1) should be [-30deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (1) should be [1 0 0 0deg\]]
@@ -860,13 +512,7 @@
   [CSS Transitions: property <rotate> from [100deg\] to [-100deg\] at (-1) should be [300deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (0.75) should be [1 0 0 112.5deg\]]
-    expected: FAIL
-
   [CSS Transitions: property <rotate> from [0 1 0 100deg\] to [0 1 0 -100deg\] at (2) should be [0 1 0 -300deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (2) should be [-0.52 0.29 0.81 208.96deg\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [100deg\] to [180deg\] at (0.875) should be [170deg\]]
@@ -875,43 +521,16 @@
   [CSS Animations: property <rotate> from [none\] to [none\] at (-1) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (-1) should be [0.22 -0.55 0.8 300deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [none\] to [30deg\] at (0.25) should be [7.5deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [0 1 0 100deg\] to [0 1 0 -100deg\] at (0) should be [0 1 0 100deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [100deg\] to [180deg\] at (1) should be [180deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (1) should be [0.22 -0.55 0.8 -100deg\]]
     expected: FAIL
 
   [CSS Transitions: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (0.75) should be [0.17 0.78 0.61 118.68deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [100deg\] to [-100deg\] at (0.75) should be [-50deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (0.25) should be [0.54 0.8 0.26 94.83deg\]]
-    expected: FAIL
-
   [CSS Animations: property <rotate> from [inherit\] to [270deg\] at (0) should be [90deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [100deg\] to [-100deg\] at (0) should be [100deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [100deg\] to [180deg\] at (2) should be [260deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [unset\] to [30deg\] at (2) should be [60deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [none\] to [30deg\] at (0.75) should be [22.5deg\]]
     expected: FAIL
 
   [CSS Animations: property <rotate> from [inherit\] to [270deg\] at (-1) should be [-90deg\]]
@@ -920,36 +539,27 @@
   [Web Animations: property <rotate> from [inherit\] to [270deg\] at (2) should be [450deg\]]
     expected: FAIL
 
-  [CSS Transitions: property <rotate> from neutral to [30deg\] at (2) should be [50deg\]]
-    expected: FAIL
-
-  [CSS Transitions: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (0.75) should be [0 1 0 7.5deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (0.25) should be [0 1 0 2.5deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [45deg\] to [-1 1 0 60deg\] at (2) should be [-0.637897 0.637897 -0.431479 124.975deg\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <rotate> from [inherit\] to [270deg\] at (2) should be [450deg\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [1 1 0 90deg\] to [0 1 1 135deg\] at (0.75) should be [0.17 0.78 0.61 118.68deg\]]
     expected: FAIL
 
   [CSS Transitions: property <rotate> from [0 1 0 0deg\] to [1 0 0 450deg\] at (0.25) should be [1 0 0 112.5deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [none\] to [7 -8 9 400grad\] at (2) should be [0.5 -0.57 0.65 800grad\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (1) should be [0.22 -0.55 0.8 -100deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (-1) should be [1 0 0 900deg\]]
+  [CSS Transitions with transition: all: property <rotate> from [100deg\] to [180deg\] at (0.875) should be [170deg\]]
     expected: FAIL
 
-  [CSS Transitions: property <rotate> from [1 0 0 450deg\] to [0 1 0 0deg\] at (1) should be [1 0 0 0deg\]]
+  [CSS Transitions with transition: all: property <rotate> from [100deg\] to [180deg\] at (0.125) should be [110deg\]]
+    expected: FAIL
+
+  [CSS Transitions: property <rotate> from [100deg\] to [180deg\] at (2) should be [260deg\]]
+    expected: FAIL
+
+  [CSS Transitions: property <rotate> from [100deg\] to [180deg\] at (0.125) should be [110deg\]]
+    expected: FAIL
+
+  [CSS Transitions: property <rotate> from [100deg\] to [180deg\] at (0.875) should be [170deg\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transforms/animation/scale-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/scale-interpolation.html.ini
@@ -92,97 +92,31 @@
   [scale interpolation]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <scale> from [26 17 9\] to [2 1\] at (0.875) should be [5 3 2\]]
-    expected: FAIL
-
   [CSS Transitions: property <scale> from [2 30 400\] to [10 110 1200\] at (2) should be [18 190 2000\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [none\] to [4 3 2\] at (2) should be [7 5 3\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [26 17 9\] to [2 1\] at (-1) should be [50 33 17\]]
     expected: FAIL
 
   [CSS Animations: property <scale> from [2 0.5 1\] to [inherit\] at (0.25) should be [1.625 0.625 1.25\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [inherit\] to [2 0.5 1\] at (1) should be [2 0.5\]]
-    expected: FAIL
-
   [CSS Animations: property <scale> from [inherit\] to [initial\] at (0) should be [0.5 1 2\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [-10 5 1\] to [1\] at (-1) should be [-21 9\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [1\] to [10 -5 0\] at (0.25) should be [3.25 -0.5 0.75\]]
     expected: FAIL
 
-  [CSS Transitions: property <scale> from [inherit\] to [initial\] at (0.25) should be [0.625 1 1.75\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from neutral to [1.5 1\] at (0.75) should be [1.4 1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [inherit\] to [initial\] at (0.75) should be [0.875 1 1.25\]]
-    expected: FAIL
-
   [CSS Animations: property <scale> from [2 0.5 1\] to [inherit\] at (0.75) should be [0.875 0.875 1.75\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [2 30 400\] to [10 110 1200\] at (1) should be [10 110 1200\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [1\] to [10 -5 0\] at (0.75) should be [7.75 -3.5 0.25\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [inherit\] to [initial\] at (0.75) should be [0.875 1 1.25\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [26 17 9\] to [2 1\] at (2) should be [-22 -15 -7\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [1\] to [10 -5 0\] at (2) should be [19 -11 -1\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [unset\] to [1.5 1\] at (-1) should be [0.5 1\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [26 17 9\] to [2 1\] at (1) should be [2 1\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [1\] to [10 -5 0\] at (-1) should be [-8 7 2\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [none\] to [none\] at (-1) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from neutral to [1.5 1\] at (2) should be [1.9 1\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [-10 5 1\] to [1\] at (0.75) should be [-1.75 2\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [-10 5\] to [10 -5\] at (2) should be [30 -15\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [2 0.5 1\] to [initial\] at (0) should be [2 0.5\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [1\] to [10 -5 0\] at (0) should be [1\]]
     expected: FAIL
 
-  [CSS Transitions: property <scale> from [none\] to [4 3 2\] at (0.125) should be [1.375 1.25 1.125\]]
-    expected: FAIL
-
   [CSS Transitions: property <scale> from [2 0.5 1\] to [inherit\] at (0.25) should be [1.625 0.625 1.25\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [1\] to [10 -5 0\] at (1) should be [10 -5 0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [-10 5\] to [10 -5\] at (2) should be [30 -15\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [none\] to [4 3 2\] at (2) should be [7 5 3\]]
@@ -192,15 +126,6 @@
     expected: FAIL
 
   [CSS Transitions with transition: all: property <scale> from [2 30 400\] to [10 110 1200\] at (-1) should be [-6 -50 -400\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [-10 5 1\] to [1\] at (-1) should be [-21 9\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [2 30 400\] to [10 110 1200\] at (0) should be [2 30 400\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [2 0.5 1\] to [inherit\] at (2) should be [-1 1.5 3\]]
     expected: FAIL
 
   [CSS Animations: property <scale> from [none\] to [none\] at (0.875) should be [none\]]
@@ -221,12 +146,6 @@
   [Web Animations: property <scale> from [2 0.5 1\] to [initial\] at (1) should be [1\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [2 0.5 1\] to [initial\] at (-1) should be [3 0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [-10 5 1\] to [1\] at (2) should be [12 -3\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [inherit\] to [2 0.5 1\] at (-1) should be [-1 1.5 3\]]
     expected: FAIL
 
@@ -236,40 +155,16 @@
   [CSS Transitions: property <scale> from [2 30 400\] to [10 110 1200\] at (0.125) should be [3 40 500\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <scale> from [-10 5\] to [10 -5\] at (0.75) should be [5 -2.5\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [2 30 400\] to [10 110 1200\] at (0) should be [2 30 400\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [2 0.5 1\] to [initial\] at (0.25) should be [1.75 0.6251\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [-10 5\] to [10 -5\] at (1) should be [10 -5\]]
     expected: FAIL
 
-  [CSS Transitions: property <scale> from [unset\] to [1.5 1\] at (2) should be [2 1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [none\] to [4 3 2\] at (-1) should be [-2 -1 0\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [26 17 9\] to [2 1\] at (0.875) should be [5 3 2\]]
     expected: FAIL
 
-  [CSS Transitions: property <scale> from [2 0.5 1\] to [inherit\] at (-1) should be [3.5 0 0\]]
-    expected: FAIL
-
   [CSS Animations: property <scale> from [none\] to [none\] at (-1) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [initial\] to [2 0.5 1\] at (2) should be [3 0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [-10 5\] to [10 -5\] at (0.75) should be [5 -2.5\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [inherit\] to [initial\] at (0.75) should be [0.875 1 1.25\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [none\] to [4 3 2\] at (1) should be [4 3 2\]]
@@ -278,25 +173,10 @@
   [Web Animations: property <scale> from [2 30 400\] to [10 110 1200\] at (2) should be [18 190 2000\]]
     expected: FAIL
 
-  [CSS Transitions: property <scale> from [26 17 9\] to [2 1\] at (0.125) should be [23 15 8\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [unset\] to [1.5 1\] at (0.75) should be [1.375 1\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [unset\] to [1.5 1\] at (0.25) should be [1.125 1\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [-10 5\] to [10 -5\] at (0) should be [-10 5\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [-10 5 1\] to [1\] at (0.25) should be [-7.25 4\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [inherit\] to [initial\] at (-1) should be [0 1 3\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [26 17 9\] to [2 1\] at (-1) should be [50 33 17\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [2 0.5 1\] to [inherit\] at (2) should be [-1 1.5 3\]]
@@ -305,40 +185,13 @@
   [CSS Animations: property <scale> from [none\] to [none\] at (0.125) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [initial\] to [2 0.5 1\] at (0) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [initial\] to [inherit\] at (2) should be [0 1 3\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [1\] to [10 -5 0\] at (2) should be [19 -11 -1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [-10 5\] to [10 -5\] at (0.25) should be [-5 2.5\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [inherit\] to [2 0.5 1\] at (2) should be [3.5 0 0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [initial\] to [2 0.5 1\] at (2) should be [3 0\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [1\] to [10 -5 0\] at (1) should be [10 -5 0\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <scale> from [2 0.5 1\] to [inherit\] at (0.75) should be [0.875 0.875 1.75\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [-10 5\] to [10 -5\] at (0.75) should be [5 -2.5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from neutral to [1.5 1\] at (2) should be [1.9 1\]]
-    expected: FAIL
-
   [CSS Animations: property <scale> from [initial\] to [inherit\] at (1) should be [0.5 1 2\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from neutral to [1.5 1\] at (0.75) should be [1.4 1\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [2 30 400\] to [10 110 1200\] at (-1) should be [-6 -50 -400\]]
@@ -347,31 +200,7 @@
   [CSS Transitions: property <scale> from [inherit\] to [2 0.5 1\] at (0.25) should be [0.875 0.875 1.75\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from neutral to [1.5 1\] at (0.25) should be [1.2 1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [1\] to [10 -5 0\] at (0.25) should be [3.25 -0.5 0.75\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [none\] to [4 3 2\] at (0.875) should be [3.625 2.75 1.875\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [2 0.5 1\] to [initial\] at (0.75) should be [1.25 0.875\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [-10 5 1\] to [1\] at (0) should be [-10 5\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [initial\] to [2 0.5 1\] at (-1) should be [0 1.5\]]
-    expected: FAIL
-
   [CSS Animations: property <scale> from [none\] to [none\] at (1) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [2 0.5 1\] to [initial\] at (0.25) should be [1.75 0.6251\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [-10 5 1\] to [1\] at (2) should be [12 -3\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [26 17 9\] to [2 1\] at (0.125) should be [23 15 8\]]
@@ -395,9 +224,6 @@
   [Web Animations: property <scale> from [none\] to [none\] at (1) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [-10 5 1\] to [1\] at (2) should be [12 -3\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [-10 5 1\] to [1\] at (0) should be [-10 5\]]
     expected: FAIL
 
@@ -416,9 +242,6 @@
   [Web Animations: property <scale> from [26 17 9\] to [2 1\] at (0) should be [26 17 9\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <scale> from [unset\] to [1.5 1\] at (0.25) should be [1.125 1\]]
-    expected: FAIL
-
   [CSS Animations: property <scale> from [2 0.5 1\] to [inherit\] at (0) should be [2 0.5\]]
     expected: FAIL
 
@@ -428,25 +251,7 @@
   [CSS Animations: property <scale> from [inherit\] to [2 0.5 1\] at (2) should be [3.5 0 0\]]
     expected: FAIL
 
-  [CSS Transitions: property <scale> from [26 17 9\] to [2 1\] at (0.875) should be [5 3 2\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [unset\] to [1.5 1\] at (2) should be [2 1\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [-10 5\] to [10 -5\] at (0.25) should be [-5 2.5\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [inherit\] to [2 0.5 1\] at (1) should be [2 0.5\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [-10 5\] to [10 -5\] at (2) should be [30 -15\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [-10 5 1\] to [1\] at (-1) should be [-21 9\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [-10 5 1\] to [1\] at (1) should be [1\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [2 0.5 1\] to [inherit\] at (-1) should be [3.5 0 0\]]
@@ -458,19 +263,10 @@
   [CSS Animations: property <scale> from [inherit\] to [initial\] at (2) should be [1.5 1 0\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [1\] to [10 -5 0\] at (0.75) should be [7.75 -3.5 0.25\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [none\] to [4 3 2\] at (2) should be [7 5 3\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <scale> from [initial\] to [2 0.5 1\] at (0.75) should be [1.75 0.625\]]
     expected: FAIL
 
   [CSS Transitions: property <scale> from [2 30 400\] to [10 110 1200\] at (0.875) should be [9 100 1100\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [1\] to [10 -5 0\] at (-1) should be [-8 7 2\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [2 0.5 1\] to [initial\] at (0.75) should be [1.25 0.875\]]
@@ -482,31 +278,13 @@
   [Web Animations: property <scale> from [2 30 400\] to [10 110 1200\] at (1) should be [10 110 1200\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <scale> from [none\] to [4 3 2\] at (0.125) should be [1.375 1.25 1.125\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <scale> from [initial\] to [inherit\] at (0.75) should be [0.625 1 1.75\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [initial\] to [2 0.5 1\] at (2) should be [3 0\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <scale> from [initial\] to [2 0.5 1\] at (0.25) should be [1.25 0.875\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <scale> from [2 0.5 1\] to [initial\] at (-1) should be [3 0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [26 17 9\] to [2 1\] at (-1) should be [50 33 17\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [unset\] to [1.5 1\] at (0.75) should be [1.375 1\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [none\] to [4 3 2\] at (1) should be [4 3 2\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [-10 5 1\] to [1\] at (0.25) should be [-7.25 4\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [unset\] to [1.5 1\] at (2) should be [2 1\]]
@@ -516,9 +294,6 @@
     expected: FAIL
 
   [CSS Animations: property <scale> from [inherit\] to [initial\] at (0.75) should be [0.875 1 1.25\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [unset\] to [1.5 1\] at (0.25) should be [1.125 1\]]
     expected: FAIL
 
   [Web Animations: property <scale> from neutral to [1.5 1\] at (1) should be [1.5 1\]]
@@ -536,19 +311,10 @@
   [CSS Animations: property <scale> from [inherit\] to [2 0.5 1\] at (0) should be [0.5 1 2\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [none\] to [4 3 2\] at (-1) should be [-2 -1 0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [2 0.5 1\] to [initial\] at (0.75) should be [1.25 0.875\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [1\] to [10 -5 0\] at (2) should be [19 -11 -1\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [inherit\] to [initial\] at (1) should be [1\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [26 17 9\] to [2 1\] at (0.875) should be [5 3 2\]]
     expected: FAIL
 
   [CSS Transitions: property <scale> from [initial\] to [inherit\] at (0.25) should be [0.875 1 1.25\]]
@@ -560,37 +326,13 @@
   [CSS Animations: property <scale> from [2 0.5 1\] to [inherit\] at (-1) should be [3.5 0 0\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from neutral to [1.5 1\] at (0.75) should be [1.4 1\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [2 0.5 1\] to [initial\] at (2) should be [0 1.5\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [-10 5 1\] to [1\] at (0.25) should be [-7.25 4\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [unset\] to [1.5 1\] at (-1) should be [0.5 1\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from neutral to [1.5 1\] at (2) should be [1.9 1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [inherit\] to [2 0.5 1\] at (-1) should be [-1 1.5 3\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [2 0.5 1\] to [initial\] at (-1) should be [3 0\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [inherit\] to [initial\] at (0) should be [0.5 1 2\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [-10 5\] to [10 -5\] at (-1) should be [-30 15\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [none\] to [4 3 2\] at (2) should be [7 5 3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [1\] to [10 -5 0\] at (-1) should be [-8 7 2\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [initial\] to [2 0.5 1\] at (2) should be [3 0\]]
@@ -602,9 +344,6 @@
   [CSS Animations: property <scale> from [initial\] to [inherit\] at (2) should be [0 1 3\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [none\] to [4 3 2\] at (0.875) should be [3.625 2.75 1.875\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [initial\] to [inherit\] at (0.75) should be [0.625 1 1.75\]]
     expected: FAIL
 
@@ -614,16 +353,10 @@
   [CSS Transitions: property <scale> from [initial\] to [2 0.5 1\] at (0.25) should be [1.25 0.875\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [2 30 400\] to [10 110 1200\] at (0.125) should be [3 40 500\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from neutral to [1.5 1\] at (0.75) should be [1.4 1\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [-10 5\] to [10 -5\] at (2) should be [30 -15\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [initial\] to [2 0.5 1\] at (-1) should be [0 1.5\]]
     expected: FAIL
 
   [Web Animations: property <scale> from neutral to [1.5 1\] at (-1) should be [0.7 1\]]
@@ -635,15 +368,6 @@
   [Web Animations: property <scale> from [2 0.5 1\] to [initial\] at (2) should be [0 1.5\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <scale> from [unset\] to [1.5 1\] at (-1) should be [0.5 1\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [1\] to [10 -5 0\] at (0.25) should be [3.25 -0.5 0.75\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [initial\] to [2 0.5 1\] at (1) should be [2 0.5\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [none\] to [4 3 2\] at (0) should be [1\]]
     expected: FAIL
 
@@ -651,9 +375,6 @@
     expected: FAIL
 
   [Web Animations: property <scale> from neutral to [1.5 1\] at (2) should be [1.9 1\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [inherit\] to [initial\] at (1) should be [1\]]
     expected: FAIL
 
   [Web Animations: property <scale> from neutral to [1.5 1\] at (0.25) should be [1.2 1\]]
@@ -668,16 +389,7 @@
   [CSS Transitions: property <scale> from [initial\] to [2 0.5 1\] at (0.75) should be [1.75 0.625\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [none\] to [4 3 2\] at (0.125) should be [1.375 1.25 1.125\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [unset\] to [1.5 1\] at (0.25) should be [1.125 1\]]
-    expected: FAIL
-
   [CSS Animations: property <scale> from [initial\] to [inherit\] at (0) should be [1\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [2 30 400\] to [10 110 1200\] at (0.875) should be [9 100 1100\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [initial\] to [2 0.5 1\] at (0.25) should be [1.25 0.875\]]
@@ -689,34 +401,10 @@
   [Web Animations: property <scale> from [initial\] to [inherit\] at (-1) should be [1.5 1 0\]]
     expected: FAIL
 
-  [CSS Transitions: property <scale> from [-10 5\] to [10 -5\] at (-1) should be [-30 15\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [unset\] to [1.5 1\] at (0) should be [1\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [unset\] to [1.5 1\] at (1) should be [1.5 1\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [2 0.5 1\] to [inherit\] at (0.25) should be [1.625 0.625 1.25\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from neutral to [1.5 1\] at (0.25) should be [1.2 1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [unset\] to [1.5 1\] at (0.75) should be [1.375 1\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [2 0.5 1\] to [initial\] at (2) should be [0 1.5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [inherit\] to [initial\] at (-1) should be [0 1 3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [inherit\] to [initial\] at (0.25) should be [0.625 1 1.75\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [inherit\] to [2 0.5 1\] at (2) should be [3.5 0 0\]]
     expected: FAIL
 
   [CSS Animations: property <scale> from [inherit\] to [2 0.5 1\] at (0.25) should be [0.875 0.875 1.75\]]
@@ -728,13 +416,7 @@
   [Web Animations: property <scale> from [inherit\] to [2 0.5 1\] at (0.25) should be [0.875 0.875 1.75\]]
     expected: FAIL
 
-  [CSS Transitions: property <scale> from [1\] to [10 -5 0\] at (0.25) should be [3.25 -0.5 0.75\]]
-    expected: FAIL
-
   [CSS Animations: property <scale> from [initial\] to [inherit\] at (0.75) should be [0.625 1 1.75\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [26 17 9\] to [2 1\] at (2) should be [-22 -15 -7\]]
     expected: FAIL
 
   [CSS Animations: property <scale> from [inherit\] to [2 0.5 1\] at (0.75) should be [1.625 0.625 1.25\]]
@@ -743,13 +425,7 @@
   [Web Animations: property <scale> from [2 0.5 1\] to [initial\] at (0.25) should be [1.75 0.6251\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <scale> from [2 0.5 1\] to [initial\] at (2) should be [0 1.5\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <scale> from [initial\] to [inherit\] at (0.25) should be [0.875 1 1.25\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [unset\] to [1.5 1\] at (2) should be [2 1\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [none\] to [none\] at (0.125) should be [none\]]
@@ -761,25 +437,13 @@
   [CSS Transitions with transition: all: property <scale> from [2 30 400\] to [10 110 1200\] at (0.875) should be [9 100 1100\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <scale> from [2 0.5 1\] to [inherit\] at (-1) should be [3.5 0 0\]]
-    expected: FAIL
-
   [CSS Animations: property <scale> from [initial\] to [inherit\] at (0.25) should be [0.875 1 1.25\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [inherit\] to [initial\] at (2) should be [1.5 1 0\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [2 0.5 1\] to [initial\] at (0) should be [2 0.5\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <scale> from [26 17 9\] to [2 1\] at (0.125) should be [23 15 8\]]
-    expected: FAIL
-
   [CSS Animations: property <scale> from [2 0.5 1\] to [inherit\] at (2) should be [-1 1.5 3\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [-10 5\] to [10 -5\] at (1) should be [10 -5\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [2 30 400\] to [10 110 1200\] at (0.875) should be [9 100 1100\]]
@@ -788,70 +452,19 @@
   [Web Animations: property <scale> from [unset\] to [1.5 1\] at (0) should be [1\]]
     expected: FAIL
 
-  [CSS Transitions: property <scale> from [initial\] to [inherit\] at (-1) should be [1.5 1 0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from neutral to [1.5 1\] at (-1) should be [0.7 1\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [-10 5 1\] to [1\] at (0.75) should be [-1.75 2\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [2 30 400\] to [10 110 1200\] at (-1) should be [-6 -50 -400\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [-10 5 1\] to [1\] at (0.25) should be [-7.25 4\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [-10 5\] to [10 -5\] at (0) should be [-10 5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [initial\] to [inherit\] at (2) should be [0 1 3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [-10 5 1\] to [1\] at (0.75) should be [-1.75 2\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [26 17 9\] to [2 1\] at (1) should be [2 1\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [-10 5\] to [10 -5\] at (0.25) should be [-5 2.5\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [-10 5\] to [10 -5\] at (-1) should be [-30 15\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [inherit\] to [2 0.5 1\] at (-1) should be [-1 1.5 3\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [-10 5 1\] to [1\] at (-1) should be [-21 9\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [26 17 9\] to [2 1\] at (0.125) should be [23 15 8\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [none\] to [4 3 2\] at (-1) should be [-2 -1 0\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [1\] to [10 -5 0\] at (2) should be [19 -11 -1\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [26 17 9\] to [2 1\] at (-1) should be [50 33 17\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from neutral to [1.5 1\] at (1) should be [1.5 1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [2 0.5 1\] to [initial\] at (0.25) should be [1.75 0.6251\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [none\] to [none\] at (2) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [none\] to [4 3 2\] at (0) should be [1\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [26 17 9\] to [2 1\] at (0) should be [26 17 9\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <scale> from [2 0.5 1\] to [inherit\] at (0.25) should be [1.625 0.625 1.25\]]
@@ -869,19 +482,7 @@
   [Web Animations: property <scale> from [initial\] to [2 0.5 1\] at (1) should be [2 0.5\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [2 0.5 1\] to [initial\] at (1) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from neutral to [1.5 1\] at (0.25) should be [1.2 1\]]
-    expected: FAIL
-
   [CSS Transitions: property <scale> from [inherit\] to [2 0.5 1\] at (0.75) should be [1.625 0.625 1.25\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [initial\] to [2 0.5 1\] at (0.75) should be [1.75 0.625\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [-10 5\] to [10 -5\] at (-1) should be [-30 15\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [initial\] to [inherit\] at (0) should be [1\]]
@@ -890,49 +491,13 @@
   [Web Animations: property <scale> from [none\] to [none\] at (0.875) should be [none\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <scale> from [26 17 9\] to [2 1\] at (2) should be [-22 -15 -7\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [none\] to [4 3 2\] at (0.875) should be [3.625 2.75 1.875\]]
-    expected: FAIL
-
   [CSS Transitions: property <scale> from [2 30 400\] to [10 110 1200\] at (-1) should be [-6 -50 -400\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from neutral to [1.5 1\] at (-1) should be [0.7 1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [initial\] to [inherit\] at (-1) should be [1.5 1 0\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from neutral to [1.5 1\] at (-1) should be [0.7 1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [inherit\] to [initial\] at (2) should be [1.5 1 0\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <scale> from [inherit\] to [2 0.5 1\] at (0.75) should be [1.625 0.625 1.25\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [unset\] to [1.5 1\] at (0.75) should be [1.375 1\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [1\] to [10 -5 0\] at (0) should be [1\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [initial\] to [2 0.5 1\] at (0) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [1\] to [10 -5 0\] at (0.75) should be [7.75 -3.5 0.25\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [2 30 400\] to [10 110 1200\] at (2) should be [18 190 2000\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [2 0.5 1\] to [initial\] at (0.75) should be [1.25 0.875\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [2 0.5 1\] to [inherit\] at (2) should be [-1 1.5 3\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [initial\] to [inherit\] at (2) should be [0 1 3\]]
@@ -941,25 +506,10 @@
   [Web Animations: property <scale> from [1\] to [10 -5 0\] at (-1) should be [-8 7 2\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <scale> from [initial\] to [2 0.5 1\] at (-1) should be [0 1.5\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [-10 5 1\] to [1\] at (1) should be [1\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [initial\] to [2 0.5 1\] at (0.25) should be [1.25 0.875\]]
-    expected: FAIL
-
   [CSS Animations: property <scale> from [initial\] to [inherit\] at (-1) should be [1.5 1 0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <scale> from [none\] to [4 3 2\] at (-1) should be [-2 -1 0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <scale> from [2 30 400\] to [10 110 1200\] at (2) should be [18 190 2000\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [unset\] to [1.5 1\] at (1) should be [1.5 1\]]
     expected: FAIL
 
   [CSS Transitions: property <scale> from [initial\] to [inherit\] at (0.75) should be [0.625 1 1.75\]]

--- a/tests/wpt/metadata/css/css-transforms/animation/transform-interpolation-001.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/transform-interpolation-001.html.ini
@@ -44,13 +44,7 @@
   [CSS Transitions with transition: all: property <transform> from [skewX(10rad) perspective(400px)\] to [skewX(20rad) perspective(500px)\] at (-1) should be [skewX(0rad) perspective(300px)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 2, 0, 450deg)\] at (1) should be [rotate3d(0, 1, 0, 450deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleZ(1) perspective(400px)\] to [scaleZ(2) perspective(500px)\] at (0.25) should be [scaleZ(1.25) perspective(425px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate3d(1, 1, 0, 90deg)\] to [rotate3d(0, 1, 1, 180deg)\] at (0.25) should be [rotate3d(0.524083, 0.804261, 0.280178, 106.91deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotate(90deg)\] to [none\] at (0.75) should be [rotate(22.5deg)\]]
@@ -77,12 +71,6 @@
   [Web Animations: property <transform> from [rotate(90deg)\] to [none\] at (0) should be [rotate(90deg)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [none\] to [rotate(90deg)\] at (0.25) should be [rotate(22.5deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad) perspective(400px)\] to [skewX(20rad) perspective(500px)\] at (0) should be [skewX(10rad) perspective(400px)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [rotateY(900deg)\] to [rotateZ(0deg)\] at (0) should be [rotateY(900deg)\]]
     expected: FAIL
 
@@ -101,12 +89,6 @@
   [CSS Animations: property <transform> from [scaleZ(1) perspective(400px)\] to [scaleZ(2) perspective(500px)\] at (0.25) should be [scaleZ(1.25) perspective(425px)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotate(90deg)\] to [none\] at (-1) should be [rotate(180deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 2, 0, 450deg)\] at (2) should be [rotate3d(0, 1, 0, 900deg)\]]
-    expected: FAIL
-
   [CSS Animations: property <transform> from [skewX(10rad) perspective(400px)\] to [skewX(20rad) perspective(500px)\] at (2) should be [skewX(30rad) perspective(600px)\]]
     expected: FAIL
 
@@ -120,9 +102,6 @@
     expected: FAIL
 
   [CSS Transitions: property <transform> from [rotateY(0deg)\] to [rotateY(800deg)\] at (2) should be [rotateY(1600deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 1, 0, 450deg)\] at (0) should be [rotate3d(0, 1, 0, 0deg)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [rotate3d(7, 8, 9, 0deg)\] to [rotate3d(7, 8, 9, 450deg)\] at (1) should be [rotate3d(7, 8, 9, 450deg)\]]
@@ -149,25 +128,13 @@
   [CSS Transitions with transition: all: property <transform> from [rotate(90deg)\] to [none\] at (-1) should be [rotate(180deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 2, 0, 450deg)\] at (0.75) should be [rotate3d(0, 1, 0, 337.5deg)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [rotateY(900deg)\] to [rotateZ(0deg)\] at (0.25) should be [rotateY(675deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [skewX(10rad) perspective(400px)\] to [skewX(20rad) perspective(500px)\] at (1) should be [skewX(20rad) perspective(500px)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [perspective(400px)\] to [perspective(500px)\] at (1) should be [perspective(500px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [rotate3d(1, 1, 0, 90deg)\] to [rotate3d(0, 1, 1, 180deg)\] at (0.75) should be [rotate3d(0.163027, 0.774382, 0.611354, 153.99deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 2, 0, 450deg)\] at (0) should be [rotate3d(0, 1, 0, 0deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotateX(0deg) rotateY(0deg) rotateZ(0deg)\] to [rotateX(700deg) rotateY(800deg) rotateZ(900deg)\] at (-1) should be [rotateX(-700deg) rotateY(-800deg) rotateZ(-900deg)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [scaleZ(1) perspective(400px)\] to [scaleZ(2) perspective(500px)\] at (2) should be [scaleZ(3) perspective(600px)\]]
@@ -176,16 +143,10 @@
   [CSS Transitions: property <transform> from [rotateX(0deg) rotateY(0deg) rotateZ(0deg)\] to [rotateX(700deg) rotateY(800deg) rotateZ(900deg)\] at (-1) should be [rotateX(-700deg) rotateY(-800deg) rotateZ(-900deg)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 1, 0, 450deg)\] at (2) should be [rotate3d(0, 1, 0, 900deg)\]]
-    expected: FAIL
-
   [CSS Animations: property <transform> from [rotateX(0deg)\] to [rotateY(900deg)\] at (0) should be [rotateY(0deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 2, 0, 450deg)\] at (1) should be [rotate3d(0, 1, 0, 450deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad) perspective(400px)\] to [skewX(20rad) perspective(500px)\] at (1) should be [skewX(20rad) perspective(500px)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [rotate3d(1, 1, 0, 90deg)\] to [rotate3d(0, 1, 1, 180deg)\] at (1) should be [rotate3d(0, 1, 1, 180deg)\]]
@@ -197,12 +158,6 @@
   [CSS Animations: property <transform> from [rotate3d(1, 1, 0, 90deg)\] to [rotate3d(0, 1, 1, 180deg)\] at (0.75) should be [rotate3d(0.163027, 0.774382, 0.611354, 153.99deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotateX(0deg)\] to [rotateX(700deg)\] at (0.25) should be [rotateX(175deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotateY(0deg)\] to [rotateY(800deg)\] at (0.75) should be [rotateY(600deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [rotate(90deg)\] to [none\] at (1) should be [rotate(0deg)\]]
     expected: FAIL
 
@@ -212,16 +167,10 @@
   [CSS Transitions: property <transform> from [none\] to [rotate(90deg)\] at (0.25) should be [rotate(22.5deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotateX(0deg)\] to [rotateX(700deg)\] at (1) should be [rotateX(700deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [rotateZ(0deg)\] to [rotateZ(900deg)\] at (1) should be [rotateZ(900deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [rotate3d(1, 1, 0, 90deg)\] to [rotate3d(0, 1, 1, 180deg)\] at (0.25) should be [rotate3d(0.524083, 0.804261, 0.280178, 106.91deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [rotate(30deg)\] to [rotate(330deg)\] at (2) should be [rotate(630deg)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [rotate(30deg)\] to [rotate(330deg)\] at (0.25) should be [rotate(105deg)\]]
@@ -257,9 +206,6 @@
   [Web Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 2, 0, 450deg)\] at (0.75) should be [rotate3d(0, 1, 0, 337.5deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [scaleZ(1) perspective(400px)\] to [scaleZ(2) perspective(500px)\] at (0) should be [scaleZ(1) perspective(400px)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 2, 0, 450deg)\] at (0.75) should be [rotate3d(0, 1, 0, 337.5deg)\]]
     expected: FAIL
 
@@ -267,9 +213,6 @@
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [none\] to [rotate(90deg)\] at (0.75) should be [rotate(67.5deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [none\] to [rotate(90deg)\] at (-1) should be [rotate(-90deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [rotateX(0deg)\] to [rotateY(900deg)\] at (-1) should be [rotateY(-900deg)\]]
@@ -285,9 +228,6 @@
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [rotateX(0deg)\] to [rotateX(700deg)\] at (0.75) should be [rotateX(525deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 1, 0, 450deg)\] at (0.75) should be [rotate3d(0, 1, 0, 337.5deg)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [rotateX(0deg)\] to [rotateY(900deg)\] at (1) should be [rotateY(900deg)\]]
@@ -326,22 +266,13 @@
   [Web Animations: property <transform> from [rotateZ(0deg)\] to [rotateZ(900deg)\] at (0) should be [rotateZ(0deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotateY(0deg)\] to [rotateY(800deg)\] at (-1) should be [rotateY(-800deg)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [rotate(90deg)\] to [none\] at (0.25) should be [rotate(67.5deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [rotateX(0deg) rotateY(0deg) rotateZ(0deg)\] to [rotateX(700deg) rotateY(800deg) rotateZ(900deg)\] at (2) should be [rotateX(1400deg) rotateY(1600deg) rotateZ(1800deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotateX(0deg)\] to [rotateX(700deg)\] at (0) should be [rotateX(0deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [none\] to [rotate(90deg)\] at (2) should be [rotate(180deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [rotateY(0deg)\] to [rotateY(800deg)\] at (2) should be [rotateY(1600deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotateY(900deg)\] to [rotateZ(0deg)\] at (0) should be [rotateY(900deg)\]]
@@ -362,13 +293,7 @@
   [CSS Transitions with transition: all: property <transform> from [scaleZ(1) perspective(400px)\] to [scaleZ(2) perspective(500px)\] at (0.25) should be [scaleZ(1.25) perspective(425px)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [none\] to [rotate(90deg)\] at (0.75) should be [rotate(67.5deg)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [rotate3d(1, 1, 0, 90deg)\] to [rotate3d(0, 1, 1, 180deg)\] at (1) should be [rotate3d(0, 1, 1, 180deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate3d(1, 1, 0, 90deg)\] to [rotate3d(0, 1, 1, 180deg)\] at (-1) should be [rotate3d(0.41, -0.41, -0.82, 120deg)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [rotate3d(7, 8, 9, 100deg)\] to [rotate3d(7, 8, 9, 260deg)\] at (0.25) should be [rotate3d(7, 8, 9, 140deg)\]]
@@ -389,19 +314,7 @@
   [CSS Transitions: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 1, 0, 450deg)\] at (0.25) should be [rotate3d(0, 1, 0, 112.5deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [none\] to [rotate(90deg)\] at (0) should be [rotate(0deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 1, 0, 450deg)\] at (-1) should be [rotate3d(0, 1, 0, -450deg)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [rotate3d(7, 8, 9, 100deg)\] to [rotate3d(7, 8, 9, 260deg)\] at (2) should be [rotate3d(7, 8, 9, 420deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [rotateX(0deg) rotateY(0deg) rotateZ(0deg)\] to [rotateX(700deg) rotateY(800deg) rotateZ(900deg)\] at (2) should be [rotateX(1400deg) rotateY(1600deg) rotateZ(1800deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotateZ(0deg)\] to [rotateZ(900deg)\] at (-1) should be [rotateZ(-900deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotateX(0deg)\] to [rotateX(700deg)\] at (-1) should be [rotateX(-700deg)\]]
@@ -419,9 +332,6 @@
   [Web Animations: property <transform> from [rotate3d(1, 1, 0, 90deg)\] to [rotate3d(0, 1, 1, 180deg)\] at (1) should be [rotate3d(0, 1, 1, 180deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [scaleZ(1) perspective(400px)\] to [scaleZ(2) perspective(500px)\] at (1) should be [scaleZ(2) perspective(500px)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [rotateY(900deg)\] to [rotateZ(0deg)\] at (1) should be [rotateY(0deg)\]]
     expected: FAIL
 
@@ -434,28 +344,16 @@
   [CSS Transitions with transition: all: property <transform> from [rotate3d(7, 8, 9, 100deg)\] to [rotate3d(7, 8, 9, 260deg)\] at (0.75) should be [rotate3d(7, 8, 9, 220deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotateX(0deg) rotateY(0deg) rotateZ(0deg)\] to [rotateX(700deg) rotateY(800deg) rotateZ(900deg)\] at (0.25) should be [rotateX(175deg) rotateY(200deg) rotateZ(225deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotateX(0deg) rotateY(0deg) rotateZ(0deg)\] to [rotateX(700deg) rotateY(800deg) rotateZ(900deg)\] at (1) should be [rotateX(700deg) rotateY(800deg) rotateZ(900deg)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [rotateX(0deg)\] to [rotateX(700deg)\] at (2) should be [rotateX(1400deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotateY(0deg)\] to [rotateY(800deg)\] at (2) should be [rotateY(1600deg)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [rotateZ(0deg)\] to [rotateZ(900deg)\] at (2) should be [rotateZ(1800deg)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [skewX(10rad) perspective(400px)\] to [skewX(20rad) perspective(500px)\] at (0.25) should be [skewX(12.5rad) perspective(425px)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotateX(0deg) rotateY(0deg) rotateZ(0deg)\] to [rotateX(700deg) rotateY(800deg) rotateZ(900deg)\] at (0) should be [rotateX(0deg) rotateY(0deg) rotateZ(0deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate(90deg)\] to [none\] at (2) should be [rotate(-90deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [rotate(30deg)\] to [rotate(330deg)\] at (2) should be [rotate(630deg)\]]
@@ -509,9 +407,6 @@
   [CSS Transitions: property <transform> from [rotate3d(7, 8, 9, 100deg)\] to [rotate3d(7, 8, 9, 260deg)\] at (0.75) should be [rotate3d(7, 8, 9, 220deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [none\] to [rotate(90deg)\] at (-1) should be [rotate(-90deg)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [rotate(90deg)\] to [none\] at (0.75) should be [rotate(22.5deg)\]]
     expected: FAIL
 
@@ -542,16 +437,10 @@
   [CSS Transitions: property <transform> from [rotateY(900deg)\] to [rotateZ(0deg)\] at (1) should be [rotateY(0deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 1, 0, 450deg)\] at (1) should be [rotate3d(0, 1, 0, 450deg)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 1, 0, 450deg)\] at (-1) should be [rotate3d(0, 1, 0, -450deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 1, 0, 450deg)\] at (0.75) should be [rotate3d(0, 1, 0, 337.5deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotateX(0deg) rotateY(0deg) rotateZ(0deg)\] to [rotateX(700deg) rotateY(800deg) rotateZ(900deg)\] at (2) should be [rotateX(1400deg) rotateY(1600deg) rotateZ(1800deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [rotateZ(0deg)\] to [rotateZ(900deg)\] at (-1) should be [rotateZ(-900deg)\]]
@@ -572,12 +461,6 @@
   [CSS Animations: property <transform> from [skewX(10rad) perspective(400px)\] to [skewX(20rad) perspective(500px)\] at (-1) should be [skewX(0rad) perspective(300px)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotateZ(0deg)\] to [rotateZ(900deg)\] at (0) should be [rotateZ(0deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [perspective(400px)\] to [perspective(500px)\] at (0) should be [perspective(400px)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [rotateY(0deg)\] to [rotateY(800deg)\] at (0.75) should be [rotateY(600deg)\]]
     expected: FAIL
 
@@ -585,9 +468,6 @@
     expected: FAIL
 
   [CSS Transitions: property <transform> from [rotateX(0deg)\] to [rotateY(900deg)\] at (0.75) should be [rotateY(675deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotateY(0deg)\] to [rotateY(800deg)\] at (1) should be [rotateY(800deg)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [skewX(10rad) perspective(400px)\] to [skewX(20rad) perspective(500px)\] at (0.75) should be [skewX(17.5rad) perspective(475px)\]]
@@ -605,9 +485,6 @@
   [CSS Transitions with transition: all: property <transform> from [rotate3d(7, 8, 9, 0deg)\] to [rotate3d(7, 8, 9, 450deg)\] at (-1) should be [rotate3d(7, 8, 9, -450deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotate(30deg)\] to [rotate(330deg)\] at (-1) should be [rotate(-270deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [perspective(400px)\] to [perspective(500px)\] at (0.25) should be [perspective(425px)\]]
     expected: FAIL
 
@@ -615,15 +492,6 @@
     expected: FAIL
 
   [CSS Transitions: property <transform> from [skewX(10rad) perspective(400px)\] to [skewX(20rad) perspective(500px)\] at (-1) should be [skewX(0rad) perspective(300px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate(30deg)\] to [rotate(330deg)\] at (0.75) should be [rotate(255deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotateX(0deg)\] to [rotateX(700deg)\] at (-1) should be [rotateX(-700deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotateZ(0deg)\] to [rotateZ(900deg)\] at (1) should be [rotateZ(900deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotateY(0deg)\] to [rotateY(800deg)\] at (0.25) should be [rotateY(200deg)\]]
@@ -635,19 +503,10 @@
   [Web Animations: property <transform> from [skewX(10rad) perspective(400px)\] to [skewX(20rad) perspective(500px)\] at (0.75) should be [skewX(17.5rad) perspective(475px)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotate(90deg)\] to [none\] at (0) should be [rotate(90deg)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [rotateY(900deg)\] to [rotateZ(0deg)\] at (2) should be [rotateY(-900deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotate3d(7, 8, 9, 100deg)\] to [rotate3d(7, 8, 9, 260deg)\] at (0.25) should be [rotate3d(7, 8, 9, 140deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotateY(0deg)\] to [rotateY(800deg)\] at (2) should be [rotateY(1600deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [rotate(90deg)\] at (2) should be [rotate(180deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotateX(0deg) rotateY(0deg) rotateZ(0deg)\] to [rotateX(700deg) rotateY(800deg) rotateZ(900deg)\] at (0.75) should be [rotateX(525deg) rotateY(600deg) rotateZ(675deg)\]]
@@ -687,9 +546,6 @@
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [rotateY(900deg)\] to [rotateZ(0deg)\] at (0.75) should be [rotateY(225deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotateZ(0deg)\] to [rotateZ(900deg)\] at (0.75) should be [rotateZ(675deg)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [rotate(90deg)\] to [none\] at (0.75) should be [rotate(22.5deg)\]]
@@ -767,9 +623,6 @@
   [CSS Transitions: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 2, 0, 450deg)\] at (2) should be [rotate3d(0, 1, 0, 900deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 1, 0, 450deg)\] at (0.25) should be [rotate3d(0, 1, 0, 112.5deg)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [rotateX(0deg)\] to [rotateY(900deg)\] at (2) should be [rotateY(1800deg)\]]
     expected: FAIL
 
@@ -785,9 +638,6 @@
   [Web Animations: property <transform> from [perspective(400px)\] to [perspective(500px)\] at (0.75) should be [perspective(475px)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotate(90deg)\] to [none\] at (0.75) should be [rotate(22.5deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [none\] to [rotate(90deg)\] at (-1) should be [rotate(-90deg)\]]
     expected: FAIL
 
@@ -797,16 +647,7 @@
   [CSS Transitions with transition: all: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 2, 0, 450deg)\] at (-1) should be [rotate3d(0, 1, 0, -450deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotateY(0deg)\] to [rotateY(800deg)\] at (0) should be [rotateY(0deg)\]]
-    expected: FAIL
-
   [CSS Animations: property <transform> from [perspective(400px)\] to [perspective(500px)\] at (-1) should be [perspective(300px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 2, 0, 450deg)\] at (0.25) should be [rotate3d(0, 1, 0, 112.5deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate(90deg)\] to [none\] at (1) should be [rotate(0deg)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [scaleZ(1) perspective(400px)\] to [scaleZ(2) perspective(500px)\] at (-1) should be [scaleZ(0) perspective(300px)\]]
@@ -828,9 +669,6 @@
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [perspective(400px)\] to [perspective(500px)\] at (0.25) should be [perspective(425px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotateZ(0deg)\] to [rotateZ(900deg)\] at (2) should be [rotateZ(1800deg)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [rotateY(900deg)\] to [rotateZ(0deg)\] at (1) should be [rotateY(0deg)\]]
@@ -864,9 +702,6 @@
     expected: FAIL
 
   [CSS Animations: property <transform> from [rotateX(0deg)\] to [rotateY(900deg)\] at (-1) should be [rotateY(-900deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate(90deg)\] to [none\] at (0.25) should be [rotate(67.5deg)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [rotate3d(7, 8, 9, 0deg)\] to [rotate3d(7, 8, 9, 450deg)\] at (2) should be [rotate3d(7, 8, 9, 900deg)\]]
@@ -914,12 +749,6 @@
   [Web Animations: property <transform> from [rotate3d(7, 8, 9, 0deg)\] to [rotate3d(7, 8, 9, 450deg)\] at (0.25) should be [rotate3d(7, 8, 9, 112.5deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotateX(0deg) rotateY(0deg) rotateZ(0deg)\] to [rotateX(700deg) rotateY(800deg) rotateZ(900deg)\] at (0.75) should be [rotateX(525deg) rotateY(600deg) rotateZ(675deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 1, 0, 450deg)\] at (2) should be [rotate3d(0, 1, 0, 900deg)\]]
-    expected: FAIL
-
   [CSS Animations: property <transform> from [rotate3d(7, 8, 9, 100deg)\] to [rotate3d(7, 8, 9, 260deg)\] at (2) should be [rotate3d(7, 8, 9, 420deg)\]]
     expected: FAIL
 
@@ -932,22 +761,13 @@
   [CSS Transitions with transition: all: property <transform> from [perspective(400px)\] to [perspective(500px)\] at (0.75) should be [perspective(475px)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotateZ(0deg)\] to [rotateZ(900deg)\] at (0.25) should be [rotateZ(225deg)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [rotate(90deg)\] to [none\] at (-1) should be [rotate(180deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [rotateX(0deg)\] to [rotateX(700deg)\] at (2) should be [rotateX(1400deg)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [skewX(10rad) perspective(400px)\] to [skewX(20rad) perspective(500px)\] at (0.25) should be [skewX(12.5rad) perspective(425px)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [skewX(10rad) perspective(400px)\] to [skewX(20rad) perspective(500px)\] at (0) should be [skewX(10rad) perspective(400px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate(30deg)\] to [rotate(330deg)\] at (2) should be [rotate(630deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotate(30deg)\] to [rotate(330deg)\] at (0.25) should be [rotate(105deg)\]]
@@ -959,13 +779,7 @@
   [CSS Transitions: property <transform> from [rotateY(0deg)\] to [rotateY(800deg)\] at (-1) should be [rotateY(-800deg)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [none\] to [rotate(90deg)\] at (2) should be [rotate(180deg)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 1, 0, 450deg)\] at (0.25) should be [rotate3d(0, 1, 0, 112.5deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate(30deg)\] to [rotate(330deg)\] at (0) should be [rotate(30deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotateX(0deg)\] to [rotateY(900deg)\] at (-1) should be [rotateY(-900deg)\]]
@@ -980,34 +794,10 @@
   [CSS Transitions: property <transform> from [skewX(10rad) perspective(400px)\] to [skewX(20rad) perspective(500px)\] at (0.75) should be [skewX(17.5rad) perspective(475px)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotateX(0deg) rotateY(0deg) rotateZ(0deg)\] to [rotateX(700deg) rotateY(800deg) rotateZ(900deg)\] at (0) should be [rotateX(0deg) rotateY(0deg) rotateZ(0deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [rotate(90deg)\] at (1) should be [rotate(90deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotateY(0deg)\] to [rotateY(800deg)\] at (0.25) should be [rotateY(200deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotateX(0deg)\] to [rotateX(700deg)\] at (0.75) should be [rotateX(525deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [rotateZ(0deg)\] to [rotateZ(900deg)\] at (2) should be [rotateZ(1800deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 2, 0, 450deg)\] at (-1) should be [rotate3d(0, 1, 0, -450deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [rotateZ(0deg)\] to [rotateZ(900deg)\] at (0.75) should be [rotateZ(675deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate(30deg)\] to [rotate(330deg)\] at (1) should be [rotate(330deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 2, 0, 450deg)\] at (0) should be [rotate3d(0, 1, 0, 0deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotateX(0deg)\] to [rotateX(700deg)\] at (2) should be [rotateX(1400deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [perspective(400px)\] to [perspective(500px)\] at (0) should be [perspective(400px)\]]
@@ -1023,15 +813,6 @@
     expected: FAIL
 
   [CSS Transitions: property <transform> from [rotateX(0deg)\] to [rotateX(700deg)\] at (0.25) should be [rotateX(175deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [rotate(90deg)\] to [none\] at (2) should be [rotate(-90deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [rotate(90deg)\] at (0.25) should be [rotate(22.5deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate(30deg)\] to [rotate(330deg)\] at (0.25) should be [rotate(105deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotateY(0deg)\] to [rotateY(800deg)\] at (1) should be [rotateY(800deg)\]]
@@ -1050,9 +831,6 @@
     expected: FAIL
 
   [Web Animations: property <transform> from [rotateY(0deg)\] to [rotateY(800deg)\] at (0) should be [rotateY(0deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [rotate3d(0, 1, 0, 0deg)\] to [rotate3d(0, 2, 0, 450deg)\] at (2) should be [rotate3d(0, 1, 0, 900deg)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [rotateY(900deg)\] to [rotateZ(0deg)\] at (2) should be [rotateY(-900deg)\]]
@@ -1080,5 +858,11 @@
     expected: FAIL
 
   [CSS Transitions: property <transform> from [rotateY(900deg)\] to [rotateZ(0deg)\] at (0.75) should be [rotateY(225deg)\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <transform> from [none\] to [rotate(90deg)\] at (0.25) should be [rotate(22.5deg)\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <transform> from [none\] to [rotate(90deg)\] at (-1) should be [rotate(-90deg)\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transforms/animation/transform-interpolation-002.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/transform-interpolation-002.html.ini
@@ -2,19 +2,7 @@
   [transform interpolation]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (0.75) should be [scaleZ(1.75)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (0.25) should be [scaleY(6)\]]
-    expected: FAIL
-
   [CSS Animations: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (2) should be [scale(2, -1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (0) should be [scale3d(2, 3, 5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (2) should be [scale3d(3, 5, 9)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (0.75) should be [scale3d(1.75, 2.5, 4)\]]
@@ -23,46 +11,19 @@
   [Web Animations: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (1) should be [scaleZ(2)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (2) should be [scaleX(30) scaleY(1.5) scaleZ(3)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (1) should be [scale3d(2, 3, 5)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (0.25) should be [scaleX(12.5)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (1) should be [scale(20, 9)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (-1) should be [scale3d(3, 5, 9)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (0.25) should be [scaleX(12.5) scaleY(0.625) scaleZ(1.25)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (1) should be [scale(1, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (2) should be [scale3d(0, -1, -3)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (-1) should be [scaleX(0) scaleY(0) scaleZ(0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (0.75) should be [scale(17.5, 8)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (-1) should be [scaleZ(0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (-1) should be [scaleX(0)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (0.75) should be [scale3d(17.5, 0.875, 1.75)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (0.25) should be [scale3d(1.25, 1.5, 2)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (0.25) should be [scale(0.25, 0.75)\]]
@@ -71,16 +32,10 @@
   [Web Animations: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (2) should be [scale3d(3, 5, 9)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (2) should be [scaleZ(3)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (0) should be [scale(0, 1)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (0) should be [scale3d(2, 3, 5)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (-1) should be [scaleX(0) scaleY(0) scaleZ(0)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (2) should be [scale(2, -1)\]]
@@ -89,31 +44,7 @@
   [CSS Transitions with transition: all: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (0.25) should be [scale(0.25, 0.75)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (0) should be [scaleX(10) scaleY(0.5) scaleZ(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (0.25) should be [scale(12.5, 6)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (2) should be [scale3d(30, 1.5, 3)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (0.25) should be [scale3d(12.5, 0.625, 1.25)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (-1) should be [scale3d(0, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (0.75) should be [scale(17.5, 8)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (0.75) should be [scale3d(1.25, 1.5, 2)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (0) should be [scaleX(10)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (0.75) should be [scaleZ(1.75)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (1) should be [scale3d(20, 1, 2)\]]
@@ -131,52 +62,10 @@
   [CSS Animations: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (-1) should be [scale(-1, 2)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (0.25) should be [scale3d(1.25, 1.5, 2)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (-1) should be [scale3d(0, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (0) should be [scaleZ(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (0) should be [scaleY(5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (0.25) should be [scaleX(12.5) scaleY(0.625) scaleZ(1.25)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (-1) should be [scaleY(1)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (2) should be [scale(30, 13)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (0.75) should be [scaleZ(1.75)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (2) should be [scale(30, 13)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (0.25) should be [scale3d(12.5, 0.625, 1.25)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (0.75) should be [scaleX(17.5) scaleY(0.875) scaleZ(1.75)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (0.75) should be [scaleY(8)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (2) should be [scale3d(30, 1.5, 3)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (0.75) should be [scale3d(17.5, 0.875, 1.75)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (2) should be [scaleX(30)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (-1) should be [scale(0, 1)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (-1) should be [scaleZ(0)\]]
@@ -188,70 +77,22 @@
   [CSS Transitions: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (0.75) should be [scale(0.75, 0.25)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (-1) should be [scaleX(0)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (0) should be [scaleY(5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (0.25) should be [scaleX(12.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (0.75) should be [scale3d(1.75, 2.5, 4)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (0.75) should be [scaleX(17.5)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (0.75) should be [scale(0.75, 0.25)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (-1) should be [scale3d(0, -1, -3)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (-1) should be [scaleY(1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (0.25) should be [scale3d(1.75, 2.5, 4)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (0.25) should be [scaleY(6)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (-1) should be [scale3d(0, 0, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (0) should be [scale3d(10, 0.5, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (0) should be [scale(10, 5)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (0.75) should be [scale3d(17.5, 0.875, 1.75)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (1) should be [scale3d(1, 1, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (2) should be [scale(30, 13)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (0.25) should be [scale3d(1.25, 1.5, 2)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (0) should be [scale3d(10, 0.5, 1)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (0) should be [scale(0, 1)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (2) should be [scaleZ(3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (1) should be [scaleZ(2)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (2) should be [scale3d(0, -1, -3)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (1) should be [scaleX(20) scaleY(1) scaleZ(2)\]]
@@ -269,76 +110,13 @@
   [Web Animations: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (1) should be [scaleX(20)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (0.75) should be [scaleX(17.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (0.75) should be [scale3d(17.5, 0.875, 1.75)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (2) should be [scaleX(30) scaleY(1.5) scaleZ(3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (1) should be [scaleX(20) scaleY(1) scaleZ(2)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (0.75) should be [scaleX(17.5) scaleY(0.875) scaleZ(1.75)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (0.75) should be [scaleY(8)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (0) should be [scale(10, 5)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (2) should be [scale3d(0, -1, -3)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (0.75) should be [scaleX(17.5) scaleY(0.875) scaleZ(1.75)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (1) should be [scaleX(20)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (2) should be [scale3d(3, 5, 9)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (0.25) should be [scale3d(1.75, 2.5, 4)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (2) should be [scale3d(3, 5, 9)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (0.25) should be [scaleZ(1.25)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (-1) should be [scale(0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (-1) should be [scale(0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (0.75) should be [scale3d(1.75, 2.5, 4)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (-1) should be [scaleZ(0)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (-1) should be [scale(0, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (0.75) should be [scaleX(17.5)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (-1) should be [scale3d(3, 5, 9)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (-1) should be [scaleY(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (-1) should be [scaleX(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (2) should be [scaleX(30)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (1) should be [scale(1, 0)\]]
@@ -347,40 +125,13 @@
   [Web Animations: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (0.25) should be [scale(0.25, 0.75)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (2) should be [scaleX(30) scaleY(1.5) scaleZ(3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (1) should be [scaleY(9)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (0.25) should be [scale(12.5, 6)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (0.25) should be [scaleZ(1.25)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (2) should be [scale3d(30, 1.5, 3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (0) should be [scale3d(1, 1, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (-1) should be [scaleZ(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (-1) should be [scale3d(0, -1, -3)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (0.25) should be [scale3d(1.25, 1.5, 2)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (1) should be [scale3d(1, 1, 1)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (0.25) should be [scaleX(12.5) scaleY(0.625) scaleZ(1.25)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (0.75) should be [scaleY(8)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (2) should be [scaleX(30) scaleY(1.5) scaleZ(3)\]]
@@ -389,22 +140,13 @@
   [Web Animations: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (0.25) should be [scale3d(1.75, 2.5, 4)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (-1) should be [scale3d(3, 5, 9)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (-1) should be [scale3d(0, 0, 0)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (0.75) should be [scale(0.75, 0.25)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (-1) should be [scaleX(0) scaleY(0) scaleZ(0)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (0) should be [scale(0, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (0.25) should be [scale3d(12.5, 0.625, 1.25)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (1) should be [scale(1, 0)\]]
@@ -413,19 +155,10 @@
   [Web Animations: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (0.75) should be [scaleX(17.5)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (0.25) should be [scaleX(12.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (0.25) should be [scaleX(12.5) scaleY(0.625) scaleZ(1.25)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (2) should be [scale(2, -1)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (0.25) should be [scale(0.25, 0.75)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (2) should be [scaleZ(3)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (-1) should be [scale3d(0, -1, -3)\]]
@@ -434,43 +167,7 @@
   [Web Animations: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (0.75) should be [scale(17.5, 8)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (-1) should be [scale3d(0, -1, -3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (0.75) should be [scale3d(1.25, 1.5, 2)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (0.75) should be [scale(17.5, 8)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (0) should be [scaleX(10)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (2) should be [scaleZ(3)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (1) should be [scaleY(9)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (0.75) should be [scale3d(1.25, 1.5, 2)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (0.75) should be [scale3d(1.75, 2.5, 4)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (0.25) should be [scale3d(1.75, 2.5, 4)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (0.75) should be [scaleZ(1.75)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scale3d(10, 0.5, 1)\] to [scale3d(20, 1, 2)\] at (1) should be [scale3d(20, 1, 2)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (-1) should be [scaleX(0) scaleY(0) scaleZ(0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (-1) should be [scaleY(1)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (2) should be [scaleY(13)\]]
@@ -482,13 +179,7 @@
   [CSS Transitions: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (2) should be [scale(2, -1)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (2) should be [scaleY(13)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (-1) should be [scale(-1, 2)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (0.25) should be [scaleZ(1.25)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (0) should be [scaleZ(1)\]]
@@ -497,31 +188,13 @@
   [CSS Transitions with transition: all: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (0.75) should be [scale(0.75, 0.25)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (0.25) should be [scaleX(12.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (0.25) should be [scale(12.5, 6)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (-1) should be [scale3d(3, 5, 9)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (0.25) should be [scaleY(6)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [scaleX(0)\] to [scaleY(0)\] at (-1) should be [scale(-1, 2)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [none\] to [scale3d(2, 3, 5)\] at (1) should be [scale3d(2, 3, 5)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scale(10, 5)\] to [scale(20, 9)\] at (0.25) should be [scale(12.5, 6)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleZ(1)\] to [scaleZ(2)\] at (0.25) should be [scaleZ(1.25)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (2) should be [scaleY(13)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (0.75) should be [scale3d(1.25, 1.5, 2)\]]
@@ -542,15 +215,6 @@
   [Web Animations: property <transform> from [scale3d(2, 3, 5)\] to [none\] at (2) should be [scale3d(0, -1, -3)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (2) should be [scaleY(13)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [scaleY(5)\] to [scaleY(9)\] at (0.75) should be [scaleY(8)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleX(10) scaleY(0.5) scaleZ(1)\] to [scaleX(20) scaleY(1) scaleZ(2)\] at (0.75) should be [scaleX(17.5) scaleY(0.875) scaleZ(1.75)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [scaleX(10)\] to [scaleX(20)\] at (2) should be [scaleX(30)\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transforms/animation/transform-interpolation-003.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/transform-interpolation-003.html.ini
@@ -14,31 +14,13 @@
   [Web Animations: property <transform> from [skewX(10rad) scaleZ(1)\] to [skewX(20rad) scaleZ(2)\] at (0) should be [skewX(10rad) scaleZ(1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [skewX(10rad) scaleZ(1)\] to [skewX(20rad) scaleZ(2)\] at (0.75) should be [skewX(17.5rad) scaleZ(1.75)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (-1) should be [translateY(50%) scaleZ(0)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [skewY(10rad)\] to [skewY(20rad)\] at (0.75) should be [skewY(17.5rad)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (2) should be [translateY(110%) scaleZ(3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (0.25) should be [translateY(75%) scaleZ(1.25)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (2) should be [translateY(110%) scaleZ(3)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (0.75) should be [skewX(17.5rad)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (0.25) should be [scaleZ(3.25) matrix3d(1, 0, 0, 0, 0.389352, 1, 0, 0, 0, 0, 1, -0.002375, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad) scaleZ(1)\] to [skewX(20rad) scaleZ(2)\] at (2) should be [skewX(30rad) scaleZ(3)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad) scaleZ(2)\] at (0.75) should be [skewX(17.5rad) scaleZ(1.75)\]]
@@ -56,25 +38,7 @@
   [Web Animations: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (-1) should be [translateY(50%) scaleZ(0)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (0.75) should be [translateY(85%) scaleZ(1.75)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (2) should be [skewX(30rad)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewY(10rad)\] to [skewY(20rad)\] at (0.25) should be [skewY(12.5rad)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (0.75) should be [scaleZ(3.75) matrix3d(1, 0, 0, 0, 1.16806, 1, 0, 0, 0, 0, 1, -0.002125, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (0.75) should be [translateY(85%) scaleZ(1.75)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (2) should be [skewX(30rad)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (0) should be [translateY(70%) scaleZ(1)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [skewX(10rad) scaleZ(1)\] to [skewX(20rad) scaleZ(2)\] at (0.75) should be [skewX(17.5rad) scaleZ(1.75)\]]
@@ -98,25 +62,10 @@
   [Web Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad) scaleZ(2)\] at (2) should be [skewX(30rad) scaleZ(3)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (2) should be [translateY(110%) scaleZ(3)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [skewY(10rad)\] to [skewY(20rad)\] at (2) should be [skewY(30rad)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad) scaleZ(1)\] to [skewX(20rad) scaleZ(2)\] at (0) should be [skewX(10rad) scaleZ(1)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [skewX(10rad) scaleZ(1)\] to [skewX(20rad) scaleZ(2)\] at (0.25) should be [skewX(12.5rad) scaleZ(1.25)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [skewY(10rad)\] to [skewY(20rad)\] at (0.75) should be [skewY(17.5rad)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (0.75) should be [translateY(85%) scaleZ(1.75)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (0.25) should be [skewX(12.5rad)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (1) should be [scaleZ(4) matrix3d(1, 0, 0, 0, 1.55741, 1, 0, 0, 0, 0, 1, -0.002, 0, 0, 0, 1)\]]
@@ -125,31 +74,13 @@
   [CSS Transitions with transition: all: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (0.25) should be [skewX(12.5rad)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [skewX(10rad) scaleZ(1)\] to [skewX(20rad) scaleZ(2)\] at (1) should be [skewX(20rad) scaleZ(2)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [skewY(10rad)\] to [skewY(20rad)\] at (2) should be [skewY(30rad)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad) scaleZ(2)\] at (-1) should be [skewX(0rad) scaleZ(0)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (1) should be [scaleZ(4) matrix3d(1, 0, 0, 0, 1.55741, 1, 0, 0, 0, 0, 1, -0.002, 0, 0, 0, 1)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (2) should be [skewX(30rad)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (0.75) should be [translateY(85%) scaleZ(1.75)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewY(10rad)\] to [skewY(20rad)\] at (2) should be [skewY(30rad)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (-1) should be [translateY(50%) scaleZ(0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (0.25) should be [translateY(75%) scaleZ(1.25)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (1) should be [scaleZ(4) matrix3d(1, 0, 0, 0, 1.55741, 1, 0, 0, 0, 0, 1, -0.002, 0, 0, 0, 1)\]]
@@ -170,28 +101,13 @@
   [CSS Transitions: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (0) should be [scaleZ(3) matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, -0.0025, 0, 0, 0, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (-1) should be [skewX(0rad)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad) scaleZ(1)\] to [skewX(20rad) scaleZ(2)\] at (-1) should be [skewX(0rad) scaleZ(0)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (2) should be [scaleZ(5) matrix3d(1, 0, 0, 0, 3.11482, 1, 0, 0, 0, 0, 1, -0.0015, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (1) should be [translateY(90%) scaleZ(2)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [skewX(10rad)\] to [skewX(20rad) scaleZ(2)\] at (-1) should be [skewX(0rad) scaleZ(0)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [skewX(10rad) scaleZ(1)\] to [skewX(20rad) scaleZ(2)\] at (0.25) should be [skewX(12.5rad) scaleZ(1.25)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (0) should be [translateY(70%)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [skewX(10rad) scaleZ(1)\] to [skewX(20rad) scaleZ(2)\] at (2) should be [skewX(30rad) scaleZ(3)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (0.25) should be [scaleZ(3.25) matrix3d(1, 0, 0, 0, 0.389352, 1, 0, 0, 0, 0, 1, -0.002375, 0, 0, 0, 1)\]]
@@ -203,16 +119,7 @@
   [CSS Transitions: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (-1) should be [scaleZ(2) matrix3d(1, 0, 0, 0, -1.55741, 1, 0, 0, 0, 0, 1, -0.003, 0, 0, 0, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad) scaleZ(2)\] at (0.75) should be [skewX(17.5rad) scaleZ(1.75)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad) scaleZ(2)\] at (2) should be [skewX(30rad) scaleZ(3)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (0.25) should be [scaleZ(3.25) matrix3d(1, 0, 0, 0, 0.389352, 1, 0, 0, 0, 0, 1, -0.002375, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (-1) should be [translateY(50%) scaleZ(0)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (-1) should be [scaleZ(2) matrix3d(1, 0, 0, 0, -1.55741, 1, 0, 0, 0, 0, 1, -0.003, 0, 0, 0, 1)\]]
@@ -236,28 +143,13 @@
   [CSS Transitions with transition: all: property <transform> from [skewX(10rad) scaleZ(1)\] to [skewX(20rad) scaleZ(2)\] at (-1) should be [skewX(0rad) scaleZ(0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (-1) should be [translateY(50%) scaleZ(0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (0.25) should be [translateY(75%) scaleZ(1.25)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad) scaleZ(2)\] at (0.25) should be [skewX(12.5rad) scaleZ(1.25)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (0) should be [skewX(10rad)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (2) should be [translateY(110%) scaleZ(3)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [skewY(10rad)\] to [skewY(20rad)\] at (-1) should be [skewY(0rad)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (0) should be [scaleZ(3) matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, -0.0025, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (2) should be [translateY(110%) scaleZ(3)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [skewY(10rad)\] to [skewY(20rad)\] at (0.75) should be [skewY(17.5rad)\]]
@@ -275,9 +167,6 @@
   [Web Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad) scaleZ(2)\] at (0.25) should be [skewX(12.5rad) scaleZ(1.25)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (0.75) should be [translateY(85%) scaleZ(1.75)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (2) should be [translateY(110%) scaleZ(3)\]]
     expected: FAIL
 
@@ -287,22 +176,10 @@
   [CSS Transitions: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (-1) should be [skewX(0rad)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [skewX(10rad)\] to [skewX(20rad) scaleZ(2)\] at (2) should be [skewX(30rad) scaleZ(3)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [skewX(10rad) scaleZ(1)\] to [skewX(20rad) scaleZ(2)\] at (2) should be [skewX(30rad) scaleZ(3)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (1) should be [translateY(90%) scaleZ(2)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewY(10rad)\] to [skewY(20rad)\] at (0) should be [skewY(10rad)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [skewY(10rad)\] to [skewY(20rad)\] at (2) should be [skewY(30rad)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewY(10rad)\] to [skewY(20rad)\] at (0.75) should be [skewY(17.5rad)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (0.25) should be [translateY(75%) scaleZ(1.25)\]]
@@ -311,16 +188,10 @@
   [Web Animations: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (1) should be [scaleZ(4) matrix3d(1, 0, 0, 0, 1.55741, 1, 0, 0, 0, 0, 1, -0.002, 0, 0, 0, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [skewY(10rad)\] to [skewY(20rad)\] at (-1) should be [skewY(0rad)\]]
-    expected: FAIL
-
   [CSS Animations: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (2) should be [scaleZ(5) matrix3d(1, 0, 0, 0, 3.11482, 1, 0, 0, 0, 0, 1, -0.0015, 0, 0, 0, 1)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (0) should be [scaleZ(3) matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, -0.0025, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (0) should be [skewX(10rad)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad) scaleZ(2)\] at (0) should be [skewX(10rad) scaleZ(1)\]]
@@ -335,31 +206,13 @@
   [CSS Transitions: property <transform> from [skewX(10rad) scaleZ(1)\] to [skewX(20rad) scaleZ(2)\] at (-1) should be [skewX(0rad) scaleZ(0)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (1) should be [skewX(20rad)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (0) should be [translateY(70%)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (0.25) should be [translateY(75%) scaleZ(1.25)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad) scaleZ(2)\] at (-1) should be [skewX(0rad) scaleZ(0)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad) scaleZ(2)\] at (0) should be [skewX(10rad) scaleZ(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (-1) should be [translateY(50%) scaleZ(0)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [skewX(10rad)\] to [skewX(20rad) scaleZ(2)\] at (0.75) should be [skewX(17.5rad) scaleZ(1.75)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (0.75) should be [skewX(17.5rad)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad) scaleZ(2)\] at (1) should be [skewX(20rad) scaleZ(2)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [skewX(10rad) scaleZ(1)\] to [skewX(20rad) scaleZ(2)\] at (0.75) should be [skewX(17.5rad) scaleZ(1.75)\]]
@@ -398,16 +251,7 @@
   [Web Animations: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (-1) should be [skewX(0rad)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (-1) should be [translateY(50%) scaleZ(0)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [skewY(10rad)\] to [skewY(20rad)\] at (-1) should be [skewY(0rad)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (0.25) should be [translateY(75%) scaleZ(1.25)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (0.75) should be [translateY(85%) scaleZ(1.75)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (0.25) should be [skewX(12.5rad)\]]
@@ -425,18 +269,9 @@
   [CSS Transitions with transition: all: property <transform> from [skewX(10rad)\] to [skewX(20rad)\] at (-1) should be [skewX(0rad)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (2) should be [translateY(110%) scaleZ(3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateY(70%)\] to [translateY(90%) scaleZ(2)\] at (0.25) should be [translateY(75%) scaleZ(1.25)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [translateY(70%) scaleZ(1)\] to [translateY(90%) scaleZ(2)\] at (0) should be [translateY(70%) scaleZ(1)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [scaleZ(3) perspective(400px)\] to [scaleZ(4) skewX(1rad) perspective(500px)\] at (-1) should be [scaleZ(2) matrix3d(1, 0, 0, 0, -1.55741, 1, 0, 0, 0, 0, 1, -0.003, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewY(10rad)\] to [skewY(20rad)\] at (1) should be [skewY(20rad)\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transforms/animation/transform-interpolation-004.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/transform-interpolation-004.html.ini
@@ -11,40 +11,13 @@
   [CSS Transitions with transition: all: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) skewX(2rad) scaleY(2)\] at (0.25) should be [translate3d(7px, -6px, 11px) skewX(1.25rad) matrix3d(1, 0, 0, 0, 0, 1.25, 0, 0, 0, 0, 1, -0.001875, 0, 0, 0, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (-1) should be [translateX(11px) translateY(50%) translateZ(1em)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (0.75) should be [translateX(12.75px) translateY(85%) translateZ(2.75em)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (-1) should be [translateY(50%)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (0.75) should be [translate3d(12.75px, 85%, 2.75em)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [skewX(10rad) translateY(70%)\] to [skewX(20rad) translateY(90%)\] at (0.75) should be [skewX(17.5rad) translateY(85%)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (0.75) should be [translateZ(2.75em)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [skewX(10rad) translateY(70%)\] to [skewX(20rad) translateY(90%)\] at (0.25) should be [skewX(12.5rad) translateY(75%)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (0.75) should be [translateY(85%)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (0.25) should be [translate3d(12.25px, 75%, 2.25em)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) skewX(2rad) scaleY(2)\] at (-1) should be [translate3d(12px, 4px, 16px) skewX(0rad) matrix3d(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, -0.005, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (0) should be [translate(12px, 70%)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (0.75) should be [translateZ(2.75em)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (-1) should be [translate3d(12px, 4px, 16px) matrix3d(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, -0.003, 0, 0, 0, 1)\]]
@@ -56,43 +29,16 @@
   [CSS Transitions: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (-1) should be [translate3d(12px, 4px, 16px) matrix3d(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, -0.003, 0, 0, 0, 1)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (0.75) should be [translateZ(2.75em)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (2) should be [translateX(14px)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [scaleY(2) skewX(2rad) perspective(500px)\] at (0) should be [matrix3d(1, 0, 0, 0, 1.5574077246549023, 1, 0, 0, -0.02, 0.01, 0.97, -0.0025, 8, -4, 12, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (0.25) should be [translateX(12.25px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (0) should be [translateY(70%)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (0) should be [translateX(12px) translateY(70%) translateZ(2em)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (0.75) should be [translate(12.75px, 85%)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (0.25) should be [translate(12.25px, 75%)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (2) should be [translate(14px, 110%)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [scaleY(2) skewX(2rad) perspective(500px)\] at (2) should be [matrix3d(1, 0, 0, 0, -11.227342763749263, 3, 0, 0, 0.021237113402061854, -0.010618556701030927, 1.03, -0.0014653608247422677, -8, 4, -12, 0.9861443298969074)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (0.25) should be [translateY(75%)\]]
-    expected: FAIL
-
   [CSS Animations: property <transform> from [translate3D(100px, 200px, 300px)\] to [none\] at (-1) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 200, 400, 600, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (-1) should be [translateZ(1em)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (0.25) should be [translateY(75%)\]]
@@ -113,12 +59,6 @@
   [Web Animations: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (0) should be [translateX(12px)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (0.75) should be [translateX(12.75px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (0.75) should be [translateY(85%)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (2) should be [translate3d(0px, -20px, 4px) matrix3d(1, 0, 0, 0, -4.67222, 3, 0, 0, 0, 0, 1, -0.0015, 0, 0, 0, 1)\]]
     expected: FAIL
 
@@ -134,16 +74,7 @@
   [CSS Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [scaleY(2) skewX(2rad) perspective(500px)\] at (0.75) should be [matrix3d(1, 0, 0, 0, -0.7525665307288518, 1.75, 0, 0, -0.005115979381443298, 0.002557989690721649, 0.9924999999999999, -0.002128247422680412, 2, -1, 3, 1.001298969072165)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (0.25) should be [translateX(12.25px)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (-1) should be [translate3d(12px, 4px, 16px) matrix3d(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, -0.003, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (1) should be [translate3d(13px, 90%, 3em)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (-1) should be [translate3d(11px, 50%, 1em)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (2) should be [translate3d(14px, 110%, 4em)\]]
@@ -167,9 +98,6 @@
   [CSS Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [scaleY(2) skewX(2rad) perspective(500px)\] at (-1) should be [matrix3d(1, 0, 0, 0, 0, 0, 0, 0, -0.03876288659793814, 0.01938144329896907, 0.94, -0.0029653608247422686, 16, -8, 24, 0.986144329896907)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (2) should be [translate3d(14px, 110%, 4em)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (0.25) should be [translateX(12.25px)\]]
     expected: FAIL
 
@@ -188,28 +116,10 @@
   [CSS Transitions: property <transform> from [skewX(1rad)\] to [translate3d(8px, -4px, 12px) skewX(2rad)\] at (0) should be [matrix(1, 0, 1.5574077246549023, 1, 0, 0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (0.75) should be [translateX(12.75px) translateY(85%) translateZ(2.75em)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [scaleY(2) skewX(2rad) perspective(500px)\] at (2) should be [matrix3d(1, 0, 0, 0, -11.227342763749263, 3, 0, 0, 0.021237113402061854, -0.010618556701030927, 1.03, -0.0014653608247422677, -8, 4, -12, 0.9861443298969074)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (0.25) should be [translateX(12.25px) translateY(75%) translateZ(2.25em)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (0) should be [translateZ(2em)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (0.25) should be [translateY(75%)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (2) should be [translateX(14px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (2) should be [translateX(14px) translateY(110%) translateZ(4em)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (2) should be [translateX(14px)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [scaleY(2) skewX(2rad) perspective(500px)\] at (-1) should be [matrix3d(1, 0, 0, 0, 0, 0, 0, 0, -0.03876288659793814, 0.01938144329896907, 0.94, -0.0029653608247422686, 16, -8, 24, 0.986144329896907)\]]
@@ -230,28 +140,16 @@
   [Web Animations: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (-1) should be [translate3d(11px, 50%, 1em)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (-1) should be [translate(11px, 50%)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (2) should be [translate3d(0px, -20px, 4px) matrix3d(1, 0, 0, 0, -4.67222, 3, 0, 0, 0, 0, 1, -0.0015, 0, 0, 0, 1)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [skewX(1rad)\] to [translate3d(8px, -4px, 12px) skewX(2rad)\] at (0) should be [matrix(1, 0, 1.5574077246549023, 1, 0, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (0.25) should be [translateY(75%)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) skewX(2rad) scaleY(2)\] at (0) should be [translate3d(8px, -4px, 12px) skewX(1rad) matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, -0.0025, 0, 0, 0, 1)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [scaleY(2) skewX(2rad) perspective(500px)\] at (1) should be [matrix3d(1, 0, 0, 0, -2.185039863261519, 2, 0, 0, 0, 0, 1, -0.002, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (0.75) should be [translate(12.75px, 85%)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (2) should be [translate(14px, 110%)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (1) should be [translateX(13px)\]]
@@ -269,16 +167,7 @@
   [CSS Transitions with transition: all: property <transform> from [skewX(1rad)\] to [translate3d(8px, -4px, 12px) skewX(2rad)\] at (2) should be [matrix3d(1, 0, 0, 0, -5.9274874511779405, 1, 0, 0, 0, 0, 1, 0, 16, -8, 24, 1)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (0.25) should be [translate3d(12.25px, 75%, 2.25em)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (-1) should be [translateX(11px) translateY(50%) translateZ(1em)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) skewX(2rad) scaleY(2)\] at (2) should be [translate3d(0px, -20px, 4px) skewX(3rad) matrix3d(1, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1, 0.0025, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (0.75) should be [translateZ(2.75em)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [translate3D(100px, 200px, 300px)\] to [none\] at (1) should be [matrix(1, 0, 0, 1, 0, 0) \]]
@@ -302,31 +191,10 @@
   [CSS Transitions: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (-1) should be [translate3d(11px, 50%, 1em)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (-1) should be [translate(11px, 50%)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (0.25) should be [translateX(12.25px)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [translate3D(100px, 200px, 300px)\] to [none\] at (2) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -100, -200, -300, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (0.25) should be [translate3d(12.25px, 75%, 2.25em)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (2) should be [translateX(14px) translateY(110%) translateZ(4em)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad) translateY(70%)\] to [skewX(20rad) translateY(90%)\] at (2) should be [skewX(30rad) translateY(110%)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [translate3D(100px, 200px, 300px)\] to [none\] at (-1) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 200, 400, 600, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (0.25) should be [translateX(12.25px) translateY(75%) translateZ(2.25em)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (-1) should be [translateY(50%)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [skewX(10rad) translateY(70%)\] to [skewX(20rad) translateY(90%)\] at (-1) should be [skewX(0rad) translateY(50%)\]]
@@ -335,19 +203,10 @@
   [CSS Animations: property <transform> from [skewX(1rad)\] to [translate3d(8px, -4px, 12px) skewX(2rad)\] at (0) should be [matrix(1, 0, 1.5574077246549023, 1, 0, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (-1) should be [translate3d(11px, 50%, 1em)\]]
-    expected: FAIL
-
   [CSS Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [scaleY(2) skewX(2rad) perspective(500px)\] at (1) should be [matrix3d(1, 0, 0, 0, -2.185039863261519, 2, 0, 0, 0, 0, 1, -0.002, 0, 0, 0, 1)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (0.75) should be [translate3d(5px, -10px, 9px) matrix3d(1, 0, 0, 0, 0.681366, 1.75, 0, 0, 0, 0, 1, -0.002125, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (0.25) should be [translateZ(2.25em)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (2) should be [translateY(110%)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [skewX(1rad)\] to [translate3d(8px, -4px, 12px) skewX(2rad)\] at (0.75) should be [matrix3d(1, 0, 0, 0, -1.2494279662824135, 1, 0, 0, 0, 0, 1, 0, 6, -3, 9, 1)\]]
@@ -359,40 +218,19 @@
   [Web Animations: property <transform> from [translate3D(100px, 200px, 300px)\] to [none\] at (0.25) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 75, 150, 225, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (0) should be [translateX(12px) translateY(70%) translateZ(2em)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (1) should be [translate(13px, 90%)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [skewX(1rad)\] to [translate3d(8px, -4px, 12px) skewX(2rad)\] at (-1) should be [matrix3d(1, 0, 0, 0, 5.2998553125713235, 1, 0, 0, 0, 0, 1, 0, -8, 4, -12, 1)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (0) should be [translate3d(8px, -4px, 12px) matrix3d(1, 0, 0, 0, 1.55741, 1, 0, 0, 0, 0, 1, -0.0025, 0, 0, 0, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (2) should be [translateY(110%)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad) translateY(70%)\] to [skewX(20rad) translateY(90%)\] at (1) should be [skewX(20rad) translateY(90%)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [translate3D(100px, 200px, 300px)\] to [none\] at (1) should be [matrix(1, 0, 0, 1, 0, 0) \]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (-1) should be [translateZ(1em)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (0.25) should be [translateZ(2.25em)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [skewX(10rad) translateY(70%)\] to [skewX(20rad) translateY(90%)\] at (0.75) should be [skewX(17.5rad) translateY(85%)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [scaleY(2) skewX(2rad) perspective(500px)\] at (0) should be [matrix3d(1, 0, 0, 0, 1.5574077246549023, 1, 0, 0, -0.02, 0.01, 0.97, -0.0025, 8, -4, 12, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (2) should be [translate3d(14px, 110%, 4em)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [skewX(10rad) translateY(70%)\] to [skewX(20rad) translateY(90%)\] at (-1) should be [skewX(0rad) translateY(50%)\]]
@@ -402,9 +240,6 @@
     expected: FAIL
 
   [CSS Transitions: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) skewX(2rad) scaleY(2)\] at (2) should be [translate3d(0px, -20px, 4px) skewX(3rad) matrix3d(1, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1, 0.0025, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (0.25) should be [translateX(12.25px) translateY(75%) translateZ(2.25em)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [translate3D(100px, 200px, 300px)\] to [none\] at (0) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 100, 200, 300, 1)\]]
@@ -428,40 +263,19 @@
   [CSS Transitions with transition: all: property <transform> from [skewX(1rad)\] to [translate3d(8px, -4px, 12px) skewX(2rad)\] at (0.25) should be [matrix3d(1, 0, 0, 0, 0.621795827675797, 1, 0, 0, 0, 0, 1, 0, 2, -1, 3, 1)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (2) should be [translate(14px, 110%)\]]
-    expected: FAIL
-
   [CSS Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (2) should be [translate3d(0px, -20px, 4px) matrix3d(1, 0, 0, 0, -4.67222, 3, 0, 0, 0, 0, 1, -0.0015, 0, 0, 0, 1)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (-1) should be [translate3d(12px, 4px, 16px) matrix3d(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, -0.003, 0, 0, 0, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [skewX(10rad) translateY(70%)\] to [skewX(20rad) translateY(90%)\] at (0) should be [skewX(10rad) translateY(70%)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (0) should be [translateZ(2em)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (2) should be [translateY(110%)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [scaleY(2) skewX(2rad) perspective(500px)\] at (0.75) should be [matrix3d(1, 0, 0, 0, -0.7525665307288518, 1.75, 0, 0, -0.005115979381443298, 0.002557989690721649, 0.9924999999999999, -0.002128247422680412, 2, -1, 3, 1.001298969072165)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (1) should be [translateX(13px)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (0) should be [translate3d(12px, 70%, 2em)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (0.25) should be [translate(12.25px, 75%)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (2) should be [translateX(14px) translateY(110%) translateZ(4em)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (2) should be [translateZ(4em)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [skewX(1rad)\] to [translate3d(8px, -4px, 12px) skewX(2rad)\] at (1) should be [matrix3d(1, 0, 0, 0, -2.185039863261519, 1, 0, 0, 0, 0, 1, 0, 8, -4, 12, 1)\]]
@@ -479,13 +293,7 @@
   [Web Animations: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (2) should be [translateX(14px)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (-1) should be [translate(11px, 50%)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (0.25) should be [translate3d(7px, -6px, 11px) matrix3d(1, 0, 0, 0, 1.46007, 1.25, 0, 0, 0, 0, 1, -0.002375, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (0.75) should be [translateX(12.75px)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [skewX(10rad) translateY(70%)\] to [skewX(20rad) translateY(90%)\] at (0.75) should be [skewX(17.5rad) translateY(85%)\]]
@@ -504,9 +312,6 @@
     expected: FAIL
 
   [CSS Transitions: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (0.75) should be [translate3d(5px, -10px, 9px) matrix3d(1, 0, 0, 0, 0.681366, 1.75, 0, 0, 0, 0, 1, -0.002125, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (2) should be [translate3d(14px, 110%, 4em)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (0.25) should be [translate3d(7px, -6px, 11px) matrix3d(1, 0, 0, 0, 1.46007, 1.25, 0, 0, 0, 0, 1, -0.002375, 0, 0, 0, 1)\]]
@@ -536,9 +341,6 @@
   [CSS Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [scaleY(2) skewX(2rad) perspective(500px)\] at (2) should be [matrix3d(1, 0, 0, 0, -11.227342763749263, 3, 0, 0, 0.021237113402061854, -0.010618556701030927, 1.03, -0.0014653608247422677, -8, 4, -12, 0.9861443298969074)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (1) should be [translateZ(3em)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [translate3D(100px, 200px, 300px)\] to [none\] at (1) should be [matrix(1, 0, 0, 1, 0, 0) \]]
     expected: FAIL
 
@@ -549,12 +351,6 @@
     expected: FAIL
 
   [Web Animations: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (2) should be [translate(14px, 110%)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (0.75) should be [translateX(12.75px) translateY(85%) translateZ(2.75em)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (-1) should be [translateY(50%)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [skewX(1rad)\] to [translate3d(8px, -4px, 12px) skewX(2rad)\] at (2) should be [matrix3d(1, 0, 0, 0, -5.9274874511779405, 1, 0, 0, 0, 0, 1, 0, 16, -8, 24, 1)\]]
@@ -575,31 +371,10 @@
   [CSS Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (0.75) should be [translate3d(5px, -10px, 9px) matrix3d(1, 0, 0, 0, 0.681366, 1.75, 0, 0, 0, 0, 1, -0.002125, 0, 0, 0, 1)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (0.75) should be [translate3d(12.75px, 85%, 2.75em)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (2) should be [translateX(14px) translateY(110%) translateZ(4em)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (1) should be [translateY(90%)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (0.75) should be [translate(12.75px, 85%)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (2) should be [translateZ(4em)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (0) should be [translateX(12px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (0.75) should be [translate3d(12.75px, 85%, 2.75em)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [scaleY(2) skewX(2rad) perspective(500px)\] at (0.25) should be [matrix3d(1, 0, 0, 0, 1.1186572632293585, 1.25, 0, 0, -0.0151159793814433, 0.00755798969072165, 0.9775, -0.002378247422680413, 6, -3, 9, 1.0012989690721648)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (-1) should be [translateX(11px) translateY(50%) translateZ(1em)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) skewX(2rad) scaleY(2)\] at (1) should be [translate3d(4px, -12px, 8px) skewX(2rad) matrix(1, 0, 0, 2, 0, 0)\]]
@@ -620,9 +395,6 @@
   [Web Animations: property <transform> from [skewX(10rad) translateY(70%)\] to [skewX(20rad) translateY(90%)\] at (2) should be [skewX(30rad) translateY(110%)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [skewX(10rad) translateY(70%)\] to [skewX(20rad) translateY(90%)\] at (-1) should be [skewX(0rad) translateY(50%)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (1) should be [translateZ(3em)\]]
     expected: FAIL
 
@@ -635,9 +407,6 @@
   [CSS Animations: property <transform> from [skewX(1rad)\] to [translate3d(8px, -4px, 12px) skewX(2rad)\] at (0.75) should be [matrix3d(1, 0, 0, 0, -1.2494279662824135, 1, 0, 0, 0, 0, 1, 0, 6, -3, 9, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (-1) should be [translateX(11px)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) skewX(2rad) scaleY(2)\] at (1) should be [translate3d(4px, -12px, 8px) skewX(2rad) matrix(1, 0, 0, 2, 0, 0)\]]
     expected: FAIL
 
@@ -645,9 +414,6 @@
     expected: FAIL
 
   [CSS Transitions: property <transform> from [translate3D(100px, 200px, 300px)\] to [none\] at (0.75) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 25, 50, 75, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (-1) should be [translateX(11px)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [translate3D(100px, 200px, 300px)\] to [none\] at (2) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, -100, -200, -300, 1)\]]
@@ -668,12 +434,6 @@
   [Web Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) skewX(2rad) scaleY(2)\] at (1) should be [translate3d(4px, -12px, 8px) skewX(2rad) matrix(1, 0, 0, 2, 0, 0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [skewX(10rad) translateY(70%)\] to [skewX(20rad) translateY(90%)\] at (2) should be [skewX(30rad) translateY(110%)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [skewX(10rad) translateY(70%)\] to [skewX(20rad) translateY(90%)\] at (0.75) should be [skewX(17.5rad) translateY(85%)\]]
-    expected: FAIL
-
   [CSS Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (0.25) should be [translate3d(7px, -6px, 11px) matrix3d(1, 0, 0, 0, 1.46007, 1.25, 0, 0, 0, 0, 1, -0.002375, 0, 0, 0, 1)\]]
     expected: FAIL
 
@@ -683,25 +443,13 @@
   [CSS Transitions with transition: all: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) scaleY(2) perspective(500px)\] at (2) should be [translate3d(0px, -20px, 4px) matrix3d(1, 0, 0, 0, -4.67222, 3, 0, 0, 0, 0, 1, -0.0015, 0, 0, 0, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translate3d(12px, 70%, 2em)\] to [translate3d(13px, 90%, 3em)\] at (0) should be [translate3d(12px, 70%, 2em)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (0.75) should be [translateY(85%)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) skewX(2rad) scaleY(2)\] at (-1) should be [translate3d(12px, 4px, 16px) skewX(0rad) matrix3d(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, -0.005, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translate(12px, 70%)\] to [translate(13px, 90%)\] at (0.25) should be [translate(12.25px, 75%)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [skewX(1rad)\] to [translate3d(8px, -4px, 12px) skewX(2rad)\] at (2) should be [matrix3d(1, 0, 0, 0, -5.9274874511779405, 1, 0, 0, 0, 0, 1, 0, 16, -8, 24, 1)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [skewX(1rad)\] to [translate3d(8px, -4px, 12px) skewX(2rad)\] at (-1) should be [matrix3d(1, 0, 0, 0, 5.2998553125713235, 1, 0, 0, 0, 0, 1, 0, -8, 4, -12, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (0.75) should be [translateX(12.75px)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [scaleY(2) skewX(2rad) perspective(500px)\] at (0) should be [matrix3d(1, 0, 0, 0, 1.5574077246549023, 1, 0, 0, -0.02, 0.01, 0.97, -0.0025, 8, -4, 12, 1)\]]
@@ -740,34 +488,16 @@
   [Web Animations: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (0.25) should be [translateX(12.25px) translateY(75%) translateZ(2.25em)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [translateY(70%)\] to [translateY(90%)\] at (1) should be [translateY(90%)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (-1) should be [translateX(11px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (1) should be [translateX(13px) translateY(90%) translateZ(3em)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [translate3d(4px, -12px, 8px) skewX(2rad) scaleY(2)\] at (0.75) should be [translate3d(5px, -10px, 9px) skewX(1.75rad) matrix3d(1, 0, 0, 0, 0, 1.75, 0, 0, 0, 0, 1, -0.000625, 0, 0, 0, 1)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [translate3D(100px, 200px, 300px)\] to [none\] at (0) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 100, 200, 300, 1)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (0.25) should be [translateZ(2.25em)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (2) should be [translateZ(4em)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [translate3d(8px, -4px, 12px) skewX(1rad) perspective(400px)\] to [scaleY(2) skewX(2rad) perspective(500px)\] at (1) should be [matrix3d(1, 0, 0, 0, -2.185039863261519, 2, 0, 0, 0, 0, 1, -0.002, 0, 0, 0, 1)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (-1) should be [translateX(11px) translateY(50%) translateZ(1em)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [translateZ(2em)\] to [translateZ(3em)\] at (-1) should be [translateZ(1em)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [translateX(12px)\] to [translateX(13px)\] at (0.75) should be [translateX(12.75px)\]]
@@ -780,5 +510,20 @@
     expected: FAIL
 
   [Web Animations: property <transform> from [skewX(10rad) translateY(70%)\] to [skewX(20rad) translateY(90%)\] at (1) should be [skewX(20rad) translateY(90%)\]]
+    expected: FAIL
+
+  [CSS Transitions: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (-1) should be [translateX(11px) translateY(50%) translateZ(1em)\]]
+    expected: FAIL
+
+  [CSS Transitions: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (0.25) should be [translateX(12.25px) translateY(75%) translateZ(2.25em)\]]
+    expected: FAIL
+
+  [CSS Transitions: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (0.75) should be [translateX(12.75px) translateY(85%) translateZ(2.75em)\]]
+    expected: FAIL
+
+  [CSS Transitions: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (2) should be [translateX(14px) translateY(110%) translateZ(4em)\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <transform> from [translateX(12px) translateY(70%) translateZ(2em)\] to [translateX(13px) translateY(90%) translateZ(3em)\] at (-1) should be [translateX(11px) translateY(50%) translateZ(1em)\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transforms/animation/transform-interpolation-005.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/transform-interpolation-005.html.ini
@@ -2,15 +2,6 @@
   [transform interpolation]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (0.25) should be [matrix(2.5, 0, 0, 4, 0, -4.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [rotate(180deg)\] at (0.75) should be [rotate(135deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (0.3333333333333333) should be [matrix(2.5000000000000004, 4.330127018922193, -0.8660254037844386, 0.5000000000000001, 4, -2)\]]
-    expected: FAIL
-
   [CSS Animations: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (0.75) should be [matrix(5.5, 0, 1.31, 1.75, 4.5, 0)\]]
     expected: FAIL
 
@@ -20,25 +11,10 @@
   [CSS Transitions: property <transform> from [rotate(180deg)\] to [none\] at (0.25) should be [rotate(135deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (1) should be [matrix(7, 0, 2, 2, 6, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [none\] to [rotate(360deg)\] at (2) should be [rotate(720deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (-1) should be [matrix(0, 5, 1, 0, -6, -12)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [none\] to [rotate(360deg)\] at (2) should be [rotate(720deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (1) should be [matrix(1, 0, 0, 1, 0, -6)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (0.25) should be [matrix3d(2.441256919175, 0.0, 0.0, 0.0, 0.0, 2.571299218825, 0.0, 0.0, 0.0, 0.0, 2.6947530634, 0.0, 20.35889062555, 20.561444082325, 20.800684839349998, 1.0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (2) should be [matrix3d(3.0761619932999995, 0.0, 0.0, 0.0, 0.0, 2.3221331858, 0.0, 0.0, 0.0, 0.0, 2.9442666928000003, 0.0, 20.5331850252, 19.7952290231, 20.002012795600002, 1.0)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [rotate(180deg)\] to [none\] at (-1) should be [rotate(360deg)\]]
@@ -47,16 +23,7 @@
   [Web Animations: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (2) should be [matrix3d(-1.2484405096414273, 0, -2.727892280477045, 0, 0, 5, 0, 0, 6.365081987779772, 0, -2.9130278558299967, 0, 0, 0, 0, 1)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (2) should be [matrix3d(0, 0, 0, 0, 0, -1, 0, 0, 1.682941969615793, 0, -1.0806046117362795, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (0.5) should be [matrix(4, 0, 2, 4, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (0) should be [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (0.5) should be [matrix(2, 0, 0, 3, 0, -3)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [none\] to [rotate(180deg)\] at (0) should be [rotate(0deg)\]]
@@ -65,55 +32,16 @@
   [CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (0.3333333333333333) should be [matrix(3, 0, 1.6667, 5, 0, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [none\] to [rotate(360deg)\] at (-1) should be [rotate(-360deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [rotate(360deg)\] at (0.75) should be [rotate(270deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (0.5) should be [matrix(2, 0, 0, 3, 0, -3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (2) should be [matrix3d(-1.2484405096414273, 0, -2.727892280477045, 0, 0, 5, 0, 0, 6.365081987779772, 0, -2.9130278558299967, 0, 0, 0, 0, 1)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [none\] to [rotate(180deg)\] at (-1) should be [rotate(-180deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (0.5) should be [matrix(2.8284271247461903, 2.82842712474619, -0.7071067811865475, 0.7071067811865476, 3, -3)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (-1) should be [matrix(5, 0, 0, 9, 0, -12)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (0.25) should be [matrix(2.5, 0, 0, 4, 0, -4.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate(180deg)\] to [none\] at (-1) should be [rotate(360deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (0.3333333333333333) should be [matrix(2.5000000000000004, 4.330127018922193, -0.8660254037844386, 0.5000000000000001, 4, -2)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (0) should be [matrix(1, 0, 0, 1, 0, -6)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate(180deg)\] to [none\] at (0.75) should be [rotate(45deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (-1) should be [matrix(5, 0, 0, 9, 0, -12)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [rotate(180deg)\] at (1) should be [rotate(180deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [rotate(360deg)\] at (1) should be [rotate(360deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (1) should be [matrix(7, 0, 1, 1, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (-1) should be [matrix3d(0, 0, 0, 0, 0, -1, 0, 0, 1.682941969615793, 0, -1.0806046117362795, 0, 0, 0, 0, 1)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [none\] to [rotate(360deg)\] at (0.75) should be [rotate(270deg)\]]
@@ -128,34 +56,13 @@
   [Web Animations: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (0.25) should be [matrix3d(1.211140527138306, 0, -0.30925494906815365, 0, 0, 1.5, 0, 0, 0.43295692869541513, 0, 1.6955967379936283, 0, 0, 0, 0, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (0.25) should be [matrix3d(1.211140527138306, 0, -0.30925494906815365, 0, 0, 1.5, 0, 0, 0.43295692869541513, 0, 1.6955967379936283, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (2) should be [matrix3d(0, 0, 0, 0, 0, -1, 0, 0, 1.682941969615793, 0, -1.0806046117362795, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (1) should be [matrix(0, 7, -1, 0, 6, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (-1) should be [matrix3d(1.9877532948000005, 0.0, 0.0, 0.0, 0.0, 2.7492749567000003, 0.0, 0.0, 0.0, 0.0, 2.5165290423999997, 0.0, 20.2343946258, 21.1087405532, 21.371164870599998, 1.0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [rotate(360deg)\] at (2) should be [rotate(720deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (1) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (1) should be [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (1) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (1) should be [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (0) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (0.25) should be [matrix(2.5, 0, 0.31, 1.25, 1.5, 0)\]]
@@ -167,13 +74,7 @@
   [Web Animations: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (0.3333333333333333) should be [matrix(2.598076211353316, 1.4999999999999998, -0.49999999999999994, 0.8660254037844387, 2, -4)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (1) should be [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (0) should be [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (0.75) should be [matrix3d(2.622658368925, 0.0, 0.0, 0.0, 0.0, 2.500108923675, 0.0, 0.0, 0.0, 0.0, 2.7660426718, 0.0, 20.408689025450002, 20.342525493975, 20.572492826850002, 1.0)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (1) should be [matrix(1, 0, 0, 1, 0, 0)\]]
@@ -182,22 +83,10 @@
   [CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (0.6666666666666666) should be [matrix(5, 0, 2, 3, 0, 0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (-1) should be [matrix3d(-1.2484405096414273, 0, -2.727892280477045, 0, 0, 5, 0, 0, 6.365081987779772, 0, -2.9130278558299967, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (2) should be [matrix(13, 0, -10, -5, 0, 0)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (0.75) should be [matrix(1.5, 0, 0, 2, 0, -1.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (2) should be [matrix(-1, 0, 0, -3, 0, 6)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (-1) should be [matrix3d(-1.2484405096414273, 0, -2.727892280477045, 0, 0, 5, 0, 0, 6.365081987779772, 0, -2.9130278558299967, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (0.25) should be [matrix3d(0.9041890962319094, 0.3522701519297133, -0.15240204298176957, -0.1428256720529315, -0.7579798772527586, 0.6803606288839232, -0.05133336076757235, 0.37904689530895724, -0.1957679784745485, 0.38554138029509327, 0.8226186974340638, 0.3370288143441876, -0.296875, -0.015625, 0.328125, 0.5930529142680923)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (-1) should be [matrix(-5, 0, -13, 13, 0, 0)\]]
@@ -209,22 +98,10 @@
   [Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (-1) should be [matrix(-5, 0, -13, 13, 0, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (0) should be [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (2) should be [matrix(-1, 0, 0, -3, 0, 6)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (0.75) should be [matrix(1.5, 0, 0, 2, 0, -1.5)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (0.25) should be [matrix3d(0.7912976716694541, -0.4517927901159618, -0.6868745974719376, 1.2522201536338506, 0.7952183069582651, 0.06340410955800829, -0.7956629784232128, 2.2561737435012983, 0.345639443327071, -0.8934490945546473, 0.830131443385676, 1.2606901484983566, -1.0078125, 0.75, -0.703125, 2.4888661932358946)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (0) should be [matrix(1, 0, 0, 7, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (-1) should be [matrix(-13, 0, 0, -1, 12, 6)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (2) should be [matrix3d(-1.1789992641434441, -0.7109729379601547, -0.4455746537954199, -21.703089533128907, -0.11137581475421703, -0.08822983871000473, -0.05695380894007451, -2.22667264132605, -3.1443917136741506, 1.8952588096345078, 2.426615889772007, -21.697523130750138, -1.5, 2.0625, -3.1875, -5.901513951904121)\]]
@@ -233,40 +110,19 @@
   [Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (2) should be [matrix(13, 0, -10, -5, 0, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (0.5) should be [matrix(2, 0, 0, 3, 0, -3)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (1) should be [matrix(7, 0, 2, 2, 6, 0)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (2) should be [matrix(13, 0, -10, -5, 0, 0)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (0.6666666666666666) should be [matrix(2.5000000000000004, 4.330127018922193, -0.8660254037844386, 0.5000000000000001, 4, -2)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [none\] to [rotate(360deg)\] at (2) should be [rotate(720deg)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (-1) should be [matrix3d(-0.0000000000000002377810622383943, -1.0671050586638147, -0.08972656766237302, 1.3740432449326199, 0.98484601036295, -2.653201092395309, 0.6753819540610847, 3.6127240080250744, -2.7988839807429846, -1.2090004194153336, -0.5183744226115445, -0.7936088631686278, 1.1875, 0.0625, -1.3125, 5.340768914473683)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (2) should be [matrix(0, 5, 1, 0, -6, -12)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (2) should be [matrix3d(-0.5844534449366048, -0.42278005999296053, -0.4650580659922564, -0.6817595809063256, 0.9156938760088464, 0.3851647027225889, 0.9244443507516923, 0.7218225020358241, -0.0803568793574344, 0.1719974850210706, -0.49676609633513097, -0.25968177786904373, -2.375, -0.125, 2.625, 5.340768914473685)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [none\] to [rotate(180deg)\] at (0.25) should be [rotate(45deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (0.3333333333333333) should be [matrix(2.5000000000000004, 4.330127018922193, -0.8660254037844386, 0.5000000000000001, 4, -2)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (2) should be [matrix(-13, 0, 0, -1, 12, 6)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (2) should be [matrix3d(0.39048513570444376, 0.14780794797065988, 0.6963068100217401, -4.857907861239344, -2.967682789284791, 0.6004978769584385, -3.5472376016872444, 26.675324787979896, -2.5953724498995308, 1.6280843851961373, 0.8163834310586356, 9.001735256585825, 1.34375, -1, 0.9375, -14.881239394516227)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [none\] to [rotate(360deg)\] at (0.25) should be [rotate(90deg)\]]
@@ -287,19 +143,7 @@
   [CSS Transitions with transition: all: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (0.25) should be [matrix3d(1.2804555205291865, 0, -1.1928678300408346, 0, 0, 2.5, 0, 0, 2.215325970075836, 0, 2.377988823839918, 0, 0, 0, 0, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (-1) should be [matrix(-13, 0, 0, -1, 12, 6)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [none\] to [rotate(180deg)\] at (0.25) should be [rotate(45deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [none\] to [rotate(180deg)\] at (2) should be [rotate(360deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (0.75) should be [matrix3d(2.622658368925, 0.0, 0.0, 0.0, 0.0, 2.500108923675, 0.0, 0.0, 0.0, 0.0, 2.7660426718, 0.0, 20.408689025450002, 20.342525493975, 20.572492826850002, 1.0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (0.75) should be [matrix3d(0.35007413226026135, 0.7254385504141292, -0.4977009150941454, 0.09582061929004702, -1.1027525038949482, -0.5884810398827429, 0.4516829688651701, 0.5447944343861767, -0.68717798815684, 0.2657772247405681, 0.5465690479810023, 1.0836207863885503, -0.890625, -0.046875, 0.984375, 0.5930529142680927)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (0.75) should be [matrix3d(1.2804555205291865, 0, -1.1928678300408346, 0, 0, 2.5, 0, 0, 2.215325970075836, 0, 2.377988823839918, 0, 0, 0, 0, 1)\]]
@@ -314,34 +158,16 @@
   [CSS Transitions with transition: all: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (-1) should be [matrix3d(-0.6299594065765657, -0.10825090106268696, -0.20133311671001855, 5.485724217214554, 6.358051978686152, 0.16496896269344588, 1.5760051143537075, -54.21568355620423, 0.7106057459805782, -1.1596356050622005, -0.11495342545397585, -4.913752963990824, -1.03125, -1.125, 3.5625, -5.901513951904114)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (-1) should be [matrix3d(0, 0, 0, 0, 0, -1, 0, 0, 1.682941969615793, 0, -1.0806046117362795, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (0.25) should be [matrix3d(0.9041890962319094, 0.3522701519297133, -0.15240204298176957, -0.1428256720529315, -0.7579798772527586, 0.6803606288839232, -0.05133336076757235, 0.37904689530895724, -0.1957679784745485, 0.38554138029509327, 0.8226186974340638, 0.3370288143441876, -0.296875, -0.015625, 0.328125, 0.5930529142680923)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (0.75) should be [matrix3d(0.6861191524977764, -0.18025672746204927, -0.8710297237546482, 0.6072134247444672, 0.2819931018922366, 0.27778974607679663, -0.6540128246146626, 0.5063632314069845, 0.5509562084361049, -0.3215202993119732, 0.5459062603735321, 2.8697154005492105, -1.3046875, 0.734375, -0.375, 1.6470169329910096)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (0.6666666666666666) should be [matrix(5, 0, 2, 3, 0, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (-1) should be [matrix(5, 0, 0, 9, 0, -12)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (0) should be [matrix(1, 0, 0, 1, 0, -6)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [none\] to [rotate(360deg)\] at (-1) should be [rotate(-360deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (0) should be [matrix(0, 7, -1, 0, 6, 0)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [rotate(180deg)\] to [none\] at (0.75) should be [rotate(45deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (-1) should be [matrix3d(-0.0000000000000002377810622383943, -1.0671050586638147, -0.08972656766237302, 1.3740432449326199, 0.98484601036295, -2.653201092395309, 0.6753819540610847, 3.6127240080250744, -2.7988839807429846, -1.2090004194153336, -0.5183744226115445, -0.7936088631686278, 1.1875, 0.0625, -1.3125, 5.340768914473683)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (0) should be [matrix(1, 0, 0, 7, 0, 0)\]]
@@ -353,46 +179,13 @@
   [CSS Transitions: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (-1) should be [matrix3d(-0.6413028394192518, -1.0702420910513302, -0.5807595966791961, -18.02447171345163, 0.8211815704840004, 1.0980679097347057, 0.9399408862655454, 22.460730852026064, 0.28421009261178104, -0.5408346238741739, 0.5194791363698213, 3.075163035391172, -2.6875, 2, -1.875, -14.881239394516232)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (-1) should be [matrix(0, 5, 1, 0, -6, -12)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (0.25) should be [matrix3d(1.211140527138306, 0, -0.30925494906815365, 0, 0, 1.5, 0, 0, 0.43295692869541513, 0, 1.6955967379936283, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (-1) should be [matrix3d(-1.2484405096414273, 0, -2.727892280477045, 0, 0, 5, 0, 0, 6.365081987779772, 0, -2.9130278558299967, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (0) should be [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (2) should be [matrix(-13, 0, 0, -1, 12, 6)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (2) should be [matrix3d(-1.2484405096414273, 0, -2.727892280477045, 0, 0, 5, 0, 0, 6.365081987779772, 0, -2.9130278558299967, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [rotate(180deg)\] to [none\] at (0.75) should be [rotate(45deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [none\] to [rotate(180deg)\] at (2) should be [rotate(360deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (0.3333333333333333) should be [matrix(2.598076211353316, 1.4999999999999998, -0.49999999999999994, 0.8660254037844387, 2, -4)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (0.6666666666666666) should be [matrix(5, 0, 2, 3, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate(180deg)\] to [none\] at (2) should be [rotate(-180deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate(180deg)\] to [none\] at (1) should be [rotate(0deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (0.25) should be [matrix3d(0.7912976716694541, -0.4517927901159618, -0.6868745974719376, 1.2522201536338506, 0.7952183069582651, 0.06340410955800829, -0.7956629784232128, 2.2561737435012983, 0.345639443327071, -0.8934490945546473, 0.830131443385676, 1.2606901484983566, -1.0078125, 0.75, -0.703125, 2.4888661932358946)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (1) should be [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (-1) should be [matrix(-5, 0, -13, 13, 0, 0)\]]
@@ -402,9 +195,6 @@
     expected: FAIL
 
   [CSS Transitions: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (-1) should be [matrix(-5, 0, 0, 0, -6, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (2) should be [matrix3d(-0.5844534449366048, -0.42278005999296053, -0.4650580659922564, -0.6817595809063256, 0.9156938760088464, 0.3851647027225889, 0.9244443507516923, 0.7218225020358241, -0.0803568793574344, 0.1719974850210706, -0.49676609633513097, -0.25968177786904373, -2.375, -0.125, 2.625, 5.340768914473685)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (0.5) should be [matrix(4, 0, 0.75, 1.5, 3, 0)\]]
@@ -422,22 +212,10 @@
   [Web Animations: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (0.25) should be [matrix(2.5, 0, 0, 4, 0, -4.5)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (0.6666666666666666) should be [matrix(2.5000000000000004, 4.330127018922193, -0.8660254037844386, 0.5000000000000001, 4, -2)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (2) should be [matrix3d(-1.1789992641434441, -0.7109729379601547, -0.4455746537954199, -21.703089533128907, -0.11137581475421703, -0.08822983871000473, -0.05695380894007451, -2.22667264132605, -3.1443917136741506, 1.8952588096345078, 2.426615889772007, -21.697523130750138, -1.5, 2.0625, -3.1875, -5.901513951904121)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (-1) should be [matrix3d(0, 0, 0, 0, 0, -1, 0, 0, 1.682941969615793, 0, -1.0806046117362795, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (2) should be [matrix3d(-1.1789992641434441, -0.7109729379601547, -0.4455746537954199, -21.703089533128907, -0.11137581475421703, -0.08822983871000473, -0.05695380894007451, -2.22667264132605, -3.1443917136741506, 1.8952588096345078, 2.426615889772007, -21.697523130750138, -1.5, 2.0625, -3.1875, -5.901513951904121)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (0.25) should be [matrix3d(1.2804555205291865, 0, -1.1928678300408346, 0, 0, 2.5, 0, 0, 2.215325970075836, 0, 2.377988823839918, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (0.25) should be [matrix(2.5, 0, 0, 4, 0, -4.5)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (0.6666666666666666) should be [matrix(2.598076211353316, 1.4999999999999998, -0.49999999999999994, 0.8660254037844387, 2, -4)\]]
@@ -446,28 +224,10 @@
   [CSS Transitions with transition: all: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (0.25) should be [matrix(2.5, 0, 0.31, 1.25, 1.5, 0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (0.25) should be [matrix3d(0.7912976716694541, -0.4517927901159618, -0.6868745974719376, 1.2522201536338506, 0.7952183069582651, 0.06340410955800829, -0.7956629784232128, 2.2561737435012983, 0.345639443327071, -0.8934490945546473, 0.830131443385676, 1.2606901484983566, -1.0078125, 0.75, -0.703125, 2.4888661932358946)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (-1) should be [matrix(0, 5, 1, 0, -6, -12)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (2) should be [matrix(0, 5, 1, 0, -6, -12)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (1) should be [matrix(0, 7, -1, 0, 6, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (2) should be [matrix3d(0.39048513570444376, 0.14780794797065988, 0.6963068100217401, -4.857907861239344, -2.967682789284791, 0.6004978769584385, -3.5472376016872444, 26.675324787979896, -2.5953724498995308, 1.6280843851961373, 0.8163834310586356, 9.001735256585825, 1.34375, -1, 0.9375, -14.881239394516227)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (-1) should be [matrix(-13, 0, 0, -1, 12, 6)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (0.5) should be [matrix(2.8284271247461903, 2.82842712474619, -0.7071067811865475, 0.7071067811865476, 3, -3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (1) should be [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (0) should be [matrix(1, 0, 0, 1, 0, 0)\]]
@@ -476,31 +236,10 @@
   [CSS Transitions with transition: all: property <transform> from [none\] to [rotate(180deg)\] at (-1) should be [rotate(-180deg)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (0.75) should be [matrix(1.5, 0, 0, 2, 0, -1.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (1) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [rotate(180deg)\] at (0) should be [rotate(0deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (1) should be [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (2) should be [matrix3d(-1.1789992641434441, -0.7109729379601547, -0.4455746537954199, -21.703089533128907, -0.11137581475421703, -0.08822983871000473, -0.05695380894007451, -2.22667264132605, -3.1443917136741506, 1.8952588096345078, 2.426615889772007, -21.697523130750138, -1.5, 2.0625, -3.1875, -5.901513951904121)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (0) should be [matrix(1, 0, 0, 1, 0, 0)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [rotate(180deg)\] to [none\] at (2) should be [rotate(-180deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (2) should be [matrix3d(-1.2484405096414273, 0, -2.727892280477045, 0, 0, 5, 0, 0, 6.365081987779772, 0, -2.9130278558299967, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate(180deg)\] to [none\] at (0.25) should be [rotate(135deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (0.75) should be [matrix3d(1.211140527138306, 0, -0.30925494906815365, 0, 0, 1.5, 0, 0, 0.43295692869541513, 0, 1.6955967379936283, 0, 0, 0, 0, 1)\]]
@@ -509,16 +248,7 @@
   [Web Animations: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (2) should be [matrix3d(-0.5844534449366048, -0.42278005999296053, -0.4650580659922564, -0.6817595809063256, 0.9156938760088464, 0.3851647027225889, 0.9244443507516923, 0.7218225020358241, -0.0803568793574344, 0.1719974850210706, -0.49676609633513097, -0.25968177786904373, -2.375, -0.125, 2.625, 5.340768914473685)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (0) should be [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (0.25) should be [matrix3d(1.2804555205291865, 0, -1.1928678300408346, 0, 0, 2.5, 0, 0, 2.215325970075836, 0, 2.377988823839918, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (0.75) should be [matrix3d(2.622658368925, 0.0, 0.0, 0.0, 0.0, 2.500108923675, 0.0, 0.0, 0.0, 0.0, 2.7660426718, 0.0, 20.408689025450002, 20.342525493975, 20.572492826850002, 1.0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (0.25) should be [matrix3d(0.33652832679595723, 0.55254445148386, -0.7544724447833296, 0.22700224951774267, -0.69720168363685, -0.036373245768780864, 0.28149188169180933, -0.2845156818045006, -0.24737156018941048, 0.31207160370190334, 0.4564821058052897, 0.9220853089096839, -1.2265625, 0.203125, 0.75, 1.647016932991011)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (0) should be [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\]]
@@ -530,49 +260,19 @@
   [Web Animations: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (0.5) should be [matrix(4, 0, 0.75, 1.5, 3, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (1) should be [matrix(1, 0, 0, 1, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (0.75) should be [matrix3d(0.6861191524977764, -0.18025672746204927, -0.8710297237546482, 0.6072134247444672, 0.2819931018922366, 0.27778974607679663, -0.6540128246146626, 0.5063632314069845, 0.5509562084361049, -0.3215202993119732, 0.5459062603735321, 2.8697154005492105, -1.3046875, 0.734375, -0.375, 1.6470169329910096)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (0.6666666666666666) should be [matrix(5, 0, 2, 3, 0, 0)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (0) should be [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (2) should be [matrix(0, 5, 1, 0, -6, -12)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (0.75) should be [matrix3d(1.0093457700315165, -0.12746048375025829, -0.24746788943106088, 1.3202120308857304, 0.6128364656690982, 0.7600694601651116, -0.22233359857303325, 1.4081483224940277, 0.21669805381113447, -0.3786082265932788, 0.908354523914928, 0.6747509193960347, -0.3359375, 0.25, -0.234375, 2.4888661932358964)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (2) should be [matrix(-1, 0, 0, -3, 0, 6)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [rotate(180deg)\] to [none\] at (0) should be [rotate(180deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (-1) should be [matrix3d(-1.2484405096414273, 0, -2.727892280477045, 0, 0, 5, 0, 0, 6.365081987779772, 0, -2.9130278558299967, 0, 0, 0, 0, 1)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (0.6666666666666666) should be [matrix(2.598076211353316, 1.4999999999999998, -0.49999999999999994, 0.8660254037844387, 2, -4)\]]
-    expected: FAIL
-
   [CSS Animations: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (-1) should be [matrix(-5, 0, 0, 0, -6, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [rotate(360deg)\] at (0) should be [rotate(0deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (2) should be [matrix3d(0, 0, 0, 0, 0, -1, 0, 0, 1.682941969615793, 0, -1.0806046117362795, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (0.75) should be [matrix3d(1.211140527138306, 0, -0.30925494906815365, 0, 0, 1.5, 0, 0, 0.43295692869541513, 0, 1.6955967379936283, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (0.6666666666666666) should be [matrix(2.598076211353316, 1.4999999999999998, -0.49999999999999994, 0.8660254037844387, 2, -4)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (2) should be [matrix(13, 0, -10, -5, 0, 0)\]]
@@ -581,46 +281,13 @@
   [CSS Transitions with transition: all: property <transform> from [none\] to [rotate(180deg)\] at (0.25) should be [rotate(45deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (2) should be [matrix3d(3.0761619932999995, 0.0, 0.0, 0.0, 0.0, 2.3221331858, 0.0, 0.0, 0.0, 0.0, 2.9442666928000003, 0.0, 20.5331850252, 19.7952290231, 20.002012795600002, 1.0)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (-1) should be [matrix(-13, 0, 0, -1, 12, 6)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (0) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [rotate(180deg)\] at (-1) should be [rotate(-180deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (0.6666666666666666) should be [matrix(2.598076211353316, 1.4999999999999998, -0.49999999999999994, 0.8660254037844387, 2, -4)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (0.25) should be [matrix3d(2.441256919175, 0.0, 0.0, 0.0, 0.0, 2.571299218825, 0.0, 0.0, 0.0, 0.0, 2.6947530634, 0.0, 20.35889062555, 20.561444082325, 20.800684839349998, 1.0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (2) should be [matrix3d(0.39048513570444376, 0.14780794797065988, 0.6963068100217401, -4.857907861239344, -2.967682789284791, 0.6004978769584385, -3.5472376016872444, 26.675324787979896, -2.5953724498995308, 1.6280843851961373, 0.8163834310586356, 9.001735256585825, 1.34375, -1, 0.9375, -14.881239394516227)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [none\] to [rotate(180deg)\] at (0.75) should be [rotate(135deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (1) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [rotate(360deg)\] at (0.25) should be [rotate(90deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (-1) should be [matrix3d(1.9877532948000005, 0.0, 0.0, 0.0, 0.0, 2.7492749567000003, 0.0, 0.0, 0.0, 0.0, 2.5165290423999997, 0.0, 20.2343946258, 21.1087405532, 21.371164870599998, 1.0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (0.75) should be [matrix3d(0.35007413226026135, 0.7254385504141292, -0.4977009150941454, 0.09582061929004702, -1.1027525038949482, -0.5884810398827429, 0.4516829688651701, 0.5447944343861767, -0.68717798815684, 0.2657772247405681, 0.5465690479810023, 1.0836207863885503, -0.890625, -0.046875, 0.984375, 0.5930529142680927)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [none\] to [rotate(180deg)\] at (0.75) should be [rotate(135deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (0.3333333333333333) should be [matrix(2.598076211353316, 1.4999999999999998, -0.49999999999999994, 0.8660254037844387, 2, -4)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (-1) should be [matrix3d(0, 0, 0, 0, 0, -1, 0, 0, 1.682941969615793, 0, -1.0806046117362795, 0, 0, 0, 0, 1)\]]
@@ -629,28 +296,16 @@
   [Web Animations: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (1) should be [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (-1) should be [matrix3d(-0.6413028394192518, -1.0702420910513302, -0.5807595966791961, -18.02447171345163, 0.8211815704840004, 1.0980679097347057, 0.9399408862655454, 22.460730852026064, 0.28421009261178104, -0.5408346238741739, 0.5194791363698213, 3.075163035391172, -2.6875, 2, -1.875, -14.881239394516232)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (2) should be [matrix(13, 0, 6, 3, 12, 0)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [none\] to [rotate(360deg)\] at (0.75) should be [rotate(270deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (0) should be [matrix(3, 0, 0, 5, 0, -6)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (0) should be [matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [rotate(180deg)\] to [none\] at (2) should be [rotate(-180deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (0.75) should be [matrix3d(0.6861191524977764, -0.18025672746204927, -0.8710297237546482, 0.6072134247444672, 0.2819931018922366, 0.27778974607679663, -0.6540128246146626, 0.5063632314069845, 0.5509562084361049, -0.3215202993119732, 0.5459062603735321, 2.8697154005492105, -1.3046875, 0.734375, -0.375, 1.6470169329910096)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (-1) should be [matrix3d(1.9877532948000005, 0.0, 0.0, 0.0, 0.0, 2.7492749567000003, 0.0, 0.0, 0.0, 0.0, 2.5165290423999997, 0.0, 20.2343946258, 21.1087405532, 21.371164870599998, 1.0)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (-1) should be [matrix3d(1.9877532948000005, 0.0, 0.0, 0.0, 0.0, 2.7492749567000003, 0.0, 0.0, 0.0, 0.0, 2.5165290423999997, 0.0, 20.2343946258, 21.1087405532, 21.371164870599998, 1.0)\]]
@@ -659,25 +314,10 @@
   [Web Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (1) should be [matrix(7, 0, 1, 1, 0, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (0.75) should be [matrix3d(1.2804555205291865, 0, -1.1928678300408346, 0, 0, 2.5, 0, 0, 2.215325970075836, 0, 2.377988823839918, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (0.75) should be [matrix3d(0.35007413226026135, 0.7254385504141292, -0.4977009150941454, 0.09582061929004702, -1.1027525038949482, -0.5884810398827429, 0.4516829688651701, 0.5447944343861767, -0.68717798815684, 0.2657772247405681, 0.5465690479810023, 1.0836207863885503, -0.890625, -0.046875, 0.984375, 0.5930529142680927)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (0.5) should be [matrix(2.8284271247461903, 2.82842712474619, -0.7071067811865475, 0.7071067811865476, 3, -3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [none\] to [rotate(180deg)\] at (0.25) should be [rotate(45deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (0.75) should be [matrix3d(1.2804555205291865, 0, -1.1928678300408346, 0, 0, 2.5, 0, 0, 2.215325970075836, 0, 2.377988823839918, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [none\] to [rotate(360deg)\] at (1) should be [rotate(360deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (0.5) should be [matrix(2.8284271247461903, 2.82842712474619, -0.7071067811865475, 0.7071067811865476, 3, -3)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [rotate(180deg)\] to [none\] at (-1) should be [rotate(360deg)\]]
@@ -695,16 +335,7 @@
   [CSS Animations: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (0.25) should be [matrix(2.5, 0, 0.31, 1.25, 1.5, 0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (0.75) should be [matrix3d(1.0093457700315165, -0.12746048375025829, -0.24746788943106088, 1.3202120308857304, 0.6128364656690982, 0.7600694601651116, -0.22233359857303325, 1.4081483224940277, 0.21669805381113447, -0.3786082265932788, 0.908354523914928, 0.6747509193960347, -0.3359375, 0.25, -0.234375, 2.4888661932358964)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (0.5) should be [matrix(2, 0, 0, 3, 0, -3)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (-1) should be [matrix(-5, 0, -13, 13, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (0.75) should be [matrix(1.5, 0, 0, 2, 0, -1.5)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (-1) should be [matrix3d(-0.6299594065765657, -0.10825090106268696, -0.20133311671001855, 5.485724217214554, 6.358051978686152, 0.16496896269344588, 1.5760051143537075, -54.21568355620423, 0.7106057459805782, -1.1596356050622005, -0.11495342545397585, -4.913752963990824, -1.03125, -1.125, 3.5625, -5.901513951904114)\]]
@@ -713,22 +344,7 @@
   [CSS Transitions with transition: all: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (-1) should be [matrix(-5, 0, 0, 0, -6, 0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (0.75) should be [matrix3d(1.211140527138306, 0, -0.30925494906815365, 0, 0, 1.5, 0, 0, 0.43295692869541513, 0, 1.6955967379936283, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (2) should be [matrix(13, 0, 6, 3, 12, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (0.75) should be [matrix3d(1.2804555205291865, 0, -1.1928678300408346, 0, 0, 2.5, 0, 0, 2.215325970075836, 0, 2.377988823839918, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (0.5) should be [matrix(2.8284271247461903, 2.82842712474619, -0.7071067811865475, 0.7071067811865476, 3, -3)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (0.25) should be [matrix3d(0.7912976716694541, -0.4517927901159618, -0.6868745974719376, 1.2522201536338506, 0.7952183069582651, 0.06340410955800829, -0.7956629784232128, 2.2561737435012983, 0.345639443327071, -0.8934490945546473, 0.830131443385676, 1.2606901484983566, -1.0078125, 0.75, -0.703125, 2.4888661932358946)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (0.5) should be [matrix(2.8284271247461903, 2.82842712474619, -0.7071067811865475, 0.7071067811865476, 3, -3)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (2) should be [matrix3d(3.0761619932999995, 0.0, 0.0, 0.0, 0.0, 2.3221331858, 0.0, 0.0, 0.0, 0.0, 2.9442666928000003, 0.0, 20.5331850252, 19.7952290231, 20.002012795600002, 1.0)\]]
@@ -737,49 +353,19 @@
   [Web Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (2) should be [matrix(0, 5, 1, 0, -6, -12)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [none\] to [rotate(180deg)\] at (2) should be [rotate(360deg)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (1) should be [matrix(1, 0, 0, 1, 0, -6)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (0.25) should be [matrix3d(2.441256919175, 0.0, 0.0, 0.0, 0.0, 2.571299218825, 0.0, 0.0, 0.0, 0.0, 2.6947530634, 0.0, 20.35889062555, 20.561444082325, 20.800684839349998, 1.0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (0.25) should be [matrix3d(0.9041890962319094, 0.3522701519297133, -0.15240204298176957, -0.1428256720529315, -0.7579798772527586, 0.6803606288839232, -0.05133336076757235, 0.37904689530895724, -0.1957679784745485, 0.38554138029509327, 0.8226186974340638, 0.3370288143441876, -0.296875, -0.015625, 0.328125, 0.5930529142680923)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [none\] to [rotate(180deg)\] at (0.75) should be [rotate(135deg)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (-1) should be [matrix(0, 5, 1, 0, -6, -12)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (0.75) should be [matrix(5.5, 0, 1.31, 1.75, 4.5, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (0.25) should be [matrix3d(0.33652832679595723, 0.55254445148386, -0.7544724447833296, 0.22700224951774267, -0.69720168363685, -0.036373245768780864, 0.28149188169180933, -0.2845156818045006, -0.24737156018941048, 0.31207160370190334, 0.4564821058052897, 0.9220853089096839, -1.2265625, 0.203125, 0.75, 1.647016932991011)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [none\] to [rotate(180deg)\] at (2) should be [rotate(360deg)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (0.6666666666666666) should be [matrix(2.5000000000000004, 4.330127018922193, -0.8660254037844386, 0.5000000000000001, 4, -2)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (2) should be [matrix3d(0.39048513570444376, 0.14780794797065988, 0.6963068100217401, -4.857907861239344, -2.967682789284791, 0.6004978769584385, -3.5472376016872444, 26.675324787979896, -2.5953724498995308, 1.6280843851961373, 0.8163834310586356, 9.001735256585825, 1.34375, -1, 0.9375, -14.881239394516227)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (0.75) should be [matrix3d(0.35007413226026135, 0.7254385504141292, -0.4977009150941454, 0.09582061929004702, -1.1027525038949482, -0.5884810398827429, 0.4516829688651701, 0.5447944343861767, -0.68717798815684, 0.2657772247405681, 0.5465690479810023, 1.0836207863885503, -0.890625, -0.046875, 0.984375, 0.5930529142680927)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (0.25) should be [matrix3d(0.33652832679595723, 0.55254445148386, -0.7544724447833296, 0.22700224951774267, -0.69720168363685, -0.036373245768780864, 0.28149188169180933, -0.2845156818045006, -0.24737156018941048, 0.31207160370190334, 0.4564821058052897, 0.9220853089096839, -1.2265625, 0.203125, 0.75, 1.647016932991011)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (0.75) should be [matrix3d(1.0093457700315165, -0.12746048375025829, -0.24746788943106088, 1.3202120308857304, 0.6128364656690982, 0.7600694601651116, -0.22233359857303325, 1.4081483224940277, 0.21669805381113447, -0.3786082265932788, 0.908354523914928, 0.6747509193960347, -0.3359375, 0.25, -0.234375, 2.4888661932358964)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (-1) should be [matrix(5, 0, 0, 9, 0, -12)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (0.5) should be [matrix(4, 0, 2, 4, 0, 0)\]]
@@ -789,15 +375,6 @@
     expected: FAIL
 
   [Web Animations: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (-1) should be [matrix3d(-0.0000000000000002377810622383943, -1.0671050586638147, -0.08972656766237302, 1.3740432449326199, 0.98484601036295, -2.653201092395309, 0.6753819540610847, 3.6127240080250744, -2.7988839807429846, -1.2090004194153336, -0.5183744226115445, -0.7936088631686278, 1.1875, 0.0625, -1.3125, 5.340768914473683)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (2) should be [matrix(-13, 0, 0, -1, 12, 6)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (0.3333333333333333) should be [matrix(2.5000000000000004, 4.330127018922193, -0.8660254037844386, 0.5000000000000001, 4, -2)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (-1) should be [matrix3d(-0.6299594065765657, -0.10825090106268696, -0.20133311671001855, 5.485724217214554, 6.358051978686152, 0.16496896269344588, 1.5760051143537075, -54.21568355620423, 0.7106057459805782, -1.1596356050622005, -0.11495342545397585, -4.913752963990824, -1.03125, -1.125, 3.5625, -5.901513951904114)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [none\] to [rotate(360deg)\] at (0.25) should be [rotate(90deg)\]]
@@ -812,9 +389,6 @@
   [CSS Transitions: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (0.75) should be [matrix(5.5, 0, 1.31, 1.75, 4.5, 0)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [none\] to [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] at (0.25) should be [matrix3d(1.211140527138306, 0, -0.30925494906815365, 0, 0, 1.5, 0, 0, 0.43295692869541513, 0, 1.6955967379936283, 0, 0, 0, 0, 1)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [rotate(180deg)\] to [none\] at (1) should be [rotate(0deg)\]]
     expected: FAIL
 
@@ -824,25 +398,13 @@
   [Web Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (0.5) should be [matrix(2.8284271247461903, 2.82842712474619, -0.7071067811865475, 0.7071067811865476, 3, -3)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (2) should be [matrix3d(3.0761619932999995, 0.0, 0.0, 0.0, 0.0, 2.3221331858, 0.0, 0.0, 0.0, 0.0, 2.9442666928000003, 0.0, 20.5331850252, 19.7952290231, 20.002012795600002, 1.0)\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform> from [none\] to [rotate(360deg)\] at (-1) should be [rotate(-360deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (0.25) should be [matrix3d(0.9041890962319094, 0.3522701519297133, -0.15240204298176957, -0.1428256720529315, -0.7579798772527586, 0.6803606288839232, -0.05133336076757235, 0.37904689530895724, -0.1957679784745485, 0.38554138029509327, 0.8226186974340638, 0.3370288143441876, -0.296875, -0.015625, 0.328125, 0.5930529142680923)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (2) should be [matrix3d(-0.5844534449366048, -0.42278005999296053, -0.4650580659922564, -0.6817595809063256, 0.9156938760088464, 0.3851647027225889, 0.9244443507516923, 0.7218225020358241, -0.0803568793574344, 0.1719974850210706, -0.49676609633513097, -0.25968177786904373, -2.375, -0.125, 2.625, 5.340768914473685)\]]
     expected: FAIL
 
   [CSS Animations: property <transform> from [matrix(1, 0, 0, 7, 0, 0)\] to [matrix(7, 0, 1, 1, 0, 0)\] at (0.5) should be [matrix(4, 0, 2, 4, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (0.75) should be [matrix3d(1.0093457700315165, -0.12746048375025829, -0.24746788943106088, 1.3202120308857304, 0.6128364656690982, 0.7600694601651116, -0.22233359857303325, 1.4081483224940277, 0.21669805381113447, -0.3786082265932788, 0.908354523914928, 0.6747509193960347, -0.3359375, 0.25, -0.234375, 2.4888661932358964)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [matrix3d(1.0806046117362795, 0, -1.682941969615793, 0, 0, 3, 0, 0, 3.365883939231586, 0, 2.161209223472559, 0, 0, 0, 0, 1)\] to [none\] at (0.75) should be [matrix3d(1.211140527138306, 0, -0.30925494906815365, 0, 0, 1.5, 0, 0, 0.43295692869541513, 0, 1.6955967379936283, 0, 0, 0, 0, 1)\]]
     expected: FAIL
 
   [CSS Transitions: property <transform> from [none\] to [matrix(7, 0, 2, 2, 6, 0)\] at (0.25) should be [matrix(2.5, 0, 0.31, 1.25, 1.5, 0)\]]
@@ -869,9 +431,6 @@
   [CSS Transitions: property <transform> from [none\] to [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] at (-1) should be [matrix3d(-0.0000000000000002377810622383943, -1.0671050586638147, -0.08972656766237302, 1.3740432449326199, 0.98484601036295, -2.653201092395309, 0.6753819540610847, 3.6127240080250744, -2.7988839807429846, -1.2090004194153336, -0.5183744226115445, -0.7936088631686278, 1.1875, 0.0625, -1.3125, 5.340768914473683)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (0.75) should be [matrix3d(0.6861191524977764, -0.18025672746204927, -0.8710297237546482, 0.6072134247444672, 0.2819931018922366, 0.27778974607679663, -0.6540128246146626, 0.5063632314069845, 0.5509562084361049, -0.3215202993119732, 0.5459062603735321, 2.8697154005492105, -1.3046875, 0.734375, -0.375, 1.6470169329910096)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (-1) should be [matrix3d(-0.6413028394192518, -1.0702420910513302, -0.5807595966791961, -18.02447171345163, 0.8211815704840004, 1.0980679097347057, 0.9399408862655454, 22.460730852026064, 0.28421009261178104, -0.5408346238741739, 0.5194791363698213, 3.075163035391172, -2.6875, 2, -1.875, -14.881239394516232)\]]
     expected: FAIL
 
@@ -881,24 +440,21 @@
   [Web Animations: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (1) should be [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [matrix(1, 0, 0, 1, 0, -6)\] to [matrix(0, 7, -1, 0, 6, 0)\] at (0.3333333333333333) should be [matrix(2.598076211353316, 1.4999999999999998, -0.49999999999999994, 0.8660254037844387, 2, -4)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [matrix3d(2.3505561943, 0.0, 0.0, 0.0, 0.0, 2.6068943664, 0.0, 0.0, 0.0, 0.0, 2.6591082592, 0.0, 20.3339914256, 20.6709033765, 20.9147808456, 1.0)\] to [matrix3d(2.7133590938, 0.0, 0.0, 0.0, 0.0, 2.4645137761, 0.0, 0.0, 0.0, 0.0, 2.801687476, 0.0, 20.4335882254, 20.2330661998, 20.4583968206, 1.0)\] at (0.75) should be [matrix3d(2.622658368925, 0.0, 0.0, 0.0, 0.0, 2.500108923675, 0.0, 0.0, 0.0, 0.0, 2.7660426718, 0.0, 20.408689025450002, 20.342525493975, 20.572492826850002, 1.0)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [rotate(180deg)\] to [none\] at (2) should be [rotate(-180deg)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [matrix(0, 7, -1, 0, 6, 0)\] to [matrix(1, 0, 0, 1, 0, -6)\] at (0) should be [matrix(0, 7, -1, 0, 6, 0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [matrix(3, 0, 0, 5, 0, -6)\] to [none\] at (2) should be [matrix(-1, 0, 0, -3, 0, 6)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [rotate(180deg)\] to [none\] at (0.75) should be [rotate(45deg)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform> from [rotate(180deg)\] to [none\] at (0.25) should be [rotate(135deg)\]]
+    expected: FAIL
+
+  [CSS Transitions: property <transform> from [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] to [none\] at (2) should be [matrix3d(0.39048513570444376, 0.14780794797065988, 0.6963068100217401, -4.857907861239344, -2.967682789284791, 0.6004978769584385, -3.5472376016872444, 26.675324787979896, -2.5953724498995308, 1.6280843851961373, 0.8163834310586356, 9.001735256585825, 1.34375, -1, 0.9375, -14.881239394516227)\]]
+    expected: FAIL
+
+  [CSS Transitions: property <transform> from [matrix3d(0, 0.6875, -0.625, 0.3125, -0.6666666666666665, -1, 0.8333333333333334, 0.125, -0.6666666666666665, 0, 0.5, 1.0625, -1.1875, -0.0625, 1.3125, 1)\] to [matrix3d(0.571428571428571, -0.625, -0.8333333333333346, -0.66666666666669, 0.5, -0.1875, -0.8125, 0.3125, 0.34375, -1, 0.8333333333333327, 1.34375, -1.34375, 1, -0.9375, 1)\] at (0.25) should be [matrix3d(0.33652832679595723, 0.55254445148386, -0.7544724447833296, 0.22700224951774267, -0.69720168363685, -0.036373245768780864, 0.28149188169180933, -0.2845156818045006, -0.24737156018941048, 0.31207160370190334, 0.4564821058052897, 0.9220853089096839, -1.2265625, 0.203125, 0.75, 1.647016932991011)\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transforms/animation/transform-interpolation-006.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/transform-interpolation-006.html.ini
@@ -2,22 +2,10 @@
   [transform interpolation]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [inherit\] to [translate(20px)\] at (0.75) should be [translate(22.5px)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from neutral to [translate(20px)\] at (0.75) should be [translate(17.5px)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [unset\] to [translate(20px)\] at (2) should be [translate(40px)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [initial\] to [translate(20px)\] at (0.75) should be [translate(15px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [initial\] to [translate(20px)\] at (-1) should be [translate(-20px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [initial\] to [translate(20px)\] at (2) should be [translate(40px)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [unset\] to [translate(20px)\] at (1) should be [translate(20px)\]]
@@ -26,58 +14,25 @@
   [Web Animations: property <transform> from [inherit\] to [translate(20px)\] at (-1) should be [translate(40px)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [inherit\] to [translate(20px)\] at (0.25) should be [translate(27.5px)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [unset\] to [translate(20px)\] at (0.75) should be [translate(15px)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [unset\] to [translate(20px)\] at (0) should be [translate(0px)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [unset\] to [translate(20px)\] at (0.75) should be [translate(15px)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from neutral to [translate(20px)\] at (2) should be [translate(30px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from neutral to [translate(20px)\] at (-1) should be [translate(0px)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from neutral to [translate(20px)\] at (0.25) should be [translate(12.5px)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from neutral to [translate(20px)\] at (0.25) should be [translate(12.5px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [unset\] to [translate(20px)\] at (0.25) should be [translate(5px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [inherit\] to [translate(20px)\] at (1) should be [translate(20px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from neutral to [translate(20px)\] at (-1) should be [translate(0px)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [unset\] to [translate(20px)\] at (-1) should be [translate(-20px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from neutral to [translate(20px)\] at (0.75) should be [translate(17.5px)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [initial\] to [translate(20px)\] at (1) should be [translate(20px)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [unset\] to [translate(20px)\] at (0.75) should be [translate(15px)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [inherit\] to [translate(20px)\] at (2) should be [translate(10px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from neutral to [translate(20px)\] at (2) should be [translate(30px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [initial\] to [translate(20px)\] at (0.75) should be [translate(15px)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [inherit\] to [translate(20px)\] at (0.25) should be [translate(27.5px)\]]
@@ -89,27 +44,6 @@
   [Web Animations: property <transform> from [unset\] to [translate(20px)\] at (2) should be [translate(40px)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from [inherit\] to [translate(20px)\] at (-1) should be [translate(40px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [unset\] to [translate(20px)\] at (0.25) should be [translate(5px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [initial\] to [translate(20px)\] at (0.25) should be [translate(5px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [initial\] to [translate(20px)\] at (0.75) should be [translate(15px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [unset\] to [translate(20px)\] at (-1) should be [translate(-20px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [initial\] to [translate(20px)\] at (0.25) should be [translate(5px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [unset\] to [translate(20px)\] at (2) should be [translate(40px)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from neutral to [translate(20px)\] at (0) should be [translate(10px)\]]
     expected: FAIL
 
@@ -119,85 +53,16 @@
   [Web Animations: property <transform> from [initial\] to [translate(20px)\] at (0) should be [translate(0px)\]]
     expected: FAIL
 
-  [CSS Animations: property <transform> from [unset\] to [translate(20px)\] at (1) should be [translate(20px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [initial\] to [translate(20px)\] at (-1) should be [translate(-20px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [unset\] to [translate(20px)\] at (-1) should be [translate(-20px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [initial\] to [translate(20px)\] at (2) should be [translate(40px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [initial\] to [translate(20px)\] at (1) should be [translate(20px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from neutral to [translate(20px)\] at (0.25) should be [translate(12.5px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from neutral to [translate(20px)\] at (0.75) should be [translate(17.5px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [inherit\] to [translate(20px)\] at (0.75) should be [translate(22.5px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from neutral to [translate(20px)\] at (2) should be [translate(30px)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [inherit\] to [translate(20px)\] at (0) should be [translate(30px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [initial\] to [translate(20px)\] at (0.25) should be [translate(5px)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [inherit\] to [translate(20px)\] at (1) should be [translate(20px)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [unset\] to [translate(20px)\] at (0.25) should be [translate(5px)\]]
-    expected: FAIL
-
   [CSS Animations: property <transform> from [inherit\] to [translate(20px)\] at (0) should be [translate(30px)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [unset\] to [translate(20px)\] at (2) should be [translate(40px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [unset\] to [translate(20px)\] at (-1) should be [translate(-20px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from neutral to [translate(20px)\] at (0.75) should be [translate(17.5px)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from [unset\] to [translate(20px)\] at (0.25) should be [translate(5px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [unset\] to [translate(20px)\] at (0.75) should be [translate(15px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [unset\] to [translate(20px)\] at (0) should be [translate(0px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [inherit\] to [translate(20px)\] at (2) should be [translate(10px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from neutral to [translate(20px)\] at (-1) should be [translate(0px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [inherit\] to [translate(20px)\] at (0.25) should be [translate(27.5px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from neutral to [translate(20px)\] at (2) should be [translate(30px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform> from [inherit\] to [translate(20px)\] at (-1) should be [translate(40px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from neutral to [translate(20px)\] at (1) should be [translate(20px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [initial\] to [translate(20px)\] at (-1) should be [translate(-20px)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from neutral to [translate(20px)\] at (-1) should be [translate(0px)\]]
@@ -209,19 +74,7 @@
   [CSS Animations: property <transform> from [inherit\] to [translate(20px)\] at (-1) should be [translate(40px)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform> from neutral to [translate(20px)\] at (0.25) should be [translate(12.5px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [initial\] to [translate(20px)\] at (0.75) should be [translate(15px)\]]
-    expected: FAIL
-
   [Web Animations: property <transform> from neutral to [translate(20px)\] at (1) should be [translate(20px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform> from [initial\] to [translate(20px)\] at (0) should be [translate(0px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform> from [inherit\] to [translate(20px)\] at (2) should be [translate(10px)\]]
     expected: FAIL
 
   [Web Animations: property <transform> from [initial\] to [translate(20px)\] at (-1) should be [translate(-20px)\]]
@@ -233,6 +86,6 @@
   [Web Animations: property <transform> from [initial\] to [translate(20px)\] at (2) should be [translate(40px)\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform> from [initial\] to [translate(20px)\] at (2) should be [translate(40px)\]]
+  [CSS Animations: property <transform> from [inherit\] to [translate(20px)\] at (2) should be [translate(10px)\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transforms/animation/transform-origin-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/transform-origin-interpolation.html.ini
@@ -5,9 +5,6 @@
   [CSS Transitions: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (0.6) should be [60% 110% 2px\]]
     expected: FAIL
 
-  [CSS Transitions: property <transform-origin> from [inherit\] to [20px 20px\] at (1.5) should be [15px 25px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform-origin> from [initial\] to [20px 20px\] at (-0.3) should be [26.5px 26.5px\]]
     expected: FAIL
 
@@ -38,12 +35,6 @@
   [Web Animations: property <transform-origin> from [unset\] to [20px 20px\] at (0.6) should be [22px 22px\]]
     expected: FAIL
 
-  [CSS Animations: property <transform-origin> from neutral to [20px 20px\] at (0.6) should be [16px 24px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (0.6) should be [60% 110% 2px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform-origin> from [initial\] to [20px 20px\] at (0) should be [25px 25px\]]
     expected: FAIL
 
@@ -54,9 +45,6 @@
     expected: FAIL
 
   [CSS Animations: property <transform-origin> from [center center\] to [0% 100px\] at (0) should be [25px 25px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform-origin> from [inherit\] to [20px 20px\] at (-0.3) should be [33px 7px\]]
     expected: FAIL
 
   [CSS Animations: property <transform-origin> from [top left\] to [bottom right\] at (0.6) should be [30px 30px\]]
@@ -77,22 +65,13 @@
   [Web Animations: property <transform-origin> from neutral to [20px 20px\] at (1.5) should be [25px 15px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (1.5) should be [150% 200% -2.5px\]]
-    expected: FAIL
-
   [Web Animations: property <transform-origin> from [inherit\] to [20px 20px\] at (1.5) should be [15px 25px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform-origin> from neutral to [20px 20px\] at (0.6) should be [16px 24px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform-origin> from [center center\] to [0% 100px\] at (-0.3) should be [32.5px 2.5px\]]
     expected: FAIL
 
   [Web Animations: property <transform-origin> from [inherit\] to [20px 20px\] at (-0.3) should be [33px 7px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform-origin> from [inherit\] to [20px 20px\] at (0.6) should be [24px 16px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform-origin> from [top left\] to [bottom right\] at (1) should be [50px 50px\]]
@@ -107,16 +86,10 @@
   [Web Animations: property <transform-origin> from [top left\] to [bottom right\] at (1.5) should be [75px 75px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform-origin> from [inherit\] to [20px 20px\] at (0.3) should be [27px 13px\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform-origin> from [center center\] to [0% 100px\] at (0.6) should be [10px 70px\]]
     expected: FAIL
 
   [Web Animations: property <transform-origin> from neutral to [20px 20px\] at (0.6) should be [16px 24px\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform-origin> from neutral to [20px 20px\] at (-0.3) should be [7px 33px\]]
     expected: FAIL
 
   [Web Animations: property <transform-origin> from [center center\] to [0% 100px\] at (0.3) should be [17.5px 47.5px\]]
@@ -135,9 +108,6 @@
     expected: FAIL
 
   [Web Animations: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (0.3) should be [30% 80% 3.5px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform-origin> from neutral to [20px 20px\] at (0.3) should be [13px 27px\]]
     expected: FAIL
 
   [CSS Transitions: property <transform-origin> from [top left\] to [bottom right\] at (1.5) should be [75px 75px\]]
@@ -161,16 +131,10 @@
   [CSS Transitions with transition: all: property <transform-origin> from [center center\] to [0% 100px\] at (0.3) should be [17.5px 47.5px\]]
     expected: FAIL
 
-  [CSS Animations: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (1) should be [100% 150% 0px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform-origin> from [initial\] to [20px 20px\] at (1.5) should be [17.5px 17.5px\]]
     expected: FAIL
 
   [Web Animations: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (0.6) should be [60% 110% 2px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform-origin> from [inherit\] to [20px 20px\] at (-0.3) should be [33px 7px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform-origin> from [top left\] to [bottom right\] at (0) should be [0px 0px\]]
@@ -185,13 +149,7 @@
   [CSS Animations: property <transform-origin> from [inherit\] to [20px 20px\] at (0.3) should be [27px 13px\]]
     expected: FAIL
 
-  [CSS Animations: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (0) should be [0% 50% 5px\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform-origin> from [initial\] to [20px 20px\] at (1) should be [20px 20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform-origin> from [inherit\] to [20px 20px\] at (0.3) should be [27px 13px\]]
     expected: FAIL
 
   [Web Animations: property <transform-origin> from [initial\] to [20px 20px\] at (1.5) should be [17.5px 17.5px\]]
@@ -230,9 +188,6 @@
   [CSS Transitions: property <transform-origin> from [unset\] to [20px 20px\] at (1.5) should be [17.5px 17.5px\]]
     expected: FAIL
 
-  [CSS Animations: property <transform-origin> from [inherit\] to [20px 20px\] at (1) should be [20px 20px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform-origin> from [unset\] to [20px 20px\] at (0.6) should be [22px 22px\]]
     expected: FAIL
 
@@ -245,25 +200,13 @@
   [CSS Animations: property <transform-origin> from [inherit\] to [20px 20px\] at (1.5) should be [15px 25px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <transform-origin> from neutral to [20px 20px\] at (1.5) should be [25px 15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform-origin> from neutral to [20px 20px\] at (1.5) should be [25px 15px\]]
-    expected: FAIL
-
   [CSS Transitions: property <transform-origin> from [initial\] to [20px 20px\] at (0.6) should be [22px 22px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform-origin> from [inherit\] to [20px 20px\] at (1.5) should be [15px 25px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform-origin> from [center center\] to [0% 100px\] at (1.5) should be [-12.5px 137.5px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform-origin> from [top left\] to [bottom right\] at (-0.3) should be [-15px -15px\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform-origin> from neutral to [20px 20px\] at (1.5) should be [25px 15px\]]
     expected: FAIL
 
   [CSS Transitions: property <transform-origin> from [top left\] to [bottom right\] at (0.6) should be [30px 30px\]]
@@ -296,9 +239,6 @@
   [CSS Animations: property <transform-origin> from [initial\] to [20px 20px\] at (0) should be [25px 25px\]]
     expected: FAIL
 
-  [CSS Animations: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (-0.3) should be [-30% 20% 6.5px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform-origin> from [initial\] to [20px 20px\] at (0.3) should be [23.5px 23.5px\]]
     expected: FAIL
 
@@ -320,9 +260,6 @@
   [CSS Animations: property <transform-origin> from [unset\] to [20px 20px\] at (0.3) should be [23.5px 23.5px\]]
     expected: FAIL
 
-  [CSS Animations: property <transform-origin> from neutral to [20px 20px\] at (0.3) should be [13px 27px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <transform-origin> from [top left\] to [bottom right\] at (1.5) should be [75px 75px\]]
     expected: FAIL
 
@@ -339,12 +276,6 @@
     expected: FAIL
 
   [Web Animations: property <transform-origin> from neutral to [20px 20px\] at (1) should be [20px 20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform-origin> from neutral to [20px 20px\] at (-0.3) should be [7px 33px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform-origin> from neutral to [20px 20px\] at (-0.3) should be [7px 33px\]]
     expected: FAIL
 
   [Web Animations: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (1.5) should be [150% 200% -2.5px\]]
@@ -365,9 +296,6 @@
   [Web Animations: property <transform-origin> from [initial\] to [20px 20px\] at (0) should be [25px 25px\]]
     expected: FAIL
 
-  [CSS Animations: property <transform-origin> from neutral to [20px 20px\] at (1) should be [20px 20px\]]
-    expected: FAIL
-
   [CSS Animations: property <transform-origin> from [center center\] to [0% 100px\] at (0.6) should be [10px 70px\]]
     expected: FAIL
 
@@ -378,9 +306,6 @@
     expected: FAIL
 
   [CSS Animations: property <transform-origin> from [unset\] to [20px 20px\] at (-0.3) should be [26.5px 26.5px\]]
-    expected: FAIL
-
-  [CSS Animations: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (0.3) should be [30% 80% 3.5px\]]
     expected: FAIL
 
   [CSS Transitions: property <transform-origin> from [unset\] to [20px 20px\] at (-0.3) should be [26.5px 26.5px\]]
@@ -425,13 +350,7 @@
   [CSS Transitions: property <transform-origin> from [center center\] to [0% 100px\] at (1.5) should be [-12.5px 137.5px\]]
     expected: FAIL
 
-  [CSS Animations: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (0.6) should be [60% 110% 2px\]]
-    expected: FAIL
-
   [Web Animations: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (1) should be [100% 150% 0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform-origin> from [inherit\] to [20px 20px\] at (0.6) should be [24px 16px\]]
     expected: FAIL
 
   [CSS Transitions: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (0.3) should be [30% 80% 3.5px\]]
@@ -446,16 +365,7 @@
   [CSS Animations: property <transform-origin> from [center center\] to [0% 100px\] at (-0.3) should be [32.5px 2.5px\]]
     expected: FAIL
 
-  [CSS Animations: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (1.5) should be [150% 200% -2.5px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <transform-origin> from neutral to [20px 20px\] at (0.6) should be [16px 24px\]]
-    expected: FAIL
-
   [Web Animations: property <transform-origin> from [initial\] to [20px 20px\] at (0.6) should be [22px 22px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <transform-origin> from neutral to [20px 20px\] at (0.3) should be [13px 27px\]]
     expected: FAIL
 
   [CSS Transitions: property <transform-origin> from [initial\] to [20px 20px\] at (0.3) should be [23.5px 23.5px\]]
@@ -465,5 +375,8 @@
     expected: FAIL
 
   [CSS Transitions with transition: all: property <transform-origin> from [unset\] to [20px 20px\] at (1) should be [20px 20px\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <transform-origin> from [0% 50% 5px\] to [100% 150% 0px\] at (0.6) should be [60% 110% 2px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transforms/animation/translate-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/translate-interpolation.html.ini
@@ -74,9 +74,6 @@
   [translate interpolation]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <translate> from [-100px -50px\] to [100px 50px\] at (2) should be [300px 150px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <translate> from [inherit\] to [200px 100px 200px\] at (-1) should be [0px 300px 400px\]]
     expected: FAIL
 
@@ -87,9 +84,6 @@
     expected: FAIL
 
   [Web Animations: property <translate> from [inherit\] to [200px 100px 200px\] at (0.75) should be [175px 125px 225px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [unset\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
   [CSS Transitions: property <translate> from [-100%\] to [100%\] at (2) should be [300%\]]
@@ -110,9 +104,6 @@
   [Web Animations: property <translate> from [none\] to [none\] at (0) should be [none\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <translate> from [inherit\] to [initial\] at (2) should be [-100px -200px -300px\]]
-    expected: FAIL
-
   [CSS Transitions: property <translate> from [200px 100px 400px\] to [initial\] at (-1) should be [400px 200px 800px\]]
     expected: FAIL
 
@@ -120,12 +111,6 @@
     expected: FAIL
 
   [Web Animations: property <translate> from [0px\] to [-100px -50px 100px\] at (0.75) should be [-75px -37.5px 75px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <translate> from neutral to [20px\] at (2) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <translate> from [unset\] to [20px\] at (0.25) should be [5px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <translate> from [inherit\] to [200px 100px 200px\] at (0.25) should be [125px 175px 275px\]]
@@ -140,25 +125,13 @@
   [Web Animations: property <translate> from [200px 100px 400px\] to [initial\] at (0.25) should be [150px 75px 300px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [-100px -50px 100px\] to [0px\] at (0.25) should be [-75px -37.5px 75px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [initial\] to [inherit\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <translate> from [unset\] to [20px\] at (0.75) should be [15px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [200px 100px 400px\] to [initial\] at (0) should be [200px 100px 400px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [unset\] to [20px\] at (2) should be [40px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [inherit\] to [initial\] at (0) should be [100px 200px 300px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100%\] to [100%\] at (0) should be [-100%\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [-100px -50px\] to [100px 50px\] at (0.25) should be [-50px -25px\]]
@@ -191,9 +164,6 @@
   [Web Animations: property <translate> from [-100px -50px 100px\] to [0px\] at (1) should be [0px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [unset\] to [20px\] at (0.75) should be [15px\]]
-    expected: FAIL
-
   [CSS Transitions: property <translate> from [initial\] to [inherit\] at (0.75) should be [75px 150px 225px\]]
     expected: FAIL
 
@@ -206,9 +176,6 @@
   [CSS Transitions: property <translate> from [-100px -50px\] to [100px 50px\] at (-1) should be [-300px -150px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [initial\] to [200px 100px 200px\] at (1) should be [200px 100px 200px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [200px 100px 200px\] to [inherit\] at (2) should be [0px 300px 400px\]]
     expected: FAIL
 
@@ -218,28 +185,13 @@
   [CSS Animations: property <translate> from [initial\] to [inherit\] at (0.25) should be [25px 50px 75px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [none\] to [8px 80% 800px\] at (-1) should be [-8px -80% -800px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (0.125) should be [230px 260px 290px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [-100px\] to [100px\] at (-1) should be [-300px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [-100%\] to [100%\] at (0.75) should be [50%\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [-100px -50px\] to [100px 50px\] at (0.75) should be [50px 25px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [0px\] to [-100px -50px 100px\] at (2) should be [-200px -100px 200px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <translate> from [initial\] to [inherit\] at (-1) should be [-100px -200px -300px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <translate> from [480px 400px 320px\] to [240% 160%\] at (2) should be [calc(480% - 480px) calc(320% - 400px) -320px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [unset\] to [20px\] at (-1) should be [-20px\]]
@@ -254,28 +206,10 @@
   [Web Animations: property <translate> from [-100px -50px 100px\] to [0px\] at (0) should be [-100px -50px 100px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [-100px -50px 100px\] to [0px\] at (1) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [200px 100px 400px\] to [initial\] at (-1) should be [400px 200px 800px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [none\] to [none\] at (-1) should be [none\]]
     expected: FAIL
 
-  [CSS Transitions: property <translate> from neutral to [20px\] at (2) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [200px 100px 400px\] to [initial\] at (1) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [none\] to [8px 80% 800px\] at (2) should be [16px 160% 1600px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [-100px\] to [100px\] at (1) should be [100px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [unset\] to [20px\] at (2) should be [40px\]]
     expected: FAIL
 
   [CSS Transitions: property <translate> from [inherit\] to [initial\] at (-1) should be [200px 400px 600px\]]
@@ -284,22 +218,13 @@
   [CSS Transitions with transition: all: property <translate> from [200px 100px 200px\] to [inherit\] at (-1) should be [300px 0px 100px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [480px 400px 320px\] to [240% 160%\] at (-1) should be [calc(960px - 240%) calc(800px - 160%) 640px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [none\] to [none\] at (0.125) should be [none\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <translate> from [-100%\] to [100%\] at (0.25) should be [-50%\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <translate> from [unset\] to [20px\] at (2) should be [40px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [none\] to [8px 80% 800px\] at (0.125) should be [1px 10% 100px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [200px 100px 400px\] to [initial\] at (0.75) should be [50px 25px 100px\]]
     expected: FAIL
 
   [CSS Animations: property <translate> from [inherit\] to [200px 100px 200px\] at (0.25) should be [125px 175px 275px\]]
@@ -308,40 +233,19 @@
   [CSS Transitions: property <translate> from [initial\] to [inherit\] at (-1) should be [-100px -200px -300px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [inherit\] to [200px 100px 200px\] at (1) should be [200px 100px 200px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100%\] to [100%\] at (0.75) should be [50%\]]
-    expected: FAIL
-
   [CSS Transitions: property <translate> from [200px 100px 200px\] to [inherit\] at (2) should be [0px 300px 400px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [none\] to [8px 80% 800px\] at (1) should be [8px 80% 800px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [-100%\] to [100%\] at (-1) should be [-300%\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [0px\] to [-100px -50px 100px\] at (1) should be [-100px -50px 100px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100px\] to [100px\] at (0) should be [-100px\]]
     expected: FAIL
 
   [CSS Transitions: property <translate> from [0px\] to [-100px -50px 100px\] at (-1) should be [100px 50px -100px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (0) should be [220px 240px 260px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [inherit\] to [200px 100px 200px\] at (-1) should be [0px 300px 400px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [none\] to [8px 80% 800px\] at (1) should be [8px 80% 800px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [initial\] to [200px 100px 200px\] at (2) should be [400px 200px 400px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [unset\] to [20px\] at (0) should be [0px\]]
@@ -351,9 +255,6 @@
     expected: FAIL
 
   [Web Animations: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (-1) should be [140px 80px 20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [480px 400px 320px\] to [240% 160%\] at (1) should be [240% 160%\]]
     expected: FAIL
 
   [CSS Transitions: property <translate> from [480px 400px 320px\] to [240% 160%\] at (2) should be [calc(480% - 480px) calc(320% - 400px) -320px\]]
@@ -377,9 +278,6 @@
   [CSS Transitions with transition: all: property <translate> from [0px\] to [-100px -50px 100px\] at (-1) should be [100px 50px -100px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [unset\] to [20px\] at (0.25) should be [5px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [0px\] to [-100px -50px 100px\] at (0) should be [0px\]]
     expected: FAIL
 
@@ -393,9 +291,6 @@
     expected: FAIL
 
   [Web Animations: property <translate> from neutral to [20px\] at (-1) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <translate> from [-100px\] to [100px\] at (2) should be [300px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [480px 400px 320px\] to [240% 160%\] at (2) should be [calc(480% - 480px) calc(320% - 400px) -320px\]]
@@ -416,9 +311,6 @@
   [CSS Animations: property <translate> from [200px 100px 200px\] to [inherit\] at (0) should be [200px 100px 200px\]]
     expected: FAIL
 
-  [CSS Transitions: property <translate> from [unset\] to [20px\] at (2) should be [40px\]]
-    expected: FAIL
-
   [CSS Transitions: property <translate> from [-100px\] to [100px\] at (0.75) should be [50px\]]
     expected: FAIL
 
@@ -434,16 +326,7 @@
   [CSS Animations: property <translate> from [inherit\] to [initial\] at (2) should be [-100px -200px -300px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <translate> from [initial\] to [200px 100px 200px\] at (2) should be [400px 200px 400px\]]
-    expected: FAIL
-
   [CSS Transitions: property <translate> from [inherit\] to [initial\] at (2) should be [-100px -200px -300px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [unset\] to [20px\] at (-1) should be [-20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100px -50px\] to [100px 50px\] at (1) should be [100px 50px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [200px 100px 400px\] to [initial\] at (-1) should be [400px 200px 800px\]]
@@ -461,9 +344,6 @@
   [Web Animations: property <translate> from [200px 100px 200px\] to [inherit\] at (0) should be [200px 100px 200px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <translate> from [-100%\] to [100%\] at (2) should be [300%\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (0) should be [220px 240px 260px\]]
     expected: FAIL
 
@@ -476,25 +356,13 @@
   [Web Animations: property <translate> from neutral to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [initial\] to [200px 100px 200px\] at (0.75) should be [150px 75px 150px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100px -50px 100px\] to [0px\] at (-1) should be [-200px -100px 200px\]]
-    expected: FAIL
-
   [CSS Transitions: property <translate> from [initial\] to [200px 100px 200px\] at (2) should be [400px 200px 400px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100%\] to [100%\] at (1) should be [100%\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <translate> from [inherit\] to [initial\] at (0.75) should be [25px 50px 75px\]]
     expected: FAIL
 
   [CSS Animations: property <translate> from [none\] to [none\] at (-1) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from neutral to [20px\] at (2) should be [30px\]]
     expected: FAIL
 
   [CSS Transitions: property <translate> from [-100px -50px\] to [100px 50px\] at (2) should be [300px 150px\]]
@@ -506,19 +374,10 @@
   [Web Animations: property <translate> from [200px 100px 400px\] to [initial\] at (0.75) should be [50px 25px 100px\]]
     expected: FAIL
 
-  [CSS Transitions: property <translate> from [unset\] to [20px\] at (0.25) should be [5px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [-100px -50px\] to [100px 50px\] at (0) should be [-100px -50px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [none\] to [8px 80% 800px\] at (0) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <translate> from [inherit\] to [initial\] at (-1) should be [200px 400px 600px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100px -50px 100px\] to [0px\] at (0.75) should be [-25px -12.5px 25px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (0.875) should be [290px 380px 470px\]]
@@ -551,46 +410,13 @@
   [CSS Transitions with transition: all: property <translate> from [initial\] to [inherit\] at (0.75) should be [75px 150px 225px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [-100%\] to [100%\] at (2) should be [300%\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from neutral to [20px\] at (0.25) should be [12.5px\]]
-    expected: FAIL
-
   [CSS Animations: property <translate> from [480px 400px 320px\] to [240% 160%\] at (0) should be [480px 400px 320px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100px -50px 100px\] to [0px\] at (0) should be [-100px -50px 100px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <translate> from neutral to [20px\] at (-1) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <translate> from [200px 100px 200px\] to [inherit\] at (2) should be [0px 300px 400px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [none\] to [8px 80% 800px\] at (0.875) should be [7px 70% 700px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [inherit\] to [initial\] at (1) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100px\] to [100px\] at (0.75) should be [50px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (2) should be [380px 560px 740px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100%\] to [100%\] at (0.25) should be [-50%\]]
     expected: FAIL
 
   [Web Animations: property <translate> from neutral to [20px\] at (2) should be [30px\]]
     expected: FAIL
 
   [CSS Transitions: property <translate> from [-100px\] to [100px\] at (2) should be [300px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <translate> from neutral to [20px\] at (0.25) should be [12.5px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [-100px -50px 100px\] to [0px\] at (0.25) should be [-75px -37.5px 75px\]]
@@ -602,9 +428,6 @@
   [Web Animations: property <translate> from [inherit\] to [initial\] at (-1) should be [200px 400px 600px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [0px\] to [-100px -50px 100px\] at (0.75) should be [-75px -37.5px 75px\]]
-    expected: FAIL
-
   [CSS Transitions: property <translate> from [inherit\] to [200px 100px 200px\] at (2) should be [300px 0px 100px\]]
     expected: FAIL
 
@@ -614,16 +437,10 @@
   [Web Animations: property <translate> from [initial\] to [200px 100px 200px\] at (1) should be [200px 100px 200px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [-100px -50px\] to [100px 50px\] at (0) should be [-100px -50px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <translate> from [inherit\] to [200px 100px 200px\] at (0.75) should be [175px 125px 225px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (2) should be [380px 560px 740px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (0.875) should be [290px 380px 470px\]]
     expected: FAIL
 
   [CSS Transitions: property <translate> from [inherit\] to [initial\] at (0.75) should be [25px 50px 75px\]]
@@ -635,19 +452,7 @@
   [Web Animations: property <translate> from [-100px -50px\] to [100px 50px\] at (2) should be [300px 150px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from neutral to [20px\] at (-1) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <translate> from neutral to [20px\] at (0.75) should be [17.5px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [inherit\] to [initial\] at (1) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [480px 400px 320px\] to [240% 160%\] at (2) should be [calc(480% - 480px) calc(320% - 400px) -320px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100px -50px 100px\] to [0px\] at (2) should be [100px 50px -100px\]]
     expected: FAIL
 
   [CSS Transitions: property <translate> from [-100px -50px 100px\] to [0px\] at (0.75) should be [-25px -12.5px 25px\]]
@@ -668,19 +473,7 @@
   [CSS Transitions with transition: all: property <translate> from [-100px\] to [100px\] at (0.25) should be [-50px\]]
     expected: FAIL
 
-  [CSS Transitions: property <translate> from [unset\] to [20px\] at (-1) should be [-20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <translate> from neutral to [20px\] at (-1) should be [0px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (-1) should be [140px 80px 20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [0px\] to [-100px -50px 100px\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <translate> from [initial\] to [inherit\] at (2) should be [200px 400px 600px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [initial\] to [200px 100px 200px\] at (0.75) should be [150px 75px 150px\]]
@@ -689,31 +482,16 @@
   [CSS Transitions with transition: all: property <translate> from [-100px\] to [100px\] at (-1) should be [-300px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [unset\] to [20px\] at (0) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [initial\] to [200px 100px 200px\] at (0.25) should be [50px 25px 50px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [-100px -50px 100px\] to [0px\] at (2) should be [100px 50px -100px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (1) should be [300px 400px 500px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <translate> from [480px 400px 320px\] to [240% 160%\] at (0) should be [480px 400px 320px\]]
     expected: FAIL
 
   [CSS Transitions: property <translate> from [0px\] to [-100px -50px 100px\] at (0.75) should be [-75px -37.5px 75px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <translate> from neutral to [20px\] at (0.75) should be [17.5px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100px -50px\] to [100px 50px\] at (0.25) should be [-50px -25px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100px -50px\] to [100px 50px\] at (-1) should be [-300px -150px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [-100px -50px\] to [100px 50px\] at (1) should be [100px 50px\]]
@@ -740,19 +518,7 @@
   [CSS Transitions with transition: all: property <translate> from [200px 100px 400px\] to [initial\] at (0.25) should be [150px 75px 300px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (2) should be [380px 560px 740px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100px -50px\] to [100px 50px\] at (2) should be [300px 150px\]]
-    expected: FAIL
-
   [CSS Animations: property <translate> from [200px 100px 200px\] to [inherit\] at (0.75) should be [125px 175px 275px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [none\] to [8px 80% 800px\] at (0.125) should be [1px 10% 100px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100px\] to [100px\] at (1) should be [100px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [-100px\] to [100px\] at (0) should be [-100px\]]
@@ -764,34 +530,19 @@
   [Web Animations: property <translate> from [initial\] to [inherit\] at (1) should be [100px 200px 300px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [480px 400px 320px\] to [240% 160%\] at (0.875) should be [calc(210% + 60px) calc(140% + 50px) 40px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [initial\] to [200px 100px 200px\] at (-1) should be [-200px -100px -200px\]]
-    expected: FAIL
-
   [CSS Transitions: property <translate> from [200px 100px 200px\] to [inherit\] at (-1) should be [300px 0px 100px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [480px 400px 320px\] to [240% 160%\] at (0.125) should be [calc(420px + 30%) calc(350px + 20%) 280px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [0px\] to [-100px -50px 100px\] at (-1) should be [100px 50px -100px\]]
-    expected: FAIL
-
   [CSS Transitions: property <translate> from [none\] to [8px 80% 800px\] at (0.875) should be [7px 70% 700px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <translate> from [unset\] to [20px\] at (0.75) should be [15px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [unset\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
   [CSS Transitions: property <translate> from [none\] to [8px 80% 800px\] at (2) should be [16px 160% 1600px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <translate> from [inherit\] to [200px 100px 200px\] at (2) should be [300px 0px 100px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [inherit\] to [200px 100px 200px\] at (0.25) should be [125px 175px 275px\]]
@@ -815,9 +566,6 @@
   [Web Animations: property <translate> from [0px\] to [-100px -50px 100px\] at (0.25) should be [-25px -12.5px 25px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <translate> from [-100px -50px 100px\] to [0px\] at (2) should be [100px 50px -100px\]]
-    expected: FAIL
-
   [CSS Transitions: property <translate> from [initial\] to [200px 100px 200px\] at (0.25) should be [50px 25px 50px\]]
     expected: FAIL
 
@@ -833,9 +581,6 @@
   [CSS Transitions with transition: all: property <translate> from [none\] to [8px 80% 800px\] at (0.125) should be [1px 10% 100px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [initial\] to [200px 100px 200px\] at (0.25) should be [50px 25px 50px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <translate> from [-100px -50px\] to [100px 50px\] at (-1) should be [-300px -150px\]]
     expected: FAIL
 
@@ -849,12 +594,6 @@
     expected: FAIL
 
   [Web Animations: property <translate> from [200px 100px 200px\] to [inherit\] at (0.75) should be [125px 175px 275px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100px\] to [100px\] at (0.25) should be [-50px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [480px 400px 320px\] to [240% 160%\] at (0.125) should be [calc(420px + 30%) calc(350px + 20%) 280px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [none\] to [8px 80% 800px\] at (-1) should be [-8px -80% -800px\]]
@@ -878,9 +617,6 @@
   [CSS Transitions: property <translate> from [none\] to [8px 80% 800px\] at (0.125) should be [1px 10% 100px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from neutral to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [-100%\] to [100%\] at (0) should be [-100%\]]
     expected: FAIL
 
@@ -896,12 +632,6 @@
   [CSS Transitions: property <translate> from [480px 400px 320px\] to [240% 160%\] at (0) should be [480px 400px 320px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [-100px\] to [100px\] at (2) should be [300px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [0px\] to [-100px -50px 100px\] at (0.25) should be [-25px -12.5px 25px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [-100%\] to [100%\] at (-1) should be [-300%\]]
     expected: FAIL
 
@@ -915,9 +645,6 @@
     expected: FAIL
 
   [Web Animations: property <translate> from [200px 100px 200px\] to [inherit\] at (1) should be [100px 200px 300px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [-100px\] to [100px\] at (-1) should be [-300px\]]
     expected: FAIL
 
   [CSS Animations: property <translate> from [200px 100px 200px\] to [inherit\] at (0.25) should be [175px 125px 225px\]]
@@ -947,12 +674,6 @@
   [CSS Animations: property <translate> from [inherit\] to [initial\] at (0.25) should be [75px 150px 225px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [initial\] to [200px 100px 200px\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <translate> from [unset\] to [20px\] at (-1) should be [-20px\]]
-    expected: FAIL
-
   [CSS Transitions: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (-1) should be [140px 80px 20px\]]
     expected: FAIL
 
@@ -971,16 +692,10 @@
   [CSS Transitions: property <translate> from [200px 100px 400px\] to [initial\] at (0.75) should be [50px 25px 100px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <translate> from [200px 100px 400px\] to [initial\] at (2) should be [-200px -100px -400px\]]
-    expected: FAIL
-
   [CSS Transitions: property <translate> from [480px 400px 320px\] to [240% 160%\] at (-1) should be [calc(960px - 240%) calc(800px - 160%) 640px\]]
     expected: FAIL
 
   [CSS Transitions: property <translate> from [-100px -50px\] to [100px 50px\] at (0.25) should be [-50px -25px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [0px\] to [-100px -50px 100px\] at (1) should be [-100px -50px 100px\]]
     expected: FAIL
 
   [CSS Transitions: property <translate> from [-100%\] to [100%\] at (0.25) should be [-50%\]]
@@ -992,22 +707,10 @@
   [CSS Transitions: property <translate> from [initial\] to [inherit\] at (0.25) should be [25px 50px 75px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <translate> from [none\] to [8px 80% 800px\] at (2) should be [16px 160% 1600px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from neutral to [20px\] at (0.75) should be [17.5px\]]
-    expected: FAIL
-
   [CSS Transitions: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (2) should be [380px 560px 740px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <translate> from [0px\] to [-100px -50px 100px\] at (2) should be [-200px -100px 200px\]]
-    expected: FAIL
-
   [CSS Transitions: property <translate> from [none\] to [8px 80% 800px\] at (-1) should be [-8px -80% -800px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [200px 100px 400px\] to [initial\] at (2) should be [-200px -100px -400px\]]
     expected: FAIL
 
   [CSS Animations: property <translate> from [inherit\] to [200px 100px 200px\] at (0) should be [100px 200px 300px\]]
@@ -1017,9 +720,6 @@
     expected: FAIL
 
   [Web Animations: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (1) should be [300px 400px 500px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [200px 100px 400px\] to [initial\] at (0.25) should be [150px 75px 300px\]]
     expected: FAIL
 
   [CSS Animations: property <translate> from [none\] to [none\] at (0) should be [none\]]
@@ -1058,9 +758,6 @@
   [Web Animations: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (0.125) should be [230px 260px 290px\]]
     expected: FAIL
 
-  [CSS Transitions: property <translate> from neutral to [20px\] at (0.25) should be [12.5px\]]
-    expected: FAIL
-
   [CSS Animations: property <translate> from [initial\] to [inherit\] at (2) should be [200px 400px 600px\]]
     expected: FAIL
 
@@ -1068,8 +765,5 @@
     expected: FAIL
 
   [Web Animations: property <translate> from [none\] to [none\] at (1) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (-1) should be [140px 80px 20px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transitions/animations/text-shadow-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/animations/text-shadow-interpolation.html.ini
@@ -2,9 +2,6 @@
   [text-shadow interpolation]
     expected: FAIL
 
-  [CSS Transitions: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px\]]
-    expected: FAIL
-
   [CSS Animations: property <text-shadow> from [unset\] to [green 20px 20px 20px\] at (1.5) should be [rgb(0, 110, 0) 15px 25px 15px\]]
     expected: FAIL
 
@@ -29,67 +26,25 @@
   [CSS Transitions: property <text-shadow> from [unset\] to [green 20px 20px 20px\] at (0.3) should be [rgb(179, 154, 0) 27px 13px 27px\]]
     expected: FAIL
 
-  [CSS Animations: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (-0.3) should be [rgba(0, 0, 0, 0) -6px -6px 0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (1.5) should be [rgb(0, 192, 0) 30px 30px 30px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (-0.3) should be [rgb(255, 176, 0) 33px 7px 33px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (0.3) should be [rgba(0, 128, 0, 0.3) 6px 6px 6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (0.3) should be [rgb(0, 38, 0) 10px 10px 10px\]]
-    expected: FAIL
-
   [Web Animations: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (1.5) should be [rgb(0, 192, 0) 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from neutral to [green 20px 20px 20px\] at (-0.3) should be [rgb(255, 176, 0) 7px 33px 7px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-shadow> from neutral to [green 20px 20px 20px\] at (0.6) should be [rgb(102, 143, 0) 16px 24px 16px\]]
     expected: FAIL
 
   [Web Animations: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (0.6) should be [rgba(0, 128, 0, 0.6) 12px 12px 12px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-shadow> from neutral to [green 20px 20px 20px\] at (0.6) should be [rgb(102, 143, 0) 16px 24px 16px\]]
-    expected: FAIL
-
   [Web Animations: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (0) should be [rgb(0, 0, 0) 15px 10px 5px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [unset\] to [green 20px 20px 20px\] at (1.5) should be [rgb(0, 110, 0) 15px 25px 15px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (0) should be [rgb(0, 0, 0) 15px 10px 5px\]]
     expected: FAIL
 
   [Web Animations: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-shadow> from neutral to [green 20px 20px 20px\] at (1.5) should be [rgb(0, 110, 0) 25px 15px 25px\]]
-    expected: FAIL
-
   [Web Animations: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (0.6) should be [rgb(102, 143, 0) 24px 16px 24px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (1) should be [rgb(255, 165, 0) -15px -10px 25px\]]
     expected: FAIL
 
   [Web Animations: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (-0.3) should be [rgb(255, 176, 0) 33px 7px 33px\]]
     expected: FAIL
 
   [Web Animations: property <text-shadow> from [unset\] to [green 20px 20px 20px\] at (0.6) should be [rgb(102, 143, 0) 24px 16px 24px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (0.6) should be [rgb(102, 143, 0) 24px 16px 24px\]]
     expected: FAIL
 
   [CSS Animations: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (0.6) should be [rgb(102, 143, 0) 24px 16px 24px\]]
@@ -101,34 +56,13 @@
   [CSS Animations: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (0.3) should be [rgb(179, 154, 0) 27px 13px 27px\]]
     expected: FAIL
 
-  [CSS Animations: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (0) should be [rgb(0, 0, 0) 10px 10px 10px\]]
-    expected: FAIL
-
   [Web Animations: property <text-shadow> from neutral to [green 20px 20px 20px\] at (0.6) should be [rgb(102, 143, 0) 16px 24px 16px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-shadow> from neutral to [green 20px 20px 20px\] at (-0.3) should be [rgb(255, 176, 0) 7px 33px 7px\]]
     expected: FAIL
 
   [Web Animations: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (0.3) should be [rgb(179, 154, 0) 27px 13px 27px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (1.5) should be [rgb(0, 192, 0) 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from neutral to [green 20px 20px 20px\] at (0.6) should be [rgb(102, 143, 0) 16px 24px 16px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (0.6) should be [rgba(0, 128, 0, 0.6) 12px 12px 12px\]]
-    expected: FAIL
-
   [Web Animations: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (1.5) should be [rgb(0, 192, 0) 10px 10px 10px\]]
     expected: FAIL
 
   [Web Animations: property <text-shadow> from [unset\] to [green 20px 20px 20px\] at (0.3) should be [rgb(179, 154, 0) 27px 13px 27px\]]
@@ -140,28 +74,7 @@
   [CSS Transitions with transition: all: property <text-shadow> from neutral to [green 20px 20px 20px\] at (0.3) should be [rgb(179, 154, 0) 13px 27px 13px\]]
     expected: FAIL
 
-  [CSS Transitions: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (1.5) should be [rgb(0, 192, 0) 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (0.6) should be [rgba(0, 128, 0, 0.6) 12px 12px 12px\]]
-    expected: FAIL
-
   [Web Animations: property <text-shadow> from [unset\] to [green 20px 20px 20px\] at (-0.3) should be [rgb(255, 176, 0) 33px 7px 33px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (1.5) should be [rgb(0, 110, 0) 15px 25px 15px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (0.6) should be [rgba(0, 128, 0, 0.6) 12px 12px 12px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (0) should be [rgba(0, 0, 0, 0) 0px 0px 0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (1) should be [rgb(0, 128, 0) 20px 20px 20px\]]
     expected: FAIL
 
   [CSS Animations: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (1.5) should be [rgb(0, 110, 0) 15px 25px 15px\]]
@@ -170,16 +83,7 @@
   [Web Animations: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (1) should be [rgb(0, 128, 0) 10px 10px 10px\]]
     expected: FAIL
 
-  [CSS Animations: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px\]]
-    expected: FAIL
-
   [Web Animations: property <text-shadow> from [unset\] to [green 20px 20px 20px\] at (1) should be [rgb(0, 128, 0) 20px 20px 20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (0.3) should be [rgb(0, 38, 0) 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px\]]
     expected: FAIL
 
   [Web Animations: property <text-shadow> from neutral to [green 20px 20px 20px\] at (-0.3) should be [rgb(255, 176, 0) 7px 33px 7px\]]
@@ -188,13 +92,7 @@
   [CSS Animations: property <text-shadow> from neutral to [green 20px 20px 20px\] at (0.3) should be [rgb(179, 154, 0) 13px 27px 13px\]]
     expected: FAIL
 
-  [CSS Animations: property <text-shadow> from [unset\] to [green 20px 20px 20px\] at (1) should be [rgb(0, 128, 0) 20px 20px 20px\]]
-    expected: FAIL
-
   [Web Animations: property <text-shadow> from neutral to [green 20px 20px 20px\] at (0) should be [rgb(255, 165, 0) 10px 30px 10px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (1.5) should be [rgb(0, 192, 0) 30px 30px 30px\]]
     expected: FAIL
 
   [CSS Transitions: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (1.5) should be [rgb(0, 110, 0) 15px 25px 15px\]]
@@ -224,31 +122,10 @@
   [Web Animations: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (-0.3) should be [rgba(0, 0, 0, 0) -6px -6px 0px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-shadow> from neutral to [green 20px 20px 20px\] at (-0.3) should be [rgb(255, 176, 0) 7px 33px 7px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [unset\] to [green 20px 20px 20px\] at (0.6) should be [rgb(102, 143, 0) 24px 16px 24px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px\]]
-    expected: FAIL
-
   [Web Animations: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (-0.3) should be [rgb(0, 0, 0) 10px 10px 10px\]]
     expected: FAIL
 
   [Web Animations: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (1) should be [rgb(0, 128, 0) 20px 20px 20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (-0.3) should be [rgb(0, 0, 0) 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (-0.3) should be [rgba(0, 0, 0, 0) -6px -6px 0px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (0.3) should be [rgb(179, 154, 0) 27px 13px 27px\]]
@@ -257,28 +134,7 @@
   [Web Animations: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (0.3) should be [rgb(0, 38, 0) 10px 10px 10px\]]
     expected: FAIL
 
-  [CSS Transitions: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (-0.3) should be [rgb(0, 0, 0) 24px 16px 0px\]]
-    expected: FAIL
-
   [CSS Animations: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (0) should be [rgb(255, 165, 0) 30px 10px 30px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (-0.3) should be [rgb(255, 176, 0) 33px 7px 33px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (0.6) should be [rgb(0, 77, 0) 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [unset\] to [green 20px 20px 20px\] at (-0.3) should be [rgb(255, 176, 0) 33px 7px 33px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (-0.3) should be [rgba(0, 0, 0, 0) -6px -6px 0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from neutral to [green 20px 20px 20px\] at (1.5) should be [rgb(0, 110, 0) 25px 15px 25px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (0.3) should be [rgba(0, 128, 0, 0.3) 6px 6px 6px\]]
     expected: FAIL
 
   [Web Animations: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (1.5) should be [rgb(0, 192, 0) 30px 30px 30px\]]
@@ -296,34 +152,10 @@
   [Web Animations: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (0) should be [rgb(255, 165, 0) 30px 10px 30px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (1.5) should be [rgb(255, 248, 0) -30px -20px 35px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (0.6) should be [rgb(0, 77, 0) 10px 10px 10px\]]
-    expected: FAIL
-
   [Web Animations: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (1) should be [rgb(0, 128, 0) 20px 20px 20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (0.3) should be [rgb(0, 38, 0) 10px 10px 10px\]]
-    expected: FAIL
-
   [CSS Animations: property <text-shadow> from [unset\] to [green 20px 20px 20px\] at (0) should be [rgb(255, 165, 0) 30px 10px 30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (1.5) should be [rgb(0, 192, 0) 30px 30px 30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (0.3) should be [rgb(77, 50, 0) 6px 4px 11px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from neutral to [green 20px 20px 20px\] at (1) should be [rgb(0, 128, 0) 20px 20px 20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (0.6) should be [rgb(0, 77, 0) 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-shadow> from [unset\] to [green 20px 20px 20px\] at (-0.3) should be [rgb(255, 176, 0) 33px 7px 33px\]]
     expected: FAIL
 
   [Web Animations: property <text-shadow> from neutral to [green 20px 20px 20px\] at (1.5) should be [rgb(0, 110, 0) 25px 15px 25px\]]
@@ -332,24 +164,9 @@
   [CSS Transitions: property <text-shadow> from neutral to [green 20px 20px 20px\] at (0.3) should be [rgb(179, 154, 0) 13px 27px 13px\]]
     expected: FAIL
 
-  [CSS Animations: property <text-shadow> from [black 10px 10px 10px\] to [currentColor 10px 10px 10px\] at (1) should be [rgb(0, 128, 0) 10px 10px 10px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (1) should be [rgb(0, 128, 0) 20px 20px 20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-shadow> from [initial\] to [green 20px 20px 20px\] at (0.3) should be [rgba(0, 128, 0, 0.3) 6px 6px 6px\]]
-    expected: FAIL
-
   [Web Animations: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (1) should be [rgb(255, 165, 0) -15px -10px 25px\]]
     expected: FAIL
 
   [Web Animations: property <text-shadow> from [black 15px 10px 5px\] to [orange -15px -10px 25px\] at (0.6) should be [rgb(153, 99, 0) -3px -2px 17px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <text-shadow> from [unset\] to [green 20px 20px 20px\] at (0.6) should be [rgb(102, 143, 0) 24px 16px 24px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-shadow> from [inherit\] to [green 20px 20px 20px\] at (0.6) should be [rgb(102, 143, 0) 24px 16px 24px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transitions/animations/vertical-align-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/animations/vertical-align-interpolation.html.ini
@@ -11,12 +11,6 @@
   [CSS Animations: property <vertical-align> from [unset\] to [40px\] at (0.3) should be [unset\]]
     expected: FAIL
 
-  [CSS Animations: property <vertical-align> from [0px\] to [100px\] at (1.5) should be [150px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <vertical-align> from [40px\] to [40%\] at (-0.5) should be [calc(60px - 20%)\]]
-    expected: FAIL
-
   [CSS Animations: property <vertical-align> from [inherit\] to [40px\] at (-0.5) should be [130px\]]
     expected: FAIL
 
@@ -29,46 +23,19 @@
   [Web Animations: property <vertical-align> from [super\] to [40%\] at (0) should be [super\]]
     expected: FAIL
 
-  [CSS Animations: property <vertical-align> from [40px\] to [40%\] at (1) should be [calc(0px + 40%)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <vertical-align> from [inherit\] to [40px\] at (-0.5) should be [130px\]]
-    expected: FAIL
-
   [Web Animations: property <vertical-align> from [initial\] to [40px\] at (1.5) should be [40px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <vertical-align> from neutral to [40px\] at (-0.5) should be [-5px\]]
     expected: FAIL
 
   [Web Animations: property <vertical-align> from [40px\] to [40%\] at (0) should be [calc(40px + 0%)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <vertical-align> from neutral to [40px\] at (1.5) should be [55px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <vertical-align> from neutral to [40px\] at (0.3) should be [19px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <vertical-align> from [0px\] to [100px\] at (0.6) should be [60px\]]
-    expected: FAIL
-
   [Web Animations: property <vertical-align> from [inherit\] to [40px\] at (1) should be [40px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <vertical-align> from [40px\] to [40%\] at (1.5) should be [calc(-20px + 60%)\]]
     expected: FAIL
 
   [CSS Animations: property <vertical-align> from [super\] to [40%\] at (0.6) should be [40%\]]
     expected: FAIL
 
-  [CSS Transitions: property <vertical-align> from neutral to [40px\] at (-0.5) should be [-5px\]]
-    expected: FAIL
-
   [CSS Animations: property <vertical-align> from [super\] to [40%\] at (0.3) should be [super\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <vertical-align> from [0px\] to [100px\] at (-0.5) should be [-50px\]]
     expected: FAIL
 
   [Web Animations: property <vertical-align> from [inherit\] to [40px\] at (0.6) should be [64px\]]
@@ -80,16 +47,7 @@
   [CSS Animations: property <vertical-align> from [inherit\] to [40px\] at (0) should be [100px\]]
     expected: FAIL
 
-  [CSS Transitions: property <vertical-align> from [0px\] to [100px\] at (0.6) should be [60px\]]
-    expected: FAIL
-
   [Web Animations: property <vertical-align> from [initial\] to [40px\] at (0.5) should be [40px\]]
-    expected: FAIL
-
-  [CSS Animations: property <vertical-align> from neutral to [40px\] at (1) should be [40px\]]
-    expected: FAIL
-
-  [CSS Animations: property <vertical-align> from [40px\] to [40%\] at (0) should be [calc(40px + 0%)\]]
     expected: FAIL
 
   [CSS Animations: property <vertical-align> from [super\] to [40%\] at (1.5) should be [40%\]]
@@ -101,22 +59,10 @@
   [Web Animations: property <vertical-align> from [40px\] to [40%\] at (-0.5) should be [calc(60px - 20%)\]]
     expected: FAIL
 
-  [CSS Animations: property <vertical-align> from neutral to [40px\] at (-0.5) should be [-5px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <vertical-align> from neutral to [40px\] at (0.6) should be [28px\]]
-    expected: FAIL
-
   [CSS Animations: property <vertical-align> from [super\] to [40%\] at (-0.3) should be [super\]]
     expected: FAIL
 
   [CSS Animations: property <vertical-align> from [initial\] to [40px\] at (0.6) should be [40px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <vertical-align> from neutral to [40px\] at (0.3) should be [19px\]]
-    expected: FAIL
-
-  [CSS Animations: property <vertical-align> from neutral to [40px\] at (0.6) should be [28px\]]
     expected: FAIL
 
   [Web Animations: property <vertical-align> from [initial\] to [40px\] at (0.3) should be [initial\]]
@@ -128,9 +74,6 @@
   [CSS Animations: property <vertical-align> from [unset\] to [40px\] at (1.5) should be [40px\]]
     expected: FAIL
 
-  [CSS Transitions: property <vertical-align> from [inherit\] to [40px\] at (0.3) should be [82px\]]
-    expected: FAIL
-
   [Web Animations: property <vertical-align> from neutral to [40px\] at (0.3) should be [19px\]]
     expected: FAIL
 
@@ -140,18 +83,6 @@
   [Web Animations: property <vertical-align> from [super\] to [40%\] at (-0.3) should be [super\]]
     expected: FAIL
 
-  [CSS Transitions: property <vertical-align> from [0px\] to [100px\] at (-0.5) should be [-50px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <vertical-align> from [40px\] to [40%\] at (0.3) should be [calc(28px + 12%)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <vertical-align> from [inherit\] to [40px\] at (-0.5) should be [130px\]]
-    expected: FAIL
-
-  [CSS Animations: property <vertical-align> from [40px\] to [40%\] at (-0.5) should be [calc(60px - 20%)\]]
-    expected: FAIL
-
   [Web Animations: property <vertical-align> from [inherit\] to [40px\] at (0.3) should be [82px\]]
     expected: FAIL
 
@@ -159,9 +90,6 @@
     expected: FAIL
 
   [CSS Animations: property <vertical-align> from [unset\] to [40px\] at (-0.3) should be [unset\]]
-    expected: FAIL
-
-  [CSS Transitions: property <vertical-align> from [40px\] to [40%\] at (1.5) should be [calc(-20px + 60%)\]]
     expected: FAIL
 
   [Web Animations: property <vertical-align> from [super\] to [40%\] at (1.5) should be [40%\]]
@@ -182,28 +110,13 @@
   [Web Animations: property <vertical-align> from neutral to [40px\] at (0) should be [10px\]]
     expected: FAIL
 
-  [CSS Animations: property <vertical-align> from [0px\] to [100px\] at (1) should be [100px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <vertical-align> from [0px\] to [100px\] at (1.5) should be [150px\]]
-    expected: FAIL
-
   [Web Animations: property <vertical-align> from [0px\] to [100px\] at (1) should be [100px\]]
     expected: FAIL
 
   [Web Animations: property <vertical-align> from [0px\] to [100px\] at (1.5) should be [150px\]]
     expected: FAIL
 
-  [CSS Animations: property <vertical-align> from neutral to [40px\] at (0.3) should be [19px\]]
-    expected: FAIL
-
   [Web Animations: property <vertical-align> from [unset\] to [40px\] at (0.6) should be [40px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <vertical-align> from [inherit\] to [40px\] at (1.5) should be [10px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <vertical-align> from [40px\] to [40%\] at (-0.5) should be [calc(60px - 20%)\]]
     expected: FAIL
 
   [Web Animations: property <vertical-align> from [unset\] to [40px\] at (0.5) should be [40px\]]
@@ -212,16 +125,7 @@
   [Web Animations: property <vertical-align> from [inherit\] to [40px\] at (1.5) should be [10px\]]
     expected: FAIL
 
-  [CSS Transitions: property <vertical-align> from neutral to [40px\] at (1.5) should be [55px\]]
-    expected: FAIL
-
   [Web Animations: property <vertical-align> from [initial\] to [40px\] at (-0.3) should be [initial\]]
-    expected: FAIL
-
-  [CSS Animations: property <vertical-align> from [inherit\] to [40px\] at (1) should be [40px\]]
-    expected: FAIL
-
-  [CSS Animations: property <vertical-align> from [0px\] to [100px\] at (-0.5) should be [-50px\]]
     expected: FAIL
 
   [CSS Animations: property <vertical-align> from [initial\] to [40px\] at (1) should be [40px\]]
@@ -236,22 +140,7 @@
   [Web Animations: property <vertical-align> from neutral to [40px\] at (1) should be [40px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <vertical-align> from [inherit\] to [40px\] at (0.6) should be [64px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <vertical-align> from neutral to [40px\] at (0.6) should be [28px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <vertical-align> from [0px\] to [100px\] at (1.5) should be [150px\]]
-    expected: FAIL
-
   [CSS Animations: property <vertical-align> from [initial\] to [40px\] at (1.5) should be [40px\]]
-    expected: FAIL
-
-  [CSS Animations: property <vertical-align> from [0px\] to [100px\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <vertical-align> from [inherit\] to [40px\] at (0.6) should be [64px\]]
     expected: FAIL
 
   [CSS Animations: property <vertical-align> from [initial\] to [40px\] at (-0.3) should be [initial\]]
@@ -263,34 +152,19 @@
   [Web Animations: property <vertical-align> from [40px\] to [40%\] at (0.3) should be [calc(28px + 12%)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <vertical-align> from [inherit\] to [40px\] at (0.3) should be [82px\]]
-    expected: FAIL
-
   [Web Animations: property <vertical-align> from [inherit\] to [40px\] at (-0.5) should be [130px\]]
     expected: FAIL
 
   [Web Animations: property <vertical-align> from [0px\] to [100px\] at (0) should be [0px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <vertical-align> from [0px\] to [100px\] at (0.3) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <vertical-align> from [40px\] to [40%\] at (0.3) should be [calc(28px + 12%)\]]
-    expected: FAIL
-
   [Web Animations: property <vertical-align> from [unset\] to [40px\] at (-0.3) should be [unset\]]
-    expected: FAIL
-
-  [CSS Transitions: property <vertical-align> from [inherit\] to [40px\] at (1.5) should be [10px\]]
     expected: FAIL
 
   [Web Animations: property <vertical-align> from [unset\] to [40px\] at (0.3) should be [unset\]]
     expected: FAIL
 
   [CSS Animations: property <vertical-align> from [super\] to [40%\] at (0) should be [super\]]
-    expected: FAIL
-
-  [CSS Animations: property <vertical-align> from [0px\] to [100px\] at (0.3) should be [30px\]]
     expected: FAIL
 
   [Web Animations: property <vertical-align> from [initial\] to [40px\] at (0.6) should be [40px\]]
@@ -305,19 +179,10 @@
   [Web Animations: property <vertical-align> from [super\] to [40%\] at (1) should be [40%\]]
     expected: FAIL
 
-  [CSS Animations: property <vertical-align> from [0px\] to [100px\] at (0.6) should be [60px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <vertical-align> from [40px\] to [40%\] at (0.3) should be [calc(28px + 12%)\]]
-    expected: FAIL
-
   [CSS Animations: property <vertical-align> from [super\] to [40%\] at (0.5) should be [40%\]]
     expected: FAIL
 
   [CSS Animations: property <vertical-align> from [unset\] to [40px\] at (0.6) should be [40px\]]
-    expected: FAIL
-
-  [CSS Animations: property <vertical-align> from [40px\] to [40%\] at (1.5) should be [calc(-20px + 60%)\]]
     expected: FAIL
 
   [Web Animations: property <vertical-align> from [unset\] to [40px\] at (1) should be [40px\]]
@@ -335,13 +200,28 @@
   [Web Animations: property <vertical-align> from [unset\] to [40px\] at (1.5) should be [40px\]]
     expected: FAIL
 
-  [CSS Animations: property <vertical-align> from neutral to [40px\] at (1.5) should be [55px\]]
-    expected: FAIL
-
   [Web Animations: property <vertical-align> from [unset\] to [40px\] at (0) should be [unset\]]
     expected: FAIL
 
   [CSS Animations: property <vertical-align> from [inherit\] to [40px\] at (0.3) should be [82px\]]
+    expected: FAIL
+
+  [CSS Animations: property <vertical-align> from [inherit\] to [40px\] at (1.5) should be [10px\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <vertical-align> from [0px\] to [100px\] at (0.6) should be [60px\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <vertical-align> from [0px\] to [100px\] at (-0.5) should be [-50px\]]
+    expected: FAIL
+
+  [CSS Transitions: property <vertical-align> from [0px\] to [100px\] at (0.6) should be [60px\]]
+    expected: FAIL
+
+  [CSS Transitions: property <vertical-align> from [0px\] to [100px\] at (-0.5) should be [-50px\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <vertical-align> from [0px\] to [100px\] at (0.3) should be [30px\]]
     expected: FAIL
 
   [CSS Transitions: property <vertical-align> from [0px\] to [100px\] at (0.3) should be [30px\]]

--- a/tests/wpt/metadata/css/css-transitions/animations/z-index-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/animations/z-index-interpolation.html.ini
@@ -1,26 +1,11 @@
 [z-index-interpolation.html]
-  [CSS Animations: property <z-index> from [2\] to [4\] at (0.6) should be [3\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from neutral to [5\] at (-0.3) should be [-4\]]
-    expected: FAIL
-
   [Web Animations: property <z-index> from [unset\] to [5\] at (1.5) should be [5\]]
     expected: FAIL
 
   [Web Animations: property <z-index> from [2\] to [4\] at (0.3) should be [3\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <z-index> from neutral to [5\] at (1.5) should be [9\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <z-index> from [2\] to [4\] at (-0.3) should be [1\]]
-    expected: FAIL
-
   [Web Animations: property <z-index> from [auto\] to [10\] at (1.5) should be [10\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <z-index> from [-2\] to [-4\] at (0.6) should be [-3\]]
     expected: FAIL
 
   [CSS Animations: property <z-index> from [unset\] to [5\] at (0.3) should be [unset\]]
@@ -32,46 +17,19 @@
   [CSS Animations: property <z-index> from [initial\] to [5\] at (1.5) should be [5\]]
     expected: FAIL
 
-  [CSS Transitions: property <z-index> from neutral to [5\] at (0.6) should be [2\]]
-    expected: FAIL
-
   [Web Animations: property <z-index> from [auto\] to [10\] at (-0.3) should be [auto\]]
     expected: FAIL
 
   [Web Animations: property <z-index> from neutral to [5\] at (-0.3) should be [-4\]]
     expected: FAIL
 
-  [CSS Animations: property <z-index> from [-5\] to [5\] at (0) should be [-5\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from [inherit\] to [5\] at (-0.3) should be [18\]]
-    expected: FAIL
-
-  [CSS Animations: property <z-index> from neutral to [5\] at (1) should be [5\]]
-    expected: FAIL
-
-  [CSS Animations: property <z-index> from [2\] to [4\] at (0) should be [2\]]
-    expected: FAIL
-
-  [CSS Animations: property <z-index> from [2\] to [4\] at (-0.3) should be [1\]]
-    expected: FAIL
-
   [Web Animations: property <z-index> from neutral to [5\] at (1.5) should be [9\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <z-index> from [-5\] to [5\] at (1.5) should be [10\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <z-index> from [inherit\] to [5\] at (1.5) should be [0\]]
     expected: FAIL
 
   [CSS Animations: property <z-index> from [initial\] to [5\] at (0) should be [initial\]]
     expected: FAIL
 
   [Web Animations: property <z-index> from [2\] to [4\] at (-0.3) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <z-index> from [2\] to [4\] at (1.5) should be [5\]]
     expected: FAIL
 
   [Web Animations: property <z-index> from [initial\] to [5\] at (0.6) should be [5\]]
@@ -83,19 +41,7 @@
   [Web Animations: property <z-index> from neutral to [5\] at (1) should be [5\]]
     expected: FAIL
 
-  [CSS Animations: property <z-index> from [-2\] to [-4\] at (0.3) should be [-3\]]
-    expected: FAIL
-
   [CSS Animations: property <z-index> from [unset\] to [5\] at (0.5) should be [5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <z-index> from [-2\] to [-4\] at (-0.3) should be [-1\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from [-5\] to [5\] at (0.6) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <z-index> from [-5\] to [5\] at (0.3) should be [-2\]]
     expected: FAIL
 
   [CSS Animations: property <z-index> from [unset\] to [5\] at (1.5) should be [5\]]
@@ -104,31 +50,16 @@
   [Web Animations: property <z-index> from [initial\] to [5\] at (0.5) should be [5\]]
     expected: FAIL
 
-  [CSS Animations: property <z-index> from [-2\] to [-4\] at (-0.3) should be [-1\]]
-    expected: FAIL
-
   [Web Animations: property <z-index> from [inherit\] to [5\] at (1.5) should be [0\]]
     expected: FAIL
 
-  [CSS Transitions: property <z-index> from [-2\] to [-4\] at (-0.3) should be [-1\]]
-    expected: FAIL
-
-  [CSS Animations: property <z-index> from [2\] to [4\] at (1) should be [4\]]
-    expected: FAIL
-
   [Web Animations: property <z-index> from [-2\] to [-4\] at (1.5) should be [-5\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from [inherit\] to [5\] at (0.3) should be [12\]]
     expected: FAIL
 
   [Web Animations: property <z-index> from [2\] to [4\] at (0.6) should be [3\]]
     expected: FAIL
 
   [Web Animations: property <z-index> from [-2\] to [-4\] at (0) should be [-2\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from [inherit\] to [5\] at (1.5) should be [0\]]
     expected: FAIL
 
   [Web Animations: property <z-index> from [-2\] to [-4\] at (1) should be [-4\]]
@@ -143,28 +74,13 @@
   [Web Animations: property <z-index> from [initial\] to [5\] at (0.3) should be [initial\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <z-index> from neutral to [5\] at (0.6) should be [2\]]
-    expected: FAIL
-
   [Web Animations: property <z-index> from [initial\] to [5\] at (1.5) should be [5\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from [inherit\] to [5\] at (0.6) should be [9\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from [2\] to [4\] at (0.3) should be [3\]]
     expected: FAIL
 
   [CSS Animations: property <z-index> from [initial\] to [5\] at (-0.3) should be [initial\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <z-index> from [-2\] to [-4\] at (1.5) should be [-5\]]
-    expected: FAIL
-
   [Web Animations: property <z-index> from [initial\] to [5\] at (0) should be [initial\]]
-    expected: FAIL
-
-  [CSS Animations: property <z-index> from neutral to [5\] at (0.6) should be [2\]]
     expected: FAIL
 
   [Web Animations: property <z-index> from [2\] to [4\] at (0) should be [2\]]
@@ -185,22 +101,7 @@
   [CSS Animations: property <z-index> from [auto\] to [10\] at (1) should be [10\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <z-index> from [-5\] to [5\] at (0.6) should be [1\]]
-    expected: FAIL
-
-  [CSS Animations: property <z-index> from [-5\] to [5\] at (1.5) should be [10\]]
-    expected: FAIL
-
-  [CSS Animations: property <z-index> from neutral to [5\] at (1.5) should be [9\]]
-    expected: FAIL
-
   [Web Animations: property <z-index> from [2\] to [4\] at (1) should be [4\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from [2\] to [4\] at (1.5) should be [5\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from neutral to [5\] at (1.5) should be [9\]]
     expected: FAIL
 
   [Web Animations: property <z-index> from [inherit\] to [5\] at (0.3) should be [12\]]
@@ -212,22 +113,10 @@
   [Web Animations: property <z-index> from [inherit\] to [5\] at (0.6) should be [9\]]
     expected: FAIL
 
-  [CSS Transitions: property <z-index> from [-5\] to [5\] at (-0.3) should be [-8\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from [-5\] to [5\] at (1.5) should be [10\]]
-    expected: FAIL
-
   [Web Animations: property <z-index> from neutral to [5\] at (0.3) should be [0\]]
     expected: FAIL
 
   [CSS Animations: property <z-index> from [auto\] to [10\] at (1.5) should be [10\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from [2\] to [4\] at (0.6) should be [3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <z-index> from [inherit\] to [5\] at (0.3) should be [12\]]
     expected: FAIL
 
   [CSS Animations: property <z-index> from [unset\] to [5\] at (0.6) should be [5\]]
@@ -236,31 +125,10 @@
   [Web Animations: property <z-index> from [-5\] to [5\] at (0.6) should be [1\]]
     expected: FAIL
 
-  [CSS Transitions: property <z-index> from [-2\] to [-4\] at (0.3) should be [-3\]]
-    expected: FAIL
-
-  [CSS Animations: property <z-index> from [-2\] to [-4\] at (0.6) should be [-3\]]
-    expected: FAIL
-
-  [CSS Animations: property <z-index> from [-2\] to [-4\] at (1.5) should be [-5\]]
-    expected: FAIL
-
   [CSS Animations: property <z-index> from [unset\] to [5\] at (1) should be [5\]]
     expected: FAIL
 
-  [CSS Animations: property <z-index> from [2\] to [4\] at (0.3) should be [3\]]
-    expected: FAIL
-
   [Web Animations: property <z-index> from [unset\] to [5\] at (0.5) should be [5\]]
-    expected: FAIL
-
-  [CSS Animations: property <z-index> from [-5\] to [5\] at (1) should be [5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <z-index> from [-5\] to [5\] at (-0.3) should be [-8\]]
-    expected: FAIL
-
-  [CSS Animations: property <z-index> from neutral to [5\] at (-0.3) should be [-4\]]
     expected: FAIL
 
   [Web Animations: property <z-index> from [2\] to [4\] at (1.5) should be [5\]]
@@ -287,22 +155,7 @@
   [Web Animations: property <z-index> from [-5\] to [5\] at (-0.3) should be [-8\]]
     expected: FAIL
 
-  [CSS Animations: property <z-index> from [2\] to [4\] at (1.5) should be [5\]]
-    expected: FAIL
-
   [CSS Animations: property <z-index> from [inherit\] to [5\] at (1.5) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from [-2\] to [-4\] at (1.5) should be [-5\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <z-index> from [2\] to [4\] at (0.3) should be [3\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <z-index> from [-2\] to [-4\] at (0.3) should be [-3\]]
-    expected: FAIL
-
-  [CSS Animations: property <z-index> from neutral to [5\] at (0.3) should be [0\]]
     expected: FAIL
 
   [CSS Animations: property <z-index> from [auto\] to [10\] at (0) should be [auto\]]
@@ -311,16 +164,10 @@
   [CSS Animations: property <z-index> from [unset\] to [5\] at (-0.3) should be [unset\]]
     expected: FAIL
 
-  [CSS Animations: property <z-index> from [-5\] to [5\] at (0.6) should be [1\]]
-    expected: FAIL
-
   [Web Animations: property <z-index> from [-2\] to [-4\] at (0.1) should be [-2\]]
     expected: FAIL
 
   [Web Animations: property <z-index> from [-5\] to [5\] at (1.5) should be [10\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from [-5\] to [5\] at (0.3) should be [-2\]]
     expected: FAIL
 
   [Web Animations: property <z-index> from [-5\] to [5\] at (0) should be [-5\]]
@@ -341,19 +188,10 @@
   [Web Animations: property <z-index> from [unset\] to [5\] at (0.3) should be [unset\]]
     expected: FAIL
 
-  [CSS Animations: property <z-index> from [inherit\] to [5\] at (1) should be [5\]]
-    expected: FAIL
-
   [CSS Animations: property <z-index> from [inherit\] to [5\] at (-0.3) should be [18\]]
     expected: FAIL
 
   [CSS Animations: property <z-index> from [initial\] to [5\] at (0.6) should be [5\]]
-    expected: FAIL
-
-  [CSS Animations: property <z-index> from [-2\] to [-4\] at (1) should be [-4\]]
-    expected: FAIL
-
-  [CSS Animations: property <z-index> from [-5\] to [5\] at (-0.3) should be [-8\]]
     expected: FAIL
 
   [Web Animations: property <z-index> from [auto\] to [10\] at (0.5) should be [10\]]
@@ -362,16 +200,7 @@
   [CSS Animations: property <z-index> from [initial\] to [5\] at (0.5) should be [5\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <z-index> from [inherit\] to [5\] at (0.6) should be [9\]]
-    expected: FAIL
-
   [Web Animations: property <z-index> from [auto\] to [10\] at (0.3) should be [auto\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from neutral to [5\] at (0.3) should be [0\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <z-index> from [2\] to [4\] at (0.6) should be [3\]]
     expected: FAIL
 
   [Web Animations: property <z-index> from [auto\] to [10\] at (0.6) should be [10\]]
@@ -383,19 +212,7 @@
   [CSS Animations: property <z-index> from [unset\] to [5\] at (0) should be [unset\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <z-index> from neutral to [5\] at (-0.3) should be [-4\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from [2\] to [4\] at (-0.3) should be [1\]]
-    expected: FAIL
-
-  [CSS Transitions: property <z-index> from [-2\] to [-4\] at (0.6) should be [-3\]]
-    expected: FAIL
-
   [CSS Animations: property <z-index> from [auto\] to [10\] at (-0.3) should be [auto\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <z-index> from neutral to [5\] at (0.3) should be [0\]]
     expected: FAIL
 
   [CSS Animations: property <z-index> from [initial\] to [5\] at (0.3) should be [initial\]]
@@ -411,9 +228,6 @@
     expected: FAIL
 
   [CSS Animations: property <z-index> from [inherit\] to [5\] at (0.3) should be [12\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <z-index> from [inherit\] to [5\] at (-0.3) should be [18\]]
     expected: FAIL
 
   [CSS Animations: property <z-index> from [auto\] to [10\] at (0.6) should be [10\]]

--- a/tests/wpt/metadata/css/css-transitions/changing-while-transition-001.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/changing-while-transition-001.html.ini
@@ -1,4 +1,0 @@
-[changing-while-transition-001.html]
-  [Changes to transition-duration should not affect in-flight transitions]
-    expected: FAIL
-

--- a/tests/wpt/metadata/css/css-transitions/changing-while-transition-002.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/changing-while-transition-002.html.ini
@@ -1,4 +1,0 @@
-[changing-while-transition-002.html]
-  [Changes to transition-timing-function should not affect in-flight transitions]
-    expected: FAIL
-

--- a/tests/wpt/metadata/css/css-transitions/changing-while-transition-003.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/changing-while-transition-003.html.ini
@@ -1,4 +1,0 @@
-[changing-while-transition-003.html]
-  [Changes to transition-delay should not affect in-flight transitions]
-    expected: FAIL
-

--- a/tests/wpt/metadata/css/css-transitions/properties-value-003.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/properties-value-003.html.ini
@@ -473,9 +473,6 @@
   [font-stretch font-stretch(keyword) / values]
     expected: FAIL
 
-  [transform-origin horizontal(keyword) / values]
-    expected: FAIL
-
   [border-top-right-radius border-radius(px) / values]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transitions/properties-value-auto-001.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/properties-value-auto-001.html.ini
@@ -2,18 +2,6 @@
   [top auto(to) / values]
     expected: FAIL
 
-  [top auto(from) / events]
-    expected: FAIL
-
-  [left auto(from) / events]
-    expected: FAIL
-
-  [right auto(from) / events]
-    expected: FAIL
-
-  [margin-top auto(to) / events]
-    expected: FAIL
-
   [z-index auto(to) / values]
     expected: FAIL
 
@@ -29,34 +17,10 @@
   [right auto(from) / values]
     expected: FAIL
 
-  [top auto(to) / events]
-    expected: FAIL
-
-  [width auto(to) / events]
-    expected: FAIL
-
-  [bottom auto(to) / events]
-    expected: FAIL
-
-  [bottom auto(from) / events]
-    expected: FAIL
-
   [marker-offset auto(to) / events]
     expected: FAIL
 
   [height auto(to) / values]
-    expected: FAIL
-
-  [height auto(to) / events]
-    expected: FAIL
-
-  [margin-bottom auto(from) / events]
-    expected: FAIL
-
-  [margin-right auto(from) / events]
-    expected: FAIL
-
-  [margin-bottom auto(to) / events]
     expected: FAIL
 
   [marker-offset auto(from) / events]
@@ -75,12 +39,6 @@
     expected: FAIL
 
   [margin-top auto(to) / values]
-    expected: FAIL
-
-  [width auto(from) / events]
-    expected: FAIL
-
-  [margin-left auto(from) / events]
     expected: FAIL
 
   [clip auto(from) / values]
@@ -107,25 +65,10 @@
   [margin-right auto(to) / values]
     expected: FAIL
 
-  [margin-top auto(from) / events]
-    expected: FAIL
-
   [right auto(to) / values]
     expected: FAIL
 
-  [right auto(to) / events]
-    expected: FAIL
-
-  [margin-right auto(to) / events]
-    expected: FAIL
-
   [margin-left auto(to) / values]
-    expected: FAIL
-
-  [margin-left auto(to) / events]
-    expected: FAIL
-
-  [height auto(from) / events]
     expected: FAIL
 
   [top auto(from) / values]
@@ -138,8 +81,5 @@
     expected: FAIL
 
   [left auto(from) / values]
-    expected: FAIL
-
-  [left auto(to) / events]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transitions/starting-of-transitions-001.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/starting-of-transitions-001.html.ini
@@ -1,4 +1,0 @@
-[starting-of-transitions-001.html]
-  [changes to transition-property should cancel in-flight transitions]
-    expected: FAIL
-

--- a/tests/wpt/metadata/css/css-ui/animation/outline-color-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-ui/animation/outline-color-interpolation.html.ini
@@ -2,16 +2,7 @@
   [outline-color interpolation]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <outline-color> from [white\] to [orange\] at (1.5) should be [rgb(255, 120, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [white\] to [orange\] at (-0.3) should be [white\]]
-    expected: FAIL
-
   [CSS Animations: property <outline-color> from [inherit\] to [green\] at (1.5) should be [rgb(0, 65, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-color> from [unset\] to [green\] at (0.6) should be [rgb(0, 77, 0)\]]
     expected: FAIL
 
   [Web Animations: property <outline-color> from [white\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]
@@ -20,19 +11,10 @@
   [Web Animations: property <outline-color> from [initial\] to [green\] at (0) should be [rgb(0, 0, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <outline-color> from [initial\] to [green\] at (0.6) should be [rgb(0, 77, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <outline-color> from [inherit\] to [green\] at (1.5) should be [rgb(0, 65, 0)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <outline-color> from neutral to [green\] at (0.3) should be [rgb(0, 38, 179)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [inherit\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-color> from [unset\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
     expected: FAIL
 
   [Web Animations: property <outline-color> from [white\] to [orange\] at (0) should be [white\]]
@@ -77,13 +59,7 @@
   [Web Animations: property <outline-color> from [initial\] to [green\] at (0.3) should be [rgb(0, 38, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <outline-color> from neutral to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <outline-color> from [white\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-color> from neutral to [green\] at (0.6) should be [rgb(0, 77, 102)\]]
     expected: FAIL
 
   [CSS Animations: property <outline-color> from [inherit\] to [green\] at (0.6) should be [rgb(102, 179, 0)\]]
@@ -98,25 +74,13 @@
   [CSS Transitions: property <outline-color> from [inherit\] to [green\] at (1.5) should be [rgb(0, 65, 0)\]]
     expected: FAIL
 
-  [CSS Animations: property <outline-color> from [initial\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <outline-color> from [initial\] to [green\] at (-0.3) should be [rgb(0, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-color> from [inherit\] to [green\] at (0.6) should be [rgb(102, 179, 0)\]]
     expected: FAIL
 
   [Web Animations: property <outline-color> from [white\] to [orange\] at (-0.3) should be [white\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-color> from neutral to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <outline-color> from [white\] to [orange\] at (1.5) should be [rgb(255, 120, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [initial\] to [green\] at (-0.3) should be [rgb(0, 0, 0)\]]
     expected: FAIL
 
   [Web Animations: property <outline-color> from [initial\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
@@ -125,61 +89,10 @@
   [CSS Animations: property <outline-color> from [inherit\] to [green\] at (0.3) should be [rgb(179, 217, 0)\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-color> from [unset\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-color> from [initial\] to [green\] at (0.6) should be [rgb(0, 77, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-color> from [initial\] to [green\] at (0.6) should be [rgb(0, 77, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [initial\] to [green\] at (0.3) should be [rgb(0, 38, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from neutral to [green\] at (1) should be [rgb(0, 128, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [unset\] to [green\] at (0) should be [rgb(0, 0, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-color> from [unset\] to [green\] at (0.3) should be [rgb(0, 38, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-color> from [white\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [white\] to [orange\] at (0) should be [white\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-color> from [unset\] to [green\] at (0.3) should be [rgb(0, 38, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [unset\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-color> from neutral to [green\] at (0.6) should be [rgb(0, 77, 102)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [unset\] to [green\] at (0.6) should be [rgb(0, 77, 0)\]]
-    expected: FAIL
-
   [CSS Animations: property <outline-color> from [white\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]
     expected: FAIL
 
-  [CSS Animations: property <outline-color> from [white\] to [orange\] at (1.5) should be [rgb(255, 120, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [unset\] to [green\] at (0.3) should be [rgb(0, 38, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-color> from [initial\] to [green\] at (0.3) should be [rgb(0, 38, 0)\]]
-    expected: FAIL
-
   [Web Animations: property <outline-color> from [inherit\] to [green\] at (0.3) should be [rgb(179, 217, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [unset\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
     expected: FAIL
 
   [Web Animations: property <outline-color> from [inherit\] to [green\] at (0) should be [rgb(255, 255, 0)\]]
@@ -188,43 +101,13 @@
   [Web Animations: property <outline-color> from [white\] to [orange\] at (1) should be [orange\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-color> from [initial\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [white\] to [orange\] at (1) should be [orange\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-color> from [unset\] to [green\] at (0.6) should be [rgb(0, 77, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [initial\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <outline-color> from [white\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]
     expected: FAIL
 
   [CSS Animations: property <outline-color> from neutral to [green\] at (0.3) should be [rgb(0, 38, 179)\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-color> from [initial\] to [green\] at (0.3) should be [rgb(0, 38, 0)\]]
-    expected: FAIL
-
   [CSS Animations: property <outline-color> from [inherit\] to [green\] at (0) should be [rgb(255, 255, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [white\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from neutral to [green\] at (0.6) should be [rgb(0, 77, 102)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-color> from [initial\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-color> from neutral to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [initial\] to [green\] at (0) should be [rgb(0, 0, 0)\]]
     expected: FAIL
 
   [Web Animations: property <outline-color> from [unset\] to [green\] at (1) should be [rgb(0, 128, 0)\]]
@@ -239,13 +122,7 @@
   [Web Animations: property <outline-color> from neutral to [green\] at (0.6) should be [rgb(0, 77, 102)\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-color> from [white\] to [orange\] at (1.5) should be [rgb(255, 120, 0)\]]
-    expected: FAIL
-
   [CSS Transitions: property <outline-color> from [white\] to [orange\] at (0.3) should be [rgb(255, 228, 179)\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-color> from [unset\] to [green\] at (-0.3) should be [rgb(0, 0, 0)\]]
     expected: FAIL
 
   [Web Animations: property <outline-color> from neutral to [green\] at (0) should be [rgb(0, 0, 255)\]]
@@ -255,14 +132,5 @@
     expected: FAIL
 
   [Web Animations: property <outline-color> from [unset\] to [green\] at (1.5) should be [rgb(0, 192, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-color> from [inherit\] to [green\] at (0.6) should be [rgb(102, 179, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-color> from [inherit\] to [green\] at (1.5) should be [rgb(0, 65, 0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-color> from [white\] to [orange\] at (0.6) should be [rgb(255, 201, 102)\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-ui/animation/outline-offset-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-ui/animation/outline-offset-interpolation.html.ini
@@ -5,13 +5,7 @@
   [Web Animations: property <outline-offset> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
     expected: FAIL
 
-  [CSS Animations: property <outline-offset> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-offset> from neutral to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from neutral to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
   [Web Animations: property <outline-offset> from neutral to [20px\] at (0.6) should be [16px\]]
@@ -23,37 +17,10 @@
   [Web Animations: property <outline-offset> from [unset\] to [20px\] at (0.6) should be [12px\]]
     expected: FAIL
 
-  [CSS Animations: property <outline-offset> from [-5px\] to [5px\] at (0.3) should be [-2px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [initial\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-offset> from [initial\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
   [Web Animations: property <outline-offset> from [initial\] to [20px\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [initial\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
   [Web Animations: property <outline-offset> from [unset\] to [20px\] at (0.3) should be [6px\]]
@@ -62,25 +29,10 @@
   [Web Animations: property <outline-offset> from [initial\] to [20px\] at (1.5) should be [30px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <outline-offset> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-offset> from [inherit\] to [20px\] at (0.3) should be [27px\]]
     expected: FAIL
 
   [Web Animations: property <outline-offset> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from [initial\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [-5px\] to [5px\] at (-0.3) should be [-8px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from [-5px\] to [5px\] at (0.6) should be [1px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from [inherit\] to [20px\] at (0.3) should be [27px\]]
     expected: FAIL
 
   [Web Animations: property <outline-offset> from [-5px\] to [5px\] at (1.5) should be [10px\]]
@@ -92,31 +44,16 @@
   [CSS Animations: property <outline-offset> from [inherit\] to [20px\] at (0.3) should be [27px\]]
     expected: FAIL
 
-  [CSS Animations: property <outline-offset> from [-5px\] to [5px\] at (0) should be [-5px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-offset> from [unset\] to [20px\] at (-0.3) should be [-6px\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-offset> from [initial\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from [unset\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-offset> from [-5px\] to [5px\] at (0.3) should be [-2px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from [unset\] to [20px\] at (0.3) should be [6px\]]
     expected: FAIL
 
   [Web Animations: property <outline-offset> from [inherit\] to [20px\] at (0) should be [30px\]]
     expected: FAIL
 
   [Web Animations: property <outline-offset> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from [-5px\] to [5px\] at (0.3) should be [-2px\]]
     expected: FAIL
 
   [Web Animations: property <outline-offset> from [unset\] to [20px\] at (1) should be [20px\]]
@@ -128,76 +65,19 @@
   [Web Animations: property <outline-offset> from neutral to [20px\] at (0) should be [10px\]]
     expected: FAIL
 
-  [CSS Animations: property <outline-offset> from neutral to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-offset> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [unset\] to [20px\] at (1.5) should be [30px\]]
     expected: FAIL
 
   [Web Animations: property <outline-offset> from [unset\] to [20px\] at (1.5) should be [30px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <outline-offset> from [-5px\] to [5px\] at (1.5) should be [10px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-offset> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [initial\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [-5px\] to [5px\] at (1) should be [5px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [-5px\] to [5px\] at (0.6) should be [1px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from [unset\] to [20px\] at (1.5) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from [-5px\] to [5px\] at (1.5) should be [10px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from [initial\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from [unset\] to [20px\] at (0.6) should be [12px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-offset> from [inherit\] to [20px\] at (0) should be [30px\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-offset> from [unset\] to [20px\] at (-0.3) should be [-6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [unset\] to [20px\] at (-0.3) should be [-6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from [inherit\] to [20px\] at (0.3) should be [27px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from [initial\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
   [CSS Animations: property <outline-offset> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [unset\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [initial\] to [20px\] at (0) should be [0px\]]
     expected: FAIL
 
   [Web Animations: property <outline-offset> from neutral to [20px\] at (0.3) should be [13px\]]
@@ -206,91 +86,22 @@
   [Web Animations: property <outline-offset> from [initial\] to [20px\] at (0.6) should be [12px\]]
     expected: FAIL
 
-  [CSS Animations: property <outline-offset> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from [initial\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
   [CSS Animations: property <outline-offset> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from [inherit\] to [20px\] at (1.5) should be [15px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-offset> from [inherit\] to [20px\] at (0.6) should be [24px\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-offset> from neutral to [20px\] at (1.5) should be [25px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from [-5px\] to [5px\] at (0.6) should be [1px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-offset> from [-5px\] to [5px\] at (0) should be [-5px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [unset\] to [20px\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from [unset\] to [20px\] at (0.3) should be [6px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from [inherit\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [inherit\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
   [Web Animations: property <outline-offset> from [-5px\] to [5px\] at (-0.3) should be [-8px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <outline-offset> from [unset\] to [20px\] at (-0.3) should be [-6px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from [unset\] to [20px\] at (0.6) should be [12px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from [inherit\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from [-5px\] to [5px\] at (-0.3) should be [-8px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [initial\] to [20px\] at (-0.3) should be [-6px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-offset> from [-5px\] to [5px\] at (-0.3) should be [-8px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-offset> from [inherit\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-offset> from [-5px\] to [5px\] at (0.3) should be [-2px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-offset> from [inherit\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-offset> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [unset\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-offset> from [unset\] to [20px\] at (0.3) should be [6px\]]
     expected: FAIL
 
   [Web Animations: property <outline-offset> from [unset\] to [20px\] at (0) should be [0px\]]

--- a/tests/wpt/metadata/css/css-ui/animation/outline-width-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-ui/animation/outline-width-interpolation.html.ini
@@ -2,16 +2,10 @@
   [outline-width interpolation]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <outline-width> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-width> from [inherit\] to [20px\] at (0.3) should be [27px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-width> from neutral to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 
   [Web Animations: property <outline-width> from [initial\] to [20px\] at (-0.3) should be [0px\]]
@@ -26,16 +20,10 @@
   [CSS Transitions: property <outline-width> from [initial\] to [20px\] at (0.6) should be [13px\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-width> from [inherit\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-width> from [unset\] to [20px\] at (1.5) should be [28px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-width> from [thick\] to [15px\] at (-2) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [0px\] to [10px\] at (0.6) should be [6px\]]
@@ -62,16 +50,7 @@
   [Web Animations: property <outline-width> from [unset\] to [20px\] at (0.3) should be [8px\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-width> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-width> from [thick\] to [15px\] at (0.3) should be [8px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-width> from [unset\] to [20px\] at (0.6) should be [13px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-width> from neutral to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [unset\] to [20px\] at (0.6) should be [13px\]]
@@ -92,13 +71,7 @@
   [Web Animations: property <outline-width> from neutral to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-width> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-width> from [0px\] to [10px\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-width> from [inherit\] to [20px\] at (0.6) should be [24px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [inherit\] to [20px\] at (0.3) should be [27px\]]
@@ -107,16 +80,10 @@
   [Web Animations: property <outline-width> from [thick\] to [15px\] at (1.5) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <outline-width> from neutral to [20px\] at (0.6) should be [16px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-width> from [thick\] to [15px\] at (1) should be [15px\]]
     expected: FAIL
 
   [Web Animations: property <outline-width> from [inherit\] to [20px\] at (0.6) should be [24px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-width> from [thick\] to [15px\] at (0.6) should be [11px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [unset\] to [20px\] at (0.3) should be [8px\]]
@@ -137,19 +104,10 @@
   [Web Animations: property <outline-width> from neutral to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <outline-width> from [unset\] to [20px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <outline-width> from [initial\] to [20px\] at (0.6) should be [13px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [thick\] to [15px\] at (1.5) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-width> from [0px\] to [10px\] at (0.6) should be [6px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-width> from [unset\] to [20px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [Web Animations: property <outline-width> from [unset\] to [20px\] at (-0.3) should be [0px\]]
@@ -158,13 +116,7 @@
   [CSS Transitions with transition: all: property <outline-width> from [unset\] to [20px\] at (0.3) should be [8px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <outline-width> from [thick\] to [15px\] at (-0.3) should be [2px\]]
-    expected: FAIL
-
   [CSS Animations: property <outline-width> from [inherit\] to [20px\] at (0) should be [30px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-width> from [inherit\] to [20px\] at (-0.3) should be [33px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from neutral to [20px\] at (1.5) should be [25px\]]
@@ -173,13 +125,7 @@
   [Web Animations: property <outline-width> from [thick\] to [15px\] at (0) should be [5px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <outline-width> from [thick\] to [15px\] at (1.5) should be [20px\]]
-    expected: FAIL
-
   [CSS Animations: property <outline-width> from [unset\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-width> from [initial\] to [20px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [initial\] to [20px\] at (1.5) should be [28px\]]
@@ -191,43 +137,19 @@
   [Web Animations: property <outline-width> from [unset\] to [20px\] at (1) should be [20px\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-width> from [inherit\] to [20px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
   [CSS Animations: property <outline-width> from neutral to [20px\] at (-0.3) should be [7px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-width> from [thick\] to [15px\] at (-0.3) should be [2px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [inherit\] to [20px\] at (0.6) should be [24px\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-width> from [thick\] to [15px\] at (0.6) should be [11px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <outline-width> from [initial\] to [20px\] at (1.5) should be [28px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-width> from [thick\] to [15px\] at (0.3) should be [8px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-width> from neutral to [20px\] at (-0.3) should be [7px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [0px\] to [10px\] at (1.5) should be [15px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <outline-width> from [thick\] to [15px\] at (-2) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <outline-width> from [initial\] to [20px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-width> from [thick\] to [15px\] at (1.5) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-width> from neutral to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [thick\] to [15px\] at (-2) should be [0px\]]
@@ -237,9 +159,6 @@
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [0px\] to [10px\] at (0.3) should be [3px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-width> from [inherit\] to [20px\] at (0.3) should be [27px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <outline-width> from [initial\] to [20px\] at (0.6) should be [13px\]]
@@ -252,9 +171,6 @@
     expected: FAIL
 
   [Web Animations: property <outline-width> from [0px\] to [10px\] at (1.5) should be [15px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-width> from [0px\] to [10px\] at (1.5) should be [15px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [thick\] to [15px\] at (1) should be [15px\]]
@@ -272,25 +188,16 @@
   [Web Animations: property <outline-width> from [thick\] to [15px\] at (-0.3) should be [2px\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-width> from [0px\] to [10px\] at (0.6) should be [6px\]]
-    expected: FAIL
-
   [CSS Animations: property <outline-width> from [initial\] to [20px\] at (0.6) should be [13px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [unset\] to [20px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
-  [CSS Transitions: property <outline-width> from [0px\] to [10px\] at (0.3) should be [3px\]]
-    expected: FAIL
-
   [CSS Animations: property <outline-width> from [unset\] to [20px\] at (1.5) should be [28px\]]
     expected: FAIL
 
   [Web Animations: property <outline-width> from neutral to [20px\] at (0.3) should be [13px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-width> from [0px\] to [10px\] at (1.5) should be [15px\]]
     expected: FAIL
 
   [Web Animations: property <outline-width> from [initial\] to [20px\] at (0) should be [3px\]]
@@ -311,9 +218,6 @@
   [CSS Animations: property <outline-width> from [thick\] to [15px\] at (0.6) should be [11px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <outline-width> from [0px\] to [10px\] at (0.3) should be [3px\]]
-    expected: FAIL
-
   [CSS Transitions: property <outline-width> from [unset\] to [20px\] at (0.6) should be [13px\]]
     expected: FAIL
 
@@ -321,9 +225,6 @@
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [inherit\] to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-width> from neutral to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <outline-width> from [initial\] to [20px\] at (0.3) should be [8px\]]
@@ -338,13 +239,7 @@
   [CSS Animations: property <outline-width> from neutral to [20px\] at (0.3) should be [13px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <outline-width> from [initial\] to [20px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <outline-width> from [unset\] to [20px\] at (1.5) should be [28px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <outline-width> from [inherit\] to [20px\] at (0.3) should be [27px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [0px\] to [10px\] at (-0.3) should be [0px\]]
@@ -354,9 +249,6 @@
     expected: FAIL
 
   [CSS Transitions: property <outline-width> from [unset\] to [20px\] at (0.3) should be [8px\]]
-    expected: FAIL
-
-  [CSS Transitions: property <outline-width> from neutral to [20px\] at (-0.3) should be [7px\]]
     expected: FAIL
 
   [CSS Transitions: property <outline-width> from [unset\] to [20px\] at (1.5) should be [28px\]]

--- a/tests/wpt/metadata/css/css-values/animations/calc-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-values/animations/calc-interpolation.html.ini
@@ -11,9 +11,6 @@
   [Web Animations: property <text-indent> from [0%\] to [100px\] at (1) should be [calc(0% + 100px)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-indent> from [0em\] to [100px\] at (1.25) should be [125px\]]
-    expected: FAIL
-
   [CSS Transitions: property <text-indent> from [0%\] to [100px\] at (0.25) should be [calc(0% + 25px)\]]
     expected: FAIL
 
@@ -24,9 +21,6 @@
     expected: FAIL
 
   [CSS Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.75) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [0%\] to [100px\] at (0.25) should be [calc(0% + 25px)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <text-indent> from [0em\] to [100px\] at (0.25) should be [25px\]]
@@ -50,31 +44,19 @@
   [CSS Transitions: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.25) should be [10px\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0) should be [calc(50% - 25px)\]]
-    expected: FAIL
-
   [CSS Transitions: property <text-indent> from [0em\] to [100px\] at (0.25) should be [25px\]]
     expected: FAIL
 
   [Web Animations: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0) should be [calc(50% - 25px)\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (1) should be [calc(100% - 10px)\]]
-    expected: FAIL
-
   [Web Animations: property <text-indent> from [0em\] to [100px\] at (1) should be [100px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [0%\] to [100px\] at (1.25) should be [calc(0% + 125px)\]]
     expected: FAIL
 
   [Web Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (1) should be [40px\]]
     expected: FAIL
 
   [CSS Transitions: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.5) should be [20px\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.25) should be [calc(((50% - 25px) * 0.75) + ((100% - 10px) * 0.25))\]]
     expected: FAIL
 
   [CSS Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (1) should be [40px\]]
@@ -86,9 +68,6 @@
   [CSS Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.25) should be [10px\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (1.25) should be [calc(((50% - 25px) * -0.25) + ((100% - 10px) * 1.25))\]]
-    expected: FAIL
-
   [CSS Transitions: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.75) should be [30px\]]
     expected: FAIL
 
@@ -96,12 +75,6 @@
     expected: FAIL
 
   [Web Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.75) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [0%\] to [100px\] at (-0.25) should be [calc(0% + -25px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.75) should be [calc(((50% - 25px) * 0.25) + ((100% - 10px) * 0.75))\]]
     expected: FAIL
 
   [CSS Transitions: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (-0.25) should be [calc(((50% - 25px) * 1.25) + ((100% - 10px) * -0.25))\]]
@@ -113,9 +86,6 @@
   [Web Animations: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (-0.25) should be [calc(((50% - 25px) * 1.25) + ((100% - 10px) * -0.25))\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.25) should be [calc(((50% - 25px) * 0.75) + ((100% - 10px) * 0.25))\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <text-indent> from [0%\] to [100px\] at (-0.25) should be [calc(0% + -25px)\]]
     expected: FAIL
 
@@ -123,9 +93,6 @@
     expected: FAIL
 
   [Web Animations: property <text-indent> from [0em\] to [100px\] at (-0.25) should be [-25px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [0%\] to [100px\] at (0) should be [0%\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.75) should be [30px\]]
@@ -140,13 +107,7 @@
   [Web Animations: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (1.25) should be [calc(((50% - 25px) * -0.25) + ((100% - 10px) * 1.25))\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-indent> from [0%\] to [100px\] at (1.25) should be [calc(0% + 125px)\]]
-    expected: FAIL
-
   [Web Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.25) should be [10px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [0em\] to [100px\] at (1.25) should be [125px\]]
     expected: FAIL
 
   [Web Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0) should be [0px\]]
@@ -185,13 +146,7 @@
   [CSS Transitions: property <text-indent> from [0em\] to [100px\] at (1.25) should be [125px\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.5) should be [calc(((50% - 25px) * 0.5) + ((100% - 10px) * 0.5))\]]
-    expected: FAIL
-
   [CSS Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (1.25) should be [50px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [0%\] to [100px\] at (0.5) should be [calc(0% + 50px)\]]
     expected: FAIL
 
   [Web Animations: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.25) should be [calc(((50% - 25px) * 0.75) + ((100% - 10px) * 0.25))\]]
@@ -203,19 +158,10 @@
   [CSS Transitions: property <text-indent> from [0em\] to [100px\] at (-0.25) should be [-25px\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.75) should be [calc(((50% - 25px) * 0.25) + ((100% - 10px) * 0.75))\]]
-    expected: FAIL
-
   [Web Animations: property <text-indent> from [0em\] to [100px\] at (0.5) should be [50px\]]
     expected: FAIL
 
   [Web Animations: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.5) should be [calc(((50% - 25px) * 0.5) + ((100% - 10px) * 0.5))\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [0em\] to [100px\] at (0.75) should be [75px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (-0.25) should be [calc(((50% - 25px) * 1.25) + ((100% - 10px) * -0.25))\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (1.25) should be [50px\]]
@@ -239,13 +185,7 @@
   [CSS Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.5) should be [20px\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from [0em\] to [100px\] at (0.25) should be [25px\]]
-    expected: FAIL
-
   [Web Animations: property <text-indent> from [0%\] to [100px\] at (-0.25) should be [calc(0% + -25px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [0%\] to [100px\] at (0.75) should be [calc(0% + 75px)\]]
     expected: FAIL
 
   [CSS Animations: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (-0.25) should be [-10px\]]
@@ -260,19 +200,7 @@
   [CSS Transitions: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.25) should be [calc(((50% - 25px) * 0.75) + ((100% - 10px) * 0.25))\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (1.25) should be [calc(((50% - 25px) * -0.25) + ((100% - 10px) * 1.25))\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [0em\] to [100px\] at (-0.25) should be [-25px\]]
-    expected: FAIL
-
   [CSS Transitions: property <text-indent> from [0em\] to [100px\] at (0.5) should be [50px\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [0%\] to [100px\] at (1) should be [calc(0% + 100px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <text-indent> from [0em\] to [100px\] at (1) should be [100px\]]
     expected: FAIL
 
   [CSS Transitions: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0) should be [0px\]]
@@ -287,12 +215,15 @@
   [CSS Transitions: property <text-indent> from [0%\] to [100px\] at (1.25) should be [calc(0% + 125px)\]]
     expected: FAIL
 
-  [CSS Animations: property <text-indent> from [0em\] to [100px\] at (0.5) should be [50px\]]
-    expected: FAIL
-
   [CSS Transitions: property <text-indent> from [0%\] to [100px\] at (0.5) should be [calc(0% + 50px)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <left> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.25) should be [10px\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.25) should be [calc(((50% - 25px) * 0.75) + ((100% - 10px) * 0.25))\]]
+    expected: FAIL
+
+  [CSS Transitions with transition: all: property <text-indent> from [calc(50% - 25px)\] to [calc(100% - 10px)\] at (0.75) should be [calc(((50% - 25px) * 0.25) + ((100% - 10px) * 0.75))\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/filter-effects/animation/filter-interpolation-001.html.ini
+++ b/tests/wpt/metadata/css/filter-effects/animation/filter-interpolation-001.html.ini
@@ -38,19 +38,7 @@
   [filter interpolation]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (-0.5) should be [hue-rotate(75deg) blur(4mm)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (0.25) should be [hue-rotate(82.5deg) blur(7mm)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [initial\] to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(30deg)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (-0.5) should be [hue-rotate(-90deg) blur(4px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(27deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from neutral to [hue-rotate(20deg)\] at (1) should be [hue-rotate(20deg)\]]
@@ -59,37 +47,13 @@
   [Web Animations: property <filter> from neutral to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(5deg)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from neutral to [hue-rotate(20deg)\] at (0.6) should be [hue-rotate(16deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from neutral to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(5deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [unset\] to [hue-rotate(20deg)\] at (0.6) should be [hue-rotate(12deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (0) should be [hue-rotate(80deg) blur(6mm)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [unset\] to [hue-rotate(20deg)\] at (1) should be [hue-rotate(20deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [initial\] to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(6deg)\]]
     expected: FAIL
 
   [CSS Animations: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (0) should be [hue-rotate(30deg)\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [unset\] to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(6deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (0.5) should be [hue-rotate(85deg) blur(8mm)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from neutral to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(25deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (0.25) should be [hue-rotate(82.5deg) blur(7mm)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from neutral to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(13deg)\]]
@@ -98,25 +62,7 @@
   [CSS Animations: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(27deg)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (1.5) should be [hue-rotate(95deg) blur(12mm)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [initial\] to [hue-rotate(20deg)\] at (0) should be [hue-rotate(0deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [initial\] to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(-10deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (1.5) should be [hue-rotate(95deg) blur(12mm)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (1) should be [hue-rotate(20deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [initial\] to [hue-rotate(20deg)\] at (1) should be [hue-rotate(20deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [initial\] to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(-10deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (0.25) should be [hue-rotate(45deg) blur(7px)\]]
@@ -137,46 +83,13 @@
   [Web Animations: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (0.25) should be [hue-rotate(45deg) blur(7px)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from neutral to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(25deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (1.5) should be [hue-rotate(270deg) blur(12px)\]]
-    expected: FAIL
-
   [CSS Transitions: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (1.5) should be [hue-rotate(95deg) blur(12mm)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (0) should be [hue-rotate(80deg) blur(6mm)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (1) should be [hue-rotate(90deg) blur(10mm)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [initial\] to [hue-rotate(20deg)\] at (0.6) should be [hue-rotate(12deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from neutral to [hue-rotate(20deg)\] at (0.6) should be [hue-rotate(16deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [initial\] to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(6deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (0.5) should be [hue-rotate(90deg) blur(8px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [initial\] to [hue-rotate(20deg)\] at (0.6) should be [hue-rotate(12deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [unset\] to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(-10deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (0.25) should be [hue-rotate(82.5deg) blur(7mm)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(27deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (-0.5) should be [hue-rotate(75deg) blur(4mm)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(15deg)\]]
@@ -185,94 +98,31 @@
   [CSS Animations: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(15deg)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [unset\] to [hue-rotate(20deg)\] at (0.6) should be [hue-rotate(12deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [initial\] to [hue-rotate(20deg)\] at (0.6) should be [hue-rotate(12deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from neutral to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(5deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [unset\] to [hue-rotate(20deg)\] at (0) should be [hue-rotate(0deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (-0.5) should be [hue-rotate(-90deg) blur(4px)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [unset\] to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(6deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [initial\] to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(30deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [unset\] to [hue-rotate(20deg)\] at (0) should be [hue-rotate(0deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [unset\] to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(-10deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [unset\] to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(-10deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from neutral to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(13deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (0.6) should be [hue-rotate(24deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (1.5) should be [hue-rotate(95deg) blur(12mm)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (0.25) should be [hue-rotate(45deg) blur(7px)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (0.5) should be [hue-rotate(90deg) blur(8px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from neutral to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(13deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [unset\] to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(30deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (0.5) should be [hue-rotate(85deg) blur(8mm)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (0.6) should be [hue-rotate(24deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [initial\] to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(-10deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [unset\] to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(30deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [initial\] to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(-10deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(15deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (1.5) should be [hue-rotate(270deg) blur(12px)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (0.5) should be [hue-rotate(90deg) blur(8px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [initial\] to [hue-rotate(20deg)\] at (1) should be [hue-rotate(20deg)\]]
     expected: FAIL
 
   [CSS Animations: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (0.6) should be [hue-rotate(24deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from neutral to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(25deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [unset\] to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(6deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from neutral to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(25deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [initial\] to [hue-rotate(20deg)\] at (0) should be [hue-rotate(0deg)\]]
@@ -284,67 +134,22 @@
   [Web Animations: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (-0.5) should be [hue-rotate(75deg) blur(4mm)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from neutral to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(13deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [unset\] to [hue-rotate(20deg)\] at (0.6) should be [hue-rotate(12deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(35deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (1) should be [hue-rotate(90deg) blur(10mm)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from neutral to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(5deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (-0.5) should be [hue-rotate(75deg) blur(4mm)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from neutral to [hue-rotate(20deg)\] at (0.6) should be [hue-rotate(16deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [initial\] to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(6deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (0.5) should be [hue-rotate(85deg) blur(8mm)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from neutral to [hue-rotate(20deg)\] at (0.6) should be [hue-rotate(16deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (1) should be [hue-rotate(20deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (0.5) should be [hue-rotate(85deg) blur(8mm)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [initial\] to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(30deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [unset\] to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(-10deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [unset\] to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(30deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (-0.5) should be [hue-rotate(-90deg) blur(4px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (0) should be [hue-rotate(0deg) blur(6px)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from neutral to [hue-rotate(20deg)\] at (0) should be [hue-rotate(10deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (0.5) should be [hue-rotate(90deg) blur(8px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(35deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(27deg)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (0.25) should be [hue-rotate(45deg) blur(7px)\]]
@@ -356,22 +161,13 @@
   [Web Animations: property <filter> from [unset\] to [hue-rotate(20deg)\] at (0.3) should be [hue-rotate(6deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (1) should be [hue-rotate(180deg) blur(10px)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (1.5) should be [hue-rotate(270deg) blur(12px)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [hue-rotate(80deg) blur(6mm)\] to [hue-rotate(100grad) blur(1cm)\] at (0.25) should be [hue-rotate(82.5deg) blur(7mm)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [unset\] to [hue-rotate(20deg)\] at (1) should be [hue-rotate(20deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (0) should be [hue-rotate(0deg) blur(6px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from neutral to [hue-rotate(20deg)\] at (1) should be [hue-rotate(20deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [initial\] to [hue-rotate(20deg)\] at (0.6) should be [hue-rotate(12deg)\]]
@@ -381,12 +177,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [hue-rotate(0deg) blur(6px)\] to [hue-rotate(180deg) blur(10px)\] at (1) should be [hue-rotate(180deg) blur(10px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (-0.5) should be [hue-rotate(35deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [inherit\] to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(15deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [unset\] to [hue-rotate(20deg)\] at (1.5) should be [hue-rotate(30deg)\]]

--- a/tests/wpt/metadata/css/filter-effects/animation/filter-interpolation-002.html.ini
+++ b/tests/wpt/metadata/css/filter-effects/animation/filter-interpolation-002.html.ini
@@ -65,16 +65,10 @@
   [CSS Transitions with transition: all: property <filter> from [hue-rotate(180deg)\] to [none\] at (-0.5) should be [hue-rotate(270deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (1.5) should be [blur(12px) hue-rotate(270deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (0.25) should be [opacity(0.875) hue-rotate(45deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (-0.5) should be [blur(4px) hue-rotate(-90deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (1) should be [blur(10px) hue-rotate(180deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (1) should be [hue-rotate(0deg)\]]
@@ -83,13 +77,7 @@
   [Web Animations: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (0.25) should be [blur(7px) hue-rotate(45deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (0) should be [opacity(1) hue-rotate(0deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (0) should be [hue-rotate(180deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (0.5) should be [hue-rotate(90deg)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px white)\]]
@@ -105,9 +93,6 @@
     expected: FAIL
 
   [CSS Transitions with transition: all: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (0.5) should be [opacity(0.75) hue-rotate(90deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [hue-rotate(180deg)\] at (0.5) should be [hue-rotate(90deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [hue-rotate(180deg)\] at (0.25) should be [hue-rotate(45deg)\]]
@@ -140,16 +125,10 @@
   [CSS Transitions: property <filter> from [hue-rotate(180deg)\] to [none\] at (1.5) should be [hue-rotate(-90deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (0) should be [blur(6px) hue-rotate(0deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (0.5) should be [hue-rotate(90deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [none\] to [hue-rotate(180deg)\] at (0.5) should be [hue-rotate(90deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (0.5) should be [blur(8px) hue-rotate(90deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px white)\]]
@@ -194,9 +173,6 @@
   [CSS Transitions with transition: all: property <filter> from [drop-shadow(20px 10px blue)\] to [drop-shadow(20px 10px green)\] at (2147483648) should be [drop-shadow(20px 10px #00FF00\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (1) should be [hue-rotate(0deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (0.5) should be [blur(10px)\]]
     expected: FAIL
 
@@ -212,16 +188,10 @@
   [CSS Animations: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (0) should be [grayscale(0) blur(0px)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [hue-rotate(180deg)\] to [none\] at (1.5) should be [hue-rotate(-90deg)\]]
-    expected: FAIL
-
   [CSS Transitions: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (1.5) should be [hue-rotate(-90deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (-0.5) should be [blur(4px) hue-rotate(-90deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (-0.5) should be [hue-rotate(270deg)\]]
@@ -245,9 +215,6 @@
   [CSS Transitions with transition: all: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (-0.5) should be [opacity(1) hue-rotate(-90deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [hue-rotate(180deg)\] at (1) should be [hue-rotate(180deg)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px #80C080)\]]
     expected: FAIL
 
@@ -260,34 +227,19 @@
   [Web Animations: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (0.3) should be [grayscale(0) blur(0px)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (1.5) should be [opacity(0.25) hue-rotate(270deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (1) should be [blur(10px)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [hue-rotate(180deg)\] at (0.5) should be [hue-rotate(90deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (-0.5) should be [opacity(1) hue-rotate(-90deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (1.5) should be [hue-rotate(-90deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (1) should be [opacity(0.5) hue-rotate(180deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (1) should be [opacity(0.5) hue-rotate(180deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [none\] to [hue-rotate(180deg)\] at (0.25) should be [hue-rotate(45deg)\]]
     expected: FAIL
 
   [CSS Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px white)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (1.5) should be [opacity(0.25) hue-rotate(270deg)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (-0.5) should be [blur(4px) hue-rotate(-90deg)\]]
@@ -302,28 +254,16 @@
   [Web Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px white)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (0) should be [hue-rotate(180deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (-0.5) should be [hue-rotate(270deg)\]]
-    expected: FAIL
-
   [CSS Transitions: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (0.25) should be [opacity(0.875) hue-rotate(45deg)\]]
     expected: FAIL
 
   [CSS Animations: property <filter> from [grayscale(0) blur(0px)\] to [blur(10px)\] at (1) should be [blur(10px)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [hue-rotate(180deg)\] at (0.25) should be [hue-rotate(45deg)\]]
-    expected: FAIL
-
   [CSS Transitions: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (0.5) should be [opacity(0.75) hue-rotate(90deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (1.5) should be [blur(12px) hue-rotate(270deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate(180deg)\] to [none\] at (0.25) should be [hue-rotate(135deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (1.5) should be [opacity(0.25) hue-rotate(270deg)\]]
@@ -338,13 +278,7 @@
   [Web Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (0.25) should be [opacity(0.875) hue-rotate(45deg)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [none\] to [hue-rotate(180deg)\] at (-0.5) should be [hue-rotate(-90deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [opacity(0.5) hue-rotate(180deg)\] at (0.5) should be [opacity(0.75) hue-rotate(90deg)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px #80C080)\]]
@@ -354,15 +288,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px #80C080)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [hue-rotate(180deg)\] at (1.5) should be [hue-rotate(270deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [hue-rotate(180deg)\] at (-0.5) should be [hue-rotate(-90deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (0.25) should be [blur(7px) hue-rotate(45deg)\]]
     expected: FAIL
 
   [CSS Animations: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px #80C080)\]]
@@ -377,16 +302,7 @@
   [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px 0px currentcolor)\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (1.5) should be [blur(12px) hue-rotate(270deg)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [hue-rotate(180deg)\] to [none\] at (0.5) should be [hue-rotate(90deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [hue-rotate(180deg)\] at (0) should be [hue-rotate(0deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [hue-rotate(180deg)\] at (1.5) should be [hue-rotate(270deg)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <filter> from [blur(6px)\] to [blur(10px) hue-rotate(180deg)\] at (0.25) should be [blur(7px) hue-rotate(45deg)\]]

--- a/tests/wpt/metadata/css/filter-effects/animation/filter-interpolation-003.html.ini
+++ b/tests/wpt/metadata/css/filter-effects/animation/filter-interpolation-003.html.ini
@@ -146,16 +146,7 @@
   [filter interpolation]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [none\] to [sepia(1)\] at (1.5) should be [sepia(1)\]]
-    expected: FAIL
-
   [CSS Animations: property <filter> from [url("#svgfilter")\] to [none\] at (1) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [contrast(0)\] to [none\] at (0.5) should be [contrast(0.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [contrast(0)\] to [none\] at (1) should be [contrast(1)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [hue-rotate(360deg)\] at (1.5) should be [hue-rotate(540deg)\]]
@@ -164,28 +155,10 @@
   [Web Animations: property <filter> from [none\] to [blur(10px)\] at (0) should be [blur(0px)\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [none\] to [invert(1)\] at (1.5) should be [invert(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [grayscale(1)\] at (1) should be [grayscale(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [blur(10px)\] at (0.5) should be [blur(5px)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [url("#svgfilter")\] to [none\] at (-0.3) should be [url("#svgfilter")\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [saturate(0)\] to [none\] at (1.5) should be [saturate(1.5)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [brightness(0)\] to [none\] at (0.5) should be [brightness(0.5)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [none\] at (0) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [blur(10px)\] at (1.5) should be [blur(15px)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
@@ -212,15 +185,6 @@
   [CSS Transitions: property <filter> from [url("#svgfilter")\] to [none\] at (0.6) should be [none\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [none\] to [sepia(1)\] at (0.5) should be [sepia(0.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [invert(1)\] at (0.5) should be [invert(0.5)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [opacity(0)\] to [none\] at (0.5) should be [opacity(0.5)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [none\] to [grayscale(1)\] at (-1) should be [grayscale(0)\]]
     expected: FAIL
 
@@ -242,16 +206,7 @@
   [Web Animations: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (0) should be [url("#svgfilter")\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [sepia(1)\] at (1.5) should be [sepia(1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [grayscale(1)\] at (0.5) should be [grayscale(0.5)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [none\] at (1.5) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [none\] to [grayscale(1)\] at (0.5) should be [grayscale(0.5)\]]
     expected: FAIL
 
   [CSS Animations: property <filter> from [url("#svgfilter")\] to [none\] at (-0.3) should be [url("#svgfilter")\]]
@@ -278,22 +233,7 @@
   [Web Animations: property <filter> from [initial\] to [sepia(1)\] at (0.5) should be [sepia(0.5)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [brightness(0)\] to [none\] at (0.5) should be [brightness(0.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [brightness(0)\] to [none\] at (-1) should be [brightness(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [brightness(0)\] to [none\] at (1.5) should be [brightness(1.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [hue-rotate(360deg)\] at (-1) should be [hue-rotate(-360deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [none\] to [invert(1)\] at (1.5) should be [invert(1)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [saturate(0)\] to [none\] at (1.5) should be [saturate(1.5)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (-0.3) should be [blur(5px)\]]
@@ -305,12 +245,6 @@
   [Web Animations: property <filter> from [url("#svgfilter")\] to [none\] at (0.3) should be [url("#svgfilter")\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [brightness(0)\] to [none\] at (1) should be [brightness(1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [brightness(0)\] to [none\] at (1.5) should be [brightness(1.5)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [none\] to [invert(1)\] at (0) should be [invert(0)\]]
     expected: FAIL
 
@@ -318,9 +252,6 @@
     expected: FAIL
 
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (1.5) should be [blur(5px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [invert(1)\] at (-1) should be [invert(0)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [none\] to [hue-rotate(360deg)\] at (-1) should be [hue-rotate(-360deg)\]]
@@ -335,43 +266,19 @@
   [Web Animations: property <filter> from [none\] to [blur(10px)\] at (-1) should be [blur(0px)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [brightness(0)\] to [none\] at (0) should be [brightness(0)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px transparent)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [blur(10px)\] at (1) should be [blur(10px)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [invert(1)\] at (1) should be [invert(1)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [invert(1)\] at (0) should be [invert(0)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [none\] to [blur(10px)\] at (1) should be [blur(10px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [none\] to [blur(10px)\] at (0.5) should be [blur(5px)\]]
     expected: FAIL
 
   [CSS Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [saturate(0)\] to [none\] at (1.5) should be [saturate(1.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [initial\] to [sepia(1)\] at (-1) should be [sepia(0)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (-0.3) should be [blur(5px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [initial\] to [sepia(1)\] at (0) should be [sepia(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [opacity(0)\] to [none\] at (1) should be [opacity(1)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [grayscale(1)\] at (0) should be [grayscale(0)\]]
@@ -389,12 +296,6 @@
   [Web Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px rgba(0, 128, 0, 0.5))\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [saturate(0)\] to [none\] at (1) should be [saturate(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [saturate(0)\] to [none\] at (-1) should be [saturate(0)\]]
-    expected: FAIL
-
   [CSS Animations: property <filter> from [url("#svgfilter")\] to [none\] at (1.5) should be [none\]]
     expected: FAIL
 
@@ -404,16 +305,7 @@
   [Web Animations: property <filter> from [brightness(0)\] to [none\] at (0) should be [brightness(0)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [grayscale(1)\] at (0) should be [grayscale(0)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px transparent)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [blur(10px)\] at (0) should be [blur(0px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [blur(10px)\] at (-1) should be [blur(0px)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [url("#svgfilter")\] to [none\] at (0) should be [url("#svgfilter")\]]
@@ -423,9 +315,6 @@
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [sepia(1)\] at (0) should be [sepia(0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [none\] to [blur(10px)\] at (1.5) should be [blur(15px)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [hue-rotate(360deg)\] at (0) should be [hue-rotate(0deg)\]]
@@ -446,19 +335,10 @@
   [CSS Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px transparent)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [sepia(1)\] at (-1) should be [sepia(0)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [contrast(0)\] to [none\] at (1) should be [contrast(1)\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [contrast(0)\] to [none\] at (0.5) should be [contrast(0.5)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [saturate(0)\] to [none\] at (1) should be [saturate(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [brightness(0)\] to [none\] at (0.5) should be [brightness(0.5)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [sepia(1)\] at (-1) should be [sepia(0)\]]
@@ -482,28 +362,10 @@
   [Web Animations: property <filter> from [initial\] to [sepia(1)\] at (1.5) should be [sepia(1)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [initial\] to [sepia(1)\] at (1.5) should be [sepia(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [contrast(0)\] to [none\] at (0) should be [contrast(0)\]]
-    expected: FAIL
-
   [CSS Animations: property <filter> from [url("#svgfilter")\] to [none\] at (0.5) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [grayscale(1)\] at (0.5) should be [grayscale(0.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [opacity(0)\] to [none\] at (1.5) should be [opacity(1)\]]
-    expected: FAIL
-
   [CSS Transitions: property <filter> from [url("#svgfilter")\] to [none\] at (1) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [invert(1)\] at (1.5) should be [invert(1)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [initial\] to [sepia(1)\] at (1.5) should be [sepia(1)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [hue-rotate(360deg)\] at (-1) should be [hue-rotate(-360deg)\]]
@@ -527,12 +389,6 @@
   [Web Animations: property <filter> from [contrast(0)\] to [none\] at (0) should be [contrast(0)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [initial\] to [sepia(1)\] at (0.5) should be [sepia(0.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [saturate(0)\] to [none\] at (0.5) should be [saturate(0.5)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #00C000)\]]
     expected: FAIL
 
@@ -540,9 +396,6 @@
     expected: FAIL
 
   [CSS Animations: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (0) should be [url("#svgfilter")\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [opacity(0)\] to [none\] at (0.5) should be [opacity(0.5)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [url("#svgfilter")\] to [none\] at (0.5) should be [none\]]
@@ -566,28 +419,10 @@
   [Web Animations: property <filter> from [none\] to [invert(1)\] at (-1) should be [invert(0)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [hue-rotate(360deg)\] at (0.5) should be [hue-rotate(180deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [hue-rotate(360deg)\] at (1.5) should be [hue-rotate(540deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [brightness(0)\] to [none\] at (1) should be [brightness(1)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [none\] to [blur(10px)\] at (1.5) should be [blur(15px)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [brightness(0)\] to [none\] at (-1) should be [brightness(0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [opacity(0)\] to [none\] at (1.5) should be [opacity(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [sepia(1)\] at (0) should be [sepia(0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [initial\] to [sepia(1)\] at (0.5) should be [sepia(0.5)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <filter> from [none\] to [hue-rotate(360deg)\] at (0.5) should be [hue-rotate(180deg)\]]
@@ -596,34 +431,13 @@
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [none\] at (0.3) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [invert(1)\] at (0.5) should be [invert(0.5)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [saturate(0)\] to [none\] at (0.5) should be [saturate(0.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [invert(1)\] at (1) should be [invert(1)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (1) should be [blur(5px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [initial\] to [sepia(1)\] at (1.5) should be [sepia(1)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (-1) should be [drop-shadow(-20px -10px transparent)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [hue-rotate(360deg)\] at (0) should be [hue-rotate(0deg)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [contrast(0)\] to [none\] at (1.5) should be [contrast(1.5)\]]
-    expected: FAIL
-
   [CSS Animations: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (1) should be [blur(5px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [opacity(0)\] to [none\] at (0) should be [opacity(0)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [url("#svgfilter")\] to [none\] at (0) should be [none\]]
@@ -635,9 +449,6 @@
   [Web Animations: property <filter> from [url("#svgfilter")\] to [none\] at (0.5) should be [none\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [initial\] to [sepia(1)\] at (0.5) should be [sepia(0.5)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [none\] at (0.5) should be [none\]]
     expected: FAIL
 
@@ -645,12 +456,6 @@
     expected: FAIL
 
   [CSS Transitions with transition: all: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1) should be [drop-shadow(20px 10px green)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [none\] to [grayscale(1)\] at (1.5) should be [grayscale(1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [grayscale(1)\] at (1.5) should be [grayscale(1)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [sepia(1)\] at (0.5) should be [sepia(0.5)\]]
@@ -665,22 +470,7 @@
   [Web Animations: property <filter> from [none\] to [grayscale(1)\] at (1) should be [grayscale(1)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [contrast(0)\] to [none\] at (-1) should be [contrast(0)\]]
-    expected: FAIL
-
   [CSS Transitions: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0) should be [drop-shadow(0px 0px 0px transparent)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [contrast(0)\] to [none\] at (1.5) should be [contrast(1.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [opacity(0)\] to [none\] at (0.5) should be [opacity(0.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [grayscale(1)\] at (-1) should be [grayscale(0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [contrast(0)\] to [none\] at (1.5) should be [contrast(1.5)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (0.6) should be [blur(5px)\]]
@@ -692,9 +482,6 @@
   [Web Animations: property <filter> from [url("#svgfilter")\] to [none\] at (1) should be [none\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [brightness(0)\] to [none\] at (1.5) should be [brightness(1.5)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [contrast(0)\] to [none\] at (0.5) should be [contrast(0.5)\]]
     expected: FAIL
 
@@ -704,13 +491,7 @@
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (0.5) should be [blur(5px)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [opacity(0)\] to [none\] at (1.5) should be [opacity(1)\]]
-    expected: FAIL
-
   [CSS Transitions: property <filter> from [url("#svgfilter")\] to [none\] at (1.5) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [grayscale(1)\] at (1.5) should be [grayscale(1)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (1) should be [blur(5px)\]]
@@ -719,28 +500,13 @@
   [CSS Transitions: property <filter> from [url("#svgfilter")\] to [blur(5px)\] at (0.3) should be [blur(5px)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [none\] to [sepia(1)\] at (1.5) should be [sepia(1)\]]
-    expected: FAIL
-
   [CSS Transitions: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (0.5) should be [drop-shadow(10px 5px rgba(0, 128, 0, 0.5))\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [none\] to [hue-rotate(360deg)\] at (0.5) should be [hue-rotate(180deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [none\] to [invert(1)\] at (1.5) should be [invert(1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [blur(10px)\] at (0.5) should be [blur(5px)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [saturate(0)\] to [none\] at (1.5) should be [saturate(1.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [saturate(0)\] to [none\] at (0) should be [saturate(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [sepia(1)\] at (0.5) should be [sepia(0.5)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [none\] to [grayscale(1)\] at (0.5) should be [grayscale(0.5)\]]
@@ -752,28 +518,10 @@
   [Web Animations: property <filter> from [none\] to [invert(1)\] at (0.5) should be [invert(0.5)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [opacity(0)\] to [none\] at (-1) should be [opacity(0)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [sepia(1)\] at (0.5) should be [sepia(0.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [none\] to [hue-rotate(360deg)\] at (1.5) should be [hue-rotate(540deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [contrast(0)\] to [none\] at (0.5) should be [contrast(0.5)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [opacity(0)\] to [none\] at (0) should be [opacity(0)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [url("#svgfilter")\] to [none\] at (0.6) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [initial\] to [sepia(1)\] at (1) should be [sepia(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [sepia(1)\] at (1) should be [sepia(1)\]]
     expected: FAIL
 
   [CSS Transitions with transition: all: property <filter> from [none\] to [drop-shadow(20px 10px green)\] at (1.5) should be [drop-shadow(30px 15px #00C000)\]]
@@ -782,16 +530,7 @@
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [none\] at (1) should be [none\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [saturate(0)\] to [none\] at (0.5) should be [saturate(0.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [none\] to [hue-rotate(360deg)\] at (1) should be [hue-rotate(360deg)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [url("#svgfilter")\] to [none\] at (-0.3) should be [none\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [none\] to [invert(1)\] at (0.5) should be [invert(0.5)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [saturate(0)\] to [none\] at (0.5) should be [saturate(0.5)\]]

--- a/tests/wpt/metadata/css/filter-effects/animation/filter-interpolation-004.html.ini
+++ b/tests/wpt/metadata/css/filter-effects/animation/filter-interpolation-004.html.ini
@@ -155,22 +155,7 @@
   [filter interpolation]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [sepia(0)\] to [sepia()\] at (0.5) should be [sepia(0.5)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [saturate(0)\] to [saturate()\] at (0.5) should be [saturate(0.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (-1) should be [hue-rotate(-360deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [contrast(0)\] to [contrast()\] at (0.5) should be [contrast(0.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [blur()\] to [blur(10px)\] at (-1) should be [blur(0px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [brightness(0)\] to [brightness()\] at (1) should be [brightness()\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [grayscale(0)\] to [grayscale()\] at (0) should be [grayscale(0)\]]
@@ -185,52 +170,19 @@
   [Web Animations: property <filter> from [blur()\] to [blur(10px)\] at (-1) should be [blur(0px)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [brightness(0)\] to [brightness()\] at (-1) should be [brightness(0)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [sepia(0)\] to [sepia()\] at (-1) should be [sepia(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [saturate(0)\] to [saturate()\] at (0) should be [saturate(0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [blur()\] to [blur(10px)\] at (0.5) should be [blur(5px)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [opacity(0)\] to [opacity()\] at (0.5) should be [opacity(0.5)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (1.5) should be [hue-rotate(540deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [blur()\] to [blur(10px)\] at (1.5) should be [blur(15px)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [contrast(0)\] to [contrast()\] at (0.5) should be [contrast(0.5)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [grayscale(0)\] to [grayscale()\] at (1.5) should be [grayscale(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [contrast(0)\] to [contrast()\] at (1) should be [contrast()\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (0) should be [hue-rotate()\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [invert(0)\] to [invert()\] at (1.5) should be [invert(1)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (0.5) should be [hue-rotate(180deg)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [invert(0)\] to [invert()\] at (0.5) should be [invert(0.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [saturate(0)\] to [saturate()\] at (-1) should be [saturate(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [grayscale(0)\] to [grayscale()\] at (0) should be [grayscale(0)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0.5) should be [drop-shadow(10px 5px 15px rgb(0, 64, 128))\]]
@@ -242,34 +194,10 @@
   [Web Animations: property <filter> from [brightness(0)\] to [brightness()\] at (1) should be [brightness()\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [invert(0)\] to [invert()\] at (1) should be [invert()\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (1.5) should be [hue-rotate(540deg)\]]
-    expected: FAIL
-
   [CSS Transitions: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1.5) should be [drop-shadow(30px 15px 45px rgb(0, 192, 0))\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [grayscale(0)\] to [grayscale()\] at (1.5) should be [grayscale(1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [sepia(0)\] to [sepia()\] at (1.5) should be [sepia(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [sepia(0)\] to [sepia()\] at (1.5) should be [sepia(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [invert(0)\] to [invert()\] at (0) should be [invert(0)\]]
-    expected: FAIL
-
   [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0) should be [drop-shadow(0px 0px blue)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [opacity(0)\] to [opacity()\] at (1.5) should be [opacity(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [grayscale(0)\] to [grayscale()\] at (-1) should be [grayscale(0)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [contrast(0)\] to [contrast()\] at (1.5) should be [contrast(1.5)\]]
@@ -281,37 +209,16 @@
   [Web Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0.5) should be [drop-shadow(10px 5px 15px rgb(0, 64, 128))\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [sepia(0)\] to [sepia()\] at (-1) should be [sepia(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [brightness(0)\] to [brightness()\] at (0) should be [brightness(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [sepia(0)\] to [sepia()\] at (1) should be [sepia()\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [invert(0)\] to [invert()\] at (1.5) should be [invert(1)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [blur()\] to [blur(10px)\] at (0) should be [blur()\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [brightness(0)\] to [brightness()\] at (1.5) should be [brightness(1.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [opacity(0)\] to [opacity()\] at (-1) should be [opacity(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [grayscale(0)\] to [grayscale()\] at (0.5) should be [grayscale(0.5)\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1) should be [drop-shadow(20px 10px 30px green)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [invert(0)\] to [invert()\] at (-1) should be [invert(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [contrast(0)\] to [contrast()\] at (1.5) should be [contrast(1.5)\]]
     expected: FAIL
 
   [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1) should be [drop-shadow(20px 10px 30px green)\]]
@@ -323,28 +230,7 @@
   [Web Animations: property <filter> from [blur()\] to [blur(10px)\] at (0) should be [blur()\]]
     expected: FAIL
 
-  [CSS Transitions: property <filter> from [invert(0)\] to [invert()\] at (1.5) should be [invert(1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [saturate(0)\] to [saturate()\] at (1.5) should be [saturate(1.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [opacity(0)\] to [opacity()\] at (0.5) should be [opacity(0.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [contrast(0)\] to [contrast()\] at (1.5) should be [contrast(1.5)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1) should be [drop-shadow(20px 10px 30px green)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [brightness(0)\] to [brightness()\] at (0.5) should be [brightness(0.5)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [blur()\] to [blur(10px)\] at (1.5) should be [blur(15px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [opacity(0)\] to [opacity()\] at (0) should be [opacity(0)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (0.5) should be [hue-rotate(180deg)\]]
@@ -353,16 +239,7 @@
   [Web Animations: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (1.5) should be [hue-rotate(540deg)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [contrast(0)\] to [contrast()\] at (0) should be [contrast(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [blur()\] to [blur(10px)\] at (0.5) should be [blur(5px)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [opacity(0)\] to [opacity()\] at (1) should be [opacity()\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [grayscale(0)\] to [grayscale()\] at (1) should be [grayscale()\]]
     expected: FAIL
 
   [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (-1) should be [drop-shadow(-20px -10px blue)\]]
@@ -374,16 +251,10 @@
   [Web Animations: property <filter> from [blur()\] to [blur(10px)\] at (1) should be [blur(10px)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [brightness(0)\] to [brightness()\] at (1.5) should be [brightness(1.5)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [invert(0)\] to [invert()\] at (1) should be [invert()\]]
     expected: FAIL
 
   [CSS Transitions: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (-1) should be [hue-rotate(-360deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (1.5) should be [hue-rotate(540deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [opacity(0)\] to [opacity()\] at (0) should be [opacity(0)\]]
@@ -407,37 +278,13 @@
   [Web Animations: property <filter> from [saturate(0)\] to [saturate()\] at (-1) should be [saturate(0)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [sepia(0)\] to [sepia()\] at (0.5) should be [sepia(0.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [blur()\] to [blur(10px)\] at (1.5) should be [blur(15px)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0) should be [drop-shadow(0px 0px blue)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (0) should be [hue-rotate()\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [saturate(0)\] to [saturate()\] at (0.5) should be [saturate(0.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [sepia(0)\] to [sepia()\] at (0.5) should be [sepia(0.5)\]]
     expected: FAIL
 
   [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1.5) should be [drop-shadow(30px 15px 45px rgb(0, 192, 0))\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [opacity(0)\] to [opacity()\] at (1.5) should be [opacity(1)\]]
-    expected: FAIL
-
   [CSS Transitions: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (-1) should be [drop-shadow(-20px -10px blue)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [blur()\] to [blur(10px)\] at (1) should be [blur(10px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (1) should be [hue-rotate(360deg)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [grayscale(0)\] to [grayscale()\] at (1) should be [grayscale()\]]
@@ -446,19 +293,7 @@
   [Web Animations: property <filter> from [grayscale(0)\] to [grayscale()\] at (0.5) should be [grayscale(0.5)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [saturate(0)\] to [saturate()\] at (1.5) should be [saturate(1.5)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [grayscale(0)\] to [grayscale()\] at (1.5) should be [grayscale(1)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [contrast(0)\] to [contrast()\] at (1.5) should be [contrast(1.5)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [opacity(0)\] to [opacity()\] at (1.5) should be [opacity(1)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [saturate(0)\] to [saturate()\] at (0.5) should be [saturate(0.5)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [invert(0)\] to [invert()\] at (0.5) should be [invert(0.5)\]]
@@ -467,40 +302,13 @@
   [Web Animations: property <filter> from [brightness(0)\] to [brightness()\] at (0.5) should be [brightness(0.5)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (0.5) should be [hue-rotate(180deg)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (1) should be [hue-rotate(360deg)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [invert(0)\] to [invert()\] at (0.5) should be [invert(0.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [contrast(0)\] to [contrast()\] at (-1) should be [contrast(0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [invert(0)\] to [invert()\] at (0.5) should be [invert(0.5)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [sepia(0)\] to [sepia()\] at (0) should be [sepia(0)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [sepia(0)\] to [sepia()\] at (0) should be [sepia(0)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [invert(0)\] to [invert()\] at (-1) should be [invert(0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [grayscale(0)\] to [grayscale()\] at (0.5) should be [grayscale(0.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [brightness(0)\] to [brightness()\] at (0.5) should be [brightness(0.5)\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [saturate(0)\] to [saturate()\] at (0) should be [saturate(0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [brightness(0)\] to [brightness()\] at (1.5) should be [brightness(1.5)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [saturate(0)\] to [saturate()\] at (1) should be [saturate()\]]
@@ -512,12 +320,6 @@
   [Web Animations: property <filter> from [brightness(0)\] to [brightness()\] at (0) should be [brightness(0)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [grayscale(0)\] to [grayscale()\] at (1.5) should be [grayscale(1)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [saturate(0)\] to [saturate()\] at (1.5) should be [saturate(1.5)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [hue-rotate()\] to [hue-rotate(360deg)\] at (-1) should be [hue-rotate(-360deg)\]]
     expected: FAIL
 
@@ -527,25 +329,10 @@
   [Web Animations: property <filter> from [opacity(0)\] to [opacity()\] at (0.5) should be [opacity(0.5)\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [brightness(0)\] to [brightness()\] at (1.5) should be [brightness(1.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [invert(0)\] to [invert()\] at (1.5) should be [invert(1)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [opacity(0)\] to [opacity()\] at (1.5) should be [opacity(1)\]]
-    expected: FAIL
-
   [CSS Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0.5) should be [drop-shadow(10px 5px 15px rgb(0, 64, 128))\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [contrast(0)\] to [contrast()\] at (0) should be [contrast(0)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [sepia(0)\] to [sepia()\] at (1.5) should be [sepia(1)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [opacity(0)\] to [opacity()\] at (1) should be [opacity()\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0) should be [drop-shadow(0px 0px blue)\]]
@@ -554,16 +341,7 @@
   [Web Animations: property <filter> from [brightness(0)\] to [brightness()\] at (-1) should be [brightness(0)\]]
     expected: FAIL
 
-  [CSS Transitions with transition: all: property <filter> from [grayscale(0)\] to [grayscale()\] at (0.5) should be [grayscale(0.5)\]]
-    expected: FAIL
-
-  [CSS Transitions with transition: all: property <filter> from [blur()\] to [blur(10px)\] at (0.5) should be [blur(5px)\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (1) should be [drop-shadow(20px 10px 30px green)\]]
-    expected: FAIL
-
-  [CSS Transitions: property <filter> from [contrast(0)\] to [contrast()\] at (0.5) should be [contrast(0.5)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [contrast(0)\] to [contrast()\] at (-1) should be [contrast(0)\]]
@@ -575,19 +353,7 @@
   [CSS Transitions with transition: all: property <filter> from [drop-shadow(0px 0px)\] to [drop-shadow(20px 10px 30px green)\] at (0.5) should be [drop-shadow(10px 5px 15px rgb(0, 64, 128))\]]
     expected: FAIL
 
-  [CSS Animations: property <filter> from [opacity(0)\] to [opacity()\] at (0.5) should be [opacity(0.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [brightness(0)\] to [brightness()\] at (0.5) should be [brightness(0.5)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [saturate(0)\] to [saturate()\] at (1) should be [saturate()\]]
-    expected: FAIL
-
   [Web Animations: property <filter> from [blur()\] to [blur(10px)\] at (1.5) should be [blur(15px)\]]
-    expected: FAIL
-
-  [CSS Animations: property <filter> from [saturate(0)\] to [saturate()\] at (0.5) should be [saturate(0.5)\]]
     expected: FAIL
 
   [Web Animations: property <filter> from [contrast(0)\] to [contrast()\] at (0.5) should be [contrast(0.5)\]]


### PR DESCRIPTION
When doing a restyle, we should apply animations and transitions to the
new style so that it is reflected in `getComputedStyle()` and the new
style information properly cascades. This is the first part of properly
ticking animations and transitions.

This causes a couple new animations tests failures (along with many new
passes), but we currently don't have support for properly handling
animations after they have completed, so this isn't totally unexpected.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #20116

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
