### PR TITLE
Update webrender

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,7 @@ dependencies = [
 name = "compositing"
 version = "0.0.1"
 dependencies = [
+ "app_units",
  "canvas",
  "crossbeam-channel",
  "embedder_traits",
@@ -1892,10 +1893,12 @@ dependencies = [
 name = "gfx_traits"
 version = "0.0.1"
 dependencies = [
+ "app_units",
  "malloc_size_of",
  "malloc_size_of_derive",
  "range",
  "serde",
+ "webrender_api",
 ]
 
 [[package]]
@@ -3018,6 +3021,7 @@ dependencies = [
 name = "libservo"
 version = "0.0.1"
 dependencies = [
+ "app_units",
  "background_hang_monitor",
  "bluetooth",
  "bluetooth_traits",
@@ -3034,6 +3038,7 @@ dependencies = [
  "euclid",
  "gaol",
  "gfx",
+ "gfx_traits",
  "gleam 0.11.0",
  "gstreamer",
  "ipc-channel",
@@ -3928,7 +3933,7 @@ dependencies = [
 [[package]]
 name = "peek-poke"
 version = "0.2.0"
-source = "git+https://github.com/servo/webrender#01082a9091ab98c392af8934d04271eb1dd546df"
+source = "git+https://github.com/servo/webrender#de3999583ab20aad7c57ea35a3e0394ed45be627"
 dependencies = [
  "euclid",
  "peek-poke-derive 0.2.1 (git+https://github.com/servo/webrender)",
@@ -3946,7 +3951,7 @@ dependencies = [
 [[package]]
 name = "peek-poke-derive"
 version = "0.2.1"
-source = "git+https://github.com/servo/webrender#01082a9091ab98c392af8934d04271eb1dd546df"
+source = "git+https://github.com/servo/webrender#de3999583ab20aad7c57ea35a3e0394ed45be627"
 dependencies = [
  "proc-macro2 1.0.17",
  "quote 1.0.2",
@@ -4410,15 +4415,6 @@ name = "rle-decode-fast"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
-
-[[package]]
-name = "ron"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da06feaa07f69125ab9ddc769b11de29090122170b402547f64b86fe16ebc399"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "ron"
@@ -6401,7 +6397,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.61.0"
-source = "git+https://github.com/servo/webrender#01082a9091ab98c392af8934d04271eb1dd546df"
+source = "git+https://github.com/servo/webrender#de3999583ab20aad7c57ea35a3e0394ed45be627"
 dependencies = [
  "base64 0.10.1",
  "bincode",
@@ -6427,7 +6423,7 @@ dependencies = [
  "num-traits",
  "plane-split",
  "rayon",
- "ron 0.1.7",
+ "ron",
  "serde",
  "serde_json",
  "smallvec 1.3.0",
@@ -6443,7 +6439,7 @@ dependencies = [
 [[package]]
 name = "webrender_api"
 version = "0.61.0"
-source = "git+https://github.com/servo/webrender#01082a9091ab98c392af8934d04271eb1dd546df"
+source = "git+https://github.com/servo/webrender#de3999583ab20aad7c57ea35a3e0394ed45be627"
 dependencies = [
  "app_units",
  "bitflags",
@@ -6464,7 +6460,7 @@ dependencies = [
 [[package]]
 name = "webrender_build"
 version = "0.0.1"
-source = "git+https://github.com/servo/webrender#01082a9091ab98c392af8934d04271eb1dd546df"
+source = "git+https://github.com/servo/webrender#de3999583ab20aad7c57ea35a3e0394ed45be627"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -6544,7 +6540,7 @@ dependencies = [
  "naga",
  "parking_lot 0.10.2",
  "peek-poke 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ron 0.5.1",
+ "ron",
  "serde",
  "smallvec 1.3.0",
  "spirv_headers",
@@ -6644,7 +6640,7 @@ dependencies = [
 [[package]]
 name = "wr_malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/webrender#01082a9091ab98c392af8934d04271eb1dd546df"
+source = "git+https://github.com/servo/webrender#de3999583ab20aad7c57ea35a3e0394ed45be627"
 dependencies = [
  "app_units",
  "euclid",

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -12,35 +12,52 @@ use ipc_channel::router::ROUTER;
 use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::thread;
+use webrender_api::{ImageData, ImageDescriptor, ImageKey};
 
 pub enum AntialiasMode {
     Default,
     None,
 }
 
+pub enum ImageUpdate {
+    Add(ImageKey, ImageDescriptor, ImageData),
+    Update(ImageKey, ImageDescriptor, ImageData),
+    Delete(ImageKey),
+}
+
+pub trait WebrenderApi {
+    fn generate_key(&self) -> webrender_api::ImageKey;
+    fn update_images(&self, updates: Vec<ImageUpdate>);
+    fn clone(&self) -> Box<dyn WebrenderApi>;
+}
+
 pub struct CanvasPaintThread<'a> {
     canvases: HashMap<CanvasId, CanvasData<'a>>,
     next_canvas_id: CanvasId,
+    webrender_api: Box<dyn WebrenderApi>,
 }
 
 impl<'a> CanvasPaintThread<'a> {
-    fn new() -> CanvasPaintThread<'a> {
+    fn new(webrender_api: Box<dyn WebrenderApi>) -> CanvasPaintThread<'a> {
         CanvasPaintThread {
             canvases: HashMap::new(),
             next_canvas_id: CanvasId(0),
+            webrender_api,
         }
     }
 
     /// Creates a new `CanvasPaintThread` and returns an `IpcSender` to
     /// communicate with it.
-    pub fn start() -> (Sender<ConstellationCanvasMsg>, IpcSender<CanvasMsg>) {
+    pub fn start(
+        webrender_api: Box<dyn WebrenderApi + Send>,
+    ) -> (Sender<ConstellationCanvasMsg>, IpcSender<CanvasMsg>) {
         let (ipc_sender, ipc_receiver) = ipc::channel::<CanvasMsg>().unwrap();
         let msg_receiver = ROUTER.route_ipc_receiver_to_new_crossbeam_receiver(ipc_receiver);
         let (create_sender, create_receiver) = unbounded();
         thread::Builder::new()
             .name("CanvasThread".to_owned())
             .spawn(move || {
-                let mut canvas_paint_thread = CanvasPaintThread::new();
+                let mut canvas_paint_thread = CanvasPaintThread::new(webrender_api);
                 loop {
                     select! {
                         recv(msg_receiver) -> msg => {
@@ -74,16 +91,9 @@ impl<'a> CanvasPaintThread<'a> {
                                 Ok(ConstellationCanvasMsg::Create {
                                     id_sender: creator,
                                     size,
-                                    webrender_sender: webrenderer_api_sender,
-                                    webrender_doc,
                                     antialias
                                 }) => {
-                                    let canvas_id = canvas_paint_thread.create_canvas(
-                                        size,
-                                        webrenderer_api_sender,
-                                        webrender_doc,
-                                        antialias,
-                                    );
+                                    let canvas_id = canvas_paint_thread.create_canvas(size, antialias);
                                     creator.send(canvas_id).unwrap();
                                 },
                                 Ok(ConstellationCanvasMsg::Exit) => break,
@@ -101,13 +111,7 @@ impl<'a> CanvasPaintThread<'a> {
         (create_sender, ipc_sender)
     }
 
-    pub fn create_canvas(
-        &mut self,
-        size: Size2D<u64>,
-        webrender_api_sender: webrender_api::RenderApiSender,
-        webrender_doc: webrender_api::DocumentId,
-        antialias: bool,
-    ) -> CanvasId {
+    pub fn create_canvas(&mut self, size: Size2D<u64>, antialias: bool) -> CanvasId {
         let antialias = if antialias {
             AntialiasMode::Default
         } else {
@@ -119,8 +123,7 @@ impl<'a> CanvasPaintThread<'a> {
 
         let canvas_data = CanvasData::new(
             size,
-            webrender_api_sender,
-            webrender_doc,
+            self.webrender_api.clone(),
             antialias,
             canvas_id.clone(),
         );

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -655,7 +655,7 @@ impl WebGLThread {
         );
 
         let image_key = Self::create_wr_external_image(
-            &self.webrender_api,
+            &mut self.webrender_api,
             self.webrender_doc,
             size.to_i32(),
             has_alpha,
@@ -718,7 +718,7 @@ impl WebGLThread {
             .contains(ContextAttributeFlags::ALPHA);
         let texture_target = current_wr_texture_target(&self.device);
         Self::update_wr_external_image(
-            &self.webrender_api,
+            &mut self.webrender_api,
             self.webrender_doc,
             size.to_i32(),
             has_alpha,
@@ -1021,7 +1021,7 @@ impl WebGLThread {
 
     /// Creates a `webrender_api::ImageKey` that uses shared textures.
     fn create_wr_external_image(
-        webrender_api: &webrender_api::RenderApi,
+        webrender_api: &mut webrender_api::RenderApi,
         webrender_doc: webrender_api::DocumentId,
         size: Size2D<i32>,
         alpha: bool,
@@ -1041,7 +1041,7 @@ impl WebGLThread {
 
     /// Updates a `webrender_api::ImageKey` that uses shared textures.
     fn update_wr_external_image(
-        webrender_api: &webrender_api::RenderApi,
+        webrender_api: &mut webrender_api::RenderApi,
         webrender_doc: webrender_api::DocumentId,
         size: Size2D<i32>,
         alpha: bool,

--- a/components/canvas_traits/lib.rs
+++ b/components/canvas_traits/lib.rs
@@ -26,8 +26,6 @@ pub enum ConstellationCanvasMsg {
     Create {
         id_sender: Sender<CanvasId>,
         size: Size2D<u64>,
-        webrender_sender: webrender_api::RenderApiSender,
-        webrender_doc: webrender_api::DocumentId,
         antialias: bool,
     },
     Exit,

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -16,6 +16,7 @@ default = []
 gl = ["gleam", "pixels"]
 
 [dependencies]
+app_units = "0.7"
 canvas = { path = "../canvas" }
 crossbeam-channel = "0.4"
 embedder_traits = { path = "../embedder_traits" }

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -587,10 +587,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
     /// instance in the parent process.
     fn handle_webrender_message(&mut self, msg: WebrenderMsg) {
         match msg {
-            WebrenderMsg::Layout(script_traits::WebrenderMsg::SendInitialTransaction(
-                _doc,
-                pipeline,
-            )) => {
+            WebrenderMsg::Layout(script_traits::WebrenderMsg::SendInitialTransaction(pipeline)) => {
                 self.waiting_on_pending_frame = true;
                 let mut txn = webrender_api::Transaction::new();
                 txn.set_display_list(
@@ -605,7 +602,6 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             },
 
             WebrenderMsg::Layout(script_traits::WebrenderMsg::SendScrollNode(
-                _doc,
                 point,
                 scroll_id,
                 clamping,
@@ -617,7 +613,6 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             },
 
             WebrenderMsg::Layout(script_traits::WebrenderMsg::SendDisplayList(
-                _doc,
                 epoch,
                 size,
                 pipeline,
@@ -644,7 +639,6 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             },
 
             WebrenderMsg::Layout(script_traits::WebrenderMsg::HitTest(
-                _doc,
                 pipeline,
                 point,
                 flags,
@@ -684,6 +678,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 self.webrender_api
                     .send_transaction(self.webrender_document, txn);
             },
+
             WebrenderMsg::Font(WebrenderFontMsg::AddFontInstance(font_key, size, sender)) => {
                 let key = self.webrender_api.generate_font_instance_key();
                 let mut txn = webrender_api::Transaction::new();
@@ -692,6 +687,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                     .send_transaction(self.webrender_document, txn);
                 let _ = sender.send(key);
             },
+
             WebrenderMsg::Font(WebrenderFontMsg::AddFont(data, sender)) => {
                 let font_key = self.webrender_api.generate_font_key();
                 let mut txn = webrender_api::Transaction::new();
@@ -703,9 +699,11 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                     .send_transaction(self.webrender_document, txn);
                 let _ = sender.send(font_key);
             },
+
             WebrenderMsg::Canvas(WebrenderCanvasMsg::GenerateKey(sender)) => {
                 let _ = sender.send(self.webrender_api.generate_image_key());
             },
+
             WebrenderMsg::Canvas(WebrenderCanvasMsg::UpdateImages(updates)) => {
                 let mut txn = webrender_api::Transaction::new();
                 for update in updates {

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -3,7 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::compositor_thread::CompositorReceiver;
-use crate::compositor_thread::{InitialCompositorState, Msg};
+use crate::compositor_thread::{
+    InitialCompositorState, Msg, WebrenderCanvasMsg, WebrenderFontMsg, WebrenderMsg,
+};
 #[cfg(feature = "gl")]
 use crate::gl;
 use crate::touch::{TouchAction, TouchHandler};
@@ -11,10 +13,11 @@ use crate::windowing::{
     self, EmbedderCoordinates, MouseWindowEvent, WebRenderDebugOption, WindowMethods,
 };
 use crate::{CompositionPipeline, ConstellationMsg, SendableFrameTree};
+use canvas::canvas_paint_thread::ImageUpdate;
 use crossbeam_channel::Sender;
 use embedder_traits::Cursor;
 use euclid::{Point2D, Rect, Scale, Vector2D};
-use gfx_traits::Epoch;
+use gfx_traits::{Epoch, FontData};
 #[cfg(feature = "gl")]
 use image::{DynamicImage, ImageFormat};
 use ipc_channel::ipc;
@@ -40,8 +43,6 @@ use std::fs::{create_dir_all, File};
 use std::io::Write;
 use std::num::NonZeroU32;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 use style_traits::viewport::ViewportConstraints;
 use style_traits::{CSSPixel, DevicePixel, PinchZoomFactor};
 use time::{now, precise_time_ns, precise_time_s};
@@ -218,7 +219,7 @@ pub struct IOCompositor<Window: WindowMethods + ?Sized> {
     /// True if a WR frame render has been requested. Screenshots
     /// taken before the render is complete will not reflect the
     /// most up to date rendering.
-    waiting_on_pending_frame: Arc<AtomicBool>,
+    waiting_on_pending_frame: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -334,7 +335,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             is_running_problem_test,
             exit_after_load,
             convert_mouse_to_touch,
-            waiting_on_pending_frame: state.pending_wr_frame,
+            waiting_on_pending_frame: false,
         }
     }
 
@@ -443,7 +444,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             },
 
             (Msg::Recomposite(reason), ShutdownState::NotShuttingDown) => {
-                self.waiting_on_pending_frame.store(false, Ordering::SeqCst);
+                self.waiting_on_pending_frame = false;
                 self.composition_request = CompositionRequest::CompositeNow(reason)
             },
 
@@ -474,7 +475,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                     self.ready_to_save_state,
                     ReadyState::WaitingForConstellationReply
                 );
-                if is_ready && !self.waiting_on_pending_frame.load(Ordering::SeqCst) {
+                if is_ready && !self.waiting_on_pending_frame {
                     self.ready_to_save_state = ReadyState::ReadyToSaveImage;
                     if self.is_running_problem_test {
                         println!("ready to save image!");
@@ -569,6 +570,10 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 }
             },
 
+            (Msg::Webrender(msg), ShutdownState::NotShuttingDown) => {
+                self.handle_webrender_message(msg);
+            },
+
             // When we are shutting_down, we need to avoid performing operations
             // such as Paint that may crash because we have begun tearing down
             // the rest of our resources.
@@ -576,6 +581,148 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
         }
 
         true
+    }
+
+    /// Accept messages from content processes that need to be relayed to the WebRender
+    /// instance in the parent process.
+    fn handle_webrender_message(&mut self, msg: WebrenderMsg) {
+        match msg {
+            WebrenderMsg::Layout(script_traits::WebrenderMsg::SendInitialTransaction(
+                _doc,
+                pipeline,
+            )) => {
+                self.waiting_on_pending_frame = true;
+                let mut txn = webrender_api::Transaction::new();
+                txn.set_display_list(
+                    webrender_api::Epoch(0),
+                    None,
+                    Default::default(),
+                    (pipeline, Default::default(), Default::default()),
+                    false,
+                );
+                self.webrender_api
+                    .send_transaction(self.webrender_document, txn);
+            },
+
+            WebrenderMsg::Layout(script_traits::WebrenderMsg::SendScrollNode(
+                _doc,
+                point,
+                scroll_id,
+                clamping,
+            )) => {
+                let mut txn = webrender_api::Transaction::new();
+                txn.scroll_node_with_id(point, scroll_id, clamping);
+                self.webrender_api
+                    .send_transaction(self.webrender_document, txn);
+            },
+
+            WebrenderMsg::Layout(script_traits::WebrenderMsg::SendDisplayList(
+                _doc,
+                epoch,
+                size,
+                pipeline,
+                size2,
+                data,
+                descriptor,
+            )) => {
+                self.waiting_on_pending_frame = true;
+                let mut txn = webrender_api::Transaction::new();
+                txn.set_display_list(
+                    epoch,
+                    None,
+                    size,
+                    (
+                        pipeline,
+                        size2,
+                        webrender_api::BuiltDisplayList::from_data(data, descriptor),
+                    ),
+                    true,
+                );
+                txn.generate_frame();
+                self.webrender_api
+                    .send_transaction(self.webrender_document, txn);
+            },
+
+            WebrenderMsg::Layout(script_traits::WebrenderMsg::HitTest(
+                _doc,
+                pipeline,
+                point,
+                flags,
+                sender,
+            )) => {
+                let result =
+                    self.webrender_api
+                        .hit_test(self.webrender_document, pipeline, point, flags);
+                let _ = sender.send(result);
+            },
+
+            WebrenderMsg::Layout(script_traits::WebrenderMsg::GenerateImageKey(sender)) |
+            WebrenderMsg::Net(net_traits::WebrenderImageMsg::GenerateImageKey(sender)) => {
+                let _ = sender.send(self.webrender_api.generate_image_key());
+            },
+
+            WebrenderMsg::Layout(script_traits::WebrenderMsg::UpdateImages(updates)) => {
+                let mut txn = webrender_api::Transaction::new();
+                for update in updates {
+                    match update {
+                        script_traits::ImageUpdate::AddImage(key, desc, data) => {
+                            txn.add_image(key, desc, data, None)
+                        },
+                        script_traits::ImageUpdate::DeleteImage(key) => txn.delete_image(key),
+                        script_traits::ImageUpdate::UpdateImage(key, desc, data) => {
+                            txn.update_image(key, desc, data, &webrender_api::DirtyRect::All)
+                        },
+                    }
+                }
+                self.webrender_api
+                    .send_transaction(self.webrender_document, txn);
+            },
+
+            WebrenderMsg::Net(net_traits::WebrenderImageMsg::AddImage(key, desc, data)) => {
+                let mut txn = webrender_api::Transaction::new();
+                txn.add_image(key, desc, data, None);
+                self.webrender_api
+                    .send_transaction(self.webrender_document, txn);
+            },
+            WebrenderMsg::Font(WebrenderFontMsg::AddFontInstance(font_key, size, sender)) => {
+                let key = self.webrender_api.generate_font_instance_key();
+                let mut txn = webrender_api::Transaction::new();
+                txn.add_font_instance(key, font_key, size, None, None, Vec::new());
+                self.webrender_api
+                    .send_transaction(self.webrender_document, txn);
+                let _ = sender.send(key);
+            },
+            WebrenderMsg::Font(WebrenderFontMsg::AddFont(data, sender)) => {
+                let font_key = self.webrender_api.generate_font_key();
+                let mut txn = webrender_api::Transaction::new();
+                match data {
+                    FontData::Raw(bytes) => txn.add_raw_font(font_key, bytes, 0),
+                    FontData::Native(native_font) => txn.add_native_font(font_key, native_font),
+                }
+                self.webrender_api
+                    .send_transaction(self.webrender_document, txn);
+                let _ = sender.send(font_key);
+            },
+            WebrenderMsg::Canvas(WebrenderCanvasMsg::GenerateKey(sender)) => {
+                let _ = sender.send(self.webrender_api.generate_image_key());
+            },
+            WebrenderMsg::Canvas(WebrenderCanvasMsg::UpdateImages(updates)) => {
+                let mut txn = webrender_api::Transaction::new();
+                for update in updates {
+                    match update {
+                        ImageUpdate::Add(key, descriptor, data) => {
+                            txn.add_image(key, descriptor, data, None)
+                        },
+                        ImageUpdate::Update(key, descriptor, data) => {
+                            txn.update_image(key, descriptor, data, &webrender_api::DirtyRect::All)
+                        },
+                        ImageUpdate::Delete(key) => txn.delete_image(key),
+                    }
+                }
+                self.webrender_api
+                    .send_transaction(self.webrender_document, txn);
+            },
+        }
     }
 
     /// Sets or unsets the animations-running flag for the given pipeline, and schedules a

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -606,7 +606,6 @@ impl UnprivilegedPipelineContent {
             self.time_profiler_chan,
             self.mem_profiler_chan,
             self.webrender_api_sender,
-            self.webrender_document,
             paint_time_metrics,
             layout_thread_busy_flag.clone(),
             self.opts.load_webfonts_synchronously,

--- a/components/gfx/font_cache_thread.rs
+++ b/components/gfx/font_cache_thread.rs
@@ -12,6 +12,7 @@ use crate::platform::font_list::system_default_family;
 use crate::platform::font_list::SANS_SERIF_FONT_FAMILY;
 use crate::platform::font_template::FontTemplateData;
 use app_units::Au;
+use gfx_traits::{FontData, WebrenderApi};
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use net_traits::request::{Destination, RequestBuilder};
 use net_traits::{fetch_async, CoreResourceThread, FetchResponseMsg};
@@ -135,9 +136,8 @@ struct FontCache {
     web_families: HashMap<LowercaseString, FontTemplates>,
     font_context: FontContextHandle,
     core_resource_thread: CoreResourceThread,
-    webrender_api: webrender_api::RenderApi,
+    webrender_api: Box<dyn WebrenderApi>,
     webrender_fonts: HashMap<Atom, webrender_api::FontKey>,
-    webrender_doc: webrender_api::DocumentId,
     font_instances: HashMap<(webrender_api::FontKey, Au), webrender_api::FontInstanceKey>,
 }
 
@@ -181,19 +181,11 @@ impl FontCache {
                 },
                 Command::GetFontInstance(font_key, size, result) => {
                     let webrender_api = &self.webrender_api;
-                    let doc = self.webrender_doc;
 
-                    let instance_key =
-                        *self
-                            .font_instances
-                            .entry((font_key, size))
-                            .or_insert_with(|| {
-                                let key = webrender_api.generate_font_instance_key();
-                                let mut txn = webrender_api::Transaction::new();
-                                txn.add_font_instance(key, font_key, size, None, None, Vec::new());
-                                webrender_api.send_transaction(doc, txn);
-                                key
-                            });
+                    let instance_key = *self
+                        .font_instances
+                        .entry((font_key, size))
+                        .or_insert_with(|| webrender_api.add_font_instance(font_key, size));
 
                     let _ = result.send(instance_key);
                 },
@@ -391,21 +383,17 @@ impl FontCache {
 
     fn get_font_template_info(&mut self, template: Arc<FontTemplateData>) -> FontTemplateInfo {
         let webrender_api = &self.webrender_api;
-        let doc = self.webrender_doc;
         let webrender_fonts = &mut self.webrender_fonts;
 
         let font_key = *webrender_fonts
             .entry(template.identifier.clone())
             .or_insert_with(|| {
-                let font_key = webrender_api.generate_font_key();
-                let mut txn = webrender_api::Transaction::new();
-                match (template.bytes_if_in_memory(), template.native_font()) {
-                    (Some(bytes), _) => txn.add_raw_font(font_key, bytes, 0),
-                    (None, Some(native_font)) => txn.add_native_font(font_key, native_font),
-                    (None, None) => txn.add_raw_font(font_key, template.bytes(), 0),
-                }
-                webrender_api.send_transaction(doc, txn);
-                font_key
+                let font = match (template.bytes_if_in_memory(), template.native_font()) {
+                    (Some(bytes), _) => FontData::Raw(bytes),
+                    (None, Some(native_font)) => FontData::Native(native_font),
+                    (None, None) => FontData::Raw(template.bytes()),
+                };
+                webrender_api.add_font(font)
             });
 
         FontTemplateInfo {
@@ -444,8 +432,7 @@ pub struct FontCacheThread {
 impl FontCacheThread {
     pub fn new(
         core_resource_thread: CoreResourceThread,
-        webrender_api: webrender_api::RenderApi,
-        webrender_doc: webrender_api::DocumentId,
+        webrender_api: Box<dyn WebrenderApi + Send>,
     ) -> FontCacheThread {
         let (chan, port) = ipc::channel().unwrap();
 
@@ -465,7 +452,6 @@ impl FontCacheThread {
                     font_context: FontContextHandle::new(),
                     core_resource_thread,
                     webrender_api,
-                    webrender_doc,
                     webrender_fonts: HashMap::new(),
                     font_instances: HashMap::new(),
                 };

--- a/components/gfx_traits/Cargo.toml
+++ b/components/gfx_traits/Cargo.toml
@@ -11,7 +11,9 @@ name = "gfx_traits"
 path = "lib.rs"
 
 [dependencies]
+app_units = "0.7"
 malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = "0.1"
 range = { path = "../range" }
 serde = "1.0"
+webrender_api = { git = "https://github.com/servo/webrender" }

--- a/components/gfx_traits/lib.rs
+++ b/components/gfx_traits/lib.rs
@@ -103,3 +103,17 @@ pub fn node_id_from_scroll_id(id: usize) -> Option<usize> {
     }
     None
 }
+
+pub enum FontData {
+    Raw(Vec<u8>),
+    Native(webrender_api::NativeFontHandle),
+}
+
+pub trait WebrenderApi {
+    fn add_font_instance(
+        &self,
+        font_key: webrender_api::FontKey,
+        size: app_units::Au,
+    ) -> webrender_api::FontInstanceKey;
+    fn add_font(&self, data: FontData) -> webrender_api::FontKey;
+}

--- a/components/layout/display_list/webrender_helpers.rs
+++ b/components/layout/display_list/webrender_helpers.rs
@@ -234,6 +234,12 @@ impl DisplayItem {
                     builder.push_iter(&stacking_context.filters);
                 }
 
+                // TODO(jdm): WebRender now requires us to create stacking context items
+                //            with the IS_BLEND_CONTAINER flag enabled if any children
+                //            of the stacking context have a blend mode applied.
+                //            This will require additional tracking during layout
+                //            before we start collecting stacking contexts so that
+                //            information will be available when we reach this point.
                 let wr_item = PushStackingContextDisplayItem {
                     origin: bounds.origin,
                     spatial_id,
@@ -243,9 +249,7 @@ impl DisplayItem {
                         mix_blend_mode: stacking_context.mix_blend_mode,
                         clip_id: None,
                         raster_space: RasterSpace::Screen,
-                        // TODO(pcwalton): Enable picture caching?
-                        cache_tiles: false,
-                        is_backdrop_root: false,
+                        flags: Default::default(),
                     },
                 };
 

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -234,6 +234,12 @@ impl StackingContext {
             ));
         }
 
+        // TODO(jdm): WebRender now requires us to create stacking context items
+        //            with the IS_BLEND_CONTAINER flag enabled if any children
+        //            of the stacking context have a blend mode applied.
+        //            This will require additional tracking during layout
+        //            before we start collecting stacking contexts so that
+        //            information will be available when we reach this point.
         builder.wr.push_stacking_context(
             LayoutPoint::zero(), // origin
             self.spatial_id,
@@ -245,8 +251,7 @@ impl StackingContext {
             &vec![], // filter_datas
             &vec![], // filter_primitives
             wr::RasterSpace::Screen,
-            false, // cache_tiles,
-            false, // false
+            wr::StackingContextFlags::empty(),
         );
 
         true

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -212,9 +212,6 @@ pub struct LayoutThread {
     /// Webrender interface.
     webrender_api: WebrenderIpcSender,
 
-    /// Webrender document.
-    webrender_document: webrender_api::DocumentId,
-
     /// Paint time metrics.
     paint_time_metrics: PaintTimeMetrics,
 
@@ -276,7 +273,6 @@ impl LayoutThreadFactory for LayoutThread {
         time_profiler_chan: profile_time::ProfilerChan,
         mem_profiler_chan: profile_mem::ProfilerChan,
         webrender_api_sender: WebrenderIpcSender,
-        webrender_document: webrender_api::DocumentId,
         paint_time_metrics: PaintTimeMetrics,
         busy: Arc<AtomicBool>,
         load_webfonts_synchronously: bool,
@@ -325,7 +321,6 @@ impl LayoutThreadFactory for LayoutThread {
                         time_profiler_chan,
                         mem_profiler_chan.clone(),
                         webrender_api_sender,
-                        webrender_document,
                         paint_time_metrics,
                         busy,
                         load_webfonts_synchronously,
@@ -495,7 +490,6 @@ impl LayoutThread {
         time_profiler_chan: profile_time::ProfilerChan,
         mem_profiler_chan: profile_mem::ProfilerChan,
         webrender_api: WebrenderIpcSender,
-        webrender_document: webrender_api::DocumentId,
         paint_time_metrics: PaintTimeMetrics,
         busy: Arc<AtomicBool>,
         load_webfonts_synchronously: bool,
@@ -510,7 +504,7 @@ impl LayoutThread {
         dump_flow_tree: bool,
     ) -> LayoutThread {
         // Let webrender know about this pipeline by sending an empty display list.
-        webrender_api.send_initial_transaction(webrender_document, id.to_webrender());
+        webrender_api.send_initial_transaction(id.to_webrender());
 
         let device = Device::new(
             MediaType::screen(),
@@ -553,7 +547,6 @@ impl LayoutThread {
             epoch: Cell::new(Epoch(1)),
             viewport_size: Size2D::new(Au(0), Au(0)),
             webrender_api,
-            webrender_document,
             stylist: Stylist::new(device, QuirksMode::NoQuirks),
             rw_data: Arc::new(Mutex::new(LayoutThreadData {
                 constellation_chan: constellation_chan,
@@ -773,7 +766,6 @@ impl LayoutThread {
 
                 let point = Point2D::new(-state.scroll_offset.x, -state.scroll_offset.y);
                 self.webrender_api.send_scroll_node(
-                    self.webrender_document,
                     webrender_api::units::LayoutPoint::from_untyped(point),
                     state.scroll_id,
                     webrender_api::ScrollClamping::ToContentBounds,
@@ -882,7 +874,6 @@ impl LayoutThread {
             self.time_profiler_chan.clone(),
             self.mem_profiler_chan.clone(),
             self.webrender_api.clone(),
-            self.webrender_document,
             info.paint_time_metrics,
             info.layout_is_busy,
             self.load_webfonts_synchronously,
@@ -1171,12 +1162,8 @@ impl LayoutThread {
                 self.paint_time_metrics
                     .maybe_observe_paint_time(self, epoch, is_contentful.0);
 
-                self.webrender_api.send_display_list(
-                    self.webrender_document,
-                    epoch,
-                    viewport_size,
-                    builder.finalize(),
-                );
+                self.webrender_api
+                    .send_display_list(epoch, viewport_size, builder.finalize());
             },
         );
     }
@@ -1578,7 +1565,6 @@ impl LayoutThread {
 
                     let client_point = webrender_api::units::WorldPoint::from_untyped(client_point);
                     let results = self.webrender_api.hit_test(
-                        self.webrender_document,
                         Some(self.id.to_webrender()),
                         client_point,
                         flags,

--- a/components/layout_traits/lib.rs
+++ b/components/layout_traits/lib.rs
@@ -44,7 +44,6 @@ pub trait LayoutThreadFactory {
         time_profiler_chan: time::ProfilerChan,
         mem_profiler_chan: mem::ProfilerChan,
         webrender_api_sender: WebrenderIpcSender,
-        webrender_document: webrender_api::DocumentId,
         paint_time_metrics: PaintTimeMetrics,
         busy: Arc<AtomicBool>,
         load_webfonts_synchronously: bool,

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -213,7 +213,10 @@ impl VideoFrameRenderer for MediaFrameRenderer {
             Some((ref mut image_key, ref mut width, ref mut height)) => {
                 self.old_frame = Some(*image_key);
 
-                let new_image_key = self.api.generate_image_key();
+                let new_image_key = match self.api.generate_image_key() {
+                    Ok(key) => key,
+                    Err(()) => return,
+                };
 
                 /* update current_frame */
                 *image_key = new_image_key;
@@ -243,7 +246,10 @@ impl VideoFrameRenderer for MediaFrameRenderer {
                 updates.push(ImageUpdate::AddImage(new_image_key, descriptor, image_data));
             },
             None => {
-                let image_key = self.api.generate_image_key();
+                let image_key = match self.api.generate_image_key() {
+                    Ok(key) => key,
+                    Err(()) => return,
+                };
                 self.current_frame = Some((image_key, frame.get_width(), frame.get_height()));
 
                 let image_data = if frame.is_gl_texture() && self.player_id.is_some() {

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -1195,12 +1195,12 @@ impl WebrenderIpcSender {
     }
 
     /// Create a new image key. Blocks until the key is available.
-    pub fn generate_image_key(&self) -> ImageKey {
+    pub fn generate_image_key(&self) -> Result<ImageKey, ()> {
         let (sender, receiver) = ipc::channel().unwrap();
         self.0
             .send(WebrenderMsg::GenerateImageKey(sender))
-            .expect("error sending image key generation");
-        receiver.recv().expect("error receiving image key result")
+            .map_err(|_| ())?;
+        receiver.recv().map_err(|_| ())
     }
 
     /// Perform a resource update operation.

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -38,6 +38,7 @@ webrender_debugger = ["webrender/debugger"]
 xr-profile = ["canvas/xr-profile", "canvas_traits/xr-profile", "script/xr-profile", "webxr/profile"]
 
 [dependencies]
+app_units = "0.7"
 background_hang_monitor = { path = "../background_hang_monitor" }
 bluetooth = { path = "../bluetooth" }
 bluetooth_traits = { path = "../bluetooth_traits" }
@@ -53,6 +54,7 @@ embedder_traits = { path = "../embedder_traits" }
 env_logger = "0.7"
 euclid = "0.20"
 gfx = { path = "../gfx" }
+gfx_traits = { path = "../gfx_traits" }
 gleam = "0.11"
 gstreamer = { version = "0.15", optional = true }
 ipc-channel = "0.14"

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -37,7 +37,6 @@ packages = [
   "wayland-sys",
   "parking_lot",
   "parking_lot_core",
-  "ron",
 
   # https://github.com/servo/servo/pull/23288#issuecomment-494687746
   "gl_generator",

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-animation.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-animation.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-animation.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-blended-element-interposed.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-blended-element-interposed.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-blended-element-interposed.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-blended-element-overflow-hidden-and-border-radius.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-blended-element-overflow-hidden-and-border-radius.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-blended-element-overflow-hidden-and-border-radius.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-blended-element-overflow-scroll.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-blended-element-overflow-scroll.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-blended-element-overflow-scroll.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-blended-element-with-transparent-pixels.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-blended-element-with-transparent-pixels.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-blended-element-with-transparent-pixels.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-blending-with-sibling.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-blending-with-sibling.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-blending-with-sibling.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-both-parent-and-blended-with-3D-transform.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-both-parent-and-blended-with-3D-transform.html.ini
@@ -1,3 +1,2 @@
 [mix-blend-mode-both-parent-and-blended-with-3D-transform.html]
-  expected:
-    if os == "linux": FAIL
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-canvas-parent.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-canvas-parent.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-canvas-parent.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-canvas-sibling.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-canvas-sibling.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-canvas-sibling.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-iframe-parent.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-iframe-parent.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-iframe-parent.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-iframe-sibling.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-iframe-sibling.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-iframe-sibling.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-image.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-image.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-image.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-intermediate-element-overflow-hidden-and-border-radius.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-intermediate-element-overflow-hidden-and-border-radius.html.ini
@@ -1,2 +1,3 @@
 [mix-blend-mode-intermediate-element-overflow-hidden-and-border-radius.html]
   fuzzy: /css/compositing/mix-blend-mode/reference/mix-blend-mode-intermediate-element-overflow-hidden-and-border-radius-ref.html:9;8
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-mask.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-mask.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-mask.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-overflowing-child-of-blended-element.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-overflowing-child-of-blended-element.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-overflowing-child-of-blended-element.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-overflowing-child.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-overflowing-child.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-overflowing-child.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-parent-element-overflow-scroll-blended-position-fixed.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-parent-element-overflow-scroll-blended-position-fixed.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-parent-element-overflow-scroll-blended-position-fixed.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-parent-element-overflow-scroll.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-parent-element-overflow-scroll.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-parent-element-overflow-scroll.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-3D-transform.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-3D-transform.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-parent-with-3D-transform.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-border-radius.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-border-radius.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-parent-with-border-radius.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-text.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-parent-with-text.html.ini
@@ -1,3 +1,2 @@
 [mix-blend-mode-parent-with-text.html]
-  expected:
-    if os == "linux": FAIL
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-script.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-script.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-script.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-sibling-with-3D-transform.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-sibling-with-3D-transform.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-sibling-with-3D-transform.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-simple.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-simple.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-simple.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-stacking-context-creates-isolation.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-stacking-context-creates-isolation.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-stacking-context-creates-isolation.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-with-transform-and-preserve-3D.html.ini
+++ b/tests/wpt/metadata/css/compositing/mix-blend-mode/mix-blend-mode-with-transform-and-preserve-3D.html.ini
@@ -1,0 +1,2 @@
+[mix-blend-mode-with-transform-and-preserve-3D.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/compositing/root-element-blend-mode.html.ini
+++ b/tests/wpt/metadata/css/compositing/root-element-blend-mode.html.ini
@@ -1,0 +1,2 @@
+[root-element-blend-mode.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/css/inline_block_baseline_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/inline_block_baseline_a.html.ini
@@ -1,3 +1,4 @@
 [inline_block_baseline_a.html]
   expected:
-    if os == "mac": FAIL
+    if os == "linux": FAIL
+  fuzzy: /_mozilla/css/inline_block_baseline_ref.html:49;2097


### PR DESCRIPTION
These changes reflect changes in webrender's API that make RenderApiSender and RenderApi objects more challenging to share. This PR moves us to a model where:
* the compositor owns the main RenderApi object
* other threads that need to create transactions or manipulate fonts proxy those operations to the compositor (script/layout use IPC, while other threads use non-IPC channels)
* the webgl thread owns its own independent RenderApi