### PR TITLE
Add support for WebGL2 MIN_PROGRAM_TEXEL_OFFSET

### DIFF
--- a/components/canvas/webgl_limits.rs
+++ b/components/canvas/webgl_limits.rs
@@ -95,7 +95,7 @@ impl GLLimitsDetect for GLLimits {
         if webgl_version == WebGLVersion::WebGL2 {
             max_uniform_block_size = gl.get_integer64(gl::MAX_UNIFORM_BLOCK_SIZE);
             max_uniform_buffer_bindings = gl.get_integer(gl::MAX_UNIFORM_BUFFER_BINDINGS);
-            min_program_texel_offset = gl.get_integer(gl::MIN_PROGRAM_TEXEL_OFFSET);
+            min_program_texel_offset = gl.get_signed_integer(gl::MIN_PROGRAM_TEXEL_OFFSET);
             max_program_texel_offset = gl.get_integer(gl::MAX_PROGRAM_TEXEL_OFFSET);
             max_transform_feedback_separate_attribs =
                 gl.get_integer(gl::MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS);
@@ -206,9 +206,11 @@ impl GLLimitsDetect for GLLimits {
 trait GLExt {
     fn try_get_integer(self, parameter: GLenum) -> Option<u32>;
     fn try_get_integer64(self, parameter: GLenum) -> Option<u64>;
+    fn try_get_signed_integer(self, parameter: GLenum) -> Option<i32>;
     fn try_get_float(self, parameter: GLenum) -> Option<f32>;
     fn get_integer(self, parameter: GLenum) -> u32;
     fn get_integer64(self, parameter: GLenum) -> u64;
+    fn get_signed_integer(self, parameter: GLenum) -> i32;
     fn get_float(self, parameter: GLenum) -> f32;
 }
 
@@ -236,5 +238,12 @@ macro_rules! create_fun {
 impl<'a> GLExt for &'a Gl {
     create_fun!(try_get_integer, get_integer, i32, get_integer_v, u32);
     create_fun!(try_get_integer64, get_integer64, i64, get_integer64_v, u64);
+    create_fun!(
+        try_get_signed_integer,
+        get_signed_integer,
+        i32,
+        get_integer_v,
+        i32
+    );
     create_fun!(try_get_float, get_float, f32, get_float_v, f32);
 }

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -793,6 +793,7 @@ parameters! {
             SampleCoverageInvert = gl::SAMPLE_COVERAGE_INVERT,
             TransformFeedbackActive = gl::TRANSFORM_FEEDBACK_ACTIVE,
             TransformFeedbackPaused = gl::TRANSFORM_FEEDBACK_PAUSED,
+            RasterizerDiscard = gl::RASTERIZER_DISCARD,
         }),
         Bool4(ParameterBool4 {
             ColorWritemask = gl::COLOR_WRITEMASK,
@@ -840,6 +841,14 @@ parameters! {
             MaxTransformFeedbackSeparateComponents = gl::MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS,
             TransformFeedbackBufferSize = gl::TRANSFORM_FEEDBACK_BUFFER_SIZE,
             TransformFeedbackBufferStart = gl::TRANSFORM_FEEDBACK_BUFFER_START,
+            PackRowLength = gl::PACK_ROW_LENGTH,
+            PackSkipPixels = gl::PACK_SKIP_PIXELS,
+            PackSkipRows = gl::PACK_SKIP_ROWS,
+            UnpackImageHeight = gl::UNPACK_IMAGE_HEIGHT,
+            UnpackRowLength = gl::UNPACK_ROW_LENGTH,
+            UnpackSkipImages = gl::UNPACK_SKIP_IMAGES,
+            UnpackSkipPixels = gl::UNPACK_SKIP_PIXELS,
+            UnpackSkipRows = gl::UNPACK_SKIP_ROWS,
         }),
         Int2(ParameterInt2 {
             MaxViewportDims = gl::MAX_VIEWPORT_DIMS,

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -1057,7 +1057,7 @@ pub struct GLLimits {
     pub max_draw_buffers: u32,
     pub max_color_attachments: u32,
     pub max_uniform_buffer_bindings: u32,
-    pub min_program_texel_offset: u32,
+    pub min_program_texel_offset: i32,
     pub max_program_texel_offset: u32,
     pub max_uniform_block_size: u64,
     pub max_combined_uniform_blocks: u32,

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -995,6 +995,9 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             constants::MAX_UNIFORM_BLOCK_SIZE => {
                 return DoubleValue(self.base.limits().max_uniform_block_size as f64)
             },
+            constants::MIN_PROGRAM_TEXEL_OFFSET => {
+                return Int32Value(self.base.limits().min_program_texel_offset)
+            },
             _ => {},
         }
 

--- a/tests/wpt/webgl/meta/conformance2/state/gl-get-calls.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/state/gl-get-calls.html.ini
@@ -2,12 +2,6 @@
   [WebGL test #55: context.getParameter(context.MAX_SAMPLES) should be >= 4. Was 1 (of type number).]
     expected: FAIL
 
-  [WebGL test #80: context.getParameter(context.MIN_PROGRAM_TEXEL_OFFSET) is not an instance of Number]
-    expected: FAIL
-
   [WebGL test #87: context.getError() should be 0. Was 1280.]
-    expected: FAIL
-
-  [WebGL test #79: context.getParameter(context.MIN_PROGRAM_TEXEL_OFFSET) should be >= -8. Was null (of type object).]
     expected: FAIL
 

--- a/tests/wpt/webgl/meta/conformance2/state/gl-get-calls.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/state/gl-get-calls.html.ini
@@ -5,36 +5,9 @@
   [WebGL test #80: context.getParameter(context.MIN_PROGRAM_TEXEL_OFFSET) is not an instance of Number]
     expected: FAIL
 
-  [WebGL test #26: context.getParameter(context.UNPACK_ROW_LENGTH) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #7: context.getParameter(context.PACK_ROW_LENGTH) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #27: context.getParameter(context.UNPACK_SKIP_IMAGES) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
   [WebGL test #87: context.getError() should be 0. Was 1280.]
     expected: FAIL
 
-  [WebGL test #29: context.getParameter(context.UNPACK_SKIP_ROWS) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #25: context.getParameter(context.UNPACK_IMAGE_HEIGHT) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
   [WebGL test #79: context.getParameter(context.MIN_PROGRAM_TEXEL_OFFSET) should be >= -8. Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #28: context.getParameter(context.UNPACK_SKIP_PIXELS) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #8: context.getParameter(context.PACK_SKIP_PIXELS) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #9: context.getParameter(context.PACK_SKIP_ROWS) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #12: context.getParameter(context.RASTERIZER_DISCARD) should be false (of type boolean). Was null (of type object).]
     expected: FAIL
 


### PR DESCRIPTION
Improves the support of the WebGL2 `MIN_PROGRAM_TEXEL_OFFSET` property (ie. stores it as a signed integer) and adds support for querying it using GetParameter.

See: https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2

<!-- Please describe your changes on the following line: -->

cc @jdm @zakorgy 

Depends on #26333 because they touch the same test files.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
