### PR TITLE
Upgrade CI to Ubuntu 20.04 LTS

### DIFF
--- a/etc/taskcluster/docker/base.dockerfile
+++ b/etc/taskcluster/docker/base.dockerfile
@@ -1,6 +1,4 @@
-# Dummy comment to force an image rebuild for https://github.com/servo/servo/issues/27758
-
-FROM ubuntu:eoan-20200608
+FROM ubuntu:20.04
 
 ENV \
     #
@@ -20,10 +18,9 @@ RUN \
         ca-certificates \
         #
         # Running mach with Python 2
-        python \
-        python-pip \
-        python-dev \
-        python-virtualenv \
+        python2 \
+        python2-dev \
+        python-is-python2 \
         #
         # Running mach with Python 3
         python3 \
@@ -38,5 +35,10 @@ RUN \
         curl \
         # Setting the default locale
         locales \
-        locales-all
-
+        locales-all \
+    && \
+    #
+    # Python 2 bits that have been removed from Ubuntu packages
+    curl https://bootstrap.pypa.io/get-pip.py -sSf -o get-pip.py && \
+    python2 get-pip.py && \
+    python2 -m pip install virtualenv


### PR DESCRIPTION
19.10 has been at end-of-life since July.

Also switch to an un-dated Docker Hub tag. Built docker images expire after a month, and when rebuilding we install the latest versions of additional packages. We might has well pick up-to-date versions of the base system as well.

We do stay within one Ubuntu release, though.