### PR TITLE
Mach test cargo target dir

### DIFF
--- a/tests/wpt/run.py
+++ b/tests/wpt/run.py
@@ -4,6 +4,7 @@
 
 import multiprocessing
 import os
+from os import path
 import sys
 import mozlog
 import grouping_formatter
@@ -72,7 +73,10 @@ def set_defaults(kwargs):
         bin_name = "servo"
         if sys.platform == "win32":
             bin_name += ".exe"
-        bin_path = servo_path("target", bin_dir, bin_name)
+        if "CARGO_TARGET_DIR" in os.environ:
+            bin_path = path.join(os.environ["CARGO_TARGET_DIR"], bin_dir, bin_name)
+        else:
+            bin_path = servo_path("target", bin_dir, bin_name)
 
         kwargs["binary"] = bin_path
         kwargs["webdriver_binary"] = bin_path


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because they're about tooling

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

This change allows launching tests this way:

```sh
CARGO_TARGET_DIR=other-dir ./mach test-wpt ...
```

The build and check commands already check for the presence of the `CARGO_TARGET_DIR` variable, but that wasn't the case for wpt tests. This resulted in an error about the `servo` executable not being found in `target/debug/servo`.