### PR TITLE
Layout 2020: Implement basic white-space: pre support

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -757,14 +757,20 @@ impl TextRun {
             let mut advance_width = Length::zero();
             let mut last_break_opportunity = None;
             let mut force_line_break = false;
+            // Fit as many glyphs within a single line as possible.
             loop {
                 let next = runs.next();
-                if next.as_ref().map_or(true, |run| {
-                    run.glyph_store.is_whitespace() || force_line_break
-                }) {
-                    if advance_width > ifc.containing_block.inline_size - ifc.inline_position ||
-                        force_line_break
-                    {
+                // If there are no more text runs we still need to check if the last
+                // run was a forced line break
+                if next
+                    .as_ref()
+                    .map_or(true, |run| run.glyph_store.is_whitespace())
+                {
+                    // If this run exceeds the bounds of the containing block, then
+                    // we need to attempt to break the line.
+                    if advance_width > ifc.containing_block.inline_size - ifc.inline_position {
+                        // Reset the text run iterator to the last whitespace if possible,
+                        // to attempt to re-layout the most recent glyphs on a new line.
                         if let Some((len, width, iter)) = last_break_opportunity.take() {
                             glyphs.truncate(len);
                             advance_width = width;
@@ -776,18 +782,24 @@ impl TextRun {
                 if let Some(run) = next {
                     if run.glyph_store.is_whitespace() {
                         last_break_opportunity = Some((glyphs.len(), advance_width, runs.clone()));
-                        if self.text.as_bytes().get(run.range.end().to_usize() - 1) == Some(&b'\n')
-                        {
-                            force_line_break = self
-                                .parent_style
+                        // If this whitespace ends with a newline, we need to check if
+                        // it's meaningful within the current style. If so, we force
+                        // a line break immediately.
+                        let last_byte = self.text.as_bytes().get(run.range.end().to_usize() - 1);
+                        if last_byte == Some(&b'\n') &&
+                            self.parent_style
                                 .get_inherited_text()
                                 .white_space
-                                .preserve_newlines();
+                                .preserve_newlines()
+                        {
+                            force_line_break = true;
+                            break;
                         }
                     }
                     glyphs.push(run.glyph_store.clone());
                     advance_width += Length::from(run.glyph_store.total_advance());
                 } else {
+                    // No more runs, so we can end the line.
                     break;
                 }
             }
@@ -822,6 +834,7 @@ impl TextRun {
                     glyphs,
                     text_decoration_line: ifc.current_nesting_level.text_decoration_line,
                 }));
+            // If this line is being broken because of a trailing newline, we can't ignore it.
             if runs.as_slice().is_empty() && !force_line_break {
                 break;
             } else {

--- a/components/style/properties/longhands/inherited_text.mako.rs
+++ b/components/style/properties/longhands/inherited_text.mako.rs
@@ -186,7 +186,6 @@ ${helpers.predefined_type(
     name="white-space"
     values="normal pre nowrap pre-wrap pre-line"
     engines="gecko servo-2013 servo-2020",
-    servo_2020_pref="layout.2020.unimplemented",
     extra_gecko_values="break-spaces -moz-pre-space"
     gecko_enum_prefix="StyleWhiteSpace"
     needs_conversion="True"

--- a/tests/wpt/metadata-layout-2020/css/CSS2/abspos/hypothetical-inline-alone-on-second-line.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/abspos/hypothetical-inline-alone-on-second-line.html.ini
@@ -1,2 +1,0 @@
-[hypothetical-inline-alone-on-second-line.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/colors/color-applies-to-008.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/colors/color-applies-to-008.xht.ini
@@ -1,2 +1,0 @@
-[color-applies-to-008.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/colors/color-applies-to-015.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/colors/color-applies-to-015.xht.ini
@@ -1,2 +1,0 @@
-[color-applies-to-015.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/css1/c562-white-sp-000.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/css1/c562-white-sp-000.xht.ini
@@ -1,2 +1,0 @@
-[c562-white-sp-000.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/float-003.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats-clear/float-003.xht.ini
@@ -1,2 +1,0 @@
-[float-003.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats/float-no-content-beside-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats/float-no-content-beside-001.html.ini
@@ -1,0 +1,2 @@
+[float-no-content-beside-001.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats/floats-placement-vertical-004.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats/floats-placement-vertical-004.xht.ini
@@ -1,0 +1,2 @@
+[floats-placement-vertical-004.xht]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats/hit-test-floats-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats/hit-test-floats-004.html.ini
@@ -1,0 +1,4 @@
+[hit-test-floats-004.html]
+  [Miss float below something else]
+    expected: FAIL
+

--- a/tests/wpt/metadata-layout-2020/css/CSS2/generated-content/content-171.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/generated-content/content-171.xht.ini
@@ -1,2 +1,0 @@
-[content-171.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/generated-content/content-173.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/generated-content/content-173.xht.ini
@@ -1,0 +1,2 @@
+[content-173.xht]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/generated-content/content-newline-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/generated-content/content-newline-001.xht.ini
@@ -1,2 +1,0 @@
-[content-newline-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/generated-content/content-white-space-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/generated-content/content-white-space-002.xht.ini
@@ -1,0 +1,2 @@
+[content-white-space-002.xht]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-percentage-inherit-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/padding-percentage-inherit-001.xht.ini
@@ -1,2 +1,0 @@
-[padding-percentage-inherit-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-replaced-width-006.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-replaced-width-006.xht.ini
@@ -1,2 +1,0 @@
-[block-replaced-width-006.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/inline-replaced-width-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/inline-replaced-width-001.xht.ini
@@ -1,2 +1,0 @@
-[inline-replaced-width-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/inline-replaced-width-006.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/inline-replaced-width-006.xht.ini
@@ -1,2 +1,0 @@
-[inline-replaced-width-006.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/inlines-016.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/inlines-016.xht.ini
@@ -1,2 +1,0 @@
-[inlines-016.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/absolute-non-replaced-height-008.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/absolute-non-replaced-height-008.xht.ini
@@ -1,2 +1,0 @@
-[absolute-non-replaced-height-008.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/position-static-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/position-static-001.xht.ini
@@ -1,2 +1,0 @@
-[position-static-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/table-anonymous-objects-009.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/table-anonymous-objects-009.xht.ini
@@ -1,0 +1,2 @@
+[table-anonymous-objects-009.xht]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/table-anonymous-objects-010.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/table-anonymous-objects-010.xht.ini
@@ -1,0 +1,2 @@
+[table-anonymous-objects-010.xht]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-004.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-004.xht.ini
@@ -1,2 +1,0 @@
-[white-space-004.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-applies-to-003.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-applies-to-003.xht.ini
@@ -1,2 +1,0 @@
-[white-space-applies-to-003.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-processing-013.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-processing-013.xht.ini
@@ -1,2 +1,0 @@
-[white-space-processing-013.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-processing-016.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-processing-016.xht.ini
@@ -1,2 +1,0 @@
-[white-space-processing-016.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-processing-017.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-processing-017.xht.ini
@@ -1,2 +1,0 @@
-[white-space-processing-017.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-processing-018.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-processing-018.xht.ini
@@ -1,2 +1,0 @@
-[white-space-processing-018.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-processing-046.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-processing-046.xht.ini
@@ -1,2 +1,0 @@
-[white-space-processing-046.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-processing-047.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-processing-047.xht.ini
@@ -1,2 +1,0 @@
-[white-space-processing-047.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-processing-052.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/text/white-space-processing-052.xht.ini
@@ -1,2 +1,0 @@
-[white-space-processing-052.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/visuren/anonymous-boxes-001b.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/visuren/anonymous-boxes-001b.xht.ini
@@ -1,2 +1,0 @@
-[anonymous-boxes-001b.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-size-027.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-size-027.html.ini
@@ -1,2 +1,0 @@
-[background-size-027.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-size-028.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-size-028.html.ini
@@ -1,2 +1,0 @@
-[background-size-028.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-size-030.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-size-030.html.ini
@@ -1,2 +1,0 @@
-[background-size-030.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-size-031.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-size-031.html.ini
@@ -1,2 +1,0 @@
-[background-size-031.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/anonymous-flex-item-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/anonymous-flex-item-004.html.ini
@@ -1,0 +1,2 @@
+[anonymous-flex-item-004.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/anonymous-flex-item-005.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/anonymous-flex-item-005.html.ini
@@ -1,0 +1,2 @@
+[anonymous-flex-item-005.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/anonymous-flex-item-006.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/anonymous-flex-item-006.html.ini
@@ -1,0 +1,2 @@
+[anonymous-flex-item-006.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-text-decor/text-decoration-subelements-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-text-decor/text-decoration-subelements-001.html.ini
@@ -1,2 +1,0 @@
-[text-decoration-subelements-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/offsetTopLeft-border-box.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/offsetTopLeft-border-box.html.ini
@@ -1,0 +1,85 @@
+[offsetTopLeft-border-box.html]
+  [container: 11]
+    expected: FAIL
+
+  [container: 10]
+    expected: FAIL
+
+  [container: 13]
+    expected: FAIL
+
+  [container: 12]
+    expected: FAIL
+
+  [container: 15]
+    expected: FAIL
+
+  [container: 14]
+    expected: FAIL
+
+  [container: 17]
+    expected: FAIL
+
+  [container: 16]
+    expected: FAIL
+
+  [container: 19]
+    expected: FAIL
+
+  [container: 18]
+    expected: FAIL
+
+  [container: 9]
+    expected: FAIL
+
+  [container: 8]
+    expected: FAIL
+
+  [container: 1]
+    expected: FAIL
+
+  [container: 0]
+    expected: FAIL
+
+  [container: 3]
+    expected: FAIL
+
+  [container: 2]
+    expected: FAIL
+
+  [container: 5]
+    expected: FAIL
+
+  [container: 4]
+    expected: FAIL
+
+  [container: 7]
+    expected: FAIL
+
+  [container: 6]
+    expected: FAIL
+
+  [container: 20]
+    expected: FAIL
+
+  [container: 21]
+    expected: FAIL
+
+  [container: 22]
+    expected: FAIL
+
+  [container: 23]
+    expected: FAIL
+
+  [container: 24]
+    expected: FAIL
+
+  [container: 25]
+    expected: FAIL
+
+  [container: 26]
+    expected: FAIL
+
+  [container: 27]
+    expected: FAIL
+

--- a/tests/wpt/metadata-layout-2020/css/cssom/serialize-values.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom/serialize-values.html.ini
@@ -23,13 +23,7 @@
   [page-break-before: always]
     expected: FAIL
 
-  [white-space: inherit]
-    expected: FAIL
-
   [page-break-after: inherit]
-    expected: FAIL
-
-  [white-space: nowrap]
     expected: FAIL
 
   [page-break-before: left]
@@ -218,9 +212,6 @@
   [display: table-cell]
     expected: FAIL
 
-  [white-space: pre]
-    expected: FAIL
-
   [text-indent: 5%]
     expected: FAIL
 
@@ -263,7 +254,7 @@
   [clear: both]
     expected: FAIL
 
-  [white-space: pre-wrap]
+  [list-style-image: url(http://localhost/)]
     expected: FAIL
 
   [outline-width: 0px]
@@ -332,9 +323,6 @@
   [vertical-align: 1px]
     expected: FAIL
 
-  [white-space: pre-line]
-    expected: FAIL
-
   [display: table-column]
     expected: FAIL
 
@@ -393,9 +381,6 @@
     expected: FAIL
 
   [float: none]
-    expected: FAIL
-
-  [white-space: normal]
     expected: FAIL
 
   [list-style-type: lower-roman]

--- a/tests/wpt/metadata-layout-2020/css/cssom/serialize-values.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom/serialize-values.html.ini
@@ -254,9 +254,6 @@
   [clear: both]
     expected: FAIL
 
-  [list-style-image: url(http://localhost/)]
-    expected: FAIL
-
   [outline-width: 0px]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta-layout-2020/css/br.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/br.html.ini
@@ -1,2 +1,0 @@
-[br.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/input_whitespace.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/input_whitespace.html.ini
@@ -1,2 +1,0 @@
-[input_whitespace.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/line_breaking_whitespace_collapse_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/line_breaking_whitespace_collapse_a.html.ini
@@ -1,2 +1,0 @@
-[line_breaking_whitespace_collapse_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/many_brs_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/many_brs_a.html.ini
@@ -1,2 +1,0 @@
-[many_brs_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/white-space-pre-line.htm.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/white-space-pre-line.htm.ini
@@ -1,0 +1,2 @@
+[white-space-pre-line.htm]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/white_space_intrinsic_sizes_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/white_space_intrinsic_sizes_a.html.ini
@@ -1,2 +1,0 @@
-[white_space_intrinsic_sizes_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/whitespace_pre.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/whitespace_pre.html.ini
@@ -1,2 +1,0 @@
-[whitespace_pre.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/word-break-keep-all-005.htm.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/word-break-keep-all-005.htm.ini
@@ -1,2 +1,0 @@
-[word-break-keep-all-005.htm]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/word-break-keep-all-006.htm.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/word-break-keep-all-006.htm.ini
@@ -1,2 +1,0 @@
-[word-break-keep-all-006.htm]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/word-break-keep-all-007.htm.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/word-break-keep-all-007.htm.ini
@@ -1,2 +1,0 @@
-[word-break-keep-all-007.htm]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/mozilla/hit_test_multiple_sc.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/mozilla/hit_test_multiple_sc.html.ini
@@ -1,0 +1,4 @@
+[hit_test_multiple_sc.html]
+  [Hit testing works for following stacking contexts]
+    expected: FAIL
+


### PR DESCRIPTION
With these changes `<pre>` and `<br>` preserve spaces and force line breaks appropriately.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #26440
- [x] There are tests for these changes