### PR TITLE
Replace IRC link with Matrix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,6 @@ In all Servo-related forums, we follow the [Rust Code of Conduct](https://www.ru
 
 ## Communication
 
-Servo contributors frequent the `#servo` channel on [`irc.mozilla.org`](https://wiki.mozilla.org/IRC).
+Servo contributors frequent the [Servo room](https://chat.mozilla.org/#/room/#servo:mozilla.org) on [Mozilla Matrix](https://wiki.mozilla.org/Matrix).
 
 You can also join the [`dev-servo` mailing list](https://lists.mozilla.org/listinfo/dev-servo).


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Replace the IRC link in `CONTRIBUTING.md` with a link to the Matrix room.

Same as servo/servo-starters#55.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors (only a docs change)
- [ ] `./mach test-tidy` does not report any errors (only a docs change)
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this is only a docs change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
