### PR TITLE
Save / restore state when updating opaque framebuffer bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6780,7 +6780,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#3e731eac4180f739e85f8b6b9dacbc5a2015aec8"
+source = "git+https://github.com/servo/webxr#53c07f787d882c1b0dede5f4bb645a3bcf38d676"
 dependencies = [
  "android_injected_glue",
  "bindgen",
@@ -6803,7 +6803,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#3e731eac4180f739e85f8b6b9dacbc5a2015aec8"
+source = "git+https://github.com/servo/webxr#53c07f787d882c1b0dede5f4bb645a3bcf38d676"
 dependencies = [
  "euclid",
  "ipc-channel",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This saves and restores the WebGL bindings for texture and framebuffer when beginning a webxr frame.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27286
- [x] These changes do not require tests because we don't reftest hololens (it would be nice if we did!)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
