### PR TITLE
Add DocumentAnimationSet and AnimationSetKey

### DIFF
--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -35,6 +35,7 @@ use gfx_traits::print_tree::PrintTree;
 use script_layout_interface::wrapper_traits::LayoutNode;
 use script_layout_interface::{LayoutElementType, LayoutNodeType};
 use servo_arc::Arc;
+use style::animation::AnimationSetKey;
 use style::dom::OpaqueNode;
 use style::properties::ComputedValues;
 use style::values::computed::Length;
@@ -446,10 +447,10 @@ impl FragmentTree {
         })
     }
 
-    pub fn remove_nodes_in_fragment_tree_from_set(&self, set: &mut FxHashSet<OpaqueNode>) {
+    pub fn remove_nodes_in_fragment_tree_from_set(&self, set: &mut FxHashSet<AnimationSetKey>) {
         self.find(|fragment, _| {
             if let Some(tag) = fragment.tag().as_ref() {
-                set.remove(&tag.node());
+                set.remove(&AnimationSetKey(tag.node()));
             }
             None::<()>
         });

--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -72,6 +72,7 @@ use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::Ordering;
 use std::sync::Arc as StdArc;
+use style::animation::AnimationSetKey;
 use style::applicable_declarations::ApplicableDeclarationBlock;
 use style::attr::AttrValue;
 use style::context::SharedStyleContext;
@@ -474,20 +475,11 @@ impl<'le> TElement for ServoLayoutElement<'le> {
     ) -> Option<Arc<StyleLocked<PropertyDeclarationBlock>>> {
         let node = self.as_node();
         let document = node.owner_doc();
-        context
-            .animation_states
-            .read()
-            .get(&node.opaque())
-            .and_then(|set| {
-                set.get_value_map_for_active_animations(context.current_time_for_animations)
-            })
-            .map(|map| {
-                Arc::new(
-                    document
-                        .style_shared_lock()
-                        .wrap(PropertyDeclarationBlock::from_animation_value_map(&map)),
-                )
-            })
+        context.animations.get_animation_declarations(
+            &AnimationSetKey(node.opaque()),
+            context.current_time_for_animations,
+            document.style_shared_lock(),
+        )
     }
 
     fn transition_rule(
@@ -496,20 +488,11 @@ impl<'le> TElement for ServoLayoutElement<'le> {
     ) -> Option<Arc<StyleLocked<PropertyDeclarationBlock>>> {
         let node = self.as_node();
         let document = node.owner_doc();
-        context
-            .animation_states
-            .read()
-            .get(&node.opaque())
-            .and_then(|set| {
-                set.get_value_map_for_active_transitions(context.current_time_for_animations)
-            })
-            .map(|map| {
-                Arc::new(
-                    document
-                        .style_shared_lock()
-                        .wrap(PropertyDeclarationBlock::from_animation_value_map(&map)),
-                )
-            })
+        context.animations.get_transition_declarations(
+            &AnimationSetKey(node.opaque()),
+            context.current_time_for_animations,
+            document.style_shared_lock(),
+        )
     }
 
     fn state(&self) -> ElementState {
@@ -634,21 +617,13 @@ impl<'le> TElement for ServoLayoutElement<'le> {
     }
 
     fn has_css_animations(&self, context: &SharedStyleContext) -> bool {
-        context
-            .animation_states
-            .read()
-            .get(&self.as_node().opaque())
-            .map(|set| set.has_active_animation())
-            .unwrap_or(false)
+        let key = AnimationSetKey(self.as_node().opaque());
+        context.animations.has_active_animations(&key)
     }
 
     fn has_css_transitions(&self, context: &SharedStyleContext) -> bool {
-        context
-            .animation_states
-            .read()
-            .get(&self.as_node().opaque())
-            .map(|set| set.has_active_transition())
-            .unwrap_or(false)
+        let key = AnimationSetKey(self.as_node().opaque());
+        context.animations.has_active_transitions(&key)
     }
 
     #[inline]

--- a/components/layout_thread_2020/dom_wrapper.rs
+++ b/components/layout_thread_2020/dom_wrapper.rs
@@ -72,6 +72,7 @@ use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::Ordering;
 use std::sync::Arc as StdArc;
+use style::animation::AnimationSetKey;
 use style::applicable_declarations::ApplicableDeclarationBlock;
 use style::attr::AttrValue;
 use style::context::SharedStyleContext;
@@ -482,20 +483,11 @@ impl<'le> TElement for ServoLayoutElement<'le> {
     ) -> Option<Arc<StyleLocked<PropertyDeclarationBlock>>> {
         let node = self.as_node();
         let document = node.owner_doc();
-        context
-            .animation_states
-            .read()
-            .get(&node.opaque())
-            .and_then(|set| {
-                set.get_value_map_for_active_animations(context.current_time_for_animations)
-            })
-            .map(|map| {
-                Arc::new(
-                    document
-                        .style_shared_lock()
-                        .wrap(PropertyDeclarationBlock::from_animation_value_map(&map)),
-                )
-            })
+        context.animations.get_animation_declarations(
+            &AnimationSetKey(node.opaque()),
+            context.current_time_for_animations,
+            document.style_shared_lock(),
+        )
     }
 
     fn transition_rule(
@@ -504,20 +496,11 @@ impl<'le> TElement for ServoLayoutElement<'le> {
     ) -> Option<Arc<StyleLocked<PropertyDeclarationBlock>>> {
         let node = self.as_node();
         let document = node.owner_doc();
-        context
-            .animation_states
-            .read()
-            .get(&node.opaque())
-            .and_then(|set| {
-                set.get_value_map_for_active_transitions(context.current_time_for_animations)
-            })
-            .map(|map| {
-                Arc::new(
-                    document
-                        .style_shared_lock()
-                        .wrap(PropertyDeclarationBlock::from_animation_value_map(&map)),
-                )
-            })
+        context.animations.get_transition_declarations(
+            &AnimationSetKey(node.opaque()),
+            context.current_time_for_animations,
+            document.style_shared_lock(),
+        )
     }
 
     fn state(&self) -> ElementState {
@@ -642,21 +625,13 @@ impl<'le> TElement for ServoLayoutElement<'le> {
     }
 
     fn has_css_animations(&self, context: &SharedStyleContext) -> bool {
-        context
-            .animation_states
-            .read()
-            .get(&self.as_node().opaque())
-            .map(|set| set.has_active_animation())
-            .unwrap_or(false)
+        let key = AnimationSetKey(self.as_node().opaque());
+        context.animations.has_active_animations(&key)
     }
 
     fn has_css_transitions(&self, context: &SharedStyleContext) -> bool {
-        context
-            .animation_states
-            .read()
-            .get(&self.as_node().opaque())
-            .map(|set| set.has_active_transition())
-            .unwrap_or(false)
+        let key = AnimationSetKey(self.as_node().opaque());
+        context.animations.has_active_transitions(&key)
     }
 
     #[inline]

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -140,7 +140,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Instant, SystemTime};
-use style::animation::ElementAnimationSet;
+use style::animation::DocumentAnimationSet;
 use style::attr::{AttrIdentifier, AttrValue, LengthOrPercentageOrAuto};
 use style::author_styles::AuthorStyles;
 use style::context::QuirksMode;
@@ -618,7 +618,7 @@ unsafe_no_jsmanaged_fields!(MediaSessionActionType);
 unsafe_no_jsmanaged_fields!(MediaMetadata);
 unsafe_no_jsmanaged_fields!(WebrenderIpcSender);
 unsafe_no_jsmanaged_fields!(StreamConsumer);
-unsafe_no_jsmanaged_fields!(ElementAnimationSet);
+unsafe_no_jsmanaged_fields!(DocumentAnimationSet);
 
 unsafe impl<'a> JSTraceable for &'a str {
     #[inline]

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -7,13 +7,11 @@ use crate::{PendingImage, TrustedNodeAddress};
 use app_units::Au;
 use crossbeam_channel::{Receiver, Sender};
 use euclid::default::{Point2D, Rect};
-use fxhash::FxHashMap;
 use gfx_traits::Epoch;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use metrics::PaintTimeMetrics;
 use msg::constellation_msg::{BackgroundHangMonitorRegister, BrowsingContextId, PipelineId};
 use net_traits::image_cache::ImageCache;
-use parking_lot::RwLock;
 use profile_traits::mem::ReportsChan;
 use script_traits::Painter;
 use script_traits::{
@@ -25,7 +23,7 @@ use servo_atoms::Atom;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use style::animation::ElementAnimationSet;
+use style::animation::DocumentAnimationSet;
 use style::context::QuirksMode;
 use style::dom::OpaqueNode;
 use style::invalidation::element::restyle_hints::RestyleHint;
@@ -215,7 +213,7 @@ pub struct ScriptReflow {
     /// The current animation timeline value.
     pub animation_timeline_value: f64,
     /// The set of animations for this document.
-    pub animations: ServoArc<RwLock<FxHashMap<OpaqueNode, ElementAnimationSet>>>,
+    pub animations: DocumentAnimationSet,
 }
 
 pub struct LayoutThreadInit {

--- a/components/style/context.rs
+++ b/components/style/context.rs
@@ -5,11 +5,9 @@
 //! The context within which style is calculated.
 
 #[cfg(feature = "servo")]
-use crate::animation::ElementAnimationSet;
+use crate::animation::DocumentAnimationSet;
 use crate::bloom::StyleBloom;
 use crate::data::{EagerPseudoStyles, ElementData};
-#[cfg(feature = "servo")]
-use crate::dom::OpaqueNode;
 use crate::dom::{SendElement, TElement};
 use crate::font_metrics::FontMetricsProvider;
 #[cfg(feature = "gecko")]
@@ -31,10 +29,9 @@ use app_units::Au;
 use euclid::default::Size2D;
 use euclid::Scale;
 use fxhash::FxHashMap;
-#[cfg(feature = "servo")]
-use parking_lot::RwLock;
 use selectors::matching::ElementSelectorFlags;
 use selectors::NthIndexCache;
+#[cfg(feature = "gecko")]
 use servo_arc::Arc;
 #[cfg(feature = "servo")]
 use servo_atoms::Atom;
@@ -167,7 +164,7 @@ pub struct SharedStyleContext<'a> {
 
     /// The state of all animations for our styled elements.
     #[cfg(feature = "servo")]
-    pub animation_states: Arc<RwLock<FxHashMap<OpaqueNode, ElementAnimationSet>>>,
+    pub animations: DocumentAnimationSet,
 
     /// Paint worklets
     #[cfg(feature = "servo")]


### PR DESCRIPTION
This will be used in order to hold animations for pseudo elements in the
DocumentAnimationSet. Also no longer store the OpaqueNode in the
animation and transition data structures. This is already part of the
DocumentAnimationSet key.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
