### PR TITLE
Store abspos boxes in a RefCell too

### DIFF
--- a/components/layout_2020/flexbox.rs
+++ b/components/layout_2020/flexbox.rs
@@ -15,7 +15,6 @@ use crate::sizing::{BoxContentSizes, ContentSizes, ContentSizesRequest};
 use crate::style_ext::DisplayGeneratingBox;
 use crate::ContainingBlock;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
-use servo_arc::Arc;
 use std::borrow::Cow;
 use style::values::computed::Length;
 use style::values::specified::text::TextDecorationLine;
@@ -31,7 +30,7 @@ pub(crate) struct FlexContainer {
 #[derive(Debug, Serialize)]
 pub(crate) enum FlexLevelBox {
     FlexItem(IndependentFormattingContext),
-    OutOfFlowAbsolutelyPositionedBox(Arc<AbsolutelyPositionedBox>),
+    OutOfFlowAbsolutelyPositionedBox(ArcRefCell<AbsolutelyPositionedBox>),
 }
 
 impl FlexContainer {
@@ -192,14 +191,14 @@ where
                     };
                     let box_ = if info.style.get_box().position.is_absolutely_positioned() {
                         // https://drafts.csswg.org/css-flexbox/#abspos-items
-                        ArcRefCell::new(FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(Arc::new(
-                            AbsolutelyPositionedBox::construct(
+                        ArcRefCell::new(FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(
+                            ArcRefCell::new(AbsolutelyPositionedBox::construct(
                                 self.context,
                                 &info,
                                 display_inside,
                                 contents,
-                            ),
-                        )))
+                            )),
+                        ))
                     } else {
                         ArcRefCell::new(FlexLevelBox::FlexItem(
                             IndependentFormattingContext::construct(

--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -571,9 +571,14 @@ where
                 kind,
             });
         } else {
-            let box_ = ArcRefCell::new(InlineLevelBox::OutOfFlowAbsolutelyPositionedBox(Arc::new(
-                AbsolutelyPositionedBox::construct(self.context, info, display_inside, contents),
-            )));
+            let box_ = ArcRefCell::new(InlineLevelBox::OutOfFlowAbsolutelyPositionedBox(
+                ArcRefCell::new(AbsolutelyPositionedBox::construct(
+                    self.context,
+                    info,
+                    display_inside,
+                    contents,
+                )),
+            ));
             self.current_inline_level_boxes().push(box_.clone());
             box_slot.set(LayoutBox::InlineLevel(box_))
         }
@@ -722,10 +727,11 @@ where
                 display_inside,
                 contents,
             } => {
-                let block_level_box =
-                    ArcRefCell::new(BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(Arc::new(
+                let block_level_box = ArcRefCell::new(
+                    BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(ArcRefCell::new(
                         AbsolutelyPositionedBox::construct(context, info, display_inside, contents),
-                    )));
+                    )),
+                );
                 (block_level_box, ContainsFloats::No)
             },
             BlockLevelCreator::OutOfFlowFloatBox {

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -52,7 +52,7 @@ pub(crate) enum BlockLevelBox {
         style: Arc<ComputedValues>,
         contents: BlockContainer,
     },
-    OutOfFlowAbsolutelyPositionedBox(Arc<AbsolutelyPositionedBox>),
+    OutOfFlowAbsolutelyPositionedBox(ArcRefCell<AbsolutelyPositionedBox>),
     OutOfFlowFloatBox(FloatBox),
     Independent(IndependentFormattingContext),
 }
@@ -322,7 +322,7 @@ impl BlockLevelBox {
                 positioning_context.push(hoisted_box);
                 Fragment::AbsoluteOrFixedPositioned(AbsoluteOrFixedPositionedFragment {
                     hoisted_fragment,
-                    position: box_.contents.style.clone_position(),
+                    position: box_.borrow().contents.style.clone_position(),
                 })
             },
             BlockLevelBox::OutOfFlowFloatBox(_box_) => {

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -207,7 +207,7 @@ impl BoxTree {
                 let contents = ReplacedContent::for_element(dirty_node)
                     .map_or(Contents::OfElement, Contents::Replaced);
                 let info = NodeAndStyleInfo::new(dirty_node, Arc::clone(&primary_style));
-                let out_of_flow_absolutely_positioned_box = Arc::new(
+                let out_of_flow_absolutely_positioned_box = ArcRefCell::new(
                     AbsolutelyPositionedBox::construct(context, &info, display_inside, contents),
                 );
                 match update_point {
@@ -267,7 +267,7 @@ fn construct_for_root_element<'dom>(
     let (contains_floats, root_box) = if box_style.position.is_absolutely_positioned() {
         (
             ContainsFloats::No,
-            BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(Arc::new(
+            BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(ArcRefCell::new(
                 AbsolutelyPositionedBox::construct(context, &info, display_inside, contents),
             )),
         )

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -64,9 +64,9 @@ pub(crate) struct PaddingBorderMargin {
 pub(crate) trait ComputedValuesExt {
     fn inline_size_is_length(&self) -> bool;
     fn inline_box_offsets_are_both_non_auto(&self) -> bool;
-    fn box_offsets(&self) -> flow_relative::Sides<LengthPercentageOrAuto>;
-    fn box_size(&self) -> flow_relative::Vec2<LengthPercentageOrAuto>;
-    fn min_box_size(&self) -> flow_relative::Vec2<LengthPercentageOrAuto>;
+    fn box_offsets(&self) -> flow_relative::Sides<LengthPercentageOrAuto<'_>>;
+    fn box_size(&self) -> flow_relative::Vec2<LengthPercentageOrAuto<'_>>;
+    fn min_box_size(&self) -> flow_relative::Vec2<LengthPercentageOrAuto<'_>>;
     fn max_box_size(&self) -> flow_relative::Vec2<Option<&LengthPercentage>>;
     fn content_box_size(
         &self,
@@ -86,7 +86,7 @@ pub(crate) trait ComputedValuesExt {
     fn padding_border_margin(&self, containing_block: &ContainingBlock) -> PaddingBorderMargin;
     fn padding(&self) -> flow_relative::Sides<&LengthPercentage>;
     fn border_width(&self) -> flow_relative::Sides<Length>;
-    fn margin(&self) -> flow_relative::Sides<LengthPercentageOrAuto>;
+    fn margin(&self) -> flow_relative::Sides<LengthPercentageOrAuto<'_>>;
     fn has_transform_or_perspective(&self) -> bool;
     fn effective_z_index(&self) -> i32;
     fn establishes_stacking_context(&self) -> bool;
@@ -117,7 +117,7 @@ impl ComputedValuesExt for ComputedValues {
         !a.is_auto() && !b.is_auto()
     }
 
-    fn box_offsets(&self) -> flow_relative::Sides<LengthPercentageOrAuto> {
+    fn box_offsets(&self) -> flow_relative::Sides<LengthPercentageOrAuto<'_>> {
         let position = self.get_position();
         flow_relative::Sides::from_physical(
             &PhysicalSides::new(
@@ -130,7 +130,7 @@ impl ComputedValuesExt for ComputedValues {
         )
     }
 
-    fn box_size(&self) -> flow_relative::Vec2<LengthPercentageOrAuto> {
+    fn box_size(&self) -> flow_relative::Vec2<LengthPercentageOrAuto<'_>> {
         let position = self.get_position();
         flow_relative::Vec2::from_physical_size(
             &PhysicalSize::new(
@@ -141,7 +141,7 @@ impl ComputedValuesExt for ComputedValues {
         )
     }
 
-    fn min_box_size(&self) -> flow_relative::Vec2<LengthPercentageOrAuto> {
+    fn min_box_size(&self) -> flow_relative::Vec2<LengthPercentageOrAuto<'_>> {
         let position = self.get_position();
         flow_relative::Vec2::from_physical_size(
             &PhysicalSize::new(
@@ -271,7 +271,7 @@ impl ComputedValuesExt for ComputedValues {
         )
     }
 
-    fn margin(&self) -> flow_relative::Sides<LengthPercentageOrAuto> {
+    fn margin(&self) -> flow_relative::Sides<LengthPercentageOrAuto<'_>> {
         let margin = self.get_margin();
         flow_relative::Sides::from_physical(
             &PhysicalSides::new(


### PR DESCRIPTION
We want to mutate them when lazily computing their content sizes, but they
are behind an Arc for the hoisting infra, so it also needs its own layer
of inner mutability.