### PR TITLE
Avoid parking_lot bustage with recent rustc nightlies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,7 +1885,7 @@ dependencies = [
  "gfx-hal",
  "lazy_static",
  "log",
- "metal 0.18.0",
+ "metal",
  "objc",
  "parking_lot 0.10.2",
  "range-alloc",
@@ -2864,7 +2864,7 @@ dependencies = [
  "msg",
  "net_traits",
  "num-traits",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
  "profile_traits",
  "range",
  "rayon",
@@ -2908,7 +2908,7 @@ dependencies = [
  "mitochondria",
  "msg",
  "net_traits",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
  "range",
  "rayon",
  "rayon_croissant",
@@ -2950,7 +2950,7 @@ dependencies = [
  "metrics",
  "msg",
  "net_traits",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
  "profile_traits",
  "range",
  "rayon",
@@ -2995,7 +2995,7 @@ dependencies = [
  "metrics",
  "msg",
  "net_traits",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
  "profile_traits",
  "range",
  "script",
@@ -3403,21 +3403,6 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83c7dcc2038e12f68493fa3de44235df27b2497178e257185b4b5b5d028a1e4"
-dependencies = [
- "bitflags",
- "block",
- "cocoa 0.19.1",
- "core-graphics 0.17.3",
- "foreign-types",
- "log",
- "objc",
-]
-
-[[package]]
-name = "metal"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e198a0ee42bdbe9ef2c09d0b9426f3b2b47d90d93a4a9b0395c4cea605e92dc0"
@@ -3614,7 +3599,7 @@ dependencies = [
  "lazy_static",
  "malloc_size_of",
  "malloc_size_of_derive",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
  "serde",
  "servo_url",
  "size_of_test",
@@ -4691,7 +4676,7 @@ dependencies = [
  "msg",
  "net_traits",
  "num-traits",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
  "percent-encoding",
  "phf",
  "phf_codegen",
@@ -4755,7 +4740,7 @@ dependencies = [
  "metrics",
  "msg",
  "net_traits",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
  "profile_traits",
  "range",
  "script_traits",
@@ -5583,7 +5568,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "owning_ref",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
  "precomputed-hash",
  "rayon",
  "regex",
@@ -5667,7 +5652,7 @@ dependencies = [
 [[package]]
 name = "surfman"
 version = "0.2.0"
-source = "git+https://github.com/servo/surfman#bc084411664b04dba777659e5ce16b5f95b7371a"
+source = "git+https://github.com/servo/surfman#2283acaa3a856c2f76028cb23b5dde7dc0030cdf"
 dependencies = [
  "bitflags",
  "cfg_aliases",
@@ -5683,9 +5668,9 @@ dependencies = [
  "libc",
  "log",
  "mach",
- "metal 0.17.1",
+ "metal",
  "objc",
- "parking_lot 0.9.0",
+ "parking_lot 0.10.2",
  "wayland-sys 0.24.0",
  "winapi",
  "winit",

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -33,7 +33,7 @@ malloc_size_of = { path = "../malloc_size_of" }
 msg = { path = "../msg" }
 net_traits = { path = "../net_traits" }
 num-traits = "0.2"
-parking_lot = "0.9"
+parking_lot = "0.10"
 profile_traits = { path = "../profile_traits" }
 range = { path = "../range" }
 rayon = "1"

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -30,7 +30,7 @@ log = "0.4"
 mitochondria = "1.1.2"
 msg = { path = "../msg" }
 net_traits = { path = "../net_traits" }
-parking_lot = "0.9"
+parking_lot = "0.10"
 range = { path = "../range" }
 rayon = "1"
 rayon_croissant = "0.2.0"

--- a/components/layout_thread/Cargo.toml
+++ b/components/layout_thread/Cargo.toml
@@ -32,7 +32,7 @@ malloc_size_of = { path = "../malloc_size_of" }
 metrics = { path = "../metrics" }
 msg = { path = "../msg" }
 net_traits = { path = "../net_traits" }
-parking_lot = { version = "0.9", features = ["nightly"] }
+parking_lot = { version = "0.10" }
 profile_traits = { path = "../profile_traits" }
 range = { path = "../range" }
 rayon = "1"

--- a/components/layout_thread_2020/Cargo.toml
+++ b/components/layout_thread_2020/Cargo.toml
@@ -31,7 +31,7 @@ malloc_size_of = { path = "../malloc_size_of" }
 metrics = { path = "../metrics" }
 msg = { path = "../msg" }
 net_traits = { path = "../net_traits" }
-parking_lot = { version = "0.9", features = ["nightly"] }
+parking_lot = { version = "0.10" }
 profile_traits = { path = "../profile_traits" }
 range = { path = "../range" }
 script = { path = "../script" }

--- a/components/msg/Cargo.toml
+++ b/components/msg/Cargo.toml
@@ -17,7 +17,7 @@ lazy_static = "1"
 ipc-channel = "0.14"
 malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = "0.1"
-parking_lot = "0.9"
+parking_lot = "0.10"
 serde = "1.0.60"
 servo_url = {path = "../url"}
 webrender_api = {git = "https://github.com/servo/webrender"}

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -79,7 +79,7 @@ mitochondria = "1.1.2"
 msg = { path = "../msg" }
 net_traits = { path = "../net_traits" }
 num-traits = "0.2"
-parking_lot = "0.9"
+parking_lot = "0.10"
 percent-encoding = "2.0"
 phf = "0.8"
 pixels = { path = "../pixels" }

--- a/components/script_layout_interface/Cargo.toml
+++ b/components/script_layout_interface/Cargo.toml
@@ -26,7 +26,7 @@ malloc_size_of_derive = "0.1"
 metrics = {path = "../metrics"}
 msg = {path = "../msg"}
 net_traits = {path = "../net_traits"}
-parking_lot = "0.9"
+parking_lot = "0.10"
 profile_traits = {path = "../profile_traits"}
 range = {path = "../range"}
 script_traits = {path = "../script_traits"}

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -54,7 +54,7 @@ num-integer = "0.1"
 num-traits = "0.2"
 num-derive = "0.3"
 owning_ref = "0.4"
-parking_lot = "0.9"
+parking_lot = "0.10"
 precomputed-hash = "0.1.1"
 rayon = "1"
 selectors = { path = "../selectors" }

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -35,7 +35,6 @@ packages = [
   "peek-poke",
   "peek-poke-derive",
   "wayland-sys",
-  "metal",
   "parking_lot",
   "parking_lot_core",
   "ron",


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #26644
- [x] There are tests for these changes