### PR TITLE
Add a pref to indicate user intent to enter webxr

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -300,6 +300,8 @@ mod gen {
                         enabled: bool,
                     },
                     sessionavailable: bool,
+                    #[serde(rename = "dom.webxr.unsafe-assume-user-intent")]
+                    unsafe_assume_user_intent: bool,
                 },
                 worklet: {
                     blockingsleep: {

--- a/ports/gstplugin/servowebsrc.rs
+++ b/ports/gstplugin/servowebsrc.rs
@@ -218,6 +218,7 @@ impl ServoThread {
             None => Some(webrender_swap_chain),
             Some(..) => {
                 set_pref!(dom.webxr.sessionavailable, true);
+                set_pref!(dom.webxr.unsafe_assume_user_intent, true);
                 servo.handle_events(vec![WindowEvent::ChangeBrowserVisibility(id, false)]);
                 None
             },

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -49,6 +49,7 @@
   "dom.webxr.layers.enabled": false,
   "dom.webxr.sessionavailable": false,
   "dom.webxr.test": false,
+  "dom.webxr.unsafe-assume-user-intent": false,
   "dom.worklet.timeout_ms": 10,
   "gfx.subpixel-text-antialiasing.enabled": true,
   "gfx.texture-swizzling.enabled": true,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Add a pref to indicate that the user has indicated intent to enter webxr.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's a command-line pref

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
