### PR TITLE
Use data_url::Mime to parse the MIME Types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4910,6 +4910,7 @@ dependencies = [
  "cookie",
  "crossbeam-channel",
  "cssparser",
+ "data-url",
  "deny_public_fields",
  "devtools_traits",
  "dom_struct",

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -43,6 +43,7 @@ content-security-policy = { version = "0.4.0", features = ["serde"] }
 cookie = "0.11"
 crossbeam-channel = "0.4"
 cssparser = "0.27"
+data-url = "0.1.0"
 deny_public_fields = { path = "../deny_public_fields" }
 devtools_traits = { path = "../devtools_traits" }
 dom_struct = { path = "../dom_struct" }

--- a/components/script/dom/headers.rs
+++ b/components/script/dom/headers.rs
@@ -10,8 +10,9 @@ use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{is_token, ByteString};
 use crate::dom::globalscope::GlobalScope;
+use data_url::mime::Mime as DataUrlMime;
 use dom_struct::dom_struct;
-use http::header::{self, HeaderMap as HyperHeaders, HeaderName, HeaderValue};
+use http::header::{HeaderMap as HyperHeaders, HeaderName, HeaderValue};
 use net_traits::request::is_cors_safelisted_request_header;
 use std::cell::Cell;
 use std::str::{self, FromStr};
@@ -269,10 +270,7 @@ impl Headers {
 
     // https://fetch.spec.whatwg.org/#concept-header-extract-mime-type
     pub fn extract_mime_type(&self) -> Vec<u8> {
-        self.header_list
-            .borrow()
-            .get(header::CONTENT_TYPE)
-            .map_or(vec![], |v| v.as_bytes().to_owned())
+        extract_mime_type(&*self.header_list.borrow()).unwrap_or(vec![])
     }
 
     pub fn sort_header_list(&self) -> Vec<(String, Vec<u8>)> {
@@ -468,4 +466,73 @@ pub fn is_obs_text(x: u8) -> bool {
         0x80..=0xFF => true,
         _ => false,
     }
+}
+
+// https://fetch.spec.whatwg.org/#concept-header-extract-mime-type
+// This function uses data_url::Mime to parse the MIME Type because
+// mime::Mime does not provide a parser following the Fetch spec
+// see https://github.com/hyperium/mime/issues/106
+pub fn extract_mime_type(headers: &HyperHeaders) -> Option<Vec<u8>> {
+    let mut charset: Option<String> = None;
+    let mut essence: String = "".to_string();
+    let mut mime_type: Option<DataUrlMime> = None;
+
+    // Step 4
+    let headers_values = headers.get_all(http::header::CONTENT_TYPE).iter();
+
+    // Step 5
+    if headers_values.size_hint() == (0, Some(0)) {
+        return None;
+    }
+
+    // Step 6
+    for header_value in headers_values {
+        // Step 6.1
+        match DataUrlMime::from_str(header_value.to_str().unwrap_or("")) {
+            // Step 6.2
+            Err(_) => continue,
+            Ok(temp_mime) => {
+                let temp_essence = format!("{}/{}", temp_mime.type_, temp_mime.subtype);
+
+                // Step 6.2
+                if temp_essence == "*/*" {
+                    continue;
+                }
+
+                let temp_charset = &temp_mime.get_parameter("charset");
+
+                // Step 6.3
+                mime_type = Some(DataUrlMime {
+                    type_: temp_mime.type_.to_string(),
+                    subtype: temp_mime.subtype.to_string(),
+                    parameters: temp_mime.parameters.clone(),
+                });
+
+                // Step 6.4
+                if temp_essence != essence {
+                    charset = temp_charset.map(|c| c.to_string());
+                    essence = temp_essence.to_owned();
+                } else {
+                    // Step 6.5
+                    if temp_charset.is_none() && charset.is_some() {
+                        let DataUrlMime {
+                            type_: t,
+                            subtype: st,
+                            parameters: p,
+                        } = mime_type.unwrap();
+                        let mut params = p;
+                        params.push(("charset".to_string(), charset.clone().unwrap()));
+                        mime_type = Some(DataUrlMime {
+                            type_: t.to_string(),
+                            subtype: st.to_string(),
+                            parameters: params,
+                        })
+                    }
+                }
+            },
+        }
+    }
+
+    // Step 7, 8
+    return mime_type.map(|m| format!("{}", m).into_bytes());
 }

--- a/tests/wpt/metadata/fetch/content-type/response.window.js.ini
+++ b/tests/wpt/metadata/fetch/content-type/response.window.js.ini
@@ -96,9 +96,6 @@
   [Request: combined response Content-Type: text/plain;charset=gbk text/plain]
     expected: NOTRUN
 
-  [fetch(): separate response Content-Type:  text/plain]
-    expected: FAIL
-
   [fetch(): combined response Content-Type: text/html;" \\" text/plain ";charset=GBK]
     expected: NOTRUN
 
@@ -311,21 +308,6 @@
 
   [fetch(): separate response Content-Type: text/plain ]
     expected: NOTRUN
-
-  [<iframe>: separate response Content-Type: text/plain */*;charset=gbk]
-    expected: FAIL
-
-  [<iframe>: separate response Content-Type: text/html */*]
-    expected: FAIL
-
-  [<iframe>: separate response Content-Type: text/html;x=" text/plain]
-    expected: FAIL
-
-  [<iframe>: combined response Content-Type: text/html;" \\" text/plain]
-    expected: FAIL
-
-  [<iframe>: separate response Content-Type: text/html;" \\" text/plain]
-    expected: FAIL
 
   [<iframe>: combined response Content-Type: text/html;x=" text/plain]
     expected: FAIL

--- a/tests/wpt/metadata/wasm/webapi/contenttype.any.js.ini
+++ b/tests/wpt/metadata/wasm/webapi/contenttype.any.js.ini
@@ -1,4 +1,16 @@
 [contenttype.any.worker.html]
+  [Response with Content-Type "application/wasm;": compileStreaming]
+    expected: FAIL
+
+  [Response with Content-Type "application/wasm;": instantiateStreaming]
+    expected: FAIL
+
+  [Response with Content-Type "application/wasm;x": compileStreaming]
+    expected: FAIL
+
+  [Response with Content-Type "application/wasm;x": instantiateStreaming]
+    expected: FAIL
+
 
 [contenttype.any.sharedworker.html]
   expected: ERROR
@@ -7,6 +19,18 @@
 
 
 [contenttype.any.html]
+  [Response with Content-Type "application/wasm;": compileStreaming]
+    expected: FAIL
+
+  [Response with Content-Type "application/wasm;": instantiateStreaming]
+    expected: FAIL
+
+  [Response with Content-Type "application/wasm;x": compileStreaming]
+    expected: FAIL
+
+  [Response with Content-Type "application/wasm;x": instantiateStreaming]
+    expected: FAIL
+
 
 [contenttype.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/metadata/xhr/overridemimetype-blob.html.ini
+++ b/tests/wpt/metadata/xhr/overridemimetype-blob.html.ini
@@ -1,10 +1,5 @@
 [overridemimetype-blob.html]
   type: testharness
-  [Use text/xml as fallback MIME type]
-    expected: FAIL
-
-  [Use text/xml as fallback MIME type, 2]
-    expected: FAIL
 
   [Bogus MIME type should end up as application/octet-stream]
     expected: FAIL

--- a/tests/wpt/metadata/xhr/responsexml-basic.htm.ini
+++ b/tests/wpt/metadata/xhr/responsexml-basic.htm.ini
@@ -1,5 +1,0 @@
-[responsexml-basic.htm]
-  type: testharness
-  [responseXML on empty response documents]
-    expected: FAIL
-

--- a/tests/wpt/metadata/xhr/responsexml-media-type.htm.ini
+++ b/tests/wpt/metadata/xhr/responsexml-media-type.htm.ini
@@ -1,4 +1,0 @@
-[responsexml-media-type.htm]
-  [XMLHttpRequest: responseXML MIME type tests ('text/plain;+xml', should not parse)]
-    expected: FAIL
-

--- a/tests/wpt/metadata/xhr/responsexml-non-well-formed.htm.ini
+++ b/tests/wpt/metadata/xhr/responsexml-non-well-formed.htm.ini
@@ -1,8 +1,5 @@
 [responsexml-non-well-formed.htm]
   type: testharness
-  [XMLHttpRequest: responseXML non well-formed tests]
-    expected: FAIL
-
   [XMLHttpRequest: responseXML non well-formed tests 1]
     expected: FAIL
 


### PR DESCRIPTION
This commit follows the spectification https://fetch.spec.whatwg.org/#concept-header-extract-mime-type

This commit partially addresses #24923 (only the content type part). I'll try to fix the parser stuff in an other commit.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
