### PR TITLE
Move action buttons above invalid certificate details.

### DIFF
--- a/resources/badcert.html
+++ b/resources/badcert.html
@@ -4,9 +4,9 @@
 </head>
 <body>
   <p>${reason}</p>
-  <pre id="bytes">${bytes}</pre>
   <button id="leave" onclick="history.back()">Go back (recommended)</button>
   <button id="allow">Allow certificate temporarily</button>
+  <pre id="bytes">${bytes}</pre>
   <script>
     let bytes = document.getElementById('bytes').textContent;
     let button = document.getElementById('allow');


### PR DESCRIPTION
Since the certificate details can fill the screen and require scrolling, let's move the user's choices so they're always in view when the SSL error page first loads.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27520