### PR TITLE
Update past yanked crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,12 +1060,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
+checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "cfg-if 0.1.10",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]


### PR DESCRIPTION
crossbeam-channel 0.4.3 was yanked in October and 0.4.4 includes https://github.com/crossbeam-rs/crossbeam/pull/533.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes