### PR TITLE
Add a fast path in Element::SetInnerHTML when the value is small and trivial text

### DIFF
--- a/components/script/dom/htmlframesetelement.rs
+++ b/components/script/dom/htmlframesetelement.rs
@@ -4,6 +4,7 @@
 
 use crate::dom::bindings::codegen::Bindings::HTMLFrameSetElementBinding::HTMLFrameSetElementMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
@@ -33,12 +34,14 @@ impl HTMLFrameSetElement {
         prefix: Option<Prefix>,
         document: &Document,
     ) -> DomRoot<HTMLFrameSetElement> {
-        Node::reflect_node(
+        let n = Node::reflect_node(
             Box::new(HTMLFrameSetElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
-        )
+        );
+        n.upcast::<Node>().set_weird_parser_insertion_mode();
+        n
     }
 }
 

--- a/components/script/dom/htmlheadelement.rs
+++ b/components/script/dom/htmlheadelement.rs
@@ -37,10 +37,13 @@ impl HTMLHeadElement {
         prefix: Option<Prefix>,
         document: &Document,
     ) -> DomRoot<HTMLHeadElement> {
-        Node::reflect_node(
+        let n = Node::reflect_node(
             Box::new(HTMLHeadElement::new_inherited(local_name, prefix, document)),
             document,
-        )
+        );
+
+        n.upcast::<Node>().set_weird_parser_insertion_mode();
+        n
     }
 
     /// <https://html.spec.whatwg.org/multipage/#meta-referrer>

--- a/components/script/dom/htmlhtmlelement.rs
+++ b/components/script/dom/htmlhtmlelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
@@ -32,9 +33,12 @@ impl HTMLHtmlElement {
         prefix: Option<Prefix>,
         document: &Document,
     ) -> DomRoot<HTMLHtmlElement> {
-        Node::reflect_node(
+        let n = Node::reflect_node(
             Box::new(HTMLHtmlElement::new_inherited(localName, prefix, document)),
             document,
-        )
+        );
+
+        n.upcast::<Node>().set_weird_parser_insertion_mode();
+        n
     }
 }

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -93,12 +93,15 @@ impl HTMLSelectElement {
         prefix: Option<Prefix>,
         document: &Document,
     ) -> DomRoot<HTMLSelectElement> {
-        Node::reflect_node(
+        let n = Node::reflect_node(
             Box::new(HTMLSelectElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
-        )
+        );
+
+        n.upcast::<Node>().set_weird_parser_insertion_mode();
+        n
     }
 
     // https://html.spec.whatwg.org/multipage/#concept-select-option-list

--- a/components/script/dom/htmltablecaptionelement.rs
+++ b/components/script/dom/htmltablecaptionelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
@@ -31,11 +32,14 @@ impl HTMLTableCaptionElement {
         prefix: Option<Prefix>,
         document: &Document,
     ) -> DomRoot<HTMLTableCaptionElement> {
-        Node::reflect_node(
+        let n = Node::reflect_node(
             Box::new(HTMLTableCaptionElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
-        )
+        );
+
+        n.upcast::<Node>().set_weird_parser_insertion_mode();
+        n
     }
 }

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -45,12 +45,15 @@ impl HTMLTableCellElement {
         prefix: Option<Prefix>,
         document: &Document,
     ) -> DomRoot<HTMLTableCellElement> {
-        Node::reflect_node(
+        let n = Node::reflect_node(
             Box::new(HTMLTableCellElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
-        )
+        );
+
+        n.upcast::<Node>().set_weird_parser_insertion_mode();
+        n
     }
 }
 

--- a/components/script/dom/htmltablecolelement.rs
+++ b/components/script/dom/htmltablecolelement.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::document::Document;
 use crate::dom::htmlelement::HTMLElement;
@@ -31,11 +32,14 @@ impl HTMLTableColElement {
         prefix: Option<Prefix>,
         document: &Document,
     ) -> DomRoot<HTMLTableColElement> {
-        Node::reflect_node(
+        let n = Node::reflect_node(
             Box::new(HTMLTableColElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
-        )
+        );
+
+        n.upcast::<Node>().set_weird_parser_insertion_mode();
+        n
     }
 }

--- a/components/script/dom/htmltableelement.rs
+++ b/components/script/dom/htmltableelement.rs
@@ -70,12 +70,15 @@ impl HTMLTableElement {
         prefix: Option<Prefix>,
         document: &Document,
     ) -> DomRoot<HTMLTableElement> {
-        Node::reflect_node(
+        let n = Node::reflect_node(
             Box::new(HTMLTableElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
-        )
+        );
+
+        n.upcast::<Node>().set_weird_parser_insertion_mode();
+        n
     }
 
     pub fn get_border(&self) -> Option<u32> {

--- a/components/script/dom/htmltablerowelement.rs
+++ b/components/script/dom/htmltablerowelement.rs
@@ -57,12 +57,15 @@ impl HTMLTableRowElement {
         prefix: Option<Prefix>,
         document: &Document,
     ) -> DomRoot<HTMLTableRowElement> {
-        Node::reflect_node(
+        let n = Node::reflect_node(
             Box::new(HTMLTableRowElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
-        )
+        );
+
+        n.upcast::<Node>().set_weird_parser_insertion_mode();
+        n
     }
 
     /// Determine the index for this `HTMLTableRowElement` within the given

--- a/components/script/dom/htmltablesectionelement.rs
+++ b/components/script/dom/htmltablesectionelement.rs
@@ -42,12 +42,15 @@ impl HTMLTableSectionElement {
         prefix: Option<Prefix>,
         document: &Document,
     ) -> DomRoot<HTMLTableSectionElement> {
-        Node::reflect_node(
+        let n = Node::reflect_node(
             Box::new(HTMLTableSectionElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
-        )
+        );
+
+        n.upcast::<Node>().set_weird_parser_insertion_mode();
+        n
     }
 }
 

--- a/components/script/dom/htmltemplateelement.rs
+++ b/components/script/dom/htmltemplateelement.rs
@@ -41,12 +41,15 @@ impl HTMLTemplateElement {
         prefix: Option<Prefix>,
         document: &Document,
     ) -> DomRoot<HTMLTemplateElement> {
-        Node::reflect_node(
+        let n = Node::reflect_node(
             Box::new(HTMLTemplateElement::new_inherited(
                 local_name, prefix, document,
             )),
             document,
-        )
+        );
+
+        n.upcast::<Node>().set_weird_parser_insertion_mode();
+        n
     }
 }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -196,6 +196,10 @@ bitflags! {
 
         /// Specifies whether this node's shadow-including root is a document.
         const IS_CONNECTED = 1 << 10;
+
+        /// Whether this node has a weird parser insertion mode. i.e whether setting innerHTML
+        /// needs extra work or not
+        const HAS_WEIRD_PARSER_INSERTION_MODE = 1 << 11;
     }
 }
 
@@ -552,6 +556,16 @@ impl Node {
 
     pub fn is_in_shadow_tree(&self) -> bool {
         self.flags.get().contains(NodeFlags::IS_IN_SHADOW_TREE)
+    }
+
+    pub fn has_weird_parser_insertion_mode(&self) -> bool {
+        self.flags
+            .get()
+            .contains(NodeFlags::HAS_WEIRD_PARSER_INSERTION_MODE)
+    }
+
+    pub fn set_weird_parser_insertion_mode(&self) {
+        self.set_flag(NodeFlags::HAS_WEIRD_PARSER_INSERTION_MODE, true)
     }
 
     pub fn is_connected(&self) -> bool {


### PR DESCRIPTION
Inspired from gecko which has a similar fast path. This makes innerHTML
more than 10 times faster for this case.

Fixes #25892
