### PR TITLE
Implement animationiteration event

### DIFF
--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -443,6 +443,7 @@ macro_rules! global_event_handlers(
     (NoOnload) => (
         event_handler!(abort, GetOnabort, SetOnabort);
         event_handler!(animationend, GetOnanimationend, SetOnanimationend);
+        event_handler!(animationiteration, GetOnanimationiteration, SetOnanimationiteration);
         event_handler!(cancel, GetOncancel, SetOncancel);
         event_handler!(canplay, GetOncanplay, SetOncanplay);
         event_handler!(canplaythrough, GetOncanplaythrough, SetOncanplaythrough);

--- a/components/script/dom/webidls/EventHandler.webidl
+++ b/components/script/dom/webidls/EventHandler.webidl
@@ -93,6 +93,7 @@ interface mixin GlobalEventHandlers {
 // https://drafts.csswg.org/css-animations/#interface-globaleventhandlers-idl
 partial interface mixin GlobalEventHandlers {
            attribute EventHandler onanimationend;
+           attribute EventHandler onanimationiteration;
 };
 
 // https://drafts.csswg.org/css-transitions/#interface-globaleventhandlers-idl

--- a/tests/wpt/metadata-layout-2020/css/css-animations/animationevent-types.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-animations/animationevent-types.html.ini
@@ -1,8 +1,5 @@
 [animationevent-types.html]
   expected: TIMEOUT
-  [animationiteration event is instanceof AnimationEvent]
-    expected: TIMEOUT
-
   [animationstart event is instanceof AnimationEvent]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata-layout-2020/css/css-animations/idlharness.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-animations/idlharness.html.ini
@@ -1,7 +1,4 @@
 [idlharness.html]
-  [HTMLElement interface: attribute onanimationiteration]
-    expected: FAIL
-
   [HTMLElement interface: attribute onanimationstart]
     expected: FAIL
 
@@ -20,16 +17,10 @@
   [Window interface: attribute onanimationstart]
     expected: FAIL
 
-  [Window interface: attribute onanimationiteration]
-    expected: FAIL
-
   [Document interface: attribute onanimationcancel]
     expected: FAIL
 
   [CSSKeyframeRule interface: attribute style]
-    expected: FAIL
-
-  [Document interface: attribute onanimationiteration]
     expected: FAIL
 
   [HTMLElement interface: attribute onanimationcancel]

--- a/tests/wpt/metadata/css/css-animations/animationevent-types.html.ini
+++ b/tests/wpt/metadata/css/css-animations/animationevent-types.html.ini
@@ -1,9 +1,6 @@
 [animationevent-types.html]
   bug: https://github.com/servo/servo/issues/21564
   expected: TIMEOUT
-  [animationiteration event is instanceof AnimationEvent]
-    expected: TIMEOUT
-
   [animationstart event is instanceof AnimationEvent]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/css/css-animations/idlharness.html.ini
+++ b/tests/wpt/metadata/css/css-animations/idlharness.html.ini
@@ -1,14 +1,8 @@
 [idlharness.html]
-  [Document interface: attribute onanimationiteration]
-    expected: FAIL
-
   [CSSKeyframeRule interface: attribute style]
     expected: FAIL
 
   [Document interface: attribute onanimationstart]
-    expected: FAIL
-
-  [HTMLElement interface: attribute onanimationiteration]
     expected: FAIL
 
   [Window interface: attribute onanimationcancel]
@@ -27,9 +21,6 @@
     expected: FAIL
 
   [HTMLElement interface: attribute onanimationcancel]
-    expected: FAIL
-
-  [Window interface: attribute onanimationiteration]
     expected: FAIL
 
   [CSSKeyframeRule interface: keyframes.cssRules[0\] must inherit property "keyText" with the proper type]

--- a/tests/wpt/metadata/dom/events/webkit-animation-iteration-event.html.ini
+++ b/tests/wpt/metadata/dom/events/webkit-animation-iteration-event.html.ini
@@ -1,9 +1,7 @@
 [webkit-animation-iteration-event.html]
+  expected: TIMEOUT
   [webkitAnimationIteration event listener is case sensitive]
-    expected: FAIL
-
-  [dispatchEvent of a webkitAnimationIteration event does not trigger an unprefixed event handler or listener]
-    expected: FAIL
+    expected: NOTRUN
 
   [onwebkitanimationiteration event handler should trigger for an animation]
     expected: FAIL
@@ -12,10 +10,10 @@
     expected: FAIL
 
   [webkitAnimationIteration event listener should trigger for an animation]
-    expected: FAIL
+    expected: TIMEOUT
 
   [webkitAnimationIteration event listener should not trigger if an unprefixed listener also exists]
-    expected: FAIL
+    expected: NOTRUN
 
   [onwebkitanimationiteration event handler should not trigger if an unprefixed event handler also exists]
     expected: FAIL
@@ -24,10 +22,10 @@
     expected: FAIL
 
   [event types for prefixed and unprefixed animationiteration event listeners should be named appropriately]
-    expected: FAIL
+    expected: NOTRUN
 
   [webkitAnimationIteration event listener should not trigger if an unprefixed event handler also exists]
-    expected: FAIL
+    expected: NOTRUN
 
   [onanimationiteration and onwebkitanimationiteration are not aliases]
     expected: FAIL


### PR DESCRIPTION
This event is triggered when an animation iterates. This change also
moves iteration out of style calculation to an "update animations" which
is the next part of having animation event handling match the HTML spec.

This change causes a few more tests to pass. Some of the other tests which
exercise this functionality require `animationstart` events.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
- [x] There are tests for these changes


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
