### PR TITLE
Make reload button clear the network cache.

### DIFF
--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -71,6 +71,8 @@ pub enum ConstellationMsg {
     AllowNavigationResponse(PipelineId, bool),
     /// Request to load a page.
     LoadUrl(TopLevelBrowsingContextId, ServoUrl),
+    /// Clear the network cache.
+    ClearCache,
     /// Request to traverse the joint session history of the provided browsing context.
     TraverseHistory(TopLevelBrowsingContextId, TraversalDirection),
     /// Inform the constellation of a window being resized.
@@ -143,6 +145,7 @@ impl fmt::Debug for ConstellationMsg {
             MediaSessionAction(..) => "MediaSessionAction",
             ChangeBrowserVisibility(..) => "ChangeBrowserVisibility",
             IMEDismissed => "IMEDismissed",
+            ClearCache => "ClearCache",
         };
         write!(formatter, "ConstellationMsg::{}", variant)
     }

--- a/components/compositing/windowing.rs
+++ b/components/compositing/windowing.rs
@@ -95,6 +95,8 @@ pub enum WindowEvent {
     ToggleWebRenderDebug(WebRenderDebugOption),
     /// Capture current WebRender
     CaptureWebRender,
+    /// Clear the network cache.
+    ClearCache,
     /// Toggle sampling profiler with the given sampling rate and max duration.
     ToggleSamplingProfiler(Duration, Duration),
     /// Sent when the user triggers a media action through the UA exposed media UI
@@ -137,6 +139,7 @@ impl Debug for WindowEvent {
             WindowEvent::MediaSessionAction(..) => write!(f, "MediaSessionAction"),
             WindowEvent::ChangeBrowserVisibility(..) => write!(f, "ChangeBrowserVisibility"),
             WindowEvent::IMEDismissed => write!(f, "IMEDismissed"),
+            WindowEvent::ClearCache => write!(f, "ClearCache"),
         }
     }
 }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1529,6 +1529,10 @@ where
                     },
                 };
             },
+            FromCompositorMsg::ClearCache => {
+                self.public_resource_threads.clear_cache();
+                self.private_resource_threads.clear_cache();
+            },
             // Load a new page from a typed url
             // If there is already a pending page (self.pending_changes), it will not be overridden;
             // However, if the id is not encompassed by another change, it will be.

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -902,4 +902,9 @@ impl HttpCache {
         // See A cache MAY complete a stored incomplete response by making a subsequent range request
         // https://tools.ietf.org/html/rfc7234#section-3.1
     }
+
+    /// Clear the contents of this cache.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
 }

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -354,6 +354,9 @@ impl ResourceChannelManager {
             CoreResourceMsg::Synchronize(sender) => {
                 let _ = sender.send(());
             },
+            CoreResourceMsg::ClearCache => {
+                http_state.http_cache.write().unwrap().clear();
+            },
             CoreResourceMsg::ToFileManager(msg) => self.resource_manager.filemanager.handle(msg),
             CoreResourceMsg::Exit(sender) => {
                 if let Some(ref config_dir) = self.config_dir {

--- a/components/net_traits/lib.rs
+++ b/components/net_traits/lib.rs
@@ -361,6 +361,10 @@ impl ResourceThreads {
             storage_thread: s,
         }
     }
+
+    pub fn clear_cache(&self) {
+        let _ = self.core_thread.send(CoreResourceMsg::ClearCache);
+    }
 }
 
 impl IpcSend<CoreResourceMsg> for ResourceThreads {
@@ -459,6 +463,8 @@ pub enum CoreResourceMsg {
     RemoveHistoryStates(Vec<HistoryStateId>),
     /// Synchronization message solely for knowing the state of the ResourceChannelManager loop
     Synchronize(IpcSender<()>),
+    /// Clear the network cache.
+    ClearCache,
     /// Send the service worker network mediator for an origin to CoreResourceThread
     NetworkMediator(IpcSender<CustomResponseMediator>, ImmutableOrigin),
     /// Message forwarded to file manager's handler

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -583,6 +583,13 @@ where
                 }
             },
 
+            WindowEvent::ClearCache => {
+                let msg = ConstellationMsg::ClearCache;
+                if let Err(e) = self.constellation_chan.send(msg) {
+                    warn!("Sending clear cache to constellation failed ({:?}).", e);
+                }
+            },
+
             WindowEvent::MouseWindowEventClass(mouse_window_event) => {
                 self.compositor
                     .on_mouse_window_event_class(mouse_window_event);

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -356,6 +356,13 @@ impl ServoGlue {
     }
 
     /// Reload the page.
+    pub fn clear_cache(&mut self) -> Result<(), &'static str> {
+        info!("clear_cache");
+        let event = WindowEvent::ClearCache;
+        self.process_event(event)
+    }
+
+    /// Reload the page.
     pub fn reload(&mut self) -> Result<(), &'static str> {
         info!("reload");
         let browser_id = self.get_browser_id()?;

--- a/ports/libsimpleservo/capi/src/lib.rs
+++ b/ports/libsimpleservo/capi/src/lib.rs
@@ -566,6 +566,14 @@ pub extern "C" fn load_uri(url: *const c_char) -> bool {
 }
 
 #[no_mangle]
+pub extern "C" fn clear_cache() {
+    catch_any_panic(|| {
+        debug!("clear_cache");
+        call(|s| s.clear_cache())
+    });
+}
+
+#[no_mangle]
 pub extern "C" fn reload() {
     catch_any_panic(|| {
         debug!("reload");

--- a/support/hololens/ServoApp/ServoControl/Servo.h
+++ b/support/hololens/ServoApp/ServoControl/Servo.h
@@ -67,7 +67,10 @@ public:
   void KeyDown(const char *k) { key_down(k); }
   void KeyUp(const char *k) { key_up(k); }
 
-  void Reload() { reload(); }
+  void Reload() {
+    clear_cache();
+    reload();
+  }
   void Stop() { stop(); }
   bool LoadUri(hstring uri) { return load_uri(*hstring2char(uri)); }
   void ChangeVisibility(bool visible) { change_visibility(visible); }


### PR DESCRIPTION
The developer workflow in FxR is frustrating right now because of bugs like https://github.com/servo/servo/issues/24385. To allow us to put out a new release soon that addresses this papercut, these changes make the reload button clear the network cache in FxR.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix (kind of) #26411.
- [x] These changes do not require tests because can't test FxR.