### PR TITLE
Avoid bare *mut JSObject arguments in webidl codegen

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -677,7 +677,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
     if type.isSequence() or type.isRecord():
         innerInfo = getJSToNativeConversionInfo(innerContainerType(type),
                                                 descriptorProvider,
-                                                isMember=isMember,
+                                                isMember="Sequence",
                                                 isAutoRooted=isAutoRooted)
         declType = wrapInNativeContainerType(type, innerInfo.declType)
         config = getConversionConfigForType(type, isEnforceRange, isClamp, treatNullAs)
@@ -1075,7 +1075,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         assert not isEnforceRange and not isClamp
         assert isMember != "Union"
 
-        if isMember == "Dictionary" or isAutoRooted:
+        if isMember in ("Dictionary", "Sequence") or isAutoRooted:
             templateBody = "${val}.get()"
 
             if defaultValue is None:
@@ -1087,7 +1087,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
             else:
                 raise TypeError("Can't handle non-null, non-undefined default value here")
 
-            if isMember == "Dictionary":
+            if not isAutoRooted:
                 templateBody = "RootedTraceableBox::from_box(Heap::boxed(%s))" % templateBody
                 if default is not None:
                     default = "RootedTraceableBox::from_box(Heap::boxed(%s))" % default
@@ -1115,15 +1115,19 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         assert not isEnforceRange and not isClamp
 
         templateBody = "${val}.get().to_object()"
-        default = "ptr::null_mut()"
 
-        if isMember in ("Dictionary", "Union"):
+        if isArgument or not isMember or isMember == "Variadic":
+            declType = CGGeneric("RawHandleObject")
+            templateBody = "RawHandleObject::from_marked_location(&" + templateBody + ")"
+            default = "RawHandleObject::null()"
+        elif not isAutoRooted:
             templateBody = "RootedTraceableBox::from_box(Heap::boxed(%s))" % templateBody
             default = "RootedTraceableBox::new(Heap::default())"
             declType = CGGeneric("RootedTraceableBox<Heap<*mut JSObject>>")
         else:
             # TODO: Need to root somehow
             # https://github.com/servo/servo/issues/6382
+            default = "ptr::null_mut()"
             declType = CGGeneric("*mut JSObject")
 
         templateBody = wrapObjectTemplate(templateBody, default,
@@ -7486,11 +7490,11 @@ class CGIterableMethodGenerator(CGGeneric):
         if methodName == "forEach":
             CGGeneric.__init__(self, fill(
                 """
-                if !IsCallable(arg0) {
+                if !IsCallable(*arg0) {
                   throw_type_error(*cx, "Argument 1 of ${ifaceName}.forEach is not callable.");
                   return false;
                 }
-                rooted!(in(*cx) let arg0 = ObjectValue(arg0));
+                rooted!(in(*cx) let arg0 = ObjectValue(*arg0));
                 rooted!(in(*cx) let mut call_arg1 = UndefinedValue());
                 rooted!(in(*cx) let mut call_arg2 = UndefinedValue());
                 let mut call_args = vec![UndefinedValue(), UndefinedValue(), ObjectValue(*_obj)];

--- a/components/script/dom/bluetooth.rs
+++ b/components/script/dom/bluetooth.rs
@@ -36,7 +36,7 @@ use dom_struct::dom_struct;
 use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
 use js::conversions::ConversionResult;
-use js::jsapi::JSObject;
+use js::jsapi::HandleObject;
 use js::jsval::{ObjectValue, UndefinedValue};
 use profile_traits::ipc as ProfiledIpc;
 use std::collections::HashMap;
@@ -609,12 +609,12 @@ impl PermissionAlgorithm for Bluetooth {
 
     fn create_descriptor(
         cx: JSContext,
-        permission_descriptor_obj: *mut JSObject,
+        permission_descriptor_obj: HandleObject,
     ) -> Result<BluetoothPermissionDescriptor, Error> {
         rooted!(in(*cx) let mut property = UndefinedValue());
         property
             .handle_mut()
-            .set(ObjectValue(permission_descriptor_obj));
+            .set(ObjectValue(permission_descriptor_obj.get()));
         match BluetoothPermissionDescriptor::new(cx, property.handle()) {
             Ok(ConversionResult::Success(descriptor)) => Ok(descriptor),
             Ok(ConversionResult::Failure(error)) => Err(Error::Type(error.into_owned())),

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1327,8 +1327,7 @@ impl HTMLInputElementMethods for HTMLInputElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-input-valueasdate
     #[allow(unsafe_code, non_snake_case)]
-    fn SetValueAsDate(&self, cx: SafeJSContext, value: *mut JSObject) -> ErrorResult {
-        rooted!(in(*cx) let value = value);
+    fn SetValueAsDate(&self, cx: SafeJSContext, value: Handle<*mut JSObject>) -> ErrorResult {
         if !self.does_value_as_date_apply() {
             return Err(Error::InvalidState);
         }
@@ -1341,13 +1340,13 @@ impl HTMLInputElementMethods for HTMLInputElement {
         // which we then reinflate into a NaiveDate for use in safe code.
         unsafe {
             let mut isDate = false;
-            if !ObjectIsDate(*cx, Handle::from(value.handle()), &mut isDate) {
+            if !ObjectIsDate(*cx, Handle::from(value), &mut isDate) {
                 return Err(Error::JSFailed);
             }
             if !isDate {
                 return Err(Error::Type("Value was not a date".to_string()));
             }
-            if !DateGetMsecSinceEpoch(*cx, Handle::from(value.handle()), &mut msecs) {
+            if !DateGetMsecSinceEpoch(*cx, Handle::from(value), &mut msecs) {
                 return Err(Error::JSFailed);
             }
             if !msecs.is_finite() {

--- a/components/script/dom/testbinding.rs
+++ b/components/script/dom/testbinding.rs
@@ -53,7 +53,7 @@ use crate::realms::InRealm;
 use crate::script_runtime::JSContext as SafeJSContext;
 use crate::timers::OneshotTimerCallback;
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSContext, JSObject};
+use js::jsapi::{HandleObject as RawHandleObject, Heap, JSContext, JSObject};
 use js::jsapi::{JS_NewPlainObject, JS_NewUint8ClampedArray};
 use js::jsval::{JSVal, NullValue};
 use js::rust::CustomAutoRooterGuard;
@@ -231,7 +231,7 @@ impl TestBindingMethods for TestBinding {
             NonNull::new(obj.get()).expect("got a null pointer")
         }
     }
-    fn SetObjectAttribute(&self, _: SafeJSContext, _: *mut JSObject) {}
+    fn SetObjectAttribute(&self, _: SafeJSContext, _: RawHandleObject) {}
 
     fn GetBooleanAttributeNullable(&self) -> Option<bool> {
         Some(false)
@@ -331,7 +331,7 @@ impl TestBindingMethods for TestBinding {
     fn GetObjectAttributeNullable(&self, _: SafeJSContext) -> Option<NonNull<JSObject>> {
         None
     }
-    fn SetObjectAttributeNullable(&self, _: SafeJSContext, _: *mut JSObject) {}
+    fn SetObjectAttributeNullable(&self, _: SafeJSContext, _: RawHandleObject) {}
     fn GetUnionAttributeNullable(&self) -> Option<HTMLElementOrLong> {
         Some(HTMLElementOrLong::Long(0))
     }
@@ -661,7 +661,7 @@ impl TestBindingMethods for TestBinding {
     fn PassUnionWithTypedef(&self, _: DocumentOrTestTypedef) {}
     fn PassUnionWithTypedef2(&self, _: LongSequenceOrTestTypedef) {}
     fn PassAny(&self, _: SafeJSContext, _: HandleValue) {}
-    fn PassObject(&self, _: SafeJSContext, _: *mut JSObject) {}
+    fn PassObject(&self, _: SafeJSContext, _: RawHandleObject) {}
     fn PassCallbackFunction(&self, _: Rc<Function>) {}
     fn PassCallbackInterface(&self, _: Rc<EventListener>) {}
     fn PassSequence(&self, _: Vec<i32>) {}
@@ -706,7 +706,7 @@ impl TestBindingMethods for TestBinding {
     fn PassNullableByteString(&self, _: Option<ByteString>) {}
     // fn PassNullableEnum(self, _: Option<TestEnum>) {}
     fn PassNullableInterface(&self, _: Option<&Blob>) {}
-    fn PassNullableObject(&self, _: SafeJSContext, _: *mut JSObject) {}
+    fn PassNullableObject(&self, _: SafeJSContext, _: RawHandleObject) {}
     fn PassNullableTypedArray(&self, _: CustomAutoRooterGuard<Option<typedarray::Int8Array>>) {}
     fn PassNullableUnion(&self, _: Option<HTMLElementOrLong>) {}
     fn PassNullableUnion2(&self, _: Option<EventOrString>) {}
@@ -743,7 +743,7 @@ impl TestBindingMethods for TestBinding {
     fn PassOptionalUnion5(&self, _: Option<UnsignedLongOrBoolean>) {}
     fn PassOptionalUnion6(&self, _: Option<ByteStringOrLong>) {}
     fn PassOptionalAny(&self, _: SafeJSContext, _: HandleValue) {}
-    fn PassOptionalObject(&self, _: SafeJSContext, _: Option<*mut JSObject>) {}
+    fn PassOptionalObject(&self, _: SafeJSContext, _: Option<RawHandleObject>) {}
     fn PassOptionalCallbackFunction(&self, _: Option<Rc<Function>>) {}
     fn PassOptionalCallbackInterface(&self, _: Option<Rc<EventListener>>) {}
     fn PassOptionalSequence(&self, _: Option<Vec<i32>>) {}
@@ -766,7 +766,7 @@ impl TestBindingMethods for TestBinding {
     fn PassOptionalNullableByteString(&self, _: Option<Option<ByteString>>) {}
     // fn PassOptionalNullableEnum(self, _: Option<Option<TestEnum>>) {}
     fn PassOptionalNullableInterface(&self, _: Option<Option<&Blob>>) {}
-    fn PassOptionalNullableObject(&self, _: SafeJSContext, _: Option<*mut JSObject>) {}
+    fn PassOptionalNullableObject(&self, _: SafeJSContext, _: Option<RawHandleObject>) {}
     fn PassOptionalNullableUnion(&self, _: Option<Option<HTMLElementOrLong>>) {}
     fn PassOptionalNullableUnion2(&self, _: Option<Option<EventOrString>>) {}
     fn PassOptionalNullableUnion3(&self, _: Option<Option<StringOrLongSequence>>) {}
@@ -810,7 +810,7 @@ impl TestBindingMethods for TestBinding {
     fn PassOptionalNullableByteStringWithDefault(&self, _: Option<ByteString>) {}
     // fn PassOptionalNullableEnumWithDefault(self, _: Option<TestEnum>) {}
     fn PassOptionalNullableInterfaceWithDefault(&self, _: Option<&Blob>) {}
-    fn PassOptionalNullableObjectWithDefault(&self, _: SafeJSContext, _: *mut JSObject) {}
+    fn PassOptionalNullableObjectWithDefault(&self, _: SafeJSContext, _: RawHandleObject) {}
     fn PassOptionalNullableUnionWithDefault(&self, _: Option<HTMLElementOrLong>) {}
     fn PassOptionalNullableUnion2WithDefault(&self, _: Option<EventOrString>) {}
     // fn PassOptionalNullableCallbackFunctionWithDefault(self, _: Option<Function>) {}
@@ -865,7 +865,7 @@ impl TestBindingMethods for TestBinding {
     fn PassVariadicUnion6(&self, _: Vec<UnsignedLongOrBoolean>) {}
     fn PassVariadicUnion7(&self, _: Vec<ByteStringOrLong>) {}
     fn PassVariadicAny(&self, _: SafeJSContext, _: Vec<HandleValue>) {}
-    fn PassVariadicObject(&self, _: SafeJSContext, _: Vec<*mut JSObject>) {}
+    fn PassVariadicObject(&self, _: SafeJSContext, _: Vec<RawHandleObject>) {}
     fn BooleanMozPreference(&self, pref_name: DOMString) -> bool {
         prefs::pref_map()
             .get(pref_name.as_ref())


### PR DESCRIPTION
The motivation here was fixing a bug where argument type calculation did not treat inner types of sequences correctly. This required updating some logic for when to choose to use `*mut JSObject` vs. `RootedTraceableBox<Heap<*mut JSObject>`, which then was a good reason to choose `HandleObject` when possible instead.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #13308
- [x] There are tests for these changes