### PR TITLE
Implement Console grouping APIs.

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -289,6 +289,9 @@ pub struct GlobalScope {
 
     /// currect https state (from previous request)
     https_state: Cell<HttpsState>,
+
+    /// The stack of active group labels for the Console APIs.
+    console_group_stack: DomRefCell<Vec<DOMString>>,
 }
 
 /// A wrapper for glue-code between the ipc router and the event-loop.
@@ -738,6 +741,7 @@ impl GlobalScope {
             gpu_id_hub,
             frozen_supported_performance_entry_types: DomRefCell::new(Default::default()),
             https_state: Cell::new(HttpsState::None),
+            console_group_stack: DomRefCell::new(Vec::new()),
         }
     }
 
@@ -2907,6 +2911,21 @@ impl GlobalScope {
 
     pub fn wgpu_id_hub(&self) -> Arc<Mutex<Identities>> {
         self.gpu_id_hub.clone()
+    }
+
+    pub(crate) fn current_group_label(&self) -> Option<DOMString> {
+        self.console_group_stack
+            .borrow()
+            .last()
+            .map(|label| DOMString::from(format!("[{}]", label)))
+    }
+
+    pub(crate) fn push_console_group(&self, group: DOMString) {
+        self.console_group_stack.borrow_mut().push(group);
+    }
+
+    pub(crate) fn pop_console_group(&self) {
+        let _ = self.console_group_stack.borrow_mut().pop();
     }
 }
 

--- a/components/script/dom/webidls/Console.webidl
+++ b/components/script/dom/webidls/Console.webidl
@@ -1,25 +1,27 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-/*
- * References:
- *   MDN Docs - https://developer.mozilla.org/en-US/docs/Web/API/console
- *   Draft Spec - https://sideshowbarker.github.io/console-spec/
- *
- * © Copyright 2014 Mozilla Foundation.
- */
+
+// https://console.spec.whatwg.org/
 
 [ClassString="Console",
  Exposed=(Window,Worker,Worklet),
  ProtoObjectHack]
 namespace console {
-  // These should be DOMString message, DOMString message2, ...
+  // Logging
   void log(DOMString... messages);
   void debug(DOMString... messages);
   void info(DOMString... messages);
   void warn(DOMString... messages);
   void error(DOMString... messages);
   void assert(boolean condition, optional DOMString message);
+
+  // Grouping
+  void group(DOMString... data);
+  void groupCollapsed(DOMString... data);
+  void groupEnd();
+
+  // Timing
   void time(DOMString message);
   void timeEnd(DOMString message);
 };

--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -90,6 +90,7 @@ WEBIDL_STANDARDS = [
     b"//drafts.csswg.org",
     b"//drafts.css-houdini.org",
     b"//drafts.fxtf.org",
+    b"//console.spec.whatwg.org",
     b"//encoding.spec.whatwg.org",
     b"//fetch.spec.whatwg.org",
     b"//html.spec.whatwg.org",


### PR DESCRIPTION
These are used by Hubs and other sites we want to run.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #9274
- [x] These changes do not require tests because we can't test stdout content or devtools messages.