### PR TITLE
Notify devtools of session history traversals

### DIFF
--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -97,6 +97,9 @@ pub struct Pipeline {
 
     /// Has this pipeline received a notification that it is completely loaded?
     pub completely_loaded: bool,
+
+    /// The title of this pipeline's document.
+    pub title: String,
 }
 
 /// Initial setup data needed to construct a pipeline.
@@ -379,6 +382,7 @@ impl Pipeline {
             history_state_id: None,
             history_states: HashSet::new(),
             completely_loaded: false,
+            title: String::new(),
         };
 
         pipeline.notify_visibility(is_visible);

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1142,9 +1142,13 @@ impl Document {
     pub fn title_changed(&self) {
         if self.browsing_context().is_some() {
             self.send_title_to_embedder();
+            let title = String::from(self.Title());
+            self.window.send_to_constellation(ScriptMsg::TitleChanged(
+                self.window.pipeline_id(),
+                title.clone(),
+            ));
             let global = self.window.upcast::<GlobalScope>();
             if let Some(ref chan) = global.devtools_chan() {
-                let title = String::from(self.Title());
                 let _ = chan.send(ScriptToDevtoolsControlMsg::TitleChanged(
                     global.pipeline_id(),
                     title,

--- a/components/script_traits/script_msg.rs
+++ b/components/script_traits/script_msg.rs
@@ -282,6 +282,8 @@ pub enum ScriptMsg {
     ),
     /// Get WebGPU channel
     GetWebGPUChan(IpcSender<WebGPU>),
+    /// Notify the constellation of a pipeline's document's title.
+    TitleChanged(PipelineId, String),
 }
 
 impl fmt::Debug for ScriptMsg {
@@ -341,6 +343,7 @@ impl fmt::Debug for ScriptMsg {
             MediaSessionEvent(..) => "MediaSessionEvent",
             RequestAdapter(..) => "RequestAdapter",
             GetWebGPUChan(..) => "GetWebGPUChan",
+            TitleChanged(..) => "TitleChanged",
         };
         write!(formatter, "ScriptMsg::{}", variant)
     }


### PR DESCRIPTION
This makes the remote devtools and devtools panel in FxR clear the console when going backwards and forwards through session history.

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27525
- [x] These changes do not require tests because no devtools tests.