### PR TITLE
Fix panic on vimeo.com

### DIFF
--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -206,7 +206,12 @@ unsafe extern "C" fn enqueue_promise_job(
     let mut result = false;
     wrap_panic(&mut || {
         let microtask_queue = &*(extra as *const MicrotaskQueue);
-        let global = GlobalScope::from_object(incumbent_global.get());
+        let global = if !incumbent_global.is_null() {
+            GlobalScope::from_object(incumbent_global.get())
+        } else {
+            let realm = AlreadyInRealm::assert_for_cx(cx);
+            GlobalScope::from_context(*cx, InRealm::in_realm(&realm))
+        };
         let pipeline = global.pipeline_id();
         let interaction = if promise.get().is_null() {
             PromiseUserInputEventHandlingState::DontCare

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14215,6 +14215,13 @@
       {}
      ]
     ],
+    "promise-no-incumbent.html": [
+     "a5458d096b5da8d6619ef5c553f232261887f45a",
+     [
+      null,
+      {}
+     ]
+    ],
     "promise.html": [
      "5925047287175f291c07ee88075359ed92a86e6a",
      [

--- a/tests/wpt/mozilla/tests/mozilla/promise-no-incumbent.html
+++ b/tests/wpt/mozilla/tests/mozilla/promise-no-incumbent.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  promise_test(function(t) {
+      let p = new Promise((r) => t.step_timeout(r, 0));
+      p.then = function() {};
+      let p2 = new Promise((r) => t.step_timeout(r, 10));
+      return Promise.race([p, p2]);
+  }, 'No panic when SM puts a dummy promise with no incumbent in the queue');
+</script>


### PR DESCRIPTION
The only time we end up enqueuing a promise reaction job with a null incumbent global argument is when SpiderMonkey does some weird stuff behind the scenes for its JS Debugger support (based on https://searchfox.org/mozilla-central/rev/2c1092dc68c63f7bad6da6a03c5883a5ab5ff2ca/js/src/builtin/Promise.cpp#3168). This commit works around that case and adds a regression test so we don't forget about that in the future.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #26930
- [x] There are tests for these changes