### PR TITLE
Don't panic in canvas thread if webrender isn't reachable

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -982,7 +982,10 @@ impl<'a> CanvasData<'a> {
                 updates.push(ImageUpdate::Update(image_key, descriptor, data));
             },
             None => {
-                let key = self.webrender_api.generate_key();
+                let key = match self.webrender_api.generate_key() {
+                    Ok(key) => key,
+                    Err(()) => return,
+                };
                 updates.push(ImageUpdate::Add(key, descriptor, data));
                 self.image_key = Some(key);
                 debug!("New image {:?}.", self.image_key);

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -26,7 +26,7 @@ pub enum ImageUpdate {
 }
 
 pub trait WebrenderApi {
-    fn generate_key(&self) -> webrender_api::ImageKey;
+    fn generate_key(&self) -> Result<webrender_api::ImageKey, ()>;
     fn update_images(&self, updates: Vec<ImageUpdate>);
     fn clone(&self) -> Box<dyn WebrenderApi>;
 }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -949,12 +949,12 @@ impl gfx_traits::WebrenderApi for FontCacheWR {
 struct CanvasWebrenderApi(CompositorProxy);
 
 impl canvas_paint_thread::WebrenderApi for CanvasWebrenderApi {
-    fn generate_key(&self) -> webrender_api::ImageKey {
+    fn generate_key(&self) -> Result<webrender_api::ImageKey, ()> {
         let (sender, receiver) = unbounded();
         let _ = self.0.send(Msg::Webrender(WebrenderMsg::Canvas(
             WebrenderCanvasMsg::GenerateKey(sender),
         )));
-        receiver.recv().unwrap()
+        receiver.recv().map_err(|_| ())
     }
     fn update_images(&self, updates: Vec<canvas_paint_thread::ImageUpdate>) {
         let _ = self.0.send(Msg::Webrender(WebrenderMsg::Canvas(


### PR DESCRIPTION
This fixes a regression from #26823. This method is only used by the css paint worklet API, and the caller handles a communication error on the channel correctly.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #26853
- [x] There are tests for these changes