### PR TITLE
Solves #27523 "Backspace in a textarea at the beginning of a line deletes the contents of the previous line"

### DIFF
--- a/tests/unit/script/textinput.rs
+++ b/tests/unit/script/textinput.rs
@@ -857,3 +857,16 @@ fn test_select_all() {
         textinput.selection_end()
     );
 }
+
+#[test]
+fn test_backspace_in_textarea_at_beginning_of_line() {
+    let mut textinput = text_input(Lines::Multiple, "servo\nhello");
+
+    for _ in 0..6 {
+        textinput.handle_keydown_aux(Key::ArrowRight, Modifiers::empty(), false);
+    }
+
+    textinput.handle_keydown_aux(Key::Backspace, Modifiers::empty(), false);
+
+    assert_eq!(textinput.get_content(), DOMString::from("servohello"));
+}


### PR DESCRIPTION
The problem was caused by some edge cases when calculating the column for the new lines. 

The changes I made feel a bit _hacky_ so I would like some feedback from someone who know this section a little better and maybe suggest a more appropriate solution (maybe @jdm ?).

Here some comments for the changes made. 
```rust
if start == end &&
// because if you delete forward on the last line and last char position, it panics (out of bounds)
end.line < self.lines.len() - 1 &&
//if you try to delete on the Edit point 0,0 it deletes that first line
self.edit_point != TextPoint::default() &&
// make sure you are not inserting chars,
insert.len_utf8() == UTF8Bytes(0)
{
  end.line += 1;
  end.index = UTF8Bytes(0);
}
```

```rust
//if the col equals 0 it means we are at the first char of a line so if we are deleting there, 
//the new column should be at the last char of the previous line. 
if col == 0 && select == Selection::Selected {
    self.edit_point.index = self.current_line_length();
} else {
    self.edit_point.index = len_of_first_n_chars(&self.lines[self.edit_point.line], col);
}
```
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #27523 

<!-- Either: -->
- [X] There are tests for these changes **(maybe some more?)**

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->


