### PR TITLE
Remove segfaults in WebGPU threads

### DIFF
--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -24,7 +24,7 @@ use euclid::default::Size2D;
 use ipc_channel::ipc;
 use script_layout_interface::HTMLCanvasDataSource;
 use std::cell::Cell;
-use webgpu::{wgpu::id, wgt, WebGPU, WebGPURequest};
+use webgpu::{wgpu::id, wgt, WebGPU, WebGPURequest, PRESENTATION_BUFFER_COUNT};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, MallocSizeOf, Ord, PartialEq, PartialOrd)]
 pub struct WebGPUContextId(pub u64);
@@ -130,8 +130,8 @@ impl GPUCanvasContextMethods for GPUCanvasContext {
         }
         *self.swap_chain.borrow_mut() = None;
 
-        let mut buffer_ids = ArrayVec::<[id::BufferId; 5]>::new();
-        for _ in 0..5 {
+        let mut buffer_ids = ArrayVec::<[id::BufferId; PRESENTATION_BUFFER_COUNT]>::new();
+        for _ in 0..PRESENTATION_BUFFER_COUNT {
             buffer_ids.push(
                 self.global()
                     .wgpu_id_hub()


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I have also increased the number of staging buffers for presentation.
Segfault occurred at 2 places-
1. RenderPipeline descriptor.
2. BufferMapAsync callback.

r?@kvark

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
