### PR TITLE
Support for webxr layer management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,7 @@ dependencies = [
  "webrender_api",
  "webrender_surfman",
  "webrender_traits",
+ "webxr",
  "webxr-api",
 ]
 
@@ -1950,15 +1951,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea4f9ba7411ae3f00516401fb811b4f4f37f5c926357f2a033d27f96b74c849"
 dependencies = [
  "gl_generator 0.13.1",
-]
-
-[[package]]
-name = "gleam"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332d1f4e6c6181ed07178f84a552b2387d43ecf6821a86c22cfb3883ea3fb1b9"
-dependencies = [
- "gl_generator 0.14.0",
 ]
 
 [[package]]
@@ -5546,8 +5538,9 @@ dependencies = [
 
 [[package]]
 name = "surfman"
-version = "0.2.0"
-source = "git+https://github.com/servo/surfman#2283acaa3a856c2f76028cb23b5dde7dc0030cdf"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d85bf0eb91b66b93dda5c04627f00074ea1fa008c2980b132a065fafe7a1ab"
 dependencies = [
  "bitflags",
  "cfg_aliases",
@@ -5557,7 +5550,7 @@ dependencies = [
  "core-graphics 0.17.3",
  "display-link",
  "euclid",
- "gl_generator 0.13.1",
+ "gl_generator 0.14.0",
  "io-surface",
  "lazy_static",
  "libc",
@@ -5575,8 +5568,9 @@ dependencies = [
 
 [[package]]
 name = "surfman-chains"
-version = "0.3.0"
-source = "git+https://github.com/asajeffrey/surfman-chains#b949a240d73ef86d3c4bd22bc3d93933fac21ee9"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51598e1772bda3dbb1b81a9dc4b46725896948ea58d0f128e5b492a92f297af"
 dependencies = [
  "euclid",
  "fnv",
@@ -6526,18 +6520,18 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#0d8d2affc4da259b88d251ab49c0bbcbe96acf4d"
+source = "git+https://github.com/servo/webxr#e507076cc6f55ea6daa58c3ecbb1867847854722"
 dependencies = [
  "android_injected_glue",
  "bindgen",
  "crossbeam-channel",
  "euclid",
  "gl_generator 0.13.1",
- "gleam 0.9.2",
  "gvr-sys",
  "log",
  "openxr",
  "serde",
+ "sparkle",
  "surfman",
  "surfman-chains",
  "time",
@@ -6549,13 +6543,12 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#0d8d2affc4da259b88d251ab49c0bbcbe96acf4d"
+source = "git+https://github.com/servo/webxr#e507076cc6f55ea6daa58c3ecbb1867847854722"
 dependencies = [
  "euclid",
  "ipc-channel",
  "log",
  "serde",
- "surfman-chains-api",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,3 @@ opt-level = 3
 
 # This is here to dedupe winapi since mio 0.6 is still using winapi 0.2.
 mio = { git = "https://github.com/servo/mio.git", branch = "servo" }
-surfman = { git = "https://github.com/servo/surfman" }
-surfman-chains = { git = "https://github.com/asajeffrey/surfman-chains" }

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -38,9 +38,9 @@ servo_config = { path = "../config" }
 sparkle = "0.1.25"
 style = { path = "../style" }
 style_traits = { path = "../style_traits" }
-# NOTE: the sm-angle feature only enables ANGLE on Windows, not other platforms!
-surfman = { version = "0.2", features = ["sm-angle", "sm-angle-default"] }
-surfman-chains = "0.3"
+# NOTE: the sm-angle feature only enables angle on windows, not other platforms!
+surfman = { version = "0.3", features = ["sm-angle","sm-angle-default"] }
+surfman-chains = "0.4"
 surfman-chains-api = "0.2"
 time = { version = "0.1.0", optional = true }
 webrender = { git = "https://github.com/servo/webrender" }
@@ -48,3 +48,4 @@ webrender_api = { git = "https://github.com/servo/webrender" }
 webrender_surfman = { path = "../webrender_surfman" }
 webrender_traits = { path = "../webrender_traits" }
 webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
+webxr = { git = "https://github.com/servo/webxr", features = ["ipc"] }

--- a/components/canvas/lib.rs
+++ b/components/canvas/lib.rs
@@ -12,9 +12,6 @@ extern crate log;
 mod raqote_backend;
 
 pub use webgl_mode::WebGLComm;
-pub use webgl_thread::SurfaceProvider;
-pub use webgl_thread::SurfaceProviders;
-pub use webgl_thread::WebGlExecutor;
 
 pub mod canvas_data;
 pub mod canvas_paint_thread;

--- a/components/canvas/webgl_mode/inprocess.rs
+++ b/components/canvas/webgl_mode/inprocess.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::webgl_thread::{SurfaceProviders, WebGLThread, WebGLThreadInit, WebGlExecutor};
+use crate::webgl_thread::{WebGLThread, WebGLThreadInit, WebXRBridgeInit};
 use canvas_traits::webgl::webgl_channel;
 use canvas_traits::webgl::{WebGLContextId, WebGLMsg, WebGLThreads};
 use euclid::default::Size2D;
@@ -11,7 +11,6 @@ use gleam;
 use servo_config::pref;
 use sparkle::gl;
 use sparkle::gl::GlType;
-use std::collections::HashMap;
 use std::default::Default;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
@@ -25,15 +24,14 @@ use webrender_surfman::WebrenderSurfman;
 use webrender_traits::{
     WebrenderExternalImageApi, WebrenderExternalImageRegistry, WebrenderImageSource,
 };
-use webxr_api::SwapChainId as WebXRSwapChainId;
+use webxr::SurfmanGL as WebXRSurfman;
+use webxr_api::LayerGrandManager as WebXRLayerGrandManager;
 
 pub struct WebGLComm {
     pub webgl_threads: WebGLThreads,
-    pub webxr_swap_chains: SwapChains<WebXRSwapChainId, Device>,
-    pub webxr_surface_providers: SurfaceProviders,
     pub image_handler: Box<dyn WebrenderExternalImageApi>,
     pub output_handler: Option<Box<dyn webrender_api::OutputImageHandler>>,
-    pub webgl_executor: WebGlExecutor,
+    pub webxr_layer_grand_manager: WebXRLayerGrandManager<WebXRSurfman>,
 }
 
 impl WebGLComm {
@@ -49,9 +47,8 @@ impl WebGLComm {
         debug!("WebGLThreads::new()");
         let (sender, receiver) = webgl_channel::<WebGLMsg>().unwrap();
         let webrender_swap_chains = SwapChains::new();
-        let webxr_swap_chains = SwapChains::new();
-        let webxr_surface_providers = Arc::new(Mutex::new(HashMap::new()));
-        let (runnable_sender, runnable_receiver) = crossbeam_channel::unbounded();
+        let webxr_init = WebXRBridgeInit::new(sender.clone());
+        let webxr_layer_grand_manager = webxr_init.layer_grand_manager();
 
         // This implementation creates a single `WebGLThread` for all the pipelines.
         let init = WebGLThreadInit {
@@ -61,12 +58,10 @@ impl WebGLComm {
             sender: sender.clone(),
             receiver,
             webrender_swap_chains: webrender_swap_chains.clone(),
-            webxr_swap_chains: webxr_swap_chains.clone(),
-            webxr_surface_providers: webxr_surface_providers.clone(),
             connection: surfman.connection(),
             adapter: surfman.adapter(),
             api_type,
-            runnable_receiver,
+            webxr_init,
         };
 
         let output_handler = if pref!(dom.webgl.dom_to_texture.enabled) {
@@ -81,11 +76,9 @@ impl WebGLComm {
 
         WebGLComm {
             webgl_threads: WebGLThreads(sender),
-            webxr_swap_chains,
-            webxr_surface_providers,
             image_handler: Box::new(external),
             output_handler: output_handler.map(|b| b as Box<_>),
-            webgl_executor: runnable_sender,
+            webxr_layer_grand_manager: webxr_layer_grand_manager,
         }
     }
 }

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -4,7 +4,6 @@
 
 //! Abstract windowing methods. The concrete implementations of these can be found in `platform/`.
 
-use canvas::{SurfaceProviders, WebGlExecutor};
 use embedder_traits::{EmbedderProxy, EventLoopWaker};
 use euclid::Scale;
 use keyboard_types::KeyboardEvent;
@@ -171,14 +170,7 @@ pub trait EmbedderMethods {
     fn create_event_loop_waker(&mut self) -> Box<dyn EventLoopWaker>;
 
     /// Register services with a WebXR Registry.
-    fn register_webxr(
-        &mut self,
-        _: &mut webxr::MainThreadRegistry,
-        _: WebGlExecutor,
-        _: SurfaceProviders,
-        _: EmbedderProxy,
-    ) {
-    }
+    fn register_webxr(&mut self, _: &mut webxr::MainThreadRegistry, _: EmbedderProxy) {}
 
     /// Returns the user agent string to report in network requests.
     fn get_user_agent_string(&self) -> Option<String> {

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -60,7 +60,6 @@ use canvas_traits::webgl::{
 use canvas_traits::webgl::{GLLimits, WebGLQueryId, WebGLSamplerId};
 use canvas_traits::webgl::{WebGLBufferId, WebGLChan, WebGLContextId, WebGLError};
 use canvas_traits::webgl::{WebGLFramebufferId, WebGLMsgSender, WebGLPipeline, WebGLProgramId};
-use canvas_traits::webgl::{WebGLOpaqueFramebufferId, WebGLTransparentFramebufferId};
 use canvas_traits::webgl::{WebGLReceiver, WebGLRenderbufferId, WebGLSLVersion, WebGLSender};
 use canvas_traits::webgl::{WebGLShaderId, WebGLSyncId, WebGLTextureId, WebGLVersion};
 use content_security_policy::CspList;
@@ -172,7 +171,6 @@ use webgpu::{
     WebGPUTexture, WebGPUTextureView,
 };
 use webrender_api::{DocumentId, ExternalImageId, ImageKey};
-use webxr_api::SwapChainId as WebXRSwapChainId;
 use webxr_api::{Finger, Hand, Ray, View};
 
 unsafe_no_jsmanaged_fields!(Tm);
@@ -550,8 +548,6 @@ unsafe_no_jsmanaged_fields!(ExternalImageId);
 unsafe_no_jsmanaged_fields!(WebGLBufferId);
 unsafe_no_jsmanaged_fields!(WebGLChan);
 unsafe_no_jsmanaged_fields!(WebGLFramebufferId);
-unsafe_no_jsmanaged_fields!(WebGLOpaqueFramebufferId);
-unsafe_no_jsmanaged_fields!(WebGLTransparentFramebufferId);
 unsafe_no_jsmanaged_fields!(WebGLMsgSender);
 unsafe_no_jsmanaged_fields!(WebGLPipeline);
 unsafe_no_jsmanaged_fields!(WebGLProgramId);
@@ -587,12 +583,12 @@ unsafe_no_jsmanaged_fields!(Option<ComputePass>);
 unsafe_no_jsmanaged_fields!(GPUBufferState);
 unsafe_no_jsmanaged_fields!(GPUCommandEncoderState);
 unsafe_no_jsmanaged_fields!(Range<u64>);
-unsafe_no_jsmanaged_fields!(WebXRSwapChainId);
 unsafe_no_jsmanaged_fields!(MediaList);
 unsafe_no_jsmanaged_fields!(
     webxr_api::Registry,
     webxr_api::Session,
     webxr_api::Frame,
+    webxr_api::LayerId,
     webxr_api::InputSource,
     webxr_api::InputId,
     webxr_api::Joint,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -106,7 +106,7 @@ use crate::stylesheet_set::StylesheetSetRef;
 use crate::task::TaskBox;
 use crate::task_source::{TaskSource, TaskSourceName};
 use crate::timers::OneshotTimerCallback;
-use canvas_traits::webgl::{self, SwapChainId, WebGLContextId, WebGLMsg};
+use canvas_traits::webgl::{self, WebGLContextId, WebGLMsg};
 use content_security_policy::{self as csp, CspList};
 use cookie::Cookie;
 use devtools_traits::ScriptToDevtoolsControlMsg;
@@ -2707,7 +2707,7 @@ impl Document {
             .borrow_mut()
             .drain()
             .filter(|(_, context)| context.onscreen())
-            .map(|(id, _)| SwapChainId::Context(id))
+            .map(|(id, _)| id)
             .collect();
 
         if dirty_context_ids.is_empty() {

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -60,8 +60,8 @@ use canvas_traits::webgl::{
     webgl_channel, AlphaTreatment, DOMToTextureCommand, GLContextAttributes, GLLimits, GlType,
     Parameter, SizedDataType, TexDataType, TexFormat, TexParameter, WebGLChan, WebGLCommand,
     WebGLCommandBacktrace, WebGLContextId, WebGLError, WebGLFramebufferBindingRequest, WebGLMsg,
-    WebGLMsgSender, WebGLOpaqueFramebufferId, WebGLProgramId, WebGLResult, WebGLSLVersion,
-    WebGLSendResult, WebGLSender, WebGLVersion, YAxisTreatment,
+    WebGLMsgSender, WebGLProgramId, WebGLResult, WebGLSLVersion, WebGLSendResult, WebGLSender,
+    WebGLVersion, YAxisTreatment,
 };
 use dom_struct::dom_struct;
 use embedder_traits::EventLoopWaker;
@@ -84,8 +84,6 @@ use std::cell::Cell;
 use std::cmp;
 use std::ptr::{self, NonNull};
 use std::rc::Rc;
-use webxr_api::SessionId;
-use webxr_api::SwapChainId as WebXRSwapChainId;
 
 // From the GLES 2.0.25 spec, page 85:
 //
@@ -404,10 +402,6 @@ impl WebGLRenderingContext {
         let _ = self
             .webgl_sender
             .send(command, capture_webgl_backtrace(self));
-    }
-
-    pub fn swap_buffers(&self, id: Option<WebGLOpaqueFramebufferId>) {
-        let _ = self.webgl_sender.send_swap_buffers(id);
     }
 
     pub fn webgl_error(&self, err: WebGLError) {
@@ -5001,19 +4995,6 @@ impl WebGLMessageSender {
 
     pub fn send(&self, msg: WebGLCommand, backtrace: WebGLCommandBacktrace) -> WebGLSendResult {
         self.wake_after_send(|| self.sender.send(msg, backtrace))
-    }
-
-    pub fn send_swap_buffers(&self, id: Option<WebGLOpaqueFramebufferId>) -> WebGLSendResult {
-        self.wake_after_send(|| self.sender.send_swap_buffers(id))
-    }
-
-    pub fn send_create_webxr_swap_chain(
-        &self,
-        size: Size2D<i32>,
-        sender: WebGLSender<Option<WebXRSwapChainId>>,
-        id: SessionId,
-    ) -> WebGLSendResult {
-        self.wake_after_send(|| self.sender.send_create_webxr_swap_chain(size, sender, id))
     }
 
     pub fn send_resize(

--- a/components/script/dom/webidls/XRLayer.webidl
+++ b/components/script/dom/webidls/XRLayer.webidl
@@ -5,9 +5,6 @@
 // https://immersive-web.github.io/layers/#xrlayertype
 [SecureContext, Exposed=Window, Pref="dom.webxr.layers.enabled"]
 interface XRLayer {
-  readonly attribute unsigned long pixelWidth;
-  readonly attribute unsigned long pixelHeight;
-
 //  attribute boolean blendTextureSourceAlpha;
 //  attribute boolean chromaticAberrationCorrection;
 

--- a/components/script/dom/webidls/XRWebGLLayer.webidl
+++ b/components/script/dom/webidls/XRWebGLLayer.webidl
@@ -12,7 +12,8 @@ dictionary XRWebGLLayerInit {
   boolean depth = true;
   boolean stencil = false;
   boolean alpha = true;
-  // double framebufferScaleFactor = 1.0;
+  boolean ignoreDepthValues = false;
+  double framebufferScaleFactor = 1.0;
 };
 
 [SecureContext, Exposed=Window, Pref="dom.webxr.enabled"]

--- a/components/script/dom/webidls/XRWebGLSubImage.webidl
+++ b/components/script/dom/webidls/XRWebGLSubImage.webidl
@@ -5,7 +5,9 @@
 // https://immersive-web.github.io/layers/#xrwebglsubimagetype
 [SecureContext, Exposed=Window, Pref="dom.webxr.layers.enabled"]
 interface XRWebGLSubImage : XRSubImage {
-  readonly attribute WebGLTexture colorTexture;
-  readonly attribute WebGLTexture? depthStencilTexture;
+  [SameObject] readonly attribute WebGLTexture colorTexture;
+  [SameObject] readonly attribute WebGLTexture? depthStencilTexture;
   readonly attribute unsigned long? imageIndex;
+  readonly attribute unsigned long textureWidth;
+  readonly attribute unsigned long textureHeight;
 };

--- a/components/script/dom/xrframe.rs
+++ b/components/script/dom/xrframe.rs
@@ -20,6 +20,8 @@ use crate::dom::xrviewerpose::XRViewerPose;
 use dom_struct::dom_struct;
 use std::cell::Cell;
 use webxr_api::Frame;
+use webxr_api::LayerId;
+use webxr_api::SubImages;
 
 #[dom_struct]
 pub struct XRFrame {
@@ -58,6 +60,14 @@ impl XRFrame {
 
     pub fn get_pose(&self, space: &XRSpace) -> Option<ApiPose> {
         space.get_pose(&self.data)
+    }
+
+    pub fn get_sub_images(&self, layer_id: LayerId) -> Option<&SubImages> {
+        self.data
+            .sub_images
+            .iter()
+            .filter(|sub_images| sub_images.layer_id == layer_id)
+            .next()
     }
 }
 

--- a/components/script/dom/xrlayer.rs
+++ b/components/script/dom/xrlayer.rs
@@ -6,30 +6,22 @@ use crate::dom::bindings::codegen::Bindings::XRLayerBinding::XRLayerBinding::XRL
 use crate::dom::bindings::reflector::Reflector;
 use crate::dom::bindings::root::Dom;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
+use crate::dom::xrframe::XRFrame;
 use crate::dom::xrsession::XRSession;
+use canvas_traits::webgl::WebGLContextId;
 use dom_struct::dom_struct;
-use euclid::Size2D;
-use webxr_api::Viewport;
+use webxr_api::LayerId;
 
 #[dom_struct]
 pub struct XRLayer {
     reflector: Reflector,
     session: Dom<XRSession>,
     context: Dom<WebGLRenderingContext>,
-    size: Size2D<u32, Viewport>,
+    #[ignore_malloc_size_of = "Layers don't heap-allocate"]
+    layer_id: LayerId,
 }
 
 impl XRLayerMethods for XRLayer {
-    /// https://immersive-web.github.io/layers/#dom-xrlayer-pixelwidth
-    fn PixelWidth(&self) -> u32 {
-        self.size.width
-    }
-
-    /// https://immersive-web.github.io/layers/#dom-xrlayer-pixelheight
-    fn PixelHeight(&self) -> u32 {
-        self.size.height
-    }
-
     /// https://immersive-web.github.io/layers/#dom-xrlayer-destroy
     fn Destroy(&self) {
         // TODO: Implement this
@@ -41,13 +33,31 @@ impl XRLayer {
     pub fn new_inherited(
         session: &XRSession,
         context: &WebGLRenderingContext,
-        size: Size2D<u32, Viewport>,
+        layer_id: LayerId,
     ) -> XRLayer {
         XRLayer {
             reflector: Reflector::new(),
             session: Dom::from_ref(session),
             context: Dom::from_ref(context),
-            size: size,
+            layer_id,
         }
+    }
+
+    pub(crate) fn layer_id(&self) -> LayerId {
+        self.layer_id
+    }
+
+    pub(crate) fn context_id(&self) -> WebGLContextId {
+        self.context.context_id()
+    }
+
+    pub fn begin_frame(&self, _frame: &XRFrame) -> Option<()> {
+        // TODO: Implement this
+        None
+    }
+
+    pub fn end_frame(&self, _frame: &XRFrame) -> Option<()> {
+        // TODO: Implement this
+        None
     }
 }

--- a/components/script/dom/xrwebglbinding.rs
+++ b/components/script/dom/xrwebglbinding.rs
@@ -16,6 +16,7 @@ use crate::dom::xrlayer::XRLayer;
 use crate::dom::xrsession::XRSession;
 use crate::dom::xrview::XRView;
 use crate::dom::xrwebglsubimage::XRWebGLSubImage;
+use canvas_traits::webgl::WebGLContextId;
 use dom_struct::dom_struct;
 
 #[dom_struct]
@@ -49,6 +50,19 @@ impl WebGLRenderingContextOrWebGL2RenderingContext {
             ) => WebGLRenderingContextOrWebGL2RenderingContext::WebGL2RenderingContext(
                 Dom::from_ref(context),
             ),
+        }
+    }
+}
+
+impl RootedWebGLRenderingContextOrWebGL2RenderingContext {
+    pub(crate) fn context_id(&self) -> WebGLContextId {
+        match self {
+            RootedWebGLRenderingContextOrWebGL2RenderingContext::WebGLRenderingContext(
+                ref context,
+            ) => context.context_id(),
+            RootedWebGLRenderingContextOrWebGL2RenderingContext::WebGL2RenderingContext(
+                ref context,
+            ) => context.base_context().context_id(),
         }
     }
 }

--- a/components/script/dom/xrwebglsubimage.rs
+++ b/components/script/dom/xrwebglsubimage.rs
@@ -8,6 +8,8 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::webgltexture::WebGLTexture;
 use crate::dom::xrsubimage::XRSubImage;
 use dom_struct::dom_struct;
+use euclid::Size2D;
+use webxr_api::Viewport;
 
 #[dom_struct]
 pub struct XRWebGLSubImage {
@@ -15,6 +17,7 @@ pub struct XRWebGLSubImage {
     color_texture: Dom<WebGLTexture>,
     depth_stencil_texture: Option<Dom<WebGLTexture>>,
     image_index: Option<u32>,
+    size: Size2D<u32, Viewport>,
 }
 
 impl XRWebGLSubImageMethods for XRWebGLSubImage {
@@ -31,5 +34,15 @@ impl XRWebGLSubImageMethods for XRWebGLSubImage {
     /// https://immersive-web.github.io/layers/#dom-xrwebglsubimage-imageindex
     fn GetImageIndex(&self) -> Option<u32> {
         self.image_index
+    }
+
+    /// https://immersive-web.github.io/layers/#dom-xrwebglsubimage-texturewidth
+    fn TextureWidth(&self) -> u32 {
+        self.size.width
+    }
+
+    /// https://immersive-web.github.io/layers/#dom-xrwebglsubimage-textureheight
+    fn TextureHeight(&self) -> u32 {
+        self.size.height
     }
 }

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -79,7 +79,7 @@ servo_url = { path = "../url" }
 sparkle = "0.1"
 style = { path = "../style", features = ["servo"] }
 style_traits = { path = "../style_traits", features = ["servo"] }
-surfman = "0.2"
+surfman = "0.3"
 webdriver_server = { path = "../webdriver_server", optional = true }
 webgpu = { path = "../webgpu" }
 webrender = { git = "https://github.com/servo/webrender" }

--- a/components/webrender_surfman/#Cargo.toml#
+++ b/components/webrender_surfman/#Cargo.toml#
@@ -13,5 +13,5 @@ path = "lib.rs"
 [dependencies]
 euclid = "0.20"
 surfman = "0.3"
-surfman-chains = "0.4"
+surfman-chains = "0.4i"
 

--- a/components/webrender_surfman/.#Cargo.toml
+++ b/components/webrender_surfman/.#Cargo.toml
@@ -1,0 +1,1 @@
+ajeffrey@ajeffrey-home.4753:1592856534

--- a/components/webrender_surfman/lib.rs
+++ b/components/webrender_surfman/lib.rs
@@ -26,7 +26,6 @@ use surfman::SurfaceAccess;
 use surfman::SurfaceInfo;
 use surfman::SurfaceTexture;
 use surfman::SurfaceType;
-use surfman_chains::SurfmanProvider;
 use surfman_chains::SwapChain;
 
 /// A bridge between webrender and surfman
@@ -68,7 +67,7 @@ impl WebrenderSurfman {
         };
         let context_attributes = ContextAttributes { flags, version };
         let context_descriptor = device.create_context_descriptor(&context_attributes)?;
-        let mut context = device.create_context(&context_descriptor)?;
+        let mut context = device.create_context(&context_descriptor, None)?;
         let surface_access = SurfaceAccess::GPUOnly;
         let headless = match surface_type {
             SurfaceType::Widget { .. } => false,
@@ -82,11 +81,10 @@ impl WebrenderSurfman {
                 err
             })?;
         let swap_chain = if headless {
-            let surface_provider = Box::new(SurfmanProvider::new(surface_access));
             Some(SwapChain::create_attached(
                 &mut device,
                 &mut context,
-                surface_provider,
+                surface_access,
             )?)
         } else {
             None

--- a/ports/gstplugin/Cargo.toml
+++ b/ports/gstplugin/Cargo.toml
@@ -29,8 +29,8 @@ libservo = { path = "../../components/servo" }
 log = "0.4"
 servo-media = { git = "https://github.com/servo/media" }
 sparkle = "0.1"
-surfman = { git = "https://github.com/servo/surfman" }
-surfman-chains = { git = "https://github.com/asajeffrey/surfman-chains" }
+surfman = "0.3"
+surfman-chains = "0.4"
 surfman-chains-api = "0.2"
 
 [build-dependencies]

--- a/ports/libsimpleservo/api/Cargo.toml
+++ b/ports/libsimpleservo/api/Cargo.toml
@@ -12,7 +12,7 @@ ipc-channel = "0.14"
 libservo = { path = "../../../components/servo" }
 log = "0.4"
 servo-media = { git = "https://github.com/servo/media" }
-surfman = { version = "0.2", features = ["sm-angle-default"] }
+surfman = { version = "0.3", features = ["sm-angle-default"] }
 webxr = { git = "https://github.com/servo/webxr"}
 webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
 

--- a/ports/libsimpleservo/capi/Cargo.toml
+++ b/ports/libsimpleservo/capi/Cargo.toml
@@ -18,7 +18,7 @@ env_logger = "0.7"
 lazy_static = "1"
 log = "0.4"
 simpleservo = { path = "../api" }
-surfman = "0.2"
+surfman = "0.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 libc = "0.2"

--- a/ports/winit/Cargo.toml
+++ b/ports/winit/Cargo.toml
@@ -57,7 +57,7 @@ libservo = { path = "../../components/servo" }
 log = "0.4"
 servo-media = { git = "https://github.com/servo/media" }
 shellwords = "1.0.0"
-surfman = { version = "0.2", features = ["sm-winit", "sm-x11"] }
+surfman = { version = "0.3", features = ["sm-winit", "sm-x11"] }
 tinyfiledialogs = "3.0"
 webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless"] }
 winit = "0.19"

--- a/ports/winit/embedder.rs
+++ b/ports/winit/embedder.rs
@@ -5,7 +5,6 @@
 //! Implements the global methods required by Servo (not window/gl/compositor related).
 
 use crate::events_loop::EventsLoop;
-use servo::canvas::{SurfaceProviders, WebGlExecutor};
 use servo::compositing::windowing::EmbedderMethods;
 use servo::embedder_traits::{EmbedderProxy, EventLoopWaker};
 use servo::servo_config::pref;
@@ -38,8 +37,6 @@ impl EmbedderMethods for EmbedderCallbacks {
     fn register_webxr(
         &mut self,
         xr: &mut webxr::MainThreadRegistry,
-        _executor: WebGlExecutor,
-        _surface_provider_registration: SurfaceProviders,
         _embedder_proxy: EmbedderProxy,
     ) {
         if pref!(dom.webxr.test) {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This adds layer management to servo's webxr implementation, and removes all the special-cased code for openxr surface creation and opaque framebuffers.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's all back-end plumbing

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
