### PR TITLE
Update mozjs 0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,8 +3702,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs"
-version = "0.13.0"
-source = "git+https://github.com/servo/rust-mozjs#5a50c377a4e1f55abc1286b74100a4cc35adc789"
+version = "0.14.1"
+source = "git+https://github.com/servo/rust-mozjs#e9f71b6458135c1e63fee9261dabcd8c3efa6ccf"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3715,8 +3715,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.68.1"
-source = "git+https://github.com/servo/mozjs?rev=aa97a46f277823a0e66017fea820ac3a9d987711#aa97a46f277823a0e66017fea820ac3a9d987711"
+version = "0.68.2"
+source = "git+https://github.com/servo/mozjs?rev=a40b829f0fefa06a743f006260c7facebcfa27aa#a40b829f0fefa06a743f006260c7facebcfa27aa"
 dependencies = [
  "bindgen",
  "cc",

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -2778,6 +2778,8 @@ rooted!(in(*cx) let obj = NewProxyObject(
     handler,
     Handle::from_raw(UndefinedHandleValue),
     proto.get(),
+    ptr::null(),
+    false,
 ));
 assert!(!obj.is_null());
 SetProxyReservedSlot(

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -511,7 +511,6 @@ impl EventTarget {
 
         // Step 3.9
 
-        let url_serialized = CString::new(handler.url.to_string()).unwrap();
         let name = CString::new(format!("on{}", &**ty)).unwrap();
 
         // Step 3.9, subsection ParameterList
@@ -528,7 +527,7 @@ impl EventTarget {
 
         let cx = window.get_cx();
         let options = unsafe {
-            CompileOptionsWrapper::new(*cx, url_serialized.as_ptr(), handler.line as u32)
+            CompileOptionsWrapper::new(*cx, &handler.url.to_string(), handler.line as u32)
         };
 
         // Step 3.9, subsection Scope steps 1-6

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -118,7 +118,6 @@ use std::borrow::Cow;
 use std::cell::Cell;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
-use std::ffi::CString;
 use std::mem;
 use std::ops::Index;
 use std::rc::Rc;
@@ -2586,7 +2585,6 @@ impl GlobalScope {
             self.time_profiler_chan().clone(),
             || {
                 let cx = self.get_cx();
-                let filename = CString::new(filename).unwrap();
 
                 let ar = enter_realm(&*self);
 
@@ -2597,7 +2595,7 @@ impl GlobalScope {
                     match code {
                         SourceCode::Text(text_code) => {
                             let options =
-                                CompileOptionsWrapper::new(*cx, filename.as_ptr(), line_number);
+                                CompileOptionsWrapper::new(*cx, filename, line_number);
 
                             debug!("compiling dom string");
                             compiled_script.set(Compile1(

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2594,8 +2594,7 @@ impl GlobalScope {
                     rooted!(in(*cx) let mut compiled_script = std::ptr::null_mut::<JSScript>());
                     match code {
                         SourceCode::Text(text_code) => {
-                            let options =
-                                CompileOptionsWrapper::new(*cx, filename, line_number);
+                            let options = CompileOptionsWrapper::new(*cx, filename, line_number);
 
                             debug!("compiling dom string");
                             compiled_script.set(Compile1(

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -58,7 +58,6 @@ use servo_config::pref;
 use servo_url::ImmutableOrigin;
 use servo_url::ServoUrl;
 use std::cell::Cell;
-use std::ffi::CString;
 use std::fs::{create_dir_all, read_to_string, File};
 use std::io::{Read, Seek, Write};
 use std::mem::replace;
@@ -424,8 +423,7 @@ impl FetchResponseListener for ClassicContext {
         let cx = global.get_cx();
         let _ar = enter_realm(&*global);
 
-        let final_url_c_str = CString::new(final_url.as_str()).unwrap();
-        let options = unsafe { CompileOptionsWrapper::new(*cx, final_url_c_str.as_ptr(), 1) };
+        let options = unsafe { CompileOptionsWrapper::new(*cx, final_url.as_str(), 1) };
 
         let can_compile_off_thread = pref!(dom.script.asynch) &&
             unsafe { CanCompileOffThread(*cx, options.ptr as *const _, source_text.len()) };

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -70,7 +70,6 @@ use net_traits::{FetchResponseListener, NetworkError};
 use net_traits::{ResourceFetchTiming, ResourceTimingType};
 use servo_url::ServoUrl;
 use std::collections::{HashMap, HashSet};
-use std::ffi;
 use std::mem;
 use std::rc::Rc;
 use std::str::FromStr;
@@ -420,12 +419,11 @@ impl ModuleTree {
         url: ServoUrl,
         options: ScriptFetchOptions,
     ) -> Result<ModuleObject, RethrowError> {
-        let url_cstr = ffi::CString::new(url.as_str().as_bytes()).unwrap();
 
         let _ac = JSAutoRealm::new(*global.get_cx(), *global.reflector().get_jsobject());
 
         let compile_options =
-            unsafe { CompileOptionsWrapper::new(*global.get_cx(), url_cstr.as_ptr(), 1) };
+            unsafe { CompileOptionsWrapper::new(*global.get_cx(), url.as_str(), 1) };
 
         unsafe {
             rooted!(in(*global.get_cx()) let mut module_script = CompileModuleDontInflate(

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -419,7 +419,6 @@ impl ModuleTree {
         url: ServoUrl,
         options: ScriptFetchOptions,
     ) -> Result<ModuleObject, RethrowError> {
-
         let _ac = JSAutoRealm::new(*global.get_cx(), *global.reflector().get_jsobject());
 
         let compile_options =

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -48,7 +48,7 @@ use ipc_channel::ipc::{self, IpcSender};
 use js::jsapi::{HandleValueArray, JSAutoRealm, JSContext, JSType, JS_IsExceptionPending};
 use js::jsval::UndefinedValue;
 use js::rust::wrappers::{JS_CallFunctionName, JS_GetProperty, JS_HasOwnProperty, JS_TypeOfValue};
-use js::rust::{Handle, HandleObject, HandleValue};
+use js::rust::{HandleObject, HandleValue};
 use msg::constellation_msg::BrowsingContextId;
 use msg::constellation_msg::PipelineId;
 use net_traits::CookieSource::{NonHTTP, HTTP};
@@ -256,7 +256,7 @@ pub unsafe fn jsval_to_webdriver(
                 &mut HandleValueArray::new(),
                 value.handle_mut(),
             ) {
-                jsval_to_webdriver(cx, global_scope, Handle::new(&value))
+                jsval_to_webdriver(cx, global_scope, value.handle())
             } else {
                 throw_dom_exception(SafeJSContext::from_ptr(cx), global_scope, Error::JSFailed);
                 Err(WebDriverJSError::JSError)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This update pulls in improvements on mozjs that now removes the need to
pass pointers to CompileOptionsWraper::new(), allows NewProxyObject to
now accept a Singleton bool and JSClass and removes an unsafe
Handle::new usage.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #27617 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they are changes in parameters that existing tests cover.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
