### PR TITLE
Update GPUObjectBase webidl and cleanup valid flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5902,6 +5902,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+dependencies = [
+ "proc-macro2 1.0.17",
+ "quote 1.0.2",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6815,7 +6835,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#71e853d6ce289cb529ce39c03263e7f101dd4db5"
+source = "git+https://github.com/gfx-rs/wgpu#73b230871ea4428ed3fb1e6e8bff81a7364fcdb2"
 dependencies = [
  "arrayvec 0.5.1",
  "bitflags",
@@ -6836,6 +6856,7 @@ dependencies = [
  "serde",
  "smallvec 1.4.1",
  "spirv_headers",
+ "thiserror",
  "tracing",
  "wgpu-types",
 ]
@@ -6843,7 +6864,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#71e853d6ce289cb529ce39c03263e7f101dd4db5"
+source = "git+https://github.com/gfx-rs/wgpu#73b230871ea4428ed3fb1e6e8bff81a7364fcdb2"
 dependencies = [
  "bitflags",
  "serde",

--- a/components/script/dom/gpubindgroup.rs
+++ b/components/script/dom/gpubindgroup.rs
@@ -6,28 +6,25 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::GPUBindGroupBinding::GPUBindGroupMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpubindgrouplayout::GPUBindGroupLayout;
 use dom_struct::dom_struct;
-use std::cell::Cell;
 use webgpu::{WebGPUBindGroup, WebGPUDevice};
 
 #[dom_struct]
 pub struct GPUBindGroup {
     reflector_: Reflector,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     bind_group: WebGPUBindGroup,
     device: WebGPUDevice,
     layout: Dom<GPUBindGroupLayout>,
-    valid: Cell<bool>,
 }
 
 impl GPUBindGroup {
     fn new_inherited(
         bind_group: WebGPUBindGroup,
         device: WebGPUDevice,
-        valid: bool,
         layout: &GPUBindGroupLayout,
     ) -> Self {
         Self {
@@ -35,7 +32,6 @@ impl GPUBindGroup {
             label: DomRefCell::new(None),
             bind_group,
             device,
-            valid: Cell::new(valid),
             layout: Dom::from_ref(layout),
         }
     }
@@ -44,13 +40,10 @@ impl GPUBindGroup {
         global: &GlobalScope,
         bind_group: WebGPUBindGroup,
         device: WebGPUDevice,
-        valid: bool,
         layout: &GPUBindGroupLayout,
     ) -> DomRoot<Self> {
         reflect_dom_object(
-            Box::new(GPUBindGroup::new_inherited(
-                bind_group, device, valid, layout,
-            )),
+            Box::new(GPUBindGroup::new_inherited(bind_group, device, layout)),
             global,
         )
     }
@@ -64,12 +57,12 @@ impl GPUBindGroup {
 
 impl GPUBindGroupMethods for GPUBindGroup {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 }

--- a/components/script/dom/gpubindgrouplayout.rs
+++ b/components/script/dom/gpubindgrouplayout.rs
@@ -6,47 +6,36 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::GPUBindGroupLayoutBinding::GPUBindGroupLayoutMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
-use std::cell::Cell;
 use webgpu::WebGPUBindGroupLayout;
 
 #[dom_struct]
 pub struct GPUBindGroupLayout {
     reflector_: Reflector,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     bind_group_layout: WebGPUBindGroupLayout,
-    valid: Cell<bool>,
 }
 
 impl GPUBindGroupLayout {
-    fn new_inherited(bind_group_layout: WebGPUBindGroupLayout, valid: bool) -> Self {
+    fn new_inherited(bind_group_layout: WebGPUBindGroupLayout) -> Self {
         Self {
             reflector_: Reflector::new(),
             label: DomRefCell::new(None),
             bind_group_layout,
-            valid: Cell::new(valid),
         }
     }
 
-    pub fn new(
-        global: &GlobalScope,
-        bind_group_layout: WebGPUBindGroupLayout,
-        valid: bool,
-    ) -> DomRoot<Self> {
+    pub fn new(global: &GlobalScope, bind_group_layout: WebGPUBindGroupLayout) -> DomRoot<Self> {
         reflect_dom_object(
-            Box::new(GPUBindGroupLayout::new_inherited(bind_group_layout, valid)),
+            Box::new(GPUBindGroupLayout::new_inherited(bind_group_layout)),
             global,
         )
     }
 }
 
 impl GPUBindGroupLayout {
-    pub fn is_valid(&self) -> bool {
-        self.valid.get()
-    }
-
     pub fn id(&self) -> WebGPUBindGroupLayout {
         self.bind_group_layout
     }
@@ -54,12 +43,12 @@ impl GPUBindGroupLayout {
 
 impl GPUBindGroupLayoutMethods for GPUBindGroupLayout {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 }

--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -9,7 +9,7 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpu::{response_async, AsyncWGPUListener};
 use crate::dom::promise::Promise;
@@ -58,11 +58,10 @@ pub struct GPUBuffer {
     reflector_: Reflector,
     #[ignore_malloc_size_of = "defined in webgpu"]
     channel: WebGPU,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     state: Cell<GPUBufferState>,
     buffer: WebGPUBuffer,
     device: WebGPUDevice,
-    valid: Cell<bool>,
     size: GPUSize64,
     #[ignore_malloc_size_of = "promises are hard"]
     map_promise: DomRefCell<Option<Rc<Promise>>>,
@@ -76,7 +75,6 @@ impl GPUBuffer {
         device: WebGPUDevice,
         state: GPUBufferState,
         size: GPUSize64,
-        valid: bool,
         map_info: DomRefCell<Option<GPUBufferMapInfo>>,
     ) -> Self {
         Self {
@@ -84,7 +82,6 @@ impl GPUBuffer {
             channel,
             label: DomRefCell::new(None),
             state: Cell::new(state),
-            valid: Cell::new(valid),
             device,
             buffer,
             map_promise: DomRefCell::new(None),
@@ -101,12 +98,11 @@ impl GPUBuffer {
         device: WebGPUDevice,
         state: GPUBufferState,
         size: GPUSize64,
-        valid: bool,
         map_info: DomRefCell<Option<GPUBufferMapInfo>>,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUBuffer::new_inherited(
-                channel, buffer, device, state, size, valid, map_info,
+                channel, buffer, device, state, size, map_info,
             )),
             global,
         )
@@ -120,10 +116,6 @@ impl GPUBuffer {
 
     pub fn state(&self) -> GPUBufferState {
         self.state.get()
-    }
-
-    pub fn is_valid(&self) -> bool {
-        self.valid.get()
     }
 }
 
@@ -305,12 +297,12 @@ impl GPUBufferMethods for GPUBuffer {
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 }

--- a/components/script/dom/gpucommandbuffer.rs
+++ b/components/script/dom/gpucommandbuffer.rs
@@ -7,7 +7,7 @@ use crate::dom::bindings::codegen::Bindings::GPUCommandBufferBinding::GPUCommand
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::Dom;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpubuffer::GPUBuffer;
 use dom_struct::dom_struct;
@@ -27,7 +27,7 @@ pub struct GPUCommandBuffer {
     reflector_: Reflector,
     #[ignore_malloc_size_of = "defined in webgpu"]
     channel: WebGPU,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     command_buffer: WebGPUCommandBuffer,
     buffers: DomRefCell<HashSet<Dom<GPUBuffer>>>,
 }
@@ -76,12 +76,12 @@ impl GPUCommandBuffer {
 
 impl GPUCommandBufferMethods for GPUCommandBuffer {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 }

--- a/components/script/dom/gpucommandencoder.rs
+++ b/components/script/dom/gpucommandencoder.rs
@@ -14,7 +14,7 @@ use crate::dom::bindings::codegen::UnionTypes::{
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpubuffer::GPUBuffer;
 use crate::dom::gpucommandbuffer::GPUCommandBuffer;
@@ -43,7 +43,7 @@ pub struct GPUCommandEncoder {
     reflector_: Reflector,
     #[ignore_malloc_size_of = "defined in webgpu"]
     channel: WebGPU,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     encoder: webgpu::WebGPUCommandEncoder,
     buffers: DomRefCell<HashSet<DomRoot<GPUBuffer>>>,
     state: DomRefCell<GPUCommandEncoderState>,
@@ -103,12 +103,12 @@ impl GPUCommandEncoder {
 
 impl GPUCommandEncoderMethods for GPUCommandEncoder {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 
@@ -229,9 +229,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
         destination_offset: GPUSize64,
         size: GPUSize64,
     ) {
-        let valid = source.is_valid() &&
-            destination.is_valid() &&
-            *self.state.borrow() == GPUCommandEncoderState::Open;
+        let valid = *self.state.borrow() == GPUCommandEncoderState::Open;
 
         if !valid {
             // TODO: Record an error in the current scope.

--- a/components/script/dom/gpucomputepassencoder.rs
+++ b/components/script/dom/gpucomputepassencoder.rs
@@ -6,7 +6,7 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::GPUComputePassEncoderBinding::GPUComputePassEncoderMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpubindgroup::GPUBindGroup;
 use crate::dom::gpubuffer::GPUBuffer;
@@ -23,7 +23,7 @@ pub struct GPUComputePassEncoder {
     reflector_: Reflector,
     #[ignore_malloc_size_of = "defined in webgpu"]
     channel: WebGPU,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     #[ignore_malloc_size_of = "defined in wgpu-core"]
     compute_pass: DomRefCell<Option<ComputePass>>,
     command_encoder: Dom<GPUCommandEncoder>,
@@ -50,12 +50,12 @@ impl GPUComputePassEncoder {
 
 impl GPUComputePassEncoderMethods for GPUComputePassEncoder {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 

--- a/components/script/dom/gpucomputepipeline.rs
+++ b/components/script/dom/gpucomputepipeline.rs
@@ -7,37 +7,30 @@ use crate::dom::bindings::codegen::Bindings::GPUComputePipelineBinding::GPUCompu
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::reflector::Reflector;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
-use std::cell::Cell;
 use webgpu::WebGPUComputePipeline;
 
 #[dom_struct]
 pub struct GPUComputePipeline {
     reflector_: Reflector,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     compute_pipeline: WebGPUComputePipeline,
-    valid: Cell<bool>,
 }
 
 impl GPUComputePipeline {
-    fn new_inherited(compute_pipeline: WebGPUComputePipeline, valid: bool) -> Self {
+    fn new_inherited(compute_pipeline: WebGPUComputePipeline) -> Self {
         Self {
             reflector_: Reflector::new(),
             label: DomRefCell::new(None),
             compute_pipeline,
-            valid: Cell::new(valid),
         }
     }
 
-    pub fn new(
-        global: &GlobalScope,
-        compute_pipeline: WebGPUComputePipeline,
-        valid: bool,
-    ) -> DomRoot<Self> {
+    pub fn new(global: &GlobalScope, compute_pipeline: WebGPUComputePipeline) -> DomRoot<Self> {
         reflect_dom_object(
-            Box::new(GPUComputePipeline::new_inherited(compute_pipeline, valid)),
+            Box::new(GPUComputePipeline::new_inherited(compute_pipeline)),
             global,
         )
     }
@@ -51,12 +44,12 @@ impl GPUComputePipeline {
 
 impl GPUComputePipelineMethods for GPUComputePipeline {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 }

--- a/components/script/dom/gpupipelinelayout.rs
+++ b/components/script/dom/gpupipelinelayout.rs
@@ -6,37 +6,30 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::GPUPipelineLayoutBinding::GPUPipelineLayoutMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
-use std::cell::Cell;
 use webgpu::WebGPUPipelineLayout;
 
 #[dom_struct]
 pub struct GPUPipelineLayout {
     reflector_: Reflector,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     pipeline_layout: WebGPUPipelineLayout,
-    valid: Cell<bool>,
 }
 
 impl GPUPipelineLayout {
-    fn new_inherited(pipeline_layout: WebGPUPipelineLayout, valid: bool) -> Self {
+    fn new_inherited(pipeline_layout: WebGPUPipelineLayout) -> Self {
         Self {
             reflector_: Reflector::new(),
             label: DomRefCell::new(None),
             pipeline_layout,
-            valid: Cell::new(valid),
         }
     }
 
-    pub fn new(
-        global: &GlobalScope,
-        pipeline_layout: WebGPUPipelineLayout,
-        valid: bool,
-    ) -> DomRoot<Self> {
+    pub fn new(global: &GlobalScope, pipeline_layout: WebGPUPipelineLayout) -> DomRoot<Self> {
         reflect_dom_object(
-            Box::new(GPUPipelineLayout::new_inherited(pipeline_layout, valid)),
+            Box::new(GPUPipelineLayout::new_inherited(pipeline_layout)),
             global,
         )
     }
@@ -46,20 +39,16 @@ impl GPUPipelineLayout {
     pub fn id(&self) -> WebGPUPipelineLayout {
         self.pipeline_layout
     }
-
-    pub fn is_valid(&self) -> bool {
-        self.valid.get()
-    }
 }
 
 impl GPUPipelineLayoutMethods for GPUPipelineLayout {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 }

--- a/components/script/dom/gpuqueue.rs
+++ b/components/script/dom/gpuqueue.rs
@@ -11,7 +11,7 @@ use crate::dom::bindings::codegen::Bindings::GPUTextureBinding::{
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpubuffer::{GPUBuffer, GPUBufferState};
 use crate::dom::gpucommandbuffer::GPUCommandBuffer;
@@ -27,7 +27,7 @@ pub struct GPUQueue {
     reflector_: Reflector,
     #[ignore_malloc_size_of = "defined in webgpu"]
     channel: WebGPU,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     queue: WebGPUQueue,
 }
 
@@ -48,12 +48,12 @@ impl GPUQueue {
 
 impl GPUQueueMethods for GPUQueue {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 
@@ -98,8 +98,7 @@ impl GPUQueueMethods for GPUQueue {
         let valid = data_offset + content_size <= bytes.len() as u64 &&
             buffer.state() == GPUBufferState::Unmapped &&
             content_size % wgt::COPY_BUFFER_ALIGNMENT == 0 &&
-            buffer_offset % wgt::COPY_BUFFER_ALIGNMENT == 0 &&
-            buffer.is_valid();
+            buffer_offset % wgt::COPY_BUFFER_ALIGNMENT == 0;
 
         if !valid {
             return Err(Error::Operation);
@@ -130,7 +129,7 @@ impl GPUQueueMethods for GPUQueue {
         size: GPUExtent3D,
     ) -> Fallible<()> {
         let bytes = data.to_vec();
-        let valid = data_layout.offset <= data.len() as u64 && destination.texture.is_valid();
+        let valid = data_layout.offset <= data.len() as u64;
 
         if !valid {
             return Err(Error::Operation);

--- a/components/script/dom/gpurenderpassencoder.rs
+++ b/components/script/dom/gpurenderpassencoder.rs
@@ -8,7 +8,7 @@ use crate::dom::bindings::codegen::Bindings::GPURenderPassEncoderBinding::GPURen
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpubindgroup::GPUBindGroup;
 use crate::dom::gpubuffer::GPUBuffer;
@@ -25,7 +25,7 @@ pub struct GPURenderPassEncoder {
     reflector_: Reflector,
     #[ignore_malloc_size_of = "defined in webgpu"]
     channel: WebGPU,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     #[ignore_malloc_size_of = "defined in wgpu-core"]
     render_pass: DomRefCell<Option<RenderPass>>,
     command_encoder: Dom<GPUCommandEncoder>,
@@ -61,12 +61,12 @@ impl GPURenderPassEncoder {
 
 impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 

--- a/components/script/dom/gpurenderpipeline.rs
+++ b/components/script/dom/gpurenderpipeline.rs
@@ -7,32 +7,25 @@ use crate::dom::bindings::codegen::Bindings::GPURenderPipelineBinding::GPURender
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::reflector::Reflector;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
-use std::cell::Cell;
 use webgpu::{WebGPUDevice, WebGPURenderPipeline};
 
 #[dom_struct]
 pub struct GPURenderPipeline {
     reflector_: Reflector,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     render_pipeline: WebGPURenderPipeline,
     device: WebGPUDevice,
-    valid: Cell<bool>,
 }
 
 impl GPURenderPipeline {
-    fn new_inherited(
-        render_pipeline: WebGPURenderPipeline,
-        device: WebGPUDevice,
-        valid: bool,
-    ) -> Self {
+    fn new_inherited(render_pipeline: WebGPURenderPipeline, device: WebGPUDevice) -> Self {
         Self {
             reflector_: Reflector::new(),
             label: DomRefCell::new(None),
             render_pipeline,
-            valid: Cell::new(valid),
             device,
         }
     }
@@ -41,14 +34,9 @@ impl GPURenderPipeline {
         global: &GlobalScope,
         render_pipeline: WebGPURenderPipeline,
         device: WebGPUDevice,
-        valid: bool,
     ) -> DomRoot<Self> {
         reflect_dom_object(
-            Box::new(GPURenderPipeline::new_inherited(
-                render_pipeline,
-                device,
-                valid,
-            )),
+            Box::new(GPURenderPipeline::new_inherited(render_pipeline, device)),
             global,
         )
     }
@@ -62,12 +50,12 @@ impl GPURenderPipeline {
 
 impl GPURenderPipelineMethods for GPURenderPipeline {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 }

--- a/components/script/dom/gpusampler.rs
+++ b/components/script/dom/gpusampler.rs
@@ -6,33 +6,25 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::GPUSamplerBinding::GPUSamplerMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
-use std::cell::Cell;
 use webgpu::{WebGPUDevice, WebGPUSampler};
 
 #[dom_struct]
 pub struct GPUSampler {
     reflector_: Reflector,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     device: WebGPUDevice,
     compare_enable: bool,
     sampler: WebGPUSampler,
-    valid: Cell<bool>,
 }
 
 impl GPUSampler {
-    fn new_inherited(
-        device: WebGPUDevice,
-        compare_enable: bool,
-        sampler: WebGPUSampler,
-        valid: bool,
-    ) -> Self {
+    fn new_inherited(device: WebGPUDevice, compare_enable: bool, sampler: WebGPUSampler) -> Self {
         Self {
             reflector_: Reflector::new(),
             label: DomRefCell::new(None),
-            valid: Cell::new(valid),
             device,
             sampler,
             compare_enable,
@@ -44,15 +36,9 @@ impl GPUSampler {
         device: WebGPUDevice,
         compare_enable: bool,
         sampler: WebGPUSampler,
-        valid: bool,
     ) -> DomRoot<Self> {
         reflect_dom_object(
-            Box::new(GPUSampler::new_inherited(
-                device,
-                compare_enable,
-                sampler,
-                valid,
-            )),
+            Box::new(GPUSampler::new_inherited(device, compare_enable, sampler)),
             global,
         )
     }
@@ -62,20 +48,16 @@ impl GPUSampler {
     pub fn id(&self) -> WebGPUSampler {
         self.sampler
     }
-
-    pub fn is_valid(&self) -> bool {
-        self.valid.get()
-    }
 }
 
 impl GPUSamplerMethods for GPUSampler {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 }

--- a/components/script/dom/gpushadermodule.rs
+++ b/components/script/dom/gpushadermodule.rs
@@ -6,7 +6,7 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::GPUShaderModuleBinding::GPUShaderModuleMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
 use webgpu::WebGPUShaderModule;
@@ -14,7 +14,7 @@ use webgpu::WebGPUShaderModule;
 #[dom_struct]
 pub struct GPUShaderModule {
     reflector_: Reflector,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     shader_module: WebGPUShaderModule,
 }
 
@@ -43,12 +43,12 @@ impl GPUShaderModule {
 
 impl GPUShaderModuleMethods for GPUShaderModule {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 }

--- a/components/script/dom/gpuswapchain.rs
+++ b/components/script/dom/gpuswapchain.rs
@@ -6,7 +6,7 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::GPUSwapChainBinding::GPUSwapChainMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpucanvascontext::GPUCanvasContext;
 use crate::dom::gputexture::GPUTexture;
@@ -18,7 +18,7 @@ pub struct GPUSwapChain {
     reflector_: Reflector,
     #[ignore_malloc_size_of = "channels are hard"]
     channel: WebGPU,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     context: Dom<GPUCanvasContext>,
     texture: Dom<GPUTexture>,
 }
@@ -67,12 +67,12 @@ impl GPUSwapChain {
 
 impl GPUSwapChainMethods for GPUSwapChain {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 

--- a/components/script/dom/gputextureview.rs
+++ b/components/script/dom/gputextureview.rs
@@ -6,34 +6,27 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::GPUTextureViewBinding::GPUTextureViewMethods;
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
-use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gputexture::GPUTexture;
 use dom_struct::dom_struct;
-use std::cell::Cell;
 use webgpu::WebGPUTextureView;
 
 #[dom_struct]
 pub struct GPUTextureView {
     reflector_: Reflector,
-    label: DomRefCell<Option<DOMString>>,
+    label: DomRefCell<Option<USVString>>,
     texture_view: WebGPUTextureView,
     texture: Dom<GPUTexture>,
-    valid: Cell<bool>,
 }
 
 impl GPUTextureView {
-    fn new_inherited(
-        texture_view: WebGPUTextureView,
-        texture: &GPUTexture,
-        valid: bool,
-    ) -> GPUTextureView {
+    fn new_inherited(texture_view: WebGPUTextureView, texture: &GPUTexture) -> GPUTextureView {
         Self {
             reflector_: Reflector::new(),
             texture: Dom::from_ref(texture),
             label: DomRefCell::new(None),
             texture_view,
-            valid: Cell::new(valid),
         }
     }
 
@@ -41,10 +34,9 @@ impl GPUTextureView {
         global: &GlobalScope,
         texture_view: WebGPUTextureView,
         texture: &GPUTexture,
-        valid: bool,
     ) -> DomRoot<GPUTextureView> {
         reflect_dom_object(
-            Box::new(GPUTextureView::new_inherited(texture_view, texture, valid)),
+            Box::new(GPUTextureView::new_inherited(texture_view, texture)),
             global,
         )
     }
@@ -54,20 +46,16 @@ impl GPUTextureView {
     pub fn id(&self) -> WebGPUTextureView {
         self.texture_view
     }
-
-    pub fn is_valid(&self) -> bool {
-        self.valid.get()
-    }
 }
 
 impl GPUTextureViewMethods for GPUTextureView {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn GetLabel(&self) -> Option<DOMString> {
+    fn GetLabel(&self) -> Option<USVString> {
         self.label.borrow().clone()
     }
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
-    fn SetLabel(&self, value: Option<DOMString>) {
+    fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
     }
 }

--- a/components/script/dom/webidls/GPUObjectBase.webidl
+++ b/components/script/dom/webidls/GPUObjectBase.webidl
@@ -5,9 +5,9 @@
 // https://gpuweb.github.io/gpuweb/#gpuobjectbase
 [Exposed=(Window)]
 interface mixin GPUObjectBase {
-    attribute DOMString? label;
+    attribute USVString? label;
 };
 
 dictionary GPUObjectDescriptorBase {
-    DOMString? label;
+    USVString label;
 };


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Update labels to be `USVString`
Remove `valid` flags in WebGPU resources. The only place where we still have that is `GPUCommandEncoder` (Only to validate the GPUCommandEncoder state. Not sure how errors would be handled/reported by server for copy commands).

r?@kvark

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
