### PR TITLE
Make textures that come from webxr invalid outside an rAF

### DIFF
--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -205,6 +205,9 @@ impl WebGLFramebuffer {
     }
 
     pub fn is_deleted(&self) -> bool {
+        // TODO: if a framebuffer has an attachment which is invalid due to
+        // being outside a webxr rAF, should this make the framebuffer invalid?
+        // https://github.com/immersive-web/layers/issues/196
         self.is_deleted.get()
     }
 
@@ -447,6 +450,9 @@ impl WebGLFramebuffer {
         } else {
             self.status.get()
         }
+        // TODO: if a framebuffer has an attachment which is invalid due to
+        // being outside a webxr rAF, should this make the framebuffer incomplete?
+        // https://github.com/immersive-web/layers/issues/196
     }
 
     pub fn check_status_for_rendering(&self) -> CompleteForRendering {
@@ -496,6 +502,10 @@ impl WebGLFramebuffer {
                 .initialize_framebuffer(clear_bits);
             self.is_initialized.set(true);
         }
+
+        // TODO: if a framebuffer has an attachment which is invalid due to
+        // being outside a webxr rAF, should this make the framebuffer incomplete?
+        // https://github.com/immersive-web/layers/issues/196
 
         CompleteForRendering::Complete
     }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -3563,7 +3563,7 @@ impl WebGLRenderingContextMethods for WebGLRenderingContext {
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.8
     fn IsTexture(&self, texture: Option<&WebGLTexture>) -> bool {
         texture.map_or(false, |tex| {
-            self.validate_ownership(tex).is_ok() && tex.target().is_some() && !tex.is_deleted()
+            self.validate_ownership(tex).is_ok() && tex.target().is_some() && !tex.is_invalid()
         })
     }
 

--- a/components/script/dom/xrwebgllayer.rs
+++ b/components/script/dom/xrwebgllayer.rs
@@ -193,10 +193,11 @@ impl XRWebGLLayer {
         let framebuffer = self.framebuffer.as_ref()?;
         let context = framebuffer.upcast::<WebGLObject>().context();
         let sub_images = frame.get_sub_images(self.layer_id()?)?;
+        let session = self.session();
         // TODO: Cache this texture
         let color_texture_id =
             WebGLTextureId::maybe_new(sub_images.sub_image.as_ref()?.color_texture)?;
-        let color_texture = WebGLTexture::new_webxr(context, color_texture_id);
+        let color_texture = WebGLTexture::new_webxr(context, color_texture_id, session);
         let target = self.texture_target();
 
         // Save the current bindings
@@ -230,7 +231,8 @@ impl XRWebGLLayer {
         if let Some(id) = sub_images.sub_image.as_ref()?.depth_stencil_texture {
             // TODO: Cache this texture
             let depth_stencil_texture_id = WebGLTextureId::maybe_new(id)?;
-            let depth_stencil_texture = WebGLTexture::new_webxr(context, depth_stencil_texture_id);
+            let depth_stencil_texture =
+                WebGLTexture::new_webxr(context, depth_stencil_texture_id, session);
             framebuffer
                 .texture2d_even_if_opaque(
                     constants::DEPTH_STENCIL_ATTACHMENT,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Implements "The colorTexture and depthStencilTexture objects MUST only be used during the XR animation frame of the current session and MUST be made invalid once the XR animation frame completes." from https://immersive-web.github.io/layers/#xrwebglsubimagetype

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are no tests for these changes because we can't test this until we have projection layers

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
