### PR TITLE
Use gstreamer on UWP targets

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -144,9 +144,8 @@ mod media_platform {
 
     #[cfg(feature = "uwp")]
     fn set_gstreamer_log_handler() {
-        use gstreamer::{debug_add_log_function, debug_remove_default_log_function, DebugLevel};
+        use gstreamer::{debug_add_log_function, DebugLevel};
 
-        debug_remove_default_log_function();
         debug_add_log_function(|cat, level, file, function, line, _, message| {
             let message = format!(
                 "{:?} {:?} {:?}:{:?}:{:?} {:?}",

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -864,6 +864,7 @@ install them, let us know by filing a bug!")
                 not target
                 or ("armv7" in target and "android" in target)
                 or "x86_64" in target
+                or "uwp" in target
             ):
                 media_stack = "gstreamer"
             else:

--- a/support/hololens/ServoApp/ServoControl/Servo.cpp
+++ b/support/hololens/ServoApp/ServoControl/Servo.cpp
@@ -281,6 +281,10 @@ Servo::Servo(std::optional<hstring> initUrl, hstring args, GLsizei width,
   sServo = this; // FIXME;
 
   auto current = ApplicationData::Current();
+  auto gstLog = std::wstring(current.LocalFolder().Path()) + L"\\gst.log";
+  SetEnvironmentVariable(L"GST_DEBUG_FILE", gstLog.c_str());
+  // SetEnvironmentVariableA("GST_DEBUG", "4");
+
   auto filePath = std::wstring(current.LocalFolder().Path()) + L"\\stdout.txt";
   sLogHandle =
       CreateFile2(filePath.c_str(), GENERIC_WRITE, 0, CREATE_ALWAYS, nullptr);


### PR DESCRIPTION
This fixes a regression that cause our arm64 builds to use the dummy media stack by default. Oops.

Fix #27531. Fix #27532.