### PR TITLE
Set `currentScript` to `null` for module scripts

### DIFF
--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -757,13 +757,17 @@ impl HTMLScriptElement {
         let old_script = document.GetCurrentScript();
 
         match script.type_ {
+            ScriptType::Classic => document.set_current_script(Some(self)),
+            ScriptType::Module => document.set_current_script(None),
+        }
+
+        match script.type_ {
             ScriptType::Classic => {
-                document.set_current_script(Some(self));
                 self.run_a_classic_script(&script);
                 document.set_current_script(old_script.as_deref());
             },
             ScriptType::Module => {
-                assert!(old_script.is_none());
+                assert!(document.GetCurrentScript().is_none());
                 self.run_a_module_script(&script, false);
             },
         }

--- a/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/module/load-error-events-inline.html.ini
+++ b/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/module/load-error-events-inline.html.ini
@@ -1,5 +1,0 @@
-
-[load-error-events-inline.html]
-  type: testharness
-  expected: CRASH
-


### PR DESCRIPTION
I misunderstood the test case when I worked on #23545. That test case is
actually not related to dynamic import; instead, the reason why it
crashes is, `currentScript` should be updated to `null`.

In spec, the step 6 of [execute-the-script-block](https://html.spec.whatwg.org/multipage/scripting.html#execute-the-script-block) only says `Assert: document's currentScript attribute is null.` but doesn't says it should be set to null. Not sure if it can be improved.


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
