### PR TITLE
Add UI for bypassing SSL handshake failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3609,6 +3609,7 @@ dependencies = [
  "pixels",
  "serde",
  "servo_arc",
+ "servo_rand",
  "servo_url",
  "std_test_override",
  "time",

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -184,12 +184,13 @@ pub(crate) fn create_tls_config(
             Err(_) => return false,
         };
 
-        // Ensure there's an entry stored in the set of known connection certs for this connection.
-        let host = ssl.ex_data(*HOST_INDEX).unwrap();
         let ssl_context = ssl.ssl_context();
-        let connection_certs = ssl_context.ex_data(*CONNECTION_INDEX).unwrap();
 
-        connection_certs.store((*host).0.clone(), pem.clone());
+        // Ensure there's an entry stored in the set of known connection certs for this connection.
+        if let Some(host) = ssl.ex_data(*HOST_INDEX) {
+            let connection_certs = ssl_context.ex_data(*CONNECTION_INDEX).unwrap();
+            connection_certs.store((*host).0.clone(), pem.clone());
+        }
 
         // Fall back to the dynamic set of allowed certs.
         let extra_certs = ssl_context.ex_data(*EXTRA_INDEX).unwrap();

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -98,11 +98,15 @@ pub type Connector = HttpsConnector<HttpConnector>;
 pub type TlsConfig = SslConnectorBuilder;
 
 #[derive(Clone)]
-pub struct ExtraCerts(pub Arc<Mutex<Vec<Vec<u8>>>>);
+pub struct ExtraCerts(Arc<Mutex<Vec<Vec<u8>>>>);
 
 impl ExtraCerts {
     pub(crate) fn new() -> Self {
         Self(Arc::new(Mutex::new(vec![])))
+    }
+
+    pub(crate) fn add(&self, bytes: Vec<u8>) {
+        self.0.lock().unwrap().push(bytes);
     }
 }
 

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -41,7 +41,7 @@ pub struct ConnectionCerts {
 }
 
 impl ConnectionCerts {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             certs: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -101,11 +101,11 @@ pub type TlsConfig = SslConnectorBuilder;
 pub struct ExtraCerts(Arc<Mutex<Vec<Vec<u8>>>>);
 
 impl ExtraCerts {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self(Arc::new(Mutex::new(vec![])))
     }
 
-    pub(crate) fn add(&self, bytes: Vec<u8>) {
+    pub fn add(&self, bytes: Vec<u8>) {
         self.0.lock().unwrap().push(bytes);
     }
 }
@@ -119,7 +119,7 @@ lazy_static! {
     static ref HOST_INDEX: Index<Ssl, Host> = Ssl::new_ex_index().unwrap();
 }
 
-pub(crate) fn create_tls_config(
+pub fn create_tls_config(
     certs: &str,
     alpn: &[u8],
     extra_certs: ExtraCerts,

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1571,7 +1571,7 @@ fn http_network_fetch(
         &url,
         &request.method,
         &request.headers,
-        request.body.as_mut().and_then(|body| body.take_stream()),
+        request.body.as_mut().map(|body| body.take_stream()),
         &request.pipeline_id,
         request_id.as_ref().map(Deref::deref),
         is_xhr,

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -727,6 +727,8 @@ impl CoreResourceManager {
             action_receiver,
             http_state.clone(),
             self.certificate_path.clone(),
+            http_state.extra_certs.clone(),
+            http_state.connection_certs.clone(),
         );
     }
 }

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -29,7 +29,7 @@ use hyper::server::conn::Http;
 use hyper::server::Server as HyperServer;
 use hyper::service::service_fn_ok;
 use hyper::{Body, Request as HyperRequest, Response as HyperResponse};
-use net::connector::{create_tls_config, ALPN_H2_H1};
+use net::connector::{create_tls_config, ConnectionCerts, ExtraCerts, ALPN_H2_H1};
 use net::fetch::cors_cache::CorsCache;
 use net::fetch::methods::{self, CancellationListener, FetchContext};
 use net::filemanager_thread::FileManager;
@@ -91,7 +91,12 @@ fn new_fetch_context(
     pool_handle: Option<Weak<CoreResourceThreadPool>>,
 ) -> FetchContext {
     let certs = resources::read_string(Resource::SSLCertificates);
-    let tls_config = create_tls_config(&certs, ALPN_H2_H1);
+    let tls_config = create_tls_config(
+        &certs,
+        ALPN_H2_H1,
+        ExtraCerts::new(),
+        ConnectionCerts::new(),
+    );
     let sender = fc.unwrap_or_else(|| create_embedder_proxy());
 
     FetchContext {

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::connector::{create_tls_config, ExtraCerts, ALPN_H1};
+use crate::connector::{create_tls_config, ConnectionCerts, ExtraCerts, ALPN_H1};
 use crate::cookie::Cookie;
 use crate::fetch::methods::should_be_blocked_due_to_bad_port;
 use crate::hosts::replace_host;
@@ -167,7 +167,8 @@ impl<'a> Handler for Client<'a> {
                 WebSocketErrorKind::Protocol,
                 format!("Unable to parse domain from {}. Needed for SSL.", url),
             ))?;
-        let tls_config = create_tls_config(&certs, ALPN_H1, ExtraCerts::new());
+        let tls_config =
+            create_tls_config(&certs, ALPN_H1, ExtraCerts::new(), ConnectionCerts::new());
         tls_config
             .build()
             .connect(domain, stream)

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::connector::{create_tls_config, ALPN_H1};
+use crate::connector::{create_tls_config, ExtraCerts, ALPN_H1};
 use crate::cookie::Cookie;
 use crate::fetch::methods::should_be_blocked_due_to_bad_port;
 use crate::hosts::replace_host;
@@ -167,7 +167,7 @@ impl<'a> Handler for Client<'a> {
                 WebSocketErrorKind::Protocol,
                 format!("Unable to parse domain from {}. Needed for SSL.", url),
             ))?;
-        let tls_config = create_tls_config(&certs, ALPN_H1);
+        let tls_config = create_tls_config(&certs, ALPN_H1, ExtraCerts::new());
         tls_config
             .build()
             .connect(domain, stream)

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -33,6 +33,7 @@ piston_image = { package = "image", version = "0.23" }
 pixels = { path = "../pixels" }
 serde = "1.0"
 servo_arc = { path = "../servo_arc" }
+servo_rand = { path = "../rand" }
 servo_url = { path = "../url" }
 time = "0.1"
 url = "2.0"

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -30,6 +30,7 @@ use ipc_channel::router::ROUTER;
 use ipc_channel::Error as IpcError;
 use mime::Mime;
 use msg::constellation_msg::HistoryStateId;
+use servo_rand::RngCore;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use time::precise_time_ns;
 use webrender_api::{ImageData, ImageDescriptor, ImageKey};
@@ -810,4 +811,8 @@ impl WebrenderIpcSender {
             warn!("Error sending image update: {}", e);
         }
     }
+}
+
+lazy_static! {
+    pub static ref PRIVILEGED_SECRET: u32 = servo_rand::ServoRng::new().next_u32();
 }

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -712,12 +712,17 @@ pub enum NetworkError {
     Internal(String),
     LoadCancelled,
     /// SSL validation error that has to be handled in the HTML parser
-    SslValidation(ServoUrl, String),
+    SslValidation(String),
 }
 
 impl NetworkError {
     pub fn from_hyper_error(error: &HyperError) -> Self {
-        NetworkError::Internal(error.to_string())
+        let s = error.to_string();
+        if s.contains("the handshake failed") {
+            NetworkError::SslValidation(s)
+        } else {
+            NetworkError::Internal(s)
+        }
     }
 
     pub fn from_http_error(error: &HttpError) -> Self {

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -712,14 +712,14 @@ pub enum NetworkError {
     Internal(String),
     LoadCancelled,
     /// SSL validation error that has to be handled in the HTML parser
-    SslValidation(String),
+    SslValidation(String, Vec<u8>),
 }
 
 impl NetworkError {
-    pub fn from_hyper_error(error: &HyperError) -> Self {
+    pub fn from_hyper_error(error: &HyperError, cert_bytes: Option<Vec<u8>>) -> Self {
         let s = error.to_string();
         if s.contains("the handshake failed") {
-            NetworkError::SslValidation(s)
+            NetworkError::SslValidation(s, cert_bytes.unwrap_or_default())
         } else {
             NetworkError::Internal(s)
         }

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -164,7 +164,7 @@ impl RequestBody {
         }
     }
 
-    pub fn take_stream(&mut self) -> Option<IpcSender<BodyChunkRequest>> {
+    pub fn take_stream(&mut self) -> IpcSender<BodyChunkRequest> {
         if self.read_from {
             match self.source {
                 BodySource::Null => panic!(
@@ -174,12 +174,12 @@ impl RequestBody {
                     let (chan, port) = ipc::channel().unwrap();
                     let _ = self.chan.send(BodyChunkRequest::Extract(port));
                     self.chan = chan.clone();
-                    return Some(chan);
+                    return chan;
                 },
             }
         }
         self.read_from = true;
-        Some(self.chan.clone())
+        self.chan.clone()
     }
 
     pub fn source_is_null(&self) -> bool {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -821,6 +821,8 @@ impl FetchResponseListener for ParserContext {
                     let page = page.replace("${reason}", &reason);
                     let page =
                         page.replace("${bytes}", std::str::from_utf8(&bytes).unwrap_or_default());
+                    let page =
+                        page.replace("${secret}", &net_traits::PRIVILEGED_SECRET.to_string());
                     parser.push_string_input_chunk(page);
                     parser.parse_sync();
                 }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -731,9 +731,9 @@ impl FetchResponseListener for ParserContext {
                 FetchMetadata::Unfiltered(m) => m,
                 FetchMetadata::Filtered { unsafe_, .. } => unsafe_,
             }),
-            Err(NetworkError::SslValidation(url, reason)) => {
+            Err(NetworkError::SslValidation(reason)) => {
                 ssl_error = Some(reason);
-                let mut meta = Metadata::default(url);
+                let mut meta = Metadata::default(self.url.clone());
                 let mime: Option<Mime> = "text/html".parse().ok();
                 meta.set_content_type(mime.as_ref());
                 Some(meta)

--- a/resources/badcert.html
+++ b/resources/badcert.html
@@ -14,11 +14,11 @@
     if (bytes.length) {
         button.onclick = function() {
             let xhr = new XMLHttpRequest();
-            xhr.open('GET', 'chrome:allowcert?secret=${secret}&bytes=' + btoa(bytes));
+            xhr.open('POST', 'chrome:allowcert');
             xhr.onloadend = function() {
                 location.reload(true);
             };
-            xhr.send();
+            xhr.send("${secret}&" + btoa(bytes));
         };
     } else {
         button.style.display = "none";

--- a/resources/badcert.html
+++ b/resources/badcert.html
@@ -3,6 +3,7 @@
 <title>Certificate error</title>
 </head>
 <body>
-    <p>${reason}</p>
+  <p>${reason}</p>
+  <pre>${bytes}</pre>
 </body>
 </html>

--- a/resources/badcert.html
+++ b/resources/badcert.html
@@ -4,6 +4,25 @@
 </head>
 <body>
   <p>${reason}</p>
-  <pre>${bytes}</pre>
+  <pre id="bytes">${bytes}</pre>
+  <button id="leave" onclick="history.back()">Go back (recommended)</button>
+  <button id="allow">Allow certificate temporarily</button>
+  <script>
+    let bytes = document.getElementById('bytes').textContent;
+    let button = document.getElementById('allow');
+    let exitButton = document.getElementById('leave');
+    if (bytes.length) {
+        button.onclick = function() {
+            let xhr = new XMLHttpRequest();
+            xhr.open('GET', 'chrome:allowcert?secret=${secret}&bytes=' + btoa(bytes));
+            xhr.onloadend = function() {
+                location.reload(true);
+            };
+            xhr.send();
+        };
+    } else {
+        button.style.display = "none";
+    }
+  </script>
 </body>
 </html>

--- a/resources/servo.css
+++ b/resources/servo.css
@@ -1,3 +1,7 @@
+button {
+    cursor: default;
+}
+
 button,
 input {
   background: white;


### PR DESCRIPTION
There are several parts to these changes:
1. resurrecting the network error classification code to distinguish between SSL failures and other network errors
1. adding an SSL verification callback to support verifying certs against a list that can change at runtime, rather than just at program initialization
1. exposing a privileged chrome://allowcert URI which accepts the PEM cert contents along with a secret token
1. extracting the PEM cert contents out of the network layer when a handshake failure occurs, and getting them into the HTML that is parsed when an SSL failure occurs
1. adding a button in the handshake failure page that performs an XHR to chrome://allowcert with knowledge of the secret token and the PEM cert contents, before reloading the original URL that failed

The presence of the secret token means that while the chrome://allowcert URL is currently visible to web content, they cannot make use of it to inject arbitrary certs into the verification process.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #26683
- [x] These changes do not require tests because the UI requires user activation and can't clearly be automated