### PR TITLE
Handle flex item cross sizing and minmax for flexbox in 2020

### DIFF
--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -939,6 +939,7 @@ impl<'a> FlexItem<'a> {
                             Some(s) => LengthOrAuto::LengthPercentage(s),
                             None => self.content_box_size.cross,
                         };
+
                         let item_as_containing_block = ContainingBlock {
                             inline_size: used_main_size,
                             block_size,
@@ -953,8 +954,18 @@ impl<'a> FlexItem<'a> {
                             &item_as_containing_block,
                             self.tree_rank,
                         );
+
+                        let hypothetical_cross_size = self
+                            .content_box_size
+                            .cross
+                            .auto_is(|| content_block_size)
+                            .clamp_between_extremums(
+                                self.content_min_size.cross,
+                                self.content_max_size.cross,
+                            );
+
                         FlexItemLayoutResult {
-                            hypothetical_cross_size: content_block_size,
+                            hypothetical_cross_size,
                             fragments,
                             positioning_context,
                         }

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/align-content-002.htm.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/align-content-002.htm.ini
@@ -1,2 +1,0 @@
-[align-content-002.htm]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/align-content_flex-start.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/align-content_flex-start.html.ini
@@ -1,2 +1,0 @@
-[align-content_flex-start.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/align-items-002.htm.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/align-items-002.htm.ini
@@ -1,2 +1,0 @@
-[align-items-002.htm]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/align-self-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/align-self-001.html.ini
@@ -1,2 +1,0 @@
-[align-self-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/align-self-007.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/align-self-007.html.ini
@@ -1,2 +1,0 @@
-[align-self-007.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/align-self-013.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/align-self-013.html.ini
@@ -1,2 +1,0 @@
-[align-self-013.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/dynamic-change-simplified-layout-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/dynamic-change-simplified-layout-002.html.ini
@@ -1,2 +1,0 @@
-[dynamic-change-simplified-layout-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/fit-content-item-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/fit-content-item-002.html.ini
@@ -1,2 +1,0 @@
-[fit-content-item-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/fit-content-item-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/fit-content-item-003.html.ini
@@ -1,2 +1,0 @@
-[fit-content-item-003.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/fit-content-item-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/fit-content-item-004.html.ini
@@ -1,2 +1,0 @@
-[fit-content-item-004.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-001.htm.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-001.htm.ini
@@ -1,2 +1,0 @@
-[flex-001.htm]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-002.htm.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-002.htm.ini
@@ -1,2 +1,0 @@
-[flex-002.htm]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-003.htm.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-003.htm.ini
@@ -1,2 +1,0 @@
-[flex-003.htm]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-004.htm.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-004.htm.ini
@@ -1,2 +1,0 @@
-[flex-004.htm]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-001.html.ini
@@ -1,2 +1,0 @@
-[flex-basis-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-002.html.ini
@@ -1,2 +1,0 @@
-[flex-basis-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-003.html.ini
@@ -1,2 +1,0 @@
-[flex-basis-003.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-004.html.ini
@@ -1,2 +1,0 @@
-[flex-basis-004.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-007.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-007.html.ini
@@ -1,2 +1,0 @@
-[flex-basis-007.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-008.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-basis-008.html.ini
@@ -1,2 +1,0 @@
-[flex-basis-008.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-box-wrap.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-box-wrap.html.ini
@@ -1,2 +1,0 @@
-[flex-box-wrap.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-container-margin.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-container-margin.html.ini
@@ -1,2 +1,0 @@
-[flex-container-margin.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-flow-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-flow-002.html.ini
@@ -1,2 +1,0 @@
-[flex-flow-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-flow-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-flow-003.html.ini
@@ -1,2 +1,0 @@
-[flex-flow-003.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-flow-005.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-flow-005.html.ini
@@ -1,2 +1,0 @@
-[flex-flow-005.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-flow-006.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-flow-006.html.ini
@@ -1,2 +1,0 @@
-[flex-flow-006.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-grow-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-grow-002.html.ini
@@ -1,2 +1,0 @@
-[flex-grow-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-grow-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-grow-004.html.ini
@@ -1,2 +1,0 @@
-[flex-grow-004.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-grow-006.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-grow-006.html.ini
@@ -1,2 +1,0 @@
-[flex-grow-006.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-grow-007.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-grow-007.html.ini
@@ -1,2 +1,0 @@
-[flex-grow-007.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-001.html.ini
@@ -1,2 +1,0 @@
-[flex-shrink-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-002.html.ini
@@ -1,2 +1,0 @@
-[flex-shrink-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-003.html.ini
@@ -1,2 +1,0 @@
-[flex-shrink-003.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-004.html.ini
@@ -1,2 +1,0 @@
-[flex-shrink-004.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-005.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-005.html.ini
@@ -1,2 +1,0 @@
-[flex-shrink-005.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-006.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-006.html.ini
@@ -1,2 +1,0 @@
-[flex-shrink-006.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-007.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-007.html.ini
@@ -1,2 +1,0 @@
-[flex-shrink-007.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-008.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-shrink-008.html.ini
@@ -1,2 +1,0 @@
-[flex-shrink-008.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-wrap-006.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-wrap-006.html.ini
@@ -1,2 +1,0 @@
-[flex-wrap-006.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-flex-wrap-flexing.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-flex-wrap-flexing.html.ini
@@ -1,2 +1,0 @@
-[flexbox-flex-wrap-flexing.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_align-content-flexstart.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_align-content-flexstart.html.ini
@@ -1,2 +1,0 @@
-[flexbox_align-content-flexstart.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_box-clear.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_box-clear.html.ini
@@ -1,2 +1,0 @@
-[flexbox_box-clear.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_fbfc.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_fbfc.html.ini
@@ -1,2 +1,0 @@
-[flexbox_fbfc.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexible-box-float.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexible-box-float.html.ini
@@ -1,2 +1,0 @@
-[flexible-box-float.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/layout-algorithm_algo-cross-line-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/layout-algorithm_algo-cross-line-001.html.ini
@@ -1,2 +1,0 @@
-[layout-algorithm_algo-cross-line-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/order-painting.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/order-painting.html.ini
@@ -1,2 +1,0 @@
-[order-painting.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/overflow-area-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/overflow-area-001.html.ini
@@ -1,2 +1,0 @@
-[overflow-area-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/overflow-area-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/overflow-area-002.html.ini
@@ -1,2 +1,0 @@
-[overflow-area-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/table-as-item-change-cell.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/table-as-item-change-cell.html.ini
@@ -1,2 +1,0 @@
-[table-as-item-change-cell.html]
-  expected: FAIL


### PR DESCRIPTION
Note: a lot more tests pass, however update-wpt is somehow not accepting them. I'm going to try and do an update again.