### PR TITLE
Fix Py3 environment setting failures

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -320,7 +320,10 @@ class MachCommands(CommandBase):
             exitcode = process.wait()
             encoding = locale.getpreferredencoding()  # See https://stackoverflow.com/a/9228117
             if exitcode == 0:
-                os.environ.update(eval(stdout.decode(encoding)))
+                decoded = stdout.decode(encoding)
+                if decoded.startswith("environ("):
+                    decoded = decoded.strip()[8:-1]
+                os.environ.update(eval(decoded))
             else:
                 print("Failed to run vcvarsall. stderr:")
                 print(stderr.decode(encoding))

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -131,17 +131,17 @@ def archive_deterministically(dir_to_archive, dest_archive, prepend_path=None):
 
 
 def normalize_env(env):
-    # There is a bug in subprocess where it doesn't like unicode types in
+    # There is a bug in Py2 subprocess where it doesn't like unicode types in
     # environment variables. Here, ensure all unicode are converted to
-    # binary. utf-8 is our globally assumed default. If the caller doesn't
-    # want UTF-8, they shouldn't pass in a unicode instance.
+    # native string type. utf-8 is our globally assumed default. If the caller
+    # doesn't want UTF-8, they shouldn't pass in a unicode instance.
     normalized_env = {}
     for k, v in env.items():
         if isinstance(k, six.text_type):
-            k = k.encode('utf-8', 'strict')
+            k = six.ensure_str(k, 'utf-8', 'strict')
 
         if isinstance(v, six.text_type):
-            v = v.encode('utf-8', 'strict')
+            v = six.ensure_str(v, 'utf-8', 'strict')
 
         normalized_env[k] = v
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

`python3 mach build -d` now proceeds to actual build. Since Gecko landed full Python 3 support, updating mozjs should allow us to drop Python 2 to build Servo. (I still see failures on other commands e.g. `test-tidy`.)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
