### PR TITLE
Add support for WebGL2 TexImage2D

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5345,9 +5345,9 @@ dependencies = [
 
 [[package]]
 name = "sparkle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cd7f292661a533c2a7e239af495ba63891b5723c3a6d48712b2e3823466174"
+checksum = "7184285ed8ddbf106cda8fef17f584207fc64a03125e3694c324b19b708825fa"
 dependencies = [
  "gl_generator 0.13.1",
 ]

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -35,7 +35,7 @@ pixels = { path = "../pixels" }
 raqote = { version = "0.8", features = ["text"] }
 servo_arc = { path = "../servo_arc" }
 servo_config = { path = "../config" }
-sparkle = "0.1.24"
+sparkle = "0.1.25"
 style = { path = "../style" }
 # NOTE: the sm-angle feature only enables ANGLE on Windows, not other platforms!
 surfman = { version = "0.2", features = ["sm-angle", "sm-angle-default"] }

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -919,7 +919,7 @@ impl WebGLThread {
                     0,
                     gl::RGBA,
                     gl::UNSIGNED_BYTE,
-                    None,
+                    gl::TexImageSource::Pixels(None),
                 );
                 self.dom_outputs.insert(
                     pipeline_id,
@@ -1595,7 +1595,31 @@ impl WebGLImpl {
                     0,
                     format.as_gl_constant(),
                     effective_data_type,
-                    Some(&pixels),
+                    gl::TexImageSource::Pixels(Some(&pixels)),
+                );
+            },
+            WebGLCommand::TexImage2DPBO {
+                target,
+                level,
+                internal_format,
+                size,
+                format,
+                effective_data_type,
+                unpacking_alignment,
+                offset,
+            } => {
+                gl.pixel_store_i(gl::UNPACK_ALIGNMENT, unpacking_alignment as i32);
+
+                gl.tex_image_2d(
+                    target,
+                    level as i32,
+                    internal_format.as_gl_constant() as i32,
+                    size.width as i32,
+                    size.height as i32,
+                    0,
+                    format.as_gl_constant(),
+                    effective_data_type,
+                    gl::TexImageSource::BufferOffset(offset),
                 );
             },
             WebGLCommand::TexSubImage2D {

--- a/components/canvas_traits/webgl.rs
+++ b/components/canvas_traits/webgl.rs
@@ -398,6 +398,16 @@ pub enum WebGLCommand {
         pixel_format: Option<PixelFormat>,
         data: TruncatedDebug<IpcSharedMemory>,
     },
+    TexImage2DPBO {
+        target: u32,
+        level: u32,
+        internal_format: TexFormat,
+        size: Size2D<u32>,
+        format: TexFormat,
+        effective_data_type: u32,
+        unpacking_alignment: u32,
+        offset: i64,
+    },
     TexSubImage2D {
         target: u32,
         level: u32,

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -29,7 +29,8 @@ use crate::dom::webglprogram::WebGLProgram;
 use crate::dom::webglquery::WebGLQuery;
 use crate::dom::webglrenderbuffer::WebGLRenderbuffer;
 use crate::dom::webglrenderingcontext::{
-    uniform_get, uniform_typed, Operation, TexPixels, VertexAttrib, WebGLRenderingContext,
+    uniform_get, uniform_typed, Operation, TexPixels, TexSource, VertexAttrib,
+    WebGLRenderingContext,
 };
 use crate::dom::webglsampler::{WebGLSampler, WebGLSamplerValue};
 use crate::dom::webglshader::WebGLShader;
@@ -2926,6 +2927,79 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         border: i32,
         format: u32,
         type_: u32,
+        pbo_offset: i64,
+    ) -> Fallible<()> {
+        let pixel_unpack_buffer = match self.bound_pixel_unpack_buffer.get() {
+            Some(pixel_unpack_buffer) => pixel_unpack_buffer,
+            None => return Ok(self.base.webgl_error(InvalidOperation)),
+        };
+
+        if let Some(tf_buffer) = self.bound_transform_feedback_buffer.get() {
+            if pixel_unpack_buffer == tf_buffer {
+                return Ok(self.base.webgl_error(InvalidOperation));
+            }
+        }
+
+        if pbo_offset < 0 || pbo_offset as usize > pixel_unpack_buffer.capacity() {
+            return Ok(self.base.webgl_error(InvalidValue));
+        }
+
+        let unpacking_alignment = self.base.texture_unpacking_alignment();
+
+        let validator = TexImage2DValidator::new(
+            &self.base,
+            target,
+            level,
+            internalformat as u32,
+            width,
+            height,
+            border,
+            format,
+            type_,
+        );
+
+        let TexImage2DValidatorResult {
+            texture,
+            target,
+            width,
+            height,
+            level,
+            border,
+            internal_format,
+            format,
+            data_type,
+        } = match validator.validate() {
+            Ok(result) => result,
+            Err(_) => return Ok(()),
+        };
+
+        self.base.tex_image_2d(
+            &texture,
+            target,
+            data_type,
+            internal_format,
+            format,
+            level,
+            border,
+            unpacking_alignment,
+            Size2D::new(width, height),
+            TexSource::BufferOffset(pbo_offset),
+        );
+
+        Ok(())
+    }
+
+    /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6
+    fn TexImage2D___(
+        &self,
+        target: u32,
+        level: i32,
+        internalformat: i32,
+        width: i32,
+        height: i32,
+        border: i32,
+        format: u32,
+        type_: u32,
         source: ImageDataOrHTMLImageElementOrHTMLCanvasElementOrHTMLVideoElement,
     ) -> Fallible<()> {
         if self.bound_pixel_unpack_buffer.get().is_some() {
@@ -2975,7 +3049,8 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             level,
             border,
             unpacking_alignment,
-            pixels,
+            pixels.size(),
+            TexSource::Pixels(pixels),
         );
 
         Ok(())
@@ -2983,7 +3058,7 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
 
     /// https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6
     #[allow(unsafe_code)]
-    fn TexImage2D___(
+    fn TexImage2D____(
         &self,
         target: u32,
         level: i32,
@@ -3060,6 +3135,8 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             return Ok(self.base.webgl_error(InvalidOperation));
         }
 
+        let size = Size2D::new(width, height);
+
         self.base.tex_image_2d(
             &texture,
             target,
@@ -3069,7 +3146,8 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
             level,
             border,
             unpacking_alignment,
-            TexPixels::from_array(buff, Size2D::new(width, height)),
+            size,
+            TexSource::Pixels(TexPixels::from_array(buff, size)),
         );
 
         Ok(())

--- a/components/script/dom/webidls/WebGL2RenderingContext.webidl
+++ b/components/script/dom/webidls/WebGL2RenderingContext.webidl
@@ -505,9 +505,9 @@ interface mixin WebGL2RenderingContextOverloads
                      GLenum format, GLenum type, TexImageSource source); // May throw DOMException
 
   // WebGL2 entrypoints:
-  //[Throws]
-  //void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
-  //                GLint border, GLenum format, GLenum type, GLintptr pboOffset);
+  [Throws]
+  void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+                  GLint border, GLenum format, GLenum type, GLintptr pboOffset);
   [Throws]
   void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                   GLint border, GLenum format, GLenum type,

--- a/tests/wpt/webgl/meta/conformance2/transform_feedback/simultaneous_binding.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/transform_feedback/simultaneous_binding.html.ini
@@ -1,5 +1,4 @@
 [simultaneous_binding.html]
-  expected: ERROR
   [WebGL test #12: getError expected: INVALID_OPERATION. Was NO_ERROR : drawArrays: buffer used as vertex attrib and tf simultaneously]
     expected: FAIL
 
@@ -73,5 +72,68 @@
     expected: FAIL
 
   [WebGL test #17: getError expected: INVALID_OPERATION. Was NO_ERROR : drawElements: buffer used as uniform buffer and tf simultaneously]
+    expected: FAIL
+
+  [WebGL test #110: getError expected: NO_ERROR. Was INVALID_OPERATION : PIXEL_UNPACK_BUFFER is not bound for transform feedback]
+    expected: FAIL
+
+  [WebGL test #101: getError expected: INVALID_OPERATION. Was NO_ERROR : bufferSubData with double bound buffer]
+    expected: FAIL
+
+  [WebGL test #85: getError expected: INVALID_OPERATION. Was NO_ERROR : PIXEL_PACK_BUFFER is bound for transform feedback]
+    expected: FAIL
+
+  [WebGL test #118: getError expected: INVALID_OPERATION. Was NO_ERROR : copyBufferSubData with double bound buffer]
+    expected: FAIL
+
+  [WebGL test #104: getError expected: INVALID_OPERATION. Was NO_ERROR : copyBufferSubData with double bound buffer]
+    expected: FAIL
+
+  [WebGL test #114: getError expected: INVALID_OPERATION. Was NO_ERROR : bufferData with double bound buffer]
+    expected: FAIL
+
+  [WebGL test #103: getError expected: INVALID_OPERATION. Was NO_ERROR : copyBufferSubData with double bound buffer]
+    expected: FAIL
+
+  [WebGL test #116: getError expected: INVALID_OPERATION. Was NO_ERROR : getBufferSubData with double bound buffer]
+    expected: FAIL
+
+  [WebGL test #88: getError expected: INVALID_OPERATION. Was NO_ERROR : getBufferSubData with double bound buffer]
+    expected: FAIL
+
+  [WebGL test #113: getError expected: INVALID_OPERATION. Was NO_ERROR : PIXEL_PACK_BUFFER is bound for transform feedback]
+    expected: FAIL
+
+  [WebGL test #83: getError expected: INVALID_OPERATION. Was NO_ERROR : PIXEL_UNPACK_BUFFER is bound for transform feedback]
+    expected: FAIL
+
+  [WebGL test #117: getError expected: INVALID_OPERATION. Was NO_ERROR : copyBufferSubData with double bound buffer]
+    expected: FAIL
+
+  [WebGL test #100: getError expected: INVALID_OPERATION. Was NO_ERROR : bufferData with double bound buffer]
+    expected: FAIL
+
+  [WebGL test #89: getError expected: INVALID_OPERATION. Was NO_ERROR : copyBufferSubData with double bound buffer]
+    expected: FAIL
+
+  [WebGL test #102: getError expected: INVALID_OPERATION. Was NO_ERROR : getBufferSubData with double bound buffer]
+    expected: FAIL
+
+  [WebGL test #111: getError expected: INVALID_OPERATION. Was NO_ERROR : PIXEL_UNPACK_BUFFER is bound for transform feedback]
+    expected: FAIL
+
+  [WebGL test #87: getError expected: INVALID_OPERATION. Was NO_ERROR : bufferSubData with double bound buffer]
+    expected: FAIL
+
+  [WebGL test #99: getError expected: INVALID_OPERATION. Was NO_ERROR : PIXEL_PACK_BUFFER is bound for transform feedback]
+    expected: FAIL
+
+  [WebGL test #86: getError expected: INVALID_OPERATION. Was NO_ERROR : bufferData with double bound buffer]
+    expected: FAIL
+
+  [WebGL test #90: getError expected: INVALID_OPERATION. Was NO_ERROR : copyBufferSubData with double bound buffer]
+    expected: FAIL
+
+  [WebGL test #115: getError expected: INVALID_OPERATION. Was NO_ERROR : bufferSubData with double bound buffer]
     expected: FAIL
 


### PR DESCRIPTION
Adds initial support for one of the WebGL2 `TexImage2D` call.

I've enabled the `tests/wpt/webgl/tests/deqp/` tests.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix part of #26512 
- [x] There are tests for these changes 

@mmatyas @zakorgy @jdm 
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
