### PR TITLE
Resolve `whenDefined` with the class constructor

### DIFF
--- a/components/script/dom/webidls/CustomElementRegistry.webidl
+++ b/components/script/dom/webidls/CustomElementRegistry.webidl
@@ -10,7 +10,7 @@ interface CustomElementRegistry {
 
   any get(DOMString name);
 
-  Promise<void> whenDefined(DOMString name);
+  Promise<CustomElementConstructor> whenDefined(DOMString name);
 
   [CEReactions] void upgrade(Node root);
 };

--- a/tests/wpt/metadata/custom-elements/CustomElementRegistry.html.ini
+++ b/tests/wpt/metadata/custom-elements/CustomElementRegistry.html.ini
@@ -32,19 +32,3 @@
 
   [customElements.define must not throw when defining another custom element in a different global object during Get(constructor, "prototype")]
     expected: FAIL
-
-  [A promise returned by customElements.whenDefined must be resolved by "define"]
-    expected: FAIL
-
-  [customElements.whenDefined must return a new resolved promise each time invoked when the registry contains the entry with the given name]
-    expected: FAIL
-
-  [A promise returned by customElements.whenDefined must be resolved with the defined class once such class is defined]
-    expected: FAIL
-
-  [customElements.whenDefined must return a resolved promise when the registry contains the entry with the given name]
-    expected: FAIL
-
-  [A promise returned by customElements.whenDefined must be resolved with the defined class]
-    expected: FAIL
-


### PR DESCRIPTION
I still don't have time to find the root cause of why nightly sync failed :( so we don't have the tests in our tree now.

But I tried to verify it with `wpt.live` that this is correct

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/6782666/92739547-f7ca0c80-f3b7-11ea-966e-fd7ecd2638cf.png">

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27626 
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
