### PR TITLE
Add GPUSampler and GPUTextureView to BindingResources and update wgpu-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-dx12"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69af46bd4fc5479cc7d90bf77ccee0da5dd88d4d27b87986a582f9eec97d02d4"
+checksum = "6e1a979a793023717bcaa7511c8cbb449bab550c093737c98674a659a2bbaf73"
 dependencies = [
  "bitflags",
  "d3d12",
@@ -1813,9 +1813,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-metal"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205f3ca8e74ed814ea2c0206d47d8925077673cab2e21f9b12d48ff781cf87ee"
+checksum = "412a1e0e53e9e325a7c2e0316f1a4e8a14cbe8d8bfb5f030bc3895692f8a8254"
 dependencies = [
  "arrayvec 0.5.1",
  "bitflags",
@@ -1840,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-vulkan"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ff36feae801fa23d29acd74082603a0145a697a23595757dd4e78828ab33da"
+checksum = "04af900c2597587b35e801e9d3f91fd8078cc06067421a22caa640ad2b1bc53e"
 dependencies = [
  "arrayvec 0.5.1",
  "ash",
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-hal"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc96180204064c9493e0fe4a9efeb721e0ac59fe8e1906d0c659142a93114fb1"
+checksum = "f13e8fd6aaa8f50146b9519999432e097da43466749d8863c53409322c705339"
 dependencies = [
  "bitflags",
  "raw-window-handle",
@@ -1881,8 +1881,7 @@ dependencies = [
 [[package]]
 name = "gfx-memory"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2eed6cda674d9cd4d92229102dbd544292124533d236904f987e9afab456137"
+source = "git+https://github.com/gfx-rs/gfx-extras?rev=438353c3f75368c12024ad2fc03cbeb15f351fd9#438353c3f75368c12024ad2fc03cbeb15f351fd9"
 dependencies = [
  "fxhash",
  "gfx-hal",
@@ -6531,7 +6530,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#ac9587e9ced5b043abad68e260cb8c9e812cffb5"
+source = "git+https://github.com/gfx-rs/wgpu#fc2dd481b2713cd0eda6ffa540faeaf7418fd051"
 dependencies = [
  "arrayvec 0.5.1",
  "bitflags",
@@ -6560,7 +6559,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#ac9587e9ced5b043abad68e260cb8c9e812cffb5"
+source = "git+https://github.com/gfx-rs/wgpu#fc2dd481b2713cd0eda6ffa540faeaf7418fd051"
 dependencies = [
  "bitflags",
  "peek-poke 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -164,10 +164,10 @@ use tendril::{StrTendril, TendrilSink};
 use time::{Duration, Timespec, Tm};
 use uuid::Uuid;
 use webgpu::{
-    wgpu::command::RawPass, WebGPU, WebGPUAdapter, WebGPUBindGroup, WebGPUBindGroupLayout,
-    WebGPUBuffer, WebGPUCommandBuffer, WebGPUCommandEncoder, WebGPUComputePipeline, WebGPUDevice,
-    WebGPUPipelineLayout, WebGPUQueue, WebGPURenderPipeline, WebGPUSampler, WebGPUShaderModule,
-    WebGPUTexture, WebGPUTextureView,
+    wgpu::command::RawPass, wgpu::id, WebGPU, WebGPUAdapter, WebGPUBindGroup,
+    WebGPUBindGroupLayout, WebGPUBuffer, WebGPUCommandBuffer, WebGPUCommandEncoder,
+    WebGPUComputePipeline, WebGPUDevice, WebGPUPipelineLayout, WebGPUQueue, WebGPURenderPipeline,
+    WebGPUSampler, WebGPUShaderModule, WebGPUTexture, WebGPUTextureView,
 };
 use webrender_api::{DocumentId, ExternalImageId, ImageKey};
 use webxr_api::SwapChainId as WebXRSwapChainId;
@@ -578,7 +578,7 @@ unsafe_no_jsmanaged_fields!(WebGPUContextId);
 unsafe_no_jsmanaged_fields!(WebGPUCommandBuffer);
 unsafe_no_jsmanaged_fields!(WebGPUCommandEncoder);
 unsafe_no_jsmanaged_fields!(WebGPUDevice);
-unsafe_no_jsmanaged_fields!(Option<RawPass>);
+unsafe_no_jsmanaged_fields!(Option<RawPass<id::CommandEncoderId>>);
 unsafe_no_jsmanaged_fields!(GPUBufferState);
 unsafe_no_jsmanaged_fields!(GPUCommandEncoderState);
 unsafe_no_jsmanaged_fields!(WebXRSwapChainId);

--- a/components/script/dom/gpuadapter.rs
+++ b/components/script/dom/gpuadapter.rs
@@ -84,7 +84,9 @@ impl GPUAdapterMethods for GPUAdapter {
             extensions: wgt::Extensions::empty(),
             limits: wgt::Limits {
                 max_bind_groups: descriptor.limits.maxBindGroups,
+                ..Default::default()
             },
+            shader_validation: true,
         };
         let id = self
             .global()

--- a/components/script/dom/gpubindgroup.rs
+++ b/components/script/dom/gpubindgroup.rs
@@ -3,19 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::cell::DomRefCell;
-use crate::dom::bindings::codegen::Bindings::GPUBindGroupBinding::{
-    GPUBindGroupEntry, GPUBindGroupMethods,
-};
+use crate::dom::bindings::codegen::Bindings::GPUBindGroupBinding::GPUBindGroupMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpubindgrouplayout::GPUBindGroupLayout;
-use crate::dom::gpubuffer::GPUBuffer;
-use crate::dom::gputextureview::TextureSubresource;
 use dom_struct::dom_struct;
 use std::cell::Cell;
-use std::collections::HashMap;
 use webgpu::{WebGPUBindGroup, WebGPUDevice};
 
 #[dom_struct]
@@ -25,10 +20,6 @@ pub struct GPUBindGroup {
     bind_group: WebGPUBindGroup,
     device: WebGPUDevice,
     layout: Dom<GPUBindGroupLayout>,
-    #[ignore_malloc_size_of = "defined in webgpu"]
-    entries: Vec<GPUBindGroupEntry>,
-    used_buffers: HashMap<Dom<GPUBuffer>, u32>,
-    used_textures: HashMap<TextureSubresource, u32>,
     valid: Cell<bool>,
 }
 
@@ -37,10 +28,7 @@ impl GPUBindGroup {
         bind_group: WebGPUBindGroup,
         device: WebGPUDevice,
         valid: bool,
-        entries: Vec<GPUBindGroupEntry>,
         layout: &GPUBindGroupLayout,
-        used_buffers: HashMap<DomRoot<GPUBuffer>, u32>,
-        used_textures: HashMap<TextureSubresource, u32>,
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
@@ -49,12 +37,6 @@ impl GPUBindGroup {
             device,
             valid: Cell::new(valid),
             layout: Dom::from_ref(layout),
-            entries,
-            used_buffers: used_buffers
-                .into_iter()
-                .map(|(key, value)| (Dom::from_ref(&*key), value))
-                .collect(),
-            used_textures,
         }
     }
 
@@ -63,20 +45,11 @@ impl GPUBindGroup {
         bind_group: WebGPUBindGroup,
         device: WebGPUDevice,
         valid: bool,
-        entries: Vec<GPUBindGroupEntry>,
         layout: &GPUBindGroupLayout,
-        used_buffers: HashMap<DomRoot<GPUBuffer>, u32>,
-        used_textures: HashMap<TextureSubresource, u32>,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUBindGroup::new_inherited(
-                bind_group,
-                device,
-                valid,
-                entries,
-                layout,
-                used_buffers,
-                used_textures,
+                bind_group, device, valid, layout,
             )),
             global,
         )

--- a/components/script/dom/gpubindgroup.rs
+++ b/components/script/dom/gpubindgroup.rs
@@ -3,36 +3,81 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::cell::DomRefCell;
-use crate::dom::bindings::codegen::Bindings::GPUBindGroupBinding::GPUBindGroupMethods;
+use crate::dom::bindings::codegen::Bindings::GPUBindGroupBinding::{
+    GPUBindGroupEntry, GPUBindGroupMethods,
+};
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::gpubindgrouplayout::GPUBindGroupLayout;
+use crate::dom::gpubuffer::GPUBuffer;
+use crate::dom::gputextureview::TextureSubresource;
 use dom_struct::dom_struct;
 use std::cell::Cell;
-use webgpu::WebGPUBindGroup;
+use std::collections::HashMap;
+use webgpu::{WebGPUBindGroup, WebGPUDevice};
 
 #[dom_struct]
 pub struct GPUBindGroup {
     reflector_: Reflector,
     label: DomRefCell<Option<DOMString>>,
     bind_group: WebGPUBindGroup,
+    device: WebGPUDevice,
+    layout: Dom<GPUBindGroupLayout>,
+    #[ignore_malloc_size_of = "defined in webgpu"]
+    entries: Vec<GPUBindGroupEntry>,
+    used_buffers: HashMap<Dom<GPUBuffer>, u32>,
+    used_textures: HashMap<TextureSubresource, u32>,
     valid: Cell<bool>,
 }
 
 impl GPUBindGroup {
-    fn new_inherited(bind_group: WebGPUBindGroup, valid: bool) -> Self {
+    fn new_inherited(
+        bind_group: WebGPUBindGroup,
+        device: WebGPUDevice,
+        valid: bool,
+        entries: Vec<GPUBindGroupEntry>,
+        layout: &GPUBindGroupLayout,
+        used_buffers: HashMap<DomRoot<GPUBuffer>, u32>,
+        used_textures: HashMap<TextureSubresource, u32>,
+    ) -> Self {
         Self {
             reflector_: Reflector::new(),
             label: DomRefCell::new(None),
             bind_group,
+            device,
             valid: Cell::new(valid),
+            layout: Dom::from_ref(layout),
+            entries,
+            used_buffers: used_buffers
+                .into_iter()
+                .map(|(key, value)| (Dom::from_ref(&*key), value))
+                .collect(),
+            used_textures,
         }
     }
 
-    pub fn new(global: &GlobalScope, bind_group: WebGPUBindGroup, valid: bool) -> DomRoot<Self> {
+    pub fn new(
+        global: &GlobalScope,
+        bind_group: WebGPUBindGroup,
+        device: WebGPUDevice,
+        valid: bool,
+        entries: Vec<GPUBindGroupEntry>,
+        layout: &GPUBindGroupLayout,
+        used_buffers: HashMap<DomRoot<GPUBuffer>, u32>,
+        used_textures: HashMap<TextureSubresource, u32>,
+    ) -> DomRoot<Self> {
         reflect_dom_object(
-            Box::new(GPUBindGroup::new_inherited(bind_group, valid)),
+            Box::new(GPUBindGroup::new_inherited(
+                bind_group,
+                device,
+                valid,
+                entries,
+                layout,
+                used_buffers,
+                used_textures,
+            )),
             global,
         )
     }

--- a/components/script/dom/gpubindgrouplayout.rs
+++ b/components/script/dom/gpubindgrouplayout.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
 use std::cell::Cell;
+use std::collections::HashMap;
 use webgpu::{WebGPU, WebGPUBindGroupLayout};
 
 #[dom_struct]
@@ -20,7 +21,7 @@ pub struct GPUBindGroupLayout {
     label: DomRefCell<Option<DOMString>>,
     bind_group_layout: WebGPUBindGroupLayout,
     #[ignore_malloc_size_of = "defined in webgpu"]
-    bindings: Vec<GPUBindGroupLayoutEntry>,
+    entry_map: HashMap<u32, GPUBindGroupLayoutEntry>,
     #[ignore_malloc_size_of = "defined in webgpu"]
     channel: WebGPU,
     valid: Cell<bool>,
@@ -30,7 +31,7 @@ impl GPUBindGroupLayout {
     fn new_inherited(
         channel: WebGPU,
         bind_group_layout: WebGPUBindGroupLayout,
-        bindings: Vec<GPUBindGroupLayoutEntry>,
+        entry_map: HashMap<u32, GPUBindGroupLayoutEntry>,
         valid: bool,
     ) -> Self {
         Self {
@@ -38,7 +39,7 @@ impl GPUBindGroupLayout {
             channel,
             label: DomRefCell::new(None),
             bind_group_layout,
-            bindings,
+            entry_map,
             valid: Cell::new(valid),
         }
     }
@@ -47,14 +48,14 @@ impl GPUBindGroupLayout {
         global: &GlobalScope,
         channel: WebGPU,
         bind_group_layout: WebGPUBindGroupLayout,
-        bindings: Vec<GPUBindGroupLayoutEntry>,
+        entry_map: HashMap<u32, GPUBindGroupLayoutEntry>,
         valid: bool,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUBindGroupLayout::new_inherited(
                 channel,
                 bind_group_layout,
-                bindings,
+                entry_map,
                 valid,
             )),
             global,
@@ -71,8 +72,8 @@ impl GPUBindGroupLayout {
         self.bind_group_layout
     }
 
-    pub fn bindings(&self) -> &[GPUBindGroupLayoutEntry] {
-        &self.bindings
+    pub fn entries(&self) -> &HashMap<u32, GPUBindGroupLayoutEntry> {
+        &self.entry_map
     }
 }
 

--- a/components/script/dom/gpubindgrouplayout.rs
+++ b/components/script/dom/gpubindgrouplayout.rs
@@ -3,61 +3,40 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::cell::DomRefCell;
-use crate::dom::bindings::codegen::Bindings::GPUBindGroupLayoutBinding::{
-    GPUBindGroupLayoutEntry, GPUBindGroupLayoutMethods,
-};
+use crate::dom::bindings::codegen::Bindings::GPUBindGroupLayoutBinding::GPUBindGroupLayoutMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
 use std::cell::Cell;
-use std::collections::HashMap;
-use webgpu::{WebGPU, WebGPUBindGroupLayout};
+use webgpu::WebGPUBindGroupLayout;
 
 #[dom_struct]
 pub struct GPUBindGroupLayout {
     reflector_: Reflector,
     label: DomRefCell<Option<DOMString>>,
     bind_group_layout: WebGPUBindGroupLayout,
-    #[ignore_malloc_size_of = "defined in webgpu"]
-    entry_map: HashMap<u32, GPUBindGroupLayoutEntry>,
-    #[ignore_malloc_size_of = "defined in webgpu"]
-    channel: WebGPU,
     valid: Cell<bool>,
 }
 
 impl GPUBindGroupLayout {
-    fn new_inherited(
-        channel: WebGPU,
-        bind_group_layout: WebGPUBindGroupLayout,
-        entry_map: HashMap<u32, GPUBindGroupLayoutEntry>,
-        valid: bool,
-    ) -> Self {
+    fn new_inherited(bind_group_layout: WebGPUBindGroupLayout, valid: bool) -> Self {
         Self {
             reflector_: Reflector::new(),
-            channel,
             label: DomRefCell::new(None),
             bind_group_layout,
-            entry_map,
             valid: Cell::new(valid),
         }
     }
 
     pub fn new(
         global: &GlobalScope,
-        channel: WebGPU,
         bind_group_layout: WebGPUBindGroupLayout,
-        entry_map: HashMap<u32, GPUBindGroupLayoutEntry>,
         valid: bool,
     ) -> DomRoot<Self> {
         reflect_dom_object(
-            Box::new(GPUBindGroupLayout::new_inherited(
-                channel,
-                bind_group_layout,
-                entry_map,
-                valid,
-            )),
+            Box::new(GPUBindGroupLayout::new_inherited(bind_group_layout, valid)),
             global,
         )
     }
@@ -70,10 +49,6 @@ impl GPUBindGroupLayout {
 
     pub fn id(&self) -> WebGPUBindGroupLayout {
         self.bind_group_layout
-    }
-
-    pub fn entries(&self) -> &HashMap<u32, GPUBindGroupLayoutEntry> {
-        &self.entry_map
     }
 }
 

--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -110,7 +110,7 @@ impl GPUBuffer {
         self.state.borrow()
     }
 
-    pub fn valid(&self) -> bool {
+    pub fn is_valid(&self) -> bool {
         self.valid.get()
     }
 }

--- a/components/script/dom/gpucommandencoder.rs
+++ b/components/script/dom/gpucommandencoder.rs
@@ -240,8 +240,8 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
             None => false,
         };
         valid &= (*self.state.borrow() == GPUCommandEncoderState::Open) &&
-            source.valid() &&
-            destination.valid() &
+            source.is_valid() &&
+            destination.is_valid() &
                 !(size & BUFFER_COPY_ALIGN_MASK == 0) &
                 !(source_offset & BUFFER_COPY_ALIGN_MASK == 0) &
                 !(destination_offset & BUFFER_COPY_ALIGN_MASK == 0) &

--- a/components/script/dom/gpucomputepassencoder.rs
+++ b/components/script/dom/gpucomputepassencoder.rs
@@ -22,6 +22,7 @@ use webgpu::{
         },
         RawPass,
     },
+    wgpu::id,
     WebGPU, WebGPURequest,
 };
 
@@ -32,7 +33,7 @@ pub struct GPUComputePassEncoder {
     channel: WebGPU,
     label: DomRefCell<Option<DOMString>>,
     #[ignore_malloc_size_of = "defined in wgpu-core"]
-    raw_pass: DomRefCell<Option<RawPass>>,
+    raw_pass: DomRefCell<Option<RawPass<id::CommandEncoderId>>>,
     command_encoder: Dom<GPUCommandEncoder>,
 }
 

--- a/components/script/dom/gpucomputepipeline.rs
+++ b/components/script/dom/gpucomputepipeline.rs
@@ -10,6 +10,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
+use std::cell::Cell;
 use webgpu::WebGPUComputePipeline;
 
 #[dom_struct]
@@ -17,20 +18,26 @@ pub struct GPUComputePipeline {
     reflector_: Reflector,
     label: DomRefCell<Option<DOMString>>,
     compute_pipeline: WebGPUComputePipeline,
+    valid: Cell<bool>,
 }
 
 impl GPUComputePipeline {
-    fn new_inherited(compute_pipeline: WebGPUComputePipeline) -> Self {
+    fn new_inherited(compute_pipeline: WebGPUComputePipeline, valid: bool) -> Self {
         Self {
             reflector_: Reflector::new(),
             label: DomRefCell::new(None),
             compute_pipeline,
+            valid: Cell::new(valid),
         }
     }
 
-    pub fn new(global: &GlobalScope, compute_pipeline: WebGPUComputePipeline) -> DomRoot<Self> {
+    pub fn new(
+        global: &GlobalScope,
+        compute_pipeline: WebGPUComputePipeline,
+        valid: bool,
+    ) -> DomRoot<Self> {
         reflect_dom_object(
-            Box::new(GPUComputePipeline::new_inherited(compute_pipeline)),
+            Box::new(GPUComputePipeline::new_inherited(compute_pipeline, valid)),
             global,
         )
     }

--- a/components/script/dom/gpupipelinelayout.rs
+++ b/components/script/dom/gpupipelinelayout.rs
@@ -10,26 +10,20 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
 use std::cell::Cell;
-use webgpu::{WebGPUBindGroupLayout, WebGPUPipelineLayout};
+use webgpu::WebGPUPipelineLayout;
 
 #[dom_struct]
 pub struct GPUPipelineLayout {
     reflector_: Reflector,
-    bind_group_layouts: Vec<WebGPUBindGroupLayout>,
     label: DomRefCell<Option<DOMString>>,
     pipeline_layout: WebGPUPipelineLayout,
     valid: Cell<bool>,
 }
 
 impl GPUPipelineLayout {
-    fn new_inherited(
-        bind_group_layouts: Vec<WebGPUBindGroupLayout>,
-        pipeline_layout: WebGPUPipelineLayout,
-        valid: bool,
-    ) -> Self {
+    fn new_inherited(pipeline_layout: WebGPUPipelineLayout, valid: bool) -> Self {
         Self {
             reflector_: Reflector::new(),
-            bind_group_layouts,
             label: DomRefCell::new(None),
             pipeline_layout,
             valid: Cell::new(valid),
@@ -38,16 +32,11 @@ impl GPUPipelineLayout {
 
     pub fn new(
         global: &GlobalScope,
-        bind_group_layouts: Vec<WebGPUBindGroupLayout>,
         pipeline_layout: WebGPUPipelineLayout,
         valid: bool,
     ) -> DomRoot<Self> {
         reflect_dom_object(
-            Box::new(GPUPipelineLayout::new_inherited(
-                bind_group_layouts,
-                pipeline_layout,
-                valid,
-            )),
+            Box::new(GPUPipelineLayout::new_inherited(pipeline_layout, valid)),
             global,
         )
     }

--- a/components/script/dom/gpurenderpassencoder.rs
+++ b/components/script/dom/gpurenderpassencoder.rs
@@ -19,6 +19,7 @@ use crate::dom::gpurenderpipeline::GPURenderPipeline;
 use dom_struct::dom_struct;
 use webgpu::{
     wgpu::command::{render_ffi as wgpu_render, RawPass},
+    wgpu::id,
     wgt, WebGPU, WebGPURequest,
 };
 
@@ -29,12 +30,16 @@ pub struct GPURenderPassEncoder {
     channel: WebGPU,
     label: DomRefCell<Option<DOMString>>,
     #[ignore_malloc_size_of = "defined in wgpu-core"]
-    raw_pass: DomRefCell<Option<RawPass>>,
+    raw_pass: DomRefCell<Option<RawPass<id::CommandEncoderId>>>,
     command_encoder: Dom<GPUCommandEncoder>,
 }
 
 impl GPURenderPassEncoder {
-    fn new_inherited(channel: WebGPU, raw_pass: RawPass, parent: &GPUCommandEncoder) -> Self {
+    fn new_inherited(
+        channel: WebGPU,
+        raw_pass: RawPass<id::CommandEncoderId>,
+        parent: &GPUCommandEncoder,
+    ) -> Self {
         Self {
             channel,
             reflector_: Reflector::new(),
@@ -47,7 +52,7 @@ impl GPURenderPassEncoder {
     pub fn new(
         global: &GlobalScope,
         channel: WebGPU,
-        raw_pass: RawPass,
+        raw_pass: RawPass<id::CommandEncoderId>,
         parent: &GPUCommandEncoder,
     ) -> DomRoot<Self> {
         reflect_dom_object(

--- a/components/script/dom/gpusampler.rs
+++ b/components/script/dom/gpusampler.rs
@@ -66,10 +66,6 @@ impl GPUSampler {
     pub fn is_valid(&self) -> bool {
         self.valid.get()
     }
-
-    pub fn compare(&self) -> bool {
-        self.compare_enable
-    }
 }
 
 impl GPUSamplerMethods for GPUSampler {

--- a/components/script/dom/gpusampler.rs
+++ b/components/script/dom/gpusampler.rs
@@ -10,13 +10,11 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
 use std::cell::Cell;
-use webgpu::{WebGPU, WebGPUDevice, WebGPUSampler};
+use webgpu::{WebGPUDevice, WebGPUSampler};
 
 #[dom_struct]
 pub struct GPUSampler {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "channels are hard"]
-    channel: WebGPU,
     label: DomRefCell<Option<DOMString>>,
     device: WebGPUDevice,
     compare_enable: bool,
@@ -26,7 +24,6 @@ pub struct GPUSampler {
 
 impl GPUSampler {
     fn new_inherited(
-        channel: WebGPU,
         device: WebGPUDevice,
         compare_enable: bool,
         sampler: WebGPUSampler,
@@ -34,7 +31,6 @@ impl GPUSampler {
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            channel,
             label: DomRefCell::new(None),
             valid: Cell::new(valid),
             device,
@@ -45,7 +41,6 @@ impl GPUSampler {
 
     pub fn new(
         global: &GlobalScope,
-        channel: WebGPU,
         device: WebGPUDevice,
         compare_enable: bool,
         sampler: WebGPUSampler,
@@ -53,7 +48,6 @@ impl GPUSampler {
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUSampler::new_inherited(
-                channel,
                 device,
                 compare_enable,
                 sampler,

--- a/components/script/dom/gpusampler.rs
+++ b/components/script/dom/gpusampler.rs
@@ -64,6 +64,20 @@ impl GPUSampler {
     }
 }
 
+impl GPUSampler {
+    pub fn id(&self) -> WebGPUSampler {
+        self.sampler
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.valid.get()
+    }
+
+    pub fn compare(&self) -> bool {
+        self.compare_enable
+    }
+}
+
 impl GPUSamplerMethods for GPUSampler {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
     fn GetLabel(&self) -> Option<DOMString> {

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -3,11 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::GPUObjectBaseBinding::GPUObjectDescriptorBase;
 use crate::dom::bindings::codegen::Bindings::GPUTextureBinding::{
     GPUExtent3DDict, GPUTextureDimension, GPUTextureFormat, GPUTextureMethods,
 };
 use crate::dom::bindings::codegen::Bindings::GPUTextureViewBinding::{
-    GPUTextureAspect, GPUTextureViewDescriptor,
+    GPUTextureAspect, GPUTextureViewDescriptor, GPUTextureViewDimension,
 };
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::DomRoot;
@@ -107,6 +108,14 @@ impl GPUTexture {
     pub fn id(&self) -> WebGPUTexture {
         self.texture
     }
+
+    pub fn sample_count(&self) -> u32 {
+        self.sample_count
+    }
+
+    pub fn usage(&self) -> u32 {
+        self.texture_usage
+    }
 }
 
 impl GPUTextureMethods for GPUTexture {
@@ -122,23 +131,28 @@ impl GPUTextureMethods for GPUTexture {
 
     /// https://gpuweb.github.io/gpuweb/#dom-gputexture-createview
     fn CreateView(&self, descriptor: &GPUTextureViewDescriptor) -> DomRoot<GPUTextureView> {
+        let dimension = if let Some(d) = descriptor.dimension {
+            d
+        } else {
+            match self.dimension {
+                GPUTextureDimension::_1d => GPUTextureViewDimension::_1d,
+                GPUTextureDimension::_2d => {
+                    if self.texture_size.depth > 1 && descriptor.arrayLayerCount == 0 {
+                        GPUTextureViewDimension::_2d_array
+                    } else {
+                        GPUTextureViewDimension::_2d
+                    }
+                },
+                GPUTextureDimension::_3d => GPUTextureViewDimension::_3d,
+            }
+        };
+
+        let format = descriptor.format.unwrap_or(self.format);
+
         let desc = wgt::TextureViewDescriptor {
             label: Default::default(),
-            format: convert_texture_format(descriptor.format.unwrap_or(self.format)),
-            dimension: match descriptor.dimension {
-                Some(d) => convert_texture_view_dimension(d),
-                None => match self.dimension {
-                    GPUTextureDimension::_1d => wgt::TextureViewDimension::D1,
-                    GPUTextureDimension::_2d => {
-                        if self.texture_size.depth > 1 && descriptor.arrayLayerCount == 0 {
-                            wgt::TextureViewDimension::D2Array
-                        } else {
-                            wgt::TextureViewDimension::D2
-                        }
-                    },
-                    GPUTextureDimension::_3d => wgt::TextureViewDimension::D3,
-                },
-            },
+            format: convert_texture_format(format),
+            dimension: convert_texture_view_dimension(dimension),
             aspect: match descriptor.aspect {
                 GPUTextureAspect::All => wgt::TextureAspect::All,
                 GPUTextureAspect::Stencil_only => wgt::TextureAspect::StencilOnly,
@@ -175,7 +189,32 @@ impl GPUTextureMethods for GPUTexture {
 
         let texture_view = WebGPUTextureView(texture_view_id);
 
-        GPUTextureView::new(&self.global(), texture_view, self.device, true)
+        let desc = GPUTextureViewDescriptor {
+            parent: GPUObjectDescriptorBase {
+                label: descriptor
+                    .parent
+                    .label
+                    .as_ref()
+                    .map(|l| l.as_ref().map(|u| u.clone())),
+            },
+            arrayLayerCount: if descriptor.arrayLayerCount == 0 {
+                self.texture_size.depth - descriptor.baseArrayLayer
+            } else {
+                descriptor.arrayLayerCount
+            },
+            aspect: descriptor.aspect,
+            baseArrayLayer: descriptor.baseArrayLayer,
+            baseMipLevel: descriptor.baseMipLevel,
+            dimension: Some(dimension),
+            format: Some(descriptor.format.unwrap_or(self.format)),
+            mipLevelCount: if descriptor.mipLevelCount == 0 {
+                self.mip_level_count - descriptor.baseMipLevel
+            } else {
+                descriptor.mipLevelCount
+            },
+        };
+
+        GPUTextureView::new(&self.global(), texture_view, &self, true, desc)
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gputexture-destroy

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -107,14 +107,6 @@ impl GPUTexture {
     pub fn id(&self) -> WebGPUTexture {
         self.texture
     }
-
-    pub fn sample_count(&self) -> u32 {
-        self.sample_count
-    }
-
-    pub fn usage(&self) -> u32 {
-        self.texture_usage
-    }
 }
 
 impl GPUTextureMethods for GPUTexture {
@@ -188,7 +180,7 @@ impl GPUTextureMethods for GPUTexture {
 
         let texture_view = WebGPUTextureView(texture_view_id);
 
-        GPUTextureView::new(&self.global(), texture_view, &self, true, dimension, format)
+        GPUTextureView::new(&self.global(), texture_view, &self, self.valid.get())
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gputexture-destroy

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::cell::DomRefCell;
-use crate::dom::bindings::codegen::Bindings::GPUObjectBaseBinding::GPUObjectDescriptorBase;
 use crate::dom::bindings::codegen::Bindings::GPUTextureBinding::{
     GPUExtent3DDict, GPUTextureDimension, GPUTextureFormat, GPUTextureMethods,
 };
@@ -189,32 +188,7 @@ impl GPUTextureMethods for GPUTexture {
 
         let texture_view = WebGPUTextureView(texture_view_id);
 
-        let desc = GPUTextureViewDescriptor {
-            parent: GPUObjectDescriptorBase {
-                label: descriptor
-                    .parent
-                    .label
-                    .as_ref()
-                    .map(|l| l.as_ref().map(|u| u.clone())),
-            },
-            arrayLayerCount: if descriptor.arrayLayerCount == 0 {
-                self.texture_size.depth - descriptor.baseArrayLayer
-            } else {
-                descriptor.arrayLayerCount
-            },
-            aspect: descriptor.aspect,
-            baseArrayLayer: descriptor.baseArrayLayer,
-            baseMipLevel: descriptor.baseMipLevel,
-            dimension: Some(dimension),
-            format: Some(descriptor.format.unwrap_or(self.format)),
-            mipLevelCount: if descriptor.mipLevelCount == 0 {
-                self.mip_level_count - descriptor.baseMipLevel
-            } else {
-                descriptor.mipLevelCount
-            },
-        };
-
-        GPUTextureView::new(&self.global(), texture_view, &self, true, desc)
+        GPUTextureView::new(&self.global(), texture_view, &self, true, dimension, format)
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gputexture-destroy

--- a/components/script/dom/gputextureview.rs
+++ b/components/script/dom/gputextureview.rs
@@ -3,10 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::cell::DomRefCell;
-use crate::dom::bindings::codegen::Bindings::GPUTextureBinding::GPUTextureFormat;
-use crate::dom::bindings::codegen::Bindings::GPUTextureViewBinding::{
-    GPUTextureViewDimension, GPUTextureViewMethods,
-};
+use crate::dom::bindings::codegen::Bindings::GPUTextureViewBinding::GPUTextureViewMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
@@ -23,8 +20,6 @@ pub struct GPUTextureView {
     texture_view: WebGPUTextureView,
     texture: Dom<GPUTexture>,
     valid: Cell<bool>,
-    dimension: GPUTextureViewDimension,
-    format: GPUTextureFormat,
 }
 
 impl GPUTextureView {
@@ -32,8 +27,6 @@ impl GPUTextureView {
         texture_view: WebGPUTextureView,
         texture: &GPUTexture,
         valid: bool,
-        dimension: GPUTextureViewDimension,
-        format: GPUTextureFormat,
     ) -> GPUTextureView {
         Self {
             reflector_: Reflector::new(),
@@ -41,8 +34,6 @@ impl GPUTextureView {
             label: DomRefCell::new(None),
             texture_view,
             valid: Cell::new(valid),
-            dimension,
-            format,
         }
     }
 
@@ -51,17 +42,9 @@ impl GPUTextureView {
         texture_view: WebGPUTextureView,
         texture: &GPUTexture,
         valid: bool,
-        dimension: GPUTextureViewDimension,
-        format: GPUTextureFormat,
     ) -> DomRoot<GPUTextureView> {
         reflect_dom_object(
-            Box::new(GPUTextureView::new_inherited(
-                texture_view,
-                texture,
-                valid,
-                dimension,
-                format,
-            )),
+            Box::new(GPUTextureView::new_inherited(texture_view, texture, valid)),
             global,
         )
     }
@@ -74,18 +57,6 @@ impl GPUTextureView {
 
     pub fn is_valid(&self) -> bool {
         self.valid.get()
-    }
-
-    pub fn dimension(&self) -> GPUTextureViewDimension {
-        self.dimension
-    }
-
-    pub fn format(&self) -> GPUTextureFormat {
-        self.format
-    }
-
-    pub fn texture(&self) -> &GPUTexture {
-        &*self.texture
     }
 }
 

--- a/components/script/dom/gputextureview.rs
+++ b/components/script/dom/gputextureview.rs
@@ -3,43 +3,85 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::GPUTextureViewBinding::GPUTextureViewDescriptor;
 use crate::dom::bindings::codegen::Bindings::GPUTextureViewBinding::GPUTextureViewMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::gputexture::GPUTexture;
 use dom_struct::dom_struct;
 use std::cell::Cell;
-use webgpu::{WebGPUDevice, WebGPUTextureView};
+use std::hash::{Hash, Hasher};
+use webgpu::WebGPUTextureView;
+
+#[derive(MallocSizeOf, JSTraceable)]
+pub struct TextureSubresource {
+    pub texture: DomRoot<GPUTexture>,
+    pub mipmap_level: u32,
+    pub array_layer: u32,
+}
+
+impl PartialEq for TextureSubresource {
+    fn eq(&self, other: &Self) -> bool {
+        self.texture.id().0 == other.texture.id().0 &&
+            self.mipmap_level == other.mipmap_level &&
+            self.array_layer == other.array_layer
+    }
+}
+
+impl Eq for TextureSubresource {}
+
+impl Hash for TextureSubresource {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.texture.id().0.hash(state);
+        self.mipmap_level.hash(state);
+        self.array_layer.hash(state);
+    }
+}
 
 #[dom_struct]
 pub struct GPUTextureView {
     reflector_: Reflector,
     label: DomRefCell<Option<DOMString>>,
     texture_view: WebGPUTextureView,
-    device: WebGPUDevice,
+    texture: Dom<GPUTexture>,
     valid: Cell<bool>,
+    #[ignore_malloc_size_of = "defined in webgpu"]
+    descriptor: GPUTextureViewDescriptor,
 }
 
 impl GPUTextureView {
-    fn new_inherited(texture_view: WebGPUTextureView, device: WebGPUDevice, valid: bool) -> Self {
+    fn new_inherited(
+        texture_view: WebGPUTextureView,
+        texture: &GPUTexture,
+        valid: bool,
+        descriptor: GPUTextureViewDescriptor,
+    ) -> GPUTextureView {
         Self {
             reflector_: Reflector::new(),
-            device,
+            texture: Dom::from_ref(texture),
             label: DomRefCell::new(None),
             texture_view,
             valid: Cell::new(valid),
+            descriptor,
         }
     }
 
     pub fn new(
         global: &GlobalScope,
         texture_view: WebGPUTextureView,
-        device: WebGPUDevice,
+        texture: &GPUTexture,
         valid: bool,
-    ) -> DomRoot<Self> {
+        descriptor: GPUTextureViewDescriptor,
+    ) -> DomRoot<GPUTextureView> {
         reflect_dom_object(
-            Box::new(GPUTextureView::new_inherited(texture_view, device, valid)),
+            Box::new(GPUTextureView::new_inherited(
+                texture_view,
+                texture,
+                valid,
+                descriptor,
+            )),
             global,
         )
     }
@@ -48,6 +90,18 @@ impl GPUTextureView {
 impl GPUTextureView {
     pub fn id(&self) -> WebGPUTextureView {
         self.texture_view
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.valid.get()
+    }
+
+    pub fn descriptor(&self) -> &GPUTextureViewDescriptor {
+        &self.descriptor
+    }
+
+    pub fn texture(&self) -> &GPUTexture {
+        &*self.texture
     }
 }
 

--- a/components/script/dom/webidls/GPUAdapter.webidl
+++ b/components/script/dom/webidls/GPUAdapter.webidl
@@ -24,12 +24,13 @@ enum GPUExtensionName {
 };
 
 dictionary GPULimits {
-    unsigned long maxBindGroups = 4;
-    unsigned long maxDynamicUniformBuffersPerPipelineLayout = 8;
-    unsigned long maxDynamicStorageBuffersPerPipelineLayout = 4;
-    unsigned long maxSampledTexturesPerShaderStage = 16;
-    unsigned long maxSamplersPerShaderStage = 16;
-    unsigned long maxStorageBuffersPerShaderStage = 4;
-    unsigned long maxStorageTexturesPerShaderStage = 4;
-    unsigned long maxUniformBuffersPerShaderStage = 12;
+    GPUSize32 maxBindGroups = 4;
+    GPUSize32 maxDynamicUniformBuffersPerPipelineLayout = 8;
+    GPUSize32 maxDynamicStorageBuffersPerPipelineLayout = 4;
+    GPUSize32 maxSampledTexturesPerShaderStage = 16;
+    GPUSize32 maxSamplersPerShaderStage = 16;
+    GPUSize32 maxStorageBuffersPerShaderStage = 4;
+    GPUSize32 maxStorageTexturesPerShaderStage = 4;
+    GPUSize32 maxUniformBuffersPerShaderStage = 12;
+    GPUSize32 maxUniformBufferBindingSize = 16384;
 };

--- a/components/script/dom/webidls/GPUBindGroup.webidl
+++ b/components/script/dom/webidls/GPUBindGroup.webidl
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // https://gpuweb.github.io/gpuweb/#gpubindgrouplayout
-[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom.webgpu.enabled"]
+[Exposed=(Window, DedicatedWorker), Pref="dom.webgpu.enabled"]
 interface GPUBindGroup {
 };
 GPUBindGroup includes GPUObjectBase;
@@ -13,10 +13,10 @@ dictionary GPUBindGroupDescriptor : GPUObjectDescriptorBase {
     required sequence<GPUBindGroupEntry> entries;
 };
 
-typedef /*(GPUSampler or GPUTextureView or*/ GPUBufferBindings/*)*/ GPUBindingResource;
+typedef (GPUSampler or GPUTextureView or GPUBufferBindings) GPUBindingResource;
 
 dictionary GPUBindGroupEntry {
-    required unsigned long binding;
+    required GPUIndex32 binding;
     required GPUBindingResource resource;
 };
 

--- a/components/script/dom/webidls/GPUBindGroupLayout.webidl
+++ b/components/script/dom/webidls/GPUBindGroupLayout.webidl
@@ -16,18 +16,11 @@ dictionary GPUBindGroupLayoutEntry {
     required GPUIndex32 binding;
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
-
-    // Used for uniform buffer and storage buffer bindings.
     boolean hasDynamicOffset = false;
-
-    // Used for sampled texture and storage texture bindings.
+    GPUSize64 minBufferBindingSize = 0;
     GPUTextureViewDimension viewDimension;
-
-    // Used for sampled texture bindings.
     GPUTextureComponentType textureComponentType;
     boolean multisampled = false;
-
-    // Used for storage texture bindings.
     GPUTextureFormat storageTextureFormat;
 };
 
@@ -36,8 +29,8 @@ enum GPUBindingType {
     "storage-buffer",
     "readonly-storage-buffer",
     "sampler",
+    "comparison-sampler",
     "sampled-texture",
     "readonly-storage-texture",
-    "writeonly-storage-texture",
-    "comparison-sampler",
+    "writeonly-storage-texture"
 };

--- a/components/script/dom/webidls/GPUBindGroupLayout.webidl
+++ b/components/script/dom/webidls/GPUBindGroupLayout.webidl
@@ -16,11 +16,19 @@ dictionary GPUBindGroupLayoutEntry {
     required GPUIndex32 binding;
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
-    GPUTextureViewDimension viewDimension = "2d";
-    GPUTextureComponentType textureComponentType = "float";
-    GPUTextureFormat storageTextureFormat;
-    boolean multisampled = false;
+
+    // Used for uniform buffer and storage buffer bindings.
     boolean hasDynamicOffset = false;
+
+    // Used for sampled texture and storage texture bindings.
+    GPUTextureViewDimension viewDimension;
+
+    // Used for sampled texture bindings.
+    GPUTextureComponentType textureComponentType;
+    boolean multisampled = false;
+
+    // Used for storage texture bindings.
+    GPUTextureFormat storageTextureFormat;
 };
 
 enum GPUBindingType {
@@ -31,5 +39,5 @@ enum GPUBindingType {
     "sampled-texture",
     "readonly-storage-texture",
     "writeonly-storage-texture",
-    //"comparison-sampler",
+    "comparison-sampler",
 };

--- a/components/webgpu/identity.rs
+++ b/components/webgpu/identity.rs
@@ -8,8 +8,8 @@ use wgpu::{
     hub::{GlobalIdentityHandlerFactory, IdentityHandler, IdentityHandlerFactory},
     id::{
         AdapterId, BindGroupId, BindGroupLayoutId, BufferId, CommandBufferId, ComputePipelineId,
-        DeviceId, PipelineLayoutId, RenderPipelineId, SamplerId, ShaderModuleId, SurfaceId,
-        SwapChainId, TextureId, TextureViewId, TypedId,
+        DeviceId, PipelineLayoutId, RenderBundleId, RenderPipelineId, SamplerId, ShaderModuleId,
+        SurfaceId, SwapChainId, TextureId, TextureViewId, TypedId,
     },
 };
 use wgt::Backend;
@@ -31,6 +31,7 @@ pub enum WebGPUMsg {
     FreeSampler(SamplerId),
     FreeSurface(SurfaceId),
     FreeShaderModule(ShaderModuleId),
+    FreeRenderBundle(RenderBundleId),
     Exit,
 }
 
@@ -73,6 +74,7 @@ impl_identity_handler!(BufferId, "buffer", WebGPUMsg::FreeBuffer);
 impl_identity_handler!(BindGroupId, "bind_group", WebGPUMsg::FreeBindGroup);
 impl_identity_handler!(SwapChainId, "swap_chain", WebGPUMsg::FreeSwapChain);
 impl_identity_handler!(ShaderModuleId, "shader_module", WebGPUMsg::FreeShaderModule);
+impl_identity_handler!(RenderBundleId, "render_bundle", WebGPUMsg::FreeRenderBundle);
 impl_identity_handler!(
     RenderPipelineId,
     "render_pipeline",

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -73,12 +73,12 @@ pub enum WebGPURequest {
         device_id: id::DeviceId,
         bind_group_id: id::BindGroupId,
         bind_group_layout_id: id::BindGroupLayoutId,
-        bindings: Vec<BindGroupEntry>,
+        entries: Vec<BindGroupEntry>,
     },
     CreateBindGroupLayout {
         device_id: id::DeviceId,
         bind_group_layout_id: id::BindGroupLayoutId,
-        bindings: Vec<BindGroupLayoutEntry>,
+        entries: Vec<BindGroupLayoutEntry>,
     },
     CreateBuffer {
         device_id: id::DeviceId,
@@ -334,13 +334,13 @@ impl WGPU {
                     device_id,
                     bind_group_id,
                     bind_group_layout_id,
-                    bindings,
+                    entries,
                 } => {
                     let global = &self.global;
                     let descriptor = BindGroupDescriptor {
                         layout: bind_group_layout_id,
-                        entries: bindings.as_ptr(),
-                        entries_length: bindings.len(),
+                        entries: entries.as_ptr(),
+                        entries_length: entries.len(),
                         label: ptr::null(),
                     };
                     let _ = gfx_select!(bind_group_id =>
@@ -349,12 +349,12 @@ impl WGPU {
                 WebGPURequest::CreateBindGroupLayout {
                     device_id,
                     bind_group_layout_id,
-                    bindings,
+                    entries,
                 } => {
                     let global = &self.global;
                     let descriptor = BindGroupLayoutDescriptor {
-                        entries: bindings.as_ptr(),
-                        entries_length: bindings.len(),
+                        entries: entries.as_ptr(),
+                        entries_length: entries.len(),
                         label: ptr::null(),
                     };
                     let _ = gfx_select!(bind_group_layout_id =>

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -28,9 +28,7 @@ use webrender_traits::{
     WebrenderImageSource,
 };
 use wgpu::{
-    binding_model::{
-        BindGroupDescriptor, BindGroupEntry, BindGroupLayoutDescriptor, BindGroupLayoutEntry,
-    },
+    binding_model::{BindGroupDescriptor, BindGroupEntry, BindingResource, BufferBinding},
     command::{BufferCopyView, TextureCopyView},
     device::HostMap,
     id,
@@ -73,12 +71,12 @@ pub enum WebGPURequest {
         device_id: id::DeviceId,
         bind_group_id: id::BindGroupId,
         bind_group_layout_id: id::BindGroupLayoutId,
-        entries: Vec<BindGroupEntry>,
+        entries: Vec<(u32, WebGPUBindings)>,
     },
     CreateBindGroupLayout {
         device_id: id::DeviceId,
         bind_group_layout_id: id::BindGroupLayoutId,
-        entries: Vec<BindGroupLayoutEntry>,
+        entries: Vec<wgt::BindGroupLayoutEntry>,
     },
     CreateBuffer {
         device_id: id::DeviceId,
@@ -193,6 +191,13 @@ pub enum WebGPURequest {
         buffer_id: id::BufferId,
         array_buffer: Vec<u8>,
     },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum WebGPUBindings {
+    Buffer(BufferBinding),
+    Sampler(id::SamplerId),
+    TextureView(id::TextureViewId),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -334,14 +339,27 @@ impl WGPU {
                     device_id,
                     bind_group_id,
                     bind_group_layout_id,
-                    entries,
+                    mut entries,
                 } => {
                     let global = &self.global;
+                    let bindings = entries
+                        .drain(..)
+                        .map(|(bind, res)| {
+                            let resource = match res {
+                                WebGPUBindings::Sampler(s) => BindingResource::Sampler(s),
+                                WebGPUBindings::TextureView(t) => BindingResource::TextureView(t),
+                                WebGPUBindings::Buffer(b) => BindingResource::Buffer(b),
+                            };
+                            BindGroupEntry {
+                                binding: bind,
+                                resource,
+                            }
+                        })
+                        .collect::<Vec<_>>();
                     let descriptor = BindGroupDescriptor {
+                        label: None,
                         layout: bind_group_layout_id,
-                        entries: entries.as_ptr(),
-                        entries_length: entries.len(),
-                        label: ptr::null(),
+                        bindings: bindings.as_slice(),
                     };
                     let _ = gfx_select!(bind_group_id =>
                         global.device_create_bind_group(device_id, &descriptor, bind_group_id));
@@ -352,10 +370,9 @@ impl WGPU {
                     entries,
                 } => {
                     let global = &self.global;
-                    let descriptor = BindGroupLayoutDescriptor {
-                        entries: entries.as_ptr(),
-                        entries_length: entries.len(),
-                        label: ptr::null(),
+                    let descriptor = wgt::BindGroupLayoutDescriptor {
+                        bindings: entries.as_slice(),
+                        label: None,
                     };
                     let _ = gfx_select!(bind_group_layout_id =>
                         global.device_create_bind_group_layout(device_id, &descriptor, bind_group_layout_id));
@@ -375,18 +392,9 @@ impl WGPU {
                     command_encoder_id,
                 } => {
                     let global = &self.global;
+                    let desc = wgt::CommandEncoderDescriptor { label: ptr::null() };
                     let _ = gfx_select!(command_encoder_id =>
-                        global.device_create_command_encoder(device_id, &Default::default(), command_encoder_id));
-                },
-                WebGPURequest::CreateContext(sender) => {
-                    let id = self
-                        .external_images
-                        .lock()
-                        .expect("Lock poisoned?")
-                        .next_id(WebrenderImageHandlerType::WebGPU);
-                    if let Err(e) = sender.send(id) {
-                        warn!("Failed to send ExternalImageId to new context ({})", e);
-                    };
+                        global.device_create_command_encoder(device_id, &desc, command_encoder_id));
                 },
                 WebGPURequest::CreateComputePipeline {
                     device_id,
@@ -406,6 +414,16 @@ impl WGPU {
                     };
                     let _ = gfx_select!(compute_pipeline_id =>
                         global.device_create_compute_pipeline(device_id, &descriptor, compute_pipeline_id));
+                },
+                WebGPURequest::CreateContext(sender) => {
+                    let id = self
+                        .external_images
+                        .lock()
+                        .expect("Lock poisoned?")
+                        .next_id(WebrenderImageHandlerType::WebGPU);
+                    if let Err(e) = sender.send(id) {
+                        warn!("Failed to send ExternalImageId to new context ({})", e);
+                    };
                 },
                 WebGPURequest::CreatePipelineLayout {
                     device_id,
@@ -631,6 +649,7 @@ impl WGPU {
                 } => {
                     let adapter_id = match self.global.pick_adapter(
                         &options,
+                        wgt::UnsafeExtensions::disallow(),
                         wgpu::instance::AdapterInputs::IdSet(&ids, |id| id.backend()),
                     ) {
                         Some(id) => id,
@@ -749,9 +768,10 @@ impl WGPU {
                     }
 
                     let buffer_size = (size.height as u32 * buffer_stride) as wgt::BufferAddress;
+                    let comm_desc = wgt::CommandEncoderDescriptor { label: ptr::null() };
                     let _ = gfx_select!(encoder_id => global.device_create_command_encoder(
                         device_id,
-                        &wgt::CommandEncoderDescriptor::default(),
+                        &comm_desc,
                         encoder_id
                     ));
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This also completes validation for `GPUBindGroup` and `GPUBindGroupLayout`.
`entry_map` is stored in `GPUBindGroupLayout` for validating `createBindGroup()`.

r?@kvark

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
