### PR TITLE
Add integrity hash for nightly builds

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -642,22 +642,16 @@ class PackageCommands(CommandBase):
                     sha256_digest.update(data)
             package_hash = sha256_digest.hexdigest()
             package_hash_fileobj = io.BytesIO(package_hash)
-            package_hash_upload_key = '{}/{}.sha256'.format(nightly_dir, filename)
             latest_hash_upload_key = '{}/servo-latest{}.sha256'.format(nightly_dir, extension)
 
             s3.upload_file(package, BUCKET, package_upload_key)
-            s3.upload_fileobj(package_hash_fileobj, BUCKET, package_hash_upload_key)
 
             copy_source = {
                 'Bucket': BUCKET,
                 'Key': package_upload_key,
             }
-            copy_source_hash = {
-                'Bucket': BUCKET,
-                'Key': package_hash_upload_key,
-            }
             s3.copy(copy_source, BUCKET, latest_upload_key)
-            s3.copy(copy_source_hash, BUCKET, latest_hash_upload_key)
+            s3.upload_fileobj(package_hash_fileobj, BUCKET, latest_hash_upload_key)
 
         def update_maven(directory):
             (aws_access_key, aws_secret_access_key) = get_s3_secret()


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Compute a SHA-256 integrity hash for nightly builds on the download.servo.org page.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors (it does, but unrelated to the change)
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix servo/download.servo.org#14 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they're in the infrastructure

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
