### PR TITLE
Embedding support for offscreen-rendering

### DIFF
--- a/components/webrender_surfman/lib.rs
+++ b/components/webrender_surfman/lib.rs
@@ -159,6 +159,23 @@ impl WebrenderSurfman {
             })
     }
 
+    /// Invoke a closure with the surface associated with the current front buffer.
+    /// This can be used to create a surfman::SurfaceTexture to blit elsewhere.
+    pub fn with_front_buffer<F: FnMut(&Device, Surface) -> Surface>(&self, mut f: F) {
+        let ref mut device = self.0.device.borrow_mut();
+        let ref mut context = self.0.context.borrow_mut();
+        let surface = device
+            .unbind_surface_from_context(context)
+            .unwrap()
+            .unwrap();
+        let surface = f(device, surface);
+        device.bind_surface_to_context(context, surface).unwrap();
+    }
+
+    pub fn device(&self) -> std::cell::Ref<Device> {
+        self.0.device.borrow()
+    }
+
     pub fn connection(&self) -> Connection {
         let ref device = self.0.device.borrow();
         device.connection()

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -161,6 +161,7 @@ pub trait HostTrait {
 }
 
 pub struct ServoGlue {
+    webrender_surfman: WebrenderSurfman,
     servo: Servo<ServoWindowCallbacks>,
     batch_mode: bool,
     callbacks: Rc<ServoWindowCallbacks>,
@@ -285,7 +286,7 @@ pub fn init(
         density: init_opts.density,
         gl_context_pointer: init_opts.gl_context_pointer,
         native_display_pointer: init_opts.native_display_pointer,
-        webrender_surfman,
+        webrender_surfman: webrender_surfman.clone(),
     });
 
     let embedder_callbacks = Box::new(ServoEmbedderCallbacks {
@@ -298,6 +299,7 @@ pub fn init(
 
     SERVO.with(|s| {
         let mut servo_glue = ServoGlue {
+            webrender_surfman,
             servo,
             batch_mode: false,
             callbacks: window_callbacks,
@@ -336,6 +338,12 @@ impl ServoGlue {
     /// Call after on_shutdown_complete
     pub fn deinit(self) {
         self.servo.deinit();
+    }
+
+    /// Returns the webrender surface management integration interface.
+    /// This provides the embedder access to the current front buffer.
+    pub fn surfman(&self) -> WebrenderSurfman {
+        self.webrender_surfman.clone()
     }
 
     /// This is the Servo heartbeat. This needs to be called

--- a/ports/libsimpleservo/capi/src/lib.rs
+++ b/ports/libsimpleservo/capi/src/lib.rs
@@ -21,6 +21,7 @@ use simpleservo::{self, gl_glue, ServoGlue, SERVO};
 use simpleservo::{
     ContextMenuResult, Coordinates, DeviceIntRect, EventLoopWaker, HostTrait, InitOptions,
     InputMethodType, MediaSessionActionType, MediaSessionPlaybackState, MouseButton, PromptResult,
+    SurfmanIntegration,
 };
 use std::ffi::{CStr, CString};
 #[cfg(target_os = "windows")]
@@ -463,7 +464,7 @@ unsafe fn init(
         xr_discovery: None,
         gl_context_pointer: gl_context,
         native_display_pointer: display,
-        native_widget: opts.native_widget,
+        surfman_integration: SurfmanIntegration::Widget(opts.native_widget),
     };
 
     let wakeup = Box::new(WakeupCallback::new(wakeup));


### PR DESCRIPTION
The current embedding API assumes it should render directly to a native widget at all times. These changes expose an option to render to an offscreen surface when starting the engine, as well as a new WebrenderSurfman API for temporarily acquiring  the surface corresponding to the front buffer so it can be used for blitting purposes.

Demonstrated to work in https://github.com/jdm/servo-embedding-example.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors