### PR TITLE
Fix re-extracting stream upon re-direct

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -911,8 +911,8 @@ pub fn http_redirect_fetch(
     }
 
     // Step 12
-    if let Some(_) = request.body {
-        // TODO: extract request's body's source
+    if let Some(body) = request.body.as_mut() {
+        body.extract_source();
     }
 
     // Step 13


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This fixes the logic in `net` regarding re-extracting a stream from the request body as part of a re-direct. 

The problem was that the `read_from` flag was never read as `true`, because it would be set on the clone of the original request used in the http fech, and the original request would then be used for the re-direct. So the original request never had a `read_from` flag set to true. 

Also, this removes the entire `read_from` concept, and instead uses a spec-compliant hook to re-extract the stream, which doesn't require tracking whether the stream has been read from in another http fetch. 

This will unblock https://github.com/servo/servo/pull/26810. I don't expect test changes in this one, although I have verified locally(using the other branch), that this fixes the issue that has emerged as part of that PR. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
