### PR TITLE
Remove AnimatedProperty

### DIFF
--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -113,7 +113,7 @@ impl Animations {
                 transition.state = AnimationState::Finished;
                 update.add_event(
                     transition.node,
-                    transition.property_animation.property_name().into(),
+                    transition.property_animation.property_id().name().into(),
                     TransitionOrAnimationEventType::TransitionEnd,
                     transition.property_animation.duration,
                 );
@@ -135,7 +135,7 @@ impl Animations {
                 // according to https://drafts.csswg.org/css-transitions/#event-transitionevent
                 update.add_event(
                     transition.node,
-                    transition.property_animation.property_name().into(),
+                    transition.property_animation.property_id().name().into(),
                     TransitionOrAnimationEventType::TransitionCancel,
                     (now - transition.start_time).max(0.),
                 );
@@ -157,7 +157,7 @@ impl Animations {
                 // according to https://drafts.csswg.org/css-transitions/#event-transitionevent
                 update.add_event(
                     transition.node,
-                    transition.property_animation.property_name().into(),
+                    transition.property_animation.property_id().name().into(),
                     TransitionOrAnimationEventType::TransitionRun,
                     0.,
                 );

--- a/tests/wpt/metadata/css/CSS2/linebox/animations/line-height-interpolation.html.ini
+++ b/tests/wpt/metadata/css/CSS2/linebox/animations/line-height-interpolation.html.ini
@@ -47,9 +47,6 @@
   [CSS Animations: property <line-height> from [14q\] to [normal\] at (0) should be [14q\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [normal\] to [normal\] at (0.3) should be [normal\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [normal\] to [4\] at (0) should be [normal\]]
     expected: FAIL
 
@@ -132,9 +129,6 @@
     expected: FAIL
 
   [Web Animations: property <line-height> from [14q\] to [normal\] at (0) should be [14q\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from [normal\] to [normal\] at (0) should be [normal\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [4\] to [14px\] at (0.5) should be [14px\]]
@@ -222,9 +216,6 @@
     expected: FAIL
 
   [Web Animations: property <line-height> from [normal\] to [14px\] at (0) should be [normal\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from [normal\] to [normal\] at (-0.3) should be [normal\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [4q\] to [14q\] at (-0.3) should be [1q\]]
@@ -323,9 +314,6 @@
   [CSS Animations: property <line-height> from [14q\] to [normal\] at (0.3) should be [14q\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [normal\] to [normal\] at (0.6) should be [normal\]]
-    expected: FAIL
-
   [Web Animations: property <line-height> from [normal\] to [14px\] at (0.3) should be [normal\]]
     expected: FAIL
 
@@ -407,13 +395,7 @@
   [Web Animations: property <line-height> from [inherit\] to [20px\] at (1.5) should be [15px\]]
     expected: FAIL
 
-  [CSS Animations: property <line-height> from [normal\] to [normal\] at (1) should be [normal\]]
-    expected: FAIL
-
   [CSS Animations: property <line-height> from [normal\] to [14px\] at (0.6) should be [14px\]]
-    expected: FAIL
-
-  [CSS Animations: property <line-height> from [normal\] to [normal\] at (1.5) should be [normal\]]
     expected: FAIL
 
   [Web Animations: property <line-height> from [inherit\] to [20px\] at (0.3) should be [27px\]]

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-animation.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-animation.html.ini
@@ -1,2 +1,0 @@
-[mix-blend-mode-animation.html]
-  expected: TIMEOUT

--- a/tests/wpt/metadata/css/css-backgrounds/animations/border-width-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/animations/border-width-interpolation.html.ini
@@ -11,9 +11,6 @@
   [CSS Animations: property <border-left-width> from [unset\] to [20px\] at (1.5) should be [28.5px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-left-width> from [0px\] to [10px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <border-left-width> from [unset\] to [20px\] at (0.3) should be [8.1px\]]
     expected: FAIL
 
@@ -26,9 +23,6 @@
   [CSS Animations: property <border-top-width> from [15px\] to [thick\] at (-2) should be [35px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-top-width> from [15px\] to [thick\] at (1.5) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <border-right-width> from [thin\] to [11px\] at (0.6) should be [7px\]]
     expected: FAIL
 
@@ -39,15 +33,6 @@
     expected: FAIL
 
   [Web Animations: property <border-left-width> from neutral to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-bottom-width> from [thick\] to [15px\] at (-2) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-left-width> from [inherit\] to [20px\] at (0) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-left-width> from [medium\] to [13px\] at (-2) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <border-left-width> from [medium\] to [13px\] at (0.6) should be [9px\]]
@@ -101,9 +86,6 @@
   [CSS Transitions with transition: all: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (1.5) should be [35px 55px 75px 95px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-right-width> from [thin\] to [11px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (1.5) should be [35px 55px 75px 95px\]]
     expected: FAIL
 
@@ -144,9 +126,6 @@
     expected: FAIL
 
   [CSS Animations: property <border-right-width> from [thin\] to [11px\] at (1.5) should be [16px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-left-width> from [initial\] to [20px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <border-right-width> from [thin\] to [11px\] at (0.3) should be [4px\]]
@@ -218,9 +197,6 @@
   [CSS Animations: property <border-left-width> from [medium\] to [13px\] at (1.5) should be [18px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-right-width> from [thin\] to [11px\] at (-2) should be [0px\]]
-    expected: FAIL
-
   [Web Animations: property <border-bottom-width> from [thick\] to [15px\] at (1.5) should be [20px\]]
     expected: FAIL
 
@@ -237,9 +213,6 @@
     expected: FAIL
 
   [CSS Animations: property <border-left-width> from [initial\] to [20px\] at (0) should be [3px\]]
-    expected: FAIL
-
-  [CSS Animations: property <border-left-width> from [inherit\] to [20px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [Web Animations: property <border-bottom-width> from [thick\] to [15px\] at (-0.3) should be [2px\]]
@@ -347,9 +320,6 @@
   [Web Animations: property <border-right-width> from [thin\] to [11px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-left-width> from [0px\] to [10px\] at (0) should be [0px\]]
-    expected: FAIL
-
   [CSS Transitions with transition: all: property <border-width> from [20px 40px 60px 80px\] to [30px 50px 70px 90px\] at (0) should be [20px 40px 60px 80px\]]
     expected: FAIL
 
@@ -383,9 +353,6 @@
   [CSS Animations: property <border-top-width> from [15px\] to [thick\] at (1) should be [5px\]]
     expected: FAIL
 
-  [CSS Animations: property <border-left-width> from [unset\] to [20px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <border-left-width> from neutral to [20px\] at (1.5) should be [25px\]]
     expected: FAIL
 
@@ -414,5 +381,8 @@
     expected: FAIL
 
   [Web Animations: property <border-left-width> from [0px\] to [10px\] at (1) should be [10px\]]
+    expected: FAIL
+
+  [CSS Animations: property <border-left-width> from [0px\] to [10px\] at (1) should be [10px\]]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transforms/animation/rotate-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/rotate-interpolation.html.ini
@@ -92,12 +92,6 @@
   [Web Animations: property <rotate> from [1 -2.5 3.64 100deg\] to [1 -2.5 3.64 -100deg\] at (-1) should be [0.22 -0.55 0.8 300deg\]]
     expected: FAIL
 
-  [CSS Animations: property <rotate> from [none\] to [none\] at (0) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [none\] to [none\] at (2) should be [none\]]
-    expected: FAIL
-
   [Web Animations: property <rotate> from neutral to [30deg\] at (1) should be [30deg\]]
     expected: FAIL
 
@@ -144,12 +138,6 @@
     expected: FAIL
 
   [Web Animations: property <rotate> from [100deg\] to [180deg\] at (0) should be [100deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [none\] to [none\] at (0.125) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [none\] to [none\] at (1) should be [none\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [none\] to [7 -8 9 400grad\] at (-1) should be [0.5 -0.57 0.65 -400grad\]]
@@ -240,9 +228,6 @@
     expected: FAIL
 
   [Web Animations: property <rotate> from [1 0 0 0deg\] to [0 1 0 10deg\] at (0) should be [0 1 0 0deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [none\] to [none\] at (0.875) should be [none\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [unset\] to [30deg\] at (2) should be [60deg\]]
@@ -351,9 +336,6 @@
     expected: FAIL
 
   [Web Animations: property <rotate> from [100deg\] to [180deg\] at (0.875) should be [170deg\]]
-    expected: FAIL
-
-  [CSS Animations: property <rotate> from [none\] to [none\] at (-1) should be [none\]]
     expected: FAIL
 
   [Web Animations: property <rotate> from [100deg\] to [180deg\] at (1) should be [180deg\]]

--- a/tests/wpt/metadata/css/css-transforms/animation/scale-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/scale-interpolation.html.ini
@@ -119,9 +119,6 @@
   [CSS Animations: property <scale> from [inherit\] to [2 0.5 1\] at (-1) should be [-1 1.5 3\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [none\] to [none\] at (0.875) should be [none\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [inherit\] to [2 0.5 1\] at (2) should be [3.5 0 0\]]
     expected: FAIL
 
@@ -149,9 +146,6 @@
   [Web Animations: property <scale> from [26 17 9\] to [2 1\] at (0.875) should be [5 3 2\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [none\] to [none\] at (-1) should be [none\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [none\] to [4 3 2\] at (1) should be [4 3 2\]]
     expected: FAIL
 
@@ -167,9 +161,6 @@
   [Web Animations: property <scale> from [2 0.5 1\] to [inherit\] at (2) should be [-1 1.5 3\]]
     expected: FAIL
 
-  [CSS Animations: property <scale> from [none\] to [none\] at (0.125) should be [none\]]
-    expected: FAIL
-
   [Web Animations: property <scale> from [1\] to [10 -5 0\] at (1) should be [10 -5 0\]]
     expected: FAIL
 
@@ -177,9 +168,6 @@
     expected: FAIL
 
   [Web Animations: property <scale> from [2 30 400\] to [10 110 1200\] at (-1) should be [-6 -50 -400\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [none\] to [none\] at (1) should be [none\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [26 17 9\] to [2 1\] at (0.125) should be [23 15 8\]]
@@ -192,9 +180,6 @@
     expected: FAIL
 
   [Web Animations: property <scale> from [inherit\] to [2 0.5 1\] at (0) should be [0.5 1 2\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [none\] to [none\] at (0) should be [none\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [none\] to [none\] at (1) should be [none\]]
@@ -216,9 +201,6 @@
     expected: FAIL
 
   [Web Animations: property <scale> from [26 17 9\] to [2 1\] at (0) should be [26 17 9\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [2 0.5 1\] to [inherit\] at (0) should be [2 0.5\]]
     expected: FAIL
 
   [Web Animations: property <scale> from [-10 5\] to [10 -5\] at (0.75) should be [5 -2.5\]]
@@ -339,9 +321,6 @@
     expected: FAIL
 
   [Web Animations: property <scale> from [inherit\] to [initial\] at (-1) should be [0 1 3\]]
-    expected: FAIL
-
-  [CSS Animations: property <scale> from [none\] to [none\] at (2) should be [none\]]
     expected: FAIL
 
   [CSS Animations: property <scale> from [initial\] to [inherit\] at (0) should be [1\]]

--- a/tests/wpt/metadata/css/css-transforms/animation/translate-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/animation/translate-interpolation.html.ini
@@ -218,9 +218,6 @@
   [Web Animations: property <translate> from [-100px -50px 100px\] to [0px\] at (-1) should be [-200px -100px 200px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [200px 100px 200px\] to [inherit\] at (0) should be [200px 100px 200px\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [inherit\] to [200px 100px 200px\] at (1) should be [200px 100px 200px\]]
     expected: FAIL
 
@@ -236,22 +233,13 @@
   [Web Animations: property <translate> from neutral to [20px\] at (0.25) should be [12.5px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [none\] to [none\] at (0.125) should be [none\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from [200px 100px 200px\] to [inherit\] at (0) should be [200px 100px 200px\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (0) should be [220px 240px 260px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [none\] to [none\] at (0.875) should be [none\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from neutral to [20px\] at (1) should be [20px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [none\] to [none\] at (-1) should be [none\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [200px 100px 400px\] to [initial\] at (0.75) should be [50px 25px 100px\]]
@@ -440,16 +428,7 @@
   [Web Animations: property <translate> from [220px 240px 260px\] to [300px 400px 500px\] at (1) should be [300px 400px 500px\]]
     expected: FAIL
 
-  [CSS Animations: property <translate> from [none\] to [none\] at (0) should be [none\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [none\] to [none\] at (2) should be [none\]]
-    expected: FAIL
-
   [Web Animations: property <translate> from neutral to [20px\] at (0.75) should be [17.5px\]]
-    expected: FAIL
-
-  [CSS Animations: property <translate> from [none\] to [none\] at (1) should be [none\]]
     expected: FAIL
 
   [Web Animations: property <translate> from [initial\] to [inherit\] at (-1) should be [-100px -200px -300px\]]

--- a/tests/wpt/metadata/css/css-ui/animation/outline-width-interpolation.html.ini
+++ b/tests/wpt/metadata/css/css-ui/animation/outline-width-interpolation.html.ini
@@ -149,12 +149,6 @@
   [CSS Animations: property <outline-width> from [0px\] to [10px\] at (1.5) should be [15px\]]
     expected: FAIL
 
-  [CSS Animations: property <outline-width> from [initial\] to [20px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-width> from [thick\] to [15px\] at (-2) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <outline-width> from [thick\] to [15px\] at (0) should be [5px\]]
     expected: FAIL
 
@@ -191,9 +185,6 @@
   [CSS Animations: property <outline-width> from [initial\] to [20px\] at (0.6) should be [13px\]]
     expected: FAIL
 
-  [CSS Animations: property <outline-width> from [unset\] to [20px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <outline-width> from [unset\] to [20px\] at (1.5) should be [28px\]]
     expected: FAIL
 
@@ -204,9 +195,6 @@
     expected: FAIL
 
   [Web Animations: property <outline-width> from [inherit\] to [20px\] at (0) should be [30px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-width> from [0px\] to [10px\] at (0) should be [0px\]]
     expected: FAIL
 
   [CSS Animations: property <outline-width> from neutral to [20px\] at (0.6) should be [16px\]]
@@ -242,9 +230,6 @@
   [CSS Transitions with transition: all: property <outline-width> from [unset\] to [20px\] at (1.5) should be [28px\]]
     expected: FAIL
 
-  [CSS Animations: property <outline-width> from [0px\] to [10px\] at (-0.3) should be [0px\]]
-    expected: FAIL
-
   [CSS Animations: property <outline-width> from [initial\] to [20px\] at (0) should be [3px\]]
     expected: FAIL
 
@@ -252,12 +237,6 @@
     expected: FAIL
 
   [CSS Transitions: property <outline-width> from [unset\] to [20px\] at (1.5) should be [28px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-width> from [unset\] to [23px\] at (0) should be [3px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-width> from [unset\] to [23px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [Web Animations: property <outline-width> from [unset\] to [23px\] at (1.5) should be [33px\]]
@@ -282,9 +261,6 @@
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [initial\] to [23px\] at (1) should be [23px\]]
-    expected: FAIL
-
-  [CSS Animations: property <outline-width> from [initial\] to [23px\] at (-0.3) should be [0px\]]
     expected: FAIL
 
   [Web Animations: property <outline-width> from [unset\] to [23px\] at (-0.3) should be [0px\]]
@@ -324,5 +300,11 @@
     expected: FAIL
 
   [CSS Animations: property <outline-width> from [initial\] to [23px\] at (1.5) should be [33px\]]
+    expected: FAIL
+
+  [CSS Animations: property <outline-width> from [unset\] to [23px\] at (0) should be [3px\]]
+    expected: FAIL
+
+  [CSS Animations: property <outline-width> from [0px\] to [10px\] at (1) should be [10px\]]
     expected: FAIL
 


### PR DESCRIPTION
This removes an extra layer of abstraction and allows Servo to share
more code with Gecko. In addition, we will need to handle raw
`AnimationValue` structs soon in order to fully implement "faster
reversing of interrupted transitions."

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
