### PR TITLE
Fix refcell_backtrace feature.

### DIFF
--- a/components/script/dom/bindings/cell.rs
+++ b/components/script/dom/bindings/cell.rs
@@ -75,8 +75,7 @@ impl<T> DomRefCell<T> {
     ///
     /// Panics if the value is currently mutably borrowed.
     pub fn borrow(&self) -> Ref<T> {
-        self.try_borrow()
-            .expect("DomRefCell<T> already mutably borrowed")
+        self.value.borrow()
     }
 
     /// Mutably borrows the wrapped value.
@@ -90,8 +89,7 @@ impl<T> DomRefCell<T> {
     ///
     /// Panics if the value is currently borrowed.
     pub fn borrow_mut(&self) -> RefMut<T> {
-        self.try_borrow_mut()
-            .expect("DomRefCell<T> already borrowed")
+        self.value.borrow_mut()
     }
 
     /// Attempts to immutably borrow the wrapped value.


### PR DESCRIPTION
This makes the output of a borrow error contain the expected list of conflicting borrows. Fixes #26971.