### PR TITLE
Don't delete GL textures created by WebXR

### DIFF
--- a/components/script/dom/xrwebgllayer.rs
+++ b/components/script/dom/xrwebgllayer.rs
@@ -229,7 +229,7 @@ impl XRWebGLLayer {
         // TODO: Cache this texture
         let color_texture_id =
             WebGLTextureId::maybe_new(sub_images.sub_image.as_ref()?.color_texture)?;
-        let color_texture = WebGLTexture::new(context, color_texture_id);
+        let color_texture = WebGLTexture::new_webxr(context, color_texture_id);
         let target = self.texture_target();
 
         // Save the current bindings
@@ -263,7 +263,7 @@ impl XRWebGLLayer {
         if let Some(id) = sub_images.sub_image.as_ref()?.depth_stencil_texture {
             // TODO: Cache this texture
             let depth_stencil_texture_id = WebGLTextureId::maybe_new(id)?;
-            let depth_stencil_texture = WebGLTexture::new(context, depth_stencil_texture_id);
+            let depth_stencil_texture = WebGLTexture::new_webxr(context, depth_stencil_texture_id);
             framebuffer
                 .texture2d_even_if_opaque(
                     constants::DEPTH_STENCIL_ATTACHMENT,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Currently WebGL assumes it owns any WebGLTexture, and deletes the backing GL texture when the object is GC'd. This isn't valid for textures created by a webxr layer manager, which can result in textures being used after they're deleted.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27427 
- [x] These changes do not require tests because we don't reftest webxr

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
