### PR TITLE
Handle cancelAnimationFrame() when called within a requestAnimationFr…

### DIFF
--- a/tests/wpt/metadata/webxr/xrSession_cancelAnimationFrame.https.html.ini
+++ b/tests/wpt/metadata/webxr/xrSession_cancelAnimationFrame.https.html.ini
@@ -1,7 +1,0 @@
-[xrSession_cancelAnimationFrame.https.html]
-  [XRSession requestAnimationFrame callbacks can be unregistered with cancelAnimationFrame for non-immersive sessions]
-    expected: FAIL
-
-  [XRSession requestAnimationFrame callbacks can be unregistered with cancelAnimationFrame for immersive sessions]
-    expected: FAIL
-


### PR DESCRIPTION
…ame() callback

<!-- Please describe your changes on the following line: -->
In order to handle `cancelAnimationFrame()` in the callback, the `raf_callback_list` is moved to 
`current_raf_callback_list`, and each callback is cloned in the iteration of `current_raf_callback_list` to avoid "borrowed twice". 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #26251 

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
