### PR TITLE
Major fixes in error reporting in GPUCommandEncoder and ErrorScope Model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6945,7 +6945,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#872a6c4c2bab5591838219c34e0cbf5fa9c2ec85"
+source = "git+https://github.com/gfx-rs/wgpu#8057acf120f9944056a6b5de6cf326f18ae7671d"
 dependencies = [
  "arrayvec 0.5.1",
  "bitflags",
@@ -6972,7 +6972,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#872a6c4c2bab5591838219c34e0cbf5fa9c2ec85"
+source = "git+https://github.com/gfx-rs/wgpu#8057acf120f9944056a6b5de6cf326f18ae7671d"
 dependencies = [
  "bitflags",
  "serde",

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -293,15 +293,12 @@ impl GPUDeviceMethods for GPUDevice {
 
     /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer
     fn CreateBuffer(&self, descriptor: &GPUBufferDescriptor) -> DomRoot<GPUBuffer> {
-        let wgpu_descriptor = wgt::BufferDescriptor {
+        let desc = wgt::BufferUsage::from_bits(descriptor.usage).map(|usg| wgt::BufferDescriptor {
             label: descriptor.parent.label.as_ref().map(|s| s.to_string()),
             size: descriptor.size,
-            usage: match wgt::BufferUsage::from_bits(descriptor.usage) {
-                Some(u) => u,
-                None => wgt::BufferUsage::empty(),
-            },
+            usage: usg,
             mapped_at_creation: descriptor.mappedAtCreation,
-        };
+        });
         let id = self
             .global()
             .wgpu_id_hub()
@@ -309,6 +306,13 @@ impl GPUDeviceMethods for GPUDevice {
             .create_buffer_id(self.device.0.backend());
 
         let scope_id = self.use_current_scope();
+        if desc.is_none() {
+            self.handle_server_msg(
+                scope_id,
+                WebGPUOpResult::ValidationError(String::from("Invalid GPUBufferUsage")),
+            );
+        }
+
         self.channel
             .0
             .send((
@@ -316,7 +320,7 @@ impl GPUDeviceMethods for GPUDevice {
                 WebGPURequest::CreateBuffer {
                     device_id: self.device.0,
                     buffer_id: id,
-                    descriptor: wgpu_descriptor,
+                    descriptor: desc,
                 },
             ))
             .expect("Failed to create WebGPU buffer");
@@ -357,13 +361,17 @@ impl GPUDeviceMethods for GPUDevice {
         &self,
         descriptor: &GPUBindGroupLayoutDescriptor,
     ) -> DomRoot<GPUBindGroupLayout> {
+        let mut valid = true;
         let entries = descriptor
             .entries
             .iter()
             .map(|bind| {
                 let visibility = match wgt::ShaderStage::from_bits(bind.visibility) {
                     Some(visibility) => visibility,
-                    None => wgt::ShaderStage::from_bits(0).unwrap(),
+                    None => {
+                        valid = false;
+                        wgt::ShaderStage::empty()
+                    },
                 };
                 let ty = match bind.type_ {
                     GPUBindingType::Uniform_buffer => wgt::BindingType::UniformBuffer {
@@ -435,13 +443,21 @@ impl GPUDeviceMethods for GPUDevice {
 
         let scope_id = self.use_current_scope();
 
-        let desc = wgt::BindGroupLayoutDescriptor {
-            label: descriptor
-                .parent
-                .label
-                .as_ref()
-                .map(|s| Cow::Owned(s.to_string())),
-            entries: Cow::Owned(entries),
+        let desc = if valid {
+            Some(wgt::BindGroupLayoutDescriptor {
+                label: descriptor
+                    .parent
+                    .label
+                    .as_ref()
+                    .map(|s| Cow::Owned(s.to_string())),
+                entries: Cow::Owned(entries),
+            })
+        } else {
+            self.handle_server_msg(
+                scope_id,
+                WebGPUOpResult::ValidationError(String::from("Invalid GPUShaderStage")),
+            );
+            None
         };
 
         let bind_group_layout_id = self
@@ -695,22 +711,20 @@ impl GPUDeviceMethods for GPUDevice {
     /// https://gpuweb.github.io/gpuweb/#dom-gpudevice-createtexture
     fn CreateTexture(&self, descriptor: &GPUTextureDescriptor) -> DomRoot<GPUTexture> {
         let size = convert_texture_size_to_dict(&descriptor.size);
-        let desc = wgt::TextureDescriptor {
-            label: descriptor.parent.label.as_ref().map(|s| s.to_string()),
-            size: convert_texture_size_to_wgt(&size),
-            mip_level_count: descriptor.mipLevelCount,
-            sample_count: descriptor.sampleCount,
-            dimension: match descriptor.dimension {
-                GPUTextureDimension::_1d => wgt::TextureDimension::D1,
-                GPUTextureDimension::_2d => wgt::TextureDimension::D2,
-                GPUTextureDimension::_3d => wgt::TextureDimension::D3,
-            },
-            format: convert_texture_format(descriptor.format),
-            usage: match wgt::TextureUsage::from_bits(descriptor.usage) {
-                Some(t) => t,
-                None => wgt::TextureUsage::empty(),
-            },
-        };
+        let desc =
+            wgt::TextureUsage::from_bits(descriptor.usage).map(|usg| wgt::TextureDescriptor {
+                label: descriptor.parent.label.as_ref().map(|s| s.to_string()),
+                size: convert_texture_size_to_wgt(&size),
+                mip_level_count: descriptor.mipLevelCount,
+                sample_count: descriptor.sampleCount,
+                dimension: match descriptor.dimension {
+                    GPUTextureDimension::_1d => wgt::TextureDimension::D1,
+                    GPUTextureDimension::_2d => wgt::TextureDimension::D2,
+                    GPUTextureDimension::_3d => wgt::TextureDimension::D3,
+                },
+                format: convert_texture_format(descriptor.format),
+                usage: usg,
+            });
 
         let texture_id = self
             .global()
@@ -719,7 +733,12 @@ impl GPUDeviceMethods for GPUDevice {
             .create_texture_id(self.device.0.backend());
 
         let scope_id = self.use_current_scope();
-
+        if desc.is_none() {
+            self.handle_server_msg(
+                scope_id,
+                WebGPUOpResult::ValidationError(String::from("Invalid GPUTextureUsage")),
+            );
+        }
         self.channel
             .0
             .send((
@@ -803,110 +822,124 @@ impl GPUDeviceMethods for GPUDevice {
     ) -> DomRoot<GPURenderPipeline> {
         let ref rs_desc = descriptor.rasterizationState;
         let ref vs_desc = descriptor.vertexState;
-
-        let desc = wgpu_pipe::RenderPipelineDescriptor {
-            layout: descriptor.parent.layout.id().0,
-            vertex_stage: wgpu_pipe::ProgrammableStageDescriptor {
-                module: descriptor.vertexStage.module.id().0,
-                entry_point: Cow::Owned(descriptor.vertexStage.entryPoint.to_string()),
-            },
-            fragment_stage: descriptor.fragmentStage.as_ref().map(|stage| {
-                wgpu_pipe::ProgrammableStageDescriptor {
-                    module: stage.module.id().0,
-                    entry_point: Cow::Owned(stage.entryPoint.to_string()),
-                }
-            }),
-            rasterization_state: Some(wgt::RasterizationStateDescriptor {
-                front_face: match rs_desc.frontFace {
-                    GPUFrontFace::Ccw => wgt::FrontFace::Ccw,
-                    GPUFrontFace::Cw => wgt::FrontFace::Cw,
-                },
-                cull_mode: match rs_desc.cullMode {
-                    GPUCullMode::None => wgt::CullMode::None,
-                    GPUCullMode::Front => wgt::CullMode::Front,
-                    GPUCullMode::Back => wgt::CullMode::Back,
-                },
-                clamp_depth: rs_desc.clampDepth,
-                depth_bias: rs_desc.depthBias,
-                depth_bias_slope_scale: *rs_desc.depthBiasSlopeScale,
-                depth_bias_clamp: *rs_desc.depthBiasClamp,
-            }),
-            primitive_topology: match descriptor.primitiveTopology {
-                GPUPrimitiveTopology::Point_list => wgt::PrimitiveTopology::PointList,
-                GPUPrimitiveTopology::Line_list => wgt::PrimitiveTopology::LineList,
-                GPUPrimitiveTopology::Line_strip => wgt::PrimitiveTopology::LineStrip,
-                GPUPrimitiveTopology::Triangle_list => wgt::PrimitiveTopology::TriangleList,
-                GPUPrimitiveTopology::Triangle_strip => wgt::PrimitiveTopology::TriangleStrip,
-            },
-            color_states: Cow::Owned(
-                descriptor
-                    .colorStates
-                    .iter()
-                    .map(|state| wgt::ColorStateDescriptor {
-                        format: convert_texture_format(state.format),
-                        alpha_blend: convert_blend_descriptor(&state.alphaBlend),
-                        color_blend: convert_blend_descriptor(&state.colorBlend),
-                        write_mask: match wgt::ColorWrite::from_bits(state.writeMask) {
-                            Some(mask) => mask,
-                            None => wgt::ColorWrite::empty(),
+        let scope_id = self.use_current_scope();
+        let mut valid = true;
+        let color_states = Cow::Owned(
+            descriptor
+                .colorStates
+                .iter()
+                .map(|state| wgt::ColorStateDescriptor {
+                    format: convert_texture_format(state.format),
+                    alpha_blend: convert_blend_descriptor(&state.alphaBlend),
+                    color_blend: convert_blend_descriptor(&state.colorBlend),
+                    write_mask: match wgt::ColorWrite::from_bits(state.writeMask) {
+                        Some(mask) => mask,
+                        None => {
+                            valid = false;
+                            wgt::ColorWrite::empty()
                         },
-                    })
-                    .collect::<Vec<_>>(),
-            ),
-            depth_stencil_state: descriptor.depthStencilState.as_ref().map(|dss_desc| {
-                wgt::DepthStencilStateDescriptor {
-                    format: convert_texture_format(dss_desc.format),
-                    depth_write_enabled: dss_desc.depthWriteEnabled,
-                    depth_compare: convert_compare_function(dss_desc.depthCompare),
-                    stencil_front: wgt::StencilStateFaceDescriptor {
-                        compare: convert_compare_function(dss_desc.stencilFront.compare),
-                        fail_op: convert_stencil_op(dss_desc.stencilFront.failOp),
-                        depth_fail_op: convert_stencil_op(dss_desc.stencilFront.depthFailOp),
-                        pass_op: convert_stencil_op(dss_desc.stencilFront.passOp),
                     },
-                    stencil_back: wgt::StencilStateFaceDescriptor {
-                        compare: convert_compare_function(dss_desc.stencilBack.compare),
-                        fail_op: convert_stencil_op(dss_desc.stencilBack.failOp),
-                        depth_fail_op: convert_stencil_op(dss_desc.stencilBack.depthFailOp),
-                        pass_op: convert_stencil_op(dss_desc.stencilBack.passOp),
-                    },
-                    stencil_read_mask: dss_desc.stencilReadMask,
-                    stencil_write_mask: dss_desc.stencilWriteMask,
-                }
-            }),
-            vertex_state: wgt::VertexStateDescriptor {
-                index_format: match vs_desc.indexFormat {
-                    GPUIndexFormat::Uint16 => wgt::IndexFormat::Uint16,
-                    GPUIndexFormat::Uint32 => wgt::IndexFormat::Uint32,
+                })
+                .collect::<Vec<_>>(),
+        );
+
+        let desc = if valid {
+            Some(wgpu_pipe::RenderPipelineDescriptor {
+                layout: descriptor.parent.layout.id().0,
+                vertex_stage: wgpu_pipe::ProgrammableStageDescriptor {
+                    module: descriptor.vertexStage.module.id().0,
+                    entry_point: Cow::Owned(descriptor.vertexStage.entryPoint.to_string()),
                 },
-                vertex_buffers: Cow::Owned(
-                    vs_desc
-                        .vertexBuffers
-                        .iter()
-                        .map(|buffer| wgt::VertexBufferDescriptor {
-                            stride: buffer.arrayStride,
-                            step_mode: match buffer.stepMode {
-                                GPUInputStepMode::Vertex => wgt::InputStepMode::Vertex,
-                                GPUInputStepMode::Instance => wgt::InputStepMode::Instance,
-                            },
-                            attributes: Cow::Owned(
-                                buffer
-                                    .attributes
-                                    .iter()
-                                    .map(|att| wgt::VertexAttributeDescriptor {
-                                        format: convert_vertex_format(att.format),
-                                        offset: att.offset,
-                                        shader_location: att.shaderLocation,
-                                    })
-                                    .collect::<Vec<_>>(),
-                            ),
-                        })
-                        .collect::<Vec<_>>(),
-                ),
-            },
-            sample_count: descriptor.sampleCount,
-            sample_mask: descriptor.sampleMask,
-            alpha_to_coverage_enabled: descriptor.alphaToCoverageEnabled,
+                fragment_stage: descriptor.fragmentStage.as_ref().map(|stage| {
+                    wgpu_pipe::ProgrammableStageDescriptor {
+                        module: stage.module.id().0,
+                        entry_point: Cow::Owned(stage.entryPoint.to_string()),
+                    }
+                }),
+                rasterization_state: Some(wgt::RasterizationStateDescriptor {
+                    front_face: match rs_desc.frontFace {
+                        GPUFrontFace::Ccw => wgt::FrontFace::Ccw,
+                        GPUFrontFace::Cw => wgt::FrontFace::Cw,
+                    },
+                    cull_mode: match rs_desc.cullMode {
+                        GPUCullMode::None => wgt::CullMode::None,
+                        GPUCullMode::Front => wgt::CullMode::Front,
+                        GPUCullMode::Back => wgt::CullMode::Back,
+                    },
+                    clamp_depth: rs_desc.clampDepth,
+                    depth_bias: rs_desc.depthBias,
+                    depth_bias_slope_scale: *rs_desc.depthBiasSlopeScale,
+                    depth_bias_clamp: *rs_desc.depthBiasClamp,
+                }),
+                primitive_topology: match descriptor.primitiveTopology {
+                    GPUPrimitiveTopology::Point_list => wgt::PrimitiveTopology::PointList,
+                    GPUPrimitiveTopology::Line_list => wgt::PrimitiveTopology::LineList,
+                    GPUPrimitiveTopology::Line_strip => wgt::PrimitiveTopology::LineStrip,
+                    GPUPrimitiveTopology::Triangle_list => wgt::PrimitiveTopology::TriangleList,
+                    GPUPrimitiveTopology::Triangle_strip => wgt::PrimitiveTopology::TriangleStrip,
+                },
+                color_states,
+                depth_stencil_state: descriptor.depthStencilState.as_ref().map(|dss_desc| {
+                    wgt::DepthStencilStateDescriptor {
+                        format: convert_texture_format(dss_desc.format),
+                        depth_write_enabled: dss_desc.depthWriteEnabled,
+                        depth_compare: convert_compare_function(dss_desc.depthCompare),
+                        stencil_front: wgt::StencilStateFaceDescriptor {
+                            compare: convert_compare_function(dss_desc.stencilFront.compare),
+                            fail_op: convert_stencil_op(dss_desc.stencilFront.failOp),
+                            depth_fail_op: convert_stencil_op(dss_desc.stencilFront.depthFailOp),
+                            pass_op: convert_stencil_op(dss_desc.stencilFront.passOp),
+                        },
+                        stencil_back: wgt::StencilStateFaceDescriptor {
+                            compare: convert_compare_function(dss_desc.stencilBack.compare),
+                            fail_op: convert_stencil_op(dss_desc.stencilBack.failOp),
+                            depth_fail_op: convert_stencil_op(dss_desc.stencilBack.depthFailOp),
+                            pass_op: convert_stencil_op(dss_desc.stencilBack.passOp),
+                        },
+                        stencil_read_mask: dss_desc.stencilReadMask,
+                        stencil_write_mask: dss_desc.stencilWriteMask,
+                    }
+                }),
+                vertex_state: wgt::VertexStateDescriptor {
+                    index_format: match vs_desc.indexFormat {
+                        GPUIndexFormat::Uint16 => wgt::IndexFormat::Uint16,
+                        GPUIndexFormat::Uint32 => wgt::IndexFormat::Uint32,
+                    },
+                    vertex_buffers: Cow::Owned(
+                        vs_desc
+                            .vertexBuffers
+                            .iter()
+                            .map(|buffer| wgt::VertexBufferDescriptor {
+                                stride: buffer.arrayStride,
+                                step_mode: match buffer.stepMode {
+                                    GPUInputStepMode::Vertex => wgt::InputStepMode::Vertex,
+                                    GPUInputStepMode::Instance => wgt::InputStepMode::Instance,
+                                },
+                                attributes: Cow::Owned(
+                                    buffer
+                                        .attributes
+                                        .iter()
+                                        .map(|att| wgt::VertexAttributeDescriptor {
+                                            format: convert_vertex_format(att.format),
+                                            offset: att.offset,
+                                            shader_location: att.shaderLocation,
+                                        })
+                                        .collect::<Vec<_>>(),
+                                ),
+                            })
+                            .collect::<Vec<_>>(),
+                    ),
+                },
+                sample_count: descriptor.sampleCount,
+                sample_mask: descriptor.sampleMask,
+                alpha_to_coverage_enabled: descriptor.alphaToCoverageEnabled,
+            })
+        } else {
+            self.handle_server_msg(
+                scope_id,
+                WebGPUOpResult::ValidationError(String::from("Invalid GPUColorWriteFlags")),
+            );
+            None
         };
 
         let render_pipeline_id = self
@@ -914,8 +947,6 @@ impl GPUDeviceMethods for GPUDevice {
             .wgpu_id_hub()
             .lock()
             .create_render_pipeline_id(self.device.0.backend());
-
-        let scope_id = self.use_current_scope();
 
         self.channel
             .0

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -16,6 +16,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpudevice::{convert_texture_format, convert_texture_view_dimension, GPUDevice};
 use crate::dom::gputextureview::GPUTextureView;
 use dom_struct::dom_struct;
+use std::num::NonZeroU32;
 use std::string::String;
 use webgpu::{wgt, WebGPU, WebGPURequest, WebGPUTexture, WebGPUTextureView};
 
@@ -152,9 +153,9 @@ impl GPUTextureMethods for GPUTexture {
                 GPUTextureAspect::Depth_only => wgt::TextureAspect::DepthOnly,
             },
             base_mip_level: descriptor.baseMipLevel,
-            level_count: descriptor.mipLevelCount.as_ref().copied(),
+            level_count: descriptor.mipLevelCount.and_then(NonZeroU32::new),
             base_array_layer: descriptor.baseArrayLayer,
-            array_layer_count: descriptor.arrayLayerCount.as_ref().copied(),
+            array_layer_count: descriptor.arrayLayerCount.and_then(NonZeroU32::new),
         };
 
         let texture_view_id = self

--- a/tests/wpt/webgpu/meta/webgpu/cts.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.html.ini
@@ -3890,15 +3890,6 @@
   [webgpu:api,validation,error_scope:if_no_error_scope_handles_an_error_it_fires_an_uncapturederror_event:]
     expected: FAIL
 
-  [webgpu:api,validation,error_scope:if_an_error_scope_matches_an_error_it_does_not_bubble_to_the_parent_scope:]
-    expected: FAIL
-
-  [webgpu:api,validation,error_scope:errors_bubble_to_the_parent_scope_if_not_handled_by_the_current_scope:]
-    expected: FAIL
-
-  [webgpu:api,validation,error_scope:simple_case_where_the_error_scope_catches_an_error:]
-    expected: FAIL
-
 
 [cts.html?q=webgpu:api,validation,createBindGroupLayout:*]
   expected: ERROR
@@ -4692,7 +4683,6 @@
 [cts.html?q=webgpu:api,validation,setBlendColor:*]
 
 [cts.html?q=webgpu:api,validation,render_pass_descriptor:*]
-  expected: CRASH
   [webgpu:api,validation,render_pass_descriptor:check_the_use_of_multisampled_textures_as_color_attachments:]
     expected: FAIL
 
@@ -4751,7 +4741,606 @@
   expected: ERROR
 
 [cts.html?q=webgpu:api,operation,resource_init,depth_stencil_attachment_clear:*]
-  expected: CRASH
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="all";mipLevelCount=1;sampleCount=1;uninitializeMethod="StoreOpClear";readMethod="DepthTest";dimension="2d";sliceCount=1;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=5;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="all";mipLevelCount=1;sampleCount=4;uninitializeMethod="Creation";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth32float";aspect="depth-only";mipLevelCount=1;sampleCount=1;uninitializeMethod="Creation";readMethod="DepthTest";dimension="2d";sliceCount=7;nonPowerOfTwo=false]
+    expected: FAIL
+
+  [webgpu:api,operation,resource_init,depth_stencil_attachment_clear:uninitialized_texture_is_zero:format="depth24plus-stencil8";aspect="stencil-only";mipLevelCount=1;sampleCount=4;uninitializeMethod="StoreOpClear";readMethod="StencilTest";dimension="2d";sliceCount=1;nonPowerOfTwo=true]
+    expected: FAIL
+
 
 [cts.html?q=webgpu:api,operation,buffers,map_detach:*]
   [webgpu:api,operation,buffers,map_detach:create_mapped:unmap=false;destroy=true]
@@ -15598,102 +16187,6 @@
 [cts.html?q=webgpu:web-platform,canvas,context_creation:*]
 
 [cts.html?q=webgpu:api,validation,setBindGroup:*]
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="compute";dynamicOffsets=[0,4294967295\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderbundle";dynamicOffsets=[1024,0\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderpass";dynamicOffsets=[0,4294967295\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderpass";dynamicOffsets=[\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderpass";dynamicOffsets=[1,2\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="compute";dynamicOffsets=[0,1024\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderpass";dynamicOffsets=[0,512\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderbundle";dynamicOffsets=[4294967295,0\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="compute";dynamicOffsets=[4294967295,0\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_passed_but_not_expected,compute_pass:type="renderpass"]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="compute";dynamicOffsets=[256\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="compute";dynamicOffsets=[0,512\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="compute";dynamicOffsets=[1,2\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderbundle";dynamicOffsets=[0,4294967295\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderpass";dynamicOffsets=[256,0,0\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderbundle";dynamicOffsets=[\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="compute";dynamicOffsets=[256,0,0\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderpass";dynamicOffsets=[4294967295,0\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderbundle";dynamicOffsets=[0,512\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderbundle";dynamicOffsets=[0,1024\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="compute";dynamicOffsets=[\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderpass";dynamicOffsets=[256\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderbundle";dynamicOffsets=[256,0,0\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderbundle";dynamicOffsets=[1,2\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderpass";dynamicOffsets=[512,0\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="compute";dynamicOffsets=[1024,0\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderbundle";dynamicOffsets=[512,0\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderpass";dynamicOffsets=[1024,0\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_passed_but_not_expected,compute_pass:type="compute"]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="compute";dynamicOffsets=[512,0\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderpass";dynamicOffsets=[0,1024\]]
-    expected: FAIL
-
-  [webgpu:api,validation,setBindGroup:dynamic_offsets_match_expectations_in_pass_encoder:type="renderbundle";dynamicOffsets=[256\]]
-    expected: FAIL
-
 
 [cts.html?q=webgpu:api,operation,command_buffer,render,rendering:*]
   [webgpu:api,operation,command_buffer,render,rendering:fullscreen_quad:]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
1. Update wgpu to use the error model on wgpu-core side. Register error Ids separately.
2. ~~Record errors only in `GPUCommandEncoder.finish()`. Errors are no longer recorded in ErrorScopes in transfer commands or while recording passes. Any errors that occur are stored on the server-side in `error_command_encoders: HashMap<id::CommandEncoderId, String>` and reported on `CommandEncoderFinish`. Note: This should be reverted when the spec gets updated.~~
3. Correct a major flaw in ErrorScope Model. If multiple operations are issued inside scope and an early operation fails, the promise resolves and script execution continues. The scope, however, was not popped until the results of all its operations were received. This meant that if the user issues another operation, it was assumed to be issued in an error scope that has already been popped by the user, which led to the failure of a number of tests. This is solved by storing a `popped` boolean to check whether `popErrorScope()` has been called on a scope or not. Operation is now issued in the lastest scope for which `popped == false`.

One of the tests used to crash, but it no longer does (All subtests under it fail now). That explains the large number of failing test expectations that have been added. Most of them fail due to the tests being outdated. I'll switch to the updated branch in the next PR.

r?@kvark

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
