### PR TITLE
Fix crashes on video playback in UWP

### DIFF
--- a/components/script/dom/mediasession.rs
+++ b/components/script/dom/mediasession.rs
@@ -20,7 +20,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::htmlmediaelement::HTMLMediaElement;
 use crate::dom::mediametadata::MediaMetadata;
 use crate::dom::window::Window;
-use crate::realms::{AlreadyInRealm, InRealm};
+use crate::realms::{enter_realm, InRealm};
 use dom_struct::dom_struct;
 use embedder_traits::MediaMetadata as EmbedderMediaMetadata;
 use embedder_traits::MediaSessionEvent;
@@ -80,8 +80,8 @@ impl MediaSession {
         if let Some(media) = self.media_instance.get() {
             match action {
                 MediaSessionActionType::Play => {
-                    let in_realm_proof = AlreadyInRealm::assert(&self.global());
-                    media.Play(InRealm::Already(&in_realm_proof));
+                    let realm = enter_realm(self);
+                    media.Play(InRealm::Entered(&realm));
                 },
                 MediaSessionActionType::Pause => {
                     media.Pause();

--- a/support/hololens/ServoApp/BrowserPage.cpp
+++ b/support/hololens/ServoApp/BrowserPage.cpp
@@ -81,6 +81,8 @@ void BrowserPage::BindServoEvents() {
   urlTextbox().GotFocus(std::bind(&BrowserPage::OnURLFocused, this, _1));
   servoView().OnMediaSessionMetadata(
       [=](hstring title, hstring artist, hstring album) {});
+  servoView().OnMediaSessionPosition(
+      [=](double duration, double position, double rate) {});
   servoView().OnMediaSessionPlaybackStateChange([=](const auto &, int state) {
     if (state == Servo::MediaSessionPlaybackState::None) {
       mediaControls().Visibility(Visibility::Collapsed);

--- a/support/hololens/ServoApp/ServoApp.vcxproj
+++ b/support/hololens/ServoApp/ServoApp.vcxproj
@@ -87,6 +87,8 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories);$(ProjectDir)\..\..\..\target\aarch64-uwp-windows-msvc\debug\</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories);$(ProjectDir)\..\..\..\target\x86_64-uwp-windows-msvc\debug\</AdditionalIncludeDirectories>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">OneCore.lib;WindowsApp.lib;%(AdditionalDependencies);simpleservo.dll.lib</AdditionalDependencies>
@@ -105,6 +107,8 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories);$(ProjectDir)\..\..\..\target\aarch64-uwp-windows-msvc\release</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories);$(ProjectDir)\..\..\..\target\x86_64-uwp-windows-msvc\release</AdditionalIncludeDirectories>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">stdcpplatest</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">OneCore.lib;WindowsApp.lib;%(AdditionalDependencies);simpleservo.dll.lib</AdditionalDependencies>

--- a/support/hololens/ServoApp/ServoControl/Servo.cpp
+++ b/support/hololens/ServoApp/ServoControl/Servo.cpp
@@ -99,6 +99,12 @@ const char *get_clipboard_contents() {
   return nullptr;
 }
 
+void on_media_session_set_position_state(double duration, double position,
+                                         double playback_rate) {
+  return sServo->Delegate().OnServoMediaSessionPosition(duration, position,
+                                                        playback_rate);
+}
+
 void on_media_session_metadata(const char *title, const char *album,
                                const char *artist) {
   return sServo->Delegate().OnServoMediaSessionMetadata(
@@ -296,29 +302,32 @@ Servo::Servo(std::optional<hstring> initUrl, hstring args, GLsizei width,
         std::to_string(GetLastError()));
   }
 
-  capi::CHostCallbacks c;
-  c.on_load_started = &on_load_started;
-  c.on_load_ended = &on_load_ended;
-  c.on_title_changed = &on_title_changed;
-  c.on_url_changed = &on_url_changed;
-  c.on_history_changed = &on_history_changed;
-  c.on_animating_changed = &on_animating_changed;
-  c.on_shutdown_complete = &on_shutdown_complete;
-  c.on_allow_navigation = &on_allow_navigation;
-  c.on_ime_show = &on_ime_show;
-  c.on_ime_hide = &on_ime_hide;
-  c.get_clipboard_contents = &get_clipboard_contents;
-  c.set_clipboard_contents = &set_clipboard_contents;
-  c.on_media_session_metadata = &on_media_session_metadata;
-  c.on_media_session_playback_state_change =
-      &on_media_session_playback_state_change;
-  c.prompt_alert = &prompt_alert;
-  c.prompt_ok_cancel = &prompt_ok_cancel;
-  c.prompt_yes_no = &prompt_yes_no;
-  c.prompt_input = &prompt_input;
-  c.on_devtools_started = &on_devtools_started;
-  c.show_context_menu = &show_context_menu;
-  c.on_log_output = &on_log_output;
+  capi::CHostCallbacks c = capi::CHostCallbacks{
+      .on_load_started = &on_load_started,
+      .on_load_ended = &on_load_ended,
+      .on_title_changed = &on_title_changed,
+      .on_allow_navigation = &on_allow_navigation,
+      .on_url_changed = &on_url_changed,
+      .on_history_changed = &on_history_changed,
+      .on_animating_changed = &on_animating_changed,
+      .on_shutdown_complete = &on_shutdown_complete,
+      .on_ime_show = &on_ime_show,
+      .on_ime_hide = &on_ime_hide,
+      .get_clipboard_contents = &get_clipboard_contents,
+      .set_clipboard_contents = &set_clipboard_contents,
+      .on_media_session_metadata = &on_media_session_metadata,
+      .on_media_session_playback_state_change =
+          &on_media_session_playback_state_change,
+      .on_media_session_set_position_state =
+          &on_media_session_set_position_state,
+      .prompt_alert = &prompt_alert,
+      .prompt_ok_cancel = &prompt_ok_cancel,
+      .prompt_yes_no = &prompt_yes_no,
+      .prompt_input = &prompt_input,
+      .on_devtools_started = &on_devtools_started,
+      .show_context_menu = &show_context_menu,
+      .on_log_output = &on_log_output,
+  };
 
   capi::register_panic_handler(&on_panic);
 

--- a/support/hololens/ServoApp/ServoControl/Servo.h
+++ b/support/hololens/ServoApp/ServoControl/Servo.h
@@ -124,6 +124,7 @@ public:
   virtual void OnServoIMEHide() = 0;
   virtual void OnServoDevtoolsStarted(bool, const unsigned int, hstring) = 0;
   virtual void OnServoMediaSessionMetadata(hstring, hstring, hstring) = 0;
+  virtual void OnServoMediaSessionPosition(double, double, double) = 0;
   virtual void OnServoMediaSessionPlaybackStateChange(int) = 0;
   virtual void OnServoPromptAlert(hstring, bool) = 0;
   virtual void OnServoShowContextMenu(std::optional<hstring>,

--- a/support/hololens/ServoApp/ServoControl/ServoControl.cpp
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.cpp
@@ -548,6 +548,12 @@ void ServoControl::OnServoIMEShow(hstring text, int32_t x, int32_t y,
   });
 }
 
+void ServoControl::OnServoMediaSessionPosition(double duration, double position,
+                                               double playback_rate) {
+  RunOnUIThread(
+      [=] { mOnMediaSessionPositionEvent(duration, position, playback_rate); });
+}
+
 void ServoControl::OnServoMediaSessionMetadata(hstring title, hstring artist,
                                                hstring album) {
   RunOnUIThread([=] { mOnMediaSessionMetadataEvent(title, artist, album); });

--- a/support/hololens/ServoApp/ServoControl/ServoControl.h
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.h
@@ -152,6 +152,14 @@ struct ServoControl : ServoControlT<ServoControl>, public servo::ServoDelegate {
   }
 
   winrt::event_token
+  OnMediaSessionPosition(MediaSessionPositionDelegate const &handler) {
+    return mOnMediaSessionPositionEvent.add(handler);
+  };
+  void OnMediaSessionPosition(winrt::event_token const &token) noexcept {
+    mOnMediaSessionPositionEvent.remove(token);
+  }
+
+  winrt::event_token
   OnMediaSessionMetadata(MediaSessionMetadataDelegate const &handler) {
     return mOnMediaSessionMetadataEvent.add(handler);
   };
@@ -187,6 +195,7 @@ struct ServoControl : ServoControlT<ServoControl>, public servo::ServoDelegate {
   virtual void OnServoMediaSessionMetadata(winrt::hstring, winrt::hstring,
                                            winrt::hstring);
   virtual void OnServoMediaSessionPlaybackStateChange(int);
+  virtual void OnServoMediaSessionPosition(double, double, double);
   virtual void OnServoPromptAlert(winrt::hstring, bool);
   virtual void OnServoShowContextMenu(std::optional<winrt::hstring>,
                                       std::vector<winrt::hstring>);
@@ -210,6 +219,7 @@ private:
   winrt::event<EventDelegate> mOnCaptureGesturesStartedEvent;
   winrt::event<EventDelegate> mOnCaptureGesturesEndedEvent;
   winrt::event<MediaSessionMetadataDelegate> mOnMediaSessionMetadataEvent;
+  winrt::event<MediaSessionPositionDelegate> mOnMediaSessionPositionEvent;
   winrt::event<Windows::Foundation::EventHandler<int>>
       mOnMediaSessionPlaybackStateChangeEvent;
 

--- a/support/hololens/ServoApp/ServoControl/ServoControl.idl
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.idl
@@ -3,6 +3,7 @@ namespace ServoApp {
   delegate void EventDelegate();
   delegate void HistoryChangedDelegate(Boolean back, Boolean forward);
   delegate void MediaSessionMetadataDelegate(String title, String artist, String album);
+  delegate void MediaSessionPositionDelegate(Double duration, Double position, Double rate);
   delegate void DevtoolsStatusChangedDelegate(DevtoolsStatus status, UInt32 port, String token);
 
   enum DevtoolsStatus {
@@ -42,6 +43,7 @@ namespace ServoApp {
       event Windows.Foundation.EventHandler<String> OnServoPanic;
       event Windows.Foundation.EventHandler<String> OnURLChanged;
       event MediaSessionMetadataDelegate OnMediaSessionMetadata;
+      event MediaSessionPositionDelegate OnMediaSessionPosition;
       event Windows.Foundation.EventHandler<int> OnMediaSessionPlaybackStateChange;
       Windows.Foundation.Collections.IVector<Pref> Preferences { get; };
       Pref GetPref(String key);


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27529 and fix #27526
- [x] These changes do not require tests because there's no way to test UWP right now.