### PR TITLE
Allow BabylonJS playground to load

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3669,6 +3669,11 @@ impl ProfilerMetadataFactory for Document {
 }
 
 impl DocumentMethods for Document {
+    // https://w3c.github.io/editing/ActiveDocuments/execCommand.html#querycommandsupported()
+    fn QueryCommandSupported(&self, _command: DOMString) -> bool {
+        false
+    }
+
     // https://drafts.csswg.org/cssom/#dom-document-stylesheets
     fn StyleSheets(&self) -> DomRoot<StyleSheetList> {
         self.stylesheet_list.or_init(|| {

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -150,6 +150,23 @@ pub enum CompiledEventListener {
 }
 
 impl CompiledEventListener {
+    #[allow(unsafe_code)]
+    pub fn associated_global(&self) -> DomRoot<GlobalScope> {
+        let obj = match self {
+            CompiledEventListener::Listener(listener) => listener.callback(),
+            CompiledEventListener::Handler(CommonEventHandler::EventHandler(handler)) => {
+                handler.callback()
+            },
+            CompiledEventListener::Handler(CommonEventHandler::ErrorEventHandler(handler)) => {
+                handler.callback()
+            },
+            CompiledEventListener::Handler(CommonEventHandler::BeforeUnloadEventHandler(
+                handler,
+            )) => handler.callback(),
+        };
+        unsafe { GlobalScope::from_object(obj) }
+    }
+
     // https://html.spec.whatwg.org/multipage/#the-event-handler-processing-algorithm
     pub fn call_or_handle_event(
         &self,

--- a/components/script/dom/webidls/Document.webidl
+++ b/components/script/dom/webidls/Document.webidl
@@ -142,7 +142,7 @@ partial /*sealed*/ interface Document {
   // boolean queryCommandEnabled(DOMString commandId);
   // boolean queryCommandIndeterm(DOMString commandId);
   // boolean queryCommandState(DOMString commandId);
-  // boolean queryCommandSupported(DOMString commandId);
+  boolean queryCommandSupported(DOMString commandId);
   // DOMString queryCommandValue(DOMString commandId);
 
   // special event handler IDL attributes that only apply to Document objects

--- a/components/script/dom/webidls/Window.webidl
+++ b/components/script/dom/webidls/Window.webidl
@@ -180,6 +180,10 @@ partial interface Window {
    Selection? getSelection();
 };
 
+// https://dom.spec.whatwg.org/#interface-window-extensions
+partial interface Window {
+  [Replaceable] readonly attribute any event; // historical
+};
 
 dictionary WindowPostMessageOptions : PostMessageOptions {
    USVString targetOrigin = "/";

--- a/tests/wpt/metadata/dom/events/event-global.html.ini
+++ b/tests/wpt/metadata/dom/events/event-global.html.ini
@@ -1,19 +1,6 @@
 [event-global.html]
-  [event exists on window, which is initially set to undefined]
-    expected: FAIL
-
-  [window.event is only defined during dispatch]
-    expected: FAIL
-
   [window.event is undefined if the target is in a shadow tree (event dispatched outside shadow tree)]
     expected: FAIL
 
   [window.event is undefined if the target is in a shadow tree (event dispatched inside shadow tree)]
     expected: FAIL
-
-  [window.event is set to the current event during dispatch]
-    expected: FAIL
-
-  [window.event is set to the current event, which is the event passed to dispatch]
-    expected: FAIL
-

--- a/tests/wpt/metadata/dom/idlharness.window.js.ini
+++ b/tests/wpt/metadata/dom/idlharness.window.js.ini
@@ -152,9 +152,6 @@
   [AbortSignal interface object length]
     expected: FAIL
 
-  [Window interface: attribute event]
-    expected: FAIL
-
   [AbortController interface: new AbortController() must inherit property "abort()" with the proper type]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/metadata/html/dom/idlharness.https.html.ini
@@ -1417,9 +1417,6 @@
   [Document interface: iframe.contentDocument must inherit property "dir" with the proper type]
     expected: FAIL
 
-  [Document interface: new Document() must inherit property "queryCommandSupported(DOMString)" with the proper type]
-    expected: FAIL
-
   [Window interface: attribute onsecuritypolicyviolation]
     expected: FAIL
 
@@ -1439,9 +1436,6 @@
     expected: FAIL
 
   [Window interface: attribute menubar]
-    expected: FAIL
-
-  [Document interface: calling queryCommandSupported(DOMString) on documentWithHandlers with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: attribute designMode]
@@ -1480,13 +1474,7 @@
   [Document interface: calling execCommand(DOMString, boolean, DOMString) on new Document() with too few arguments must throw TypeError]
     expected: FAIL
 
-  [Document interface: calling queryCommandSupported(DOMString) on new Document() with too few arguments must throw TypeError]
-    expected: FAIL
-
   [Window interface: operation focus()]
-    expected: FAIL
-
-  [Document interface: documentWithHandlers must inherit property "queryCommandSupported(DOMString)" with the proper type]
     expected: FAIL
 
   [Window interface: attribute scrollbars]
@@ -1514,9 +1502,6 @@
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "queryCommandValue(DOMString)" with the proper type]
-    expected: FAIL
-
-  [Document interface: operation queryCommandSupported(DOMString)]
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "all" with the proper type]
@@ -1588,9 +1573,6 @@
   [Window interface: window must inherit property "blur()" with the proper type]
     expected: FAIL
 
-  [Document interface: iframe.contentDocument must inherit property "queryCommandSupported(DOMString)" with the proper type]
-    expected: FAIL
-
   [Document interface: calling execCommand(DOMString, boolean, DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
     expected: FAIL
 
@@ -1619,9 +1601,6 @@
     expected: FAIL
 
   [Document interface: iframe.contentDocument must inherit property "queryCommandEnabled(DOMString)" with the proper type]
-    expected: FAIL
-
-  [Document interface: calling queryCommandSupported(DOMString) on iframe.contentDocument with too few arguments must throw TypeError]
     expected: FAIL
 
   [Window interface: operation blur()]


### PR DESCRIPTION
These changes fix the JS errors that currently appear when loading the page. You can't use the editor, but the webgl canvas works just fine.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #26428 and fix #25478
- [x] There are tests for these changes
