### PR TITLE
Add support for WebGL2 TexImage2D

### DIFF
--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -638,7 +638,7 @@ impl WebGLRenderingContext {
         }
     }
 
-    fn get_image_pixels(&self, source: TexImageSource) -> Fallible<Option<TexPixels>> {
+    pub fn get_image_pixels(&self, source: TexImageSource) -> Fallible<Option<TexPixels>> {
         Ok(Some(match source {
             TexImageSource::ImageData(image_data) => TexPixels::new(
                 image_data.to_shared_memory(),

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -508,10 +508,10 @@ interface mixin WebGL2RenderingContextOverloads
   //[Throws]
   //void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
   //                GLint border, GLenum format, GLenum type, GLintptr pboOffset);
-  //[Throws]
-  //void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
-  //                GLint border, GLenum format, GLenum type,
-  //                TexImageSource source); // May throw DOMException
+  [Throws]
+  void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+                  GLint border, GLenum format, GLenum type,
+                  TexImageSource source); // May throw DOMException
   [Throws]
   void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                   GLint border, GLenum format, GLenum type, /*[AllowShared]*/ ArrayBufferView srcData,

--- a/tests/wpt/webgl/meta/conformance2/textures/image/__dir__.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/__dir__.ini
@@ -1,1 +1,1 @@
-disabled: for now
+

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r11f_g11f_b10f-rgb-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r11f_g11f_b10f-rgb-float.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-r11f_g11f_b10f-rgb-float.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r11f_g11f_b10f-rgb-half_float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r11f_g11f_b10f-rgb-half_float.html.ini
@@ -1,0 +1,74 @@
+[tex-2d-r11f_g11f_b10f-rgb-half_float.html]
+  expected: ERROR
+  [WebGL test #15: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #8: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #19: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #4: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #1: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #18: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #12: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #10: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #7: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #3: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #20: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #23: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #13: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #0: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #5: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #6: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #11: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #21: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #17: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #16: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #22: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #14: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #9: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r16f-red-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r16f-red-float.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-r16f-red-float.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r16f-red-half_float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r16f-red-half_float.html.ini
@@ -1,0 +1,50 @@
+[tex-2d-r16f-red-half_float.html]
+  expected: ERROR
+  [WebGL test #11: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #8: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #1: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #12: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #7: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #3: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #20: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #22: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #23: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #13: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #5: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #21: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #17: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #14: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #9: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r32f-red-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r32f-red-float.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-r32f-red-float.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r8-red-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r8-red-unsigned_byte.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-r8-red-unsigned_byte.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r8ui-red_integer-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-r8ui-red_integer-unsigned_byte.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-r8ui-red_integer-unsigned_byte.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rg16f-rg-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rg16f-rg-float.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rg16f-rg-float.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rg16f-rg-half_float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rg16f-rg-half_float.html.ini
@@ -1,0 +1,74 @@
+[tex-2d-rg16f-rg-half_float.html]
+  expected: ERROR
+  [WebGL test #15: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #8: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #19: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #4: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #1: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #18: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #12: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #10: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #7: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #3: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #20: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #23: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #13: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #0: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #5: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #6: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #11: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #21: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #17: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #16: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #22: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #14: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #9: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rg32f-rg-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rg32f-rg-float.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rg32f-rg-float.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rg8-rg-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rg8-rg-unsigned_byte.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rg8-rg-unsigned_byte.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rg8ui-rg_integer-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rg8ui-rg_integer-unsigned_byte.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rg8ui-rg_integer-unsigned_byte.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb16f-rgb-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb16f-rgb-float.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rgb16f-rgb-float.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb16f-rgb-half_float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb16f-rgb-half_float.html.ini
@@ -1,0 +1,74 @@
+[tex-2d-rgb16f-rgb-half_float.html]
+  expected: ERROR
+  [WebGL test #15: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #8: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #19: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #4: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #1: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #18: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #12: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #10: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #7: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #3: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #20: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #23: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #13: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #0: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #5: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #6: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #11: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #21: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #17: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #16: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #22: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #14: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #9: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb32f-rgb-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb32f-rgb-float.html.ini
@@ -1,0 +1,26 @@
+[tex-2d-rgb32f-rgb-float.html]
+  expected: ERROR
+  [WebGL test #10: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #16: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #9: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,255,0]
+    expected: FAIL
+
+  [WebGL test #19: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #17: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,255,0]
+    expected: FAIL
+
+  [WebGL test #14: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 255,0,0]
+    expected: FAIL
+
+  [WebGL test #13: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #12: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 255,0,0]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb565-rgb-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb565-rgb-unsigned_byte.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rgb565-rgb-unsigned_byte.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb565-rgb-unsigned_short_5_6_5.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb565-rgb-unsigned_short_5_6_5.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rgb565-rgb-unsigned_short_5_6_5.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb5_a1-rgba-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb5_a1-rgba-unsigned_byte.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rgb5_a1-rgba-unsigned_byte.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb8-rgb-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb8-rgb-unsigned_byte.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rgb8-rgb-unsigned_byte.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb8ui-rgb_integer-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb8ui-rgb_integer-unsigned_byte.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rgb8ui-rgb_integer-unsigned_byte.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb9_e5-rgb-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb9_e5-rgb-float.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rgb9_e5-rgb-float.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb9_e5-rgb-half_float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgb9_e5-rgb-half_float.html.ini
@@ -1,0 +1,74 @@
+[tex-2d-rgb9_e5-rgb-half_float.html]
+  expected: ERROR
+  [WebGL test #15: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #8: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #19: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #4: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #1: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #18: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #12: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #10: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #7: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #3: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #20: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #23: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #13: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #0: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #5: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #6: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #11: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #21: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #17: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #16: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #22: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #14: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #9: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgba16f-rgba-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgba16f-rgba-float.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rgba16f-rgba-float.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgba16f-rgba-half_float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgba16f-rgba-half_float.html.ini
@@ -1,0 +1,74 @@
+[tex-2d-rgba16f-rgba-half_float.html]
+  expected: ERROR
+  [WebGL test #15: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #8: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #19: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #4: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #2: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #1: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #18: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #12: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #10: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #7: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #3: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #20: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #23: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #13: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #0: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #5: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #6: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #11: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #21: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #17: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #16: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #22: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+
+  [WebGL test #14: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #9: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,0,0]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgba32f-rgba-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgba32f-rgba-float.html.ini
@@ -1,0 +1,26 @@
+[tex-2d-rgba32f-rgba-float.html]
+  expected: ERROR
+  [WebGL test #10: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #16: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #9: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,255,0]
+    expected: FAIL
+
+  [WebGL test #19: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #17: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,255,0]
+    expected: FAIL
+
+  [WebGL test #14: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 255,0,0]
+    expected: FAIL
+
+  [WebGL test #13: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #12: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 255,0,0]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgba4-rgba-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgba4-rgba-unsigned_byte.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rgba4-rgba-unsigned_byte.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgba8-rgba-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgba8-rgba-unsigned_byte.html.ini
@@ -1,0 +1,26 @@
+[tex-2d-rgba8-rgba-unsigned_byte.html]
+  expected: ERROR
+  [WebGL test #10: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #16: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #9: shouldBe 255,0,0\nat (4, 24) expected: 255,0,0 was 0,255,0]
+    expected: FAIL
+
+  [WebGL test #19: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #17: shouldBe 255,0,0\nat (4, 4) expected: 255,0,0 was 0,255,0]
+    expected: FAIL
+
+  [WebGL test #14: shouldBe 0,255,0\nat (4, 4) expected: 0,255,0 was 255,0,0]
+    expected: FAIL
+
+  [WebGL test #13: getError expected: NO_ERROR. Was INVALID_ENUM : after evaluating: gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);]
+    expected: FAIL
+
+  [WebGL test #12: shouldBe 0,255,0\nat (4, 24) expected: 0,255,0 was 255,0,0]
+    expected: FAIL
+

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgba8ui-rgba_integer-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-rgba8ui-rgba_integer-unsigned_byte.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-rgba8ui-rgba_integer-unsigned_byte.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-srgb8-rgb-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-srgb8-rgb-unsigned_byte.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-srgb8-rgb-unsigned_byte.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-srgb8_alpha8-rgba-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-2d-srgb8_alpha8-rgba-unsigned_byte.html.ini
@@ -1,0 +1,4 @@
+[tex-2d-srgb8_alpha8-rgba-unsigned_byte.html]
+  expected:
+    if os == "mac": TIMEOUT
+    if os == "linux": CRASH

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r11f_g11f_b10f-rgb-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r11f_g11f_b10f-rgb-float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-r11f_g11f_b10f-rgb-float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r11f_g11f_b10f-rgb-half_float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r11f_g11f_b10f-rgb-half_float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-r11f_g11f_b10f-rgb-half_float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r16f-red-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r16f-red-float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-r16f-red-float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r16f-red-half_float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r16f-red-half_float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-r16f-red-half_float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r32f-red-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r32f-red-float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-r32f-red-float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r8-red-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r8-red-unsigned_byte.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-r8-red-unsigned_byte.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r8ui-red_integer-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-r8ui-red_integer-unsigned_byte.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-r8ui-red_integer-unsigned_byte.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rg16f-rg-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rg16f-rg-float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rg16f-rg-float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rg16f-rg-half_float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rg16f-rg-half_float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rg16f-rg-half_float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rg32f-rg-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rg32f-rg-float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rg32f-rg-float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rg8-rg-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rg8-rg-unsigned_byte.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rg8-rg-unsigned_byte.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rg8ui-rg_integer-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rg8ui-rg_integer-unsigned_byte.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rg8ui-rg_integer-unsigned_byte.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb16f-rgb-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb16f-rgb-float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgb16f-rgb-float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb16f-rgb-half_float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb16f-rgb-half_float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgb16f-rgb-half_float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb32f-rgb-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb32f-rgb-float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgb32f-rgb-float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb565-rgb-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb565-rgb-unsigned_byte.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgb565-rgb-unsigned_byte.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb565-rgb-unsigned_short_5_6_5.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb565-rgb-unsigned_short_5_6_5.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgb565-rgb-unsigned_short_5_6_5.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb5_a1-rgba-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb5_a1-rgba-unsigned_byte.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgb5_a1-rgba-unsigned_byte.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb8-rgb-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb8-rgb-unsigned_byte.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgb8-rgb-unsigned_byte.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb8ui-rgb_integer-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb8ui-rgb_integer-unsigned_byte.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgb8ui-rgb_integer-unsigned_byte.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb9_e5-rgb-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb9_e5-rgb-float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgb9_e5-rgb-float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb9_e5-rgb-half_float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgb9_e5-rgb-half_float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgb9_e5-rgb-half_float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgba16f-rgba-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgba16f-rgba-float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgba16f-rgba-float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgba16f-rgba-half_float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgba16f-rgba-half_float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgba16f-rgba-half_float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgba32f-rgba-float.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgba32f-rgba-float.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgba32f-rgba-float.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgba4-rgba-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgba4-rgba-unsigned_byte.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgba4-rgba-unsigned_byte.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgba8-rgba-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgba8-rgba-unsigned_byte.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgba8-rgba-unsigned_byte.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgba8ui-rgba_integer-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-rgba8ui-rgba_integer-unsigned_byte.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-rgba8ui-rgba_integer-unsigned_byte.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-srgb8-rgb-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-srgb8-rgb-unsigned_byte.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-srgb8-rgb-unsigned_byte.html]
+  expected: ERROR

--- a/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-srgb8_alpha8-rgba-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/textures/image/tex-3d-srgb8_alpha8-rgba-unsigned_byte.html.ini
@@ -1,0 +1,2 @@
+[tex-3d-srgb8_alpha8-rgba-unsigned_byte.html]
+  expected: ERROR


### PR DESCRIPTION
Adds initial support for one of the WebGL2 `TexImage2D` call.

<!-- Please describe your changes on the following line: -->
I've enabled the `conformance2/textures/image/` tests and updated the test expectations.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->
@mmatyas @zakorgy @jdm
<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
