### PR TITLE
Canvas text and macOS font fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,7 @@ dependencies = [
  "log",
  "lyon_geom 0.14.1",
  "num-traits",
+ "pathfinder_geometry",
  "pixels",
  "raqote",
  "servo_arc",

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -31,6 +31,7 @@ ipc-channel = "0.14"
 log = "0.4"
 lyon_geom = "0.14"
 num-traits = "0.2"
+pathfinder_geometry = "0.5"
 pixels = { path = "../pixels" }
 raqote = { version = "0.8", features = ["text"] }
 servo_arc = { path = "../servo_arc" }

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -523,16 +523,10 @@ impl<'a> CanvasData<'a> {
                         .first(font_context)
                         .expect("couldn't find font");
                     let font = font.borrow_mut();
-                    // Retrieving bytes from font template seems to panic for some core text fonts.
-                    // This check avoids having to obtain bytes from the font template data if they
-                    // are not already in the memory.
-                    if let Some(bytes) = font.handle.template().bytes_if_in_memory() {
-                        Font::from_bytes(Arc::new(bytes), 0)
-                            .ok()
-                            .or_else(|| load_system_font_from_style(Some(style)))
-                    } else {
-                        load_system_font_from_style(Some(style))
-                    }
+                    let template = font.handle.template();
+                    Font::from_bytes(Arc::new(template.bytes()), 0)
+                        .ok()
+                        .or_else(|| load_system_font_from_style(Some(style)))
                 })
             },
         );

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -527,11 +527,33 @@ impl GenericDrawTarget for raqote::DrawTarget {
         pattern: &canvas_data::Pattern,
         options: &DrawOptions,
     ) {
-        self.draw_text(
+        let mut start = pathfinder_geometry::vector::vec2f(start.x, start.y);
+        let mut ids = Vec::new();
+        let mut positions = Vec::new();
+        for c in text.chars() {
+            let id = match font.glyph_for_char(c) {
+                Some(id) => id,
+                None => {
+                    warn!("Skipping non-existent glyph {}", c);
+                    continue;
+                },
+            };
+            ids.push(id);
+            positions.push(Point2D::new(start.x(), start.y()));
+            let advance = match font.advance(id) {
+                Ok(advance) => advance,
+                Err(e) => {
+                    warn!("Skipping glyph {} with missing advance: {:?}", c, e);
+                    continue;
+                },
+            };
+            start += advance * point_size / 24. / 96.;
+        }
+        self.draw_glyphs(
             font,
             point_size,
-            text,
-            start,
+            &ids,
+            &positions,
             &pattern.source(),
             options.as_raqote(),
         );


### PR DESCRIPTION
These changes work around a source of panics by skipping glyphs that don't exist when drawing text to the canvas. Ideally we would have font fallback and/or tofu characters, but that's a larger project than I wanted to get into right now.

Relatedly, while investigating the non-panic errors observed in #27476, I realized that the underlying source of #24622 could be dealt with because we shouldn't actually need to open the CTFont by a file path to get the bytes, since we already have bytes available that we use to create the CTFont.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #24622 and fix #27476 and fix the panic observed in #20445.
- [x] There are tests for these changes