### PR TITLE
Use build-std instead of xargo.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4026,9 +4026,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -60,7 +60,7 @@ http = "0.1"
 hyper = "0.12"
 hyper_serde = "0.11"
 image = "0.23"
-indexmap = "1.0.2"
+indexmap = { version = "1.0.2", features = ["std"] }
 ipc-channel = "0.14"
 itertools = "0.8"
 js = { package = "mozjs", git = "https://github.com/servo/rust-mozjs" }

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -273,7 +273,6 @@ class MachCommands(CommandBase):
         if uwp:
             # Ensure libstd is ready for the new UWP target.
             check_call(["rustup", "component", "add", "rust-src"])
-            env['RUST_SYSROOT'] = path.expanduser('~\\.xargo')
 
             # Don't try and build a desktop port.
             libsimpleservo = True

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -608,7 +608,6 @@ install them, let us know by filing a bug!")
             extra_path += [path.join(self.msvc_package_dir("llvm"), "bin")]
             extra_path += [path.join(self.msvc_package_dir("ninja"), "bin")]
             extra_path += [self.msvc_package_dir("nuget")]
-            extra_path += [path.join(self.msvc_package_dir("xargo"))]
 
             arch = (target or host_triple()).split('-')[0]
             vcpkg_arch = {
@@ -932,9 +931,8 @@ install them, let us know by filing a bug!")
         args += ["--features", " ".join(features)]
 
         if target and 'uwp' in target:
-            return call(["xargo", command] + args + cargo_args, env=env, verbose=verbose)
-        else:
-            return self.call_rustup_run(["cargo", command] + args + cargo_args, env=env, verbose=verbose)
+            cargo_args += ["-Z", "build-std"]
+        return self.call_rustup_run(["cargo", command] + args + cargo_args, env=env, verbose=verbose)
 
     def android_support_dir(self):
         return path.join(self.context.topdir, "support", "android")

--- a/python/servo/packages.py
+++ b/python/servo/packages.py
@@ -11,5 +11,4 @@ WINDOWS_MSVC = {
     "openssl": "111.3.0+1.1.1c-vs2017-2019-09-18",
     "gstreamer-uwp": "1.16.0.5",
     "openxr-loader-uwp": "1.0",
-    "xargo": "v0.3.22",
 }


### PR DESCRIPTION
The changes to num-integer and indexmap are to work around https://github.com/cuviper/autocfg/issues/34.