### PR TITLE
Document a GStreamer plugin workaround

### DIFF
--- a/ports/gstplugin/README.md
+++ b/ports/gstplugin/README.md
@@ -111,6 +111,18 @@ You may need to include other directories on the plugin search path, e.g. Servo'
 GST_PLUGIN_PATH=$PWD/target/gstplugins/:$PWD/support/linux/gstreamer/gst/lib
 ```
 
+If you get complaints `could not get/set settings from/on resource.` right after finding a GL context then try `tee`-ing to `glimagesink` and `gldownload`:
+```
+LD_PRELOAD=$PWD/target/gstplugins/libgstservoplugin.so \
+GST_PLUGIN_PATH=target/gstplugins \
+  gst-launch-1.0 servowebsrc \
+    ! video/x-raw\(memory:GLMemory\),framerate=50/1,width=512,height=256 \
+    !  tee name=t \
+ t. ! queue ! glimagesink 
+ t. ! queue ! glcolorconvert ! gldownload ! theoraenc ! oggmux ! filesink location=test.ogg
+```
+
+
 Under X11 you may get complaints about X11 threads not being initialized:
 ```
 GST_GL_XINITTHREADS=1


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Based on conversation in Issue #27013 this documents a workaround in the gstreamer CLI for a failure of the GStreamer plugin to find usable a GL context without a downstream glimagesink  

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's a document change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
