### PR TITLE
Add support for WebGL2 buffer types in GetBufferParameter

### DIFF
--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -867,8 +867,10 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
     }
 
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
-    fn GetBufferParameter(&self, cx: JSContext, target: u32, parameter: u32) -> JSVal {
-        self.base.GetBufferParameter(cx, target, parameter)
+    fn GetBufferParameter(&self, _cx: JSContext, target: u32, parameter: u32) -> JSVal {
+        let buffer =
+            handle_potential_webgl_error!(self.base, self.bound_buffer(target), return NullValue());
+        self.base.get_buffer_param(buffer, parameter)
     }
 
     #[allow(unsafe_code)]

--- a/tests/wpt/webgl/meta/conformance2/state/gl-object-get-calls.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/state/gl-object-get-calls.html.ini
@@ -6,25 +6,10 @@
   [WebGL test #201: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_WRAP_R) should be 33071 (of type number). Was null (of type object).]
     expected: FAIL
 
-  [WebGL test #10: gl.getBufferParameter(gl.COPY_WRITE_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #9: gl.getBufferParameter(gl.COPY_WRITE_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #16: gl.getBufferParameter(gl.PIXEL_UNPACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #4: gl.getBufferParameter(gl.ELEMENT_ARRAY_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
-    expected: FAIL
-
   [WebGL test #203: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_IMMUTABLE_LEVELS) should be 0 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #204: getTexParameter returned 1 instead of null for invalid parameter enum: 0x84fe]
-    expected: FAIL
-
-  [WebGL test #13: gl.getBufferParameter(gl.PIXEL_PACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #196: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_COMPARE_FUNC) should be 515 (of type number). Was null (of type object).]
@@ -36,9 +21,6 @@
   [WebGL test #199: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_MAX_LOD) should be 10 (of type number). Was null (of type object).]
     expected: FAIL
 
-  [WebGL test #15: gl.getBufferParameter(gl.PIXEL_UNPACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
   [WebGL test #202: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_IMMUTABLE_FORMAT) should be false (of type boolean). Was null (of type object).]
     expected: FAIL
 
@@ -46,9 +28,6 @@
     expected: FAIL
 
   [WebGL test #337: gl.getActiveUniformBlockName(program, 0) should be Transform. Was _uTransform.]
-    expected: FAIL
-
-  [WebGL test #22: gl.getBufferParameter(gl.UNIFORM_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #259: gl.getUniform(samplerForWebGL2Program, s2DArrayValLoc) should be 1. Was 0.]
@@ -64,30 +43,6 @@
     expected: FAIL
 
   [WebGL test #195: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_BASE_LEVEL) should be 0 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #3: gl.getBufferParameter(gl.ELEMENT_ARRAY_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #5: getBufferParameter did not generate INVALID_ENUM for invalid parameter enum: NO_ERROR]
-    expected: FAIL
-
-  [WebGL test #18: gl.getBufferParameter(gl.TRANSFORM_FEEDBACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #19: gl.getBufferParameter(gl.TRANSFORM_FEEDBACK_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #21: gl.getBufferParameter(gl.UNIFORM_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #7: gl.getBufferParameter(gl.COPY_READ_BUFFER, gl.BUFFER_USAGE) should be 35048 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #6: gl.getBufferParameter(gl.COPY_READ_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
-    expected: FAIL
-
-  [WebGL test #12: gl.getBufferParameter(gl.PIXEL_PACK_BUFFER, gl.BUFFER_SIZE) should be 16 (of type number). Was null (of type object).]
     expected: FAIL
 
   [WebGL test #197: gl.getTexParameter(gl.TEXTURE_2D, gl.TEXTURE_COMPARE_MODE) should be 34894 (of type number). Was null (of type object).]


### PR DESCRIPTION
This makes the new buffer types introduced in WebGL2 usable by the GetBufferParameter call.

<!-- Please describe your changes on the following line: -->

cc @jdm @zakorgy 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
