### PR TITLE
Silently ignore failures to queue websocket tasks

### DIFF
--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -68,7 +68,7 @@ mod close_code {
     pub const TLS_FAILED: u16 = 1015;
 }
 
-pub fn close_the_websocket_connection(
+fn close_the_websocket_connection(
     address: Trusted<WebSocket>,
     task_source: &WebsocketTaskSource,
     canceller: &TaskCanceller,
@@ -81,12 +81,10 @@ pub fn close_the_websocket_connection(
         code: code,
         reason: Some(reason),
     };
-    task_source
-        .queue_with_canceller(close_task, &canceller)
-        .unwrap();
+    let _ = task_source.queue_with_canceller(close_task, &canceller);
 }
 
-pub fn fail_the_websocket_connection(
+fn fail_the_websocket_connection(
     address: Trusted<WebSocket>,
     task_source: &WebsocketTaskSource,
     canceller: &TaskCanceller,
@@ -97,9 +95,7 @@ pub fn fail_the_websocket_connection(
         code: Some(close_code::ABNORMAL),
         reason: None,
     };
-    task_source
-        .queue_with_canceller(close_task, &canceller)
-        .unwrap();
+    let _ = task_source.queue_with_canceller(close_task, &canceller);
 }
 
 #[dom_struct]
@@ -221,18 +217,14 @@ impl WebSocket {
                         address: address.clone(),
                         protocol_in_use,
                     };
-                    task_source
-                        .queue_with_canceller(open_thread, &canceller)
-                        .unwrap();
+                    let _ = task_source.queue_with_canceller(open_thread, &canceller);
                 },
                 WebSocketNetworkEvent::MessageReceived(message) => {
                     let message_thread = MessageReceivedTask {
                         address: address.clone(),
                         message: message,
                     };
-                    task_source
-                        .queue_with_canceller(message_thread, &canceller)
-                        .unwrap();
+                    let _ = task_source.queue_with_canceller(message_thread, &canceller);
                 },
                 WebSocketNetworkEvent::Fail => {
                     fail_the_websocket_connection(address.clone(), &task_source, &canceller);

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -11248,6 +11248,10 @@
       []
      ]
     },
+    "websocket_disconnect_worker.js": [
+     "b8b61957913572b0b121b0aa77c2ec247235fcaa",
+     []
+    ],
     "worker_member_test.js": [
      "abca5cd280ac07914cb21ee4968ac4d27e7feb68",
      []
@@ -14586,6 +14590,13 @@
     },
     "websocket_connection_fail.html": [
      "95c56636d53407fd9f18cb089bdd05bad5b1a4d9",
+     [
+      null,
+      {}
+     ]
+    ],
+    "websocket_disconnect.html": [
+     "797342743a4bc69d6c8748d0f2dd6841566e6ca5",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/websocket_disconnect.html
+++ b/tests/wpt/mozilla/tests/mozilla/websocket_disconnect.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script>
+  async_test((t) => {
+      let w = new Worker('websocket_disconnect_worker.js');
+      w.onmessage = () => {
+          w.terminate();
+          t.step_timeout(t.step_func_done(), 0);
+      };
+  }, "Web socket doesn't panic when worker disappears");
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/websocket_disconnect_worker.js
+++ b/tests/wpt/mozilla/tests/mozilla/websocket_disconnect_worker.js
@@ -1,0 +1,10 @@
+// Create a websocket and queue up a bunch of activity, then signal the parent to
+// terminate this worker before the queued activity is complete.
+importScripts('/websockets/websocket.sub.js');
+var w = CreateWebSocket(false, true, false);
+w.onopen = () => {
+  postMessage("close");
+  for (var i = 0; i < 1000; i++) {
+    w.send('hello' + i);
+  }
+};


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #26977
- [x] There are tests for these changes