### PR TITLE
Add a sessionavailable event that allows content to enter an XR session without a user gesture

### DIFF
--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -115,6 +115,7 @@ selectend
 selectionchange
 selectstart
 serif
+sessionavailable
 signalingstatechange
 squeeze
 squeezeend

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -281,7 +281,8 @@ mod gen {
                     },
                     layers: {
                         enabled: bool,
-                    }
+                    },
+                    sessionavailable: bool,
                 },
                 worklet: {
                     blockingsleep: {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -17,6 +17,7 @@ use crate::dom::bindings::codegen::Bindings::EventBinding::EventBinding::EventMe
 use crate::dom::bindings::codegen::Bindings::HTMLIFrameElementBinding::HTMLIFrameElementBinding::HTMLIFrameElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLInputElementBinding::HTMLInputElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLTextAreaElementBinding::HTMLTextAreaElementMethods;
+use crate::dom::bindings::codegen::Bindings::NavigatorBinding::NavigatorBinding::NavigatorMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::codegen::Bindings::NodeFilterBinding::NodeFilter;
 use crate::dom::bindings::codegen::Bindings::PerformanceBinding::PerformanceMethods;
@@ -2266,6 +2267,17 @@ impl Document {
 
         // Step 11.
         // TODO: ready for post-load tasks.
+
+        // The dom.webxr.sessionavailable pref allows webxr
+        // content to immediately begin a session without waiting for a user gesture.
+        // TODO: should this only happen on the first document loaded?
+        // https://immersive-web.github.io/webxr/#user-intention
+        // https://github.com/immersive-web/navigation/issues/10
+        if pref!(dom.webxr.sessionavailable) {
+            if self.window.is_top_level() {
+                self.window.Navigator().Xr().dispatch_sessionavailable();
+            }
+        }
 
         // Step 12: completely loaded.
         // https://html.spec.whatwg.org/multipage/#completely-loaded

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -41,6 +41,7 @@
   "dom.webxr.glwindow.spherical": false,
   "dom.webxr.hands.enabled": false,
   "dom.webxr.layers.enabled": false,
+  "dom.webxr.sessionavailable": false,
   "dom.webxr.test": false,
   "dom.worklet.timeout_ms": 10,
   "gfx.subpixel-text-antialiasing.enabled": true,

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14731,6 +14731,13 @@
       null,
       {}
      ]
+    ],
+    "sessionavailable.html": [
+     "dd9a071d05c4d696471be87428c12cea573cba60",
+     [
+      null,
+      {}
+     ]
     ]
    }
   }

--- a/tests/wpt/mozilla/meta/webxr/sessionavailable.html.ini
+++ b/tests/wpt/mozilla/meta/webxr/sessionavailable.html.ini
@@ -1,0 +1,2 @@
+prefs: [dom.webxr.sessionavailable:true]
+

--- a/tests/wpt/mozilla/tests/webxr/sessionavailable.html
+++ b/tests/wpt/mozilla/tests/webxr/sessionavailable.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<body>
+  <script src=/resources/testharness.js></script>
+  <script src=/resources/testharnessreport.js></script>
+  <script src="./resources/webxr-util.js"></script>
+  <script>
+    navigator.xr.test.simulateDeviceConnection({
+      supportedModes: ["immersive-vr"],
+      views: TEST_VIEWS,
+    });
+    async_test((t) => {
+      navigator.xr.addEventListener("sessionavailable", (evt) => {
+        navigator.xr.requestSession("immersive-vr")
+          .then((session) => {
+            t.done();
+          })
+      });
+    }, "Requesting immersive session in a sessionavailable handler should succeed");
+  </script>
+</body>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This allows servo to implement immersive web apps. https://immersive-web.github.io/webxr/#application-launch

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because I'm not sure we should have a WPT for something this non-standard.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
