### PR TITLE
webaudio: Throw when setting invalid automationRate on AudioBufferSourceNode

### DIFF
--- a/components/script/dom/audiobuffersourcenode.rs
+++ b/components/script/dom/audiobuffersourcenode.rs
@@ -10,7 +10,7 @@ use js::rust::HandleObject;
 use servo_media::audio::buffer_source_node::{
     AudioBufferSourceNodeMessage, AudioBufferSourceNodeOptions,
 };
-use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage};
+use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage, AudioNodeType};
 use servo_media::audio::param::ParamType;
 
 use crate::dom::audiobuffer::AudioBuffer;
@@ -61,6 +61,7 @@ impl AudioBufferSourceNode {
             &window,
             context,
             node_id,
+            AudioNodeType::AudioBufferSourceNode,
             ParamType::PlaybackRate,
             AutomationRate::K_rate,
             *options.playbackRate,
@@ -71,6 +72,7 @@ impl AudioBufferSourceNode {
             &window,
             context,
             node_id,
+            AudioNodeType::AudioBufferSourceNode,
             ParamType::Detune,
             AutomationRate::K_rate,
             *options.detune,

--- a/components/script/dom/audiolistener.rs
+++ b/components/script/dom/audiolistener.rs
@@ -5,6 +5,7 @@
 use std::f32;
 
 use dom_struct::dom_struct;
+use servo_media::audio::node::AudioNodeType;
 use servo_media::audio::param::{ParamDir, ParamType};
 
 use crate::dom::audioparam::AudioParam;
@@ -41,6 +42,7 @@ impl AudioListener {
             window,
             context,
             node,
+            AudioNodeType::AudioListenerNode,
             ParamType::Position(ParamDir::X),
             AutomationRate::A_rate,
             0.,       // default value
@@ -51,6 +53,7 @@ impl AudioListener {
             window,
             context,
             node,
+            AudioNodeType::AudioListenerNode,
             ParamType::Position(ParamDir::Y),
             AutomationRate::A_rate,
             0.,       // default value
@@ -61,6 +64,7 @@ impl AudioListener {
             window,
             context,
             node,
+            AudioNodeType::AudioListenerNode,
             ParamType::Position(ParamDir::Z),
             AutomationRate::A_rate,
             0.,       // default value
@@ -71,6 +75,7 @@ impl AudioListener {
             window,
             context,
             node,
+            AudioNodeType::AudioListenerNode,
             ParamType::Forward(ParamDir::X),
             AutomationRate::A_rate,
             0.,       // default value
@@ -81,6 +86,7 @@ impl AudioListener {
             window,
             context,
             node,
+            AudioNodeType::AudioListenerNode,
             ParamType::Forward(ParamDir::Y),
             AutomationRate::A_rate,
             0.,       // default value
@@ -91,6 +97,7 @@ impl AudioListener {
             window,
             context,
             node,
+            AudioNodeType::AudioListenerNode,
             ParamType::Forward(ParamDir::Z),
             AutomationRate::A_rate,
             -1.,      // default value
@@ -101,6 +108,7 @@ impl AudioListener {
             window,
             context,
             node,
+            AudioNodeType::AudioListenerNode,
             ParamType::Up(ParamDir::X),
             AutomationRate::A_rate,
             0.,       // default value
@@ -111,6 +119,7 @@ impl AudioListener {
             window,
             context,
             node,
+            AudioNodeType::AudioListenerNode,
             ParamType::Up(ParamDir::Y),
             AutomationRate::A_rate,
             1.,       // default value
@@ -121,6 +130,7 @@ impl AudioListener {
             window,
             context,
             node,
+            AudioNodeType::AudioListenerNode,
             ParamType::Up(ParamDir::Z),
             AutomationRate::A_rate,
             0.,       // default value

--- a/components/script/dom/biquadfilternode.rs
+++ b/components/script/dom/biquadfilternode.rs
@@ -10,7 +10,7 @@ use js::rust::HandleObject;
 use servo_media::audio::biquad_filter_node::{
     BiquadFilterNodeMessage, BiquadFilterNodeOptions, FilterType,
 };
-use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage};
+use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage, AudioNodeType};
 use servo_media::audio::param::ParamType;
 
 use crate::dom::audionode::AudioNode;
@@ -62,6 +62,7 @@ impl BiquadFilterNode {
             window,
             context,
             node.node_id(),
+            AudioNodeType::BiquadFilterNode,
             ParamType::Gain,
             AutomationRate::A_rate,
             options.gain, // default value
@@ -72,6 +73,7 @@ impl BiquadFilterNode {
             window,
             context,
             node.node_id(),
+            AudioNodeType::BiquadFilterNode,
             ParamType::Q,
             AutomationRate::A_rate,
             options.q, // default value
@@ -82,6 +84,7 @@ impl BiquadFilterNode {
             window,
             context,
             node.node_id(),
+            AudioNodeType::BiquadFilterNode,
             ParamType::Frequency,
             AutomationRate::A_rate,
             options.frequency, // default value
@@ -92,6 +95,7 @@ impl BiquadFilterNode {
             window,
             context,
             node.node_id(),
+            AudioNodeType::BiquadFilterNode,
             ParamType::Detune,
             AutomationRate::A_rate,
             options.detune, // default value

--- a/components/script/dom/constantsourcenode.rs
+++ b/components/script/dom/constantsourcenode.rs
@@ -7,7 +7,7 @@ use std::f32;
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use servo_media::audio::constant_source_node::ConstantSourceNodeOptions as ServoMediaConstantSourceOptions;
-use servo_media::audio::node::AudioNodeInit;
+use servo_media::audio::node::{AudioNodeInit, AudioNodeType};
 use servo_media::audio::param::ParamType;
 
 use crate::dom::audioparam::AudioParam;
@@ -48,6 +48,7 @@ impl ConstantSourceNode {
             window,
             context,
             node_id,
+            AudioNodeType::ConstantSourceNode,
             ParamType::Offset,
             AutomationRate::A_rate,
             *options.offset,

--- a/components/script/dom/gainnode.rs
+++ b/components/script/dom/gainnode.rs
@@ -7,7 +7,7 @@ use std::f32;
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use servo_media::audio::gain_node::GainNodeOptions;
-use servo_media::audio::node::AudioNodeInit;
+use servo_media::audio::node::{AudioNodeInit, AudioNodeType};
 use servo_media::audio::param::ParamType;
 
 use crate::dom::audionode::AudioNode;
@@ -51,6 +51,7 @@ impl GainNode {
             window,
             context,
             node.node_id(),
+            AudioNodeType::GainNode,
             ParamType::Gain,
             AutomationRate::A_rate,
             *options.gain, // default value

--- a/components/script/dom/oscillatornode.rs
+++ b/components/script/dom/oscillatornode.rs
@@ -7,7 +7,7 @@ use std::f32;
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
-use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage};
+use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage, AudioNodeType};
 use servo_media::audio::oscillator_node::{
     OscillatorNodeMessage, OscillatorNodeOptions as ServoMediaOscillatorOptions,
     OscillatorType as ServoMediaOscillatorType,
@@ -60,6 +60,7 @@ impl OscillatorNode {
             window,
             context,
             node_id,
+            AudioNodeType::OscillatorNode,
             ParamType::Frequency,
             AutomationRate::A_rate,
             440.,
@@ -70,6 +71,7 @@ impl OscillatorNode {
             window,
             context,
             node_id,
+            AudioNodeType::OscillatorNode,
             ParamType::Detune,
             AutomationRate::A_rate,
             0.,

--- a/components/script/dom/pannernode.rs
+++ b/components/script/dom/pannernode.rs
@@ -7,7 +7,7 @@ use std::f32;
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
-use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage};
+use servo_media::audio::node::{AudioNodeInit, AudioNodeMessage, AudioNodeType};
 use servo_media::audio::panner_node::{
     DistanceModel, PannerNodeMessage, PannerNodeOptions, PanningModel,
 };
@@ -98,6 +98,7 @@ impl PannerNode {
             window,
             context,
             id,
+            AudioNodeType::PannerNode,
             ParamType::Position(ParamDir::X),
             AutomationRate::A_rate,
             options.position_x, // default value
@@ -108,6 +109,7 @@ impl PannerNode {
             window,
             context,
             id,
+            AudioNodeType::PannerNode,
             ParamType::Position(ParamDir::Y),
             AutomationRate::A_rate,
             options.position_y, // default value
@@ -118,6 +120,7 @@ impl PannerNode {
             window,
             context,
             id,
+            AudioNodeType::PannerNode,
             ParamType::Position(ParamDir::Z),
             AutomationRate::A_rate,
             options.position_z, // default value
@@ -128,6 +131,7 @@ impl PannerNode {
             window,
             context,
             id,
+            AudioNodeType::PannerNode,
             ParamType::Orientation(ParamDir::X),
             AutomationRate::A_rate,
             options.orientation_x, // default value
@@ -138,6 +142,7 @@ impl PannerNode {
             window,
             context,
             id,
+            AudioNodeType::PannerNode,
             ParamType::Orientation(ParamDir::Y),
             AutomationRate::A_rate,
             options.orientation_y, // default value
@@ -148,6 +153,7 @@ impl PannerNode {
             window,
             context,
             id,
+            AudioNodeType::PannerNode,
             ParamType::Orientation(ParamDir::Z),
             AutomationRate::A_rate,
             options.orientation_z, // default value

--- a/components/script/dom/stereopannernode.rs
+++ b/components/script/dom/stereopannernode.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
-use servo_media::audio::node::AudioNodeInit;
+use servo_media::audio::node::{AudioNodeInit, AudioNodeType};
 use servo_media::audio::param::ParamType;
 use servo_media::audio::stereo_panner::StereoPannerOptions as ServoMediaStereoPannerOptions;
 
@@ -59,6 +59,7 @@ impl StereoPannerNode {
             window,
             context,
             node_id,
+            AudioNodeType::StereoPannerNode,
             ParamType::Pan,
             AutomationRate::A_rate,
             *options.pan,

--- a/components/script/dom/webidls/AudioParam.webidl
+++ b/components/script/dom/webidls/AudioParam.webidl
@@ -14,7 +14,7 @@ enum AutomationRate {
 [Exposed=Window]
 interface AudioParam {
              attribute float value;
-             attribute AutomationRate automationRate;
+             [SetterThrows] attribute AutomationRate automationRate;
     readonly attribute float defaultValue;
     readonly attribute float minValue;
     readonly attribute float maxValue;

--- a/tests/wpt/meta-legacy-layout/webaudio/the-audio-api/the-audioparam-interface/automation-rate.html.ini
+++ b/tests/wpt/meta-legacy-layout/webaudio/the-audio-api/the-audioparam-interface/automation-rate.html.ini
@@ -2,12 +2,6 @@
   [< [AudioBufferSourceNode\] 2 out of 4 assertions were failed.]
     expected: FAIL
 
-  [X Set AudioBufferSourceNode.detune.automationRate to "a-rate" did not throw an exception.]
-    expected: FAIL
-
-  [X Set AudioBufferSourceNode.playbackRate.automationRate to "a-rate" did not throw an exception.]
-    expected: FAIL
-
   [Executing "DelayNode"]
     expected: FAIL
 

--- a/tests/wpt/meta/webaudio/the-audio-api/the-audioparam-interface/automation-rate.html.ini
+++ b/tests/wpt/meta/webaudio/the-audio-api/the-audioparam-interface/automation-rate.html.ini
@@ -5,12 +5,6 @@
   [Executing "DynamicsCompressorNode"]
     expected: FAIL
 
-  [X Set AudioBufferSourceNode.detune.automationRate to "a-rate" did not throw an exception.]
-    expected: FAIL
-
-  [X Set AudioBufferSourceNode.playbackRate.automationRate to "a-rate" did not throw an exception.]
-    expected: FAIL
-
   [< [AudioBufferSourceNode\] 2 out of 4 assertions were failed.]
     expected: FAIL
 


### PR DESCRIPTION
The [webaudio spec](https://webaudio.github.io/web-audio-api/#AudioParam-attributes) specifies that some nodes have constraints certain constraints when setting `automationRate`. This change sets those constraints for `AudioBufferSourceNode`.

---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes (partially) fix https://github.com/servo/servo/issues/43407
- [x] There are tests for these changes


