### PR TITLE
Adapt layout 2020 viewer to new BoxTree and FragmentTree structs

### DIFF
--- a/etc/layout_viewer/viewer_2020.html
+++ b/etc/layout_viewer/viewer_2020.html
@@ -210,11 +210,11 @@
 
       function flatten_trace(trace_node) {
         const fragment_tree_root = Object.values(
-          trace_node.fragment_tree.children
+          trace_node.fragment_tree.root_fragments
         )[0];
         return {
           fragment_tree: create_fragment_tree(fragment_tree_root),
-          box_tree: box_tree_from_bfc(trace_node.box_tree)
+          box_tree: box_tree_from_bfc(trace_node.box_tree.root)
         };
       }
 


### PR DESCRIPTION
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

#26414 introduced some changes to how we represent the box and fragment trees, so we need to adapt the layout viewer to support them.