### PR TITLE
Reject incompatible webgl texture pixel data

### DIFF
--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -1313,7 +1313,39 @@ impl TexFormat {
     }
 }
 
+#[derive(PartialEq)]
+pub enum SizedDataType {
+    Int8,
+    Int16,
+    Int32,
+    Uint8,
+    Uint16,
+    Uint32,
+    Float32,
+}
+
 impl TexDataType {
+    /// Returns the compatible sized data type for this texture data type.
+    pub fn sized_data_type(&self) -> SizedDataType {
+        match self {
+            TexDataType::Byte => SizedDataType::Int8,
+            TexDataType::UnsignedByte => SizedDataType::Uint8,
+            TexDataType::Short => SizedDataType::Int16,
+            TexDataType::UnsignedShort |
+            TexDataType::UnsignedShort4444 |
+            TexDataType::UnsignedShort5551 |
+            TexDataType::UnsignedShort565 => SizedDataType::Uint16,
+            TexDataType::Int => SizedDataType::Int32,
+            TexDataType::UnsignedInt |
+            TexDataType::UnsignedInt10f11f11fRev |
+            TexDataType::UnsignedInt2101010Rev |
+            TexDataType::UnsignedInt5999Rev |
+            TexDataType::UnsignedInt248 => SizedDataType::Uint32,
+            TexDataType::HalfFloat => SizedDataType::Uint16,
+            TexDataType::Float | TexDataType::Float32UnsignedInt248Rev => SizedDataType::Float32,
+        }
+    }
+
     /// Returns the size in bytes of each element of data.
     pub fn element_size(&self) -> u32 {
         use self::*;

--- a/components/script/dom/webgl_extensions/extensions.rs
+++ b/components/script/dom/webgl_extensions/extensions.rs
@@ -106,6 +106,7 @@ impl WebGLExtensionFeatures {
             disabled_get_parameter_names,
             disabled_get_tex_parameter_names,
             disabled_get_vertex_attrib_names,
+            not_filterable_tex_types,
             element_index_uint_enabled,
             blend_minmax_enabled,
         ) = match webgl_version {
@@ -123,6 +124,7 @@ impl WebGLExtensionFeatures {
                     .iter()
                     .cloned()
                     .collect(),
+                DEFAULT_NOT_FILTERABLE_TEX_TYPES.iter().cloned().collect(),
                 false,
                 false,
             ),
@@ -137,6 +139,7 @@ impl WebGLExtensionFeatures {
                     .cloned()
                     .collect(),
                 Default::default(),
+                Default::default(),
                 true,
                 true,
             ),
@@ -144,7 +147,7 @@ impl WebGLExtensionFeatures {
         Self {
             gl_extensions: Default::default(),
             disabled_tex_types,
-            not_filterable_tex_types: DEFAULT_NOT_FILTERABLE_TEX_TYPES.iter().cloned().collect(),
+            not_filterable_tex_types,
             effective_tex_internal_formats: Default::default(),
             hint_targets: Default::default(),
             disabled_get_parameter_names,


### PR DESCRIPTION
The tests that would make these changes most visibly correct unfortunately rely on texImage3D which isn't implemented yet, so they error out too soon. However, when I comment out that code, these changes avoid a bunch of panics in the webgl thread because of invalid data type combinations being accepted, and removing the incorrect non-filterable texture fallback behaviour for webgl 2 when more texture formats are supposed to be filterable.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes