### PR TITLE
Implement GPUUncapturedErrorEvent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6945,7 +6945,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#8057acf120f9944056a6b5de6cf326f18ae7671d"
+source = "git+https://github.com/gfx-rs/wgpu#430b29d781200009ef02839e41136718ff62456a"
 dependencies = [
  "arrayvec 0.5.1",
  "bitflags",
@@ -6972,7 +6972,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#8057acf120f9944056a6b5de6cf326f18ae7671d"
+source = "git+https://github.com/gfx-rs/wgpu#430b29d781200009ef02839e41136718ff62456a"
 dependencies = [
  "bitflags",
  "serde",

--- a/components/atoms/static_atoms.txt
+++ b/components/atoms/static_atoms.txt
@@ -137,6 +137,7 @@ transitioncancel
 transitionend
 transitionrun
 transitionstart
+uncapturederror
 unhandledrejection
 unload
 url

--- a/components/script/dom/gpuuncapturederrorevent.rs
+++ b/components/script/dom/gpuuncapturederrorevent.rs
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::dom::bindings::codegen::Bindings::EventBinding::EventBinding::EventMethods;
+use crate::dom::bindings::codegen::Bindings::GPUUncapturedErrorEventBinding::{
+    GPUUncapturedErrorEventInit, GPUUncapturedErrorEventMethods,
+};
+use crate::dom::bindings::codegen::Bindings::GPUValidationErrorBinding::GPUError;
+use crate::dom::bindings::reflector::reflect_dom_object;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::event::Event;
+use crate::dom::globalscope::GlobalScope;
+use dom_struct::dom_struct;
+use servo_atoms::Atom;
+
+#[dom_struct]
+pub struct GPUUncapturedErrorEvent {
+    event: Event,
+    #[ignore_malloc_size_of = "Because it is non-owning"]
+    gpu_error: GPUError,
+}
+
+impl GPUUncapturedErrorEvent {
+    fn new_inherited(init: &GPUUncapturedErrorEventInit) -> Self {
+        Self {
+            gpu_error: clone_gpu_error(&init.error),
+            event: Event::new_inherited(),
+        }
+    }
+
+    pub fn new(
+        global: &GlobalScope,
+        type_: DOMString,
+        init: &GPUUncapturedErrorEventInit,
+    ) -> DomRoot<Self> {
+        let ev = reflect_dom_object(
+            Box::new(GPUUncapturedErrorEvent::new_inherited(init)),
+            global,
+        );
+        ev.event.init_event(
+            Atom::from(type_),
+            init.parent.bubbles,
+            init.parent.cancelable,
+        );
+        ev
+    }
+
+    /// https://gpuweb.github.io/gpuweb/#dom-gpuuncapturederrorevent-gpuuncapturederrorevent
+    #[allow(non_snake_case)]
+    pub fn Constructor(
+        global: &GlobalScope,
+        type_: DOMString,
+        init: &GPUUncapturedErrorEventInit,
+    ) -> DomRoot<Self> {
+        GPUUncapturedErrorEvent::new(global, type_, init)
+    }
+}
+
+impl GPUUncapturedErrorEvent {
+    pub fn event(&self) -> &Event {
+        &self.event
+    }
+}
+
+impl GPUUncapturedErrorEventMethods for GPUUncapturedErrorEvent {
+    /// https://gpuweb.github.io/gpuweb/#dom-gpuuncapturederrorevent-error
+    fn Error(&self) -> GPUError {
+        clone_gpu_error(&self.gpu_error)
+    }
+
+    /// https://dom.spec.whatwg.org/#dom-event-istrusted
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
+    }
+}
+
+fn clone_gpu_error(error: &GPUError) -> GPUError {
+    match *error {
+        GPUError::GPUValidationError(ref v) => GPUError::GPUValidationError(v.clone()),
+        GPUError::GPUOutOfMemoryError(ref w) => GPUError::GPUOutOfMemoryError(w.clone()),
+    }
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -349,6 +349,7 @@ pub mod gpuswapchain;
 pub mod gputexture;
 pub mod gputextureusage;
 pub mod gputextureview;
+pub mod gpuuncapturederrorevent;
 pub mod gpuvalidationerror;
 pub mod hashchangeevent;
 pub mod headers;

--- a/components/script/dom/webidls/GPUUncapturedErrorEvent.webidl
+++ b/components/script/dom/webidls/GPUUncapturedErrorEvent.webidl
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://gpuweb.github.io/gpuweb/#gpuuncapturederrorevent
+[Exposed=(Window, DedicatedWorker), Pref="dom.webgpu.enabled"]
+interface GPUUncapturedErrorEvent : Event {
+    constructor(
+        DOMString type,
+        GPUUncapturedErrorEventInit gpuUncapturedErrorEventInitDict
+    );
+    /*[SameObject]*/ readonly attribute GPUError error;
+};
+
+dictionary GPUUncapturedErrorEventInit : EventInit {
+    required GPUError error;
+};
+
+partial interface GPUDevice {
+    [Exposed=(Window, DedicatedWorker)]
+    attribute EventHandler onuncapturederror;
+};

--- a/tests/wpt/webgpu/meta/webgpu/cts.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.html.ini
@@ -137,9 +137,6 @@
 
 
 [cts.html?q=webgpu:api,validation,error_scope:*]
-  [webgpu:api,validation,error_scope:if_no_error_scope_handles_an_error_it_fires_an_uncapturederror_event:]
-    expected: FAIL
-
 
 [cts.html?q=webgpu:api,validation,resource_usages,textureUsageInRender:*]
   expected: CRASH


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
A new `uncapturederror` variant is added to atoms/static-atoms.txt. `GPUUncapturedErrorEvent` is fired when an error is not captured by any `ErrorScope`.
All tests for error scopes `PASS` now.

r?@kvark


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes
<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
