### PR TITLE
Make WebGPU resource creation async and prevent panic during shutdown if WebGPU is enabled.

### DIFF
--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -179,10 +179,16 @@ impl GPUBufferMethods for GPUBuffer {
             },
             _ => {},
         };
-        self.channel
+        if let Err(e) = self
+            .channel
             .0
             .send(WebGPURequest::DestroyBuffer(self.buffer.0))
-            .unwrap();
+        {
+            warn!(
+                "Failed to send WebGPURequest::DestroyBuffer({:?}) ({})",
+                self.buffer.0, e
+            );
+        };
         *self.state.borrow_mut() = GPUBufferState::Destroyed;
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2016,6 +2016,7 @@ impl ScriptThread {
             WebGPUMsg::FreeCommandBuffer(id) => self.gpu_id_hub.lock().kill_command_buffer_id(id),
             WebGPUMsg::FreeSampler(id) => self.gpu_id_hub.lock().kill_sampler_id(id),
             WebGPUMsg::FreeShaderModule(id) => self.gpu_id_hub.lock().kill_shader_module_id(id),
+            WebGPUMsg::Exit => *self.webgpu_port.borrow_mut() = None,
             _ => {},
         }
     }

--- a/components/webgpu/identity.rs
+++ b/components/webgpu/identity.rs
@@ -31,6 +31,7 @@ pub enum WebGPUMsg {
     FreeSampler(SamplerId),
     FreeSurface(SurfaceId),
     FreeShaderModule(ShaderModuleId),
+    Exit,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
1. Make WebGPU resource creation async.
2. Remove some unused code in `WebGPURequest::RequestAdapter`.
3. Prevent panic during shutdown. Since WGPU thread is killed before script, sender and receiver in the script panic at either of the two places-
a. If a buffer is still alive, script tries to send `WebGPURequest::DestroyBuffer` to server while dropping the buffer during shutdown. 
https://github.com/servo/servo/blob/7170a69695212ba8c24a9f0c4202f0ddfe52f742/components/script/dom/gpubuffer.rs#L118-L122 https://github.com/servo/servo/blob/7170a69695212ba8c24a9f0c4202f0ddfe52f742/components/script/dom/gpubuffer.rs#L182-L186
b. Receiver in script-thread panics with `RecvError` as soon as sender on server side is dropped. https://github.com/servo/servo/blob/7170a69695212ba8c24a9f0c4202f0ddfe52f742/components/script/script_thread.rs#L1456-L1457

r?@kvark

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #25472 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
