### PR TITLE
Show the real commit hash for `./servo --version`, not the bundle hash

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -741,10 +741,10 @@ install them, let us know by filing a bug!")
 
             git_sha = None
             # Check if it's a bundle commit
-            if git_commit_subject.startswith("Shallow version of commit "):
+            if git_commit_subject.startswith(b"Shallow version of commit "):
                 # This is a bundle commit
                 # Get the SHA-1 from the bundle subject: "Shallow version of commit {sha1}"
-                git_sha = git_commit_subject.split(' ')[-1].strip()
+                git_sha = git_commit_subject.split(b' ')[-1].strip()
                 # Shorten hash
                 # NOTE: Partially verifies the hash, but it will still pass if it's, e.g., a tree
                 git_sha = subprocess.check_output([

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -734,15 +734,27 @@ install them, let us know by filing a bug!")
 
         git_info = []
         if os.path.isdir('.git') and is_build:
-            # Get the subject of the bundle commit
-            git_bundle_subject = subprocess.check_output([
+            # Get the subject of the commit
+            git_commit_subject = subprocess.check_output([
                 'git', 'show', '-s', '--format=%s', 'HEAD'
             ]).strip()
-            # Get the SHA-1 from the bundle subject: "Shallow version of commit {sha1}"
-            git_sha = git_bundle_subject.split(' ')[-1]
-            # Verify that it's a valid commit
-            # NOTE: this will pass even if `git_sha` is 'master' or another branch or ref
-            subprocess.check_call(['git', 'cat-file', 'commit', git_sha])
+
+            git_sha = None
+            # Check if it's a bundle commit
+            if git_commit_subject.startswith("Shallow version of commit "):
+                # This is a bundle commit
+                # Get the SHA-1 from the bundle subject: "Shallow version of commit {sha1}"
+                git_sha = git_commit_subject.split(' ')[-1].strip()
+                # Shorten hash
+                # NOTE: Partially verifies the hash, but it will still pass if it's, e.g., a tree
+                git_sha = subprocess.check_output([
+                    'git', 'rev-parse', '--short', git_sha
+                ])
+            else:
+                # This is a regular commit
+                git_sha = subprocess.check_output([
+                    'git', 'rev-parse', '--short', 'HEAD'
+                ]).strip()
 
             git_is_dirty = bool(subprocess.check_output([
                 'git', 'status', '--porcelain'

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -742,7 +742,7 @@ install them, let us know by filing a bug!")
             git_sha = git_bundle_subject.split(' ')[-1]
             # Verify that it's a valid commit
             # NOTE: this will pass even if `git_sha` is 'master' or another branch or ref
-            subprocess.check_call('git', 'cat-file', 'commit', git_sha)
+            subprocess.check_call(['git', 'cat-file', 'commit', git_sha])
 
             git_is_dirty = bool(subprocess.check_output([
                 'git', 'status', '--porcelain'

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -734,9 +734,16 @@ install them, let us know by filing a bug!")
 
         git_info = []
         if os.path.isdir('.git') and is_build:
-            git_sha = subprocess.check_output([
-                'git', 'rev-parse', '--short', 'HEAD'
+            # Get the subject of the bundle commit
+            git_bundle_subject = subprocess.check_output([
+                'git', 'show', '-s', '--format=%s', 'HEAD'
             ]).strip()
+            # Get the SHA-1 from the bundle subject: "Shallow version of commit {sha1}"
+            git_sha = git_bundle_subject.split(' ')[-1]
+            # Verify that it's a valid commit
+            # NOTE: this will pass even if `git_sha` is 'master' or another branch or ref
+            subprocess.check_call('git', 'cat-file', 'commit', git_sha)
+
             git_is_dirty = bool(subprocess.check_output([
                 'git', 'status', '--porcelain'
             ]).strip())


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Show the real commit hash of the build when run on a bundle commit, rather than showing the bundle's hash.

It gets the real commit hash by extracting it from the bundle commit message, which has the form `Shallow version of commit {sha1}`, where `{sha1}` is the real commit hash.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors (edits Python code, no Rust changes)
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #26386 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this only changes infrastructure

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
