### PR TITLE
 [WIP] Drop impls for DOM types should be forbidden

### DIFF
--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -63,15 +63,17 @@ impl CanvasRenderingContext2D {
         canvas: Option<&HTMLCanvasElement>,
         size: Size2D<u32>,
     ) -> CanvasRenderingContext2D {
-        let canvas_state =
-            CanvasState::new(global, Size2D::new(size.width as u64, size.height as u64));
-        let canvas_id = canvas_state.get_canvas_id();
-        let ipc_renderer = canvas_state.get_ipc_renderer().clone();
+        let remote_canvas_state = CanvasState::remote_canvas_state(
+            global,
+            Size2D::new(size.width as u64, size.height as u64),
+        );
+        let canvas_id = remote_canvas_state.get_canvas_id();
+        let ipc_renderer = remote_canvas_state.get_ipc_renderer().clone();
 
         CanvasRenderingContext2D {
             reflector_: Reflector::new(),
             canvas: canvas.map(Dom::from_ref),
-            canvas_state: canvas_state,
+            canvas_state: CanvasState::new(global, remote_canvas_state),
             droppable_fields: CanvasRenderingContext2DDroppableFields {
                 canvas_id: canvas_id,
                 ipc_renderer: ipc_renderer,

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -49,7 +49,10 @@ impl OffscreenCanvasRenderingContext2D {
             reflector_: Reflector::new(),
             canvas: Dom::from_ref(canvas),
             htmlcanvas: htmlcanvas.map(Dom::from_ref),
-            canvas_state: CanvasState::new(global, canvas.get_size()),
+            canvas_state: CanvasState::new(
+                global,
+                CanvasState::remote_canvas_state(global, canvas.get_size()),
+            ),
         }
     }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Drop impls for DOM types should be forbidden
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #26488 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it is a refactor and the compiler will check

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
Status of the PR
- [X] CanvasRenderingContext2D
- [x] EventSource
- [ ] GPUBuffer
- [ ] GPUTexture
- [ ] HTMLMediaElement
- [ ] Promise
- [ ] WebGLBuffer
- [ ] WebGLFramebuffer
- [ ] WebGLProgram
- [ ] WebGLQuery
- [ ] WebGLRenderbuffer
- [ ] WebGLRenderingContext
- [ ] WebGLSampler
- [ ] WebGLShader
- [ ] WebGLSync
- [ ] WebGLTexture
- [ ] WebGLTransformFeedback
- [ ] Worklet
