### PR TITLE
Use `asynch` instead of `r#async`

### DIFF
--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -400,9 +400,9 @@ impl HTMLScriptElement {
 
         // Step 3.
         let element = self.upcast::<Element>();
-        let r#async = element.has_attribute(&local_name!("async"));
+        let asynch = element.has_attribute(&local_name!("async"));
         // Note: confusingly, this is done if the element does *not* have an "async" attribute.
-        if was_parser_inserted && !r#async {
+        if was_parser_inserted && !asynch {
             self.non_blocking.set(true);
         }
 
@@ -554,14 +554,14 @@ impl HTMLScriptElement {
                     // Preparation for step 26.
                     let kind = if element.has_attribute(&local_name!("defer")) &&
                         was_parser_inserted &&
-                        !r#async
+                        !asynch
                     {
                         // Step 26.a: classic, has src, has defer, was parser-inserted, is not async.
                         ExternalScriptKind::Deferred
-                    } else if was_parser_inserted && !r#async {
+                    } else if was_parser_inserted && !asynch {
                         // Step 26.c: classic, has src, was parser-inserted, is not async.
                         ExternalScriptKind::ParsingBlocking
-                    } else if !r#async && !self.non_blocking.get() {
+                    } else if !asynch && !self.non_blocking.get() {
                         // Step 26.d: classic, has src, is not async, is not non-blocking.
                         ExternalScriptKind::AsapInOrder
                     } else {
@@ -598,9 +598,9 @@ impl HTMLScriptElement {
                         credentials_mode.unwrap(),
                     );
 
-                    if !r#async && was_parser_inserted {
+                    if !asynch && was_parser_inserted {
                         doc.add_deferred_script(self);
-                    } else if !r#async && !self.non_blocking.get() {
+                    } else if !asynch && !self.non_blocking.get() {
                         doc.push_asap_in_order_script(self);
                     } else {
                         doc.add_asap_script(self);
@@ -637,9 +637,9 @@ impl HTMLScriptElement {
                     // We should add inline module script elements
                     // into those vectors in case that there's no
                     // descendants in the inline module script.
-                    if !r#async && was_parser_inserted {
+                    if !asynch && was_parser_inserted {
                         doc.add_deferred_script(self);
-                    } else if !r#async && !self.non_blocking.get() {
+                    } else if !asynch && !self.non_blocking.get() {
                         doc.push_asap_in_order_script(self);
                     } else {
                         doc.add_asap_script(self);

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -340,7 +340,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
         &self,
         method: ByteString,
         url: USVString,
-        r#async: bool,
+        asynch: bool,
         username: Option<USVString>,
         password: Option<USVString>,
     ) -> ErrorResult {
@@ -396,7 +396,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
                 }
 
                 // Step 10
-                if !r#async {
+                if !asynch {
                     // FIXME: This should only happen if the global environment is a document environment
                     if self.timeout.get() != 0 ||
                         self.response_type.get() != XMLHttpRequestResponseType::_empty
@@ -416,7 +416,7 @@ impl XMLHttpRequestMethods for XMLHttpRequest {
                 // Step 12
                 *self.request_method.borrow_mut() = parsed_method;
                 *self.request_url.borrow_mut() = Some(parsed_url);
-                self.sync.set(!r#async);
+                self.sync.set(!asynch);
                 *self.request_headers.borrow_mut() = HeaderMap::new();
                 self.send_flag.set(false);
                 *self.status_text.borrow_mut() = ByteString::new(vec![]);

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -865,14 +865,14 @@ impl ModuleOwner {
                     }
                 };
 
-                let r#async = script
+                let asynch = script
                     .root()
                     .upcast::<Element>()
                     .has_attribute(&local_name!("async"));
 
-                if !r#async && (&*script.root()).get_parser_inserted() {
+                if !asynch && (&*script.root()).get_parser_inserted() {
                     document.deferred_script_loaded(&*script.root(), load);
-                } else if !r#async && !(&*script.root()).get_non_blocking() {
+                } else if !asynch && !(&*script.root()).get_non_blocking() {
                     document.asap_in_order_script_loaded(&*script.root(), load);
                 } else {
                     document.asap_script_loaded(&*script.root(), load);


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This is a vestige of the transition from 2015 to 2018 edition Rust.
`async` was added as a keyword in 2018 edition Rust, so `cargo fix`
changed the variable name here to `r#async`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because this is just an internal name change

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
