### PR TITLE
Allow embedder to bypass devtools prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,6 +1208,7 @@ dependencies = [
  "msg",
  "serde",
  "serde_json",
+ "servo_rand",
  "servo_url",
  "time",
  "uuid",

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4"
 msg = { path = "../msg" }
 serde = "1.0"
 serde_json = "1.0"
+servo_rand = { path = "../rand" }
 servo_url = { path = "../url" }
 time = "0.1"
 uuid = { version = "0.8", features = ["v4"] }

--- a/components/embedder_traits/lib.rs
+++ b/components/embedder_traits/lib.rs
@@ -207,8 +207,8 @@ pub enum EmbedderMsg {
     /// Notifies the embedder about media session events
     /// (i.e. when there is metadata for the active media session, playback state changes...).
     MediaSessionEvent(MediaSessionEvent),
-    /// Report the status of Devtools Server
-    OnDevtoolsStarted(Result<u16, ()>),
+    /// Report the status of Devtools Server with a token that can be used to bypass the permission prompt.
+    OnDevtoolsStarted(Result<u16, ()>, String),
 }
 
 impl Debug for EmbedderMsg {

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -146,7 +146,7 @@ pub trait HostTrait {
     /// Called when the media session position state is set.
     fn on_media_session_set_position_state(&self, duration: f64, position: f64, playback_rate: f64);
     /// Called when devtools server is started
-    fn on_devtools_started(&self, port: Result<u16, ()>);
+    fn on_devtools_started(&self, port: Result<u16, ()>, token: String);
 }
 
 pub struct ServoGlue {
@@ -751,8 +751,10 @@ impl ServoGlue {
                             ),
                     };
                 },
-                EmbedderMsg::OnDevtoolsStarted(port) => {
-                    self.callbacks.host_callbacks.on_devtools_started(port);
+                EmbedderMsg::OnDevtoolsStarted(port, token) => {
+                    self.callbacks
+                        .host_callbacks
+                        .on_devtools_started(port, token);
                 },
                 EmbedderMsg::Status(..) |
                 EmbedderMsg::SelectFiles(..) |

--- a/ports/winit/browser.rs
+++ b/ports/winit/browser.rs
@@ -515,7 +515,7 @@ where
                     debug!("MediaSessionEvent received");
                     // TODO(ferjm): MediaSession support for winit based browsers.
                 },
-                EmbedderMsg::OnDevtoolsStarted(port) => {
+                EmbedderMsg::OnDevtoolsStarted(port, _token) => {
                     match port {
                         Ok(p) => info!("Devtools Server running on port {}", p),
                         Err(()) => error!("Error running devtools server"),

--- a/support/hololens/ServoApp/BrowserPage.cpp
+++ b/support/hololens/ServoApp/BrowserPage.cpp
@@ -80,9 +80,10 @@ void BrowserPage::BindServoEvents() {
                                  : Visibility::Visible);
   });
   servoControl().OnDevtoolsStatusChanged(
-      [=](DevtoolsStatus status, unsigned int port) {
+      [=](DevtoolsStatus status, unsigned int port, hstring token) {
         mDevtoolsStatus = status;
         mDevtoolsPort = port;
+        mDevtoolsToken = token;
       });
   Window::Current().VisibilityChanged(
       [=](const auto &, const VisibilityChangedEventArgs &args) {
@@ -318,8 +319,8 @@ void BrowserPage::OnDevtoolsButtonClicked(IInspectable const &,
     hstring port = to_hstring(mDevtoolsPort);
     if (mDevtoolsClient == nullptr) {
       DevtoolsDelegate *dd = static_cast<DevtoolsDelegate *>(this);
-      mDevtoolsClient =
-          std::make_unique<DevtoolsClient>(L"localhost", port, *dd);
+      mDevtoolsClient = std::make_unique<DevtoolsClient>(L"localhost", port,
+                                                         mDevtoolsToken, *dd);
     }
     mDevtoolsClient->Run();
     std::wstring message =

--- a/support/hololens/ServoApp/BrowserPage.cpp
+++ b/support/hololens/ServoApp/BrowserPage.cpp
@@ -325,14 +325,14 @@ void BrowserPage::OnDevtoolsButtonClicked(IInspectable const &,
     mDevtoolsClient->Run();
     std::wstring message =
         resourceLoader.GetString(L"devtoolsStatus/Running").c_str();
-    std::wstring formatted = format(message, port.c_str());
-    DevtoolsStatusMessage().Text(formatted);
+    hstring formatted{format(message, port.c_str())};
+    OnDevtoolsMessage(servo::DevtoolsMessageLevel::None, L"", formatted);
   } else if (mDevtoolsStatus == DevtoolsStatus::Failed) {
-    DevtoolsStatusMessage().Text(
-        resourceLoader.GetString(L"devtoolsStatus/Failed"));
+    auto body = resourceLoader.GetString(L"devtoolsStatus/Failed");
+    OnDevtoolsMessage(servo::DevtoolsMessageLevel::Error, L"", body);
   } else if (mDevtoolsStatus == DevtoolsStatus::Stopped) {
-    DevtoolsStatusMessage().Text(
-        resourceLoader.GetString(L"devtoolsStatus/Stopped"));
+    auto body = resourceLoader.GetString(L"devtoolsStatus/Stopped");
+    OnDevtoolsMessage(servo::DevtoolsMessageLevel::None, L"", body);
   }
 }
 

--- a/support/hololens/ServoApp/BrowserPage.h
+++ b/support/hololens/ServoApp/BrowserPage.h
@@ -57,6 +57,7 @@ private:
   void BuildPrefList();
   DevtoolsStatus mDevtoolsStatus = DevtoolsStatus::Stopped;
   unsigned int mDevtoolsPort = 0;
+  hstring mDevtoolsToken;
   std::unique_ptr<servo::DevtoolsClient> mDevtoolsClient;
   Collections::IObservableVector<IInspectable> mLogs;
 };

--- a/support/hololens/ServoApp/BrowserPage.xaml
+++ b/support/hololens/ServoApp/BrowserPage.xaml
@@ -186,9 +186,6 @@
                     <TextBox MinHeight="12" FontFamily="Consolas" FontSize="12" Grid.Row="1" IsTabStop="true" x:Name="JSInput" VerticalAlignment="Center" KeyUp="OnJSInputEdited" IsSpellCheckEnabled="False"/>
                 </Grid>
             </muxc:TabViewItem>
-            <muxc:TabViewItem x:Uid="devtoolsTabServer" IsClosable="False">
-                <TextBlock x:Name="DevtoolsStatusMessage" Margin="10"></TextBlock>
-            </muxc:TabViewItem>
             <muxc:TabViewItem x:Uid="devtoolsTabPrefs" IsClosable="False">
                 <Grid VerticalAlignment="Stretch">
                     <Grid.RowDefinitions>

--- a/support/hololens/ServoApp/Devtools/Client.cpp
+++ b/support/hololens/ServoApp/Devtools/Client.cpp
@@ -31,6 +31,11 @@ void DevtoolsClient::Run() {
   connecting.Completed([=](const auto &, const auto &) {
     mDataReader = DataReader(socket.InputStream());
     mDataWriter = DataWriter(socket.OutputStream());
+
+    JsonObject out;
+    out.Insert(L"auth_token", JsonValue::CreateStringValue(mToken));
+    Send(out);
+
     mReceiveOp = {Loop()};
     mReceiveOp->Completed([=](const auto &, const auto &) {
       mReceiveOp = {};

--- a/support/hololens/ServoApp/Devtools/Client.h
+++ b/support/hololens/ServoApp/Devtools/Client.h
@@ -19,8 +19,9 @@ enum DevtoolsMessageLevel { Error, Warn, None };
 class DevtoolsClient {
 
 public:
-  DevtoolsClient(hstring hostname, hstring port, DevtoolsDelegate &d)
-      : mDelegate(d), mHostname(hostname), mPort(port){};
+  DevtoolsClient(hstring hostname, hstring port, hstring token,
+                 DevtoolsDelegate &d)
+      : mDelegate(d), mHostname(hostname), mToken(token), mPort(port){};
 
   ~DevtoolsClient() { Stop(); }
   void Run();
@@ -30,6 +31,7 @@ public:
 
 private:
   hstring mPort;
+  hstring mToken;
   hstring mHostname;
   DevtoolsDelegate &mDelegate;
   std::optional<DataReader> mDataReader;

--- a/support/hololens/ServoApp/ServoControl/Servo.cpp
+++ b/support/hololens/ServoApp/ServoControl/Servo.cpp
@@ -83,9 +83,9 @@ void show_context_menu(const char *title, const char *const *items_list,
 }
 
 void on_devtools_started(Servo::DevtoolsServerState result,
-                         const unsigned int port) {
-  sServo->Delegate().OnServoDevtoolsStarted(
-      result == Servo::DevtoolsServerState::Started, port);
+                         const unsigned int port, const char *token) {
+  auto state = result == Servo::DevtoolsServerState::Started;
+  sServo->Delegate().OnServoDevtoolsStarted(state, port, char2hstring(token));
 }
 
 void on_log_output(const char *buffer, uint32_t buffer_length) {

--- a/support/hololens/ServoApp/ServoControl/Servo.h
+++ b/support/hololens/ServoApp/ServoControl/Servo.h
@@ -108,7 +108,7 @@ public:
   virtual bool OnServoAllowNavigation(hstring) = 0;
   virtual void OnServoAnimatingChanged(bool) = 0;
   virtual void OnServoIMEStateChanged(bool) = 0;
-  virtual void OnServoDevtoolsStarted(bool, const unsigned int) = 0;
+  virtual void OnServoDevtoolsStarted(bool, const unsigned int, hstring) = 0;
   virtual void OnServoMediaSessionMetadata(hstring, hstring, hstring) = 0;
   virtual void OnServoMediaSessionPlaybackStateChange(int) = 0;
   virtual void OnServoPromptAlert(hstring, bool) = 0;

--- a/support/hololens/ServoApp/ServoControl/ServoControl.cpp
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.cpp
@@ -571,11 +571,11 @@ std::optional<hstring> ServoControl::OnServoPromptInput(winrt::hstring message,
   return string;
 }
 
-void ServoControl::OnServoDevtoolsStarted(bool success,
-                                          const unsigned int port) {
+void ServoControl::OnServoDevtoolsStarted(bool success, const unsigned int port,
+                                          hstring token) {
   RunOnUIThread([=] {
     auto status = success ? DevtoolsStatus::Running : DevtoolsStatus::Failed;
-    mOnDevtoolsStatusChangedEvent(status, port);
+    mOnDevtoolsStatusChangedEvent(status, port, token);
   });
 }
 

--- a/support/hololens/ServoApp/ServoControl/ServoControl.h
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.h
@@ -185,7 +185,7 @@ struct ServoControl : ServoControlT<ServoControl>, public servo::ServoDelegate {
   virtual servo::Servo::PromptResult OnServoPromptYesNo(winrt::hstring, bool);
   virtual std::optional<hstring> OnServoPromptInput(winrt::hstring,
                                                     winrt::hstring, bool);
-  virtual void OnServoDevtoolsStarted(bool, const unsigned int);
+  virtual void OnServoDevtoolsStarted(bool, const unsigned int, winrt::hstring);
 
   DevtoolsStatus GetDevtoolsStatus();
 

--- a/support/hololens/ServoApp/ServoControl/ServoControl.idl
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.idl
@@ -3,7 +3,7 @@ namespace ServoApp {
   delegate void EventDelegate();
   delegate void HistoryChangedDelegate(Boolean back, Boolean forward);
   delegate void MediaSessionMetadataDelegate(String title, String artist, String album);
-  delegate void DevtoolsStatusChangedDelegate(DevtoolsStatus status, UInt32 port);
+  delegate void DevtoolsStatusChangedDelegate(DevtoolsStatus status, UInt32 port, String token);
 
   enum DevtoolsStatus {
     Running = 0,

--- a/support/hololens/ServoApp/Strings/en-US/Resources.resw
+++ b/support/hololens/ServoApp/Strings/en-US/Resources.resw
@@ -108,9 +108,6 @@
   <data name="urlTextbox.PlaceholderText" xml:space="preserve">
     <value>Type a URL</value>
   </data>
-  <data name="devtoolsTabServer.[using:Microsoft.UI.Xaml.Controls]TabViewItem.Header" xml:space="preserve">
-    <value>Devtools Server</value>
-  </data>
   <data name="devtoolsTabConsole.[using:Microsoft.UI.Xaml.Controls]TabViewItem.Header" xml:space="preserve">
     <value>Console</value>
   </data>

--- a/support/hololens/ServoApp/Strings/fr-FR/Resources.resw
+++ b/support/hololens/ServoApp/Strings/fr-FR/Resources.resw
@@ -104,9 +104,6 @@
   <data name="urlTextbox.PlaceholderText" xml:space="preserve">
     <value>Saisir une adresse</value>
   </data>
-  <data name="devtoolsTabServer.[using:Microsoft.UI.Xaml.Controls]TabViewItem.Header" xml:space="preserve">
-    <value>Serveur DevTools</value>
-  </data>
   <data name="devtoolsTabPrefs.[using:Microsoft.UI.Xaml.Controls]TabViewItem.Header" xml:space="preserve">
     <value>Préférences</value>
   </data>


### PR DESCRIPTION
This introduces a token shared by servo and the embedder that can be used during the initial phase of the devtools connection.

Added also a commit to remove the devtools server panel. We just print the devtools port in the console now.