### PR TITLE
Support replacing all nodes without firing mutation events

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -79,7 +79,7 @@ use crate::dom::location::Location;
 use crate::dom::messageevent::MessageEvent;
 use crate::dom::mouseevent::MouseEvent;
 use crate::dom::node::{self, document_from_node, window_from_node, CloneChildrenFlag};
-use crate::dom::node::{Node, NodeDamage, NodeFlags, ShadowIncluding};
+use crate::dom::node::{Node, NodeDamage, NodeFlags, SuppressObserver, ShadowIncluding};
 use crate::dom::nodeiterator::NodeIterator;
 use crate::dom::nodelist::NodeList;
 use crate::dom::pagetransitionevent::PageTransitionEvent;
@@ -5015,8 +5015,7 @@ impl DocumentMethods for Document {
         }
 
         // Step 11
-        // TODO: https://github.com/servo/servo/issues/21936
-        Node::replace_all(None, self.upcast::<Node>());
+        Node::replace_all(None, self.upcast::<Node>(), SuppressObserver::Suppressed);
 
         // Specs and tests are in a state of flux about whether
         // we want to clear the selection when we remove the contents;

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -71,7 +71,7 @@ use crate::dom::mutationobserver::{Mutation, MutationObserver};
 use crate::dom::namednodemap::NamedNodeMap;
 use crate::dom::node::{document_from_node, window_from_node};
 use crate::dom::node::{BindContext, NodeDamage, NodeFlags, UnbindContext};
-use crate::dom::node::{ChildrenMutation, LayoutNodeHelpers, Node, ShadowIncluding};
+use crate::dom::node::{ChildrenMutation, LayoutNodeHelpers, Node, SuppressObserver, ShadowIncluding};
 use crate::dom::nodelist::NodeList;
 use crate::dom::promise::Promise;
 use crate::dom::raredata::ElementRareData;
@@ -2536,7 +2536,7 @@ impl ElementMethods for Element {
         // Step 1.
         let frag = self.parse_fragment(value)?;
 
-        Node::replace_all(Some(frag.upcast()), &target);
+        Node::replace_all(Some(frag.upcast()), &target, SuppressObserver::Unsuppressed);
         Ok(())
     }
 

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -28,7 +28,7 @@ use crate::dom::htmlinputelement::{HTMLInputElement, InputType};
 use crate::dom::htmllabelelement::HTMLLabelElement;
 use crate::dom::htmltextareaelement::HTMLTextAreaElement;
 use crate::dom::node::{document_from_node, window_from_node};
-use crate::dom::node::{Node, ShadowIncluding};
+use crate::dom::node::{Node, SuppressObserver, ShadowIncluding};
 use crate::dom::text::Text;
 use crate::dom::virtualmethods::VirtualMethods;
 use dom_struct::dom_struct;
@@ -498,7 +498,7 @@ impl HTMLElementMethods for HTMLElement {
         }
 
         // Step 7.
-        Node::replace_all(Some(fragment.upcast()), self.upcast::<Node>());
+        Node::replace_all(Some(fragment.upcast()), self.upcast::<Node>(), SuppressObserver::Unsuppressed);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-translate

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -24,7 +24,7 @@ use crate::dom::document::Document;
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::element::Element;
 use crate::dom::htmlscriptelement::HTMLScriptElement;
-use crate::dom::node::{Node, ShadowIncluding, UnbindContext};
+use crate::dom::node::{Node, ShadowIncluding, SuppressObserver, UnbindContext};
 use crate::dom::selection::Selection;
 use crate::dom::text::Text;
 use crate::dom::window::Window;
@@ -946,7 +946,7 @@ impl RangeMethods for Range {
         let fragment = self.ExtractContents()?;
 
         // Step 4.
-        Node::replace_all(None, new_parent);
+        Node::replace_all(None, new_parent, SuppressObserver::Unsuppressed);
 
         // Step 5.
         self.InsertNode(new_parent)?;


### PR DESCRIPTION
Adding a flag to the Node::replace_all function to queue (or not) mutation events

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #21936

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
