### PR TITLE
Fix infinite stream and its missing incumbent script environment when newing a new stream

### DIFF
--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -117,7 +117,7 @@ pub enum ParserMetadata {
 }
 
 /// <https://fetch.spec.whatwg.org/#concept-body-source>
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub enum BodySource {
     Null,
     Object,
@@ -178,10 +178,7 @@ impl RequestBody {
     }
 
     pub fn source_is_null(&self) -> bool {
-        if let BodySource::Null = self.source {
-            return true;
-        }
-        false
+        self.source == BodySource::Null
     }
 
     pub fn len(&self) -> Option<usize> {

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -6,7 +6,7 @@ use crate::dom::bindings::conversions::{ConversionBehavior, ConversionResult};
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::settings_stack::AutoEntryScript;
+use crate::dom::bindings::settings_stack::{AutoEntryScript, AutoIncumbentScript};
 use crate::dom::bindings::utils::get_dictionary_property;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
@@ -118,6 +118,7 @@ impl ReadableStream {
         source: ExternalUnderlyingSource,
     ) -> DomRoot<ReadableStream> {
         let _ar = enter_realm(global);
+        let _ais = AutoIncumbentScript::new(global);
         let cx = global.get_cx();
 
         let source = Rc::new(ExternalUnderlyingSourceController::new(source));


### PR DESCRIPTION


---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #26807 
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___
