### PR TITLE
Switch to single WebGPU thread

### DIFF
--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -472,31 +472,22 @@ impl WGPU {
                     options,
                     ids,
                 } => {
-                    let adapter_id = if let Some(pos) = self
-                        .adapters
-                        .iter()
-                        .position(|adapter| ids.contains(&adapter.0))
-                    {
-                        self.adapters[pos].0
-                    } else {
-                        let adapter_id = match self.global.pick_adapter(
-                            &options,
-                            wgpu::instance::AdapterInputs::IdSet(&ids, |id| id.backend()),
-                        ) {
-                            Some(id) => id,
-                            None => {
-                                if let Err(e) =
-                                    sender.send(Err("Failed to get webgpu adapter".to_string()))
-                                {
-                                    warn!(
-                                        "Failed to send response to WebGPURequest::RequestAdapter ({})",
-                                        e
-                                    )
-                                }
-                                return;
-                            },
-                        };
-                        adapter_id
+                    let adapter_id = match self.global.pick_adapter(
+                        &options,
+                        wgpu::instance::AdapterInputs::IdSet(&ids, |id| id.backend()),
+                    ) {
+                        Some(id) => id,
+                        None => {
+                            if let Err(e) =
+                                sender.send(Err("Failed to get webgpu adapter".to_string()))
+                            {
+                                warn!(
+                                    "Failed to send response to WebGPURequest::RequestAdapter ({})",
+                                    e
+                                )
+                            }
+                            return;
+                        },
                     };
                     let adapter = WebGPUAdapter(adapter_id);
                     self.adapters.push(adapter);


### PR DESCRIPTION
Replace the current-one thread per host in a browsing context group-implementation to a single thread across the browser. Remove some garbage code in request adapter on wgpu server-side.

<!-- Please describe your changes on the following line: -->
r?@kvark @jdm 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
