### PR TITLE
layout_2020: Fix WebRender display list dumping

### DIFF
--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -1302,15 +1302,19 @@ impl LayoutThread {
             fragment_tree.scrollable_overflow(),
         );
 
+        // `dump_serialized_display_list` doesn't actually print anything. It sets up
+        // the display list for printing the serialized version when `finalize()` is called.
+        // We need to call this before adding any display items so that they are printed
+        // during `finalize()`.
+        if self.dump_display_list {
+            display_list.wr.dump_serialized_display_list();
+        }
+
         fragment_tree.build_display_list(&mut display_list);
 
         if self.dump_flow_tree {
             fragment_tree.print();
         }
-        if self.dump_display_list {
-            display_list.wr.dump_serialized_display_list();
-        }
-
         debug!("Layout done!");
 
         let mut epoch = self.epoch.get();


### PR DESCRIPTION
We need to enable display list serialization before building the display
list for it to work properly.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just fix debug output.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
