### PR TITLE
Return Option for Window's layout channel

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13361,6 +13361,13 @@
       {}
      ]
     ],
+    "detached_layout.html": [
+     "b9fe090cc29c147f493732327e36b06702c4f846",
+     [
+      null,
+      {}
+     ]
+    ],
     "deterministic-raf.html": [
      "441664829a14379ebc92306f42ab0bad6581257e",
      [

--- a/tests/wpt/mozilla/tests/mozilla/detached_layout.html
+++ b/tests/wpt/mozilla/tests/mozilla/detached_layout.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Detached layout doesn't panic</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe></iframe>
+<script>
+    setup({ single_test: true });
+
+    var i = document.querySelector('iframe');
+    var d = i.contentDocument;
+    var e = d.createElement('div');
+    d.body.appendChild(e);
+    i.remove();
+
+    setTimeout(function () {
+        let r = e.getBoundingClientRect();
+        assert_equals(r.width, 0, "rectangle should be zero-sized");
+        assert_equals(r.height, 0, "rectangle should be zero-sized");
+
+        done();
+    }, 10);
+</script>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

`Window::layout_chan()` now returns an `Option<Sender<Msg>>`, returning `None` if the window is dead.

FIX #26969 
FIX #26429 
FIX #21208
FIX #19092
FIX #22559
FIX #22584
FIX #22652

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #23053 

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

This is my first contribution, I'm trying to figure things out!

This fix passes the test case shown in #23053, however I don't know what the behavior should be in `Document` and `ScriptThread` if `Window::is_alive()` is false : simply ignore it, don't do anything ? Or is this something that should not happen now that we return false in `Window::force_reflow()` ?

I'm not sure about the directory where the test case should go, any advice?