### PR TITLE
Fix streaming request bodies

### DIFF
--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -33,8 +33,8 @@ use net::http_loader::determine_request_referrer;
 use net::resource_thread::AuthCacheEntry;
 use net::test::replace_host_table;
 use net_traits::request::{
-    BodyChunkRequest, BodySource, CredentialsMode, Destination, RequestBody, RequestBuilder,
-    RequestMode,
+    BodyChunkRequest, BodyChunkResponse, BodySource, CredentialsMode, Destination, RequestBody,
+    RequestBuilder, RequestMode,
 };
 use net_traits::response::{HttpsState, ResponseBody};
 use net_traits::{CookieSource, NetworkError, ReferrerPolicy};
@@ -108,7 +108,8 @@ fn create_request_body_with_content(content: Vec<u8>) -> RequestBody {
         Box::new(move |message| {
             let request = message.to().unwrap();
             if let BodyChunkRequest::Connect(sender) = request {
-                let _ = sender.send(content.clone());
+                let _ = sender.send(BodyChunkResponse::Chunk(content.clone()));
+                let _ = sender.send(BodyChunkResponse::Done);
             }
         }),
     );

--- a/tests/wpt/metadata/fetch/api/basic/request-upload.any.js.ini
+++ b/tests/wpt/metadata/fetch/api/basic/request-upload.any.js.ini
@@ -1,41 +1,9 @@
 [request-upload.any.html]
-  type: testharness
   [Fetch with POST with ReadableStream]
-    expected: FAIL
-
-  [Fetch with POST with ReadableStream containing String]
-    expected: FAIL
-
-  [Fetch with POST with ReadableStream containing null]
-    expected: FAIL
-
-  [Fetch with POST with ReadableStream containing number]
-    expected: FAIL
-
-  [Fetch with POST with ReadableStream containing ArrayBuffer]
-    expected: FAIL
-
-  [Fetch with POST with ReadableStream containing Blob]
     expected: FAIL
 
 
 [request-upload.any.worker.html]
-  type: testharness
   [Fetch with POST with ReadableStream]
-    expected: FAIL
-
-  [Fetch with POST with ReadableStream containing String]
-    expected: FAIL
-
-  [Fetch with POST with ReadableStream containing null]
-    expected: FAIL
-
-  [Fetch with POST with ReadableStream containing number]
-    expected: FAIL
-
-  [Fetch with POST with ReadableStream containing ArrayBuffer]
-    expected: FAIL
-
-  [Fetch with POST with ReadableStream containing Blob]
     expected: FAIL
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

FIX #26904

At this point I'm not sure if the hyper `Body::wrap_stream` integration by way of the IPC route is broken, or if perhaps there is a problem with the WPT server not handling the requests properly, as I am getting a bunch of:

```
 0:04.54 INFO STDERR: 127.0.0.1 - - [13/Jun/2020 18:22:08] code 400, message Bad request syntax ('4')
 0:04.54 INFO STDERR: 127.0.0.1 - - [13/Jun/2020 18:22:08] "4" 400 -
```

In any case, the `start_reading` call in `body.rs` had to be put into the other function, since it should not be called for each chunk(this was actually failing before). 

I've also added the chunked header in case the source is a stream.

Last thing to figure out, why is the request data not actually reaching the server, or not being handled properly by it. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
