### PR TITLE
Fix file extension for Linux nightly

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -628,8 +628,8 @@ class PackageCommands(CommandBase):
             nightly_dir = 'nightly/{}'.format(platform)
             filename = nightly_filename(package, timestamp)
             package_upload_key = '{}/{}'.format(nightly_dir, filename)
-            extension = path.splitext(path.basename(package))[1]
-            latest_upload_key = '{}/servo-latest{}'.format(nightly_dir, extension)
+            extension = path.basename(package).partition('.')[2]
+            latest_upload_key = '{}/servo-latest.{}'.format(nightly_dir, extension)
 
             # Compute the hash
             SHA_BUF_SIZE = 1048576  # read in 1 MiB chunks
@@ -642,7 +642,7 @@ class PackageCommands(CommandBase):
                     sha256_digest.update(data)
             package_hash = sha256_digest.hexdigest()
             package_hash_fileobj = io.BytesIO(package_hash)
-            latest_hash_upload_key = '{}/servo-latest{}.sha256'.format(nightly_dir, extension)
+            latest_hash_upload_key = '{}/servo-latest.{}.sha256'.format(nightly_dir, extension)
 
             s3.upload_file(package, BUCKET, package_upload_key)
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Fix file extension for the Linux nightly download. It should be published as `servo-latest.tar.gz` but was instead published as `servo-latest.gz`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors (doesn't change Rust code)
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #26522 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this is an infrastructure bug fix

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
