### PR TITLE
Improve devtools output for console APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3481,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.13.0"
-source = "git+https://github.com/servo/rust-mozjs#8615f86310d2e1021f7f1e5db4a0df98f4c8edb0"
+source = "git+https://github.com/servo/rust-mozjs#11cabdef2cbf0884a2cc33e3c73719646bd31ce5"
 dependencies = [
  "cc",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,4 @@ spirv_cross = { git = "https://github.com/servo/spirv_cross", branch = "wgpu-ser
 backtrace = { git = "https://github.com/MeFisto94/backtrace-rs", branch = "fix-strtab-freeing-crash" }
 surfman-chains = { git = "https://github.com/asajeffrey/surfman-chains" }
 surfman = { git = "https://github.com/servo/surfman" }
+

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -34,7 +34,7 @@ pub fn handle_evaluate_js(global: &GlobalScope, eval: String, reply: IpcSender<E
         let cx = global.get_cx();
         let _ac = enter_realm(global);
         rooted!(in(*cx) let mut rval = UndefinedValue());
-        global.evaluate_js_on_global_with_result(&eval, rval.handle_mut());
+        global.evaluate_script_on_global_with_result(&eval, "<eval>", rval.handle_mut(), 1);
 
         if rval.is_undefined() {
             EvaluateJSReply::VoidValue


### PR DESCRIPTION
These changes use the new API from https://github.com/servo/rust-mozjs/pull/508 to report meaningful filenames and line numbers for APIs that trigger devtools output. They also cause error messages originating from uncompiled event handlers to report a more relevant filename; this differs from Gecko's behaviour, but provides a more useful debugging experience in my opinion.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #9604 and fix #26344.
- [x] These changes do not require tests because devtools aren't tested.