### PR TITLE
[WIP] Add address sanitizer support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "peek-poke"
 version = "0.2.0"
-source = "git+https://github.com/servo/webrender#0bf15cbdbda530f733511f169194439e197e0f40"
+source = "git+https://github.com/servo/webrender#46791f3fd9188ab3178ab612de168ec554669be7"
 dependencies = [
  "euclid",
  "peek-poke-derive",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "peek-poke-derive"
 version = "0.2.1"
-source = "git+https://github.com/servo/webrender#0bf15cbdbda530f733511f169194439e197e0f40"
+source = "git+https://github.com/servo/webrender#46791f3fd9188ab3178ab612de168ec554669be7"
 dependencies = [
  "proc-macro2 1.0.17",
  "quote 1.0.2",
@@ -6786,7 +6786,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.61.0"
-source = "git+https://github.com/servo/webrender#0bf15cbdbda530f733511f169194439e197e0f40"
+source = "git+https://github.com/servo/webrender#46791f3fd9188ab3178ab612de168ec554669be7"
 dependencies = [
  "base64 0.10.1",
  "bincode",
@@ -6829,13 +6829,14 @@ dependencies = [
 [[package]]
 name = "webrender_api"
 version = "0.61.0"
-source = "git+https://github.com/servo/webrender#0bf15cbdbda530f733511f169194439e197e0f40"
+source = "git+https://github.com/servo/webrender#46791f3fd9188ab3178ab612de168ec554669be7"
 dependencies = [
  "app_units",
  "bitflags",
  "byteorder",
  "core-foundation 0.9.0",
  "core-graphics 0.22.0",
+ "crossbeam-channel",
  "derive_more",
  "euclid",
  "malloc_size_of_derive",
@@ -6850,7 +6851,7 @@ dependencies = [
 [[package]]
 name = "webrender_build"
 version = "0.0.1"
-source = "git+https://github.com/servo/webrender#0bf15cbdbda530f733511f169194439e197e0f40"
+source = "git+https://github.com/servo/webrender#46791f3fd9188ab3178ab612de168ec554669be7"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -7029,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "wr_malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/webrender#0bf15cbdbda530f733511f169194439e197e0f40"
+source = "git+https://github.com/servo/webrender#46791f3fd9188ab3178ab612de168ec554669be7"
 dependencies = [
  "app_units",
  "euclid",

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -99,6 +99,7 @@ def tasks(task_for):
         macos_nightly()
         update_wpt()
         uwp_nightly()
+        macos_wpt_asan()
 
 
 ping_on_daily_task_failure = "SimonSapin, nox, emilio"

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -582,6 +582,7 @@ def macos_wpt(asan_target=None):
         repo_dir="repo",
         total_chunks=20,
         processes=8,
+        asan_target=asan_target,
     )
 
 
@@ -602,11 +603,12 @@ def linux_wpt_common(total_chunks, layout_2020, asan_target=None):
     def linux_run_task(name):
         return linux_task(name).with_dockerfile(dockerfile_path("run")).with_repo_bundle()
     wpt_chunks("Linux x64", linux_run_task, release_build_task, repo_dir="/repo",
-               processes=20, total_chunks=total_chunks, layout_2020=layout_2020)
+               processes=20, total_chunks=total_chunks, layout_2020=layout_2020,
+               asan_target=asan_target)
 
 
 def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
-               repo_dir, chunks="all", layout_2020=False):
+               repo_dir, chunks="all", layout_2020=False, asan_target=None):
     if layout_2020:
         start = 1  # Skip the "extra" WPT testing, a.k.a. chunk 0
         name_prefix = "Layout 2020 "
@@ -617,6 +619,11 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
         name_prefix = ""
         job_id_prefix = ""
         args = []
+
+    if asan_target:
+        name_prefix += "ASAN"
+        job_id_prefix += "asan-"
+        args += ["--target", asan_target]
 
     # Our Mac CI runs on machines with an Intel 4000 GPU, so need to work around
     # https://github.com/servo/webrender/wiki/Driver-issues#bug-1570736---texture-swizzling-affects-wrap-modes-on-some-intel-gpus

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -623,7 +623,7 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
     if asan_target:
         name_prefix += "ASAN"
         job_id_prefix += "asan-"
-        args += ["--target", asan_target, "--timeout-multipiler=4"]
+        args += ["--target", asan_target, "--timeout-multiplier=4"]
 
     # Our Mac CI runs on machines with an Intel 4000 GPU, so need to work around
     # https://github.com/servo/webrender/wiki/Driver-issues#bug-1570736---texture-swizzling-affects-wrap-modes-on-some-intel-gpus

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -621,7 +621,7 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
         args = []
 
     if asan_target:
-        name_prefix += "ASAN"
+        name_prefix += "ASAN "
         job_id_prefix += "asan-"
         args += ["--target", asan_target, "--timeout-multiplier=4"]
 
@@ -669,7 +669,7 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
                     --log-errorsummary wpt-mp-errorsummary.log \
                     eventsource \
                     | cat
-                time env PYTHONIOENCODING=utf-8 python3 ./mach test-wpt {target}  --release \
+                time env PYTHONIOENCODING=utf-8 python3 ./mach test-wpt $WPT_ARGS  --release \
                     --processes $PROCESSES \
                     --log-raw test-wpt-py3.log \
                     --log-errorsummary wpt-py3-errorsummary.log \

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -623,10 +623,7 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
     if asan_target:
         name_prefix += "ASAN"
         job_id_prefix += "asan-"
-        args += ["--target", asan_target]
-        target = "--target " + asan_target
-    else:
-        target = ""
+        args += ["--target", asan_target, "--timeout-multipiler=4"]
 
     # Our Mac CI runs on machines with an Intel 4000 GPU, so need to work around
     # https://github.com/servo/webrender/wiki/Driver-issues#bug-1570736---texture-swizzling-affects-wrap-modes-on-some-intel-gpus
@@ -666,7 +663,7 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
         # https://github.com/servo/servo/issues/22438
         if this_chunk == 0:
             task.with_script("""
-                time python ./mach test-wpt {target} --release --binary-arg=--multiprocess \
+                time python ./mach test-wpt $WPT_ARGS --release --binary-arg=--multiprocess \
                     --processes $PROCESSES \
                     --log-raw test-wpt-mp.log \
                     --log-errorsummary wpt-mp-errorsummary.log \
@@ -678,18 +675,18 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
                     --log-errorsummary wpt-py3-errorsummary.log \
                     url \
                     | cat
-                time ./mach test-wpt {target} --release --product=servodriver --headless  \
+                time ./mach test-wpt $WPT_ARGS --release --product=servodriver --headless  \
                     tests/wpt/mozilla/tests/mozilla/DOMParser.html \
                     tests/wpt/mozilla/tests/css/per_glyph_font_fallback_a.html \
                     tests/wpt/mozilla/tests/css/img_simple.html \
                     tests/wpt/mozilla/tests/mozilla/secure.https.html \
                     | cat
-                time ./mach test-wpt {target} --release --processes $PROCESSES --product=servodriver \
+                time ./mach test-wpt $WPT_ARGS --release --processes $PROCESSES --product=servodriver \
                     --headless --log-raw test-bluetooth.log \
                     --log-errorsummary bluetooth-errorsummary.log \
                     bluetooth \
                     | cat
-                time ./mach test-wpt {target} --release --processes $PROCESSES --timeout-multiplier=4 \
+                time ./mach test-wpt $WPT_ARGS --release --processes $PROCESSES --timeout-multiplier=4 \
                     --headless --log-raw test-wdspec.log \
                     --log-servojson wdspec-jsonsummary.log \
                     --always-succeed \
@@ -701,7 +698,7 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
                     --log-filteredsummary filtered-wdspec-errorsummary.log \
                     --tracker-api default \
                     --reporter-api default
-            """.format(target=target))
+            """)
         else:
             task.with_script("""
                 ./mach test-wpt \

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -624,6 +624,9 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
         name_prefix += "ASAN"
         job_id_prefix += "asan-"
         args += ["--target", asan_target]
+        target = "--target " + asan_target
+    else:
+        target = ""
 
     # Our Mac CI runs on machines with an Intel 4000 GPU, so need to work around
     # https://github.com/servo/webrender/wiki/Driver-issues#bug-1570736---texture-swizzling-affects-wrap-modes-on-some-intel-gpus
@@ -663,30 +666,30 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
         # https://github.com/servo/servo/issues/22438
         if this_chunk == 0:
             task.with_script("""
-                time python ./mach test-wpt --release --binary-arg=--multiprocess \
+                time python ./mach test-wpt {target} --release --binary-arg=--multiprocess \
                     --processes $PROCESSES \
                     --log-raw test-wpt-mp.log \
                     --log-errorsummary wpt-mp-errorsummary.log \
                     eventsource \
                     | cat
-                time env PYTHONIOENCODING=utf-8 python3 ./mach test-wpt --release \
+                time env PYTHONIOENCODING=utf-8 python3 ./mach test-wpt {target}  --release \
                     --processes $PROCESSES \
                     --log-raw test-wpt-py3.log \
                     --log-errorsummary wpt-py3-errorsummary.log \
                     url \
                     | cat
-                time ./mach test-wpt --release --product=servodriver --headless  \
+                time ./mach test-wpt {target} --release --product=servodriver --headless  \
                     tests/wpt/mozilla/tests/mozilla/DOMParser.html \
                     tests/wpt/mozilla/tests/css/per_glyph_font_fallback_a.html \
                     tests/wpt/mozilla/tests/css/img_simple.html \
                     tests/wpt/mozilla/tests/mozilla/secure.https.html \
                     | cat
-                time ./mach test-wpt --release --processes $PROCESSES --product=servodriver \
+                time ./mach test-wpt {target} --release --processes $PROCESSES --product=servodriver \
                     --headless --log-raw test-bluetooth.log \
                     --log-errorsummary bluetooth-errorsummary.log \
                     bluetooth \
                     | cat
-                time ./mach test-wpt --release --processes $PROCESSES --timeout-multiplier=4 \
+                time ./mach test-wpt {target} --release --processes $PROCESSES --timeout-multiplier=4 \
                     --headless --log-raw test-wdspec.log \
                     --log-servojson wdspec-jsonsummary.log \
                     --always-succeed \
@@ -698,7 +701,7 @@ def wpt_chunks(platform, make_chunk_task, build_task, total_chunks, processes,
                     --log-filteredsummary filtered-wdspec-errorsummary.log \
                     --tracker-api default \
                     --reporter-api default
-            """)
+            """.format(target=target))
         else:
             task.with_script("""
                 ./mach test-wpt \

--- a/etc/taskcluster/decision_task.py
+++ b/etc/taskcluster/decision_task.py
@@ -58,7 +58,8 @@ def tasks(task_for):
             # https://github.com/servo/saltfs/blob/master/homu/map.jinja
 
             "try-mac": [macos_unit],
-            "try-linux": [linux_wpt_asan, macos_wpt_asan],
+            #"try-linux": [linux_wpt_asan, macos_wpt_asan],
+            "try-linux": [macos_wpt_asan],
             "try-windows": [windows_unit, windows_arm64, windows_uwp_x64],
             "try-arm": [windows_arm64],
             "try-wpt": [linux_wpt],

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -652,6 +652,10 @@ class MachCommands(CommandBase):
             env["RUSTFLAGS"] = env.get("RUSTFLAGS", "") + " -Zsanitizer=address"
             target = target or host
             opts += ["-Zbuild-std"]
+            env.setdefault("CFLAGS", "")
+            env.setdefault("CXXFLAGS", "")
+            env["CFLAGS"] += " -fsanitize=address"
+            env["CXXFLAGS"] += " -fsanitize=address"
 
         if very_verbose:
             print(["Calling", "cargo", "build"] + opts)

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -652,10 +652,10 @@ class MachCommands(CommandBase):
             env["RUSTFLAGS"] = env.get("RUSTFLAGS", "") + " -Zsanitizer=address"
             target = target or host
             opts += ["-Zbuild-std"]
-            env.setdefault("CFLAGS", "")
-            env.setdefault("CXXFLAGS", "")
-            env["CFLAGS"] += " -fsanitize=address"
-            env["CXXFLAGS"] += " -fsanitize=address"
+            #env.setdefault("CFLAGS", "")
+            #env.setdefault("CXXFLAGS", "")
+            #env["CFLAGS"] += " -fsanitize=address"
+            #env["CXXFLAGS"] += " -fsanitize=address"
 
         if very_verbose:
             print(["Calling", "cargo", "build"] + opts)

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -170,13 +170,14 @@ class MachCommands(CommandBase):
                      action='store_true',
                      help='Build for HoloLens (x64)')
     @CommandArgument('--win-arm64', action='store_true', help="Use arm64 Windows target")
+    @CommandArgument('--with-asan', action='store_true', help="Enable AddressSanitizer")
     @CommandArgument('params', nargs='...',
                      help="Command-line arguments to be passed through to Cargo")
     @CommandBase.build_like_command_arguments
     def build(self, release=False, dev=False, jobs=None, params=None, media_stack=None,
               no_package=False, verbose=False, very_verbose=False,
               target=None, android=False, magicleap=False, libsimpleservo=False,
-              features=None, uwp=False, win_arm64=False, **kwargs):
+              features=None, uwp=False, win_arm64=False, with_asan=False, **kwargs):
         # Force the UWP-enabled target if the convenience UWP flags are passed.
         if uwp and not target:
             if win_arm64:
@@ -645,6 +646,12 @@ class MachCommands(CommandBase):
         # Prepend so that e.g. `-Ztimings` (which means `-Ztimings=info,html`)
         # given on the command line can override it
         opts = ["-Ztimings=info"] + opts
+
+        if with_asan:
+            check_call(["rustup", "component", "add", "rust-src"])
+            env["RUSTFLAGS"] = env.get("RUSTFLAGS", "") + " -Zsanitizer=address"
+            target = target or host
+            opts += ["-Zbuild-std"]
 
         if very_verbose:
             print(["Calling", "cargo", "build"] + opts)

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -74,11 +74,14 @@ class PostBuildCommands(CommandBase):
                      help='Launch with specific binary')
     @CommandArgument('--nightly', '-n', default=None,
                      help='Specify a YYYY-MM-DD nightly build to run')
+    @CommandArgument('--target', default=None, type=str,
+                     help='Specify a target directory to use')
     @CommandArgument(
         'params', nargs='...',
         help="Command-line arguments to be passed through to Servo")
     def run(self, params, release=False, dev=False, android=None, debug=False, debugger=None,
-            headless=False, software=False, bin=None, emulator=False, usb=False, nightly=None):
+            headless=False, software=False, bin=None, emulator=False, usb=False, nightly=None,
+            target=None):
         self.set_run_env(android is not None)
         env = self.build_env()
         env["RUST_BACKTRACE"] = "1"
@@ -124,7 +127,7 @@ class PostBuildCommands(CommandBase):
             shell.communicate("\n".join(script) + "\n")
             return shell.wait()
 
-        args = [bin or self.get_nightly_binary_path(nightly) or self.get_binary_path(release, dev)]
+        args = [bin or self.get_nightly_binary_path(nightly) or self.get_binary_path(release, dev, target=target)]
 
         if headless:
             args.append('-z')

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -72,6 +72,8 @@ def create_parser_wpt():
     parser = wptcommandline.create_parser()
     parser.add_argument('--release', default=False, action="store_true",
                         help="Run with a release build of servo")
+    parser.add_argument('--target', default=None, type=str,
+                        help="Run the binary for a particular target")
     parser.add_argument('--rr-chaos', default=False, action="store_true",
                         help="Run under chaos mode in rr until a failure is captured")
     parser.add_argument('--pref', default=[], action="append", dest="prefs",

--- a/tests/wpt/run.py
+++ b/tests/wpt/run.py
@@ -4,7 +4,6 @@
 
 import multiprocessing
 import os
-from os import path
 import sys
 import mozlog
 import grouping_formatter
@@ -74,9 +73,15 @@ def set_defaults(kwargs):
         if sys.platform == "win32":
             bin_name += ".exe"
         if "CARGO_TARGET_DIR" in os.environ:
-            bin_path = path.join(os.environ["CARGO_TARGET_DIR"], bin_dir, bin_name)
+            base_path = os.environ["CARGO_TARGET_DIR"]
         else:
-            bin_path = servo_path("target", bin_dir, bin_name)
+            base_path = servo_path("target")
+
+        target = kwargs.pop('target')
+        if target:
+            base_path = os.path.join(base_path, target)
+
+        bin_path = os.path.join(base_path, bin_dir, bin_name)
 
         kwargs["binary"] = bin_path
         kwargs["webdriver_binary"] = bin_path


### PR DESCRIPTION
These changes allow building Servo with ASAN enabled using `./mach build --with-asan`, then running it with `./mach run --target x86_64-apple-darwin` (or `--target x86_64-unknown-linux-gnu` as appropriate) or `./mach test-wpt --target ...`.

CI tasks for running tests with ASAN builds are also included, mostly to check if any interesting surprises appear.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27190
- [x] There are tests for these changes