### PR TITLE
preferences actor now returns real values.

### DIFF
--- a/components/devtools/actors/preference.rs
+++ b/components/devtools/actors/preference.rs
@@ -67,8 +67,47 @@ impl Actor for PreferenceActor {
                 let _ = stream.write_json_packet(&reply);
                 ActorMessageStatus::Processed
             },
-            PrefValue::Missing => ActorMessageStatus::Ignored,
+            PrefValue::Missing => handle_missing_preference(self.name(), msg_type, stream),
         })
+    }
+}
+
+// if the preferences are missing from pref_map then we return a
+// fake preference response based on msg_type.
+fn handle_missing_preference(
+    name: String,
+    msg_type: &str,
+    stream: &mut TcpStream,
+) -> ActorMessageStatus {
+    match msg_type {
+        "getBoolPref" => {
+            let reply = BoolReply {
+                from: name,
+                value: false,
+            };
+            let _ = stream.write_json_packet(&reply);
+            ActorMessageStatus::Processed
+        },
+
+        "getCharPref" => {
+            let reply = CharReply {
+                from: name,
+                value: "".to_owned(),
+            };
+            let _ = stream.write_json_packet(&reply);
+            ActorMessageStatus::Processed
+        },
+
+        "getIntPref" => {
+            let reply = IntReply {
+                from: name,
+                value: 0,
+            };
+            let _ = stream.write_json_packet(&reply);
+            ActorMessageStatus::Processed
+        },
+
+        _ => ActorMessageStatus::Ignored,
     }
 }
 


### PR DESCRIPTION
The preferences actor was previously returning mock values. This changes
picks up the pref_values from the pref_map which is global preferences
state and returns values from there.

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #27510 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because none of the actors have tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
