### PR TITLE
Workarounds for webxr glwindow on macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6428,7 +6428,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#e1e935abacbef378efd3c5a676dfe63d4e5a6692"
+source = "git+https://github.com/servo/webxr#ac9a7b23e72436b09e84be980914adf8abb71c96"
 dependencies = [
  "android_injected_glue",
  "bindgen",
@@ -6451,7 +6451,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#e1e935abacbef378efd3c5a676dfe63d4e5a6692"
+source = "git+https://github.com/servo/webxr#ac9a7b23e72436b09e84be980914adf8abb71c96"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,3 @@ winapi = { git = "https://github.com/servo/winapi-rs", branch = "patch-1" }
 spirv_cross = { git = "https://github.com/servo/spirv_cross", branch = "wgpu-servo" }
 surfman-chains = { git = "https://github.com/asajeffrey/surfman-chains" }
 surfman = { git = "https://github.com/servo/surfman" }
-

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -300,6 +300,8 @@ mod gen {
                     glwindow: {
                         #[serde(default)]
                         enabled: bool,
+                        #[serde(rename = "dom.webxr.glwindow.left-right")]
+                        left_right: bool,
                         #[serde(rename = "dom.webxr.glwindow.red-cyan")]
                         red_cyan: bool,
                     },

--- a/ports/glutin/headed_window.rs
+++ b/ports/glutin/headed_window.rs
@@ -655,8 +655,10 @@ impl webxr::glwindow::GlWindow for XRWindow {
     fn get_mode(&self) -> webxr::glwindow::GlWindowMode {
         if pref!(dom.webxr.glwindow.red_cyan) {
             webxr::glwindow::GlWindowMode::StereoRedCyan
-        } else {
+        } else if pref!(dom.webxr.glwindow.left_right) {
             webxr::glwindow::GlWindowMode::StereoLeftRight
+        } else {
+            webxr::glwindow::GlWindowMode::Blit
         }
     }
 }

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -34,6 +34,7 @@
   "dom.webvtt.enabled": false,
   "dom.webxr.enabled": true,
   "dom.webxr.glwindow.enabled": true,
+  "dom.webxr.glwindow.left-right": false,
   "dom.webxr.glwindow.red-cyan": false,
   "dom.webxr.hands.enabled": false,
   "dom.webxr.layers.enabled": false,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Makes the default glwindow mode one which does blitting rather than using a shader, since that works on macos.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #26340

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
