### PR TITLE
Fix undefined behavior in `energymon::init`

### DIFF
--- a/components/profile_traits/energy.rs
+++ b/components/profile_traits/energy.rs
@@ -29,7 +29,6 @@ mod energymon {
 
     use self::energy_monitor::EnergyMonitor;
     use self::energymon::EnergyMon;
-    use std::mem;
     use std::sync::{Once, ONCE_INIT};
 
     static mut EM: Option<*mut EnergyMon> = None;
@@ -41,7 +40,7 @@ mod energymon {
             if let Ok(em) = EnergyMon::new() {
                 println!("Started energy monitoring from: {}", em.source());
                 unsafe {
-                    EM = Some(mem::transmute(Box::new(em)));
+                    EM = Some(Box::into_raw(Box::new(em)));
                 }
             }
         });


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The layout of [`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) is implicitly [`#[repr(Rust)]`](https://doc.rust-lang.org/nomicon/repr-rust.html), so it is undefined behavior to transmute it to another type. [`Box::into_raw`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.into_raw) can safely convert it to a pointer.

I did not run the test suite locally. I thought it would be better to let CI run than to set up the development environment for such a simple change. I did test that the file works individually with this change.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because the undefined behavior is not visible

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
