### PR TITLE
Add GPUSampler to WebGPU implementation

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -160,7 +160,7 @@ use uuid::Uuid;
 use webgpu::{
     wgpu::command::RawPass, WebGPU, WebGPUAdapter, WebGPUBindGroup, WebGPUBindGroupLayout,
     WebGPUBuffer, WebGPUCommandBuffer, WebGPUCommandEncoder, WebGPUComputePipeline, WebGPUDevice,
-    WebGPUPipelineLayout, WebGPUQueue, WebGPUShaderModule,
+    WebGPUPipelineLayout, WebGPUQueue, WebGPUSampler, WebGPUShaderModule,
 };
 use webrender_api::{DocumentId, ImageKey};
 use webxr_api::SwapChainId as WebXRSwapChainId;
@@ -559,6 +559,7 @@ unsafe_no_jsmanaged_fields!(WebGPUComputePipeline);
 unsafe_no_jsmanaged_fields!(WebGPUPipelineLayout);
 unsafe_no_jsmanaged_fields!(WebGPUQueue);
 unsafe_no_jsmanaged_fields!(WebGPUShaderModule);
+unsafe_no_jsmanaged_fields!(WebGPUSampler);
 unsafe_no_jsmanaged_fields!(WebGPUCommandBuffer);
 unsafe_no_jsmanaged_fields!(WebGPUCommandEncoder);
 unsafe_no_jsmanaged_fields!(WebGPUDevice);

--- a/components/script/dom/gpusampler.rs
+++ b/components/script/dom/gpusampler.rs
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::GPUSamplerBinding::GPUSamplerMethods;
+use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::globalscope::GlobalScope;
+use dom_struct::dom_struct;
+use std::cell::Cell;
+use webgpu::{WebGPU, WebGPUDevice, WebGPUSampler};
+
+#[dom_struct]
+pub struct GPUSampler {
+    reflector_: Reflector,
+    #[ignore_malloc_size_of = "channels are hard"]
+    channel: WebGPU,
+    label: DomRefCell<Option<DOMString>>,
+    device: WebGPUDevice,
+    compare_enable: bool,
+    sampler: WebGPUSampler,
+    valid: Cell<bool>,
+}
+
+impl GPUSampler {
+    fn new_inherited(
+        channel: WebGPU,
+        device: WebGPUDevice,
+        compare_enable: bool,
+        sampler: WebGPUSampler,
+        valid: bool,
+    ) -> GPUSampler {
+        Self {
+            reflector_: Reflector::new(),
+            channel,
+            label: DomRefCell::new(None),
+            valid: Cell::new(valid),
+            device,
+            sampler,
+            compare_enable,
+        }
+    }
+
+    pub fn new(
+        global: &GlobalScope,
+        channel: WebGPU,
+        device: WebGPUDevice,
+        compare_enable: bool,
+        sampler: WebGPUSampler,
+        valid: bool,
+    ) -> DomRoot<GPUSampler> {
+        reflect_dom_object(
+            Box::new(GPUSampler::new_inherited(
+                channel,
+                device,
+                compare_enable,
+                sampler,
+                valid,
+            )),
+            global,
+        )
+    }
+}
+
+impl GPUSamplerMethods for GPUSampler {
+    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    fn GetLabel(&self) -> Option<DOMString> {
+        self.label.borrow().clone()
+    }
+
+    /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
+    fn SetLabel(&self, value: Option<DOMString>) {
+        *self.label.borrow_mut() = value;
+    }
+}

--- a/components/script/dom/identityhub.rs
+++ b/components/script/dom/identityhub.rs
@@ -7,7 +7,7 @@ use webgpu::wgpu::{
     hub::IdentityManager,
     id::{
         AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandEncoderId, ComputePipelineId,
-        DeviceId, PipelineLayoutId, ShaderModuleId,
+        DeviceId, PipelineLayoutId, SamplerId, ShaderModuleId,
     },
 };
 use webgpu::wgt::Backend;
@@ -23,11 +23,11 @@ pub struct IdentityHub {
     pipeline_layouts: IdentityManager,
     shader_modules: IdentityManager,
     command_encoders: IdentityManager,
-    backend: Backend,
+    samplers: IdentityManager,
 }
 
 impl IdentityHub {
-    fn new(backend: Backend) -> Self {
+    fn new() -> Self {
         IdentityHub {
             adapters: IdentityManager::default(),
             devices: IdentityManager::default(),
@@ -38,44 +38,8 @@ impl IdentityHub {
             pipeline_layouts: IdentityManager::default(),
             shader_modules: IdentityManager::default(),
             command_encoders: IdentityManager::default(),
-            backend,
+            samplers: IdentityManager::default(),
         }
-    }
-
-    fn create_adapter_id(&mut self) -> AdapterId {
-        self.adapters.alloc(self.backend)
-    }
-
-    fn create_device_id(&mut self) -> DeviceId {
-        self.devices.alloc(self.backend)
-    }
-
-    fn create_buffer_id(&mut self) -> BufferId {
-        self.buffers.alloc(self.backend)
-    }
-
-    fn create_bind_group_id(&mut self) -> BindGroupId {
-        self.bind_groups.alloc(self.backend)
-    }
-
-    fn create_bind_group_layout_id(&mut self) -> BindGroupLayoutId {
-        self.bind_group_layouts.alloc(self.backend)
-    }
-
-    fn create_compute_pipeline_id(&mut self) -> ComputePipelineId {
-        self.compute_pipelines.alloc(self.backend)
-    }
-
-    fn create_pipeline_layout_id(&mut self) -> PipelineLayoutId {
-        self.pipeline_layouts.alloc(self.backend)
-    }
-
-    fn create_shader_module_id(&mut self) -> ShaderModuleId {
-        self.shader_modules.alloc(self.backend)
-    }
-
-    fn create_command_encoder_id(&mut self) -> CommandEncoderId {
-        self.command_encoders.alloc(self.backend)
     }
 }
 
@@ -98,14 +62,14 @@ impl Identities {
         Identities {
             surface: IdentityManager::default(),
             #[cfg(any(target_os = "linux", target_os = "windows"))]
-            vk_hub: IdentityHub::new(Backend::Vulkan),
+            vk_hub: IdentityHub::new(),
             #[cfg(target_os = "windows")]
-            dx12_hub: IdentityHub::new(Backend::Dx12),
+            dx12_hub: IdentityHub::new(),
             #[cfg(target_os = "windows")]
-            dx11_hub: IdentityHub::new(Backend::Dx11),
+            dx11_hub: IdentityHub::new(),
             #[cfg(any(target_os = "ios", target_os = "macos"))]
-            metal_hub: IdentityHub::new(Backend::Metal),
-            dummy_hub: IdentityHub::new(Backend::Empty),
+            metal_hub: IdentityHub::new(),
+            dummy_hub: IdentityHub::new(),
         }
     }
 
@@ -123,22 +87,22 @@ impl Identities {
         }
     }
 
-    fn hubs(&mut self) -> Vec<&mut IdentityHub> {
+    fn hubs(&mut self) -> Vec<(&mut IdentityHub, Backend)> {
         vec![
             #[cfg(any(target_os = "linux", target_os = "windows"))]
-            &mut self.vk_hub,
+            (&mut self.vk_hub, Backend::Vulkan),
             #[cfg(target_os = "windows")]
-            &mut self.dx12_hub,
+            (&mut self.dx12_hub, Backend::Dx12),
             #[cfg(target_os = "windows")]
-            &mut self.dx11_hub,
+            (&mut self.dx11_hub, Backend::Dx11),
             #[cfg(any(target_os = "ios", target_os = "macos"))]
-            &mut self.metal_hub,
-            &mut self.dummy_hub,
+            (&mut self.metal_hub, Backend::Metal),
+            (&mut self.dummy_hub, Backend::Empty),
         ]
     }
 
     pub fn create_device_id(&mut self, backend: Backend) -> DeviceId {
-        self.select(backend).create_device_id()
+        self.select(backend).devices.alloc(backend)
     }
 
     pub fn kill_device_id(&mut self, id: DeviceId) {
@@ -147,8 +111,8 @@ impl Identities {
 
     pub fn create_adapter_ids(&mut self) -> SmallVec<[AdapterId; 4]> {
         let mut ids = SmallVec::new();
-        for hub in self.hubs() {
-            ids.push(hub.create_adapter_id())
+        for hubs in self.hubs() {
+            ids.push(hubs.0.adapters.alloc(hubs.1));
         }
         ids
     }
@@ -158,7 +122,7 @@ impl Identities {
     }
 
     pub fn create_buffer_id(&mut self, backend: Backend) -> BufferId {
-        self.select(backend).create_buffer_id()
+        self.select(backend).buffers.alloc(backend)
     }
 
     pub fn kill_buffer_id(&mut self, id: BufferId) {
@@ -166,7 +130,7 @@ impl Identities {
     }
 
     pub fn create_bind_group_id(&mut self, backend: Backend) -> BindGroupId {
-        self.select(backend).create_bind_group_id()
+        self.select(backend).bind_groups.alloc(backend)
     }
 
     pub fn kill_bind_group_id(&mut self, id: BindGroupId) {
@@ -174,7 +138,7 @@ impl Identities {
     }
 
     pub fn create_bind_group_layout_id(&mut self, backend: Backend) -> BindGroupLayoutId {
-        self.select(backend).create_bind_group_layout_id()
+        self.select(backend).bind_group_layouts.alloc(backend)
     }
 
     pub fn kill_bind_group_layout_id(&mut self, id: BindGroupLayoutId) {
@@ -182,7 +146,7 @@ impl Identities {
     }
 
     pub fn create_compute_pipeline_id(&mut self, backend: Backend) -> ComputePipelineId {
-        self.select(backend).create_compute_pipeline_id()
+        self.select(backend).compute_pipelines.alloc(backend)
     }
 
     pub fn kill_compute_pipeline_id(&mut self, id: ComputePipelineId) {
@@ -190,7 +154,7 @@ impl Identities {
     }
 
     pub fn create_pipeline_layout_id(&mut self, backend: Backend) -> PipelineLayoutId {
-        self.select(backend).create_pipeline_layout_id()
+        self.select(backend).pipeline_layouts.alloc(backend)
     }
 
     pub fn kill_pipeline_layout_id(&mut self, id: PipelineLayoutId) {
@@ -198,7 +162,7 @@ impl Identities {
     }
 
     pub fn create_shader_module_id(&mut self, backend: Backend) -> ShaderModuleId {
-        self.select(backend).create_shader_module_id()
+        self.select(backend).shader_modules.alloc(backend)
     }
 
     pub fn kill_shader_module_id(&mut self, id: ShaderModuleId) {
@@ -206,10 +170,18 @@ impl Identities {
     }
 
     pub fn create_command_encoder_id(&mut self, backend: Backend) -> CommandEncoderId {
-        self.select(backend).create_command_encoder_id()
+        self.select(backend).command_encoders.alloc(backend)
     }
 
     pub fn kill_command_buffer_id(&mut self, id: CommandEncoderId) {
         self.select(id.backend()).command_encoders.free(id);
+    }
+
+    pub fn create_sampler_id(&mut self, backend: Backend) -> SamplerId {
+        self.select(backend).samplers.alloc(backend)
+    }
+
+    pub fn kill_sampler_id(&mut self, id: SamplerId) {
+        self.select(id.backend()).samplers.free(id);
     }
 }

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -332,6 +332,7 @@ pub mod gpucomputepipeline;
 pub mod gpudevice;
 pub mod gpupipelinelayout;
 pub mod gpuqueue;
+pub mod gpusampler;
 pub mod gpushadermodule;
 pub mod gpushaderstage;
 pub mod hashchangeevent;

--- a/components/script/dom/webidls/GPUDevice.webidl
+++ b/components/script/dom/webidls/GPUDevice.webidl
@@ -14,7 +14,7 @@ interface GPUDevice : EventTarget {
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
     GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor);
     // GPUTexture createTexture(GPUTextureDescriptor descriptor);
-    // GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});
+    GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});
 
     GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor);
     GPUPipelineLayout createPipelineLayout(GPUPipelineLayoutDescriptor descriptor);

--- a/components/script/dom/webidls/GPUSampler.webidl
+++ b/components/script/dom/webidls/GPUSampler.webidl
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://gpuweb.github.io/gpuweb/#gpusampler
+[Exposed=(Window, DedicatedWorker), Pref="dom.webgpu.enabled"]
+interface GPUSampler {
+};
+GPUSampler includes GPUObjectBase;
+
+dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
+    GPUAddressMode addressModeU = "clamp-to-edge";
+    GPUAddressMode addressModeV = "clamp-to-edge";
+    GPUAddressMode addressModeW = "clamp-to-edge";
+    GPUFilterMode magFilter = "nearest";
+    GPUFilterMode minFilter = "nearest";
+    GPUFilterMode mipmapFilter = "nearest";
+    float lodMinClamp = 0;
+    float lodMaxClamp = 0xfffff; // TODO: Update this. Value in spec was too big
+    GPUCompareFunction compare;
+};
+
+enum GPUAddressMode {
+    "clamp-to-edge",
+    "repeat",
+    "mirror-repeat"
+};
+
+enum GPUFilterMode {
+    "nearest",
+    "linear"
+};
+
+enum GPUCompareFunction {
+    "never",
+    "less",
+    "equal",
+    "less-equal",
+    "greater",
+    "not-equal",
+    "greater-equal",
+    "always"
+};

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2014,6 +2014,7 @@ impl ScriptThread {
                 self.gpu_id_hub.lock().kill_bind_group_layout_id(id)
             },
             WebGPUMsg::FreeCommandBuffer(id) => self.gpu_id_hub.lock().kill_command_buffer_id(id),
+            WebGPUMsg::FreeSampler(id) => self.gpu_id_hub.lock().kill_sampler_id(id),
             WebGPUMsg::FreeShaderModule(id) => self.gpu_id_hub.lock().kill_shader_module_id(id),
             _ => {},
         }


### PR DESCRIPTION
Add dom_struct and webidl for GPUSampler, implement GPUDevice.createSampler() method.

<!-- Please describe your changes on the following line: -->
r?@kvark

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
