### PR TITLE
2020: Implement table map construction

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -445,6 +445,9 @@ mod gen {
                 flexbox: {
                     enabled: bool,
                 },
+                table: {
+                    enabled: bool,
+                },
                 #[serde(default = "default_layout_threads")]
                 threads: i64,
                 viewport: {

--- a/components/layout_2020/flexbox/construct.rs
+++ b/components/layout_2020/flexbox/construct.rs
@@ -163,9 +163,7 @@ where
                     contents,
                     box_slot,
                 } => {
-                    let display_inside = match display {
-                        DisplayGeneratingBox::OutsideInside { inside, .. } => inside,
-                    };
+                    let display_inside = display.display_inside();
                     let box_ = if info.style.get_box().position.is_absolutely_positioned() {
                         // https://drafts.csswg.org/css-flexbox/#abspos-items
                         ArcRefCell::new(FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(

--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -290,7 +290,7 @@ where
                     }
                 },
             },
-            DisplayGeneratingBox::Internal(internal) => {
+            DisplayGeneratingBox::Internal(_internal) => {
                 // XXXManishearth This can be unreachable once we have table fixups
                 todo!()
             },

--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -289,7 +289,10 @@ where
                         self.handle_block_level_element(info, inside, contents, box_slot)
                     }
                 },
-                DisplayOutside::TableCaption | DisplayOutside::InternalTable => todo!(),
+            },
+            DisplayGeneratingBox::Internal(internal) => {
+                // XXXManishearth This can be unreachable once we have table fixups
+                todo!()
             },
         }
     }

--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -289,6 +289,7 @@ where
                         self.handle_block_level_element(info, inside, contents, box_slot)
                     }
                 },
+                DisplayOutside::TableCaption | DisplayOutside::InternalTable => todo!(),
             },
         }
     }

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -304,6 +304,8 @@ impl InlineFormattingContext {
                                     inline: match outside {
                                         DisplayOutside::Inline => ifc.inline_position,
                                         DisplayOutside::Block => Length::zero(),
+                                        DisplayOutside::TableCaption |
+                                        DisplayOutside::InternalTable => todo!(),
                                     },
                                     block: ifc.lines.next_line_block_position,
                                 },

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -304,10 +304,13 @@ impl InlineFormattingContext {
                                     inline: match outside {
                                         DisplayOutside::Inline => ifc.inline_position,
                                         DisplayOutside::Block => Length::zero(),
-                                        DisplayOutside::TableCaption |
-                                        DisplayOutside::InternalTable => todo!(),
                                     },
                                     block: ifc.lines.next_line_block_position,
+                                },
+                                Display::GeneratingBox(DisplayGeneratingBox::Internal(_)) => {
+                                    panic!(
+                                    "the result of blockification is never a layout-internal value"
+                                );
                                 },
                                 Display::Contents => {
                                     panic!("display:contents does not generate an abspos box")

--- a/components/layout_2020/flow/root.rs
+++ b/components/layout_2020/flow/root.rs
@@ -260,7 +260,7 @@ fn construct_for_root_element<'dom>(
             unreachable!()
         },
         // The root element is blockified, ignore DisplayOutside
-        Display::GeneratingBox(DisplayGeneratingBox::OutsideInside { inside, .. }) => inside,
+        Display::GeneratingBox(oi) => oi.display_inside(),
     };
 
     let contents =

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -91,6 +91,14 @@ impl IndependentFormattingContext {
                             propagated_text_decoration_line,
                         ))
                     },
+                    DisplayInside::Table |
+                    DisplayInside::TableRowGroup |
+                    DisplayInside::TableColumn |
+                    DisplayInside::TableColumnGroup |
+                    DisplayInside::TableHeaderGroup |
+                    DisplayInside::TableFooterGroup |
+                    DisplayInside::TableRow |
+                    DisplayInside::TableCell => todo!(),
                 };
                 Self::NonReplaced(NonReplacedFormattingContext {
                     tag: Tag::from_node_and_style_info(info),

--- a/components/layout_2020/formatting_contexts.rs
+++ b/components/layout_2020/formatting_contexts.rs
@@ -101,13 +101,6 @@ impl IndependentFormattingContext {
                             propagated_text_decoration_line,
                         ))
                     },
-                    DisplayInside::TableRowGroup |
-                    DisplayInside::TableColumn |
-                    DisplayInside::TableColumnGroup |
-                    DisplayInside::TableHeaderGroup |
-                    DisplayInside::TableFooterGroup |
-                    DisplayInside::TableRow |
-                    DisplayInside::TableCell => todo!(),
                 };
                 Self::NonReplaced(NonReplacedFormattingContext {
                     tag: Tag::from_node_and_style_info(info),

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -29,6 +29,7 @@ pub mod query;
 mod replaced;
 mod sizing;
 mod style_ext;
+pub mod table;
 pub mod traversal;
 pub mod wrapper;
 

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -21,14 +21,14 @@ use style::values::specified::box_ as stylo;
 use style::Zero;
 use webrender_api as wr;
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub(crate) enum Display {
     None,
     Contents,
     GeneratingBox(DisplayGeneratingBox),
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub(crate) enum DisplayGeneratingBox {
     OutsideInside {
         outside: DisplayOutside,
@@ -38,7 +38,7 @@ pub(crate) enum DisplayGeneratingBox {
     // https://drafts.csswg.org/css-display-3/#layout-specific-display
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub(crate) enum DisplayOutside {
     Block,
     Inline,
@@ -46,7 +46,7 @@ pub(crate) enum DisplayOutside {
     InternalTable,
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub(crate) enum DisplayInside {
     // “list-items are limited to the Flow Layout display types”
     // https://drafts.csswg.org/css-display/#list-items

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -42,6 +42,8 @@ pub(crate) enum DisplayGeneratingBox {
 pub(crate) enum DisplayOutside {
     Block,
     Inline,
+    TableCaption,
+    InternalTable,
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -51,6 +53,14 @@ pub(crate) enum DisplayInside {
     Flow { is_list_item: bool },
     FlowRoot { is_list_item: bool },
     Flex,
+    Table,
+    TableRowGroup,
+    TableColumn,
+    TableColumnGroup,
+    TableHeaderGroup,
+    TableFooterGroup,
+    TableRow,
+    TableCell,
 }
 
 /// Percentages resolved but not `auto` margins
@@ -452,7 +462,14 @@ impl From<stylo::Display> for Display {
                 is_list_item: packed.is_list_item(),
             },
             stylo::DisplayInside::Flex => DisplayInside::Flex,
-
+            stylo::DisplayInside::Table => DisplayInside::Table,
+            stylo::DisplayInside::TableRowGroup => DisplayInside::TableRowGroup,
+            stylo::DisplayInside::TableColumn => DisplayInside::TableColumn,
+            stylo::DisplayInside::TableColumnGroup => DisplayInside::TableColumnGroup,
+            stylo::DisplayInside::TableHeaderGroup => DisplayInside::TableHeaderGroup,
+            stylo::DisplayInside::TableFooterGroup => DisplayInside::TableFooterGroup,
+            stylo::DisplayInside::TableRow => DisplayInside::TableRow,
+            stylo::DisplayInside::TableCell => DisplayInside::TableCell,
             // These should not be values of DisplayInside, but oh well
             stylo::DisplayInside::None => return Display::None,
             stylo::DisplayInside::Contents => return Display::Contents,
@@ -460,7 +477,8 @@ impl From<stylo::Display> for Display {
         let outside = match packed.outside() {
             stylo::DisplayOutside::Block => DisplayOutside::Block,
             stylo::DisplayOutside::Inline => DisplayOutside::Inline,
-
+            stylo::DisplayOutside::TableCaption => DisplayOutside::TableCaption,
+            stylo::DisplayOutside::InternalTable => DisplayOutside::InternalTable,
             // This should not be a value of DisplayInside, but oh well
             stylo::DisplayOutside::None => return Display::None,
         };

--- a/components/layout_2020/style_ext.rs
+++ b/components/layout_2020/style_ext.rs
@@ -480,6 +480,7 @@ impl ComputedValuesExt for ComputedValues {
 impl From<stylo::Display> for Display {
     fn from(packed: stylo::Display) -> Self {
         let outside = packed.outside();
+        let inside = packed.inside();
         let outside = match outside {
             stylo::DisplayOutside::Block => DisplayOutside::Block,
             stylo::DisplayOutside::Inline => DisplayOutside::Inline,
@@ -502,9 +503,11 @@ impl From<stylo::Display> for Display {
                 return Display::GeneratingBox(DisplayGeneratingBox::Internal(internal));
             },
             // This should not be a value of DisplayInside, but oh well
+            // special-case display: contents because we still want it to work despite the early return
+            stylo::DisplayOutside::None if inside == stylo::DisplayInside::Contents => return Display::Contents,
             stylo::DisplayOutside::None => return Display::None,
         };
-        let inside = match packed.inside() {
+        let inside = match inside {
             stylo::DisplayInside::Flow => DisplayInside::Flow {
                 is_list_item: packed.is_list_item(),
             },

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -28,26 +28,26 @@ pub(crate) struct TableSlots {
 #[derive(Debug, Default, Serialize)]
 /// A row in the table slot map
 pub(crate) struct TableSlotsRow {
-    cells: Vec<TableSlot>,
+    slots: Vec<TableSlot>,
 }
 
 impl TableSlots {
     /// Get the slot at (x, y)
     pub fn get(&self, x: usize, y: usize) -> Option<&TableSlot> {
-        self.rows.get(y)?.cells.get(x)
+        self.rows.get(y)?.slots.get(x)
     }
 
     /// Inserts a new slot into the last row
     fn push(&mut self, slot: TableSlot) {
         let y = self.rows.len() - 1;
-        self.rows[y].cells.push(slot)
+        self.rows[y].slots.push(slot)
     }
 
     /// Convenience method for get() that returns a SlotAndLocation
     fn get_loc(&self, x: usize, y: usize) -> Option<SlotAndLocation> {
         self.rows
             .get(y)?
-            .cells
+            .slots
             .get(x)
             .map(|slot| SlotAndLocation { slot, x, y })
     }
@@ -227,7 +227,7 @@ struct TableContainerBuilder<'a, Node> {
     /// rows that still need to be spanned. Negative values indicate rowspan=0
     ///
     /// This vector is reused for the outgoing rowspans, if there is already a cell
-    /// in the cell map the value in this array represents the incoming rowspan for the *next* row
+    /// in the slot map the value in this array represents the incoming rowspan for the *next* row
     incoming_rowspans: Vec<isize>,
 }
 
@@ -331,7 +331,7 @@ impl<'a, 'builder, Node> TableRowBuilder<'a, 'builder, Node> {
 
     fn current_x(&self) -> usize {
         self.builder.slots.rows[self.builder.current_y()]
-            .cells
+            .slots
             .len()
     }
 }
@@ -429,7 +429,7 @@ where
     }
 
     /// https://html.spec.whatwg.org/multipage/#algorithm-for-processing-rows
-    /// Push a single cell onto the cell slot map, handling any colspans it may have, and
+    /// Push a single cell onto the slot map, handling any colspans it may have, and
     /// setting up the outgoing rowspans
     fn handle_cell(&mut self, info: &NodeAndStyleInfo<Node>) {
         let current_x = self.current_x();

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -1,0 +1,80 @@
+use super::TableContainer;
+use crate::context::LayoutContext;
+use crate::dom_traversal::{
+    BoxSlot, Contents, NodeAndStyleInfo, NodeExt, NonReplacedContents, TraversalHandler,
+};
+use crate::style_ext::{DisplayInside, DisplayGeneratingBox};
+use std::borrow::Cow;
+use style::values::specified::text::TextDecorationLine;
+
+#[derive(Debug, Serialize, Default)]
+pub(crate) struct TableSlots {
+    rows: Vec<TableSlotsRow>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TableSlotsRow {
+    cells: Vec<TableSlot>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) enum TableSlot {
+    /// A table cell, with a width and height
+    Cell {
+        cell: TableCellBox,
+        // the width of the cell
+        width: u32,
+        // the height of the cell
+        height: u32,
+    },
+    /// This slot is spanned by the cell at offset (-x, -y)
+    Spanned(u32, u32),
+    /// This slot is spanned by two cells at the given negative coordinate offsets. Oops.
+    DoubleSpanned((u32, u32), (u32, u32)),
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TableCellBox {}
+
+struct TableContainerBuilder<'a, Node> {
+    context: &'a LayoutContext<'a>,
+    info: &'a NodeAndStyleInfo<Node>,
+    slots: TableSlots
+}
+
+impl TableContainer {
+    pub fn construct<'dom>(
+        context: &LayoutContext,
+        info: &NodeAndStyleInfo<impl NodeExt<'dom>>,
+        contents: NonReplacedContents,
+        // XXXManishearth is this useful?
+        _propagated_text_decoration_line: TextDecorationLine,
+    ) -> Self {
+        let mut builder = TableContainerBuilder { context, info, slots: TableSlots::default() };
+        contents.traverse(context, info, &mut builder);
+        TableContainer {}
+    }
+}
+
+impl<'a, 'dom, Node: 'dom> TraversalHandler<'dom, Node> for TableContainerBuilder<'a, Node>
+where
+    Node: NodeExt<'dom>,
+{
+    fn handle_text(&mut self, info: &NodeAndStyleInfo<Node>, text: Cow<'dom, str>) {
+        println!("text {:?}", text);
+        // TODO: this might need to be wrapped in something
+    }
+
+    /// Or pseudo-element
+    fn handle_element(
+        &mut self,
+        info: &NodeAndStyleInfo<Node>,
+        display: DisplayGeneratingBox,
+        contents: Contents,
+        box_slot: BoxSlot<'dom>,
+    ) {
+
+        ::std::mem::forget(box_slot)
+        // do something?
+    }
+}

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -4,16 +4,132 @@ use crate::dom_traversal::{
     BoxSlot, Contents, NodeAndStyleInfo, NodeExt, NonReplacedContents, TraversalHandler,
 };
 use crate::style_ext::{DisplayGeneratingBox, DisplayInternal};
+use script_layout_interface::wrapper_traits::ThreadSafeLayoutNode;
 use std::borrow::Cow;
+use std::cmp;
 use std::convert::TryFrom;
 use style::values::specified::text::TextDecorationLine;
 
 #[derive(Debug, Serialize, Default)]
+/// A map of table slots to cells
 pub(crate) struct TableSlots {
     rows: Vec<TableSlotsRow>,
 }
 
-#[derive(Debug, Serialize)]
+impl TableSlots {
+    /// Get the slot at (x, y)
+    pub fn get(&self, x: usize, y: usize) -> Option<&TableSlot> {
+        self.rows.get(y)?.cells.get(x)
+    }
+
+    fn insert(&mut self, slot: TableSlot) {
+        let y = self.rows.len() - 1;
+        self.rows[y].cells.push(slot)
+    }
+
+    /// Convenience method for get() that returns a SlotAndLocation
+    fn get_loc(&self, x: usize, y: usize) -> Option<SlotAndLocation> {
+        self.rows
+            .get(y)?
+            .cells
+            .get(x)
+            .map(|slot| SlotAndLocation { slot, x, y })
+    }
+
+    /// Get the slot from the previous row at x
+    fn get_above(&self, x: usize) -> Option<SlotAndLocation> {
+        if self.rows.len() > 1 {
+            self.get_loc(x, self.rows.len() - 2)
+        } else {
+            None
+        }
+    }
+
+    /// Given a slot and location, find the originating TableSlot::Cell.
+    /// In the case of a table model error, there may be multiple, returning
+    /// the oldest cell first
+    fn resolve_slot<'a>(
+        &'a self,
+        location: SlotAndLocation<'a>,
+    ) -> (SlotAndLocation<'a>, Vec<SlotAndLocation<'a>>) {
+        match *location.slot {
+            TableSlot::Cell { .. } => (location, Vec::new()),
+            TableSlot::Spanned(x, y) => (
+                self.get_loc(location.x - x, location.y - y)
+                    .expect("Spanned slot reference must resolve"),
+                Vec::new(),
+            ),
+            TableSlot::MultiSpanned(ref vec) => {
+                let mut v: Vec<_> = vec
+                    .iter()
+                    .map(|(x, y)| {
+                        self.get_loc(location.x - x, location.y - y)
+                            .expect("Spanned slot reference must resolve")
+                    })
+                    .collect();
+                (v.pop().unwrap(), v)
+            },
+        }
+    }
+
+    /// If (x, y) is spanned by an already resolved `spanner`, return offsets for a TableSlot::Spanned() for it
+    fn spanned_slot_single(
+        &self,
+        x: usize,
+        y: usize,
+        spanner: SlotAndLocation,
+    ) -> Option<(usize, usize)> {
+        if let TableSlot::Cell { width, height, .. } = spanner.slot {
+            if x >= spanner.x && y >= spanner.y && x < spanner.x + *width {
+                if *height == 0 || y < spanner.y + *height {
+                    Some((x - spanner.x, y - spanner.y))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            panic!("spanned_slot_single cannot be called with a non-resolved slot")
+        }
+    }
+
+    /// If (x, y) is spanned by the resolution of `spanner`, return a
+    /// TableSlot::Spanned() or TableSlot::MultiSpanned() for it
+    fn spanned_slot(&self, x: usize, y: usize, spanner: SlotAndLocation) -> Option<TableSlot> {
+        let (first, mut rest) = self.resolve_slot(spanner);
+        if rest.is_empty() {
+            self.spanned_slot_single(x, y, first)
+                .map(|spanned| TableSlot::Spanned(spanned.0, spanned.1))
+        } else {
+            rest.push(first);
+
+            let coordinates: Vec<_> = rest
+                .into_iter()
+                .filter_map(|slot| self.spanned_slot_single(x, y, slot))
+                .collect();
+            if coordinates.is_empty() {
+                return None;
+            }
+
+            if coordinates.len() == 1 {
+                Some(TableSlot::Spanned(coordinates[0].0, coordinates[0].1))
+            } else {
+                Some(TableSlot::MultiSpanned(coordinates))
+            }
+        }
+    }
+}
+
+// A reference to a slot and its coordinates in the table
+#[derive(Copy, Clone, Debug)]
+struct SlotAndLocation<'a> {
+    slot: &'a TableSlot,
+    x: usize,
+    y: usize,
+}
+
+#[derive(Debug, Serialize, Default)]
 pub(crate) struct TableSlotsRow {
     cells: Vec<TableSlot>,
 }
@@ -23,15 +139,30 @@ pub(crate) enum TableSlot {
     /// A table cell, with a width and height
     Cell {
         cell: TableCellBox,
-        // the width of the cell
-        width: u32,
-        // the height of the cell
-        height: u32,
+        /// the width of the cell
+        width: usize,
+        /// the height of the cell (0 for rowspan=0)
+        // XXXManishearth should we fixup rowspan=0 later?
+        height: usize,
     },
     /// This slot is spanned by the cell at offset (-x, -y)
-    Spanned(u32, u32),
-    /// This slot is spanned by two cells at the given negative coordinate offsets. Oops.
-    DoubleSpanned((u32, u32), (u32, u32)),
+    Spanned(usize, usize),
+    /// This slot is spanned by multiple cells at the given negative coordinate offsets. Oops.
+    /// This is a table model error, but we still keep track of it
+    /// https://html.spec.whatwg.org/multipage/tables.html#table-model-error
+    ///
+    /// The Vec is in the order of newest to oldest cell
+    MultiSpanned(Vec<(usize, usize)>),
+}
+
+impl TableSlot {
+    pub fn as_spanned(&self) -> (usize, usize) {
+        if let TableSlot::Spanned(x, y) = *self {
+            (x, y)
+        } else {
+            panic!("TableSlot::as_spanned called with a non-Spanned TableSlot")
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -41,6 +172,10 @@ struct TableContainerBuilder<'a, Node> {
     context: &'a LayoutContext<'a>,
     info: &'a NodeAndStyleInfo<Node>,
     slots: TableSlots,
+    /// If there is an incoming rowspanned cell in this column,
+    /// this value will be nonzero. Positive values indicate the number of
+    /// rows that still need to be spanned. Negative values indicate rowspan=0
+    incoming_rowspans: Vec<i32>,
 }
 
 impl TableContainer {
@@ -63,7 +198,12 @@ impl<'a, Node> TableContainerBuilder<'a, Node> {
             context,
             info,
             slots: TableSlots::default(),
+            incoming_rowspans: Vec::new(),
         }
+    }
+
+    fn current_y(&self) -> usize {
+        self.slots.rows.len() - 1
     }
 }
 
@@ -96,7 +236,10 @@ where
                 },
                 DisplayInternal::TableRow => {
                     let context = self.context;
+                    // XXXManishearth use with_capacity
+                    self.slots.rows.push(TableSlotsRow::default());
                     let mut row_builder = TableRowBuilder::new(self);
+                    row_builder.consume_rowspans();
                     NonReplacedContents::try_from(contents).unwrap().traverse(
                         context,
                         info,
@@ -119,11 +262,15 @@ where
 
 struct TableRowBuilder<'a, 'builder, Node> {
     builder: &'builder mut TableContainerBuilder<'a, Node>,
+    current_x: usize,
 }
 
 impl<'a, 'builder, Node> TableRowBuilder<'a, 'builder, Node> {
     fn new(builder: &'builder mut TableContainerBuilder<'a, Node>) -> Self {
-        TableRowBuilder { builder }
+        TableRowBuilder {
+            builder,
+            current_x: 0,
+        }
     }
 }
 
@@ -136,7 +283,7 @@ where
         // TODO: this might need to be wrapped in something
     }
 
-    /// https://html.spec.whatwg.org/multipage/tables.html#forming-a-table
+    /// https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-processing-rows
     fn handle_element(
         &mut self,
         info: &NodeAndStyleInfo<Node>,
@@ -146,9 +293,7 @@ where
     ) {
         match display {
             DisplayGeneratingBox::Internal(i) => match i {
-                DisplayInternal::TableCell => {
-                    // XXXManishearth handle cells
-                },
+                DisplayInternal::TableCell => self.handle_cell(&info),
                 _ => (), // XXXManishearth handle unparented row groups/etc ?
             },
             _ => {
@@ -157,5 +302,43 @@ where
         }
         ::std::mem::forget(box_slot)
         // do something?
+    }
+}
+
+impl<'a, 'builder, 'dom, Node> TableRowBuilder<'a, 'builder, Node>
+where
+    Node: NodeExt<'dom>,
+{
+    fn consume_rowspans(&mut self) {
+        loop {
+            if let Some(span) = self.builder.incoming_rowspans.get_mut(self.current_x) {
+                if *span != 0 {
+                    *span -= 1;
+                    let previous = self
+                        .builder
+                        .slots
+                        .get_above(self.current_x)
+                        .expect("Cannot have nonzero incoming rowspan with no slot above");
+                    let new_slot = self.builder
+                        .slots.spanned_slot(self.current_x, self.builder.current_y(), previous)
+                        .expect("Nonzero incoming rowspan cannot occur without a cell spannign this slot");
+                    self.builder.slots.insert(new_slot);
+                    self.current_x += 1;
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-processing-rows
+    fn handle_cell(&mut self, info: &NodeAndStyleInfo<Node>) {
+        let node = info.node.to_threadsafe();
+        // This value will already have filtered out rowspan=0
+        // in quirks mode, so we don't have to worry about that
+        let rowspan = cmp::min(node.get_rowspan(), 1000);
+        let colspan = cmp::min(node.get_colspan(), 1000);
     }
 }

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -8,6 +8,7 @@ use script_layout_interface::wrapper_traits::ThreadSafeLayoutNode;
 use std::borrow::Cow;
 use std::cmp;
 use std::convert::TryFrom;
+use std::fmt;
 use style::values::specified::text::TextDecorationLine;
 
 #[derive(Debug, Default, Serialize)]
@@ -136,7 +137,7 @@ struct SlotAndLocation<'a> {
     y: usize,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Serialize)]
 /// A single table slot. It may be an actual cell, or a reference
 /// to a previous cell that is spanned here
 ///
@@ -181,6 +182,16 @@ impl TableSlot {
                 *self = TableSlot::MultiSpanned(vec![(x, y), (x1, y1)])
             }
             TableSlot::MultiSpanned(ref mut vec) => vec.insert(0, (x, y))
+        }
+    }
+}
+
+impl fmt::Debug for TableSlot {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            TableSlot::Cell { width, height, .. } => write!(f, "Cell({}, {})", width, height),
+            TableSlot::Spanned(x, y) => write!(f, "Spanned({}, {})", x, y),
+            TableSlot::MultiSpanned(ref vec) => write!(f, "MultiSpanned({:?})", vec),
         }
     }
 }

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use super::TableContainer;
 use crate::context::LayoutContext;
 use crate::dom_traversal::{
@@ -159,7 +163,7 @@ pub(crate) enum TableSlot {
     Spanned(usize, usize),
     /// This slot is spanned by multiple cells at the given negative coordinate offsets. Oops.
     /// This is a table model error, but we still keep track of it
-    /// https://html.spec.whatwg.org/multipage/tables.html#table-model-error
+    /// https://html.spec.whatwg.org/multipage/#table-model-error
     ///
     /// The Vec is in the order of newest to oldest cell
     MultiSpanned(Vec<(usize, usize)>),
@@ -260,7 +264,7 @@ where
         // TODO: this might need to be wrapped in something
     }
 
-    /// https://html.spec.whatwg.org/multipage/tables.html#forming-a-table
+    /// https://html.spec.whatwg.org/multipage/#forming-a-table
     fn handle_element(
         &mut self,
         info: &NodeAndStyleInfo<Node>,
@@ -337,7 +341,7 @@ where
         // TODO: this might need to be wrapped in something
     }
 
-    /// https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-processing-rows
+    /// https://html.spec.whatwg.org/multipage/#algorithm-for-processing-rows
     fn handle_element(
         &mut self,
         info: &NodeAndStyleInfo<Node>,
@@ -420,7 +424,7 @@ where
         }
     }
 
-    /// https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-processing-rows
+    /// https://html.spec.whatwg.org/multipage/#algorithm-for-processing-rows
     /// Push a single cell onto the cell slot map, handling any colspans it may have, and
     /// setting up the outgoing rowspans
     fn handle_cell(&mut self, info: &NodeAndStyleInfo<Node>) {

--- a/components/layout_2020/table/construct.rs
+++ b/components/layout_2020/table/construct.rs
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+//! Constructs the slot map for a table
+//!
+//! Based on https://html.spec.whatwg.org/multipage/#table-processing-model
+
 use super::TableContainer;
 use crate::context::LayoutContext;
 use crate::dom_traversal::{

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -4,6 +4,7 @@ use crate::formatting_contexts::IndependentLayout;
 use crate::positioned::PositioningContext;
 use crate::sizing::ContentSizes;
 use crate::ContainingBlock;
+use style::values::computed::Length;
 
 impl TableContainer {
     pub fn inline_content_sizes(&self) -> ContentSizes {
@@ -18,6 +19,10 @@ impl TableContainer {
         containing_block: &ContainingBlock,
         tree_rank: usize,
     ) -> IndependentLayout {
-        todo!()
+        // XXXManishearth implement table layout
+        IndependentLayout {
+            fragments: Vec::new(),
+            content_block_size: Length::new(0.),
+        }
     }
 }

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1,0 +1,23 @@
+use super::TableContainer;
+use crate::context::LayoutContext;
+use crate::formatting_contexts::IndependentLayout;
+use crate::positioned::PositioningContext;
+use crate::sizing::ContentSizes;
+use crate::ContainingBlock;
+
+impl TableContainer {
+    pub fn inline_content_sizes(&self) -> ContentSizes {
+        // FIXME
+        ContentSizes::zero()
+    }
+
+    pub(crate) fn layout(
+        &self,
+        layout_context: &LayoutContext,
+        positioning_context: &mut PositioningContext,
+        containing_block: &ContainingBlock,
+        tree_rank: usize,
+    ) -> IndependentLayout {
+        todo!()
+    }
+}

--- a/components/layout_2020/table/layout.rs
+++ b/components/layout_2020/table/layout.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use super::TableContainer;
 use crate::context::LayoutContext;
 use crate::formatting_contexts::IndependentLayout;

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -1,0 +1,5 @@
+pub mod construct;
+pub mod layout;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TableContainer {}

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 #![allow(dead_code, unused_variables)]
 
 pub mod construct;

--- a/components/layout_2020/table/mod.rs
+++ b/components/layout_2020/table/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_variables)]
+
 pub mod construct;
 pub mod layout;
 

--- a/resources/prefs.json
+++ b/resources/prefs.json
@@ -100,6 +100,7 @@
   "layout.animations.test.enabled": false,
   "layout.columns.enabled": false,
   "layout.flexbox.enabled": false,
+  "layout.table.enabled": false,
   "layout.threads": 3,
   "layout.viewport.enabled": false,
   "layout.writing-mode.enabled": false,


### PR DESCRIPTION
Progress towards https://github.com/servo/servo/issues/27459

This PR does not do any table  layout whatsoever, nor does it even
construct boxes for table elements.

What this does is construct the CellMap, which makes it easy to find
which cells are occupying each slot of the table. This will be useful
when iterating over the table repeatedly during the layout algorithms.