### PR TITLE
Initiate redirect fetching iff the request has a location

### DIFF
--- a/tests/wpt/metadata/cookies/http-state/domain-tests.html.ini
+++ b/tests/wpt/metadata/cookies/http-state/domain-tests.html.ini
@@ -1,2 +1,67 @@
 [domain-tests.html]
-  expected: TIMEOUT
+  [domain0036 - domain0036]
+    expected: FAIL
+
+  [domain0035 - domain0035]
+    expected: FAIL
+
+  [domain0029 - domain0029]
+    expected: FAIL
+
+  [domain0022 - domain0022]
+    expected: FAIL
+
+  [domain0005 - domain0005]
+    expected: FAIL
+
+  [optional-domain0041 - optional-domain0041]
+    expected: FAIL
+
+  [domain0003 - domain0003]
+    expected: FAIL
+
+  [domain0019 - domain0019]
+    expected: FAIL
+
+  [domain0040 - domain0040]
+    expected: FAIL
+
+  [domain0025 - domain0025]
+    expected: FAIL
+
+  [domain0020 - domain0020]
+    expected: FAIL
+
+  [domain0001 - domain0001]
+    expected: FAIL
+
+  [domain0038 - domain0038]
+    expected: FAIL
+
+  [domain0039 - domain0039]
+    expected: FAIL
+
+  [domain0033 - domain0033]
+    expected: FAIL
+
+  [domain0031 - domain0031]
+    expected: FAIL
+
+  [domain0023 - domain0023]
+    expected: FAIL
+
+  [domain0012 - domain0012]
+    expected: FAIL
+
+  [domain0008 - domain0008]
+    expected: FAIL
+
+  [domain0009 - domain0009]
+    expected: FAIL
+
+  [domain0026 - domain0026]
+    expected: FAIL
+
+  [domain0004 - domain0004]
+    expected: FAIL
+

--- a/tests/wpt/metadata/cookies/http-state/ordering-tests.html.ini
+++ b/tests/wpt/metadata/cookies/http-state/ordering-tests.html.ini
@@ -1,2 +1,4 @@
 [ordering-tests.html]
-  expected: TIMEOUT
+  [ordering0001 - ordering0001]
+    expected: FAIL
+

--- a/tests/wpt/metadata/cookies/http-state/path-tests.html.ini
+++ b/tests/wpt/metadata/cookies/http-state/path-tests.html.ini
@@ -1,2 +1,40 @@
 [path-tests.html]
-  expected: TIMEOUT
+  [path0015 - path0015]
+    expected: FAIL
+
+  [path0002 - path0002]
+    expected: FAIL
+
+  [path0003 - path0003]
+    expected: FAIL
+
+  [path0004 - path0004]
+    expected: FAIL
+
+  [path0001 - path0001]
+    expected: FAIL
+
+  [path0016 - path0016]
+    expected: FAIL
+
+  [path0026 - path0026]
+    expected: FAIL
+
+  [path0017 - path0017]
+    expected: FAIL
+
+  [path0032 - path0032]
+    expected: FAIL
+
+  [path0029 - path0029]
+    expected: FAIL
+
+  [disabled-path0029 - disabled-path0029]
+    expected: FAIL
+
+  [path0010 - path0010]
+    expected: FAIL
+
+  [path0007 - path0007]
+    expected: FAIL
+


### PR DESCRIPTION
Without this checking, we will run into a TIMEOUT request because
http_redirect_fetch will return immediately when location doesn't exist.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes partially fix #25606
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
