### PR TITLE
Use backtrace fork with UWP-specific fix.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,8 +242,7 @@ dependencies = [
 [[package]]
 name = "backtrace"
 version = "0.3.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
+source = "git+https://github.com/servo/backtrace-rs?branch=uwp-fix#5366f72ca5be2e2341f418923a71b70acbb653ad"
 dependencies = [
  "addr2line",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ opt-level = 3
 # This is here to dedupe winapi since mio 0.6 is still using winapi 0.2.
 mio = { git = "https://github.com/servo/mio.git", branch = "servo-mio-0.6.22" }
 
+# https://github.com/rust-lang/backtrace-rs/pull/363/
+backtrace = { git = "https://github.com/servo/backtrace-rs", branch = "uwp-fix" }
+
 # https://github.com/servo/servo/issues/27039#issuecomment-654400150
 [patch."https://github.com/servo/webrender"]
 webrender = { git = "https://github.com/jdm/webrender", branch = "crash-backtrace" }


### PR DESCRIPTION
Fixes #27367, which was introduced by 57f4f0a09fbb0d26448f63a3f61dc11fb4209f8f. I'd like to do a new release in the store, and I would prefer not to wait for a new version of backtrace to be released before that can happen.