### PR TITLE
Do not fire `invalid` event on form elements

### DIFF
--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -673,8 +673,6 @@ impl HTMLFormElement {
             // Step 6.3
             if !submitter.no_validate(self) {
                 if self.interactive_validation().is_err() {
-                    // TODO: Implement event handlers on all form control elements
-                    self.upcast::<EventTarget>().fire_event(atom!("invalid"));
                     self.firing_submission_events.set(false);
                     return;
                 }

--- a/tests/wpt/metadata/html/semantics/forms/form-submission-0/historical.window.js.ini
+++ b/tests/wpt/metadata/html/semantics/forms/form-submission-0/historical.window.js.ini
@@ -1,4 +1,0 @@
-[historical.window.html]
-  [invalid event is only supported for form controls]
-    expected: FAIL
-


### PR DESCRIPTION
This is a follow-up to my [previous PR](https://github.com/servo/servo/pull/27100) suggested by @gterzian.

`invalid` event on the `<form>` element has been [recently removed](https://github.com/whatwg/html/issues/4626) from the spec.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27133

<!-- Either: -->
- [x] [WPT test](https://github.com/servo/servo/blob/master/tests/wpt/web-platform-tests/html/semantics/forms/form-submission-0/historical.window.js) marked as passing
