### PR TITLE
Add libxcb dependencies to README and bootstrap.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ If `./mach bootstrap` doesn't work, file a bug, and, run the commands below:
 sudo apt install git curl autoconf libx11-dev libfreetype6-dev libgl1-mesa-dri \
     libglib2.0-dev xorg-dev gperf g++ build-essential cmake libssl-dev \
     liblzma-dev libxmu6 libxmu-dev \
+    libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
     libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev libharfbuzz-dev ccache \
     clang libunwind-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
     libgstreamer-plugins-bad1.0-dev autoconf2.13 llvm-dev

--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -95,6 +95,7 @@ def linux(context, force=False):
                 'libgl1-mesa-dri', 'libglib2.0-dev', 'xorg-dev', 'gperf', 'g++',
                 'build-essential', 'cmake', 'libssl-dev',
                 'liblzma-dev', 'libxmu6', 'libxmu-dev',
+                "libxcb-render0-dev", "libxcb-shape0-dev", "libxcb-xfixes0-dev",
                 'libgles2-mesa-dev', 'libegl1-mesa-dev', 'libdbus-1-dev',
                 'libharfbuzz-dev', 'ccache', 'clang', 'libunwind-dev',
                 'libgstreamer1.0-dev', 'libgstreamer-plugins-base1.0-dev',


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Gets servo to build on Ubuntu xenial+ again.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27327
- [x] These changes do not require tests because it's fixing build breakage

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
