### PR TITLE
UWP: allow servo's initial URL to be set before Servo starts

### DIFF
--- a/support/hololens/ServoApp/DefaultUrl.h
+++ b/support/hololens/ServoApp/DefaultUrl.h
@@ -4,5 +4,5 @@
 
 // For development purpose.
 // Will override DEFAULT_URL_PROD or any locally stored preferences.
-// #define OVERRIDE_DEFAULT_URL "data:text/html,<input>"
-// #define OVERRIDE_DEFAULT_URL "http://localhost:8000/test.html"
+// #define OVERRIDE_DEFAULT_URL L"data:text/html,<input>"
+// #define OVERRIDE_DEFAULT_URL L"http://localhost:8000/test.html"

--- a/support/hololens/ServoApp/ServoControl/Servo.h
+++ b/support/hololens/ServoApp/ServoControl/Servo.h
@@ -26,7 +26,8 @@ class ServoDelegate;
 
 class Servo {
 public:
-  Servo(hstring, GLsizei, GLsizei, EGLNativeWindowType, float, ServoDelegate &);
+  Servo(std::optional<hstring>, hstring, GLsizei, GLsizei, EGLNativeWindowType,
+        float, ServoDelegate &);
   ~Servo();
   ServoDelegate &Delegate() { return mDelegate; }
 

--- a/support/hololens/ServoApp/ServoControl/ServoControl.cpp
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.cpp
@@ -379,6 +379,8 @@ void ServoControl::TryLoadUri(hstring input) {
         });
       }
     });
+  } else {
+    mInitUrl = input;
   }
 }
 
@@ -398,8 +400,8 @@ void ServoControl::Loop() {
     log(L"Entering loop");
     ServoDelegate *sd = static_cast<ServoDelegate *>(this);
     EGLNativeWindowType win = GetNativeWindow();
-    mServo = std::make_unique<Servo>(mArgs, mPanelWidth, mPanelHeight, win,
-                                     mDPI, *sd);
+    mServo = std::make_unique<Servo>(mInitUrl, mArgs, mPanelWidth, mPanelHeight,
+                                     win, mDPI, *sd);
   } else {
     // FIXME: this will fail since create_task didn't pick the thread
     // where Servo was running initially.

--- a/support/hololens/ServoApp/ServoControl/ServoControl.h
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.h
@@ -217,6 +217,7 @@ private:
   float mDPI = 1;
   hstring mCurrentUrl = L"";
   bool mTransient = false;
+  std::optional<hstring> mInitUrl = {};
 
   Windows::UI::Xaml::Controls::SwapChainPanel ServoControl::Panel();
   void CreateNativeWindow();


### PR DESCRIPTION
Fix #27165 