### PR TITLE
Initialize colorama only once

### DIFF
--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -1140,13 +1140,12 @@ def scan(only_changed_files=False, progress=True, stylo=False, no_wpt=False):
                              file_errors, dep_license_errors)
 
     error = None
+    colorama.init()
     for error in errors:
-        colorama.init()
         print("\r\033[94m{}\033[0m:\033[93m{}\033[0m: \033[91m{}\033[0m".format(*error))
 
     print()
     if error is None:
-        colorama.init()
         print("\033[92mtidy reported no errors.\033[0m")
 
     return int(error is not None)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Repeated initialization wraps colorama inside colorama, making the loop O(n^2) and causes stack overflow when running `mach test-tidy --all`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
