### PR TITLE
Fix radial gradients for html canvas element

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4284,7 +4284,7 @@ checksum = "dd5927936723a9e8b715d37d7e4b390455087c4bdf25b9f702309460577b14f9"
 [[package]]
 name = "raqote"
 version = "0.7.15-alpha.0"
-source = "git+https://github.com/jrmuizel/raqote#ca35017005a5ff4764cc931bab4d9dc74fc5a818"
+source = "git+https://github.com/jrmuizel/raqote#357934688fd31056cb243a9304d74f022ed3069f"
 dependencies = [
  "euclid",
  "font-kit",
@@ -5606,9 +5606,9 @@ checksum = "c666f0fed8e1e20e057af770af9077d72f3d5a33157b8537c1475dd8ffd6d32b"
 
 [[package]]
 name = "sw-composite"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb14ea6254cc7c0417e9e26ba52691a8cf3d4fc9740870d40eac37b162f96973"
+checksum = "1a7df67551cbd26026a76fcc6f6938d96a267601a676534bf62967be17e47dba"
 
 [[package]]
 name = "swapper"

--- a/tests/wpt/metadata-layout-2020/html/canvas/element/drawing-images-to-the-canvas/drawimage_canvas.html.ini
+++ b/tests/wpt/metadata-layout-2020/html/canvas/element/drawing-images-to-the-canvas/drawimage_canvas.html.ini
@@ -11,19 +11,10 @@
   [Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,70 should be blue.]
     expected: FAIL
 
-  [Test scenario 10: sx = 0, sy = 0, sw = 50, sh = 50, dx = 0, dy = 0, dw = 200, dh = 200 --- Pixel 20,99 should be black.]
-    expected: FAIL
-
-  [Test scenario 10: sx = 0, sy = 0, sw = 50, sh = 50, dx = 0, dy = 0, dw = 200, dh = 200 --- Pixel 99,20 should be black.]
-    expected: FAIL
-
   [Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,99 should be black.]
     expected: FAIL
 
   [Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 70,99 should be blue.]
-    expected: FAIL
-
-  [Test scenario 10: sx = 0, sy = 0, sw = 50, sh = 50, dx = 0, dy = 0, dw = 200, dh = 200 --- Pixel 20,20 should be black.]
     expected: FAIL
 
   [Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 84,99 should be black.]

--- a/tests/wpt/metadata-layout-2020/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.cone.beside.html.ini
+++ b/tests/wpt/metadata-layout-2020/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.cone.beside.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.cone.beside.html]
-  [Canvas test: 2d.gradient.radial.cone.beside]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch1.html.ini
+++ b/tests/wpt/metadata-layout-2020/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch1.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch1.html]
-  [Canvas test: 2d.gradient.radial.touch1]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch2.html.ini
+++ b/tests/wpt/metadata-layout-2020/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch2.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch2.html]
-  [Canvas test: 2d.gradient.radial.touch2]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch3.html.ini
+++ b/tests/wpt/metadata-layout-2020/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch3.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch3.html]
-  [Canvas test: 2d.gradient.radial.touch3]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.cone.beside.html.ini
+++ b/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.cone.beside.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.cone.beside.html]
-  [OffscreenCanvas test: 2d.gradient.radial.cone.beside]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.cone.beside.worker.js.ini
+++ b/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.cone.beside.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.cone.beside.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch1.html.ini
+++ b/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch1.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch1.html]
-  [OffscreenCanvas test: 2d.gradient.radial.touch1]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch1.worker.js.ini
+++ b/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch1.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch1.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch2.html.ini
+++ b/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch2.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch2.html]
-  [OffscreenCanvas test: 2d.gradient.radial.touch2]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch2.worker.js.ini
+++ b/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch2.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch2.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch3.html.ini
+++ b/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch3.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch3.html]
-  [OffscreenCanvas test: 2d.gradient.radial.touch3]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch3.worker.js.ini
+++ b/tests/wpt/metadata-layout-2020/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch3.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch3.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/canvas/element/drawing-images-to-the-canvas/drawimage_canvas.html.ini
+++ b/tests/wpt/metadata/html/canvas/element/drawing-images-to-the-canvas/drawimage_canvas.html.ini
@@ -11,19 +11,10 @@
   [Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,70 should be blue.]
     expected: FAIL
 
-  [Test scenario 10: sx = 0, sy = 0, sw = 50, sh = 50, dx = 0, dy = 0, dw = 200, dh = 200 --- Pixel 20,99 should be black.]
-    expected: FAIL
-
-  [Test scenario 10: sx = 0, sy = 0, sw = 50, sh = 50, dx = 0, dy = 0, dw = 200, dh = 200 --- Pixel 99,20 should be black.]
-    expected: FAIL
-
   [Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 99,99 should be black.]
     expected: FAIL
 
   [Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 70,99 should be blue.]
-    expected: FAIL
-
-  [Test scenario 10: sx = 0, sy = 0, sw = 50, sh = 50, dx = 0, dy = 0, dw = 200, dh = 200 --- Pixel 20,20 should be black.]
     expected: FAIL
 
   [Test scenario 12: sx = -20, sy = -20, sw = 50, sh = 50, dx = 20, dy = 20, dw = 125, dh = 125 --- Pixel 84,99 should be black.]

--- a/tests/wpt/metadata/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.cone.beside.html.ini
+++ b/tests/wpt/metadata/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.cone.beside.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.cone.beside.html]
-  [Canvas test: 2d.gradient.radial.cone.beside]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch1.html.ini
+++ b/tests/wpt/metadata/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch1.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch1.html]
-  [Canvas test: 2d.gradient.radial.touch1]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch2.html.ini
+++ b/tests/wpt/metadata/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch2.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch2.html]
-  [Canvas test: 2d.gradient.radial.touch2]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch3.html.ini
+++ b/tests/wpt/metadata/html/canvas/element/fill-and-stroke-styles/2d.gradient.radial.touch3.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch3.html]
-  [Canvas test: 2d.gradient.radial.touch3]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.cone.beside.html.ini
+++ b/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.cone.beside.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.cone.beside.html]
-  [OffscreenCanvas test: 2d.gradient.radial.cone.beside]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.cone.beside.worker.js.ini
+++ b/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.cone.beside.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.cone.beside.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch1.html.ini
+++ b/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch1.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch1.html]
-  [OffscreenCanvas test: 2d.gradient.radial.touch1]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch1.worker.js.ini
+++ b/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch1.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch1.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch2.html.ini
+++ b/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch2.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch2.html]
-  [OffscreenCanvas test: 2d.gradient.radial.touch2]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch2.worker.js.ini
+++ b/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch2.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch2.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch3.html.ini
+++ b/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch3.html.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch3.html]
-  [OffscreenCanvas test: 2d.gradient.radial.touch3]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch3.worker.js.ini
+++ b/tests/wpt/metadata/html/canvas/offscreen/fill-and-stroke-styles/2d.gradient.radial.touch3.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.gradient.radial.touch3.worker.html]
-  [2d]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The latest version of raqote provides a fix for properly handling boundary conditions for TwoCircleRadialGradients.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix part of #25331

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
