### PR TITLE
Move secondary view support into a pref

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6826,7 +6826,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#2ff286efcf8bc85fbe2fc91df1aefb1aff911781"
+source = "git+https://github.com/servo/webxr#ae74e50cc89cb4965ec4897b3b9ff4cfedf7a6ca"
 dependencies = [
  "android_injected_glue",
  "bindgen",
@@ -6849,7 +6849,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#2ff286efcf8bc85fbe2fc91df1aefb1aff911781"
+source = "git+https://github.com/servo/webxr#ae74e50cc89cb4965ec4897b3b9ff4cfedf7a6ca"
 dependencies = [
  "euclid",
  "ipc-channel",

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -282,6 +282,7 @@ mod gen {
                     enabled: bool,
                     #[serde(default)]
                     test: bool,
+                    first_person_observer_view: bool,
                     glwindow: {
                         #[serde(default)]
                         enabled: bool,

--- a/components/script/dom/xrsystem.rs
+++ b/components/script/dom/xrsystem.rs
@@ -26,6 +26,7 @@ use ipc_channel::ipc::{self as ipc_crate, IpcReceiver};
 use ipc_channel::router::ROUTER;
 use msg::constellation_msg::PipelineId;
 use profile_traits::ipc;
+use servo_config::pref;
 use std::cell::Cell;
 use std::rc::Rc;
 use webxr_api::{Error as XRError, Frame, Session, SessionInit, SessionMode};
@@ -215,6 +216,7 @@ impl XRSystemMethods for XRSystem {
         let init = SessionInit {
             required_features,
             optional_features,
+            first_person_observer_view: pref!(dom.webxr.first_person_observer_view),
         };
 
         let mut trusted = Some(TrustedPromise::new(promise.clone()));

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -843,7 +843,7 @@ impl EmbedderMethods for ServoEmbedderCallbacks {
             }
         }
 
-        if openxr::create_instance(false).is_ok() {
+        if openxr::create_instance(false, false).is_ok() {
             let discovery =
                 openxr::OpenXrDiscovery::new(Box::new(ContextMenuCallback(embedder_proxy)));
             registry.register(discovery);

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -40,6 +40,7 @@
   "dom.webvr.test": false,
   "dom.webvtt.enabled": false,
   "dom.webxr.enabled": true,
+  "dom.webxr.first_person_observer_view": false,
   "dom.webxr.glwindow.cubemap": false,
   "dom.webxr.glwindow.enabled": true,
   "dom.webxr.glwindow.left-right": false,


### PR DESCRIPTION
Needs https://github.com/servo/webxr/pull/188

Adds a `dom.webxr.first_person_observer_view` pref that toggles FPO views.