### PR TITLE
Focus correctness improvements

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1025,6 +1025,17 @@ impl Document {
         *self.focus_transaction.borrow_mut() = FocusTransaction::InTransaction(Default::default());
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#focus-fixup-rule>
+    pub(crate) fn perform_focus_fixup_rule(&self, not_focusable: &Element) {
+        if Some(not_focusable) != self.focused.get().as_ref().map(|e| &**e) {
+            return;
+        }
+        self.request_focus(
+            self.GetBody().as_ref().map(|e| &*e.upcast()),
+            FocusType::Element,
+        )
+    }
+
     /// Request that the given element receive focus once the current transaction is complete.
     /// If None is passed, then whatever element is currently focused will no longer be focused
     /// once the transaction is complete.

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -233,6 +233,7 @@ impl VirtualMethods for HTMLButtonElement {
                         el.check_ancestors_disabled_state_for_form_control();
                     },
                 }
+                el.update_sequentially_focusable_status();
             },
             &local_name!("type") => match mutation {
                 AttributeMutation::Set(_) => {

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -411,9 +411,7 @@ impl HTMLElementMethods for HTMLElement {
         // TODO: Mark the element as locked for focus and run the focusing steps.
         // https://html.spec.whatwg.org/multipage/#focusing-steps
         let document = document_from_node(self);
-        document.begin_focus_transaction();
-        document.request_focus(self.upcast());
-        document.commit_focus_transaction(FocusType::Element);
+        document.request_focus(Some(self.upcast()), FocusType::Element);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-blur
@@ -424,9 +422,7 @@ impl HTMLElementMethods for HTMLElement {
         }
         // https://html.spec.whatwg.org/multipage/#unfocusing-steps
         let document = document_from_node(self);
-        document.begin_focus_transaction();
-        // If `request_focus` is not called, focus will be set to None.
-        document.commit_focus_transaction(FocusType::Element);
+        document.request_focus(None, FocusType::Element);
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetparent

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -28,7 +28,7 @@ use crate::dom::htmlinputelement::{HTMLInputElement, InputType};
 use crate::dom::htmllabelelement::HTMLLabelElement;
 use crate::dom::htmltextareaelement::HTMLTextAreaElement;
 use crate::dom::node::{document_from_node, window_from_node};
-use crate::dom::node::{BindContext, Node, NodeFlags, ShadowIncluding};
+use crate::dom::node::{Node, ShadowIncluding};
 use crate::dom::text::Text;
 use crate::dom::virtualmethods::VirtualMethods;
 use dom_struct::dom_struct;
@@ -90,53 +90,6 @@ impl HTMLElement {
     fn is_body_or_frameset(&self) -> bool {
         let eventtarget = self.upcast::<EventTarget>();
         eventtarget.is::<HTMLBodyElement>() || eventtarget.is::<HTMLFrameSetElement>()
-    }
-
-    fn update_sequentially_focusable_status(&self) {
-        let element = self.upcast::<Element>();
-        let node = self.upcast::<Node>();
-        if element.has_attribute(&local_name!("tabindex")) {
-            node.set_flag(NodeFlags::SEQUENTIALLY_FOCUSABLE, true);
-        } else {
-            match node.type_id() {
-                NodeTypeId::Element(ElementTypeId::HTMLElement(
-                    HTMLElementTypeId::HTMLButtonElement,
-                )) |
-                NodeTypeId::Element(ElementTypeId::HTMLElement(
-                    HTMLElementTypeId::HTMLSelectElement,
-                )) |
-                NodeTypeId::Element(ElementTypeId::HTMLElement(
-                    HTMLElementTypeId::HTMLIFrameElement,
-                )) |
-                NodeTypeId::Element(ElementTypeId::HTMLElement(
-                    HTMLElementTypeId::HTMLTextAreaElement,
-                )) => node.set_flag(NodeFlags::SEQUENTIALLY_FOCUSABLE, true),
-                NodeTypeId::Element(ElementTypeId::HTMLElement(
-                    HTMLElementTypeId::HTMLLinkElement,
-                )) |
-                NodeTypeId::Element(ElementTypeId::HTMLElement(
-                    HTMLElementTypeId::HTMLAnchorElement,
-                )) => {
-                    if element.has_attribute(&local_name!("href")) {
-                        node.set_flag(NodeFlags::SEQUENTIALLY_FOCUSABLE, true);
-                    }
-                },
-                _ => {
-                    if let Some(attr) = element.get_attribute(&ns!(), &local_name!("draggable")) {
-                        let value = attr.value();
-                        let is_true = match *value {
-                            AttrValue::String(ref string) => string == "true",
-                            _ => false,
-                        };
-                        node.set_flag(NodeFlags::SEQUENTIALLY_FOCUSABLE, is_true);
-                    } else {
-                        node.set_flag(NodeFlags::SEQUENTIALLY_FOCUSABLE, false);
-                    }
-                    //TODO set SEQUENTIALLY_FOCUSABLE flag if editing host
-                    //TODO set SEQUENTIALLY_FOCUSABLE flag if "sorting interface th elements"
-                },
-            }
-        }
     }
 }
 
@@ -853,13 +806,6 @@ impl VirtualMethods for HTMLElement {
             },
             _ => {},
         }
-    }
-
-    fn bind_to_tree(&self, context: &BindContext) {
-        if let Some(ref s) = self.super_type() {
-            s.bind_to_tree(context);
-        }
-        self.update_sequentially_focusable_status();
     }
 
     fn parse_plain_attribute(&self, name: &LocalName, value: DOMString) -> AttrValue {

--- a/components/script/dom/htmlfieldsetelement.rs
+++ b/components/script/dom/htmlfieldsetelement.rs
@@ -182,14 +182,17 @@ impl VirtualMethods for HTMLFieldSetElement {
                         let el = field.downcast::<Element>().unwrap();
                         el.set_disabled_state(true);
                         el.set_enabled_state(false);
+                        el.update_sequentially_focusable_status();
                     }
                 } else {
                     for field in fields {
                         let el = field.downcast::<Element>().unwrap();
                         el.check_disabled_attribute();
                         el.check_ancestors_disabled_state_for_form_control();
+                        el.update_sequentially_focusable_status();
                     }
                 }
+                el.update_sequentially_focusable_status();
             },
             &local_name!("form") => {
                 self.form_attribute_mutated(mutation);

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2291,6 +2291,8 @@ impl VirtualMethods for HTMLInputElement {
                     let read_write = !(self.ReadOnly() || el.disabled_state());
                     el.set_read_write_state(read_write);
                 }
+
+                el.update_sequentially_focusable_status();
             },
             &local_name!("checked") if !self.checked_changed.get() => {
                 let checked_state = match mutation {

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2520,7 +2520,6 @@ impl VirtualMethods for HTMLInputElement {
 
             //TODO: set the editing position for text inputs
 
-            document_from_node(self).request_focus(self.upcast());
             if self.input_type().is_textual_or_password() &&
                 // Check if we display a placeholder. Layout doesn't know about this.
                 !self.textinput.borrow().is_empty()

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -23,7 +23,7 @@ use crate::dom::htmlfieldsetelement::HTMLFieldSetElement;
 use crate::dom::htmlformelement::{FormControl, HTMLFormElement};
 use crate::dom::htmlinputelement::HTMLInputElement;
 use crate::dom::keyboardevent::KeyboardEvent;
-use crate::dom::node::{document_from_node, window_from_node};
+use crate::dom::node::window_from_node;
 use crate::dom::node::{
     BindContext, ChildrenMutation, CloneChildrenFlag, Node, NodeDamage, UnbindContext,
 };
@@ -606,8 +606,6 @@ impl VirtualMethods for HTMLTextAreaElement {
 
         if event.type_() == atom!("click") && !event.DefaultPrevented() {
             //TODO: set the editing position for text inputs
-
-            document_from_node(self).request_focus(self.upcast());
         } else if event.type_() == atom!("keydown") && !event.DefaultPrevented() {
             if let Some(kevent) = event.downcast::<KeyboardEvent>() {
                 // This can't be inlined, as holding on to textinput.borrow_mut()

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -478,6 +478,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                         }
                     },
                 }
+                el.update_sequentially_focusable_status();
             },
             local_name!("maxlength") => match *attr.value() {
                 AttrValue::Int(_, value) => {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2504,9 +2504,7 @@ impl ScriptThread {
         let frame_element = doc.find_iframe(browsing_context_id);
 
         if let Some(ref frame_element) = frame_element {
-            doc.begin_focus_transaction();
-            doc.request_focus(frame_element.upcast());
-            doc.commit_focus_transaction(FocusType::Parent);
+            doc.request_focus(Some(frame_element.upcast()), FocusType::Parent);
         }
     }
 

--- a/tests/wpt/metadata/html/interaction/focus/processing-model/focus-fixup-rule-one-no-dialogs.html.ini
+++ b/tests/wpt/metadata/html/interaction/focus/processing-model/focus-fixup-rule-one-no-dialogs.html.ini
@@ -2,21 +2,6 @@
   [Disabling contenteditable]
     expected: FAIL
 
-  [Hiding the active element]
-    expected: FAIL
-
-  [Disabling the active element (making it expressly inert)]
-    expected: FAIL
-
   [Changing the first legend element in disabled <fieldset>]
-    expected: FAIL
-
-  [Disabling <fieldset> affects its descendants]
-    expected: FAIL
-
-  [Removing the tabindex attribute from a div]
-    expected: FAIL
-
-  [Removing the active element from the DOM]
     expected: FAIL
 


### PR DESCRIPTION
These changes improve the behaviour of focus in Hubs rooms, and are expected to improve web compat around other dynamic pages that receive keyboard events as well.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #26901 and fix #26900.
- [x] There are tests for these changes