### PR TITLE
Add support for WebGL2 TexImage2D

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -306,6 +306,10 @@ impl WebGLRenderingContext {
         &self.limits
     }
 
+    pub fn texture_unpacking_alignment(&self) -> u32 {
+        self.texture_unpacking_alignment.get()
+    }
+
     pub fn current_vao(&self) -> DomRoot<WebGLVertexArrayObjectOES> {
         self.current_vao.or_init(|| {
             DomRoot::from_ref(
@@ -697,14 +701,14 @@ impl WebGLRenderingContext {
     }
 
     // TODO(emilio): Move this logic to a validator.
-    fn validate_tex_image_2d_data(
+    pub fn validate_tex_image_2d_data(
         &self,
         width: u32,
         height: u32,
         format: TexFormat,
         data_type: TexDataType,
         unpacking_alignment: u32,
-        data: &Option<ArrayBufferView>,
+        data: Option<&ArrayBufferView>,
     ) -> Result<u32, ()> {
         let element_size = data_type.element_size();
         let components_per_element = data_type.components_per_element();
@@ -742,7 +746,7 @@ impl WebGLRenderingContext {
         }
     }
 
-    fn tex_image_2d(
+    pub fn tex_image_2d(
         &self,
         texture: &WebGLTexture,
         target: TexImageTarget,
@@ -4276,7 +4280,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
                 format,
                 data_type,
                 unpacking_alignment,
-                &*pixels,
+                pixels.as_ref(),
             )
         } {
             Ok(byte_length) => byte_length,
@@ -4503,7 +4507,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
                 format,
                 data_type,
                 unpacking_alignment,
-                &*pixels,
+                pixels.as_ref(),
             )
         } {
             Ok(byte_length) => byte_length,
@@ -4881,7 +4885,7 @@ impl TextureUnit {
     }
 }
 
-struct TexPixels {
+pub struct TexPixels {
     data: IpcSharedMemory,
     size: Size2D<u32>,
     pixel_format: Option<PixelFormat>,
@@ -4903,7 +4907,7 @@ impl TexPixels {
         }
     }
 
-    fn from_array(data: IpcSharedMemory, size: Size2D<u32>) -> Self {
+    pub fn from_array(data: IpcSharedMemory, size: Size2D<u32>) -> Self {
         Self {
             data,
             size,

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -512,10 +512,10 @@ interface mixin WebGL2RenderingContextOverloads
   //void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
   //                GLint border, GLenum format, GLenum type,
   //                TexImageSource source); // May throw DOMException
-  //[Throws]
-  //void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
-  //                GLint border, GLenum format, GLenum type, /*[AllowShared]*/ ArrayBufferView srcData,
-  //                GLuint srcOffset);
+  [Throws]
+  void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+                  GLint border, GLenum format, GLenum type, /*[AllowShared]*/ ArrayBufferView srcData,
+                  GLuint srcOffset);
 
   //[Throws]
   //void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,

--- a/tests/wpt/webgl/meta/conformance2/misc/views-with-offsets.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/misc/views-with-offsets.html.ini
@@ -1,11 +1,8 @@
 [views-with-offsets.html]
   expected: ERROR
-  [WebGL test #0: Does not support texImage2D with offsets into views.]
+  [WebGL test #47: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
     expected: FAIL
 
-  [WebGL test #1: Does not support texSubImage2D with offsets into views.]
-    expected: FAIL
-
-  [WebGL test #2: successfullyParsed should be true (of type boolean). Was undefined (of type undefined).]
+  [WebGL test #46: Does not support texSubImage2D with offsets into views.]
     expected: FAIL
 


### PR DESCRIPTION
Adds initial support for one of the WebGL2 `TexImage2D` call.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix part of #26512 
- [x] There are tests for these changes

@mmatyas @zakorgy @jdm 
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
