### PR TITLE
Implement GPUPipelineBase for implicit pipeline layouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#7e8b51b4286bd9452567eb1a56edb8e9b7c7f684"
+source = "git+https://github.com/gfx-rs/wgpu#f7ec6cc1fe73651cfeda44295cd41533ec60f850"
 dependencies = [
  "arrayvec 0.5.1",
  "bitflags",
@@ -6982,7 +6982,7 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#7e8b51b4286bd9452567eb1a56edb8e9b7c7f684"
+source = "git+https://github.com/gfx-rs/wgpu#f7ec6cc1fe73651cfeda44295cd41533ec60f850"
 dependencies = [
  "bitflags",
  "serde",

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -18,6 +18,7 @@ use crate::dom::bindings::codegen::Bindings::GPUComputePipelineBinding::GPUCompu
 use crate::dom::bindings::codegen::Bindings::GPUDeviceBinding::{
     GPUCommandEncoderDescriptor, GPUDeviceMethods,
 };
+use crate::dom::bindings::codegen::Bindings::GPUObjectBaseBinding::GPUObjectDescriptorBase;
 use crate::dom::bindings::codegen::Bindings::GPUPipelineLayoutBinding::GPUPipelineLayoutDescriptor;
 use crate::dom::bindings::codegen::Bindings::GPURenderBundleEncoderBinding::GPURenderBundleEncoderDescriptor;
 use crate::dom::bindings::codegen::Bindings::GPURenderPipelineBinding::{
@@ -322,11 +323,7 @@ impl GPUDeviceMethods for GPUDevice {
     fn CreateBuffer(&self, descriptor: &GPUBufferDescriptor) -> DomRoot<GPUBuffer> {
         let desc =
             wgt::BufferUsage::from_bits(descriptor.usage).map(|usg| wgpu_res::BufferDescriptor {
-                label: descriptor
-                    .parent
-                    .label
-                    .as_ref()
-                    .map(|s| Cow::Owned(s.to_string())),
+                label: convert_label(&descriptor.parent),
                 size: descriptor.size as wgt::BufferAddress,
                 usage: usg,
                 mapped_at_creation: descriptor.mappedAtCreation,
@@ -482,11 +479,7 @@ impl GPUDeviceMethods for GPUDevice {
 
         let desc = if valid {
             Some(wgpu_bind::BindGroupLayoutDescriptor {
-                label: descriptor
-                    .parent
-                    .label
-                    .as_ref()
-                    .map(|s| Cow::Owned(s.to_string())),
+                label: convert_label(&descriptor.parent),
                 entries: Cow::Owned(entries),
             })
         } else {
@@ -529,11 +522,7 @@ impl GPUDeviceMethods for GPUDevice {
         descriptor: &GPUPipelineLayoutDescriptor,
     ) -> DomRoot<GPUPipelineLayout> {
         let desc = wgpu_bind::PipelineLayoutDescriptor {
-            label: descriptor
-                .parent
-                .label
-                .as_ref()
-                .map(|s| Cow::Owned(s.to_string())),
+            label: convert_label(&descriptor.parent),
             bind_group_layouts: Cow::Owned(
                 descriptor
                     .bindGroupLayouts
@@ -597,11 +586,7 @@ impl GPUDeviceMethods for GPUDevice {
             .collect::<Vec<_>>();
 
         let desc = wgpu_bind::BindGroupDescriptor {
-            label: descriptor
-                .parent
-                .label
-                .as_ref()
-                .map(|l| Cow::Owned(l.to_string())),
+            label: convert_label(&descriptor.parent),
             layout: descriptor.layout.id().0,
             entries: Cow::Owned(entries),
         };
@@ -688,12 +673,7 @@ impl GPUDeviceMethods for GPUDevice {
         let scope_id = self.use_current_scope();
 
         let desc = wgpu_pipe::ComputePipelineDescriptor {
-            label: descriptor
-                .parent
-                .parent
-                .label
-                .as_ref()
-                .map(|s| Cow::Owned(s.to_string())),
+            label: convert_label(&descriptor.parent.parent),
             layout: Some(descriptor.parent.layout.id().0),
             compute_stage: wgpu_pipe::ProgrammableStageDescriptor {
                 module: descriptor.computeStage.module.id().0,
@@ -739,11 +719,7 @@ impl GPUDeviceMethods for GPUDevice {
                 WebGPURequest::CreateCommandEncoder {
                     device_id: self.device.0,
                     command_encoder_id,
-                    label: descriptor
-                        .parent
-                        .label
-                        .as_ref()
-                        .map(|l| Cow::Owned(l.to_string())),
+                    label: convert_label(&descriptor.parent),
                 },
             ))
             .expect("Failed to create WebGPU command encoder");
@@ -765,11 +741,7 @@ impl GPUDeviceMethods for GPUDevice {
         let size = convert_texture_size_to_dict(&descriptor.size);
         let desc =
             wgt::TextureUsage::from_bits(descriptor.usage).map(|usg| wgpu_res::TextureDescriptor {
-                label: descriptor
-                    .parent
-                    .label
-                    .as_ref()
-                    .map(|l| Cow::Owned(l.to_string())),
+                label: convert_label(&descriptor.parent),
                 size: convert_texture_size_to_wgt(&size),
                 mip_level_count: descriptor.mipLevelCount,
                 sample_count: descriptor.sampleCount,
@@ -833,11 +805,7 @@ impl GPUDeviceMethods for GPUDevice {
             .create_sampler_id(self.device.0.backend());
         let compare_enable = descriptor.compare.is_some();
         let desc = wgpu_res::SamplerDescriptor {
-            label: descriptor
-                .parent
-                .label
-                .as_ref()
-                .map(|s| Cow::Owned(s.to_string())),
+            label: convert_label(&descriptor.parent),
             address_modes: [
                 convert_address_mode(descriptor.addressModeU),
                 convert_address_mode(descriptor.addressModeV),
@@ -907,12 +875,7 @@ impl GPUDeviceMethods for GPUDevice {
 
         let desc = if valid {
             Some(wgpu_pipe::RenderPipelineDescriptor {
-                label: descriptor
-                    .parent
-                    .parent
-                    .label
-                    .as_ref()
-                    .map(|s| Cow::Owned(s.to_string())),
+                label: convert_label(&descriptor.parent.parent),
                 layout: Some(descriptor.parent.layout.id().0),
                 vertex_stage: wgpu_pipe::ProgrammableStageDescriptor {
                     module: descriptor.vertexStage.module.id().0,
@@ -1048,11 +1011,7 @@ impl GPUDeviceMethods for GPUDevice {
         descriptor: &GPURenderBundleEncoderDescriptor,
     ) -> DomRoot<GPURenderBundleEncoder> {
         let desc = wgpu_com::RenderBundleEncoderDescriptor {
-            label: descriptor
-                .parent
-                .label
-                .as_ref()
-                .map(|s| Cow::Owned(s.to_string())),
+            label: convert_label(&descriptor.parent),
             color_formats: Cow::Owned(
                 descriptor
                     .colorFormats
@@ -1322,4 +1281,8 @@ pub fn convert_texture_size_to_wgt(size: &GPUExtent3DDict) -> wgt::Extent3d {
         height: size.height,
         depth: size.depth,
     }
+}
+
+pub fn convert_label(parent: &GPUObjectDescriptorBase) -> Option<Cow<'static, str>> {
+    parent.label.as_ref().map(|s| Cow::Owned(s.to_string()))
 }

--- a/components/script/dom/gpupipelinelayout.rs
+++ b/components/script/dom/gpupipelinelayout.rs
@@ -9,21 +9,27 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use dom_struct::dom_struct;
-use webgpu::WebGPUPipelineLayout;
+use webgpu::{WebGPUBindGroupLayout, WebGPUPipelineLayout};
 
 #[dom_struct]
 pub struct GPUPipelineLayout {
     reflector_: Reflector,
     label: DomRefCell<Option<USVString>>,
     pipeline_layout: WebGPUPipelineLayout,
+    bind_group_layouts: Vec<WebGPUBindGroupLayout>,
 }
 
 impl GPUPipelineLayout {
-    fn new_inherited(pipeline_layout: WebGPUPipelineLayout, label: Option<USVString>) -> Self {
+    fn new_inherited(
+        pipeline_layout: WebGPUPipelineLayout,
+        label: Option<USVString>,
+        bgls: Vec<WebGPUBindGroupLayout>,
+    ) -> Self {
         Self {
             reflector_: Reflector::new(),
             label: DomRefCell::new(label),
             pipeline_layout,
+            bind_group_layouts: bgls,
         }
     }
 
@@ -31,9 +37,14 @@ impl GPUPipelineLayout {
         global: &GlobalScope,
         pipeline_layout: WebGPUPipelineLayout,
         label: Option<USVString>,
+        bgls: Vec<WebGPUBindGroupLayout>,
     ) -> DomRoot<Self> {
         reflect_dom_object(
-            Box::new(GPUPipelineLayout::new_inherited(pipeline_layout, label)),
+            Box::new(GPUPipelineLayout::new_inherited(
+                pipeline_layout,
+                label,
+                bgls,
+            )),
             global,
         )
     }
@@ -42,6 +53,10 @@ impl GPUPipelineLayout {
 impl GPUPipelineLayout {
     pub fn id(&self) -> WebGPUPipelineLayout {
         self.pipeline_layout
+    }
+
+    pub fn bind_group_layouts(&self) -> Vec<WebGPUBindGroupLayout> {
+        self.bind_group_layouts.clone()
     }
 }
 

--- a/components/script/dom/gpurenderbundleencoder.rs
+++ b/components/script/dom/gpurenderbundleencoder.rs
@@ -11,11 +11,10 @@ use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::gpubindgroup::GPUBindGroup;
 use crate::dom::gpubuffer::GPUBuffer;
-use crate::dom::gpudevice::GPUDevice;
+use crate::dom::gpudevice::{convert_label, GPUDevice};
 use crate::dom::gpurenderbundle::GPURenderBundle;
 use crate::dom::gpurenderpipeline::GPURenderPipeline;
 use dom_struct::dom_struct;
-use std::borrow::Cow;
 use webgpu::{
     wgpu::command::{bundle_ffi as wgpu_bundle, RenderBundleEncoder},
     wgt, WebGPU, WebGPURenderBundle, WebGPURequest,
@@ -185,11 +184,7 @@ impl GPURenderBundleEncoderMethods for GPURenderBundleEncoder {
     /// https://gpuweb.github.io/gpuweb/#dom-gpurenderbundleencoder-finish
     fn Finish(&self, descriptor: &GPURenderBundleDescriptor) -> DomRoot<GPURenderBundle> {
         let desc = wgt::RenderBundleDescriptor {
-            label: descriptor
-                .parent
-                .label
-                .as_ref()
-                .map(|l| Cow::Owned(l.to_string())),
+            label: convert_label(&descriptor.parent),
         };
         let encoder = self.render_bundle_encoder.borrow_mut().take().unwrap();
         let render_bundle_id = self

--- a/components/script/dom/gpurenderpipeline.rs
+++ b/components/script/dom/gpurenderpipeline.rs
@@ -3,48 +3,51 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::GPUAdapterBinding::GPULimits;
 use crate::dom::bindings::codegen::Bindings::GPURenderPipelineBinding::GPURenderPipelineMethods;
-use crate::dom::bindings::reflector::reflect_dom_object;
-use crate::dom::bindings::reflector::Reflector;
+use crate::dom::bindings::error::{Error, Fallible};
+use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::gpubindgrouplayout::GPUBindGroupLayout;
 use dom_struct::dom_struct;
-use webgpu::{WebGPUDevice, WebGPURenderPipeline};
+use std::string::String;
+use webgpu::{WebGPUBindGroupLayout, WebGPURenderPipeline};
 
 #[dom_struct]
 pub struct GPURenderPipeline {
     reflector_: Reflector,
     label: DomRefCell<Option<USVString>>,
     render_pipeline: WebGPURenderPipeline,
-    device: WebGPUDevice,
+    bind_group_layouts: Vec<WebGPUBindGroupLayout>,
 }
 
 impl GPURenderPipeline {
     fn new_inherited(
         render_pipeline: WebGPURenderPipeline,
-        device: WebGPUDevice,
         label: Option<USVString>,
+        bgls: Vec<WebGPUBindGroupLayout>,
     ) -> Self {
         Self {
             reflector_: Reflector::new(),
             label: DomRefCell::new(label),
             render_pipeline,
-            device,
+            bind_group_layouts: bgls,
         }
     }
 
     pub fn new(
         global: &GlobalScope,
         render_pipeline: WebGPURenderPipeline,
-        device: WebGPUDevice,
         label: Option<USVString>,
+        bgls: Vec<WebGPUBindGroupLayout>,
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPURenderPipeline::new_inherited(
                 render_pipeline,
-                device,
                 label,
+                bgls,
             )),
             global,
         )
@@ -66,5 +69,18 @@ impl GPURenderPipelineMethods for GPURenderPipeline {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label
     fn SetLabel(&self, value: Option<USVString>) {
         *self.label.borrow_mut() = value;
+    }
+
+    /// https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout
+    fn GetBindGroupLayout(&self, index: u32) -> Fallible<DomRoot<GPUBindGroupLayout>> {
+        if index > self.bind_group_layouts.len() as u32 || index > GPULimits::empty().maxBindGroups
+        {
+            return Err(Error::Range(String::from("Index out of bounds")));
+        }
+        return Ok(GPUBindGroupLayout::new(
+            &self.global(),
+            self.bind_group_layouts[index as usize],
+            None,
+        ));
     }
 }

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -13,10 +13,11 @@ use crate::dom::bindings::reflector::{reflect_dom_object, DomObject, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::gpudevice::{convert_texture_format, convert_texture_view_dimension, GPUDevice};
+use crate::dom::gpudevice::{
+    convert_label, convert_texture_format, convert_texture_view_dimension, GPUDevice,
+};
 use crate::dom::gputextureview::GPUTextureView;
 use dom_struct::dom_struct;
-use std::borrow::Cow;
 use std::num::NonZeroU32;
 use std::string::String;
 use webgpu::{
@@ -142,15 +143,9 @@ impl GPUTextureMethods for GPUTexture {
 
         let desc = if valid {
             Some(resource::TextureViewDescriptor {
-                label: descriptor
-                    .parent
-                    .label
-                    .as_ref()
-                    .map(|l| Cow::Owned(l.to_string())),
-                format: descriptor.format.map(|fr| convert_texture_format(fr)),
-                dimension: descriptor
-                    .dimension
-                    .map(|dm| convert_texture_view_dimension(dm)),
+                label: convert_label(&descriptor.parent),
+                format: descriptor.format.map(convert_texture_format),
+                dimension: descriptor.dimension.map(convert_texture_view_dimension),
                 aspect: match descriptor.aspect {
                     GPUTextureAspect::All => wgt::TextureAspect::All,
                     GPUTextureAspect::Stencil_only => wgt::TextureAspect::StencilOnly,

--- a/components/script/dom/webidls/GPUComputePipeline.webidl
+++ b/components/script/dom/webidls/GPUComputePipeline.webidl
@@ -7,9 +7,10 @@
 interface GPUComputePipeline {
 };
 GPUComputePipeline includes GPUObjectBase;
+GPUComputePipeline includes GPUPipelineBase;
 
 dictionary GPUPipelineDescriptorBase : GPUObjectDescriptorBase {
-    required GPUPipelineLayout layout;
+    GPUPipelineLayout layout;
 };
 
 dictionary GPUProgrammableStageDescriptor {
@@ -19,4 +20,8 @@ dictionary GPUProgrammableStageDescriptor {
 
 dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
     required GPUProgrammableStageDescriptor computeStage;
+};
+
+interface mixin GPUPipelineBase {
+    [Throws] GPUBindGroupLayout getBindGroupLayout(unsigned long index);
 };

--- a/components/script/dom/webidls/GPURenderPipeline.webidl
+++ b/components/script/dom/webidls/GPURenderPipeline.webidl
@@ -7,6 +7,7 @@
 interface GPURenderPipeline {
 };
 GPURenderPipeline includes GPUObjectBase;
+GPURenderPipeline includes GPUPipelineBase;
 
 dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     required GPUProgrammableStageDescriptor vertexStage;


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Store `Vec<WebGPUBindGroupLayout>` in `GPUxxxPipeline` to return a new object from `GetBindGroupLayout()`.

r?@kvark


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
