### PR TITLE
Implemented get element target algorithm

### DIFF
--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -31,6 +31,7 @@ use crate::dom::file::File;
 use crate::dom::formdata::FormData;
 use crate::dom::formdataevent::FormDataEvent;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::htmlanchorelement::{get_element_noopener, get_element_target};
 use crate::dom::htmlbuttonelement::HTMLButtonElement;
 use crate::dom::htmlcollection::CollectionFilter;
 use crate::dom::htmldatalistelement::HTMLDataListElement;
@@ -576,12 +577,12 @@ impl HTMLFormElementMethods for HTMLFormElement {
         return names_vec;
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-form-checkvalidity
+    /// https://html.spec.whatwg.org/multipage/#dom-form-checkvalidity
     fn CheckValidity(&self) -> bool {
         self.static_validation().is_ok()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-form-reportvalidity
+    /// https://html.spec.whatwg.org/multipage/#dom-form-reportvalidity
     fn ReportValidity(&self) -> bool {
         self.interactive_validation().is_ok()
     }
@@ -746,10 +747,26 @@ impl HTMLFormElement {
         let enctype = submitter.enctype();
         let method = submitter.method();
 
-        // Step 17-21
-        let target_attribute_value = submitter.target();
+        // Step 17
+        let target_attribute_value =
+            if submitter.is_submit_button() && submitter.target() != DOMString::new() {
+                Some(submitter.target())
+            } else {
+                let form_owner = submitter.form_owner();
+                let form = form_owner.as_ref().map(|form| &**form).unwrap_or(self);
+                get_element_target(form.upcast::<Element>())
+            };
+
+        // Step 18
+        let noopener =
+            get_element_noopener(self.upcast::<Element>(), target_attribute_value.clone());
+
+        // Step 19
         let source = doc.browsing_context().unwrap();
-        let (maybe_chosen, _new) = source.choose_browsing_context(target_attribute_value, false);
+        let (maybe_chosen, _new) = source
+            .choose_browsing_context(target_attribute_value.unwrap_or(DOMString::new()), noopener);
+
+        // Step 20
         let chosen = match maybe_chosen {
             Some(proxy) => proxy,
             None => return,
@@ -758,6 +775,7 @@ impl HTMLFormElement {
             Some(doc) => doc,
             None => return,
         };
+        // Step 21
         let target_window = target_document.window();
         let mut load_data = LoadData::new(
             LoadOrigin::Script(doc.origin().immutable().clone()),

--- a/tests/wpt/metadata/css/CSS2/linebox/inline-negative-margin-001.html.ini
+++ b/tests/wpt/metadata/css/CSS2/linebox/inline-negative-margin-001.html.ini
@@ -8,6 +8,9 @@
   [[data-expected-height\] 3]
     expected: FAIL
 
-  [[data-expected-height\] 4]
+  [[data-expected-height\] 1]
+    expected: FAIL
+
+  [[data-expected-height\] 2]
     expected: FAIL
 

--- a/tests/wpt/metadata/fetch/nosniff/parsing-nosniff.window.js.ini
+++ b/tests/wpt/metadata/fetch/nosniff/parsing-nosniff.window.js.ini
@@ -11,6 +11,3 @@
   [X-Content-Type-Options%3A%20nosniff%2C%2C%40%23%24%23%25%25%26%5E%26%5E*()()11!]
     expected: FAIL
 
-  [X-Content-Type-Options%3A%20%2Cnosniff]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/browsers/windows/auxiliary-browsing-contexts/opener-closed.html.ini
+++ b/tests/wpt/metadata/html/browsers/windows/auxiliary-browsing-contexts/opener-closed.html.ini
@@ -1,0 +1,5 @@
+[opener-closed.html]
+  expected: TIMEOUT
+  [An auxiliary browsing context should report `null` for `window.opener` when that browsing context is discarded]
+    expected: TIMEOUT
+

--- a/tests/wpt/metadata/html/browsers/windows/browsing-context-names/choose-_blank-003.html.ini
+++ b/tests/wpt/metadata/html/browsers/windows/browsing-context-names/choose-_blank-003.html.ini
@@ -1,0 +1,3 @@
+[choose-_blank-003.html]
+  [Context created by link targeting "_blank" should retain opener reference]
+    expected: FAIL

--- a/tests/wpt/metadata/html/semantics/forms/form-submission-target/rel-button-target.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/form-submission-target/rel-button-target.html.ini
@@ -2,19 +2,10 @@
   [<form rel="opener noopener"> with <button formtarget>]
     expected: FAIL
 
-  [<form rel="noopener noreferrer"> with <button formtarget>]
-    expected: FAIL
-
   [<form rel=""> with <button formtarget>]
     expected: FAIL
 
-  [<form rel="noreferrer opener"> with <button formtarget>]
-    expected: FAIL
-
   [<form rel="noopener"> with <button formtarget>]
-    expected: FAIL
-
-  [<form rel="noreferrer"> with <button formtarget>]
     expected: FAIL
 
   [<form rel="opener"> with <button formtarget>]

--- a/tests/wpt/metadata/html/semantics/forms/form-submission-target/rel-form-target.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/form-submission-target/rel-form-target.html.ini
@@ -1,13 +1,4 @@
 [rel-form-target.html]
-  [<form rel="noopener noreferrer"> with <form target>]
-    expected: FAIL
-
-  [<form rel="noreferrer opener"> with <form target>]
-    expected: FAIL
-
-  [<form rel="noreferrer"> with <form target>]
-    expected: FAIL
-
   [<form rel="opener noopener"> with <form target>]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/forms/form-submission-target/rel-input-target.html.ini
+++ b/tests/wpt/metadata/html/semantics/forms/form-submission-target/rel-input-target.html.ini
@@ -8,15 +8,6 @@
   [<form rel=""> with <input formtarget>]
     expected: FAIL
 
-  [<form rel="noreferrer opener"> with <input formtarget>]
-    expected: FAIL
-
-  [<form rel="noopener noreferrer"> with <input formtarget>]
-    expected: FAIL
-
-  [<form rel="noreferrer"> with <input formtarget>]
-    expected: FAIL
-
   [<form rel="noopener"> with <input formtarget>]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_noopener.html.ini
+++ b/tests/wpt/metadata/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_noopener.html.ini
@@ -3,15 +3,9 @@
   [Check that targeting of rel=noopener with a given name ignores an existing window with that name]
     expected: NOTRUN
 
-  [Check that rel=noopener with target=_parent does a normal load]
-    expected: FAIL
-
   [Check that targeting of rel=noopener with a given name reuses an existing window with that name]
     expected: FAIL
 
   [Check that rel=noopener with target=_top does a normal load]
-    expected: FAIL
-
-  [Check that rel=noopener with target=_self does a normal load]
     expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/links/links-created-by-a-and-area-elements/target_blank_implicit_noopener.html.ini
+++ b/tests/wpt/metadata/html/semantics/links/links-created-by-a-and-area-elements/target_blank_implicit_noopener.html.ini
@@ -9,9 +9,6 @@
   [Area element with target=_blank with rel=opener]
     expected: TIMEOUT
 
-  [Anchor element with target=_blank with implicit rel=noopener]
-    expected: FAIL
-
   [Area element with target=_blank with implicit rel=noopener]
     expected: TIMEOUT
 


### PR DESCRIPTION
Added check for area and anchor element

Finished issue: Implemented get target and no opener algorithm

Implemented get element target and get element noopener algorithms.

<!-- Please describe your changes on the following line: -->
Used the algorithms in html spec to implement target and no opener algorithms.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #27253 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
