### PR TITLE
Use an appropriate graphics adapter when openxr is present.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5554,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "surfman"
 version = "0.2.0"
-source = "git+https://github.com/servo/surfman#41ac1ee64bc2d1978aeed0f8bf549c57f20ec7c8"
+source = "git+https://github.com/servo/surfman#bc084411664b04dba777659e5ce16b5f95b7371a"
 dependencies = [
  "bitflags",
  "cfg_aliases",
@@ -5570,6 +5570,7 @@ dependencies = [
  "libc",
  "log",
  "mach",
+ "metal",
  "objc",
  "parking_lot",
  "wayland-sys 0.24.0",
@@ -6446,7 +6447,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#755a872672c80d71651a305600b97526952d5293"
+source = "git+https://github.com/servo/webxr#e30ebd848c4deb95833c2fea91d7d8d34f6d8ed8"
 dependencies = [
  "android_injected_glue",
  "bindgen",
@@ -6469,7 +6470,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#755a872672c80d71651a305600b97526952d5293"
+source = "git+https://github.com/servo/webxr#e30ebd848c4deb95833c2fea91d7d8d34f6d8ed8"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -6477,7 +6478,6 @@ dependencies = [
  "serde",
  "surfman-chains-api",
  "time",
- "winit",
 ]
 
 [[package]]


### PR DESCRIPTION
The surfman upgrade broke our fragile process of choosing a graphics adapter that is always compatible with openxr. These changes ensure that won't happen in the future.

Depends on https://github.com/servo/webxr/pull/174.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #26474
- [x] These changes do not require tests because we can't test the emulator configuration