### PR TITLE
Fire mouseenter and mouseleave events

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -940,7 +940,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
         let results = self.hit_test_at_point(cursor);
         if let Some(item) = results.items.first() {
             let node_address = Some(UntrustedNodeAddress(item.tag.0 as *const c_void));
-            let event = MouseMoveEvent(Some(item.point_in_viewport.to_untyped()), node_address, 0);
+            let event = MouseMoveEvent(item.point_in_viewport.to_untyped(), node_address, 0);
             let pipeline_id = PipelineId::from_webrender(item.pipeline);
             let msg = ConstellationMsg::ForwardEvent(pipeline_id, event);
             if let Err(e) = self.constellation_chan.send(msg) {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -560,7 +560,8 @@ impl Document {
 
         let new_dirty_root = element
             .upcast::<Node>()
-            .common_ancestor(dirty_root.upcast(), ShadowIncluding::Yes);
+            .common_ancestor(dirty_root.upcast(), ShadowIncluding::Yes)
+            .expect("Couldn't find common ancestor");
 
         let mut has_dirty_descendants = true;
         for ancestor in dirty_root
@@ -1515,10 +1516,12 @@ impl Document {
             FireMouseEventType::Enter | FireMouseEventType::Leave
         ));
 
-        let common_ancestor = related_target.as_ref().map_or_else(
-            || DomRoot::from_ref(&*event_target),
-            |related_target| event_target.common_ancestor(related_target, ShadowIncluding::No),
-        );
+        let common_ancestor = match related_target.as_ref() {
+            Some(related_target) => event_target
+                .common_ancestor(related_target, ShadowIncluding::No)
+                .unwrap_or_else(|| DomRoot::from_ref(&*event_target)),
+            None => DomRoot::from_ref(&*event_target),
+        };
 
         // We need to create a target chain in case the event target shares
         // its boundaries with its ancestors.

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -708,16 +708,16 @@ impl Node {
         &self,
         other: &Node,
         shadow_including: ShadowIncluding,
-    ) -> DomRoot<Node> {
+    ) -> Option<DomRoot<Node>> {
         for ancestor in self.inclusive_ancestors(shadow_including) {
             if other
                 .inclusive_ancestors(shadow_including)
                 .any(|node| node == ancestor)
             {
-                return ancestor;
+                return Some(ancestor);
             }
         }
-        unreachable!();
+        None
     }
 
     pub fn is_inclusive_ancestor_of(&self, parent: &Node) -> bool {

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -298,6 +298,7 @@ impl RangeMethods for Range {
     fn CommonAncestorContainer(&self) -> DomRoot<Node> {
         self.EndContainer()
             .common_ancestor(&self.StartContainer(), ShadowIncluding::No)
+            .expect("Couldn't find common ancestor container")
     }
 
     // https://dom.spec.whatwg.org/#dom-range-setstart

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -552,7 +552,7 @@ pub enum CompositorEvent {
     ),
     /// The mouse was moved over a point (or was moved out of the recognizable region).
     MouseMoveEvent(
-        Option<Point2D<f32>>,
+        Point2D<f32>,
         Option<UntrustedNodeAddress>,
         // Bitmask of MouseButton values representing the currently pressed buttons
         u16,

--- a/tests/html/test_mouse_events_order_1.html
+++ b/tests/html/test_mouse_events_order_1.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Mouse Events Order 1</title>
+    <meta name="specification" content="https://w3c.github.io/uievents/#events-mouseevent-event-order">
+    <style>
+        .box {
+            width: 16ex;
+            height: 16ex;
+            padding: 1ex;
+            color: white;
+            font-weight: bold;
+            text-align: right;
+            position: absolute;
+        }
+
+        .blue {
+            background: #99DDFF;
+        }
+
+        .green {
+            left: 22ex;
+            background: #44BB99;
+        }
+    </style>
+</head>
+
+<body>
+    <p><strong>Description:</strong> Tests the order of mouse events when a pointing device transitions from a
+        visible element A to another visible element B.</p>
+
+    <div id="box-1" class="box blue">A</div>
+    <div id="box-2" class="box green">B</div>
+
+    <script>
+        function print(label, message) {
+            console.log(`${label}: ${message}`);
+        }
+
+        function handleMouseEvents(element, label) {
+            element.addEventListener("mouseup", _ => print(label, "mouseup"));
+            element.addEventListener("mousedown", _ => print(label, "mousedown"));
+            element.addEventListener("mouseenter", _ => print(label, "mouseenter"));
+            element.addEventListener("mouseleave", _ => print(label, "mouseleave"));
+            element.addEventListener("mousemove", _ => print(label, "mousemove"));
+            element.addEventListener("mouseout", _ => print(label, "mouseout"));
+            element.addEventListener("mouseover", _ => print(label, "mouseover"));
+        }
+
+        handleMouseEvents(document.getElementById("box-1"), "A");
+        handleMouseEvents(document.getElementById("box-2"), "B");
+    </script>
+</body>
+
+</html>

--- a/tests/html/test_mouse_events_order_2.html
+++ b/tests/html/test_mouse_events_order_2.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Mouse Events Order 2</title>
+    <meta name="specification" content="https://w3c.github.io/uievents/#events-mouseevent-event-order">
+    <style>
+        .box {
+            width: 16ex;
+            height: 16ex;
+            color: white;
+            font-weight: bold;
+            text-align: right;
+            padding: 1ex;
+            position: absolute;
+        }
+
+        .blue {
+            background: #99DDFF;
+        }
+
+        .green {
+            width: 10ex;
+            height: 10ex;
+            left: 3ex;
+            top: 3ex;
+            background: #44BB99;
+        }
+    </style>
+</head>
+
+<body>
+    <p><strong>Description:</strong> Tests the order of mouse events when a pointing device is moved into an element A,
+        and then into a nested element B and then back out again.</p>
+
+    <div id="box-1" class="box blue">A
+        <div id="box-2" class="box green">B</div>
+    </div>
+
+    <script>
+        function print(label, msg) {
+            console.log(`${label}: ${msg}`);
+        }
+
+        function handleMouseEvents(element, label) {
+            element.addEventListener("mouseup", _ => print(label, "mouseup"));
+            element.addEventListener("mousedown", _ => print(label, "mousedown"));
+            element.addEventListener("mouseenter", _ => print(label, "mouseenter"));
+            element.addEventListener("mouseleave", _ => print(label, "mouseleave"));
+            element.addEventListener("mousemove", _ => print(label, "mousemove"));
+            element.addEventListener("mouseout", _ => print(label, "mouseout"));
+            element.addEventListener("mouseover", _ => print(label, "mouseover"));
+        }
+
+        handleMouseEvents(document.getElementById("box-1"), "A");
+        handleMouseEvents(document.getElementById("box-2"), "B");
+    </script>
+</body>
+
+</html>

--- a/tests/html/test_mouse_events_order_3.html
+++ b/tests/html/test_mouse_events_order_3.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Mouse Events Order 3</title>
+    <meta name="specification" content="https://w3c.github.io/uievents/#events-mouseevent-event-order">
+    <style>
+        .box {
+            width: 16ex;
+            height: 16ex;
+            color: white;
+            font-weight: bold;
+            text-align: right;
+            position: absolute;
+        }
+
+        .blue {
+            background: #99DDFF;
+        }
+
+        .green {
+            background: #44BB99;
+        }
+
+        .yellow {
+            background: #EEDD88;
+        }
+    </style>
+</head>
+
+<body>
+    <p><strong>Description: </strong> Tests the order of mouse events when a pointing device is moved into a visually
+        overlapped stack of elements having the same dimensions and absolute positions and then moved out again.</p>
+
+    <div id="box-1" class="box blue">A
+        <div id="box-2" class="box green">B
+            <div id="box-3" class="box yellow">C</div>
+        </div>
+    </div>
+
+    <script>
+        function print(label, msg) {
+            console.log(`${label}: ${msg}`);
+        }
+
+        function handleMouseEvents(element, label) {
+            element.addEventListener("mouseup", _ => print(label, "mouseup"));
+            element.addEventListener("mousedown", _ => print(label, "mousedown"));
+            element.addEventListener("mouseenter", _ => print(label, "mouseenter"));
+            element.addEventListener("mouseleave", _ => print(label, "mouseleave"));
+            element.addEventListener("mousemove", _ => print(label, "mousemove"));
+            element.addEventListener("mouseout", _ => print(label, "mouseout"));
+            element.addEventListener("mouseover", _ => print(label, "mouseover"));
+        }
+
+        handleMouseEvents(document.getElementById("box-1"), "A");
+        handleMouseEvents(document.getElementById("box-2"), "B");
+        handleMouseEvents(document.getElementById("box-3"), "C");
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
The PR primarily consists of changes for:
- Fixing the order in which `mousemove` events are fired.
- Firing `mouseenter` and `mouseleave` events.
---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #26958 
- [ ] There are tests for these changes 
