### PR TITLE
Split animation cancellation from update_style_for_animation

### DIFF
--- a/components/layout/animation.rs
+++ b/components/layout/animation.rs
@@ -128,17 +128,16 @@ pub fn handle_running_animations(
     let mut running_animations =
         std::mem::replace(&mut animation_state.running_animations, Vec::new());
     for mut running_animation in running_animations.drain(..) {
-        let still_running = !running_animation.is_expired() &&
-            match running_animation {
-                Animation::Transition(_, started_at, ref property_animation) => {
-                    now < started_at + (property_animation.duration)
-                },
-                Animation::Keyframes(_, _, _, ref mut state) => {
-                    // This animation is still running, or we need to keep
-                    // iterating.
-                    now < state.started_at + state.duration || state.tick()
-                },
-            };
+        let still_running = match running_animation {
+            Animation::Transition(_, started_at, ref property_animation) => {
+                now < started_at + (property_animation.duration)
+            },
+            Animation::Keyframes(_, _, _, ref mut state) => {
+                // This animation is still running, or we need to keep
+                // iterating.
+                now < state.started_at + state.duration || state.tick()
+            },
+        };
 
         // If the animation is still running, add it back to the list of running animations.
         if still_running {
@@ -165,9 +164,8 @@ pub fn handle_cancelled_animations(
             Animation::Transition(_, _, ref property_animation) => {
                 send_transition_event(property_animation, TransitionEventType::TransitionCancel)
             },
-            Animation::Keyframes(..) => {
-                warn!("Got unexpected animation in finished transitions list.")
-            },
+            // TODO(mrobinson): We should send animationcancel events.
+            Animation::Keyframes(..) => {},
         }
     }
 }

--- a/components/style/matching.rs
+++ b/components/style/matching.rs
@@ -7,8 +7,6 @@
 #![allow(unsafe_code)]
 #![deny(missing_docs)]
 
-#[cfg(feature = "servo")]
-use crate::animation;
 use crate::computed_value_flags::ComputedValueFlags;
 use crate::context::{ElementCascadeInputs, QuirksMode, SelectorFlagsMap};
 use crate::context::{SharedStyleContext, StyleContext};
@@ -455,28 +453,13 @@ trait PrivateMatchMethods: TElement {
             );
         }
 
-        // Trigger any present animations if necessary.
-        animation::maybe_start_animations(
-            *self,
+        animation_state.update_animations_for_new_style(*self, &shared_context, &new_values);
+        animation_state.update_transitions_for_new_style(
             &shared_context,
             this_opaque,
-            &new_values,
-            &mut animation_state,
+            old_values.as_ref(),
+            new_values,
         );
-
-        // Trigger transitions if necessary. This will set `new_values` to
-        // the starting value of the transition if it did trigger a transition.
-        if let Some(ref old_values) = old_values {
-            let transitioning_properties = animation::start_transitions_if_applicable(
-                shared_context,
-                this_opaque,
-                old_values,
-                new_values,
-                &mut animation_state,
-            );
-            animation_state
-                .cancel_transitions_with_nontransitioning_properties(&transitioning_properties);
-        }
 
         animation_state.apply_running_animations::<Self>(
             shared_context,


### PR DESCRIPTION
`update_style_for_animation` previously handled both canceling defunct
animations and also updating style to reflect current animation state.
This change splits those two concerns because we want to start handling
replaced or canceled animations and finished animations in two different
places.

This is a refactor, so ideally it shouldn't change any behavior.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
