### PR TITLE
Add initial support for WebGL 2 `blitFramebuffer`

### DIFF
--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -1388,6 +1388,22 @@ impl WebGLImpl {
             WebGLCommand::BindTexture(target, id) => unsafe {
                 gl.bind_texture(target, id.map(WebGLTextureId::glow))
             },
+            WebGLCommand::BlitFrameBuffer(
+                src_x0,
+                src_y0,
+                src_x1,
+                src_y1,
+                dst_x0,
+                dst_y0,
+                dst_x1,
+                dst_y1,
+                mask,
+                filter,
+            ) => unsafe {
+                gl.blit_framebuffer(
+                    src_x0, src_y0, src_x1, src_y1, dst_x0, dst_y0, dst_x1, dst_y1, mask, filter,
+                );
+            },
             WebGLCommand::Uniform1f(uniform_id, v) => unsafe {
                 gl.uniform_1_f32(native_uniform_location(uniform_id).as_ref(), v)
             },

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -7,6 +7,7 @@ use std::cmp;
 use std::ptr::{self, NonNull};
 use std::rc::Rc;
 
+use bitflags::bitflags;
 use canvas_traits::webgl::WebGLError::*;
 use canvas_traits::webgl::{
     webgl_channel, GLContextAttributes, InternalFormatParameter, WebGLCommand, WebGLResult,
@@ -3319,6 +3320,107 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     fn RenderbufferStorage(&self, target: u32, internal_format: u32, width: i32, height: i32) {
         self.base
             .RenderbufferStorage(target, internal_format, width, height)
+    }
+
+    /// <https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.4S>
+    fn BlitFramebuffer(
+        &self,
+        src_x0: i32,
+        src_y0: i32,
+        src_x1: i32,
+        src_y1: i32,
+        dst_x0: i32,
+        dst_y0: i32,
+        dst_x1: i32,
+        dst_y1: i32,
+        mask: u32,
+        filter: u32,
+    ) {
+        bitflags! {
+            struct BlitFrameBufferFlags: u32 {
+                const DEPTH = constants::DEPTH_BUFFER_BIT;
+                const COLOR = constants::COLOR_BUFFER_BIT;
+                const STENCIL = constants::STENCIL_BUFFER_BIT;
+                const DEPTH_STENCIL = constants::DEPTH_BUFFER_BIT | constants::STENCIL_BUFFER_BIT;
+            }
+        };
+        let Some(bits) = BlitFrameBufferFlags::from_bits(mask) else {
+            return self.base.webgl_error(InvalidValue);
+        };
+        let attributes = self.base.GetContextAttributes().unwrap();
+
+        if bits.intersects(BlitFrameBufferFlags::DEPTH_STENCIL) {
+            match filter {
+                constants::LINEAR => return self.base.webgl_error(InvalidOperation),
+                constants::NEAREST => {},
+                _ => return self.base.webgl_error(InvalidOperation),
+            }
+        }
+
+        let src_fb = self.base.get_read_framebuffer_slot().get();
+        let dst_fb = self.base.get_draw_framebuffer_slot().get();
+
+        let get_default_formats = || -> WebGLResult<(Option<u32>, Option<u32>, Option<u32>)> {
+            // All attempts to blit to an antialiased back buffer should fail.
+            if attributes.antialias {
+                return Err(InvalidOperation);
+            };
+            let color = if attributes.alpha {
+                Some(constants::RGBA8)
+            } else {
+                Some(constants::RGB8)
+            };
+            let (depth, stencil) = match (attributes.depth, attributes.stencil) {
+                (true, true) => (
+                    Some(constants::DEPTH24_STENCIL8),
+                    Some(constants::DEPTH24_STENCIL8),
+                ),
+                (true, false) => (Some(constants::DEPTH_COMPONENT16), None),
+                (false, true) => (None, Some(constants::STENCIL_INDEX8)),
+                _ => (None, None),
+            };
+            Ok((color, depth, stencil))
+        };
+
+        let (src_color, src_depth, src_stencil) = match src_fb {
+            Some(fb) => {
+                handle_potential_webgl_error!(self.base, fb.get_attachment_formats(), return)
+            },
+            None => handle_potential_webgl_error!(self.base, get_default_formats(), return),
+        };
+        let (dst_color, dst_depth, dst_stencil) = match dst_fb {
+            Some(fb) => {
+                handle_potential_webgl_error!(self.base, fb.get_attachment_formats(), return)
+            },
+            None => handle_potential_webgl_error!(self.base, get_default_formats(), return),
+        };
+
+        if bits.intersects(BlitFrameBufferFlags::COLOR) && src_color != dst_color {
+            return self.base.webgl_error(InvalidOperation);
+        }
+        if bits.intersects(BlitFrameBufferFlags::DEPTH) && src_depth != dst_depth {
+            return self.base.webgl_error(InvalidOperation);
+        }
+        if bits.intersects(BlitFrameBufferFlags::STENCIL) && src_stencil != dst_stencil {
+            return self.base.webgl_error(InvalidOperation);
+        }
+
+        let src_width = src_x1.checked_sub(src_x0);
+        let dst_width = dst_x1.checked_sub(dst_x0);
+        let src_height = src_y1.checked_sub(src_y0);
+        let dst_height = dst_y1.checked_sub(dst_y0);
+
+        if src_width.is_none() ||
+            dst_width.is_none() ||
+            src_height.is_none() ||
+            dst_height.is_none()
+        {
+            return self.base.webgl_error(InvalidOperation);
+        }
+
+        self.base.send_command(WebGLCommand::BlitFrameBuffer(
+            src_x0, src_y0, src_x1, src_y1, dst_x0, dst_y0, dst_x1, dst_y1, mask, filter,
+        ));
     }
 
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6>

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -234,6 +234,25 @@ impl WebGLFramebuffer {
         self.size.get()
     }
 
+    pub fn get_attachment_formats(&self) -> WebGLResult<(Option<u32>, Option<u32>, Option<u32>)> {
+        if self.check_status() != constants::FRAMEBUFFER_COMPLETE {
+            return Err(WebGLError::InvalidFramebufferOperation);
+        }
+        let color = match self.attachment(constants::COLOR_ATTACHMENT0) {
+            Some(WebGLFramebufferAttachmentRoot::Renderbuffer(rb)) => Some(rb.internal_format()),
+            _ => None,
+        };
+        let depth = match self.attachment(constants::DEPTH_ATTACHMENT) {
+            Some(WebGLFramebufferAttachmentRoot::Renderbuffer(rb)) => Some(rb.internal_format()),
+            _ => None,
+        };
+        let stencil = match self.attachment(constants::STENCIL_ATTACHMENT) {
+            Some(WebGLFramebufferAttachmentRoot::Renderbuffer(rb)) => Some(rb.internal_format()),
+            _ => None,
+        };
+        Ok((color, depth, stencil))
+    }
+
     fn check_attachment_constraints<'a>(
         &self,
         attachment: &Option<WebGLFramebufferAttachment>,

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -295,8 +295,8 @@ interface mixin WebGL2RenderingContextBase
                         optional GLuint dstOffset = 0, optional GLuint length = 0);
 
   /* Framebuffer objects */
-  // void blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0,
-  //                      GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
+  undefined blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0,
+                       GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
   undefined framebufferTextureLayer(GLenum target, GLenum attachment, WebGLTexture? texture, GLint level,
                                GLint layer);
   undefined invalidateFramebuffer(GLenum target, sequence<GLenum> attachments);

--- a/components/shared/canvas/webgl.rs
+++ b/components/shared/canvas/webgl.rs
@@ -272,6 +272,7 @@ pub enum WebGLCommand {
     BindFramebuffer(u32, WebGLFramebufferBindingRequest),
     BindRenderbuffer(u32, Option<WebGLRenderbufferId>),
     BindTexture(u32, Option<WebGLTextureId>),
+    BlitFrameBuffer(i32, i32, i32, i32, i32, i32, i32, i32, u32, u32),
     DisableVertexAttribArray(u32),
     EnableVertexAttribArray(u32),
     FramebufferRenderbuffer(u32, u32, u32, Option<WebGLRenderbufferId>),

--- a/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
@@ -22,3 +22,18 @@
 
   [WebGL test #7: makeXRCompatible]
     expected: FAIL
+
+  [WebGL test #0: Property either does not exist or is not a function: texImage3D]
+    expected: FAIL
+
+  [WebGL test #1: Property either does not exist or is not a function: texSubImage3D]
+    expected: FAIL
+
+  [WebGL test #2: Property either does not exist or is not a function: copyTexSubImage3D]
+    expected: FAIL
+
+  [WebGL test #3: Property either does not exist or is not a function: compressedTexImage3D]
+    expected: FAIL
+
+  [WebGL test #4: Property either does not exist or is not a function: compressedTexSubImage3D]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/invalidate-framebuffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/invalidate-framebuffer.html.ini
@@ -1,8 +1,13 @@
 [invalidate-framebuffer.html]
   bug: https://github.com/servo/servo/issues/20529
   expected:
-    if os == "linux": ERROR
+    if os == "linux": OK
     if os == "mac": CRASH
   [WebGL test #17: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #25: getError expected one of: INVALID_OPERATION or INVALID_ENUM. Was NO_ERROR : calling invalidateSubFramebuffer to invalidate a COLOR_ATTACHMENT that exceeds MAX_COLOR_ATTACHMENT should generate INVALID_ENUM or INVALID_OPERATION.]
+    expected: FAIL
+
+  [WebGL test #26: getError expected one of: INVALID_OPERATION or INVALID_ENUM. Was NO_ERROR : calling invalidateFramebuffer to invalidate a COLOR_ATTACHMENT that exceeds MAX_COLOR_ATTACHMENT should generate INVALID_ENUM or INVALID_OPERATION.]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/multisample-draws-between-blits.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/multisample-draws-between-blits.html.ini
@@ -1,4 +1,45 @@
 [multisample-draws-between-blits.html]
-  expected: ERROR
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL
+
+  [WebGL test #0: whole thing\nat (0, 0) expected: 255,0,0,255 was 65,255,65,255]
+    expected: FAIL
+
+  [WebGL test #1: left\nat (0, 0) expected: 255,0,0,255 was 65,255,65,255]
+    expected: FAIL
+
+  [WebGL test #2: right\nat (64, 0) expected: 0,255,0,255 was 65,255,65,255]
+    expected: FAIL
+
+  [WebGL test #3: left edge\nat (0, 0) expected: 255,0,0,255 was 65,255,65,255]
+    expected: FAIL
+
+  [WebGL test #4: right edge\nat (96, 0) expected: 0,255,0,255 was 65,255,65,255]
+    expected: FAIL
+
+  [WebGL test #5: left of center\nat (32, 0) expected: 255,128,128,255 was 65,255,65,255]
+    expected: FAIL
+
+  [WebGL test #6: right of center\nat (64, 0) expected: 128,255,128,255 was 65,255,65,255]
+    expected: FAIL
+
+  [WebGL test #0: whole thing\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #1: left\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #2: right\nat (64, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #3: left edge\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #4: right edge\nat (96, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #5: left of center\nat (32, 0) expected: 255,128,128,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #6: right of center\nat (64, 0) expected: 128,255,128,255 was 0,0,0,0]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/multisample-with-full-sample-counts.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/multisample-with-full-sample-counts.html.ini
@@ -1,5 +1,51 @@
 [multisample-with-full-sample-counts.html]
-  expected: ERROR
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #0: User buffer has been rendered to red with sample = 1, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #1: User buffer has been rendered to red with sample = 1, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #2: User buffer has been rendered to red with sample = 2, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #3: User buffer has been rendered to red with sample = 2, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #4: User buffer has been rendered to red with sample = 3, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #5: User buffer has been rendered to red with sample = 3, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #6: User buffer has been rendered to red with sample = 4, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #7: User buffer has been rendered to red with sample = 4, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #8: User buffer has been rendered to red with sample = 5, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #9: User buffer has been rendered to red with sample = 5, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #10: User buffer has been rendered to red with sample = 6, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #11: User buffer has been rendered to red with sample = 6, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #12: User buffer has been rendered to red with sample = 7, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #13: User buffer has been rendered to red with sample = 7, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #14: User buffer has been rendered to red with sample = 8, coverageValue = 1 and isInverted = false\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #15: User buffer has been rendered to red with sample = 8, coverageValue = 0 and isInverted = true\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html.ini
@@ -1,5 +1,4 @@
 [multisampled-depth-renderbuffer-initialization.html]
-  expected: ERROR
   [WebGL test #5: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
@@ -10,4 +9,58 @@
     expected: FAIL
 
   [WebGL test #8: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL
+
+  [WebGL test #9: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #17: should be 0,0,255,255\nat (16, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #25: should be 0,0,255,255\nat (1, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #33: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #39: getError expected: NO_ERROR. Was INVALID_OPERATION : should be no error after renderbufferStorageMultisample(DEPTH_COMPONENT16).]
+    expected: FAIL
+
+  [WebGL test #42: should be 0,0,255,255\nat (1, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #50: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #58: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #66: should be 0,0,255,255\nat (1, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #74: should be 0,0,255,255\nat (1, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #80: getError expected: NO_ERROR. Was INVALID_OPERATION : should be no error after renderbufferStorageMultisample(DEPTH_COMPONENT16).]
+    expected: FAIL
+
+  [WebGL test #83: should be 0,0,255,255\nat (1, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #17: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #25: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #42: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #66: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #74: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #83: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
     expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-renderbuffer-initialization.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-renderbuffer-initialization.html.ini
@@ -1,5 +1,33 @@
 [multisampled-renderbuffer-initialization.html]
-  expected: ERROR
   [WebGL test #9: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #10: user buffer has been initialized to 0\nat (0, 0) expected: 0,0,0,0 was 65,255,65,255]
+    expected: FAIL
+
+  [WebGL test #22: user buffer has been initialized to 0\nat (0, 0) expected: 0,0,0,0 was 4,255,1,134]
+    expected: FAIL
+
+  [WebGL test #35: user buffer has been initialized to 0\nat (0, 0) expected: 0,0,0,0 was 5,0,0,50]
+    expected: FAIL
+
+  [WebGL test #48: user buffer has been initialized to 0\nat (0, 0) expected: 0,0,0,0 was 65,255,65,255]
+    expected: FAIL
+
+  [WebGL test #61: user buffer has been initialized to 0\nat (0, 0) expected: 0,0,0,0 was 5,0,252,190]
+    expected: FAIL
+
+  [WebGL test #73: user buffer has been initialized to 0\nat (0, 0) expected: 0,0,0,0 was 65,255,65,255]
+    expected: FAIL
+
+  [WebGL test #85: user buffer has been initialized to 0\nat (0, 0) expected: 0,0,0,0 was 65,255,65,255]
+    expected: FAIL
+
+  [WebGL test #98: user buffer has been initialized to 0\nat (0, 0) expected: 0,0,0,0 was 65,255,65,255]
+    expected: FAIL
+
+  [WebGL test #111: user buffer has been initialized to 0\nat (0, 0) expected: 0,0,0,0 was 65,255,65,255]
+    expected: FAIL
+
+  [WebGL test #124: user buffer has been initialized to 0\nat (0, 0) expected: 0,0,0,0 was 65,255,65,255]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-stencil-renderbuffer-initialization.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/renderbuffers/multisampled-stencil-renderbuffer-initialization.html.ini
@@ -1,5 +1,36 @@
 [multisampled-stencil-renderbuffer-initialization.html]
-  expected: ERROR
   [WebGL test #5: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #6: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #22: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #30: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #36: getError expected: NO_ERROR. Was INVALID_OPERATION : should be no error after renderbufferStorageMultisample(STENCIL_INDEX8).]
+    expected: FAIL
+
+  [WebGL test #39: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #47: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #55: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #63: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #71: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL
+
+  [WebGL test #77: getError expected: NO_ERROR. Was INVALID_OPERATION : should be no error after renderbufferStorageMultisample(STENCIL_INDEX8).]
+    expected: FAIL
+
+  [WebGL test #80: should be 0,0,255,255\nat (0, 0) expected: 0,0,255,255 was 0,255,0,255]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-filter-outofbounds.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-filter-outofbounds.html.ini
@@ -1,5 +1,39 @@
 [blitframebuffer-filter-outofbounds.html]
-  expected: ERROR
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #421: pixel at [4, 4\] should be (0,0,0,0), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #422: pixel at [5, 4\] should be (0,0,0,0), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #423: pixel at [6, 4\] should be (0,0,0,0), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #424: pixel at [7, 4\] should be (0,0,0,0), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #429: pixel at [4, 5\] should be (0,0,0,0), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #437: pixel at [4, 6\] should be (0,0,0,0), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #445: pixel at [4, 7\] should be (0,0,0,0), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #494: pixel at [5, 5\] should be (32,32,32,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #495: pixel at [6, 5\] should be (32,32,32,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #496: pixel at [7, 5\] should be (32,32,32,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #502: pixel at [5, 6\] should be (32,32,32,255), but the actual color is (0,0,0,0)]
+    expected: FAIL
+
+  [WebGL test #510: pixel at [5, 7\] should be (32,32,32,255), but the actual color is (0,0,0,0)]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-filter-srgb.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-filter-srgb.html.ini
@@ -1,5 +1,852 @@
 [blitframebuffer-filter-srgb.html]
-  expected: ERROR
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #1: pixel at [0, 0\] should be (110,110,110,255), but the actual color is (40,40,40,255)]
+    expected: FAIL
+
+  [WebGL test #2: pixel at [1, 0\] should be (110,110,255,145), but the actual color is (40,40,255,72)]
+    expected: FAIL
+
+  [WebGL test #3: pixel at [0, 1\] should be (212,212,212,255), but the actual color is (168,168,168,255)]
+    expected: FAIL
+
+  [WebGL test #4: pixel at [1, 1\] should be (212,212,255,229), but the actual color is (168,168,255,200)]
+    expected: FAIL
+
+  [WebGL test #6: pixel at [1, 0\] should be (0,0,255,34), but the actual color is (0,0,255,4)]
+    expected: FAIL
+
+  [WebGL test #7: pixel at [2, 0\] should be (0,255,34,34), but the actual color is (0,255,4,4)]
+    expected: FAIL
+
+  [WebGL test #8: pixel at [3, 0\] should be (255,34,34,34), but the actual color is (255,4,4,4)]
+    expected: FAIL
+
+  [WebGL test #9: pixel at [4, 0\] should be (34,34,34,255), but the actual color is (4,4,4,255)]
+    expected: FAIL
+
+  [WebGL test #10: pixel at [5, 0\] should be (34,34,255,61), but the actual color is (4,4,255,12)]
+    expected: FAIL
+
+  [WebGL test #11: pixel at [6, 0\] should be (34,255,61,61), but the actual color is (4,255,12,12)]
+    expected: FAIL
+
+  [WebGL test #12: pixel at [7, 0\] should be (255,61,61,61), but the actual color is (255,12,12,12)]
+    expected: FAIL
+
+  [WebGL test #13: pixel at [0, 1\] should be (71,71,71,255), but the actual color is (16,16,16,255)]
+    expected: FAIL
+
+  [WebGL test #14: pixel at [1, 1\] should be (71,71,255,79), but the actual color is (16,16,255,20)]
+    expected: FAIL
+
+  [WebGL test #15: pixel at [2, 1\] should be (71,255,79,79), but the actual color is (16,255,20,20)]
+    expected: FAIL
+
+  [WebGL test #16: pixel at [3, 1\] should be (255,79,79,79), but the actual color is (255,20,20,20)]
+    expected: FAIL
+
+  [WebGL test #17: pixel at [4, 1\] should be (79,79,79,255), but the actual color is (20,20,20,255)]
+    expected: FAIL
+
+  [WebGL test #18: pixel at [5, 1\] should be (79,79,255,93), but the actual color is (20,20,255,28)]
+    expected: FAIL
+
+  [WebGL test #19: pixel at [6, 1\] should be (79,255,93,93), but the actual color is (20,255,28,28)]
+    expected: FAIL
+
+  [WebGL test #20: pixel at [7, 1\] should be (255,93,93,93), but the actual color is (255,28,28,28)]
+    expected: FAIL
+
+  [WebGL test #21: pixel at [0, 2\] should be (120,120,120,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #22: pixel at [1, 2\] should be (120,120,255,125), but the actual color is (48,48,255,52)]
+    expected: FAIL
+
+  [WebGL test #23: pixel at [2, 2\] should be (120,255,125,125), but the actual color is (48,255,52,52)]
+    expected: FAIL
+
+  [WebGL test #24: pixel at [3, 2\] should be (255,125,125,125), but the actual color is (255,52,52,52)]
+    expected: FAIL
+
+  [WebGL test #25: pixel at [4, 2\] should be (125,125,125,255), but the actual color is (52,52,52,255)]
+    expected: FAIL
+
+  [WebGL test #26: pixel at [5, 2\] should be (125,125,255,133), but the actual color is (52,52,255,60)]
+    expected: FAIL
+
+  [WebGL test #27: pixel at [6, 2\] should be (125,255,133,133), but the actual color is (52,255,60,60)]
+    expected: FAIL
+
+  [WebGL test #28: pixel at [7, 2\] should be (255,133,133,133), but the actual color is (255,60,60,60)]
+    expected: FAIL
+
+  [WebGL test #29: pixel at [0, 3\] should be (152,152,152,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #30: pixel at [1, 3\] should be (152,152,255,155), but the actual color is (80,80,255,84)]
+    expected: FAIL
+
+  [WebGL test #31: pixel at [2, 3\] should be (152,255,155,155), but the actual color is (80,255,84,84)]
+    expected: FAIL
+
+  [WebGL test #32: pixel at [3, 3\] should be (255,155,155,155), but the actual color is (255,84,84,84)]
+    expected: FAIL
+
+  [WebGL test #33: pixel at [4, 3\] should be (155,155,155,255), but the actual color is (84,84,84,255)]
+    expected: FAIL
+
+  [WebGL test #34: pixel at [5, 3\] should be (155,155,255,162), but the actual color is (84,84,255,92)]
+    expected: FAIL
+
+  [WebGL test #35: pixel at [6, 3\] should be (155,255,162,162), but the actual color is (84,255,92,92)]
+    expected: FAIL
+
+  [WebGL test #36: pixel at [7, 3\] should be (255,162,162,162), but the actual color is (255,92,92,92)]
+    expected: FAIL
+
+  [WebGL test #37: pixel at [0, 4\] should be (177,177,177,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #38: pixel at [1, 4\] should be (177,177,255,180), but the actual color is (112,112,255,116)]
+    expected: FAIL
+
+  [WebGL test #39: pixel at [2, 4\] should be (177,255,180,180), but the actual color is (112,255,116,116)]
+    expected: FAIL
+
+  [WebGL test #40: pixel at [3, 4\] should be (255,180,180,180), but the actual color is (255,116,116,116)]
+    expected: FAIL
+
+  [WebGL test #41: pixel at [4, 4\] should be (180,180,180,255), but the actual color is (116,116,116,255)]
+    expected: FAIL
+
+  [WebGL test #42: pixel at [5, 4\] should be (180,180,255,185), but the actual color is (116,116,255,124)]
+    expected: FAIL
+
+  [WebGL test #43: pixel at [6, 4\] should be (180,255,185,185), but the actual color is (116,255,124,124)]
+    expected: FAIL
+
+  [WebGL test #44: pixel at [7, 4\] should be (255,185,185,185), but the actual color is (255,124,124,124)]
+    expected: FAIL
+
+  [WebGL test #45: pixel at [0, 5\] should be (198,198,198,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #46: pixel at [1, 5\] should be (198,198,255,200), but the actual color is (144,144,255,148)]
+    expected: FAIL
+
+  [WebGL test #47: pixel at [2, 5\] should be (198,255,200,200), but the actual color is (144,255,148,148)]
+    expected: FAIL
+
+  [WebGL test #48: pixel at [3, 5\] should be (255,200,200,200), but the actual color is (255,148,148,148)]
+    expected: FAIL
+
+  [WebGL test #49: pixel at [4, 5\] should be (200,200,200,255), but the actual color is (148,148,148,255)]
+    expected: FAIL
+
+  [WebGL test #50: pixel at [5, 5\] should be (200,200,255,205), but the actual color is (148,148,255,156)]
+    expected: FAIL
+
+  [WebGL test #51: pixel at [6, 5\] should be (200,255,205,205), but the actual color is (148,255,156,156)]
+    expected: FAIL
+
+  [WebGL test #52: pixel at [7, 5\] should be (255,205,205,205), but the actual color is (255,156,156,156)]
+    expected: FAIL
+
+  [WebGL test #53: pixel at [0, 6\] should be (216,216,216,255), but the actual color is (176,176,176,255)]
+    expected: FAIL
+
+  [WebGL test #54: pixel at [1, 6\] should be (216,216,255,219), but the actual color is (176,176,255,180)]
+    expected: FAIL
+
+  [WebGL test #55: pixel at [2, 6\] should be (216,255,219,219), but the actual color is (176,255,180,180)]
+    expected: FAIL
+
+  [WebGL test #56: pixel at [3, 6\] should be (255,219,219,219), but the actual color is (255,180,180,180)]
+    expected: FAIL
+
+  [WebGL test #57: pixel at [4, 6\] should be (219,219,219,255), but the actual color is (180,180,180,255)]
+    expected: FAIL
+
+  [WebGL test #58: pixel at [5, 6\] should be (219,219,255,223), but the actual color is (180,180,255,188)]
+    expected: FAIL
+
+  [WebGL test #59: pixel at [6, 6\] should be (219,255,223,223), but the actual color is (180,255,188,188)]
+    expected: FAIL
+
+  [WebGL test #60: pixel at [7, 6\] should be (255,223,223,223), but the actual color is (255,188,188,188)]
+    expected: FAIL
+
+  [WebGL test #61: pixel at [0, 7\] should be (225,225,225,255), but the actual color is (192,192,192,255)]
+    expected: FAIL
+
+  [WebGL test #62: pixel at [1, 7\] should be (225,225,255,227), but the actual color is (192,192,255,196)]
+    expected: FAIL
+
+  [WebGL test #63: pixel at [2, 7\] should be (225,255,227,227), but the actual color is (192,255,196,196)]
+    expected: FAIL
+
+  [WebGL test #64: pixel at [3, 7\] should be (255,227,227,227), but the actual color is (255,196,196,196)]
+    expected: FAIL
+
+  [WebGL test #65: pixel at [4, 7\] should be (227,227,227,255), but the actual color is (196,196,196,255)]
+    expected: FAIL
+
+  [WebGL test #66: pixel at [5, 7\] should be (227,227,255,231), but the actual color is (196,196,255,204)]
+    expected: FAIL
+
+  [WebGL test #67: pixel at [6, 7\] should be (227,255,231,231), but the actual color is (196,255,204,204)]
+    expected: FAIL
+
+  [WebGL test #68: pixel at [7, 7\] should be (255,231,231,231), but the actual color is (255,204,204,204)]
+    expected: FAIL
+
+  [WebGL test #69: pixel at [0, 0\] should be (8,8,8,255), but the actual color is (40,40,40,255)]
+    expected: FAIL
+
+  [WebGL test #70: pixel at [1, 0\] should be (8,8,255,21), but the actual color is (40,40,255,72)]
+    expected: FAIL
+
+  [WebGL test #71: pixel at [0, 1\] should be (105,105,105,255), but the actual color is (168,168,168,255)]
+    expected: FAIL
+
+  [WebGL test #72: pixel at [1, 1\] should be (105,105,255,153), but the actual color is (168,168,255,200)]
+    expected: FAIL
+
+  [WebGL test #78: pixel at [5, 0\] should be (0,0,255,1), but the actual color is (4,4,255,12)]
+    expected: FAIL
+
+  [WebGL test #79: pixel at [6, 0\] should be (0,255,1,1), but the actual color is (4,255,12,12)]
+    expected: FAIL
+
+  [WebGL test #80: pixel at [7, 0\] should be (255,1,1,1), but the actual color is (255,12,12,12)]
+    expected: FAIL
+
+  [WebGL test #81: pixel at [0, 1\] should be (3,3,3,255), but the actual color is (16,16,16,255)]
+    expected: FAIL
+
+  [WebGL test #82: pixel at [1, 1\] should be (3,3,255,4), but the actual color is (16,16,255,20)]
+    expected: FAIL
+
+  [WebGL test #83: pixel at [2, 1\] should be (3,255,4,4), but the actual color is (16,255,20,20)]
+    expected: FAIL
+
+  [WebGL test #84: pixel at [3, 1\] should be (255,4,4,4), but the actual color is (255,20,20,20)]
+    expected: FAIL
+
+  [WebGL test #85: pixel at [4, 1\] should be (4,4,4,255), but the actual color is (20,20,20,255)]
+    expected: FAIL
+
+  [WebGL test #86: pixel at [5, 1\] should be (4,4,255,5), but the actual color is (20,20,255,28)]
+    expected: FAIL
+
+  [WebGL test #87: pixel at [6, 1\] should be (4,255,5,5), but the actual color is (20,255,28,28)]
+    expected: FAIL
+
+  [WebGL test #88: pixel at [7, 1\] should be (255,5,5,5), but the actual color is (255,28,28,28)]
+    expected: FAIL
+
+  [WebGL test #89: pixel at [0, 2\] should be (10,10,10,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #90: pixel at [1, 2\] should be (10,10,255,11), but the actual color is (48,48,255,52)]
+    expected: FAIL
+
+  [WebGL test #91: pixel at [2, 2\] should be (10,255,11,11), but the actual color is (48,255,52,52)]
+    expected: FAIL
+
+  [WebGL test #92: pixel at [3, 2\] should be (255,11,11,11), but the actual color is (255,52,52,52)]
+    expected: FAIL
+
+  [WebGL test #93: pixel at [4, 2\] should be (11,11,11,255), but the actual color is (52,52,52,255)]
+    expected: FAIL
+
+  [WebGL test #94: pixel at [5, 2\] should be (11,11,255,14), but the actual color is (52,52,255,60)]
+    expected: FAIL
+
+  [WebGL test #95: pixel at [6, 2\] should be (11,255,14,14), but the actual color is (52,255,60,60)]
+    expected: FAIL
+
+  [WebGL test #96: pixel at [7, 2\] should be (255,14,14,14), but the actual color is (255,60,60,60)]
+    expected: FAIL
+
+  [WebGL test #97: pixel at [0, 3\] should be (23,23,23,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #98: pixel at [1, 3\] should be (23,23,255,26), but the actual color is (80,80,255,84)]
+    expected: FAIL
+
+  [WebGL test #99: pixel at [2, 3\] should be (23,255,26,26), but the actual color is (80,255,84,84)]
+    expected: FAIL
+
+  [WebGL test #100: pixel at [3, 3\] should be (255,26,26,26), but the actual color is (255,84,84,84)]
+    expected: FAIL
+
+  [WebGL test #101: pixel at [4, 3\] should be (26,26,26,255), but the actual color is (84,84,84,255)]
+    expected: FAIL
+
+  [WebGL test #102: pixel at [5, 3\] should be (26,26,255,30), but the actual color is (84,84,255,92)]
+    expected: FAIL
+
+  [WebGL test #103: pixel at [6, 3\] should be (26,255,30,30), but the actual color is (84,255,92,92)]
+    expected: FAIL
+
+  [WebGL test #104: pixel at [7, 3\] should be (255,30,30,30), but the actual color is (255,92,92,92)]
+    expected: FAIL
+
+  [WebGL test #105: pixel at [0, 4\] should be (44,44,44,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #106: pixel at [1, 4\] should be (44,44,255,48), but the actual color is (112,112,255,116)]
+    expected: FAIL
+
+  [WebGL test #107: pixel at [2, 4\] should be (44,255,48,48), but the actual color is (112,255,116,116)]
+    expected: FAIL
+
+  [WebGL test #108: pixel at [3, 4\] should be (255,48,48,48), but the actual color is (255,116,116,116)]
+    expected: FAIL
+
+  [WebGL test #109: pixel at [4, 4\] should be (48,48,48,255), but the actual color is (116,116,116,255)]
+    expected: FAIL
+
+  [WebGL test #110: pixel at [5, 4\] should be (48,48,255,55), but the actual color is (116,116,255,124)]
+    expected: FAIL
+
+  [WebGL test #111: pixel at [6, 4\] should be (48,255,55,55), but the actual color is (116,255,124,124)]
+    expected: FAIL
+
+  [WebGL test #112: pixel at [7, 4\] should be (255,55,55,55), but the actual color is (255,124,124,124)]
+    expected: FAIL
+
+  [WebGL test #113: pixel at [0, 5\] should be (75,75,75,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #114: pixel at [1, 5\] should be (75,75,255,79), but the actual color is (144,144,255,148)]
+    expected: FAIL
+
+  [WebGL test #115: pixel at [2, 5\] should be (75,255,79,79), but the actual color is (144,255,148,148)]
+    expected: FAIL
+
+  [WebGL test #116: pixel at [3, 5\] should be (255,79,79,79), but the actual color is (255,148,148,148)]
+    expected: FAIL
+
+  [WebGL test #117: pixel at [4, 5\] should be (79,79,79,255), but the actual color is (148,148,148,255)]
+    expected: FAIL
+
+  [WebGL test #118: pixel at [5, 5\] should be (79,79,255,89), but the actual color is (148,148,255,156)]
+    expected: FAIL
+
+  [WebGL test #119: pixel at [6, 5\] should be (79,255,89,89), but the actual color is (148,255,156,156)]
+    expected: FAIL
+
+  [WebGL test #120: pixel at [7, 5\] should be (255,89,89,89), but the actual color is (255,156,156,156)]
+    expected: FAIL
+
+  [WebGL test #121: pixel at [0, 6\] should be (114,114,114,255), but the actual color is (176,176,176,255)]
+    expected: FAIL
+
+  [WebGL test #122: pixel at [1, 6\] should be (114,114,255,120), but the actual color is (176,176,255,180)]
+    expected: FAIL
+
+  [WebGL test #123: pixel at [2, 6\] should be (114,255,120,120), but the actual color is (176,255,180,180)]
+    expected: FAIL
+
+  [WebGL test #124: pixel at [3, 6\] should be (255,120,120,120), but the actual color is (255,180,180,180)]
+    expected: FAIL
+
+  [WebGL test #125: pixel at [4, 6\] should be (120,120,120,255), but the actual color is (180,180,180,255)]
+    expected: FAIL
+
+  [WebGL test #126: pixel at [5, 6\] should be (120,120,255,132), but the actual color is (180,180,255,188)]
+    expected: FAIL
+
+  [WebGL test #127: pixel at [6, 6\] should be (120,255,132,132), but the actual color is (180,255,188,188)]
+    expected: FAIL
+
+  [WebGL test #128: pixel at [7, 6\] should be (255,132,132,132), but the actual color is (255,188,188,188)]
+    expected: FAIL
+
+  [WebGL test #129: pixel at [0, 7\] should be (134,134,134,255), but the actual color is (192,192,192,255)]
+    expected: FAIL
+
+  [WebGL test #130: pixel at [1, 7\] should be (134,134,255,141), but the actual color is (192,192,255,196)]
+    expected: FAIL
+
+  [WebGL test #131: pixel at [2, 7\] should be (134,255,141,141), but the actual color is (192,255,196,196)]
+    expected: FAIL
+
+  [WebGL test #132: pixel at [3, 7\] should be (255,141,141,141), but the actual color is (255,196,196,196)]
+    expected: FAIL
+
+  [WebGL test #133: pixel at [4, 7\] should be (141,141,141,255), but the actual color is (196,196,196,255)]
+    expected: FAIL
+
+  [WebGL test #134: pixel at [5, 7\] should be (141,141,255,154), but the actual color is (196,196,255,204)]
+    expected: FAIL
+
+  [WebGL test #135: pixel at [6, 7\] should be (141,255,154,154), but the actual color is (196,255,204,204)]
+    expected: FAIL
+
+  [WebGL test #136: pixel at [7, 7\] should be (255,154,154,154), but the actual color is (255,204,204,204)]
+    expected: FAIL
+
+  [WebGL test #137: pixel at [0, 0\] should be (50,50,50,255), but the actual color is (40,40,40,255)]
+    expected: FAIL
+
+  [WebGL test #138: pixel at [1, 0\] should be (50,50,255,81), but the actual color is (40,40,255,72)]
+    expected: FAIL
+
+  [WebGL test #149: pixel at [0, 1\] should be (28,28,28,255), but the actual color is (16,16,16,255)]
+    expected: FAIL
+
+  [WebGL test #150: pixel at [1, 1\] should be (28,28,255,34), but the actual color is (16,16,255,20)]
+    expected: FAIL
+
+  [WebGL test #151: pixel at [2, 1\] should be (28,255,34,34), but the actual color is (16,255,20,20)]
+    expected: FAIL
+
+  [WebGL test #152: pixel at [3, 1\] should be (255,34,34,34), but the actual color is (255,20,20,20)]
+    expected: FAIL
+
+  [WebGL test #153: pixel at [4, 1\] should be (34,34,34,255), but the actual color is (20,20,20,255)]
+    expected: FAIL
+
+  [WebGL test #154: pixel at [5, 1\] should be (34,34,255,38), but the actual color is (20,20,255,28)]
+    expected: FAIL
+
+  [WebGL test #155: pixel at [6, 1\] should be (34,255,38,38), but the actual color is (20,255,28,28)]
+    expected: FAIL
+
+  [WebGL test #156: pixel at [7, 1\] should be (255,38,38,38), but the actual color is (255,28,28,28)]
+    expected: FAIL
+
+  [WebGL test #157: pixel at [0, 2\] should be (56,56,56,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #158: pixel at [1, 2\] should be (56,56,255,59), but the actual color is (48,48,255,52)]
+    expected: FAIL
+
+  [WebGL test #159: pixel at [2, 2\] should be (56,255,59,59), but the actual color is (48,255,52,52)]
+    expected: FAIL
+
+  [WebGL test #205: pixel at [0, 0\] should be (152,152,152,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #206: pixel at [1, 0\] should be (152,152,255,177), but the actual color is (80,80,255,112)]
+    expected: FAIL
+
+  [WebGL test #207: pixel at [0, 1\] should be (233,233,233,255), but the actual color is (208,208,208,255)]
+    expected: FAIL
+
+  [WebGL test #208: pixel at [1, 1\] should be (233,233,255,248), but the actual color is (208,208,255,240)]
+    expected: FAIL
+
+  [WebGL test #214: pixel at [5, 0\] should be (0,0,255,71), but the actual color is (0,0,255,16)]
+    expected: FAIL
+
+  [WebGL test #215: pixel at [6, 0\] should be (0,255,71,71), but the actual color is (0,255,16,16)]
+    expected: FAIL
+
+  [WebGL test #216: pixel at [7, 0\] should be (255,71,71,71), but the actual color is (255,16,16,16)]
+    expected: FAIL
+
+  [WebGL test #222: pixel at [5, 1\] should be (0,0,255,71), but the actual color is (0,0,255,16)]
+    expected: FAIL
+
+  [WebGL test #223: pixel at [6, 1\] should be (0,255,71,71), but the actual color is (0,255,16,16)]
+    expected: FAIL
+
+  [WebGL test #224: pixel at [7, 1\] should be (255,71,71,71), but the actual color is (255,16,16,16)]
+    expected: FAIL
+
+  [WebGL test #225: pixel at [0, 2\] should be (137,137,137,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #226: pixel at [1, 2\] should be (137,137,255,137), but the actual color is (64,64,255,64)]
+    expected: FAIL
+
+  [WebGL test #227: pixel at [2, 2\] should be (137,255,137,137), but the actual color is (64,255,64,64)]
+    expected: FAIL
+
+  [WebGL test #228: pixel at [3, 2\] should be (255,137,137,137), but the actual color is (255,64,64,64)]
+    expected: FAIL
+
+  [WebGL test #229: pixel at [4, 2\] should be (137,137,137,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #230: pixel at [5, 2\] should be (137,137,255,152), but the actual color is (64,64,255,80)]
+    expected: FAIL
+
+  [WebGL test #231: pixel at [6, 2\] should be (137,255,152,152), but the actual color is (64,255,80,80)]
+    expected: FAIL
+
+  [WebGL test #232: pixel at [7, 2\] should be (255,152,152,152), but the actual color is (255,80,80,80)]
+    expected: FAIL
+
+  [WebGL test #233: pixel at [0, 3\] should be (137,137,137,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #234: pixel at [1, 3\] should be (137,137,255,137), but the actual color is (64,64,255,64)]
+    expected: FAIL
+
+  [WebGL test #235: pixel at [2, 3\] should be (137,255,137,137), but the actual color is (64,255,64,64)]
+    expected: FAIL
+
+  [WebGL test #236: pixel at [3, 3\] should be (255,137,137,137), but the actual color is (255,64,64,64)]
+    expected: FAIL
+
+  [WebGL test #237: pixel at [4, 3\] should be (137,137,137,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #238: pixel at [5, 3\] should be (137,137,255,152), but the actual color is (64,64,255,80)]
+    expected: FAIL
+
+  [WebGL test #239: pixel at [6, 3\] should be (137,255,152,152), but the actual color is (64,255,80,80)]
+    expected: FAIL
+
+  [WebGL test #240: pixel at [7, 3\] should be (255,152,152,152), but the actual color is (255,80,80,80)]
+    expected: FAIL
+
+  [WebGL test #241: pixel at [0, 4\] should be (188,188,188,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #242: pixel at [1, 4\] should be (188,188,255,188), but the actual color is (128,128,255,128)]
+    expected: FAIL
+
+  [WebGL test #243: pixel at [2, 4\] should be (188,255,188,188), but the actual color is (128,255,128,128)]
+    expected: FAIL
+
+  [WebGL test #244: pixel at [3, 4\] should be (255,188,188,188), but the actual color is (255,128,128,128)]
+    expected: FAIL
+
+  [WebGL test #245: pixel at [4, 4\] should be (188,188,188,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #246: pixel at [5, 4\] should be (188,188,255,198), but the actual color is (128,128,255,144)]
+    expected: FAIL
+
+  [WebGL test #247: pixel at [6, 4\] should be (188,255,198,198), but the actual color is (128,255,144,144)]
+    expected: FAIL
+
+  [WebGL test #248: pixel at [7, 4\] should be (255,198,198,198), but the actual color is (255,144,144,144)]
+    expected: FAIL
+
+  [WebGL test #249: pixel at [0, 5\] should be (188,188,188,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #250: pixel at [1, 5\] should be (188,188,255,188), but the actual color is (128,128,255,128)]
+    expected: FAIL
+
+  [WebGL test #251: pixel at [2, 5\] should be (188,255,188,188), but the actual color is (128,255,128,128)]
+    expected: FAIL
+
+  [WebGL test #252: pixel at [3, 5\] should be (255,188,188,188), but the actual color is (255,128,128,128)]
+    expected: FAIL
+
+  [WebGL test #253: pixel at [4, 5\] should be (188,188,188,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #254: pixel at [5, 5\] should be (188,188,255,198), but the actual color is (128,128,255,144)]
+    expected: FAIL
+
+  [WebGL test #255: pixel at [6, 5\] should be (188,255,198,198), but the actual color is (128,255,144,144)]
+    expected: FAIL
+
+  [WebGL test #256: pixel at [7, 5\] should be (255,198,198,198), but the actual color is (255,144,144,144)]
+    expected: FAIL
+
+  [WebGL test #257: pixel at [0, 6\] should be (225,225,225,255), but the actual color is (192,192,192,255)]
+    expected: FAIL
+
+  [WebGL test #258: pixel at [1, 6\] should be (225,225,255,225), but the actual color is (192,192,255,192)]
+    expected: FAIL
+
+  [WebGL test #259: pixel at [2, 6\] should be (225,255,225,225), but the actual color is (192,255,192,192)]
+    expected: FAIL
+
+  [WebGL test #260: pixel at [3, 6\] should be (255,225,225,225), but the actual color is (255,192,192,192)]
+    expected: FAIL
+
+  [WebGL test #261: pixel at [4, 6\] should be (225,225,225,255), but the actual color is (192,192,192,255)]
+    expected: FAIL
+
+  [WebGL test #262: pixel at [5, 6\] should be (225,225,255,233), but the actual color is (192,192,255,208)]
+    expected: FAIL
+
+  [WebGL test #263: pixel at [6, 6\] should be (225,255,233,233), but the actual color is (192,255,208,208)]
+    expected: FAIL
+
+  [WebGL test #264: pixel at [7, 6\] should be (255,233,233,233), but the actual color is (255,208,208,208)]
+    expected: FAIL
+
+  [WebGL test #265: pixel at [0, 7\] should be (225,225,225,255), but the actual color is (192,192,192,255)]
+    expected: FAIL
+
+  [WebGL test #266: pixel at [1, 7\] should be (225,225,255,225), but the actual color is (192,192,255,192)]
+    expected: FAIL
+
+  [WebGL test #267: pixel at [2, 7\] should be (225,255,225,225), but the actual color is (192,255,192,192)]
+    expected: FAIL
+
+  [WebGL test #268: pixel at [3, 7\] should be (255,225,225,225), but the actual color is (255,192,192,192)]
+    expected: FAIL
+
+  [WebGL test #269: pixel at [4, 7\] should be (225,225,225,255), but the actual color is (192,192,192,255)]
+    expected: FAIL
+
+  [WebGL test #270: pixel at [5, 7\] should be (225,225,255,233), but the actual color is (192,192,255,208)]
+    expected: FAIL
+
+  [WebGL test #271: pixel at [6, 7\] should be (225,255,233,233), but the actual color is (192,255,208,208)]
+    expected: FAIL
+
+  [WebGL test #272: pixel at [7, 7\] should be (255,233,233,233), but the actual color is (255,208,208,208)]
+    expected: FAIL
+
+  [WebGL test #273: pixel at [0, 0\] should be (20,20,20,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #274: pixel at [1, 0\] should be (20,20,255,41), but the actual color is (80,80,255,112)]
+    expected: FAIL
+
+  [WebGL test #275: pixel at [0, 1\] should be (161,161,161,255), but the actual color is (208,208,208,255)]
+    expected: FAIL
+
+  [WebGL test #276: pixel at [1, 1\] should be (161,161,255,222), but the actual color is (208,208,255,240)]
+    expected: FAIL
+
+  [WebGL test #282: pixel at [5, 0\] should be (0,0,255,1), but the actual color is (0,0,255,16)]
+    expected: FAIL
+
+  [WebGL test #283: pixel at [6, 0\] should be (0,255,1,1), but the actual color is (0,255,16,16)]
+    expected: FAIL
+
+  [WebGL test #284: pixel at [7, 0\] should be (255,1,1,1), but the actual color is (255,16,16,16)]
+    expected: FAIL
+
+  [WebGL test #290: pixel at [5, 1\] should be (0,0,255,1), but the actual color is (0,0,255,16)]
+    expected: FAIL
+
+  [WebGL test #291: pixel at [6, 1\] should be (0,255,1,1), but the actual color is (0,255,16,16)]
+    expected: FAIL
+
+  [WebGL test #292: pixel at [7, 1\] should be (255,1,1,1), but the actual color is (255,16,16,16)]
+    expected: FAIL
+
+  [WebGL test #293: pixel at [0, 2\] should be (13,13,13,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #294: pixel at [1, 2\] should be (13,13,255,13), but the actual color is (64,64,255,64)]
+    expected: FAIL
+
+  [WebGL test #295: pixel at [2, 2\] should be (13,255,13,13), but the actual color is (64,255,64,64)]
+    expected: FAIL
+
+  [WebGL test #296: pixel at [3, 2\] should be (255,13,13,13), but the actual color is (255,64,64,64)]
+    expected: FAIL
+
+  [WebGL test #297: pixel at [4, 2\] should be (13,13,13,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #298: pixel at [5, 2\] should be (13,13,255,20), but the actual color is (64,64,255,80)]
+    expected: FAIL
+
+  [WebGL test #299: pixel at [6, 2\] should be (13,255,20,20), but the actual color is (64,255,80,80)]
+    expected: FAIL
+
+  [WebGL test #300: pixel at [7, 2\] should be (255,20,20,20), but the actual color is (255,80,80,80)]
+    expected: FAIL
+
+  [WebGL test #301: pixel at [0, 3\] should be (13,13,13,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #302: pixel at [1, 3\] should be (13,13,255,13), but the actual color is (64,64,255,64)]
+    expected: FAIL
+
+  [WebGL test #303: pixel at [2, 3\] should be (13,255,13,13), but the actual color is (64,255,64,64)]
+    expected: FAIL
+
+  [WebGL test #304: pixel at [3, 3\] should be (255,13,13,13), but the actual color is (255,64,64,64)]
+    expected: FAIL
+
+  [WebGL test #305: pixel at [4, 3\] should be (13,13,13,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #306: pixel at [5, 3\] should be (13,13,255,20), but the actual color is (64,64,255,80)]
+    expected: FAIL
+
+  [WebGL test #307: pixel at [6, 3\] should be (13,255,20,20), but the actual color is (64,255,80,80)]
+    expected: FAIL
+
+  [WebGL test #308: pixel at [7, 3\] should be (255,20,20,20), but the actual color is (255,80,80,80)]
+    expected: FAIL
+
+  [WebGL test #309: pixel at [0, 4\] should be (55,55,55,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #310: pixel at [1, 4\] should be (55,55,255,55), but the actual color is (128,128,255,128)]
+    expected: FAIL
+
+  [WebGL test #311: pixel at [2, 4\] should be (55,255,55,55), but the actual color is (128,255,128,128)]
+    expected: FAIL
+
+  [WebGL test #312: pixel at [3, 4\] should be (255,55,55,55), but the actual color is (255,128,128,128)]
+    expected: FAIL
+
+  [WebGL test #313: pixel at [4, 4\] should be (55,55,55,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #314: pixel at [5, 4\] should be (55,55,255,71), but the actual color is (128,128,255,144)]
+    expected: FAIL
+
+  [WebGL test #315: pixel at [6, 4\] should be (55,255,71,71), but the actual color is (128,255,144,144)]
+    expected: FAIL
+
+  [WebGL test #316: pixel at [7, 4\] should be (255,71,71,71), but the actual color is (255,144,144,144)]
+    expected: FAIL
+
+  [WebGL test #317: pixel at [0, 5\] should be (55,55,55,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #318: pixel at [1, 5\] should be (55,55,255,55), but the actual color is (128,128,255,128)]
+    expected: FAIL
+
+  [WebGL test #319: pixel at [2, 5\] should be (55,255,55,55), but the actual color is (128,255,128,128)]
+    expected: FAIL
+
+  [WebGL test #320: pixel at [3, 5\] should be (255,55,55,55), but the actual color is (255,128,128,128)]
+    expected: FAIL
+
+  [WebGL test #321: pixel at [4, 5\] should be (55,55,55,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #322: pixel at [5, 5\] should be (55,55,255,71), but the actual color is (128,128,255,144)]
+    expected: FAIL
+
+  [WebGL test #323: pixel at [6, 5\] should be (55,255,71,71), but the actual color is (128,255,144,144)]
+    expected: FAIL
+
+  [WebGL test #324: pixel at [7, 5\] should be (255,71,71,71), but the actual color is (255,144,144,144)]
+    expected: FAIL
+
+  [WebGL test #325: pixel at [0, 6\] should be (134,134,134,255), but the actual color is (192,192,192,255)]
+    expected: FAIL
+
+  [WebGL test #326: pixel at [1, 6\] should be (134,134,255,134), but the actual color is (192,192,255,192)]
+    expected: FAIL
+
+  [WebGL test #327: pixel at [2, 6\] should be (134,255,134,134), but the actual color is (192,255,192,192)]
+    expected: FAIL
+
+  [WebGL test #328: pixel at [3, 6\] should be (255,134,134,134), but the actual color is (255,192,192,192)]
+    expected: FAIL
+
+  [WebGL test #329: pixel at [4, 6\] should be (134,134,134,255), but the actual color is (192,192,192,255)]
+    expected: FAIL
+
+  [WebGL test #330: pixel at [5, 6\] should be (134,134,255,161), but the actual color is (192,192,255,208)]
+    expected: FAIL
+
+  [WebGL test #331: pixel at [6, 6\] should be (134,255,161,161), but the actual color is (192,255,208,208)]
+    expected: FAIL
+
+  [WebGL test #332: pixel at [7, 6\] should be (255,161,161,161), but the actual color is (255,208,208,208)]
+    expected: FAIL
+
+  [WebGL test #333: pixel at [0, 7\] should be (134,134,134,255), but the actual color is (192,192,192,255)]
+    expected: FAIL
+
+  [WebGL test #334: pixel at [1, 7\] should be (134,134,255,134), but the actual color is (192,192,255,192)]
+    expected: FAIL
+
+  [WebGL test #335: pixel at [2, 7\] should be (134,255,134,134), but the actual color is (192,255,192,192)]
+    expected: FAIL
+
+  [WebGL test #336: pixel at [3, 7\] should be (255,134,134,134), but the actual color is (255,192,192,192)]
+    expected: FAIL
+
+  [WebGL test #337: pixel at [4, 7\] should be (134,134,134,255), but the actual color is (192,192,192,255)]
+    expected: FAIL
+
+  [WebGL test #338: pixel at [5, 7\] should be (134,134,255,161), but the actual color is (192,192,255,208)]
+    expected: FAIL
+
+  [WebGL test #339: pixel at [6, 7\] should be (134,255,161,161), but the actual color is (192,255,208,208)]
+    expected: FAIL
+
+  [WebGL test #340: pixel at [7, 7\] should be (255,161,161,161), but the actual color is (255,208,208,208)]
+    expected: FAIL
+
+  [WebGL test #69: pixel at [0, 0\] should be (9,9,9,255), but the actual color is (40,40,40,255)]
+    expected: FAIL
+
+  [WebGL test #70: pixel at [1, 0\] should be (9,9,255,21), but the actual color is (40,40,255,72)]
+    expected: FAIL
+
+  [WebGL test #71: pixel at [0, 1\] should be (106,106,106,255), but the actual color is (168,168,168,255)]
+    expected: FAIL
+
+  [WebGL test #72: pixel at [1, 1\] should be (106,106,255,154), but the actual color is (168,168,255,200)]
+    expected: FAIL
+
+  [WebGL test #97: pixel at [0, 3\] should be (24,24,24,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #98: pixel at [1, 3\] should be (24,24,255,26), but the actual color is (80,80,255,84)]
+    expected: FAIL
+
+  [WebGL test #99: pixel at [2, 3\] should be (24,255,26,26), but the actual color is (80,255,84,84)]
+    expected: FAIL
+
+  [WebGL test #105: pixel at [0, 4\] should be (45,45,45,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #106: pixel at [1, 4\] should be (45,45,255,48), but the actual color is (112,112,255,116)]
+    expected: FAIL
+
+  [WebGL test #107: pixel at [2, 4\] should be (45,255,48,48), but the actual color is (112,255,116,116)]
+    expected: FAIL
+
+  [WebGL test #114: pixel at [1, 5\] should be (75,75,255,80), but the actual color is (144,144,255,148)]
+    expected: FAIL
+
+  [WebGL test #115: pixel at [2, 5\] should be (75,255,80,80), but the actual color is (144,255,148,148)]
+    expected: FAIL
+
+  [WebGL test #116: pixel at [3, 5\] should be (255,80,80,80), but the actual color is (255,148,148,148)]
+    expected: FAIL
+
+  [WebGL test #117: pixel at [4, 5\] should be (80,80,80,255), but the actual color is (148,148,148,255)]
+    expected: FAIL
+
+  [WebGL test #118: pixel at [5, 5\] should be (80,80,255,89), but the actual color is (148,148,255,156)]
+    expected: FAIL
+
+  [WebGL test #119: pixel at [6, 5\] should be (80,255,89,89), but the actual color is (148,255,156,156)]
+    expected: FAIL
+
+  [WebGL test #122: pixel at [1, 6\] should be (114,114,255,121), but the actual color is (176,176,255,180)]
+    expected: FAIL
+
+  [WebGL test #123: pixel at [2, 6\] should be (114,255,121,121), but the actual color is (176,255,180,180)]
+    expected: FAIL
+
+  [WebGL test #124: pixel at [3, 6\] should be (255,121,121,121), but the actual color is (255,180,180,180)]
+    expected: FAIL
+
+  [WebGL test #125: pixel at [4, 6\] should be (121,121,121,255), but the actual color is (180,180,180,255)]
+    expected: FAIL
+
+  [WebGL test #126: pixel at [5, 6\] should be (121,121,255,132), but the actual color is (180,180,255,188)]
+    expected: FAIL
+
+  [WebGL test #127: pixel at [6, 6\] should be (121,255,132,132), but the actual color is (180,255,188,188)]
+    expected: FAIL
+
+  [WebGL test #137: pixel at [0, 0\] should be (53,53,53,255), but the actual color is (40,40,40,255)]
+    expected: FAIL
+
+  [WebGL test #138: pixel at [1, 0\] should be (53,53,255,81), but the actual color is (40,40,255,72)]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-multisampled-readbuffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-multisampled-readbuffer.html.ini
@@ -1,5 +1,4 @@
 [blitframebuffer-multisampled-readbuffer.html]
-  expected: ERROR
   [WebGL test #1: Framebuffer incomplete.]
     expected:
       if os == "linux": FAIL
@@ -15,3 +14,14 @@
   [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_OPERATION : blitframebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #4: should be 254,184,69,255\nat (0, 0) expected: 254,184,69,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #6: getError expected: NO_ERROR. Was INVALID_OPERATION : blitframebuffer should succeed]
+    expected: FAIL
+
+  [WebGL test #8: should be 254,184,69,255\nat (0, 0) expected: 254,184,69,255 was 0,0,0,0]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-outside-readbuffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-outside-readbuffer.html.ini
@@ -1,5 +1,363 @@
 [blitframebuffer-outside-readbuffer.html]
-  expected: ERROR
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #249: pixel at [2, 2\] should be (99,99,99,255), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #250: pixel at [3, 2\] should be (120,120,120,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #251: pixel at [4, 2\] should be (137,137,137,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #256: pixel at [2, 3\] should be (152,152,152,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #257: pixel at [3, 3\] should be (165,165,165,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #258: pixel at [4, 3\] should be (177,177,177,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #263: pixel at [2, 4\] should be (188,188,188,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #264: pixel at [3, 4\] should be (198,198,198,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #265: pixel at [4, 4\] should be (208,208,208,255), but the actual color is (160,160,160,255)]
+    expected: FAIL
+
+  [WebGL test #298: pixel at [2, 2\] should be (208,208,208,255), but the actual color is (160,160,160,255)]
+    expected: FAIL
+
+  [WebGL test #299: pixel at [3, 2\] should be (198,198,198,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #300: pixel at [4, 2\] should be (188,188,188,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #305: pixel at [2, 3\] should be (177,177,177,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #306: pixel at [3, 3\] should be (165,165,165,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #307: pixel at [4, 3\] should be (152,152,152,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #312: pixel at [2, 4\] should be (137,137,137,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #313: pixel at [3, 4\] should be (120,120,120,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #314: pixel at [4, 4\] should be (99,99,99,255), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #347: pixel at [2, 2\] should be (208,208,208,255), but the actual color is (160,160,160,255)]
+    expected: FAIL
+
+  [WebGL test #348: pixel at [3, 2\] should be (198,198,198,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #349: pixel at [4, 2\] should be (188,188,188,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #354: pixel at [2, 3\] should be (177,177,177,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #355: pixel at [3, 3\] should be (165,165,165,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #356: pixel at [4, 3\] should be (152,152,152,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #361: pixel at [2, 4\] should be (137,137,137,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #362: pixel at [3, 4\] should be (120,120,120,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #363: pixel at [4, 4\] should be (99,99,99,255), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #396: pixel at [2, 2\] should be (99,99,99,255), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #397: pixel at [3, 2\] should be (120,120,120,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #398: pixel at [4, 2\] should be (137,137,137,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #403: pixel at [2, 3\] should be (152,152,152,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #404: pixel at [3, 3\] should be (165,165,165,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #405: pixel at [4, 3\] should be (177,177,177,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #410: pixel at [2, 4\] should be (188,188,188,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #411: pixel at [3, 4\] should be (198,198,198,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #412: pixel at [4, 4\] should be (208,208,208,255), but the actual color is (160,160,160,255)]
+    expected: FAIL
+
+  [WebGL test #430: pixel at [2, 2\] should be (99,99,99,255), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #431: pixel at [3, 2\] should be (120,120,120,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #433: pixel at [2, 3\] should be (152,152,152,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #434: pixel at [3, 3\] should be (165,165,165,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #436: pixel at [2, 4\] should be (188,188,188,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #437: pixel at [3, 4\] should be (198,198,198,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #441: pixel at [2, 2\] should be (99,99,99,255), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #442: pixel at [3, 2\] should be (120,120,120,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #443: pixel at [4, 2\] should be (137,137,137,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #444: pixel at [2, 3\] should be (152,152,152,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #445: pixel at [3, 3\] should be (165,165,165,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #446: pixel at [4, 3\] should be (177,177,177,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #447: pixel at [3, 2\] should be (120,120,120,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #448: pixel at [4, 2\] should be (137,137,137,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #450: pixel at [3, 3\] should be (165,165,165,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #451: pixel at [4, 3\] should be (177,177,177,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #453: pixel at [3, 4\] should be (198,198,198,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #454: pixel at [4, 4\] should be (208,208,208,255), but the actual color is (160,160,160,255)]
+    expected: FAIL
+
+  [WebGL test #456: pixel at [2, 3\] should be (152,152,152,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #457: pixel at [3, 3\] should be (165,165,165,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #458: pixel at [4, 3\] should be (177,177,177,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #459: pixel at [2, 4\] should be (188,188,188,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #460: pixel at [3, 4\] should be (198,198,198,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #461: pixel at [4, 4\] should be (208,208,208,255), but the actual color is (160,160,160,255)]
+    expected: FAIL
+
+  [WebGL test #481: pixel at [2, 2\] should be (4,4,4,255), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #482: pixel at [3, 2\] should be (8,8,8,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #483: pixel at [4, 2\] should be (13,13,13,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #488: pixel at [2, 3\] should be (20,20,20,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #489: pixel at [3, 3\] should be (30,30,30,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #490: pixel at [4, 3\] should be (41,41,41,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #495: pixel at [2, 4\] should be (55,55,55,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #496: pixel at [3, 4\] should be (71,71,71,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #497: pixel at [4, 4\] should be (90,90,90,255), but the actual color is (160,160,160,255)]
+    expected: FAIL
+
+  [WebGL test #530: pixel at [2, 2\] should be (90,90,90,255), but the actual color is (160,160,160,255)]
+    expected: FAIL
+
+  [WebGL test #531: pixel at [3, 2\] should be (71,71,71,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #532: pixel at [4, 2\] should be (55,55,55,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #537: pixel at [2, 3\] should be (41,41,41,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #538: pixel at [3, 3\] should be (30,30,30,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #539: pixel at [4, 3\] should be (20,20,20,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #544: pixel at [2, 4\] should be (13,13,13,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #545: pixel at [3, 4\] should be (8,8,8,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #546: pixel at [4, 4\] should be (4,4,4,255), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #579: pixel at [2, 2\] should be (90,90,90,255), but the actual color is (160,160,160,255)]
+    expected: FAIL
+
+  [WebGL test #580: pixel at [3, 2\] should be (71,71,71,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #581: pixel at [4, 2\] should be (55,55,55,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #586: pixel at [2, 3\] should be (41,41,41,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #587: pixel at [3, 3\] should be (30,30,30,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #588: pixel at [4, 3\] should be (20,20,20,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #593: pixel at [2, 4\] should be (13,13,13,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #594: pixel at [3, 4\] should be (8,8,8,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #595: pixel at [4, 4\] should be (4,4,4,255), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #628: pixel at [2, 2\] should be (4,4,4,255), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #629: pixel at [3, 2\] should be (8,8,8,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #630: pixel at [4, 2\] should be (13,13,13,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #635: pixel at [2, 3\] should be (20,20,20,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #636: pixel at [3, 3\] should be (30,30,30,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #637: pixel at [4, 3\] should be (41,41,41,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #642: pixel at [2, 4\] should be (55,55,55,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #643: pixel at [3, 4\] should be (71,71,71,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #644: pixel at [4, 4\] should be (90,90,90,255), but the actual color is (160,160,160,255)]
+    expected: FAIL
+
+  [WebGL test #662: pixel at [2, 2\] should be (4,4,4,255), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #663: pixel at [3, 2\] should be (8,8,8,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #665: pixel at [2, 3\] should be (20,20,20,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #666: pixel at [3, 3\] should be (30,30,30,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #668: pixel at [2, 4\] should be (55,55,55,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #669: pixel at [3, 4\] should be (71,71,71,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #673: pixel at [2, 2\] should be (4,4,4,255), but the actual color is (32,32,32,255)]
+    expected: FAIL
+
+  [WebGL test #674: pixel at [3, 2\] should be (8,8,8,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #675: pixel at [4, 2\] should be (13,13,13,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #676: pixel at [2, 3\] should be (20,20,20,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #677: pixel at [3, 3\] should be (30,30,30,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #678: pixel at [4, 3\] should be (41,41,41,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #679: pixel at [3, 2\] should be (8,8,8,255), but the actual color is (48,48,48,255)]
+    expected: FAIL
+
+  [WebGL test #680: pixel at [4, 2\] should be (13,13,13,255), but the actual color is (64,64,64,255)]
+    expected: FAIL
+
+  [WebGL test #682: pixel at [3, 3\] should be (30,30,30,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #683: pixel at [4, 3\] should be (41,41,41,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #685: pixel at [3, 4\] should be (71,71,71,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #686: pixel at [4, 4\] should be (90,90,90,255), but the actual color is (160,160,160,255)]
+    expected: FAIL
+
+  [WebGL test #688: pixel at [2, 3\] should be (20,20,20,255), but the actual color is (80,80,80,255)]
+    expected: FAIL
+
+  [WebGL test #689: pixel at [3, 3\] should be (30,30,30,255), but the actual color is (96,96,96,255)]
+    expected: FAIL
+
+  [WebGL test #690: pixel at [4, 3\] should be (41,41,41,255), but the actual color is (112,112,112,255)]
+    expected: FAIL
+
+  [WebGL test #691: pixel at [2, 4\] should be (55,55,55,255), but the actual color is (128,128,128,255)]
+    expected: FAIL
+
+  [WebGL test #692: pixel at [3, 4\] should be (71,71,71,255), but the actual color is (144,144,144,255)]
+    expected: FAIL
+
+  [WebGL test #693: pixel at [4, 4\] should be (90,90,90,255), but the actual color is (160,160,160,255)]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-resolve-to-back-buffer.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-resolve-to-back-buffer.html.ini
@@ -1,5 +1,9 @@
 [blitframebuffer-resolve-to-back-buffer.html]
-  expected: ERROR
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #8: getError expected: NO_ERROR. Was INVALID_OPERATION : should be legal to blit/resolve to default back buffer]
+    expected: FAIL
+
+  [WebGL test #10: should be 0,255,0,255\nat (0, 0) expected: 0,255,0,255 was 0,0,0,255]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-scissor-enabled.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-scissor-enabled.html.ini
@@ -1,5 +1,3 @@
 [blitframebuffer-scissor-enabled.html]
-  expected: ERROR
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-size-overflow.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-size-overflow.html.ini
@@ -1,5 +1,21 @@
 [blitframebuffer-size-overflow.html]
-  expected: ERROR
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #3: getError expected: INVALID_VALUE. Was INVALID_OPERATION : Using source width/height greater than max 32-bit integer should fail.]
+    expected: FAIL
+
+  [WebGL test #4: getError expected: INVALID_VALUE. Was NO_ERROR : Using source width/height greater than max 32-bit integer should fail.]
+    expected: FAIL
+
+  [WebGL test #5: getError expected: INVALID_VALUE. Was INVALID_OPERATION : Using destination width/height greater than max 32-bit integer should fail.]
+    expected: FAIL
+
+  [WebGL test #6: getError expected: INVALID_VALUE. Was NO_ERROR : Using destination width/height greater than max 32-bit integer should fail.]
+    expected: FAIL
+
+  [WebGL test #7: getError expected: INVALID_VALUE. Was INVALID_OPERATION : Using both source and destination width/height greater than max 32-bit integer should fail.]
+    expected: FAIL
+
+  [WebGL test #8: getError expected: INVALID_VALUE. Was INVALID_OPERATION : Using minimum and maximum integers for all boundaries should fail.]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-srgb-and-linear-drawbuffers.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-srgb-and-linear-drawbuffers.html.ini
@@ -1,5 +1,3 @@
 [blitframebuffer-srgb-and-linear-drawbuffers.html]
-  expected: ERROR
   [WebGL test #3: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-stencil-only.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-stencil-only.html.ini
@@ -1,5 +1,9 @@
 [blitframebuffer-stencil-only.html]
-  expected: ERROR
   [WebGL test #11: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #14: stencil test should be green\nat (0, 0) expected: 0,255,0,255 was 255,255,0,255]
+    expected: FAIL
+
+  [WebGL test #24: stencil test should be green\nat (0, 0) expected: 0,255,0,255 was 255,255,0,255]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-test.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-test.html.ini
@@ -3,3 +3,23 @@
   [WebGL test #1: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
+  [WebGL test #1: should be red at first\nat (0, 0) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #2: should be green\nat (0, 0) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #3: getError expected: NO_ERROR. Was INVALID_OPERATION : blitFramebuffer should succeed.]
+    expected: FAIL
+
+  [WebGL test #4: getError expected: INVALID_OPERATION. Was NO_ERROR : blitFramebuffer should generate INVALID_OPERATION if read/draw buffer are identical.]
+    expected: FAIL
+
+  [WebGL test #5: getError expected: INVALID_OPERATION. Was NO_ERROR : blitFramebuffer should generate INVALID_OPERATION if read/draw buffer are identical.]
+    expected: FAIL
+
+  [WebGL test #6: getError expected: INVALID_OPERATION. Was NO_ERROR : blitFramebuffer should generate INVALID_OPERATION if read/draw color buffer are identical.]
+    expected: FAIL
+
+  [WebGL test #9: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-unaffected-by-colormask.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/blitframebuffer-unaffected-by-colormask.html.ini
@@ -1,2 +1,0 @@
-[blitframebuffer-unaffected-by-colormask.html]
-  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/rendering/draw-buffers-driver-hang.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/draw-buffers-driver-hang.html.ini
@@ -1,2 +1,0 @@
-[draw-buffers-driver-hang.html]
-  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/rendering/framebuffer-to-texture.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/framebuffer-to-texture.html.ini
@@ -1,2 +1,9 @@
 [framebuffer-to-texture.html]
-  expected: ERROR
+  [WebGL test #6: user-defined framebuffer: center quad should be green\nat (17, 17) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #7: user-defined framebuffer: lower left quad should be green\nat (1, 1) expected: 0,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #10: getError expected: NO_ERROR. Was INVALID_OPERATION : Should be no errors at the end of the test.]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/rendering/line-rendering-quality.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/line-rendering-quality.html.ini
@@ -1,9 +1,8 @@
 [line-rendering-quality.html]
-  expected: ERROR
   bug: https://github.com/servo/servo/issues/25937
   [WebGL test #5: Found 0 lines, looking in the vertical direction, expected 2]
     expected:
       if os == "linux": FAIL
+
   [WebGL test #10: successfullyParsed should be true. Threw exception ReferenceError: can't access lexical declaration 'successfullyParsed' before initialization]
     expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance2/rendering/multisampling-depth-resolve.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/multisampling-depth-resolve.html.ini
@@ -1,2 +1,12 @@
 [multisampling-depth-resolve.html]
-  expected: ERROR
+  [WebGL test #0: multisampling-depth-resolve: outer pixels should be red\nat (1, 1) expected: 255,0,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #1: multisampling-depth-resolve: outer quad should be yellow\nat (10, 10) expected: 255,255,0,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #2: multisampling-depth-resolve: center quad should be blue\nat (17, 17) expected: 0,0,255,255 was 0,0,0,0]
+    expected: FAIL
+
+  [WebGL test #3: getError expected: NO_ERROR. Was INVALID_OPERATION : Should be no errors at the end of the test.]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance2/rendering/multisampling-fragment-evaluation.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/rendering/multisampling-fragment-evaluation.html.ini
@@ -1,5 +1,3 @@
 [multisampling-fragment-evaluation.html]
-  expected: ERROR
   [WebGL test #0: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance2/transform_feedback/too-small-buffers.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/transform_feedback/too-small-buffers.html.ini
@@ -1,6 +1,5 @@
 [too-small-buffers.html]
   expected: TIMEOUT
-
   [WebGL test #60: getError expected: NO_ERROR. Was INVALID_OPERATION : before draw]
     expected: FAIL
 


### PR DESCRIPTION
Add initial support for the WebGL2 BlitFramebuffer call.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes