### PR TITLE
layout_2020: Tag fragments with their pseudo content type

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -4,7 +4,7 @@
 
 use crate::context::LayoutContext;
 use crate::display_list::conversions::ToWebRender;
-use crate::fragments::{BoxFragment, Fragment, TextFragment};
+use crate::fragments::{BoxFragment, Fragment, Tag, TextFragment};
 use crate::geom::{PhysicalPoint, PhysicalRect};
 use crate::replaced::IntrinsicSizes;
 use crate::style_ext::ComputedValuesExt;
@@ -348,7 +348,7 @@ impl<'a> BuilderForBoxFragment<'a> {
     }
 
     fn build_background(&mut self, builder: &mut DisplayListBuilder) {
-        if self.fragment.tag == builder.element_for_canvas_background {
+        if self.fragment.tag.node() == builder.element_for_canvas_background {
             // This background is already painted for the canvas, don’t paint it again here.
             return;
         }
@@ -405,7 +405,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                     let (width, height, key) = match image_url.url() {
                         Some(url) => {
                             match builder.context.get_webrender_image_for_url(
-                                self.fragment.tag,
+                                self.fragment.tag.node(),
                                 url.clone(),
                                 UsePlaceholder::No,
                             ) {
@@ -541,7 +541,7 @@ fn glyphs(
     glyphs
 }
 
-fn hit_info(style: &ComputedValues, tag: OpaqueNode, auto_cursor: Cursor) -> HitInfo {
+fn hit_info(style: &ComputedValues, tag: Tag, auto_cursor: Cursor) -> HitInfo {
     use style::computed_values::pointer_events::T as PointerEvents;
 
     let inherited_ui = style.get_inherited_ui();
@@ -549,7 +549,7 @@ fn hit_info(style: &ComputedValues, tag: OpaqueNode, auto_cursor: Cursor) -> Hit
         None
     } else {
         let cursor = cursor(inherited_ui.cursor.keyword, auto_cursor);
-        Some((tag.0 as u64, cursor as u16))
+        Some((tag.node().0 as u64, cursor as u16))
     }
 }
 

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -11,7 +11,6 @@ use crate::fragments::{
 use crate::geom::PhysicalRect;
 use crate::style_ext::ComputedValuesExt;
 use euclid::default::Rect;
-use gfx_traits::{combine_id_with_fragment_type, FragmentType};
 use servo_arc::Arc as ServoArc;
 use std::cmp::Ordering;
 use std::mem;
@@ -329,7 +328,7 @@ impl StackingContext {
 
         // The `StackingContextFragment` we found is for the root DOM element:
         debug_assert_eq!(
-            box_fragment.tag,
+            box_fragment.tag.node(),
             fragment_tree.canvas_background.root_element
         );
 
@@ -705,12 +704,10 @@ impl BoxFragment {
         let overflow_y = self.style.get_box().overflow_y;
         let original_scroll_and_clip_info = builder.current_space_and_clip;
         if overflow_x != ComputedOverflow::Visible || overflow_y != ComputedOverflow::Visible {
-            // TODO(mrobinson): We should use the correct fragment type, once we generate
-            // fragments from ::before and ::after generated content selectors.
-            let id =
-                combine_id_with_fragment_type(self.tag.id() as usize, FragmentType::FragmentBody)
-                    as u64;
-            let external_id = wr::ExternalScrollId(id, builder.wr.pipeline_id);
+            let external_id = wr::ExternalScrollId(
+                self.tag.to_display_list_fragment_id(),
+                builder.wr.pipeline_id,
+            );
 
             let sensitivity = if ComputedOverflow::Hidden == overflow_x &&
                 ComputedOverflow::Hidden == overflow_y

--- a/components/layout_2020/flow/float.rs
+++ b/components/layout_2020/flow/float.rs
@@ -3,12 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::context::LayoutContext;
-use crate::dom_traversal::{Contents, NodeExt};
+use crate::dom_traversal::{Contents, NodeAndStyleInfo, NodeExt};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::sizing::ContentSizesRequest;
 use crate::style_ext::{ComputedValuesExt, DisplayInside};
-use servo_arc::Arc;
-use style::properties::ComputedValues;
 use style::values::specified::text::TextDecorationLine;
 
 #[derive(Debug, Serialize)]
@@ -30,17 +28,15 @@ impl FloatContext {
 impl FloatBox {
     pub fn construct<'dom>(
         context: &LayoutContext,
-        node: impl NodeExt<'dom>,
-        style: Arc<ComputedValues>,
+        info: &NodeAndStyleInfo<impl NodeExt<'dom>>,
         display_inside: DisplayInside,
         contents: Contents,
     ) -> Self {
-        let content_sizes = ContentSizesRequest::inline_if(!style.inline_size_is_length());
+        let content_sizes = ContentSizesRequest::inline_if(!info.style.inline_size_is_length());
         Self {
             contents: IndependentFormattingContext::construct(
                 context,
-                node,
-                style,
+                info,
                 display_inside,
                 contents,
                 content_sizes,

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -9,7 +9,7 @@ use crate::flow::FlowLayout;
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragments::{
     AbsoluteOrFixedPositionedFragment, AnonymousFragment, BoxFragment, CollapsedBlockMargins,
-    DebugId, FontMetrics, Fragment, TextFragment,
+    DebugId, FontMetrics, Fragment, Tag, TextFragment,
 };
 use crate::geom::flow_relative::{Rect, Sides, Vec2};
 use crate::positioned::{
@@ -22,7 +22,6 @@ use crate::ContainingBlock;
 use app_units::Au;
 use gfx::text::text_run::GlyphRun;
 use servo_arc::Arc;
-use style::dom::OpaqueNode;
 use style::properties::ComputedValues;
 use style::values::computed::{Length, LengthPercentage, Percentage};
 use style::values::specified::text::TextAlignKeyword;
@@ -47,7 +46,7 @@ pub(crate) enum InlineLevelBox {
 
 #[derive(Debug, Serialize)]
 pub(crate) struct InlineBox {
-    pub tag: OpaqueNode,
+    pub tag: Tag,
     #[serde(skip_serializing)]
     pub style: Arc<ComputedValues>,
     pub first_fragment: bool,
@@ -58,7 +57,7 @@ pub(crate) struct InlineBox {
 /// https://www.w3.org/TR/css-display-3/#css-text-run
 #[derive(Debug, Serialize)]
 pub(crate) struct TextRun {
-    pub tag: OpaqueNode,
+    pub tag: Tag,
     #[serde(skip_serializing)]
     pub parent_style: Arc<ComputedValues>,
     pub text: String,
@@ -78,7 +77,7 @@ struct InlineNestingLevelState<'box_tree> {
 }
 
 struct PartialInlineBoxFragment<'box_tree> {
-    tag: OpaqueNode,
+    tag: Tag,
     style: Arc<ComputedValues>,
     start_corner: Vec2<Length>,
     padding: Sides<Length>,

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -9,8 +9,10 @@ use crate::context::LayoutContext;
 use crate::flow::float::{FloatBox, FloatContext};
 use crate::flow::inline::InlineFormattingContext;
 use crate::formatting_contexts::{IndependentFormattingContext, IndependentLayout, NonReplacedIFC};
-use crate::fragments::{AbsoluteOrFixedPositionedFragment, AnonymousFragment, BoxFragment};
-use crate::fragments::{CollapsedBlockMargins, CollapsedMargin, Fragment};
+use crate::fragments::{
+    AbsoluteOrFixedPositionedFragment, AnonymousFragment, BoxFragment, CollapsedBlockMargins,
+    CollapsedMargin, Fragment, Tag,
+};
 use crate::geom::flow_relative::{Rect, Sides, Vec2};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
 use crate::replaced::ReplacedContent;
@@ -19,7 +21,6 @@ use crate::ContainingBlock;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use rayon_croissant::ParallelIteratorExt;
 use servo_arc::Arc;
-use style::dom::OpaqueNode;
 use style::properties::ComputedValues;
 use style::values::computed::{Length, LengthOrAuto};
 use style::Zero;
@@ -46,7 +47,7 @@ pub(crate) enum BlockContainer {
 #[derive(Debug, Serialize)]
 pub(crate) enum BlockLevelBox {
     SameFormattingContextBlock {
-        tag: OpaqueNode,
+        tag: Tag,
         #[serde(skip_serializing)]
         style: Arc<ComputedValues>,
         contents: BlockContainer,
@@ -345,7 +346,7 @@ fn layout_in_flow_non_replaced_block_level(
     layout_context: &LayoutContext,
     positioning_context: &mut PositioningContext,
     containing_block: &ContainingBlock,
-    tag: OpaqueNode,
+    tag: Tag,
     style: &Arc<ComputedValues>,
     block_level_kind: NonReplacedContents,
     tree_rank: usize,
@@ -500,7 +501,7 @@ fn layout_in_flow_non_replaced_block_level(
 /// https://drafts.csswg.org/css2/visudet.html#inline-replaced-height
 fn layout_in_flow_replaced_block_level<'a>(
     containing_block: &ContainingBlock,
-    tag: OpaqueNode,
+    tag: Tag,
     style: &Arc<ComputedValues>,
     replaced: &ReplacedContent,
 ) -> BoxFragment {

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -4,7 +4,7 @@
 
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
-use crate::dom_traversal::{Contents, NodeExt};
+use crate::dom_traversal::{Contents, NodeAndStyleInfo, NodeExt};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragments::{BoxFragment, CollapsedBlockMargins, Fragment};
 use crate::geom::flow_relative::{Rect, Sides, Vec2};
@@ -71,25 +71,23 @@ pub(crate) enum AbsoluteBoxOffsets {
 impl AbsolutelyPositionedBox {
     pub fn construct<'dom>(
         context: &LayoutContext,
-        node: impl NodeExt<'dom>,
-        style: Arc<ComputedValues>,
+        node_info: &NodeAndStyleInfo<impl NodeExt<'dom>>,
         display_inside: DisplayInside,
         contents: Contents,
     ) -> Self {
         // "Shrink-to-fit" in https://drafts.csswg.org/css2/visudet.html#abs-non-replaced-width
         let content_sizes = ContentSizesRequest::inline_if(
             // If inline-size is non-auto, that value is used without shrink-to-fit
-            !style.inline_size_is_length() &&
+            !node_info.style.inline_size_is_length() &&
             // If it is, then the only case where shrink-to-fit is *not* used is
             // if both offsets are non-auto, leaving inline-size as the only variable
             // in the constraint equation.
-            !style.inline_box_offsets_are_both_non_auto(),
+            !node_info.style.inline_box_offsets_are_both_non_auto(),
         );
         Self {
             contents: IndependentFormattingContext::construct(
                 context,
-                node,
-                style,
+                node_info,
                 display_inside,
                 contents,
                 content_sizes,

--- a/tests/wpt/metadata-layout-2020/css/cssom/getComputedStyle-pseudo.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom/getComputedStyle-pseudo.html.ini
@@ -1,10 +1,4 @@
 [getComputedStyle-pseudo.html]
-  [Resolution of width is correct for ::before and ::after pseudo-elements of display: contents elements]
-    expected: FAIL
-
-  [Resolution of width is correct for ::before and ::after pseudo-elements]
-    expected: FAIL
-
   [Item-based blockification of nonexistent pseudo-elements]
     expected: FAIL
 


### PR DESCRIPTION
This will allow us to answer queries and properly handle animations in
the future for fragments generated for pseudo content.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
