### PR TITLE
Add stub isContextLost API.

### DIFF
--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -1119,6 +1119,11 @@ impl WebGL2RenderingContextMethods for WebGL2RenderingContext {
         self.base.GetContextAttributes()
     }
 
+    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.13
+    fn IsContextLost(&self) -> bool {
+        self.base.IsContextLost()
+    }
+
     /// https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14
     fn GetSupportedExtensions(&self) -> Option<Vec<DOMString>> {
         self.base.GetSupportedExtensions()

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -2319,6 +2319,11 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
         })
     }
 
+    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.13
+    fn IsContextLost(&self) -> bool {
+        false
+    }
+
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14
     fn GetSupportedExtensions(&self) -> Option<Vec<DOMString>> {
         self.extension_manager

--- a/components/script/dom/webidls/WebGLRenderingContext.webidl
+++ b/components/script/dom/webidls/WebGLRenderingContext.webidl
@@ -470,8 +470,7 @@ interface mixin WebGLRenderingContextBase
     readonly attribute GLsizei drawingBufferHeight;
 
     [WebGLHandlesContextLoss] WebGLContextAttributes? getContextAttributes();
-    // FIXME: https://github.com/servo/servo/issues/15266
-    // [WebGLHandlesContextLoss] boolean isContextLost();
+    [WebGLHandlesContextLoss] boolean isContextLost();
 
     sequence<DOMString>? getSupportedExtensions();
     object? getExtension(DOMString name);

--- a/tests/wpt/webgl/meta/conformance/context/context-lost.html.ini
+++ b/tests/wpt/webgl/meta/conformance/context/context-lost.html.ini
@@ -1,5 +1,0 @@
-[context-lost.html]
-  bug: https://github.com/servo/servo/issues/15266
-  [WebGL test #0: gl.isContextLost() should be false. Threw exception TypeError: gl.isContextLost is not a function]
-    expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance/context/methods.html.ini
+++ b/tests/wpt/webgl/meta/conformance/context/methods.html.ini
@@ -1,7 +1,4 @@
 [methods.html]
-  bug: https://github.com/servo/servo/issues/15266
-  [WebGL test #0: Property either does not exist or is not a function: isContextLost]
-    expected: FAIL
   [WebGL test #1: Also found the following extra methods:]
     expected: FAIL
   [WebGL test #2: makeXRCompatible]

--- a/tests/wpt/webgl/meta/conformance/more/conformance/methods.html.ini
+++ b/tests/wpt/webgl/meta/conformance/more/conformance/methods.html.ini
@@ -1,5 +1,0 @@
-[methods.html]
-  bug: https://github.com/servo/servo/issues/15266
-  [WebGL test #0: testOES20Methods]
-    expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/context/methods-2.html.ini
@@ -1,22 +1,19 @@
 [methods-2.html]
-  [WebGL test #1: Property either does not exist or is not a function: blitFramebuffer]
+  [WebGL test #0: Property either does not exist or is not a function: blitFramebuffer]
     expected: FAIL
 
-  [WebGL test #4: Property either does not exist or is not a function: copyTexSubImage3D]
+  [WebGL test #3: Property either does not exist or is not a function: copyTexSubImage3D]
     expected: FAIL
 
-  [WebGL test #5: Property either does not exist or is not a function: compressedTexImage3D]
+  [WebGL test #4: Property either does not exist or is not a function: compressedTexImage3D]
     expected: FAIL
 
-  [WebGL test #2: Property either does not exist or is not a function: texImage3D]
+  [WebGL test #1: Property either does not exist or is not a function: texImage3D]
     expected: FAIL
 
-  [WebGL test #3: Property either does not exist or is not a function: texSubImage3D]
+  [WebGL test #2: Property either does not exist or is not a function: texSubImage3D]
     expected: FAIL
 
-  [WebGL test #6: Property either does not exist or is not a function: compressedTexSubImage3D]
-    expected: FAIL
-
-  [WebGL test #0: Property either does not exist or is not a function: isContextLost]
+  [WebGL test #5: Property either does not exist or is not a function: compressedTexSubImage3D]
     expected: FAIL
 


### PR DESCRIPTION
We don't support losing contexts yet, so it's not lying to say that the context is never lost.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27116
- [x] There are tests for these changes