### PR TITLE
Report exceptions for async script executions to webdriver

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1220,18 +1220,16 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         }
     }
 
-    #[allow(unsafe_code)]
-    fn WebdriverCallback(&self, cx: JSContext, val: HandleValue) {
-        let rv = unsafe { jsval_to_webdriver(*cx, &self.globalscope, val) };
+    fn WebdriverCallback(&self, cx: JSContext, val: HandleValue, realm: InRealm, can_gc: CanGc) {
+        let rv = jsval_to_webdriver(cx, &self.globalscope, val, realm, can_gc);
         let opt_chan = self.webdriver_script_chan.borrow_mut().take();
         if let Some(chan) = opt_chan {
             chan.send(rv).unwrap();
         }
     }
 
-    #[allow(unsafe_code)]
-    fn WebdriverException(&self, cx: JSContext, val: HandleValue) {
-        let rv = unsafe { jsval_to_webdriver(*cx, &self.globalscope, val) };
+    fn WebdriverException(&self, cx: JSContext, val: HandleValue, realm: InRealm, can_gc: CanGc) {
+        let rv = jsval_to_webdriver(cx, &self.globalscope, val, realm, can_gc);
         let opt_chan = self.webdriver_script_chan.borrow_mut().take();
         if let Some(chan) = opt_chan {
             if let Ok(rv) = rv {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1229,6 +1229,19 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         }
     }
 
+    #[allow(unsafe_code)]
+    fn WebdriverException(&self, cx: JSContext, val: HandleValue) {
+        let rv = unsafe { jsval_to_webdriver(*cx, &self.globalscope, val) };
+        let opt_chan = self.webdriver_script_chan.borrow_mut().take();
+        if let Some(chan) = opt_chan {
+            if let Ok(rv) = rv {
+                chan.send(Err(WebDriverJSError::JSException(rv))).unwrap();
+            } else {
+                chan.send(rv).unwrap();
+            }
+        }
+    }
+
     fn WebdriverTimeout(&self) {
         let opt_chan = self.webdriver_script_chan.borrow_mut().take();
         if let Some(chan) = opt_chan {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2303,6 +2303,7 @@ impl ScriptThread {
                     node_id,
                     name,
                     reply,
+                    can_gc,
                 )
             },
             WebDriverScriptCommand::GetElementCSS(node_id, name, reply) => {

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cmp;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::CString;
 use std::ptr::NonNull;
 
@@ -183,12 +183,38 @@ unsafe fn is_arguments_object(cx: *mut JSContext, value: HandleValue) -> bool {
     jsstring_to_str(cx, class_name) == "[object Arguments]"
 }
 
+#[derive(Eq, Hash, PartialEq)]
+struct HashableJSVal(u64);
+
+impl From<HandleValue<'_>> for HashableJSVal {
+    fn from(v: HandleValue<'_>) -> HashableJSVal {
+        HashableJSVal(v.get().asBits_)
+    }
+}
+
 #[allow(unsafe_code)]
 pub(crate) unsafe fn jsval_to_webdriver(
     cx: *mut JSContext,
     global_scope: &GlobalScope,
     val: HandleValue,
 ) -> WebDriverJSResult {
+    let mut seen = HashSet::new();
+    jsval_to_webdriver_inner(cx, global_scope, val, &mut seen)
+}
+
+#[allow(unsafe_code)]
+unsafe fn jsval_to_webdriver_inner(
+    cx: *mut JSContext,
+    global_scope: &GlobalScope,
+    val: HandleValue,
+    seen: &mut HashSet<HashableJSVal>,
+) -> WebDriverJSResult {
+    let hashable = val.into();
+    if seen.contains(&hashable) {
+        return Err(WebDriverJSError::JSError);
+    }
+    seen.insert(hashable);
+
     let _ac = enter_realm(global_scope);
     if val.get().is_undefined() {
         Ok(WebDriverJSValue::Undefined)
@@ -254,9 +280,11 @@ pub(crate) unsafe fn jsval_to_webdriver(
             for i in 0..length {
                 rooted!(in(cx) let mut item = UndefinedValue());
                 match get_property_jsval(cx, object.handle(), &i.to_string(), item.handle_mut()) {
-                    Ok(_) => match jsval_to_webdriver(cx, global_scope, item.handle()) {
-                        Ok(converted_item) => result.push(converted_item),
-                        err @ Err(_) => return err,
+                    Ok(_) => {
+                        match jsval_to_webdriver_inner(cx, global_scope, item.handle(), seen) {
+                            Ok(converted_item) => result.push(converted_item),
+                            err @ Err(_) => return err,
+                        }
                     },
                     Err(error) => {
                         throw_dom_exception(
@@ -298,7 +326,7 @@ pub(crate) unsafe fn jsval_to_webdriver(
                 &HandleValueArray::empty(),
                 value.handle_mut(),
             ) {
-                jsval_to_webdriver(cx, global_scope, value.handle())
+                jsval_to_webdriver_inner(cx, global_scope, value.handle(), seen)
             } else {
                 throw_dom_exception(
                     SafeJSContext::from_ptr(cx),
@@ -349,7 +377,9 @@ pub(crate) unsafe fn jsval_to_webdriver(
                         return Err(WebDriverJSError::JSError);
                     };
 
-                    if let Ok(value) = jsval_to_webdriver(cx, global_scope, property.handle()) {
+                    if let Ok(value) =
+                        jsval_to_webdriver_inner(cx, global_scope, property.handle(), seen)
+                    {
                         result.insert(name.into(), value);
                     } else {
                         return Err(WebDriverJSError::JSError);
@@ -421,9 +451,7 @@ pub(crate) fn handle_execute_async_script(
                 global_scope.api_base_url(),
                 can_gc,
             ) {
-                reply_sender
-                    .send(Err(WebDriverJSError::JSError))
-                    .unwrap();
+                reply_sender.send(Err(WebDriverJSError::JSError)).unwrap();
             }
         },
         None => {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -642,8 +642,8 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['Stop', 'Fetch', 'Scroll', 'Scroll_','ScrollBy', 'ScrollBy_', 'Stop', 'Fetch', 'Open', 'CreateImageBitmap', 'TrustedTypes'],
-    'inRealms': ['Fetch', 'GetOpener'],
+    'canGc': ['Stop', 'Fetch', 'Scroll', 'Scroll_','ScrollBy', 'ScrollBy_', 'Stop', 'Fetch', 'Open', 'CreateImageBitmap', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException'],
+    'inRealms': ['Fetch', 'GetOpener', 'WebdriverCallback', 'WebdriverException'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
 },
 

--- a/components/script_bindings/webidls/Window.webidl
+++ b/components/script_bindings/webidls/Window.webidl
@@ -148,6 +148,7 @@ partial interface Window {
 partial interface Window {
   // Shouldn't be public, but just to make things work for now
   undefined webdriverCallback(optional any result);
+  undefined webdriverException(optional any result);
   undefined webdriverTimeout();
 };
 

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -170,6 +170,7 @@ pub enum WebDriverJSError {
     /// Occurs when handler received an event message for a layout channel that is not
     /// associated with the current script thread
     BrowsingContextNotFound,
+    JSException(WebDriverJSValue),
     JSError,
     StaleElementReference,
     Timeout,


### PR DESCRIPTION
Improving the accuracy of the async script execution for our webdriver implementation allows us to run many more webdriver tests without timeouts, which should help with https://github.com/web-platform-tests/wpt/issues/24257.

Specification:
* https://w3c.github.io/webdriver/#dfn-clone-an-object
* https://w3c.github.io/webdriver/#execute-async-script

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27036 and fix #27035 and fix #27031.
- [x] There are tests for these changes (but we don't run them in CI yet)