### PR TITLE
Add support for even more WebGL2 GetParameter enums

### DIFF
--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -793,6 +793,7 @@ parameters! {
             SampleCoverageInvert = gl::SAMPLE_COVERAGE_INVERT,
             TransformFeedbackActive = gl::TRANSFORM_FEEDBACK_ACTIVE,
             TransformFeedbackPaused = gl::TRANSFORM_FEEDBACK_PAUSED,
+            RasterizerDiscard = gl::RASTERIZER_DISCARD,
         }),
         Bool4(ParameterBool4 {
             ColorWritemask = gl::COLOR_WRITEMASK,
@@ -840,6 +841,14 @@ parameters! {
             MaxTransformFeedbackSeparateComponents = gl::MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS,
             TransformFeedbackBufferSize = gl::TRANSFORM_FEEDBACK_BUFFER_SIZE,
             TransformFeedbackBufferStart = gl::TRANSFORM_FEEDBACK_BUFFER_START,
+            PackRowLength = gl::PACK_ROW_LENGTH,
+            PackSkipPixels = gl::PACK_SKIP_PIXELS,
+            PackSkipRows = gl::PACK_SKIP_ROWS,
+            UnpackImageHeight = gl::UNPACK_IMAGE_HEIGHT,
+            UnpackRowLength = gl::UNPACK_ROW_LENGTH,
+            UnpackSkipImages = gl::UNPACK_SKIP_IMAGES,
+            UnpackSkipPixels = gl::UNPACK_SKIP_PIXELS,
+            UnpackSkipRows = gl::UNPACK_SKIP_ROWS,
         }),
         Int2(ParameterInt2 {
             MaxViewportDims = gl::MAX_VIEWPORT_DIMS,

--- a/tests/wpt/webgl/meta/conformance2/state/gl-get-calls.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/state/gl-get-calls.html.ini
@@ -5,36 +5,9 @@
   [WebGL test #80: context.getParameter(context.MIN_PROGRAM_TEXEL_OFFSET) is not an instance of Number]
     expected: FAIL
 
-  [WebGL test #26: context.getParameter(context.UNPACK_ROW_LENGTH) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #7: context.getParameter(context.PACK_ROW_LENGTH) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #27: context.getParameter(context.UNPACK_SKIP_IMAGES) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
   [WebGL test #87: context.getError() should be 0. Was 1280.]
     expected: FAIL
 
-  [WebGL test #29: context.getParameter(context.UNPACK_SKIP_ROWS) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #25: context.getParameter(context.UNPACK_IMAGE_HEIGHT) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
   [WebGL test #79: context.getParameter(context.MIN_PROGRAM_TEXEL_OFFSET) should be >= -8. Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #28: context.getParameter(context.UNPACK_SKIP_PIXELS) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #8: context.getParameter(context.PACK_SKIP_PIXELS) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #9: context.getParameter(context.PACK_SKIP_ROWS) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #12: context.getParameter(context.RASTERIZER_DISCARD) should be false (of type boolean). Was null (of type object).]
     expected: FAIL
 


### PR DESCRIPTION
Adds support for the following new WebGL2 GetParameter values:

- `PACK_ROW_LENGTH`
- `PACK_SKIP_PIXELS`
- `PACK_SKIP_ROWS`
- `RASTERIZER_DISCARD`
- `UNPACK_IMAGE_HEIGHT`
- `UNPACK_ROW_LENGTH`
- `UNPACK_SKIP_IMAGES`
- `UNPACK_SKIP_PIXELS`
- `UNPACK_SKIP_ROWS`

See: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2

<!-- Please describe your changes on the following line: -->

Depends on #26265 because they touch the same test file.

cc @jdm @zakorgy 


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
