### PR TITLE
Improve precision of sequence types for WebIDL codegen.

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -677,7 +677,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
     if type.isSequence() or type.isRecord():
         innerInfo = getJSToNativeConversionInfo(innerContainerType(type),
                                                 descriptorProvider,
-                                                isMember=isMember,
+                                                isMember="Sequence",
                                                 isAutoRooted=isAutoRooted)
         declType = wrapInNativeContainerType(type, innerInfo.declType)
         config = getConversionConfigForType(type, isEnforceRange, isClamp, treatNullAs)
@@ -1075,7 +1075,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         assert not isEnforceRange and not isClamp
         assert isMember != "Union"
 
-        if isMember == "Dictionary" or isAutoRooted:
+        if isMember in ("Dictionary", "Sequence") or isAutoRooted:
             templateBody = "${val}.get()"
 
             if defaultValue is None:
@@ -1087,7 +1087,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
             else:
                 raise TypeError("Can't handle non-null, non-undefined default value here")
 
-            if isMember == "Dictionary":
+            if not isAutoRooted:
                 templateBody = "RootedTraceableBox::from_box(Heap::boxed(%s))" % templateBody
                 if default is not None:
                     default = "RootedTraceableBox::from_box(Heap::boxed(%s))" % default
@@ -1117,7 +1117,7 @@ def getJSToNativeConversionInfo(type, descriptorProvider, failureCode=None,
         templateBody = "${val}.get().to_object()"
         default = "ptr::null_mut()"
 
-        if isMember in ("Dictionary", "Union"):
+        if isMember in ("Dictionary", "Union", "Sequence") and not isAutoRooted:
             templateBody = "RootedTraceableBox::from_box(Heap::boxed(%s))" % templateBody
             default = "RootedTraceableBox::new(Heap::default())"
             declType = CGGeneric("RootedTraceableBox<Heap<*mut JSObject>>")


### PR DESCRIPTION
Unlike #26699, this doesn't attempt to improve any of the resulting types and only maintains the status quo.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes