### PR TITLE
Refactor and improve GPUErrorScopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,6 +771,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cocoa-foundation"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318"
+dependencies = [
+ "bitflags",
+ "block",
+ "core-foundation 0.9.0",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +936,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b5ed8e7e76c45974e15e41bfa8d5b0483cd90191639e01d8f5f1e606299d3fb"
+dependencies = [
+ "core-foundation-sys 0.8.0",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +956,12 @@ name = "core-foundation-sys"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a21fa21941700a3cd8fcb4091f361a6a712fac632f85d9f487cc892045d55c6"
 
 [[package]]
 name = "core-graphics"
@@ -952,6 +983,18 @@ checksum = "59e78b2e0aaf43f08e7ae0d6bc96895ef72ff0921c7d4ff4762201b2dba376dd"
 dependencies = [
  "bitflags",
  "core-foundation 0.7.0",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e92f5d519093a4178296707dbaa3880eae85a5ef5386675f361a1cf25376e93c"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.0",
  "foreign-types",
  "libc",
 ]
@@ -1889,22 +1932,21 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-metal"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "412a1e0e53e9e325a7c2e0316f1a4e8a14cbe8d8bfb5f030bc3895692f8a8254"
+checksum = "92804d20b194de6c84cb4bec14ec6a6dcae9c51f0a9186817fb412a590131ae6"
 dependencies = [
  "arrayvec 0.5.1",
  "bitflags",
  "block",
- "cocoa 0.20.1",
+ "cocoa-foundation",
  "copyless",
- "core-graphics 0.19.0",
  "foreign-types",
  "gfx-auxil",
  "gfx-hal",
  "lazy_static",
  "log",
- "metal",
+ "metal 0.20.0",
  "objc",
  "parking_lot 0.10.2",
  "range-alloc",
@@ -1916,14 +1958,14 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-vulkan"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2e8bb53e5bea0bfec7035462a75717cd04d733963a225c816339a671ef108b"
+checksum = "aec9c919cfc236d2c36aaa38609c1906a92f2df99a3c7f53022b01936f98275a"
 dependencies = [
  "arrayvec 0.5.1",
  "ash",
  "byteorder",
- "core-graphics 0.19.0",
+ "core-graphics-types",
  "gfx-hal",
  "lazy_static",
  "log",
@@ -3428,6 +3470,20 @@ dependencies = [
  "block",
  "cocoa 0.20.1",
  "core-graphics 0.19.0",
+ "foreign-types",
+ "log",
+ "objc",
+]
+
+[[package]]
+name = "metal"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4e8a431536529327e28c9ba6992f2cb0c15d4222f0602a16e6d7695ff3bccf"
+dependencies = [
+ "bitflags",
+ "block",
+ "cocoa-foundation",
  "foreign-types",
  "log",
  "objc",
@@ -5782,7 +5838,7 @@ dependencies = [
  "libc",
  "log",
  "mach",
- "metal",
+ "metal 0.18.0",
  "objc",
  "parking_lot 0.10.2",
  "wayland-sys 0.24.0",
@@ -6861,7 +6917,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#8a2ee26fffcdf02fc5e7f0a29771f4720522f7d8"
+source = "git+https://github.com/gfx-rs/wgpu#9e4839eb049707629fa8a91e3603085433f352a4"
 dependencies = [
  "arrayvec 0.5.1",
  "bitflags",
@@ -6875,7 +6931,6 @@ dependencies = [
  "gfx-descriptor",
  "gfx-hal",
  "gfx-memory",
- "log",
  "naga",
  "parking_lot 0.10.2",
  "ron",
@@ -6889,7 +6944,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#8a2ee26fffcdf02fc5e7f0a29771f4720522f7d8"
+source = "git+https://github.com/gfx-rs/wgpu#9e4839eb049707629fa8a91e3603085433f352a4"
 dependencies = [
  "bitflags",
  "serde",

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -169,7 +169,6 @@ use time::{Duration, Timespec, Tm};
 use uuid::Uuid;
 use webgpu::{
     wgpu::command::{ComputePass, RenderBundleEncoder, RenderPass},
-    wgt::BindGroupLayoutEntry,
     WebGPU, WebGPUAdapter, WebGPUBindGroup, WebGPUBindGroupLayout, WebGPUBuffer,
     WebGPUCommandBuffer, WebGPUCommandEncoder, WebGPUComputePipeline, WebGPUDevice,
     WebGPUPipelineLayout, WebGPUQueue, WebGPURenderBundle, WebGPURenderPipeline, WebGPUSampler,
@@ -629,7 +628,6 @@ unsafe_no_jsmanaged_fields!(WebGPUContextId);
 unsafe_no_jsmanaged_fields!(WebGPUCommandBuffer);
 unsafe_no_jsmanaged_fields!(WebGPUCommandEncoder);
 unsafe_no_jsmanaged_fields!(WebGPUDevice);
-unsafe_no_jsmanaged_fields!(BindGroupLayoutEntry);
 unsafe_no_jsmanaged_fields!(Option<RenderPass>);
 unsafe_no_jsmanaged_fields!(Option<RenderBundleEncoder>);
 unsafe_no_jsmanaged_fields!(Option<ComputePass>);

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -5,7 +5,6 @@
 use crate::dom::bindings::cell::{DomRefCell, RefMut};
 use crate::dom::bindings::codegen::Bindings::BroadcastChannelBinding::BroadcastChannelMethods;
 use crate::dom::bindings::codegen::Bindings::EventSourceBinding::EventSourceBinding::EventSourceMethods;
-use crate::dom::bindings::codegen::Bindings::GPUValidationErrorBinding::GPUError;
 use crate::dom::bindings::codegen::Bindings::ImageBitmapBinding::{
     ImageBitmapOptions, ImageBitmapSource,
 };
@@ -36,8 +35,6 @@ use crate::dom::eventsource::EventSource;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::file::File;
 use crate::dom::gpudevice::GPUDevice;
-use crate::dom::gpuoutofmemoryerror::GPUOutOfMemoryError;
-use crate::dom::gpuvalidationerror::GPUValidationError;
 use crate::dom::htmlscriptelement::{ScriptId, SourceCode};
 use crate::dom::identityhub::Identities;
 use crate::dom::imagebitmap::ImageBitmap;
@@ -3023,18 +3020,12 @@ impl GlobalScope {
         let _ = self.gpu_devices.borrow_mut().remove(&device);
     }
 
-    pub fn handle_wgpu_msg(&self, device: WebGPUDevice, scope: u64, result: WebGPUOpResult) {
-        let result = match result {
-            WebGPUOpResult::Success => Ok(()),
-            WebGPUOpResult::ValidationError(m) => {
-                let val_err = GPUValidationError::new(&self, DOMString::from_string(m));
-                Err(GPUError::GPUValidationError(val_err))
-            },
-            WebGPUOpResult::OutOfMemoryError => {
-                let oom_err = GPUOutOfMemoryError::new(&self);
-                Err(GPUError::GPUOutOfMemoryError(oom_err))
-            },
-        };
+    pub fn handle_wgpu_msg(
+        &self,
+        device: WebGPUDevice,
+        scope: Option<u64>,
+        result: WebGPUOpResult,
+    ) {
         self.gpu_devices
             .borrow()
             .get(&device)

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -10,21 +10,21 @@ use crate::dom::bindings::codegen::Bindings::GPUTextureViewBinding::{
     GPUTextureAspect, GPUTextureViewDescriptor, GPUTextureViewDimension,
 };
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::gpudevice::{convert_texture_format, convert_texture_view_dimension};
+use crate::dom::gpudevice::{convert_texture_format, convert_texture_view_dimension, GPUDevice};
 use crate::dom::gputextureview::GPUTextureView;
 use dom_struct::dom_struct;
 use std::string::String;
-use webgpu::{wgt, WebGPU, WebGPUDevice, WebGPURequest, WebGPUTexture, WebGPUTextureView};
+use webgpu::{wgt, WebGPU, WebGPURequest, WebGPUTexture, WebGPUTextureView};
 
 #[dom_struct]
 pub struct GPUTexture {
     reflector_: Reflector,
     texture: WebGPUTexture,
     label: DomRefCell<Option<USVString>>,
-    device: WebGPUDevice,
+    device: Dom<GPUDevice>,
     #[ignore_malloc_size_of = "channels are hard"]
     channel: WebGPU,
     #[ignore_malloc_size_of = "defined in webgpu"]
@@ -39,7 +39,7 @@ pub struct GPUTexture {
 impl GPUTexture {
     fn new_inherited(
         texture: WebGPUTexture,
-        device: WebGPUDevice,
+        device: &GPUDevice,
         channel: WebGPU,
         texture_size: GPUExtent3DDict,
         mip_level_count: u32,
@@ -53,7 +53,7 @@ impl GPUTexture {
             reflector_: Reflector::new(),
             texture,
             label: DomRefCell::new(label),
-            device,
+            device: Dom::from_ref(device),
             channel,
             texture_size,
             mip_level_count,
@@ -67,7 +67,7 @@ impl GPUTexture {
     pub fn new(
         global: &GlobalScope,
         texture: WebGPUTexture,
-        device: WebGPUDevice,
+        device: &GPUDevice,
         channel: WebGPU,
         texture_size: GPUExtent3DDict,
         mip_level_count: u32,
@@ -126,7 +126,7 @@ impl GPUTextureMethods for GPUTexture {
             match self.dimension {
                 GPUTextureDimension::_1d => GPUTextureViewDimension::_1d,
                 GPUTextureDimension::_2d => {
-                    if self.texture_size.depth > 1 && descriptor.arrayLayerCount == 0 {
+                    if self.texture_size.depth > 1 && descriptor.arrayLayerCount.is_none() {
                         GPUTextureViewDimension::_2d_array
                     } else {
                         GPUTextureViewDimension::_2d
@@ -152,31 +152,27 @@ impl GPUTextureMethods for GPUTexture {
                 GPUTextureAspect::Depth_only => wgt::TextureAspect::DepthOnly,
             },
             base_mip_level: descriptor.baseMipLevel,
-            level_count: if descriptor.mipLevelCount == 0 {
-                self.mip_level_count - descriptor.baseMipLevel
-            } else {
-                descriptor.mipLevelCount
-            },
+            level_count: descriptor.mipLevelCount.as_ref().copied(),
             base_array_layer: descriptor.baseArrayLayer,
-            array_layer_count: if descriptor.arrayLayerCount == 0 {
-                self.texture_size.depth - descriptor.baseArrayLayer
-            } else {
-                descriptor.arrayLayerCount
-            },
+            array_layer_count: descriptor.arrayLayerCount.as_ref().copied(),
         };
 
         let texture_view_id = self
             .global()
             .wgpu_id_hub()
             .lock()
-            .create_texture_view_id(self.device.0.backend());
+            .create_texture_view_id(self.device.id().0.backend());
+
+        let scope_id = self.device.use_current_scope();
 
         self.channel
             .0
             .send(WebGPURequest::CreateTextureView {
                 texture_id: self.texture.0,
                 texture_view_id,
+                device_id: self.device.id().0,
                 descriptor: desc,
+                scope_id,
             })
             .expect("Failed to create WebGPU texture view");
 

--- a/components/script/dom/webidls/GPUTextureView.webidl
+++ b/components/script/dom/webidls/GPUTextureView.webidl
@@ -13,9 +13,9 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
     GPUTextureViewDimension dimension;
     GPUTextureAspect aspect = "all";
     GPUIntegerCoordinate baseMipLevel = 0;
-    GPUIntegerCoordinate mipLevelCount = 0;
+    GPUIntegerCoordinate mipLevelCount;
     GPUIntegerCoordinate baseArrayLayer = 0;
-    GPUIntegerCoordinate arrayLayerCount = 0;
+    GPUIntegerCoordinate arrayLayerCount;
 };
 
 enum GPUTextureViewDimension {

--- a/components/webgpu/identity.rs
+++ b/components/webgpu/identity.rs
@@ -43,7 +43,7 @@ pub enum WebGPUMsg {
     FreeRenderBundle(RenderBundleId),
     WebGPUOpResult {
         device: WebGPUDevice,
-        scope_id: u64,
+        scope_id: Option<u64>,
         pipeline_id: PipelineId,
         result: WebGPUOpResult,
     },

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -34,6 +34,7 @@ packages = [
   "cocoa",
   "gleam",
   "libloading",
+  "metal",
   "miniz_oxide",
   "parking_lot",
   "parking_lot_core",


### PR DESCRIPTION
- Remove use of equivalent BGLs
- Capture errors from more `Createxxx` operations
- Address crashes on macOS in #27402 

Improved ErrorScope model attempts to- 

1. Identify and report `OutOfMemoryError` separately.
1. Match `GPUErrorFilter` and pass on uncaptured errors to parent scope.

r?@kvark

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
