### PR TITLE
Defer Encoding errors to GPUCommandEncoder.finish()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-auxil"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67bdbf8e8d6883c70e5a0d7379ad8ab3ac95127a3761306b36122d8f1c177a8e"
+checksum = "6311ee3cc7a3b4c8ae94c4513cd2cbe888ec37990cf0ffa672bd275391b12eb1"
 dependencies = [
  "fxhash",
  "gfx-hal",
@@ -1922,16 +1931,16 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-dx11"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92de0ddc0fde1a89b2a0e92dcc6bbb554bd34af0135e53a28d5ef064611094a4"
+checksum = "de0a460b6458f3857af43064c687b1a010fe1f1b2e8c68fcd1d5db7206fa0809"
 dependencies = [
  "bitflags",
  "gfx-auxil",
  "gfx-hal",
- "libloading 0.5.2",
+ "libloading 0.6.1",
  "log",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.0",
  "range-alloc",
  "raw-window-handle",
  "smallvec 1.4.2",
@@ -1942,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-dx12"
-version = "0.5.8"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05218b5c94539f22ac7d6feb4b2482431b89f6cc897132494701ac48619218d7"
+checksum = "c392af02ae88bc127abf94e1b88c817b7274d8d977aae986d5f2829392a30b0b"
 dependencies = [
  "bitflags",
  "d3d12",
@@ -1960,19 +1969,20 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-empty"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67bd2d7bc022b257ddbdabc5fa3b10c29c292372c3409f2b6a6e3f4e11cdb85"
+checksum = "2085227c12b78f6657a900c829f2d0deb46a9be3eaf86844fde263cdc218f77c"
 dependencies = [
  "gfx-hal",
+ "log",
  "raw-window-handle",
 ]
 
 [[package]]
 name = "gfx-backend-metal"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92804d20b194de6c84cb4bec14ec6a6dcae9c51f0a9186817fb412a590131ae6"
+checksum = "42518c5b571be5ba337a89cfba5abfaf2d90b83fc4db96357f64f2ea05f20f81"
 dependencies = [
  "arrayvec 0.5.1",
  "bitflags",
@@ -1986,7 +1996,7 @@ dependencies = [
  "log",
  "metal 0.20.0",
  "objc",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.0",
  "range-alloc",
  "raw-window-handle",
  "smallvec 1.4.2",
@@ -1996,15 +2006,16 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-vulkan"
-version = "0.5.11"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec9c919cfc236d2c36aaa38609c1906a92f2df99a3c7f53022b01936f98275a"
+checksum = "a84bda4200a82e1912d575801e2bb76ae19c6256359afbc0adfbbaec02fcadc6"
 dependencies = [
  "arrayvec 0.5.1",
  "ash",
  "byteorder",
  "core-graphics-types",
  "gfx-hal",
+ "inplace_it",
  "lazy_static",
  "log",
  "objc",
@@ -2015,9 +2026,11 @@ dependencies = [
 
 [[package]]
 name = "gfx-descriptor"
-version = "0.1.0"
-source = "git+https://github.com/gfx-rs/gfx-extras?rev=473a4cdc63463e7986707507c4a7f6a3a767e329#473a4cdc63463e7986707507c4a7f6a3a767e329"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8c7afcd000f279d541a490e27117e61037537279b9342279abf4938fe60c6b"
 dependencies = [
+ "arrayvec 0.5.1",
  "fxhash",
  "gfx-hal",
  "log",
@@ -2025,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-hal"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18534b23d4c262916231511309bc1f307c74cda8dcb68b93a10ca213a22814b"
+checksum = "18d0754f5b7a43915fd7466883b2d1bb0800d7cc4609178d0b27bf143b9e5123"
 dependencies = [
  "bitflags",
  "raw-window-handle",
@@ -2035,8 +2048,9 @@ dependencies = [
 
 [[package]]
 name = "gfx-memory"
-version = "0.1.3"
-source = "git+https://github.com/gfx-rs/gfx-extras?rev=473a4cdc63463e7986707507c4a7f6a3a767e329#473a4cdc63463e7986707507c4a7f6a3a767e329"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe8d8855df07f438eb8a765e90356d5b821d644ea3b59b870091450b89576a9f"
 dependencies = [
  "fxhash",
  "gfx-hal",
@@ -2774,6 +2788,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inplace_it"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd01a2a73f2f399df96b22dc88ea687ef4d76226284e7531ae3c7ee1dc5cb534"
+
+[[package]]
 name = "input_buffer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2781,6 +2801,12 @@ checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
  "bytes 0.5.5",
 ]
+
+[[package]]
+name = "instant"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
 
 [[package]]
 name = "io-surface"
@@ -3137,9 +3163,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.70"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
+checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
 name = "libdbus-sys"
@@ -3293,6 +3319,15 @@ name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
 dependencies = [
  "scopeguard",
 ]
@@ -3724,8 +3759,9 @@ checksum = "0419348c027fa7be448d2ae7ea0e4e04c2334c31dc4e74ab29f00a2a7ca69204"
 
 [[package]]
 name = "naga"
-version = "0.1.0"
-source = "git+https://github.com/gfx-rs/naga?rev=1eb637038dd15fc1dad770eca8e6943424dbc122#1eb637038dd15fc1dad770eca8e6943424dbc122"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0873deb76cf44b7454fba7b2ba6a89d3de70c08aceffd2c489379b3d9d08e661"
 dependencies = [
  "bitflags",
  "fxhash",
@@ -4117,7 +4153,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
  "parking_lot_core 0.6.2",
  "rustc_version",
 ]
@@ -4128,8 +4164,19 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
- "lock_api",
+ "lock_api 0.3.4",
  "parking_lot_core 0.7.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api 0.4.1",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -4139,7 +4186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
  "rustc_version",
@@ -4154,7 +4201,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.4.2",
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi 0.1.0",
+ "instant",
  "libc",
  "redox_syscall",
  "smallvec 1.4.2",
@@ -4711,6 +4773,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ece421e0c4129b90e4a35b6f625e472e96c552136f5093a2f4fa2bbb75a62d5"
 dependencies = [
  "base64 0.10.1",
+ "bitflags",
+ "serde",
+]
+
+[[package]]
+name = "ron"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91260f321dbf3b5a16ff91c451dc9eb644ce72775a6812f9c3dfffe63818f8f"
+dependencies = [
+ "base64 0.12.0",
  "bitflags",
  "serde",
 ]
@@ -5700,11 +5773,11 @@ dependencies = [
 
 [[package]]
 name = "storage-map"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0a4829a5c591dc24a944a736d6b1e4053e51339a79fd5d4702c4c999a9c45e"
+checksum = "418bb14643aa55a7841d5303f72cf512cfb323b8cc221d51580500a1ca75206c"
 dependencies = [
- "lock_api",
+ "lock_api 0.4.1",
 ]
 
 [[package]]
@@ -6856,7 +6929,7 @@ dependencies = [
  "num-traits",
  "plane-split",
  "rayon",
- "ron",
+ "ron 0.5.1",
  "serde",
  "serde_json",
  "sig",
@@ -6954,8 +7027,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#f7ec6cc1fe73651cfeda44295cd41533ec60f850"
+version = "0.6.0"
+source = "git+https://github.com/gfx-rs/wgpu#1d0e0ce37ede5ec53000ab252c27b8cf856865b2"
 dependencies = [
  "arrayvec 0.5.1",
  "bitflags",
@@ -6970,8 +7043,8 @@ dependencies = [
  "gfx-hal",
  "gfx-memory",
  "naga",
- "parking_lot 0.10.2",
- "ron",
+ "parking_lot 0.11.0",
+ "ron 0.6.0",
  "serde",
  "smallvec 1.4.2",
  "thiserror",
@@ -6981,8 +7054,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.5.0"
-source = "git+https://github.com/gfx-rs/wgpu#f7ec6cc1fe73651cfeda44295cd41533ec60f850"
+version = "0.6.0"
+source = "git+https://github.com/gfx-rs/wgpu#1d0e0ce37ede5ec53000ab252c27b8cf856865b2"
 dependencies = [
  "bitflags",
  "serde",

--- a/components/script/dom/gpucommandencoder.rs
+++ b/components/script/dom/gpucommandencoder.rs
@@ -292,6 +292,7 @@ impl GPUCommandEncoderMethods for GPUCommandEncoder {
         size: GPUSize64,
     ) {
         let scope_id = self.device.use_current_scope();
+        println!("CopyBufferToBuffer scope_id {:?}", scope_id);
 
         if !(*self.state.borrow() == GPUCommandEncoderState::Open) {
             self.device.handle_server_msg(

--- a/components/script/dom/gpucomputepassencoder.rs
+++ b/components/script/dom/gpucomputepassencoder.rs
@@ -99,10 +99,9 @@ impl GPUComputePassEncoderMethods for GPUComputePassEncoder {
         self.channel
             .0
             .send((
-                self.command_encoder.device().use_current_scope(),
+                None,
                 WebGPURequest::RunComputePass {
                     command_encoder_id: self.command_encoder.id().0,
-                    device_id: self.command_encoder.device().id().0,
                     compute_pass,
                 },
             ))

--- a/components/script/dom/gpudevice.rs
+++ b/components/script/dom/gpudevice.rs
@@ -178,7 +178,6 @@ impl GPUDevice {
     }
 
     pub fn handle_server_msg(&self, scope: Option<ErrorScopeId>, result: WebGPUOpResult) {
-        println!("handle_server_msg {:?}, {:?}", scope, result);
         let result = match result {
             WebGPUOpResult::Success => Ok(()),
             WebGPUOpResult::ValidationError(m) => {
@@ -222,7 +221,6 @@ impl GPUDevice {
     }
 
     fn handle_error(&self, scope: ErrorScopeId, error: GPUError) {
-        println!("handle_error {}", scope);
         let mut context = self.scope_context.borrow_mut();
         if let Some(mut err_scope) = context.error_scopes.get_mut(&scope) {
             if err_scope.error.is_none() {
@@ -234,7 +232,6 @@ impl GPUDevice {
     }
 
     fn try_remove_scope(&self, scope: ErrorScopeId) {
-        println!("try_remove_scope {}", scope);
         let mut context = self.scope_context.borrow_mut();
         let remove = if let Some(mut err_scope) = context.error_scopes.get_mut(&scope) {
             err_scope.op_count -= 1;
@@ -253,7 +250,6 @@ impl GPUDevice {
             false
         };
         if remove {
-            println!("remove {}", scope);
             let _ = context.error_scopes.remove(&scope);
             context.scope_stack.retain(|meta| meta.id != scope);
         }
@@ -374,7 +370,6 @@ impl GPUDeviceMethods for GPUDevice {
             .create_buffer_id(self.device.0.backend());
 
         let scope_id = self.use_current_scope();
-        println!("CreateBuffer scope {:?}", scope_id);
         if desc.is_none() {
             self.handle_server_msg(
                 scope_id,
@@ -780,7 +775,6 @@ impl GPUDeviceMethods for GPUDevice {
             self.channel.clone(),
             &self,
             encoder,
-            true,
             descriptor.parent.label.as_ref().cloned(),
         )
     }
@@ -1093,7 +1087,6 @@ impl GPUDeviceMethods for GPUDevice {
     fn PushErrorScope(&self, filter: GPUErrorFilter) {
         let mut context = self.scope_context.borrow_mut();
         let scope_id = context.next_scope_id;
-        println!("PushErrorScope {}", scope_id);
         context.next_scope_id = ErrorScopeId::new(scope_id.get() + 1).unwrap();
         let err_scope = ErrorScopeInfo {
             op_count: 0,
@@ -1121,7 +1114,6 @@ impl GPUDeviceMethods for GPUDevice {
                 promise.reject_error(Error::Operation);
                 return promise;
             };
-        println!("PopErrorScope {}", scope_id);
         let remove = if let Some(mut err_scope) = context.error_scopes.get_mut(&scope_id) {
             if let Some(ref e) = err_scope.error {
                 promise.resolve_native(e);
@@ -1135,7 +1127,6 @@ impl GPUDeviceMethods for GPUDevice {
             false
         };
         if remove {
-            println!("PopErrorScope remove {}", scope_id);
             let _ = context.error_scopes.remove(&scope_id);
             context.scope_stack.retain(|meta| meta.id != scope_id);
         }

--- a/components/script/dom/gpurenderpassencoder.rs
+++ b/components/script/dom/gpurenderpassencoder.rs
@@ -164,10 +164,9 @@ impl GPURenderPassEncoderMethods for GPURenderPassEncoder {
         self.channel
             .0
             .send((
-                self.command_encoder.device().use_current_scope(),
+                None,
                 WebGPURequest::RunRenderPass {
                     command_encoder_id: self.command_encoder.id().0,
-                    device_id: self.command_encoder.device().id().0,
                     render_pass,
                 },
             ))

--- a/components/script/dom/gpuswapchain.rs
+++ b/components/script/dom/gpuswapchain.rs
@@ -90,7 +90,6 @@ impl GPUSwapChainMethods for GPUSwapChain {
     /// https://gpuweb.github.io/gpuweb/#dom-gpuswapchain-getcurrenttexture
     fn GetCurrentTexture(&self) -> DomRoot<GPUTexture> {
         self.context.mark_as_dirty();
-        //self.context.send_swap_chain_present();
         DomRoot::from_ref(&*self.texture)
     }
 }

--- a/components/webgpu/Cargo.toml
+++ b/components/webgpu/Cargo.toml
@@ -22,5 +22,5 @@ servo_config = { path = "../config" }
 smallvec = { version = "0.6", features = ["serde"] }
 webrender_api = { git = "https://github.com/servo/webrender" }
 webrender_traits = { path = "../webrender_traits" }
-wgpu-core = { version = "0.5.0", git = "https://github.com/gfx-rs/wgpu", features = ["replay", "trace", "serial-pass"] }
-wgpu-types = { version = "0.5.0", git = "https://github.com/gfx-rs/wgpu", features = ["replay", "trace"] }
+wgpu-core = { version = "0.6.0", git = "https://github.com/gfx-rs/wgpu", features = ["replay", "trace", "serial-pass"] }
+wgpu-types = { version = "0.6.0", git = "https://github.com/gfx-rs/wgpu", features = ["replay", "trace"] }

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -1127,17 +1127,20 @@ impl<'a> WGPU<'a> {
                             status: BufferMapAsyncStatus,
                             userdata: *mut u8,
                         ) {
-                            let info =
-                                Rc::from_raw(userdata as *const BufferMapInfo<WebGPURequest>);
+                            let info = Rc::from_raw(
+                                userdata
+                                    as *const BufferMapInfo<(Option<ErrorScopeId>, WebGPURequest)>,
+                            );
                             match status {
                                 BufferMapAsyncStatus::Success => {
-                                    if let Err(e) =
-                                        info.sender.send(WebGPURequest::UpdateWebRenderData {
+                                    if let Err(e) = info.sender.send((
+                                        None,
+                                        WebGPURequest::UpdateWebRenderData {
                                             buffer_id: info.buffer_id,
                                             buffer_size: info.size,
                                             external_id: info.external_id.unwrap(),
-                                        })
-                                    {
+                                        },
+                                    )) {
                                         warn!("Could not send UpdateWebRenderData ({})", e);
                                     }
                                 },

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -496,6 +496,7 @@ impl<'a> WGPU<'a> {
                             destination_offset,
                             size
                         ));
+                        println!("CopyBufferToBuffer result {:?}", result);
                         self.send_result(device_id, scope_id, result);
                     },
                     WebGPURequest::CopyBufferToTexture {
@@ -593,6 +594,7 @@ impl<'a> WGPU<'a> {
                             self.send_result(device_id, scope_id, result);
                         } else {
                             let _ = gfx_select!(buffer_id => global.buffer_error(buffer_id));
+                            println!("CreateBuffer error {:?}", buffer_id);
                         }
                     },
                     WebGPURequest::CreateCommandEncoder {

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -31,14 +31,17 @@ rand = [
 packages = [
   "arrayvec",
   "base64",
+  "cloudabi",
   "cocoa",
   "gleam",
   "libloading",
+  "lock_api",
   "metal",
   "miniz_oxide",
   "num-rational",
   "parking_lot",
   "parking_lot_core",
+  "ron",
   "wayland-sys",
 
   # https://github.com/servo/servo/issues/26933

--- a/tests/wpt/webgpu/meta/webgpu/cts.html.ini
+++ b/tests/wpt/webgpu/meta/webgpu/cts.html.ini
@@ -4,22 +4,10 @@
 
 
 [cts.html?q=webgpu:api,validation,render_pass,resolve:*]
-  [webgpu:api,validation,render_pass,resolve:resolve_attachment:resolveTargetWidth=4]
-    expected: FAIL
-
   [webgpu:api,validation,render_pass,resolve:resolve_attachment:resolveTargetViewBaseMipLevel=1;resolveTargetViewMipCount=2;resolveTargetHeight=4;resolveTargetWidth=4]
     expected: FAIL
 
-  [webgpu:api,validation,render_pass,resolve:resolve_attachment:colorAttachmentHeight=4]
-    expected: FAIL
-
-  [webgpu:api,validation,render_pass,resolve:resolve_attachment:resolveTargetUsage=1]
-    expected: FAIL
-
   [webgpu:api,validation,render_pass,resolve:resolve_attachment:resolveTargetFormat="bgra8unorm"]
-    expected: FAIL
-
-  [webgpu:api,validation,render_pass,resolve:resolve_attachment:colorAttachmentSamples=1]
     expected: FAIL
 
   [webgpu:api,validation,render_pass,resolve:resolve_attachment:resolveTargetFormat="rgba8unorm-srgb"]
@@ -31,19 +19,10 @@
   [webgpu:api,validation,render_pass,resolve:resolve_attachment:colorAttachmentFormat="rgba8unorm-srgb"]
     expected: FAIL
 
-  [webgpu:api,validation,render_pass,resolve:resolve_attachment:resolveTargetHeight=4]
-    expected: FAIL
-
-  [webgpu:api,validation,render_pass,resolve:resolve_attachment:resolveTargetSamples=4]
-    expected: FAIL
-
   [webgpu:api,validation,render_pass,resolve:resolve_attachment:resolveTargetViewArrayLayerCount=2]
     expected: FAIL
 
   [webgpu:api,validation,render_pass,resolve:resolve_attachment:colorAttachmentFormat="bgra8unorm"]
-    expected: FAIL
-
-  [webgpu:api,validation,render_pass,resolve:resolve_attachment:colorAttachmentWidth=4]
     expected: FAIL
 
   [webgpu:api,validation,render_pass,resolve:resolve_attachment:resolveTargetViewBaseArrayLayer=1;resolveTargetViewArrayLayerCount=2]
@@ -144,9 +123,6 @@
 [cts.html?q=webgpu:api,validation,setBlendColor:*]
 
 [cts.html?q=webgpu:api,validation,render_pass_descriptor:*]
-  [webgpu:api,validation,render_pass_descriptor:check_the_use_of_multisampled_textures_as_color_attachments:]
-    expected: FAIL
-
   [webgpu:api,validation,render_pass_descriptor:check_mip_level_count_for_color_or_depth_stencil:mipLevelCount=2;baseMipLevel=0]
     expected: FAIL
 
@@ -156,37 +132,16 @@
   [webgpu:api,validation,render_pass_descriptor:use_a_resolve_target_in_a_format_different_than_the_attachment_is_not_allowed:]
     expected: FAIL
 
-  [webgpu:api,validation,render_pass_descriptor:it_is_invalid_to_use_a_resolve_target_in_error_state:]
-    expected: FAIL
-
-  [webgpu:api,validation,render_pass_descriptor:size_of_the_resolve_target_must_be_the_same_as_the_color_attachment:]
-    expected: FAIL
-
-  [webgpu:api,validation,render_pass_descriptor:attachments_must_have_the_same_size:]
-    expected: FAIL
-
   [webgpu:api,validation,render_pass_descriptor:check_layer_count_for_color_or_depth_stencil:arrayLayerCount=5;baseArrayLayer=0]
     expected: FAIL
 
   [webgpu:api,validation,render_pass_descriptor:it_is_invalid_to_use_a_resolve_target_with_mipmap_level_count_greater_than_1:]
     expected: FAIL
 
-  [webgpu:api,validation,render_pass_descriptor:it_is_invalid_to_set_resolve_target_if_color_attachment_is_non_multisampled:]
-    expected: FAIL
-
   [webgpu:api,validation,render_pass_descriptor:OOB_color_attachment_indices_are_handled:colorAttachmentsCount=5]
     expected: FAIL
 
   [webgpu:api,validation,render_pass_descriptor:attachments_must_match_whether_they_are_used_for_color_or_depth_stencil:]
-    expected: FAIL
-
-  [webgpu:api,validation,render_pass_descriptor:it_is_invalid_to_use_a_multisampled_resolve_target:]
-    expected: FAIL
-
-  [webgpu:api,validation,render_pass_descriptor:it_is_invalid_to_use_a_resolve_target_whose_usage_is_not_output_attachment:]
-    expected: FAIL
-
-  [webgpu:api,validation,render_pass_descriptor:check_depth_stencil_attachment_sample_counts_mismatch:]
     expected: FAIL
 
 
@@ -255,12 +210,6 @@
   [webgpu:api,validation,render_pass,storeOp:store_op_and_read_only:readonly=false;stencilReadOnly=true]
     expected: FAIL
 
-  [webgpu:api,validation,render_pass,storeOp:store_op_and_read_only:readonly=true;stencilStoreOp="clear"]
-    expected: FAIL
-
-  [webgpu:api,validation,render_pass,storeOp:store_op_and_read_only:readonly=true;depthStoreOp="clear"]
-    expected: FAIL
-
   [webgpu:api,validation,render_pass,storeOp:store_op_and_read_only:readonly="_undef_";depthReadOnly=true]
     expected: FAIL
 
@@ -273,49 +222,7 @@
 [cts.html?q=webgpu:api,operation,command_buffer,render,basic:*]
 
 [cts.html?q=webgpu:api,validation,copyBufferToBuffer:*]
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=1;dstUsage=32]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_offset_alignment:srcOffset=2;dstOffset=0]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_with_invalid_buffer:]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=8;dstUsage=128]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=16;dstUsage=256]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_overflow:srcOffset=0;dstOffset=9007199254740984;copySize=16]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=64;dstUsage=8]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=4;dstUsage=4]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=1;dstUsage=128]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=64;dstUsage=4]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=64;dstUsage=2]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=4;dstUsage=2]
-    expected: FAIL
-
   [webgpu:api,validation,copyBufferToBuffer:copy_within_same_buffer:srcOffset=4;dstOffset=0;copySize=8]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=16;dstUsage=64]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_overflow:srcOffset=0;dstOffset=16;copySize=9007199254740984]
     expected: FAIL
 
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=64;dstUsage=512]
@@ -324,19 +231,7 @@
   [webgpu:api,validation,copyBufferToBuffer:copy_out_of_bounds:srcOffset=0;dstOffset=36;copySize=0]
     expected: FAIL
 
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=16;dstUsage=128]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=32;dstUsage=16]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_out_of_bounds:srcOffset=0;dstOffset=36;copySize=4]
-    expected: FAIL
-
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=512;dstUsage=8]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=8;dstUsage=256]
     expected: FAIL
 
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=512;dstUsage=4]
@@ -345,73 +240,13 @@
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=512;dstUsage=2]
     expected: FAIL
 
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=128;dstUsage=128]
-    expected: FAIL
-
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=512;dstUsage=1]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=16;dstUsage=2]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=4;dstUsage=32]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=16;dstUsage=1]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=16;dstUsage=4]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=16;dstUsage=8]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_overflow:srcOffset=0;dstOffset=9007199254740984;copySize=9007199254740984]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=128;dstUsage=64]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=16;dstUsage=16]
     expected: FAIL
 
   [webgpu:api,validation,copyBufferToBuffer:copy_out_of_bounds:srcOffset=36;dstOffset=0;copySize=0]
     expected: FAIL
 
-  [webgpu:api,validation,copyBufferToBuffer:copy_out_of_bounds:srcOffset=36;dstOffset=0;copySize=4]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=8;dstUsage=8]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=1;dstUsage=4]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=1;dstUsage=2]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=1;dstUsage=1]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=8;dstUsage=1]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=8;dstUsage=2]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=8;dstUsage=4]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=1;dstUsage=8]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=64;dstUsage=64]
-    expected: FAIL
-
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=8;dstUsage=512]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_overflow:srcOffset=9007199254740984;dstOffset=0;copySize=16]
     expected: FAIL
 
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=512;dstUsage=256]
@@ -420,61 +255,13 @@
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=1;dstUsage=512]
     expected: FAIL
 
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=32;dstUsage=32]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=256;dstUsage=4]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=256;dstUsage=2]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=256;dstUsage=1]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_size_alignment:copySize=5]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_size_alignment:copySize=2]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=128;dstUsage=256]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=256;dstUsage=8]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=4;dstUsage=16]
-    expected: FAIL
-
   [webgpu:api,validation,copyBufferToBuffer:copy_within_same_buffer:srcOffset=0;dstOffset=4;copySize=8]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=2;dstUsage=256]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_overflow:srcOffset=9007199254740984;dstOffset=9007199254740984;copySize=9007199254740984]
     expected: FAIL
 
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=2;dstUsage=512]
     expected: FAIL
 
-  [webgpu:api,validation,copyBufferToBuffer:copy_offset_alignment:srcOffset=0;dstOffset=2]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_offset_alignment:srcOffset=0;dstOffset=5]
-    expected: FAIL
-
   [webgpu:api,validation,copyBufferToBuffer:copy_within_same_buffer:srcOffset=0;dstOffset=8;copySize=4]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=32;dstUsage=128]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=128;dstUsage=32]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=8;dstUsage=32]
     expected: FAIL
 
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=4;dstUsage=512]
@@ -483,25 +270,10 @@
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=512;dstUsage=16]
     expected: FAIL
 
-  [webgpu:api,validation,copyBufferToBuffer:copy_out_of_bounds:srcOffset=0;dstOffset=20;copySize=16]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=32;dstUsage=64]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=4;dstUsage=1]
-    expected: FAIL
-
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=512;dstUsage=32]
     expected: FAIL
 
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=64;dstUsage=1]
-    expected: FAIL
-
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=256;dstUsage=512]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=4;dstUsage=64]
     expected: FAIL
 
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=16;dstUsage=512]
@@ -510,142 +282,19 @@
   [webgpu:api,validation,copyBufferToBuffer:copy_within_same_buffer:srcOffset=8;dstOffset=0;copySize=4]
     expected: FAIL
 
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=2;dstUsage=4]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=2;dstUsage=2]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=2;dstUsage=1]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_overflow:srcOffset=0;dstOffset=0;copySize=9007199254740984]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=2;dstUsage=8]
-    expected: FAIL
-
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=512;dstUsage=64]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=2;dstUsage=16]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=128;dstUsage=4]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=128;dstUsage=2]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=128;dstUsage=1]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=32;dstUsage=2]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=128;dstUsage=8]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=1;dstUsage=64]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=256;dstUsage=32]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=64;dstUsage=32]
     expected: FAIL
 
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=512;dstUsage=128]
     expected: FAIL
 
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=8;dstUsage=16]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=16;dstUsage=32]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=256;dstUsage=128]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=2;dstUsage=64]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=32;dstUsage=256]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=1;dstUsage=16]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=256;dstUsage=64]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_overflow:srcOffset=9007199254740984;dstOffset=0;copySize=9007199254740984]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=1;dstUsage=256]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=2;dstUsage=128]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=128;dstUsage=16]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=8;dstUsage=64]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=256;dstUsage=256]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=2;dstUsage=32]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_overflow:srcOffset=16;dstOffset=0;copySize=9007199254740984]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=4;dstUsage=256]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=256;dstUsage=16]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=64;dstUsage=128]
-    expected: FAIL
-
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=512;dstUsage=512]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_out_of_bounds:srcOffset=20;dstOffset=0;copySize=16]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_out_of_bounds:srcOffset=0;dstOffset=0;copySize=36]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=64;dstUsage=16]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=32;dstUsage=1]
     expected: FAIL
 
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=32;dstUsage=512]
     expected: FAIL
 
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=32;dstUsage=4]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=32;dstUsage=8]
-    expected: FAIL
-
   [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=128;dstUsage=512]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:copy_offset_alignment:srcOffset=5;dstOffset=0]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=4;dstUsage=128]
-    expected: FAIL
-
-  [webgpu:api,validation,copyBufferToBuffer:buffer_usage:srcUsage=64;dstUsage=256]
     expected: FAIL
 
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Errors that occur are stored in `HashMap<id::CommandEncoderId, String>`.

This also upgrades wgpu to v0.6

r?@kvark


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
