### PR TITLE
Use ExtendableMessageEvent for messageerror in service workers #25241

### DIFF
--- a/components/script/dom/extendablemessageevent.rs
+++ b/components/script/dom/extendablemessageevent.rs
@@ -28,11 +28,16 @@ use servo_atoms::Atom;
 #[dom_struct]
 #[allow(non_snake_case)]
 pub struct ExtendableMessageEvent {
+    /// https://w3c.github.io/ServiceWorker/#extendableevent
     event: ExtendableEvent,
+    /// https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-data
     #[ignore_malloc_size_of = "mozjs"]
     data: Heap<JSVal>,
+    /// <https://w3c.github.io/ServiceWorker/#extendablemessage-event-origin>
     origin: DOMString,
+    /// https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-lasteventid
     lastEventId: DOMString,
+    /// https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-ports
     ports: Vec<Dom<MessagePort>>,
     #[ignore_malloc_size_of = "mozjs"]
     frozen_ports: DomRefCell<Option<Heap<JSVal>>>,
@@ -95,8 +100,8 @@ impl ExtendableMessageEvent {
             init.parent.parent.bubbles,
             init.parent.parent.cancelable,
             init.data.handle(),
-            init.origin.clone().unwrap(),
-            init.lastEventId.clone().unwrap(),
+            init.origin.clone(),
+            init.lastEventId.clone(),
             vec![],
         );
         Ok(ev)
@@ -122,6 +127,21 @@ impl ExtendableMessageEvent {
             ports,
         );
         Extendablemessageevent.upcast::<Event>().fire(target);
+    }
+
+    pub fn dispatch_error(target: &EventTarget, scope: &GlobalScope) {
+        let init = ExtendableMessageEventBinding::ExtendableMessageEventInit::empty();
+        let ExtendableMsgEvent = ExtendableMessageEvent::new(
+            scope,
+            atom!("messageerror"),
+            init.parent.parent.bubbles,
+            init.parent.parent.cancelable,
+            init.data.handle(),
+            init.origin.clone(),
+            init.lastEventId.clone(),
+            init.ports.clone(),
+        );
+        ExtendableMsgEvent.upcast::<Event>().fire(target);
     }
 }
 

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -19,7 +19,6 @@ use crate::dom::extendableevent::ExtendableEvent;
 use crate::dom::extendablemessageevent::ExtendableMessageEvent;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::identityhub::Identities;
-use crate::dom::messageevent::MessageEvent;
 use crate::dom::worker::TrustedWorkerAddress;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::fetch::load_whole_resource;
@@ -446,7 +445,7 @@ impl ServiceWorkerGlobalScope {
                         ports,
                     );
                 } else {
-                    MessageEvent::dispatch_error(target, scope.upcast());
+                    ExtendableMessageEvent::dispatch_error(target, scope.upcast());
                 }
             },
             CommonWorker(WorkerScriptMsg::Common(msg)) => {

--- a/components/script/dom/webidls/ExtendableMessageEvent.webidl
+++ b/components/script/dom/webidls/ExtendableMessageEvent.webidl
@@ -16,9 +16,9 @@ interface ExtendableMessageEvent : ExtendableEvent {
 };
 
 dictionary ExtendableMessageEventInit : ExtendableEventInit {
-  any data;
-  DOMString origin;
-  DOMString lastEventId;
+  any data = null;
+  DOMString origin = "";
+  DOMString lastEventId = "";
   // (Client or ServiceWorker /*or MessagePort*/)? source;
-  // sequence<MessagePort>? ports;
+  sequence<MessagePort> ports = [];
 };


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
added function dispatch_error to the ExtendableMessageEvent implmentation and replaced the MessageEvent dispatch error call with the ExtendableMessageEvent dispatch error call in serviceworkerglobalscope.rs

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] These changes fix #25241 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [x] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
