### PR TITLE
Remove a TODO from the implementation of getComputedStyle

### DIFF
--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -242,8 +242,6 @@ impl CSSStyleDeclaration {
             CSSStyleOwner::Element(ref el) => {
                 let node = el.upcast::<Node>();
                 if !node.is_connected() {
-                    // TODO: Node should be matched against the style rules of this window.
-                    // Firefox is currently the only browser to implement this.
                     return DOMString::new();
                 }
                 let addr = node.to_trusted_node_address();


### PR DESCRIPTION
The spec is now clear that disconnected elements shouldn't return a
style.

Closes #6860.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #6860
- [x] These changes do not require tests because they just update a comment.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
