### PR TITLE
Use `Rc` instead of cloning the `DOMString`

### DIFF
--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -651,7 +651,7 @@ impl HTMLScriptElement {
 
                     fetch_inline_module_script(
                         ModuleOwner::Window(Trusted::new(self)),
-                        Rc::clone(&text_rc),
+                        text_rc,
                         base_url.clone(),
                         self.id.clone(),
                         credentials_mode.unwrap(),

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -613,9 +613,11 @@ impl HTMLScriptElement {
             // Step 25.
             assert!(!text.is_empty());
 
+            let text_rc = Rc::new(text);
+
             // Step 25-1. & 25-2.
             let result = Ok(ScriptOrigin::internal(
-                Rc::new(text.clone()),
+                Rc::clone(&text_rc),
                 base_url.clone(),
                 script_type.clone(),
             ));
@@ -649,7 +651,7 @@ impl HTMLScriptElement {
 
                     fetch_inline_module_script(
                         ModuleOwner::Window(Trusted::new(self)),
-                        Rc::new(text.clone()),
+                        Rc::clone(&text_rc),
                         base_url.clone(),
                         self.id.clone(),
                         credentials_mode.unwrap(),


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
I changed the `text` field of `ScriptOrigin` from a `DOMString` to an `Rc<DOMString>`. Then I updated all the related code to work with an `Rc`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27254 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because this doesn't introduce new code and should only need to be checked by the compiler

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
