### PR TITLE
Add a preference to control ImageBitmap while it's incomplete.

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -193,6 +193,9 @@ mod gen {
                 gamepad: {
                     enabled: bool,
                 },
+                imagebitmap: {
+                    enabled: bool,
+                },
                 microdata: {
                     testing: {
                         enabled: bool,

--- a/components/script/dom/webidls/ImageBitmap.webidl
+++ b/components/script/dom/webidls/ImageBitmap.webidl
@@ -10,7 +10,7 @@
  */
 
 //[Exposed=(Window,Worker), Serializable, Transferable]
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), Pref="dom.imagebitmap.enabled"]
 interface ImageBitmap {
   readonly attribute unsigned long width;
   readonly attribute unsigned long height;

--- a/components/script/dom/webidls/WindowOrWorkerGlobalScope.webidl
+++ b/components/script/dom/webidls/WindowOrWorkerGlobalScope.webidl
@@ -24,6 +24,7 @@ interface mixin WindowOrWorkerGlobalScope {
   void queueMicrotask(VoidFunction callback);
 
   // ImageBitmap
+  [Pref="dom.imagebitmap.enabled"]
   Promise<ImageBitmap> createImageBitmap(ImageBitmapSource image, optional ImageBitmapOptions options = {});
   // Promise<ImageBitmap> createImageBitmap(
   //   ImageBitmapSource image, long sx, long sy, long sw, long sh, optional ImageBitmapOptions options);

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -9,6 +9,7 @@
   "dom.forcetouch.enabled": false,
   "dom.fullscreen.test": false,
   "dom.gamepad.enabled": false,
+  "dom.imagebitmap.enabled": false,
   "dom.microdata.enabled": false,
   "dom.microdata.testing.enabled": false,
   "dom.mouseevent.which.enabled": false,

--- a/tests/wpt/metadata/__dir__.ini
+++ b/tests/wpt/metadata/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: ["dom.imagebitmap.enabled:true"]

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13901,14 +13901,14 @@
      ]
     ],
     "interfaces.html": [
-     "b6034be26af3c2edd1ef41703857fa99bd2cd639",
+     "145c902ff033ba1de46b41dec07992fae4fd2f13",
      [
       null,
       {}
      ]
     ],
     "interfaces.worker.js": [
-     "a74a91489541ab99ae58001e3f63afc9ecc5c553",
+     "c1223084790b2980c8184e3cd9ab5ae17bc8b303",
      [
       "mozilla/interfaces.worker.html",
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.html
@@ -162,7 +162,6 @@ test_interfaces([
   "HTMLUnknownElement",
   "HTMLVideoElement",
   "ImageData",
-  "ImageBitmap",
   "Image",
   "InputEvent",
   "KeyboardEvent",

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
@@ -35,7 +35,6 @@ test_interfaces([
   "Headers",
   "History",
   "ImageData",
-  "ImageBitmap",
   "MessageChannel",
   "MessageEvent",
   "MessagePort",

--- a/tests/wpt/webgl/meta/conformance/__dir__.ini
+++ b/tests/wpt/webgl/meta/conformance/__dir__.ini
@@ -1,1 +1,1 @@
-prefs: ["dom.offscreen_canvas.enabled:true"]
+prefs: ["dom.offscreen_canvas.enabled:true","dom.imagebitmap.enabled:true"]

--- a/tests/wpt/webgl/meta/conformance2/__dir__.ini
+++ b/tests/wpt/webgl/meta/conformance2/__dir__.ini
@@ -1,2 +1,2 @@
-prefs: ["dom.webgl2.enabled:true","dom.offscreen_canvas.enabled:true"]
+prefs: ["dom.webgl2.enabled:true","dom.offscreen_canvas.enabled:true","dom.imagebitmap.enabled:true"]
 


### PR DESCRIPTION
Hubs tries to make use of incomplete APIs to load textures and this causes errors. It works fine if we hide the interface instead.