### PR TITLE
UWP Crash reporter

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -482,6 +482,9 @@ mod gen {
                 max_length: i64,
             },
             shell: {
+                crash_reporter: {
+                    enabled: bool,
+                },
                 homepage: String,
                 keep_screen_on: {
                     enabled: bool,

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -148,6 +148,8 @@ pub trait HostTrait {
     fn on_media_session_set_position_state(&self, duration: f64, position: f64, playback_rate: f64);
     /// Called when devtools server is started
     fn on_devtools_started(&self, port: Result<u16, ()>, token: String);
+    /// Called when we get a panic message from constellation
+    fn on_panic(&self, reason: String, backtrace: Option<String>);
 }
 
 pub struct ServoGlue {
@@ -764,6 +766,9 @@ impl ServoGlue {
                         .host_callbacks
                         .on_devtools_started(port, token);
                 },
+                EmbedderMsg::Panic(reason, backtrace) => {
+                    self.callbacks.host_callbacks.on_panic(reason, backtrace);
+                },
                 EmbedderMsg::Status(..) |
                 EmbedderMsg::SelectFiles(..) |
                 EmbedderMsg::MoveTo(..) |
@@ -773,7 +778,6 @@ impl ServoGlue {
                 EmbedderMsg::NewFavicon(..) |
                 EmbedderMsg::HeadParsed |
                 EmbedderMsg::SetFullscreenState(..) |
-                EmbedderMsg::Panic(..) |
                 EmbedderMsg::ReportProfile(..) => {},
             }
         }

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -111,6 +111,7 @@
   "network.http-cache.disabled": false,
   "network.mime.sniff": false,
   "session-history.max-length": 20,
+  "shell.crash_reporter.enabled": false,
   "shell.homepage": "https://servo.org",
   "shell.keep_screen_on.enabled": false,
   "shell.native-orientation": "both",

--- a/support/hololens/ServoApp/BrowserPage.h
+++ b/support/hololens/ServoApp/BrowserPage.h
@@ -41,6 +41,8 @@ public:
   void Shutdown();
   void LoadFXRURI(Uri uri);
   void SetArgs(hstring);
+  void OnDismissCrashReport(IInspectable const &, RoutedEventArgs const &);
+  void OnSubmitCrashReport(IInspectable const &, RoutedEventArgs const &);
   void OnMediaControlsPlayClicked(IInspectable const &,
                                   RoutedEventArgs const &);
   void OnMediaControlsPauseClicked(IInspectable const &,
@@ -55,11 +57,15 @@ public:
 private:
   void SetTransientMode(bool);
   void UpdatePref(ServoApp::Pref, Controls::Control);
+  void CheckCrashReport();
   void BindServoEvents();
   void BuildPrefList();
+  void ShowToolbox();
+  void HideToolbox();
   DevtoolsStatus mDevtoolsStatus = DevtoolsStatus::Stopped;
   unsigned int mDevtoolsPort = 0;
   hstring mDevtoolsToken;
+  bool mPanicking = false;
   std::unique_ptr<servo::DevtoolsClient> mDevtoolsClient;
   Collections::IObservableVector<IInspectable> mLogs;
 };

--- a/support/hololens/ServoApp/BrowserPage.xaml
+++ b/support/hololens/ServoApp/BrowserPage.xaml
@@ -150,7 +150,7 @@
                     </Button>
                 </Grid>
             </muxc:TabView.TabStripFooter>
-            <muxc:TabViewItem x:Uid="devtoolsTabConsole" IsClosable="False">
+            <muxc:TabViewItem x:Uid="devtoolsTabConsole" x:Name="devtoolsTabConsole" IsClosable="False">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*"/>
@@ -198,6 +198,20 @@
                         <StackPanel x:Name="prefList"/>
                     </ScrollViewer>
                 </Grid>
+            </muxc:TabViewItem>
+            <muxc:TabViewItem x:Uid="crashTab" x:Name="crashTab" IsClosable="False" Visibility="Collapsed">
+              <Grid VerticalAlignment="Stretch">
+                <Grid.RowDefinitions>
+                  <RowDefinition Height="auto"/>
+                  <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <StackPanel Grid.Row="0" Padding="4" Orientation="Horizontal">
+                  <TextBlock VerticalAlignment="Center" x:Name="crashTabMessage"></TextBlock>
+                  <Button IsTabStop="true" x:Uid="SubmitCrashReportButton" Margin="4" Click="OnSubmitCrashReport"/>
+                  <Button IsTabStop="true" x:Uid="DismissCrashReportButton" Margin="4" Click="OnDismissCrashReport"/>
+                </StackPanel>
+                <TextBox Grid.Row="1" TextWrapping="Wrap" IsTabStop="true" x:Name="crashReport" AcceptsReturn="True" IsSpellCheckEnabled="False" Margin="3"/>
+              </Grid>
             </muxc:TabViewItem>
         </muxc:TabView>
         <ProgressBar x:Name="transientLoadingIndicator" Visibility="Collapsed" Grid.Row="3"/>

--- a/support/hololens/ServoApp/Devtools/Client.cpp
+++ b/support/hololens/ServoApp/Devtools/Client.cpp
@@ -79,7 +79,7 @@ IAsyncAction DevtoolsClient::Loop() {
       } catch (...) {
         throw hresult_error(E_FAIL, L"Can't parse message header:" + c);
       }
-      if (len >= 10000) {
+      if (len >= 100000) {
         throw hresult_error(E_FAIL, L"Message length too long");
       }
     }

--- a/support/hololens/ServoApp/ServoControl/Servo.h
+++ b/support/hololens/ServoApp/ServoControl/Servo.h
@@ -31,6 +31,8 @@ public:
         float, ServoDelegate &, bool);
   ~Servo();
   ServoDelegate &Delegate() { return mDelegate; }
+  hstring CurrentUrl() { return mUrl; }
+  void CurrentUrl(hstring url) { mUrl = url; }
 
   typedef std::tuple<hstring, winrt::Windows::Foundation::IInspectable, bool>
       PrefTuple;
@@ -96,6 +98,7 @@ public:
 
 private:
   ServoDelegate &mDelegate;
+  hstring mUrl;
   GLsizei mWindowWidth;
   GLsizei mWindowHeight;
   static void SaveUserPref(PrefTuple);
@@ -115,6 +118,7 @@ public:
   virtual void OnServoURLChanged(hstring) = 0;
   virtual bool OnServoAllowNavigation(hstring) = 0;
   virtual void OnServoAnimatingChanged(bool) = 0;
+  virtual void OnServoPanic(hstring) = 0;
   virtual void OnServoIMEShow(hstring text, int32_t x, int32_t y, int32_t width,
                               int32_t height) = 0;
   virtual void OnServoIMEHide() = 0;

--- a/support/hololens/ServoApp/ServoControl/ServoControl.cpp
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.cpp
@@ -418,34 +418,48 @@ void ServoControl::Loop() {
 
   while (true) {
     EnterCriticalSection(&mGLLock);
-    while (mTasks.size() == 0 && !mAnimating && mLooping) {
-      SleepConditionVariableCS(&mGLCondVar, &mGLLock, INFINITE);
-    }
-    if (!mLooping) {
+    try {
+      while (mTasks.size() == 0 && !mAnimating && mLooping) {
+        SleepConditionVariableCS(&mGLCondVar, &mGLLock, INFINITE);
+      }
+      if (!mLooping) {
+        LeaveCriticalSection(&mGLLock);
+        break;
+      }
+      for (auto &&task : mTasks) {
+        task();
+      }
+      mTasks.clear();
       LeaveCriticalSection(&mGLLock);
-      break;
+      mServo->PerformUpdates();
+    } catch (hresult_error const &e) {
+      log(L"GL Thread exception: %s", e.message().c_str());
+      throw e;
+    } catch (...) {
+      log(L"GL Thread exception");
+      throw winrt::hresult_error(E_FAIL, L"GL Thread exception");
     }
-    for (auto &&task : mTasks) {
-      task();
-    }
-    mTasks.clear();
-    LeaveCriticalSection(&mGLLock);
-    mServo->PerformUpdates();
   }
   mServo->DeInit();
 }
 
 void ServoControl::StartRenderLoop() {
   if (mLooping) {
-#if defined _DEBUG
     throw winrt::hresult_error(E_FAIL, L"GL thread is already looping");
-#else
-    return;
-#endif
   }
   mLooping = true;
   log(L"BrowserPage::StartRenderLoop(). UI thread: %i", GetCurrentThreadId());
-  auto task = Concurrency::create_task([=] { Loop(); });
+  auto task = Concurrency::create_task([=] {
+    try {
+      Loop();
+    } catch (...) {
+      // Do our best to recover. Exception has been logged at that point.
+      mLooping = false;
+      mLoopTask.reset();
+      mServo.reset();
+      LeaveCriticalSection(&mGLLock);
+    }
+  });
   mLoopTask = std::make_unique<Concurrency::task<void>>(task);
 }
 
@@ -500,6 +514,10 @@ bool ServoControl::OnServoAllowNavigation(hstring uri) {
     RunOnUIThread([=] { Launcher::LaunchUriAsync(Uri{uri}); });
   }
   return !mTransient;
+}
+
+void ServoControl::OnServoPanic(hstring backtrace) {
+  RunOnUIThread([=] { mOnServoPanic(*this, backtrace); });
 }
 
 void ServoControl::OnServoAnimatingChanged(bool animating) {

--- a/support/hololens/ServoApp/ServoControl/ServoControl.h
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.h
@@ -100,6 +100,14 @@ struct ServoControl : ServoControlT<ServoControl>, public servo::ServoDelegate {
     mOnTitleChangedEvent.remove(token);
   }
 
+  winrt::event_token
+  OnServoPanic(Windows::Foundation::EventHandler<hstring> const &handler) {
+    return mOnServoPanic.add(handler);
+  };
+  void OnServoPanic(winrt::event_token const &token) noexcept {
+    mOnServoPanic.remove(token);
+  }
+
   winrt::event_token OnHistoryChanged(HistoryChangedDelegate const &handler) {
     return mOnHistoryChangedEvent.add(handler);
   };
@@ -173,6 +181,7 @@ struct ServoControl : ServoControlT<ServoControl>, public servo::ServoDelegate {
   virtual void OnServoURLChanged(winrt::hstring);
   virtual bool OnServoAllowNavigation(winrt::hstring);
   virtual void OnServoAnimatingChanged(bool);
+  virtual void OnServoPanic(hstring);
   virtual void OnServoIMEHide();
   virtual void OnServoIMEShow(hstring text, int32_t, int32_t, int32_t, int32_t);
   virtual void OnServoMediaSessionMetadata(winrt::hstring, winrt::hstring,
@@ -193,6 +202,7 @@ struct ServoControl : ServoControlT<ServoControl>, public servo::ServoDelegate {
 private:
   winrt::event<Windows::Foundation::EventHandler<hstring>> mOnURLChangedEvent;
   winrt::event<Windows::Foundation::EventHandler<hstring>> mOnTitleChangedEvent;
+  winrt::event<Windows::Foundation::EventHandler<hstring>> mOnServoPanic;
   winrt::event<HistoryChangedDelegate> mOnHistoryChangedEvent;
   winrt::event<DevtoolsStatusChangedDelegate> mOnDevtoolsStatusChangedEvent;
   winrt::event<EventDelegate> mOnLoadStartedEvent;

--- a/support/hololens/ServoApp/ServoControl/ServoControl.idl
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.idl
@@ -39,6 +39,7 @@ namespace ServoApp {
       event DevtoolsStatusChangedDelegate OnDevtoolsStatusChanged;
       event HistoryChangedDelegate OnHistoryChanged;
       event Windows.Foundation.EventHandler<String> OnTitleChanged;
+      event Windows.Foundation.EventHandler<String> OnServoPanic;
       event Windows.Foundation.EventHandler<String> OnURLChanged;
       event MediaSessionMetadataDelegate OnMediaSessionMetadata;
       event Windows.Foundation.EventHandler<int> OnMediaSessionPlaybackStateChange;

--- a/support/hololens/ServoApp/Strings/en-US/Resources.resw
+++ b/support/hololens/ServoApp/Strings/en-US/Resources.resw
@@ -114,6 +114,21 @@
   <data name="devtoolsTabPrefs.[using:Microsoft.UI.Xaml.Controls]TabViewItem.Header" xml:space="preserve">
     <value>Preferences</value>
   </data>
+  <data name="crashTab.[using:Microsoft.UI.Xaml.Controls]TabViewItem.Header" xml:space="preserve">
+    <value>Crash Report</value>
+  </data>
+  <data name="crash.Happening" xml:space="preserve">
+    <value>Internal crash detected. Application might be unstable:</value>
+  </data>
+  <data name="crash.Happened" xml:space="preserve">
+    <value>Internal crash was detected during last run:</value>
+  </data>
+  <data name="SubmitCrashReportButton.Content" xml:space="preserve">
+    <value>Send crash report</value>
+  </data>
+  <data name="DismissCrashReportButton.Content" xml:space="preserve">
+    <value>Dismiss</value>
+  </data>
   <data name="preferenceSearchbox.PlaceholderText" xml:space="preserve">
     <value>Search Preferences</value>
   </data>


### PR DESCRIPTION
This is supposed to address #27167 and #26523. Also fix #27435.

These changes are still WIP as I found a few bugs, it needs more testing and the actual code to upload is not implemented yet. But I'd like to get an early feedback.

First, panics are caught via `panic::set_hook` instead of `catch_unwind` allowing us to catch more panics.
We also now report panics reported via the `Embedder:Panic` message.
Once the panic is caught, if possible, we try to recover.
I haven't found a way to recover when the panic is caught is a non-GL thread. We need a generic way to throw from the UWP code, and even trying to add a UnhandledEvent handler doesn't appear to work.

Once a panic is caught (even if we can not recover) a crash-report file is created, including the backtrace, stdout, and the current url.

If the app did not crash at that point, or after a restart if it did, we check if the crash report file is present, and if so, we present a panel to the user to allow them to upload the report. At that point the user can also add details to the report.

<img width="1079" alt="Screen Shot 2020-07-29 at 12 35 44" src="https://user-images.githubusercontent.com/373579/88790406-6d777180-d198-11ea-9237-6f80dc9d0340.png">