### PR TITLE
Mutably borrow to do layout of independent formatting contexts

### DIFF
--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -275,7 +275,7 @@ impl InlineFormattingContext {
 
         loop {
             if let Some(child) = ifc.current_nesting_level.remaining_boxes.next() {
-                match &*child.borrow() {
+                match &mut *child.borrow_mut() {
                     InlineLevelBox::InlineBox(inline) => {
                         let partial = inline.start_layout(child.clone(), &mut ifc);
                         ifc.partial_inline_boxes_stack.push(partial)
@@ -529,7 +529,7 @@ impl<'box_tree> PartialInlineBoxFragment<'box_tree> {
 fn layout_atomic(
     layout_context: &LayoutContext,
     ifc: &mut InlineFormattingContextState,
-    atomic: &IndependentFormattingContext,
+    atomic: &mut IndependentFormattingContext,
 ) {
     let pbm = atomic.style.padding_border_margin(&ifc.containing_block);
     let margin = pbm.margin.auto_is(Length::zero);

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -206,7 +206,7 @@ fn layout_block_level_children(
                 .iter()
                 .enumerate()
                 .map(|(tree_rank, box_)| {
-                    let mut fragment = box_.borrow().layout(
+                    let mut fragment = box_.borrow_mut().layout(
                         layout_context,
                         positioning_context,
                         containing_block,
@@ -226,7 +226,7 @@ fn layout_block_level_children(
                 .mapfold_reduce_into(
                     positioning_context,
                     |positioning_context, (tree_rank, box_)| {
-                        box_.borrow().layout(
+                        box_.borrow_mut().layout(
                             layout_context,
                             positioning_context,
                             containing_block,
@@ -259,7 +259,7 @@ fn layout_block_level_children(
 
 impl BlockLevelBox {
     fn layout(
-        &self,
+        &mut self,
         layout_context: &LayoutContext,
         positioning_context: &mut PositioningContext,
         containing_block: &ContainingBlock,


### PR DESCRIPTION
We want to compute content sizes on demand rather than eagerly so we will
need to mutate the independent formatting contexts that own the content sizes.