### PR TITLE
Remove some unused dependency declarations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,7 +508,6 @@ dependencies = [
  "canvas_traits",
  "crossbeam-channel",
  "cssparser",
- "embedder_traits",
  "euclid",
  "fnv",
  "gleam 0.11.0",
@@ -551,16 +550,6 @@ dependencies = [
  "time",
  "webrender_api",
  "webxr-api",
-]
-
-[[package]]
-name = "caseless"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808dab3318747be122cb31d36de18d4d1c81277a76f8332a02b81a3d73463d7f"
-dependencies = [
- "regex",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -838,7 +827,6 @@ dependencies = [
  "script_traits",
  "serde",
  "servo_config",
- "servo_geometry",
  "servo_rand",
  "servo_remutex",
  "servo_url",
@@ -2834,11 +2822,9 @@ dependencies = [
  "atomic_refcell",
  "bitflags",
  "canvas_traits",
- "crossbeam-channel",
  "embedder_traits",
  "euclid",
  "fnv",
- "fxhash",
  "gfx",
  "gfx_traits",
  "html5ever",
@@ -2903,7 +2889,6 @@ dependencies = [
  "serde",
  "serde_json",
  "servo_arc",
- "servo_geometry",
  "servo_url",
  "style",
  "style_traits",
@@ -2949,7 +2934,6 @@ dependencies = [
  "servo_arc",
  "servo_atoms",
  "servo_config",
- "servo_geometry",
  "servo_url",
  "style",
  "style_traits",
@@ -2992,11 +2976,9 @@ dependencies = [
  "servo_arc",
  "servo_atoms",
  "servo_config",
- "servo_geometry",
  "servo_url",
  "style",
  "style_traits",
- "time",
  "webrender_api",
 ]
 
@@ -3005,7 +2987,6 @@ name = "layout_traits"
 version = "0.0.1"
 dependencies = [
  "crossbeam-channel",
- "euclid",
  "gfx",
  "ipc-channel",
  "metrics",
@@ -3013,7 +2994,6 @@ dependencies = [
  "net_traits",
  "profile_traits",
  "script_traits",
- "servo_geometry",
  "servo_url",
  "webrender_api",
 ]
@@ -3587,7 +3567,6 @@ dependencies = [
  "malloc_size_of_derive",
  "parking_lot 0.10.2",
  "serde",
- "servo_url",
  "size_of_test",
  "webrender_api",
 ]
@@ -4251,7 +4230,6 @@ dependencies = [
  "servo_config",
  "task_info",
  "time",
- "tokio",
 ]
 
 [[package]]
@@ -4268,7 +4246,6 @@ dependencies = [
 name = "profile_traits"
 version = "0.0.1"
 dependencies = [
- "bincode",
  "crossbeam-channel",
  "energy-monitor",
  "energymon",
@@ -4614,11 +4591,9 @@ dependencies = [
  "app_units",
  "backtrace",
  "base64 0.10.1",
- "bincode",
  "bitflags",
  "bluetooth_traits",
  "canvas_traits",
- "caseless",
  "chrono",
  "content-security-policy",
  "cookie",
@@ -4791,7 +4766,6 @@ dependencies = [
  "smallvec 0.6.13",
  "style_traits",
  "time",
- "url",
  "uuid",
  "webdriver",
  "webgpu",
@@ -4894,7 +4868,6 @@ dependencies = [
  "clipboard",
  "euclid",
  "getopts",
- "gleam 0.11.0",
  "image",
  "keyboard-types",
  "lazy_static",
@@ -4907,7 +4880,6 @@ dependencies = [
  "surfman",
  "tinyfiledialogs",
  "webxr",
- "webxr-api",
  "winapi",
  "winit",
  "winres",
@@ -4959,7 +4931,6 @@ version = "0.0.1"
 dependencies = [
  "crossbeam-channel",
  "euclid",
- "gleam 0.11.0",
  "glib",
  "gst-plugin-version-helper",
  "gstreamer",
@@ -6478,7 +6449,6 @@ dependencies = [
  "servo_config",
  "servo_url",
  "style_traits",
- "url",
  "uuid",
  "webdriver",
 ]
@@ -6487,7 +6457,6 @@ dependencies = [
 name = "webgpu"
 version = "0.0.1"
 dependencies = [
- "embedder_traits",
  "ipc-channel",
  "log",
  "malloc_size_of",
@@ -6584,7 +6553,6 @@ name = "webrender_traits"
 version = "0.0.1"
 dependencies = [
  "euclid",
- "servo_geometry",
  "webrender_api",
 ]
 

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -21,7 +21,6 @@ byteorder = "1"
 canvas_traits = { path = "../canvas_traits" }
 crossbeam-channel = "0.4"
 cssparser = "0.27"
-embedder_traits = { path = "../embedder_traits" }
 euclid = "0.20"
 fnv = "1.0"
 gleam = "0.11"

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -37,7 +37,6 @@ profile_traits = { path = "../profile_traits" }
 script_traits = { path = "../script_traits" }
 serde = "1.0"
 servo_config = { path = "../config" }
-servo_geometry = { path = "../geometry" }
 servo_rand = {path = "../rand" }
 servo_remutex = { path = "../remutex" }
 servo_url = { path = "../url" }

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -17,11 +17,9 @@ app_units = "0.7"
 atomic_refcell = "0.1"
 bitflags = "1.0"
 canvas_traits = { path = "../canvas_traits" }
-crossbeam-channel = "0.4"
 embedder_traits = { path = "../embedder_traits" }
 euclid = "0.20"
 fnv = "1.0"
-fxhash = "0.2"
 gfx = { path = "../gfx" }
 gfx_traits = { path = "../gfx_traits" }
 html5ever = "0.25"

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -39,7 +39,6 @@ script_traits = { path = "../script_traits" }
 serde = "1.0"
 serde_json = "1.0"
 servo_arc = { path = "../servo_arc" }
-servo_geometry = { path = "../geometry" }
 servo_url = { path = "../url" }
 style = { path = "../style", features = ["servo", "servo-layout-2020"] }
 style_traits = { path = "../style_traits" }

--- a/components/layout_thread/Cargo.toml
+++ b/components/layout_thread/Cargo.toml
@@ -45,7 +45,6 @@ servo_allocator = { path = "../allocator" }
 servo_arc = { path = "../servo_arc" }
 servo_atoms = { path = "../atoms" }
 servo_config = { path = "../config" }
-servo_geometry = { path = "../geometry" }
 servo_url = { path = "../url" }
 style = { path = "../style" }
 style_traits = { path = "../style_traits" }

--- a/components/layout_thread_2020/Cargo.toml
+++ b/components/layout_thread_2020/Cargo.toml
@@ -42,9 +42,7 @@ servo_allocator = { path = "../allocator" }
 servo_arc = { path = "../servo_arc" }
 servo_atoms = { path = "../atoms" }
 servo_config = { path = "../config" }
-servo_geometry = { path = "../geometry" }
 servo_url = { path = "../url" }
 style = { path = "../style" }
 style_traits = { path = "../style_traits" }
-time = "0.1.17"
 webrender_api = { git = "https://github.com/servo/webrender" }

--- a/components/layout_traits/Cargo.toml
+++ b/components/layout_traits/Cargo.toml
@@ -12,7 +12,6 @@ path = "lib.rs"
 
 [dependencies]
 crossbeam-channel = "0.4"
-euclid = "0.20"
 gfx = { path = "../gfx" }
 ipc-channel = "0.14"
 metrics = { path = "../metrics" }
@@ -20,6 +19,5 @@ msg = { path = "../msg" }
 net_traits = { path = "../net_traits" }
 profile_traits = { path = "../profile_traits" }
 script_traits = { path = "../script_traits" }
-servo_geometry = { path = "../geometry" }
 servo_url = { path = "../url" }
 webrender_api = { git = "https://github.com/servo/webrender" }

--- a/components/msg/Cargo.toml
+++ b/components/msg/Cargo.toml
@@ -19,7 +19,6 @@ malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = "0.1"
 parking_lot = "0.10"
 serde = "1.0.60"
-servo_url = { path = "../url" }
 webrender_api = { git = "https://github.com/servo/webrender" }
 
 [dev-dependencies]

--- a/components/net/lib.rs
+++ b/components/net/lib.rs
@@ -44,3 +44,6 @@ pub mod test {
     pub use crate::hosts::{parse_hostsfile, replace_host_table};
     pub use crate::http_loader::HttpState;
 }
+
+// This dependency gives `build.rs` access to the `DEP_OPENSSL_VERSION_NUMBER` env variable.
+use openssl_sys as _;

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -19,7 +19,6 @@ serde = "1.0"
 serde_json = "1.0"
 servo_config = {path = "../config"}
 time_crate = {package = "time", version = "0.1.12"}
-tokio = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 task_info = {path = "../../support/rust-task_info"}

--- a/components/profile_traits/Cargo.toml
+++ b/components/profile_traits/Cargo.toml
@@ -14,7 +14,6 @@ path = "lib.rs"
 energy-profiling = ["energymon", "energy-monitor"]
 
 [dependencies]
-bincode = "1"
 crossbeam-channel = "0.4"
 energy-monitor = {version = "0.2.0", optional = true}
 energymon = {git = "https://github.com/energymon/energymon-rust.git", optional = true}

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -34,11 +34,9 @@ accountable-refcell = { version = "0.2.0", optional = true }
 app_units = "0.7"
 backtrace = { version = "0.3", optional = true }
 base64 = "0.10.1"
-bincode = "1"
 bitflags = "1.0"
 bluetooth_traits = { path = "../bluetooth_traits" }
 canvas_traits = { path = "../canvas_traits" }
-caseless = "0.2"
 chrono = "0.4"
 content-security-policy = { version = "0.4.0", features = ["serde"] }
 cookie = "0.11"

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -40,7 +40,6 @@ servo_url = {path = "../url"}
 smallvec = "0.6"
 style_traits = {path = "../style_traits", features = ["servo"]}
 time = "0.1.12"
-url = "2.0"
 uuid = {version = "0.8", features = ["v4"]}
 webdriver = "0.40"
 webgpu = {path = "../webgpu"}

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -16,7 +16,8 @@ path = "lib.rs"
 doctest = false
 
 [features]
-gecko = ["style_traits/gecko", "fallible/known_system_malloc", "bindgen", "regex", "toml"]
+gecko = ["style_traits/gecko", "fallible/known_system_malloc", "bindgen", "regex", "toml",
+         "num_cpus", "thin-slice"]
 servo = ["serde", "style_traits/servo", "servo_atoms", "servo_config", "html5ever",
          "cssparser/serde", "encoding_rs", "malloc_size_of/servo", "servo_url",
          "string_cache", "to_shmem/servo",
@@ -49,7 +50,7 @@ lazy_static = "1"
 log = { version = "0.4", features = ["std"] }
 malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = "0.1"
-num_cpus = {version = "1.1.0"}
+num_cpus = {version = "1.1.0", optional = true}
 num-integer = "0.1"
 num-traits = "0.2"
 num-derive = "0.3"
@@ -68,7 +69,7 @@ string_cache = { version = "0.8", optional = true }
 style_derive = {path = "../style_derive"}
 style_traits = {path = "../style_traits"}
 servo_url = {path = "../url", optional = true}
-thin-slice = "0.1.0"
+thin-slice = {version = "0.1.0", optional = true}
 to_shmem = {path = "../to_shmem"}
 to_shmem_derive = {path = "../to_shmem_derive"}
 time = "0.1"

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -29,6 +29,5 @@ script_traits = {path = "../script_traits"}
 servo_config = {path = "../config"}
 servo_url = {path = "../url"}
 style_traits = {path = "../style_traits"}
-url = "2.0"
 uuid = {version = "0.8", features = ["v4"]}
 webdriver = "0.40"

--- a/components/webgpu/Cargo.toml
+++ b/components/webgpu/Cargo.toml
@@ -11,7 +11,6 @@ name = "webgpu"
 path = "lib.rs"
 
 [dependencies]
-embedder_traits = {path = "../embedder_traits"}
 ipc-channel = "0.14"
 log = "0.4"
 malloc_size_of = { path = "../malloc_size_of" }

--- a/components/webrender_traits/Cargo.toml
+++ b/components/webrender_traits/Cargo.toml
@@ -12,6 +12,5 @@ path = "lib.rs"
 
 [dependencies]
 euclid = "0.20"
-servo_geometry = {path = "../geometry"}
 webrender_api = {git = "https://github.com/servo/webrender"}
 

--- a/ports/gstplugin/Cargo.toml
+++ b/ports/gstplugin/Cargo.toml
@@ -17,7 +17,6 @@ path = "lib.rs"
 [dependencies]
 crossbeam-channel = "0.4"
 euclid = "0.20"
-gleam = "0.11"
 glib = "0.9"
 gstreamer = "0.15"
 gstreamer-base = "0.15"

--- a/ports/winit/Cargo.toml
+++ b/ports/winit/Cargo.toml
@@ -52,7 +52,6 @@ backtrace = "0.3"
 clipboard = "0.5"
 euclid = "0.20"
 getopts = "0.2.11"
-gleam = "0.11"
 keyboard-types = "0.4.3"
 lazy_static = "1"
 libc = "0.2"
@@ -63,7 +62,6 @@ shellwords = "1.0.0"
 surfman = { version = "0.2", features = ["sm-winit", "sm-x11"] }
 tinyfiledialogs = "3.0"
 webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless"] }
-webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
 winit = "0.19"
 
 [target.'cfg(any(target_os = "linux", target_os = "windows"))'.dependencies]


### PR DESCRIPTION
This is based on compiling with `RUSTFLAGS="-W unused_crate_dependencies"` (CC https://github.com/rust-lang/rust/pull/72342) in a recent Nightly (more so than used in the tree as of this writing, CC https://github.com/servo/servo/issues/26661 for work-arounds).

Only one crate is actually removed from the dependency graph, others are still dependended from other places.