### PR TITLE
Call eglMakeCurrent with non-null surfaces before anything else

### DIFF
--- a/components/webrender_surfman/lib.rs
+++ b/components/webrender_surfman/lib.rs
@@ -80,6 +80,9 @@ impl WebrenderSurfman {
                 let _ = device.destroy_surface(&mut context, &mut surface);
                 err
             })?;
+
+        device.make_context_current(&context)?;
+
         let swap_chain = if headless {
             Some(SwapChain::create_attached(
                 &mut device,


### PR DESCRIPTION
First call to eglMakeCurrent with no draw or read surface leads to black window on Nvidia/X11. This change ensures first call to eglMakeCurrent made with non-null surfaces.
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #26353  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
