### PR TITLE
Handle `inset: auto` values for absolutely positioned elements

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -916,7 +916,7 @@ impl AbsoluteOrFixedPositionedFragment {
         stacking_context: &mut StackingContext,
     ) {
         let hoisted_fragment = self.hoisted_fragment.borrow();
-        let fragment_ref = match hoisted_fragment.as_ref() {
+        let fragment_ref = match hoisted_fragment.fragment.as_ref() {
             Some(fragment_ref) => fragment_ref,
             None => unreachable!("Found hoisted box with missing fragment."),
         };

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -201,7 +201,18 @@ fn layout_block_level_children(
                     placement_state.current_margin.solve() + fragment_block_size;
                 placement_state.current_margin = fragment_block_margins.end;
             },
-            Fragment::Anonymous(_) | Fragment::AbsoluteOrFixedPositioned(_) => {},
+            Fragment::AbsoluteOrFixedPositioned(fragment) => {
+                let offset = Vec2 {
+                    block: placement_state.current_margin.solve() +
+                        placement_state.current_block_direction_position,
+                    inline: Length::new(0.),
+                };
+                fragment
+                    .hoisted_fragment
+                    .borrow_mut()
+                    .adjust_offsets(offset);
+            },
+            Fragment::Anonymous(_) => {},
             _ => unreachable!(),
         }
     }

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -352,6 +352,9 @@ impl BlockLevelBox {
             BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(box_) => {
                 let hoisted_box = AbsolutelyPositionedBox::to_hoisted(
                     box_.clone(),
+                    // This is incorrect, however we do not know the
+                    // correct positioning until later, in place_block_level_fragment,
+                    // and this value will be adjusted there
                     Vec2::zero(),
                     tree_rank,
                     containing_block,

--- a/components/layout_2020/fragments.rs
+++ b/components/layout_2020/fragments.rs
@@ -8,6 +8,7 @@ use crate::geom::flow_relative::{Rect, Sides};
 use crate::geom::{PhysicalPoint, PhysicalRect};
 #[cfg(debug_assertions)]
 use crate::layout_debug;
+use crate::positioned::HoistedSharedFragment;
 use gfx::font::FontMetrics as GfxFontMetrics;
 use gfx::text::glyph::GlyphStore;
 use gfx_traits::print_tree::PrintTree;
@@ -74,7 +75,7 @@ pub(crate) enum Fragment {
 #[derive(Serialize)]
 pub(crate) struct AbsoluteOrFixedPositionedFragment {
     pub position: ComputedPosition,
-    pub hoisted_fragment: ArcRefCell<Option<ArcRefCell<Fragment>>>,
+    pub hoisted_fragment: ArcRefCell<HoistedSharedFragment>,
 }
 
 #[derive(Serialize)]

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -41,8 +41,6 @@ pub(crate) struct HoistedAbsolutelyPositionedBox {
     /// static positions when going up the tree.
     pub(crate) tree_rank: usize,
 
-    box_offsets: Vec2<AbsoluteBoxOffsets>,
-
     /// A reference to a Fragment which is shared between this `HoistedAbsolutelyPositionedBox`
     /// and its placeholder `AbsoluteOrFixedPositionedFragment` in the original tree position.
     /// This will be used later in order to paint this hoisted box in tree order.
@@ -54,16 +52,20 @@ pub(crate) struct HoistedAbsolutelyPositionedBox {
 /// This will be used later in order to paint this hoisted box in tree order.
 #[derive(Serialize)]
 pub(crate) struct HoistedSharedFragment {
-    pub fragment: Option<ArcRefCell<Fragment>>,
+    pub(crate) fragment: Option<ArcRefCell<Fragment>>,
+    pub(crate) box_offsets: Vec2<AbsoluteBoxOffsets>,
 }
 
 impl HoistedSharedFragment {
-    pub(crate) fn new() -> Self {
-        HoistedSharedFragment { fragment: None }
+    pub(crate) fn new(box_offsets: Vec2<AbsoluteBoxOffsets>) -> Self {
+        HoistedSharedFragment {
+            fragment: None,
+            box_offsets,
+        }
     }
 }
 
-impl HoistedAbsolutelyPositionedBox {
+impl HoistedSharedFragment {
     /// In some cases `inset: auto`-positioned elements do not know their precise
     /// position until after they're hoisted. This lets us adjust auto values
     /// after the fact.
@@ -73,7 +75,7 @@ impl HoistedAbsolutelyPositionedBox {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub(crate) enum AbsoluteBoxOffsets {
     StaticStart {
         start: Length,
@@ -162,8 +164,7 @@ impl AbsolutelyPositionedBox {
         };
         HoistedAbsolutelyPositionedBox {
             tree_rank,
-            box_offsets,
-            fragment: ArcRefCell::new(HoistedSharedFragment::new()),
+            fragment: ArcRefCell::new(HoistedSharedFragment::new(box_offsets)),
             absolutely_positioned_box: self_,
         }
     }
@@ -442,13 +443,15 @@ impl HoistedAbsolutelyPositionedBox {
                 .content_box_size(&containing_block.into(), &pbm),
         };
 
+        let shared_fragment = self.fragment.borrow();
+
         let inline_axis = solve_axis(
             cbis,
             pbm.padding_border_sums.inline,
             pbm.margin.inline_start,
             pbm.margin.inline_end,
             /* avoid_negative_margin_start */ true,
-            &self.box_offsets.inline,
+            &shared_fragment.box_offsets.inline,
             size.inline,
         );
 
@@ -458,7 +461,7 @@ impl HoistedAbsolutelyPositionedBox {
             pbm.margin.block_start,
             pbm.margin.block_end,
             /* avoid_negative_margin_start */ false,
-            &self.box_offsets.block,
+            &shared_fragment.box_offsets.block,
             size.block,
         );
 
@@ -688,11 +691,13 @@ fn adjust_static_positions(
             _ => unreachable!(),
         };
 
-        if let AbsoluteBoxOffsets::StaticStart { start } = &mut abspos_fragment.box_offsets.inline {
+        let mut shared_fragment = abspos_fragment.fragment.borrow_mut();
+
+        if let AbsoluteBoxOffsets::StaticStart { start } = &mut shared_fragment.box_offsets.inline {
             *start += child_fragment_rect.start_corner.inline;
         }
 
-        if let AbsoluteBoxOffsets::StaticStart { start } = &mut abspos_fragment.box_offsets.block {
+        if let AbsoluteBoxOffsets::StaticStart { start } = &mut shared_fragment.box_offsets.block {
             *start += child_fragment_rect.start_corner.block;
         }
     }

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -49,6 +49,16 @@ pub(crate) struct HoistedAbsolutelyPositionedBox {
     pub fragment: ArcRefCell<Option<ArcRefCell<Fragment>>>,
 }
 
+impl HoistedAbsolutelyPositionedBox {
+    /// In some cases `inset: auto`-positioned elements do not know their precise
+    /// position until after they're hoisted. This lets us adjust auto values
+    /// after the fact.
+    pub(crate) fn adjust_offsets(&mut self, offsets: Vec2<Length>) {
+        self.box_offsets.inline.adjust_offset(offsets.inline);
+        self.box_offsets.block.adjust_offset(offsets.block);
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum AbsoluteBoxOffsets {
     StaticStart {
@@ -64,6 +74,15 @@ pub(crate) enum AbsoluteBoxOffsets {
         start: LengthPercentage,
         end: LengthPercentage,
     },
+}
+
+impl AbsoluteBoxOffsets {
+    fn adjust_offset(&mut self, new_offset: Length) {
+        match *self {
+            AbsoluteBoxOffsets::StaticStart {ref mut start} => *start = new_offset,
+            _ => ()
+        }
+    }
 }
 
 impl AbsolutelyPositionedBox {

--- a/tests/wpt/metadata-layout-2020/css/CSS2/linebox/inline-negative-margin-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/linebox/inline-negative-margin-001.html.ini
@@ -14,3 +14,33 @@
   [[data-expected-height\] 4]
     expected: FAIL
 
+  [[data-expected-height\] 1]
+    expected: FAIL
+
+  [[data-expected-height\] 10]
+    expected: FAIL
+
+  [[data-expected-height\] 2]
+    expected: FAIL
+
+  [[data-expected-height\] 5]
+    expected: FAIL
+
+  [[data-expected-height\] 6]
+    expected: FAIL
+
+  [[data-expected-height\] 9]
+    expected: FAIL
+
+  [[data-expected-height\] 8]
+    expected: FAIL
+
+  [[data-expected-height\] 13]
+    expected: FAIL
+
+  [[data-expected-height\] 12]
+    expected: FAIL
+
+  [[data-expected-height\] 11]
+    expected: FAIL
+

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-038.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-038.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-038.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-102.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/margin-padding-clear/margin-collapse-102.xht.ini
@@ -1,2 +1,0 @@
-[margin-collapse-102.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-formatting-context-height-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-formatting-context-height-001.xht.ini
@@ -1,2 +1,0 @@
-[block-formatting-context-height-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-formatting-context-height-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-formatting-context-height-002.xht.ini
@@ -1,2 +1,0 @@
-[block-formatting-context-height-002.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-formatting-context-height-003.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-formatting-context-height-003.xht.ini
@@ -1,2 +1,0 @@
-[block-formatting-context-height-003.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-formatting-contexts-009.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-formatting-contexts-009.xht.ini
@@ -1,2 +1,0 @@
-[block-formatting-contexts-009.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-non-replaced-width-004.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-non-replaced-width-004.xht.ini
@@ -1,2 +1,0 @@
-[block-non-replaced-width-004.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/blocks-021.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/blocks-021.xht.ini
@@ -1,2 +1,0 @@
-[blocks-021.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/max-width-106.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/max-width-106.xht.ini
@@ -1,2 +1,0 @@
-[max-width-106.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/abspos-028.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/abspos-028.xht.ini
@@ -1,2 +1,2 @@
-[abspos-001.xht]
+[abspos-028.xht]
   expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/left-applies-to-013.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/left-applies-to-013.xht.ini
@@ -1,2 +1,0 @@
-[left-applies-to-013.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/left-applies-to-014.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/left-applies-to-014.xht.ini
@@ -1,2 +1,0 @@
-[left-applies-to-014.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/position-relative-004.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/position-relative-004.xht.ini
@@ -1,2 +1,0 @@
-[position-relative-004.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/position-relative-005.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/position-relative-005.xht.ini
@@ -1,2 +1,0 @@
-[position-relative-005.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/position-relative-014.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/position-relative-014.xht.ini
@@ -1,2 +1,0 @@
-[position-relative-014.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/position-relative-016.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/position-relative-016.xht.ini
@@ -1,2 +1,0 @@
-[position-relative-016.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/position-relative-019.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/position-relative-019.xht.ini
@@ -1,2 +1,0 @@
-[position-relative-019.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/right-applies-to-013.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/right-applies-to-013.xht.ini
@@ -1,2 +1,0 @@
-[right-applies-to-013.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/right-applies-to-014.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/right-applies-to-014.xht.ini
@@ -1,2 +1,0 @@
-[right-applies-to-014.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-inline-table-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-inline-table-001.xht.ini
@@ -1,2 +1,0 @@
-[height-width-inline-table-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-inline-table-001a.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-inline-table-001a.xht.ini
@@ -1,2 +1,0 @@
-[height-width-inline-table-001a.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-inline-table-001b.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-inline-table-001b.xht.ini
@@ -1,2 +1,0 @@
-[height-width-inline-table-001b.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-inline-table-001c.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-inline-table-001c.xht.ini
@@ -1,2 +1,0 @@
-[height-width-inline-table-001c.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-inline-table-001d.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-inline-table-001d.xht.ini
@@ -1,2 +1,0 @@
-[height-width-inline-table-001d.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-inline-table-001e.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-inline-table-001e.xht.ini
@@ -1,2 +1,0 @@
-[height-width-inline-table-001e.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-table-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-table-001.xht.ini
@@ -1,2 +1,0 @@
-[height-width-table-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-table-001a.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-table-001a.xht.ini
@@ -1,2 +1,0 @@
-[height-width-table-001a.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-table-001b.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-table-001b.xht.ini
@@ -1,2 +1,0 @@
-[height-width-table-001b.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-table-001c.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-table-001c.xht.ini
@@ -1,2 +1,0 @@
-[height-width-table-001c.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-table-001d.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-table-001d.xht.ini
@@ -1,2 +1,0 @@
-[height-width-table-001d.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-table-001e.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/tables/height-width-table-001e.xht.ini
@@ -1,2 +1,0 @@
-[height-width-table-001e.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/visudet/line-height-202.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/visudet/line-height-202.html.ini
@@ -1,2 +1,0 @@
-[line-height-202.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/visudet/line-height-203.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/visudet/line-height-203.html.ini
@@ -1,0 +1,2 @@
+[line-height-203.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/visudet/line-height-204.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/visudet/line-height-204.html.ini
@@ -1,2 +1,0 @@
-[line-height-204.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/visufx/clip-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/visufx/clip-001.xht.ini
@@ -1,2 +1,0 @@
-[clip-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/visuren/left-offset-position-fixed-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/visuren/left-offset-position-fixed-001.xht.ini
@@ -1,2 +1,0 @@
-[left-offset-position-fixed-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-015.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-015.xht.ini
@@ -1,2 +1,0 @@
-[z-index-015.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-016.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-016.xht.ini
@@ -1,2 +1,0 @@
-[z-index-016.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-017.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-017.xht.ini
@@ -1,2 +1,0 @@
-[z-index-017.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-018.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-018.xht.ini
@@ -1,2 +1,0 @@
-[z-index-018.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-019.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-019.xht.ini
@@ -1,2 +1,0 @@
-[z-index-019.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-abspos-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-abspos-001.xht.ini
@@ -1,2 +1,0 @@
-[z-index-abspos-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-abspos-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-abspos-002.xht.ini
@@ -1,2 +1,0 @@
-[z-index-abspos-002.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-abspos-003.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-abspos-003.xht.ini
@@ -1,2 +1,0 @@
-[z-index-abspos-003.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-abspos-004.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-abspos-004.xht.ini
@@ -1,2 +1,0 @@
-[z-index-abspos-004.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-abspos-005.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-abspos-005.xht.ini
@@ -1,2 +1,0 @@
-[z-index-abspos-005.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-abspos-007.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/zindex/z-index-abspos-007.xht.ini
@@ -1,2 +1,0 @@
-[z-index-abspos-007.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-origin-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-origin-002.html.ini
@@ -1,2 +1,0 @@
-[background-origin-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-origin-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-origin-003.html.ini
@@ -1,2 +1,0 @@
-[background-origin-003.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-origin-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-origin-004.html.ini
@@ -1,2 +1,0 @@
-[background-origin-004.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-origin-005.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-origin-005.html.ini
@@ -1,2 +1,0 @@
-[background-origin-005.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-origin-007.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-origin-007.html.ini
@@ -1,2 +1,0 @@
-[background-origin-007.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-origin-008.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-origin-008.html.ini
@@ -1,2 +1,0 @@
-[background-origin-008.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/align-items-006.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/align-items-006.html.ini
@@ -1,2 +1,0 @@
-[align-items-006.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/align-items-007.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/align-items-007.html.ini
@@ -1,2 +1,0 @@
-[align-items-007.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/auto-margins-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/auto-margins-002.html.ini
@@ -1,2 +1,0 @@
-[auto-margins-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-aspect-ratio-img-column-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-aspect-ratio-img-column-001.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-column-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-aspect-ratio-img-column-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-aspect-ratio-img-column-002.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-column-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-aspect-ratio-img-column-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-aspect-ratio-img-column-003.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-column-003.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-aspect-ratio-img-row-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-aspect-ratio-img-row-001.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-row-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-aspect-ratio-img-row-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-aspect-ratio-img-row-002.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-row-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-aspect-ratio-img-row-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-aspect-ratio-img-row-003.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-row-003.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-002.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-002.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-004.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-004.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-004.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-005.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-005.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-005.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-006.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-006.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-006.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-007.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-007.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-007.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-008.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-008.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-008.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-019.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-019.html.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-019.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-004.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-004.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-width-flex-items-004.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-005.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-005.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-width-flex-items-005.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-006.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-006.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-width-flex-items-006.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-007.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-007.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-width-flex-items-007.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-008.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-008.xht.ini
@@ -1,2 +1,0 @@
-[flex-minimum-width-flex-items-008.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-009.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-009.html.ini
@@ -1,2 +1,0 @@
-[flex-minimum-width-flex-items-009.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-010.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-010.html.ini
@@ -1,2 +1,0 @@
-[flex-minimum-width-flex-items-010.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-013.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-width-flex-items-013.html.ini
@@ -1,2 +1,0 @@
-[flex-minimum-width-flex-items-013.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-wrap-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-wrap-003.html.ini
@@ -1,2 +1,0 @@
-[flex-wrap-003.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-wrap-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-wrap-004.html.ini
@@ -1,2 +1,0 @@
-[flex-wrap-004.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-wrap-005.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-wrap-005.html.ini
@@ -1,2 +1,0 @@
-[flex-wrap-005.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/gap-012.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/gap-012.html.ini
@@ -1,2 +1,0 @@
-[gap-012.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/image-items-flake-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/image-items-flake-001.html.ini
@@ -1,2 +1,0 @@
-[image-items-flake-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/stretch-obeys-min-max-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/stretch-obeys-min-max-002.html.ini
@@ -1,2 +1,0 @@
-[stretch-obeys-min-max-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/perspective-origin-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/perspective-origin-001.html.ini
@@ -1,2 +1,0 @@
-[perspective-origin-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/perspective-origin-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/perspective-origin-002.html.ini
@@ -1,2 +1,0 @@
-[perspective-origin-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/perspective-origin-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/perspective-origin-003.html.ini
@@ -1,2 +1,0 @@
-[perspective-origin-003.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/perspective-origin-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/perspective-origin-004.html.ini
@@ -1,2 +1,0 @@
-[perspective-origin-004.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/perspective-origin-005.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/perspective-origin-005.html.ini
@@ -1,2 +1,0 @@
-[perspective-origin-005.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/perspective-origin-006.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/perspective-origin-006.html.ini
@@ -1,2 +1,0 @@
-[perspective-origin-006.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/scalex.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/scalex.html.ini
@@ -1,2 +1,0 @@
-[scalex.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-ui/box-sizing-026.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-ui/box-sizing-026.html.ini
@@ -1,2 +1,0 @@
-[box-sizing-026.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/MediaQueryList-addListener-handleEvent.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/MediaQueryList-addListener-handleEvent.html.ini
@@ -8,3 +8,12 @@
   [throws if handleEvent is thruthy and not callable]
     expected: FAIL
 
+  [looks up handleEvent method on every event dispatch]
+    expected: FAIL
+
+  [calls handleEvent method of event listener]
+    expected: FAIL
+
+  [doesn't look up handleEvent method on callable event listeners]
+    expected: FAIL
+

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/MediaQueryList-addListener-removeListener.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/MediaQueryList-addListener-removeListener.html.ini
@@ -2,3 +2,18 @@
   [listeners are called when <iframe> is resized]
     expected: FAIL
 
+  [removing listener from one MQL doesn't remove it from all MQLs]
+    expected: FAIL
+
+  [listeners are called in order they were added]
+    expected: FAIL
+
+  [listeners are called in order their MQLs were created]
+    expected: FAIL
+
+  [listener that was added twice is called only once]
+    expected: FAIL
+
+  [listeners are called correct number of times]
+    expected: FAIL
+

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/MediaQueryList-extends-EventTarget.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/MediaQueryList-extends-EventTarget.html.ini
@@ -1,8 +1,13 @@
 [MediaQueryList-extends-EventTarget.html]
-  expected: TIMEOUT
   [addEventListener "once" option is respected]
-    expected: TIMEOUT
+    expected: FAIL
 
-  [removeEventListener removes listener]
-    expected: NOTRUN
+  [onchange removes listener]
+    expected: FAIL
+
+  [onchange adds listener]
+    expected: FAIL
+
+  [listeners for "change" type are called]
+    expected: FAIL
 

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPosition.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPosition.html.ini
@@ -14,6 +14,6 @@
   [test some point of the element: bottom right corner]
     expected: FAIL
 
-  [test the top of layer]
+  [test some point of the element: top left corner]
     expected: FAIL
 

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/negativeMargins.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/negativeMargins.html.ini
@@ -2,3 +2,6 @@
   [cssom-view - elementFromPoint and elementsFromPoint dealing with negative margins 1]
     expected: FAIL
 
+  [cssom-view - elementFromPoint and elementsFromPoint dealing with negative margins]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_abs_cb_with_non_cb_kid_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_abs_cb_with_non_cb_kid_a.html.ini
@@ -1,2 +1,0 @@
-[position_abs_cb_with_non_cb_kid_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_abs_static_y_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_abs_static_y_a.html.ini
@@ -1,2 +1,0 @@
-[position_abs_static_y_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/css/position_fixed_static_y_a.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/css/position_fixed_static_y_a.html.ini
@@ -1,2 +1,0 @@
-[position_fixed_static_y_a.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/mozilla/fetch_cannot_overwhelm_system.window.js.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/mozilla/fetch_cannot_overwhelm_system.window.js.ini
@@ -1,2 +1,0 @@
-[fetch_cannot_overwhelm_system.window.html]
-  expected: CRASH


### PR DESCRIPTION
Fixes #27387

This is the same as https://github.com/servo/servo/pull/27397 , but written to share the box offset data instead of bubbling the hoisted box up based on comments from @SimonSapin.