### PR TITLE
Use the size of the containing block, not the size of the block formatting context, to place floats in layout 2020.

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -80,7 +80,7 @@ impl BlockFormattingContext {
     ) -> IndependentLayout {
         let mut float_context;
         let float_context = if self.contains_floats {
-            float_context = FloatContext::new(containing_block.inline_size);
+            float_context = FloatContext::new();
             Some(&mut float_context)
         } else {
             None


### PR DESCRIPTION
The containing block for a float is not necessarily the same as the block
formatting context the float is in per CSS 2.1 [1]:

"For other elements, if the element’s position is relative or static, the
containing block is formed by the content edge of the nearest block container
ancestor box."

This shows up in the simplest case:

	<html>
	<body>
	<div style="float: left">Hello</div>
	</body>
	</html>

In this case, the `<html>` element is the block formatting context with inline
size equal to the width of the window, but the `<body>` element with nonzero
inline margins is the containing block for the float. The float placement must
respect the content box of the `<body>` element (i.e. floats must not overlap
the `<body>` element's margins), not that of the `<html>` element.

Because a single block formatting context may contain floats with different
containing blocks, the left and right "walls" of that containing block become
properties of individual floats at the time of placement, not properties of the
float context itself.

Additionally, this commit generalizes the float placement logic a bit to allow
the placement of arbitrary objects, not just floats. This is intended to
support inline layout and block formatting context placement.

This commit updates the `FloatContext` and associated tests only and doesn't
actually wire the context up to the rest of layout, so floats in pages still
aren't actually laid out.

[1]: https://drafts.csswg.org/css2/#containing-block-details

r? @Manishearth 

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
