### PR TITLE
Cancel animations for nodes which are removed from the DOM

### DIFF
--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -99,6 +99,27 @@ impl Animations {
         self.unroot_unused_nodes(&sets);
     }
 
+    /// Cancel animations for the given node, if any exist.
+    pub(crate) fn cancel_animations_for_node(&self, node: &Node) {
+        let mut animations = self.sets.sets.write();
+        let mut cancel_animations_for = |key| {
+            animations.get_mut(&key).map(|set| {
+                set.cancel_all_animations();
+            });
+        };
+
+        let opaque_node = node.to_opaque();
+        cancel_animations_for(AnimationSetKey::new_for_non_pseudo(opaque_node));
+        cancel_animations_for(AnimationSetKey::new_for_pseudo(
+            opaque_node,
+            PseudoElement::Before,
+        ));
+        cancel_animations_for(AnimationSetKey::new_for_pseudo(
+            opaque_node,
+            PseudoElement::After,
+        ));
+    }
+
     /// Processes any new animations that were discovered after reflow. Collect messages
     /// that trigger events for any animations that changed state.
     pub(crate) fn do_post_reflow_update(&self, window: &Window, now: f64) {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3855,6 +3855,10 @@ impl Document {
             .borrow()
             .do_post_reflow_update(&self.window, self.current_animation_timeline_value());
     }
+
+    pub(crate) fn cancel_animations_for_node(&self, node: &Node) {
+        self.animations.borrow().cancel_animations_for_node(node);
+    }
 }
 
 impl Element {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -281,6 +281,11 @@ impl Node {
         }
     }
 
+    pub fn clean_up_layout_data(&self) {
+        self.owner_doc().cancel_animations_for_node(self);
+        self.style_and_layout_data.borrow_mut().take();
+    }
+
     /// Clean up flags and unbind from tree.
     pub fn complete_remove_subtree(root: &Node, context: &UnbindContext) {
         for node in root.traverse_preorder(ShadowIncluding::Yes) {
@@ -295,6 +300,8 @@ impl Node {
             );
         }
         for node in root.traverse_preorder(ShadowIncluding::Yes) {
+            node.clean_up_layout_data();
+
             // This needs to be in its own loop, because unbind_from_tree may
             // rely on the state of IS_IN_DOC of the context node's descendants,
             // e.g. when removing a <form>.

--- a/tests/wpt/metadata-layout-2020/css/css-transitions/disconnected-element-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transitions/disconnected-element-001.html.ini
@@ -1,8 +1,0 @@
-[disconnected-element-001.html]
-  expected: TIMEOUT
-  [Transitions are canceled when an element is re-parented to the same node]
-    expected: NOTRUN
-
-  [Transitions are canceled when an element is re-parented]
-    expected: TIMEOUT
-

--- a/tests/wpt/metadata-layout-2020/css/css-transitions/properties-value-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transitions/properties-value-001.html.ini
@@ -212,9 +212,6 @@
   [text-indent length(in) / events]
     expected: FAIL
 
-  [visibility visibility(keyword) / events]
-    expected: FAIL
-
   [text-indent length(pc) / events]
     expected: FAIL
 
@@ -225,9 +222,6 @@
     expected: FAIL
 
   [text-indent length(cm) / events]
-    expected: FAIL
-
-  [visibility visibility(keyword) / values]
     expected: FAIL
 
   [outline-width length(cm) / events]

--- a/tests/wpt/metadata-layout-2020/css/css-transitions/properties-value-inherit-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transitions/properties-value-inherit-001.html.ini
@@ -104,9 +104,6 @@
   [vertical-align length(cm) / values]
     expected: FAIL
 
-  [visibility visibility(keyword) / events]
-    expected: FAIL
-
   [vertical-align length(ex) / values]
     expected: FAIL
 

--- a/tests/wpt/metadata-layout-2020/css/css-transitions/properties-value-inherit-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transitions/properties-value-inherit-002.html.ini
@@ -212,9 +212,6 @@
   [text-indent length(in) / events]
     expected: FAIL
 
-  [visibility visibility(keyword) / events]
-    expected: FAIL
-
   [text-indent length(pc) / events]
     expected: FAIL
 
@@ -225,9 +222,6 @@
     expected: FAIL
 
   [text-indent length(cm) / events]
-    expected: FAIL
-
-  [visibility visibility(keyword) / values]
     expected: FAIL
 
   [outline-width length(cm) / events]

--- a/tests/wpt/metadata/css/css-transitions/disconnected-element-001.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/disconnected-element-001.html.ini
@@ -1,8 +1,0 @@
-[disconnected-element-001.html]
-  expected: TIMEOUT
-  [Transitions are canceled when an element is re-parented to the same node]
-    expected: NOTRUN
-
-  [Transitions are canceled when an element is re-parented]
-    expected: TIMEOUT
-


### PR DESCRIPTION

This includes nodes which are being reparented.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
