### PR TITLE
Use temporary files instead of pipes for JS unminification.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4726,6 +4726,7 @@ dependencies = [
  "style",
  "style_traits",
  "swapper",
+ "tempfile",
  "tendril",
  "time",
  "unicode-bidi",

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -106,6 +106,7 @@ sparkle = "0.1"
 style = { path = "../style", features = ["servo"] }
 style_traits = { path = "../style_traits" }
 swapper = "0.1"
+tempfile = "3"
 tendril = { version = "0.4.1", features = ["encoding_rs"] }
 time = "0.1.12"
 unicode-bidi = "0.3.4"


### PR DESCRIPTION
This change allows me to use `--unminify-js` when loading a local Hubs server. Previously there would be multiple hung js-beautifier processes and the page would never make any progress.