### PR TITLE
Implement client-side logic for WebGPU id recycling

### DIFF
--- a/components/msg/constellation_msg.rs
+++ b/components/msg/constellation_msg.rs
@@ -655,6 +655,7 @@ pub enum ScriptHangAnnotation {
     WebVREvent,
     PerformanceTimelineTask,
     PortMessage,
+    WebGPUMsg,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]

--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -151,6 +151,7 @@ impl Formattable for ProfilerCategory {
             ProfilerCategory::ScriptWebVREvent => "Script WebVR Event",
             ProfilerCategory::ScriptWorkletEvent => "Script Worklet Event",
             ProfilerCategory::ScriptPerformanceEvent => "Script Performance Event",
+            ProfilerCategory::ScriptWebGPUMsg => "Script WebGPU Message",
             ProfilerCategory::TimeToFirstPaint => "Time To First Paint",
             ProfilerCategory::TimeToFirstContentfulPaint => "Time To First Contentful Paint",
             ProfilerCategory::TimeToInteractive => "Time to Interactive",

--- a/components/profile_traits/time.rs
+++ b/components/profile_traits/time.rs
@@ -109,6 +109,7 @@ pub enum ProfilerCategory {
     ScriptPerformanceEvent = 0x7b,
     ScriptHistoryEvent = 0x7c,
     ScriptPortMessage = 0x7d,
+    ScriptWebGPUMsg = 0x7e,
     TimeToFirstPaint = 0x80,
     TimeToFirstContentfulPaint = 0x81,
     TimeToInteractive = 0x82,

--- a/components/script/dom/identityhub.rs
+++ b/components/script/dom/identityhub.rs
@@ -74,7 +74,7 @@ impl IdentityHub {
         self.shader_modules.alloc(self.backend)
     }
 
-    pub fn create_command_encoder_id(&mut self) -> CommandEncoderId {
+    fn create_command_encoder_id(&mut self) -> CommandEncoderId {
         self.command_encoders.alloc(self.backend)
     }
 }
@@ -141,6 +141,10 @@ impl Identities {
         self.select(backend).create_device_id()
     }
 
+    pub fn kill_device_id(&mut self, id: DeviceId) {
+        self.select(id.backend()).devices.free(id);
+    }
+
     pub fn create_adapter_ids(&mut self) -> SmallVec<[AdapterId; 4]> {
         let mut ids = SmallVec::new();
         for hub in self.hubs() {
@@ -149,31 +153,63 @@ impl Identities {
         ids
     }
 
+    pub fn kill_adapter_id(&mut self, id: AdapterId) {
+        self.select(id.backend()).adapters.free(id);
+    }
+
     pub fn create_buffer_id(&mut self, backend: Backend) -> BufferId {
         self.select(backend).create_buffer_id()
+    }
+
+    pub fn kill_buffer_id(&mut self, id: BufferId) {
+        self.select(id.backend()).buffers.free(id);
     }
 
     pub fn create_bind_group_id(&mut self, backend: Backend) -> BindGroupId {
         self.select(backend).create_bind_group_id()
     }
 
+    pub fn kill_bind_group_id(&mut self, id: BindGroupId) {
+        self.select(id.backend()).bind_groups.free(id);
+    }
+
     pub fn create_bind_group_layout_id(&mut self, backend: Backend) -> BindGroupLayoutId {
         self.select(backend).create_bind_group_layout_id()
+    }
+
+    pub fn kill_bind_group_layout_id(&mut self, id: BindGroupLayoutId) {
+        self.select(id.backend()).bind_group_layouts.free(id);
     }
 
     pub fn create_compute_pipeline_id(&mut self, backend: Backend) -> ComputePipelineId {
         self.select(backend).create_compute_pipeline_id()
     }
 
+    pub fn kill_compute_pipeline_id(&mut self, id: ComputePipelineId) {
+        self.select(id.backend()).compute_pipelines.free(id);
+    }
+
     pub fn create_pipeline_layout_id(&mut self, backend: Backend) -> PipelineLayoutId {
         self.select(backend).create_pipeline_layout_id()
+    }
+
+    pub fn kill_pipeline_layout_id(&mut self, id: PipelineLayoutId) {
+        self.select(id.backend()).pipeline_layouts.free(id);
     }
 
     pub fn create_shader_module_id(&mut self, backend: Backend) -> ShaderModuleId {
         self.select(backend).create_shader_module_id()
     }
 
+    pub fn kill_shader_module_id(&mut self, id: ShaderModuleId) {
+        self.select(id.backend()).shader_modules.free(id);
+    }
+
     pub fn create_command_encoder_id(&mut self, backend: Backend) -> CommandEncoderId {
         self.select(backend).create_command_encoder_id()
+    }
+
+    pub fn kill_command_buffer_id(&mut self, id: CommandEncoderId) {
+        self.select(id.backend()).command_encoders.free(id);
     }
 }

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -159,7 +159,7 @@ pub struct WorkletGlobalScopeInit {
     pub is_headless: bool,
     /// An optional string allowing the user agent to be set for testing
     pub user_agent: Cow<'static, str>,
-    /// Channel to WebGPU
+    /// Identity manager for WebGPU resources
     pub gpu_id_hub: Arc<Mutex<Identities>>,
 }
 

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -157,6 +157,7 @@ pub enum ScriptThreadEventCategory {
     EnterFullscreen,
     ExitFullscreen,
     PerformanceTimelineTask,
+    WebGPUMsg,
 }
 
 /// An interface for receiving ScriptMsg values in an event loop. Used for synchronous DOM

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -66,6 +66,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use style_traits::CSSPixel;
 use style_traits::SpeculativePainter;
+use webgpu::identity::WebGPUMsg;
 use webrender_api::units::{
     DeviceIntSize, DevicePixel, LayoutPixel, LayoutPoint, LayoutSize, WorldPoint,
 };
@@ -401,6 +402,8 @@ pub enum ConstellationControlMsg {
     PaintMetric(PipelineId, ProgressiveWebMetricType, u64),
     /// Notifies the media session about a user requested media session action.
     MediaSessionAction(PipelineId, MediaSessionActionType),
+    /// Notifies script thread that WebGPU server has started
+    SetWebGPUPort(IpcReceiver<WebGPUMsg>),
 }
 
 impl fmt::Debug for ConstellationControlMsg {
@@ -438,6 +441,7 @@ impl fmt::Debug for ConstellationControlMsg {
             PaintMetric(..) => "PaintMetric",
             ExitFullScreen(..) => "ExitFullScreen",
             MediaSessionAction(..) => "MediaSessionAction",
+            SetWebGPUPort(..) => "SetWebGPUPort",
         };
         write!(formatter, "ConstellationControlMsg::{}", variant)
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
1. Set up `WebGPUMsg` receiver in script thread and add respective message handler function.
2. Add `kill_xxx_id()` methods to `Identities`.

r?@kvark

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
