### PR TITLE
Import localpaths to support loading third party modules to avoid breaking WPT sync

### DIFF
--- a/tests/wpt/update/__init__.py
+++ b/tests/wpt/update/__init__.py
@@ -15,6 +15,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(here, os.pardir, "web-platform-t
 sys.path.insert(0, os.path.abspath(os.path.join(here, os.pardir, "web-platform-tests", "tools", "wptserve")))
 sys.path.insert(0, os.path.abspath(os.path.join(here, os.pardir, "web-platform-tests", "tools")))
 
+import localpaths
+
 from wptrunner.update import setup_logging, WPTUpdate
 from wptrunner.update.base import exit_unclean
 


### PR DESCRIPTION



---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27622
- [x] These changes do not require tests because this is about fixing WPT sync

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
