### PR TITLE
Implement HTMLFormElement.requestSubmit()

### DIFF
--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -77,6 +77,11 @@ impl HTMLButtonElement {
             document,
         )
     }
+
+    #[inline]
+    pub fn is_submit_button(&self) -> bool {
+        self.button_type.get() == ButtonType::Submit
+    }
 }
 
 impl HTMLButtonElementMethods for HTMLButtonElement {

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -405,6 +405,12 @@ impl HTMLInputElement {
         self.input_type.get()
     }
 
+    #[inline]
+    pub fn is_submit_button(&self) -> bool {
+        let input_type = self.input_type.get();
+        input_type == InputType::Submit || input_type == InputType::Image
+    }
+
     pub fn disable_sanitization(&self) {
         self.sanitization_flag.set(false);
     }

--- a/components/script/dom/webidls/HTMLFormElement.webidl
+++ b/components/script/dom/webidls/HTMLFormElement.webidl
@@ -32,6 +32,7 @@ interface HTMLFormElement : HTMLElement {
   getter (RadioNodeList or Element) (DOMString name);
 
   void submit();
+  [Throws] void requestSubmit(optional HTMLElement? submitter = null);
   [CEReactions]
   void reset();
   boolean checkValidity();

--- a/tests/wpt/metadata-layout-2020/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/metadata-layout-2020/html/dom/idlharness.https.html.ini
@@ -1650,9 +1650,6 @@
 
 
 [idlharness.https.html?include=HTML.*]
-  [HTMLFormElement interface: calling requestSubmit(optional HTMLElement?) on document.createElement("form") with too few arguments must throw TypeError]
-    expected: FAIL
-
   [HTMLTableSectionElement interface: document.createElement("tfoot") must inherit property "align" with the proper type]
     expected: FAIL
 
@@ -2305,9 +2302,6 @@
     expected: FAIL
 
   [HTMLObjectElement interface: document.createElement("object") must inherit property "archive" with the proper type]
-    expected: FAIL
-
-  [HTMLFormElement interface: operation requestSubmit(optional HTMLElement?)]
     expected: FAIL
 
   [HTMLTableColElement interface: document.createElement("col") must inherit property "chOff" with the proper type]

--- a/tests/wpt/metadata/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/metadata/html/dom/idlharness.https.html.ini
@@ -3621,9 +3621,6 @@
   [HTMLAreaElement interface: document.createElement("area") must inherit property "download" with the proper type]
     expected: FAIL
 
-  [HTMLFormElement interface: calling requestSubmit(HTMLElement) on document.createElement("form") with too few arguments must throw TypeError]
-    expected: FAIL
-
   [HTMLProgressElement interface: attribute value]
     expected: FAIL
 
@@ -3711,9 +3708,6 @@
   [HTMLImageElement interface: document.createElement("img") must inherit property "loading" with the proper type]
     expected: FAIL
 
-  [HTMLFormElement interface: calling requestSubmit(optional HTMLElement?) on document.createElement("form") with too few arguments must throw TypeError]
-    expected: FAIL
-
   [HTMLSlotElement interface: calling assignedNodes(optional AssignedNodesOptions) on document.createElement("slot") with too few arguments must throw TypeError]
     expected: FAIL
 
@@ -3732,16 +3726,10 @@
   [HTMLAllCollection interface: document.all must inherit property "item(optional DOMString)" with the proper type]
     expected: FAIL
 
-  [HTMLFormElement interface: operation requestSubmit(optional HTMLElement?)]
-    expected: FAIL
-
   [HTMLAllCollection interface: calling item(optional DOMString) on document.all with too few arguments must throw TypeError]
     expected: FAIL
 
   [HTMLAllCollection interface: operation item(optional DOMString)]
-    expected: FAIL
-
-  [HTMLFormElement interface: document.createElement("form") must inherit property "requestSubmit(optional HTMLElement?)" with the proper type]
     expected: FAIL
 
   [HTMLCanvasElement interface: document.createElement("canvas") must inherit property "toBlob(BlobCallback, optional DOMString, optional any)" with the proper type]

--- a/tests/wpt/metadata/html/semantics/forms/form-submission-0/form-submission-algorithm.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/form-submission-0/form-submission-algorithm.html.ini
@@ -1,19 +1,3 @@
 [form-submission-algorithm.html]
-  [If form's firing submission events is true, then return; 'invalid' event]
-    expected: FAIL
-
-  [firing an event named submit; form.requestSubmit(submitter)]
-    expected: FAIL
-
-  [firing an event named submit; form.requestSubmit(null)]
-    expected: FAIL
-
-  [firing an event named submit; form.requestSubmit()]
-    expected: FAIL
-
   [Submission URL should always have a non-null query part]
     expected: FAIL
-
-  [If firing submission events flag of form is true, then return]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/semantics/forms/the-form-element/form-requestsubmit.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/the-form-element/form-requestsubmit.html.ini
@@ -1,22 +1,6 @@
 [form-requestsubmit.html]
-  [requestSubmit() doesn't run interactive validation reentrantly]
-    expected: FAIL
-
   [The value of the submitter should be appended, and form* attributes of the submitter should be handled.]
-    expected: FAIL
-
-  [Passing a submit button not owned by the context object should throw]
-    expected: FAIL
-
-  [requestSubmit() for a disconnected form should not submit the form]
     expected: FAIL
 
   [requestSubmit() should trigger interactive form validation]
     expected: FAIL
-
-  [requestSubmit() doesn't run form submission reentrantly]
-    expected: FAIL
-
-  [requestSubmit() should accept button[type=submit\], input[type=submit\], and input[type=image\]]
-    expected: FAIL
-


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR contains an implementation of [HTMLFormElement.requestSubmit()](https://html.spec.whatwg.org/multipage/forms.html#dom-form-requestsubmit)

This is literally my first hundred lines of Rust code, so if I crossed a few sacred lines here and there, please go easy on me :)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #23417

<!-- Either: -->
- [x] [WPT tests](https://github.com/servo/servo/blob/master/tests/wpt/web-platform-tests/html/semantics/forms/the-form-element/form-requestsubmit.html) for these changes
There are two tests that still fail because we don't support `:invalid` CSS selector (see #10781). I verified that they pass if you change them to not use `:invalid`. Should be unlocked by #26729.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
