### PR TITLE
[return value version] Handle `inset: auto` values for absolutely positioned elements

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -352,6 +352,9 @@ impl BlockLevelBox {
             BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(box_) => {
                 let hoisted_box = AbsolutelyPositionedBox::to_hoisted(
                     box_.clone(),
+                    // This is incorrect, however we do not know the
+                    // correct positioning until later, in place_block_level_fragment,
+                    // and this value will be adjusted there
                     Vec2::zero(),
                     tree_rank,
                     containing_block,

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -216,7 +216,8 @@ fn layout_block_level_children(
                 // https://drafts.csswg.org/css-position-3/#staticpos-rect
                 if let Some(mut hoisted) = maybe_hoisted {
                     hoisted.adjust_offsets(Vec2 {
-                        block: placement_state.current_block_direction_position,
+                        block: placement_state.current_block_direction_position +
+                            placement_state.current_margin.solve(),
                         inline: Length::new(0.),
                     });
                     positioning_context.push(hoisted)

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -79,8 +79,8 @@ pub(crate) enum AbsoluteBoxOffsets {
 impl AbsoluteBoxOffsets {
     fn adjust_offset(&mut self, new_offset: Length) {
         match *self {
-            AbsoluteBoxOffsets::StaticStart {ref mut start} => *start = new_offset,
-            _ => ()
+            AbsoluteBoxOffsets::StaticStart { ref mut start } => *start = new_offset,
+            _ => (),
         }
     }
 }

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -49,6 +49,16 @@ pub(crate) struct HoistedAbsolutelyPositionedBox {
     pub fragment: ArcRefCell<Option<ArcRefCell<Fragment>>>,
 }
 
+impl HoistedAbsolutelyPositionedBox {
+    /// In some cases `inset: auto`-positioned elements do not know their precise
+    /// position until after they're hoisted. This lets us adjust auto values
+    /// after the fact.
+    pub(crate) fn adjust_offsets(&mut self, offsets: Vec2<Length>) {
+        self.box_offsets.inline.adjust_offset(offsets.inline);
+        self.box_offsets.block.adjust_offset(offsets.block);
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum AbsoluteBoxOffsets {
     StaticStart {
@@ -64,6 +74,15 @@ pub(crate) enum AbsoluteBoxOffsets {
         start: LengthPercentage,
         end: LengthPercentage,
     },
+}
+
+impl AbsoluteBoxOffsets {
+    fn adjust_offset(&mut self, new_offset: Length) {
+        match *self {
+            AbsoluteBoxOffsets::StaticStart {ref mut start} => *start = new_offset,
+            _ => ()
+        }
+    }
 }
 
 impl AbsolutelyPositionedBox {


### PR DESCRIPTION
Fixes https://github.com/servo/servo/issues/27387

I'm not 100% sure of this approach, i don't like reconstructing the
vector there.

Also, when tried on the testcase in https://github.com/servo/servo/issues/27387, while the square no longer overlaps, it's still very close to the previous line. I think I need to handle margins.