### PR TITLE
Use the latest stable MixedReality runtime

### DIFF
--- a/support/hololens/ServoApp/Package.appxmanifest
+++ b/support/hololens/ServoApp/Package.appxmanifest
@@ -9,7 +9,7 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
-    <PackageDependency Name="Microsoft.WindowsMixedReality.Runtime" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="100.2004.3007.0"/>
+    <PackageDependency Name="Microsoft.WindowsMixedReality.Runtime" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="102.2006.3006.0"/>
   </Dependencies>
   <Resources>
     <Resource Language="x-generate" />

--- a/support/hololens/ServoApp/ServoControl/Servo.cpp
+++ b/support/hololens/ServoApp/ServoControl/Servo.cpp
@@ -129,8 +129,6 @@ Servo::Servo(hstring url, hstring args, GLsizei width, GLsizei height,
              EGLNativeWindowType eglNativeWindow, float dpi,
              ServoDelegate &aDelegate)
     : mWindowHeight(height), mWindowWidth(width), mDelegate(aDelegate) {
-  SetEnvironmentVariableA("PreviewRuntimeEnabled", "1");
-
   Windows::Storage::ApplicationDataContainer localSettings =
       Windows::Storage::ApplicationData::Current().LocalSettings();
   if (!localSettings.Containers().HasKey(L"servoUserPrefs")) {


### PR DESCRIPTION
Per Microsoft, the preview runtime is now stable and we can depend on it without hidden environment variables.