### PR TITLE
Output to stdout instead of calling `OutputDebugString`

### DIFF
--- a/support/hololens/ServoApp/strutils.h
+++ b/support/hololens/ServoApp/strutils.h
@@ -18,5 +18,5 @@ std::wstring format(const std::wstring &txt, Args... args) {
 }
 
 template <typename... Args> void log(const std::wstring &txt, Args... args) {
-  OutputDebugString((format(txt, args...) + L"\r\n").c_str());
+  std::cout << (format(txt, args...) + L"\r\n").c_str();
 }

--- a/support/hololens/ServoApp/strutils.h
+++ b/support/hololens/ServoApp/strutils.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <iostream>
+
 template <typename... Args>
 std::wstring format(const std::wstring &txt, Args... args) {
   size_t size = swprintf(nullptr, 0, txt.c_str(), args...) + 1;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Output to stdout instead of calling `OutputDebugString` since stdout redirects to `OutputDebugString` anyway and also to a log file.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27441 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

r? @jdm
