### PR TITLE
PoC Secure Contexts

### DIFF
--- a/components/constellation/browsingcontext.rs
+++ b/components/constellation/browsingcontext.rs
@@ -24,6 +24,9 @@ pub struct NewBrowsingContextInfo {
     /// Whether this browsing context is in private browsing mode.
     pub is_private: bool,
 
+    /// Whether this browsing context inherits a secure context.
+    pub inherited_secure_context: Option<bool>,
+
     /// Whether this browsing context should be treated as visible for the
     /// purposes of scheduling and resource management.
     pub is_visible: bool,
@@ -50,6 +53,9 @@ pub struct BrowsingContext {
 
     /// Whether this browsing context is in private browsing mode.
     pub is_private: bool,
+
+    /// Whether this browsing context inherits a secure context.
+    pub inherited_secure_context: Option<bool>,
 
     /// Whether this browsing context should be treated as visible for the
     /// purposes of scheduling and resource management.
@@ -78,6 +84,7 @@ impl BrowsingContext {
         parent_pipeline_id: Option<PipelineId>,
         size: Size2D<f32, CSSPixel>,
         is_private: bool,
+        inherited_secure_context: Option<bool>,
         is_visible: bool,
     ) -> BrowsingContext {
         let mut pipelines = HashSet::new();
@@ -88,6 +95,7 @@ impl BrowsingContext {
             top_level_id,
             size,
             is_private,
+            inherited_secure_context,
             is_visible,
             pipeline_id,
             parent_pipeline_id,

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -573,6 +573,7 @@ impl UnprivilegedPipelineContent {
                 layout_is_busy: layout_thread_busy_flag.clone(),
                 player_context: self.player_context.clone(),
                 event_loop_waker,
+                inherited_secure_context: self.load_data.inherited_secure_context.clone(),
             },
             self.load_data.clone(),
             self.opts.profile_script_events,

--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1517,7 +1517,7 @@ def getRetvalDeclarationForType(returnType, descriptorProvider):
                     returnType)
 
 
-def MemberCondition(pref, func, exposed):
+def MemberCondition(pref, func, exposed, secure):
     """
     A string representing the condition for a member to actually be exposed.
     Any of the arguments can be None. If not None, they should have the
@@ -1526,11 +1526,16 @@ def MemberCondition(pref, func, exposed):
     pref: The name of the preference.
     func: The name of the function.
     exposed: One or more names of an exposed global.
+    secure: Requires secure context.
     """
     assert pref is None or isinstance(pref, str)
     assert func is None or isinstance(func, str)
     assert exposed is None or isinstance(exposed, set)
-    assert func is None or pref is None or exposed is None
+    #assert secure is None or isinstance(secure, str)
+    # JKTODO It looks like the webidl guards only support a single check
+    assert func is None or pref is None or exposed is None or secure is None
+    if secure:
+        return 'Condition::SecureContext()'
     if pref:
         return 'Condition::Pref("%s")' % pref
     if func:
@@ -1580,7 +1585,8 @@ class PropertyDefiner:
                                           "Pref"),
             PropertyDefiner.getStringAttr(interfaceMember,
                                           "Func"),
-            interfaceMember.exposureSet)
+            interfaceMember.exposureSet,
+            interfaceMember.getExtendedAttribute("SecureContext"))
 
     def generateGuardedArray(self, array, name, specTemplate, specTerminator,
                              specType, getCondition, getDataTuple):
@@ -3038,7 +3044,7 @@ let global = incumbent_global.reflector().get_jsobject();\n"""
         for m in interface.members:
             if m.isAttr() and not m.isStatic() and m.type.isJSONType():
                 name = m.identifier.name
-                conditions = MemberCondition(None, None, m.exposureSet)
+                conditions = MemberCondition(None, None, m.exposureSet, None)
                 ret_conditions = '&[' + ", ".join(conditions) + "]"
                 ret += fill(
                     """
@@ -7838,6 +7844,7 @@ impl %(base)s {
                 if PropertyDefiner.getStringAttr(m, 'Pref') or \
                    PropertyDefiner.getStringAttr(m, 'Func') or \
                    PropertyDefiner.getStringAttr(m, 'Exposed') or \
+                   m.getExtendedAttribute('SecureContext') or \
                    (m.isMethod() and m.isIdentifierLess()):
                     continue
                 display = m.identifier.name + ('()' if m.isMethod() else '')

--- a/components/script/dom/bindings/interface.rs
+++ b/components/script/dom/bindings/interface.rs
@@ -139,6 +139,7 @@ pub unsafe fn create_global_object(
     options.creationOptions_.traceGlobal_ = Some(trace);
     options.creationOptions_.sharedMemoryAndAtomics_ = false;
     options.creationOptions_.streams_ = true;
+    //options.creationOptions_.secureContext_ = true;  // JKTODO this should be from the global?
 
     rval.set(JS_NewGlobalObject(
         *cx,

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -63,6 +63,7 @@ impl DissimilarOriginWindow {
                 global_to_clone_from.is_headless(),
                 global_to_clone_from.get_user_agent(),
                 global_to_clone_from.wgpu_id_hub(),
+                Some(global_to_clone_from.is_secure_context()),
             ),
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -703,12 +703,14 @@ pub fn follow_hyperlink(subject: &Element, hyperlink_suffix: Option<String>) {
 
         // Step 14
         let pipeline_id = target_window.upcast::<GlobalScope>().pipeline_id();
+        let secure = target_window.upcast::<GlobalScope>().is_secure_context();
         let load_data = LoadData::new(
             LoadOrigin::Script(document.origin().immutable().clone()),
             url,
             Some(pipeline_id),
             referrer,
             referrer_policy,
+            Some(secure),
         );
         let target = Trusted::new(target_window);
         let task = task!(navigate_follow_hyperlink: move || {

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -811,6 +811,7 @@ impl HTMLFormElement {
             None,
             target_window.upcast::<GlobalScope>().get_referrer(),
             target_document.get_referrer_policy(),
+            Some(target_window.upcast::<GlobalScope>().is_secure_context()),
         );
 
         // Step 22

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -170,6 +170,7 @@ impl HTMLIFrameElement {
             top_level_browsing_context_id: top_level_browsing_context_id,
             new_pipeline_id: new_pipeline_id,
             is_private: false, // FIXME
+            inherited_secure_context: load_data.inherited_secure_context,
             replace: replace,
         };
 
@@ -244,6 +245,7 @@ impl HTMLIFrameElement {
                 pipeline_id,
                 window.upcast::<GlobalScope>().get_referrer(),
                 document.get_referrer_policy(),
+                Some(window.upcast::<GlobalScope>().is_secure_context()),
             );
             let element = self.upcast::<Element>();
             load_data.srcdoc = String::from(element.get_string_attribute(&local_name!("srcdoc")));
@@ -327,6 +329,7 @@ impl HTMLIFrameElement {
             creator_pipeline_id,
             window.upcast::<GlobalScope>().get_referrer(),
             document.get_referrer_policy(),
+            Some(window.upcast::<GlobalScope>().is_secure_context()),
         );
 
         let pipeline_id = self.pipeline_id();
@@ -354,6 +357,7 @@ impl HTMLIFrameElement {
             pipeline_id,
             window.upcast::<GlobalScope>().get_referrer(),
             document.get_referrer_policy(),
+            Some(window.upcast::<GlobalScope>().is_secure_context()),
         );
         let browsing_context_id = BrowsingContextId::new();
         let top_level_browsing_context_id = window.window_proxy().top_level_browsing_context_id();

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -52,6 +52,7 @@ impl Location {
             Some(pipeline_id),
             referrer,
             referrer_policy,
+            None, // Top navigation doesn't inherit secure context
         );
         // TODO: rethrow exceptions, set exceptions enabled flag.
         self.window

--- a/components/script/dom/webidls/WindowOrWorkerGlobalScope.webidl
+++ b/components/script/dom/webidls/WindowOrWorkerGlobalScope.webidl
@@ -36,5 +36,10 @@ partial interface mixin WindowOrWorkerGlobalScope {
     readonly attribute Performance performance;
 };
 
+// https://w3c.github.io/webappsec-secure-contexts/#monkey-patching-global-object
+partial interface mixin WindowOrWorkerGlobalScope {
+  readonly attribute boolean isSecureContext;
+};
+
 Window includes WindowOrWorkerGlobalScope;
 WorkerGlobalScope includes WindowOrWorkerGlobalScope;

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1381,6 +1381,10 @@ impl WindowMethods for Window {
         }
         rval.get()
     }
+
+    fn IsSecureContext(&self) -> bool {
+        self.upcast::<GlobalScope>().is_secure_context()
+    }
 }
 
 impl Window {
@@ -2376,6 +2380,7 @@ impl Window {
         player_context: WindowGLContext,
         event_loop_waker: Option<Box<dyn EventLoopWaker>>,
         gpu_id_hub: Arc<ParkMutex<Identities>>,
+        inherited_secure_context: Option<bool>,
     ) -> DomRoot<Self> {
         let layout_rpc: Box<dyn LayoutRPC + Send> = {
             let (rpc_send, rpc_recv) = unbounded();
@@ -2400,6 +2405,7 @@ impl Window {
                 is_headless,
                 user_agent,
                 gpu_id_hub,
+                inherited_secure_context,
             ),
             script_chan,
             task_manager,

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -307,6 +307,7 @@ impl WindowProxy {
                 None,
                 document.global().get_referrer(),
                 document.get_referrer_policy(),
+                None, // Doesn't inherit secure context
             );
             let load_info = AuxiliaryBrowsingContextLoadInfo {
                 load_data: load_data.clone(),
@@ -511,12 +512,14 @@ impl WindowProxy {
             // Step 14.5
             let referrer_policy = target_document.get_referrer_policy();
             let pipeline_id = target_window.upcast::<GlobalScope>().pipeline_id();
+            let secure = target_window.upcast::<GlobalScope>().is_secure_context();
             let load_data = LoadData::new(
                 LoadOrigin::Script(existing_document.origin().immutable().clone()),
                 url,
                 Some(pipeline_id),
                 referrer,
                 referrer_policy,
+                Some(secure),
             );
             let replacement_flag = if new {
                 HistoryEntryReplacement::Enabled

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -82,6 +82,7 @@ pub fn prepare_workerscope_init(
         origin: global.origin().immutable().clone(),
         is_headless: global.is_headless(),
         user_agent: global.get_user_agent(),
+        inherited_secure_context: Some(global.is_secure_context()),
     };
 
     init
@@ -145,6 +146,7 @@ impl WorkerGlobalScope {
                 init.is_headless,
                 init.user_agent,
                 gpu_id_hub,
+                init.inherited_secure_context,
             ),
             worker_id: init.worker_id,
             worker_name,
@@ -404,6 +406,10 @@ impl WorkerGlobalScopeMethods for WorkerGlobalScope {
                 .immutable()
                 .ascii_serialization(),
         )
+    }
+
+    fn IsSecureContext(&self) -> bool {
+        self.upcast::<GlobalScope>().is_secure_context()
     }
 }
 

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -75,6 +75,7 @@ impl WorkletGlobalScope {
                 init.is_headless,
                 init.user_agent.clone(),
                 init.gpu_id_hub.clone(),
+                init.inherited_secure_context,
             ),
             base_url,
             to_script_thread_sender: init.to_script_thread_sender.clone(),
@@ -166,6 +167,8 @@ pub struct WorkletGlobalScopeInit {
     pub user_agent: Cow<'static, str>,
     /// Identity manager for WebGPU resources
     pub gpu_id_hub: Arc<Mutex<Identities>>,
+    /// Is considered secure
+    pub inherited_secure_context: Option<bool>,
 }
 
 /// <https://drafts.css-houdini.org/worklets/#worklet-global-scope-type>

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -216,6 +216,8 @@ struct InProgressLoad {
     canceller: FetchCanceller,
     /// Flag for sharing with the layout thread that is not yet created.
     layout_is_busy: Arc<AtomicBool>,
+    /// If inheriting the security context
+    inherited_secure_context: Option<bool>,
 }
 
 impl InProgressLoad {
@@ -231,6 +233,7 @@ impl InProgressLoad {
         url: ServoUrl,
         origin: MutableOrigin,
         layout_is_busy: Arc<AtomicBool>,
+        inherited_secure_context: Option<bool>,
     ) -> InProgressLoad {
         let current_time = get_time();
         let navigation_start_precise = precise_time_ns();
@@ -253,6 +256,7 @@ impl InProgressLoad {
             navigation_start_precise: navigation_start_precise,
             canceller: Default::default(),
             layout_is_busy: layout_is_busy,
+            inherited_secure_context: inherited_secure_context,
         }
     }
 }
@@ -692,6 +696,9 @@ pub struct ScriptThread {
 
     /// Receiver to receive commands from optional WebGPU server.
     webgpu_port: RefCell<Option<Receiver<WebGPUMsg>>>,
+
+    // Secure context
+    inherited_secure_context: Option<bool>,
 }
 
 struct BHMExitSignal {
@@ -778,6 +785,7 @@ impl ScriptThreadFactory for ScriptThread {
                 let top_level_browsing_context_id = state.top_level_browsing_context_id;
                 let parent_info = state.parent_info;
                 let opener = state.opener;
+                let secure = load_data.inherited_secure_context.clone();
                 let mem_profiler_chan = state.mem_profiler_chan.clone();
                 let window_size = state.window_size;
                 let layout_is_busy = state.layout_is_busy.clone();
@@ -816,6 +824,7 @@ impl ScriptThreadFactory for ScriptThread {
                     load_data.url.clone(),
                     origin,
                     layout_is_busy,
+                    secure,
                 );
                 script_thread.pre_page_load(new_load, load_data);
 
@@ -1149,6 +1158,7 @@ impl ScriptThread {
                         is_headless: script_thread.headless,
                         user_agent: script_thread.user_agent.clone(),
                         gpu_id_hub: script_thread.gpu_id_hub.clone(),
+                        inherited_secure_context: script_thread.inherited_secure_context.clone(),
                     };
                     Rc::new(WorkletThreadPool::spawn(init))
                 })
@@ -1404,6 +1414,7 @@ impl ScriptThread {
             is_user_interacting: Cell::new(false),
             gpu_id_hub: Arc::new(Mutex::new(Identities::new())),
             webgpu_port: RefCell::new(None),
+            inherited_secure_context: state.inherited_secure_context,
         }
     }
 
@@ -2523,6 +2534,7 @@ impl ScriptThread {
             load_data.url.clone(),
             origin,
             layout_is_busy.clone(),
+            load_data.inherited_secure_context.clone(), // JKTODO check if this is correct
         );
         if load_data.url.as_str() == "about:blank" {
             self.start_page_load_about_blank(new_load, load_data.js_eval_result);
@@ -3290,6 +3302,7 @@ impl ScriptThread {
             self.player_context.clone(),
             self.event_loop_waker.as_ref().map(|w| (*w).clone_box()),
             self.gpu_id_hub.clone(),
+            incomplete.inherited_secure_context,
         );
 
         // Initialize the browsing context for the window.

--- a/components/script_traits/lib.rs
+++ b/components/script_traits/lib.rs
@@ -182,6 +182,8 @@ pub struct LoadData {
 
     /// The source to use instead of a network response for a srcdoc document.
     pub srcdoc: String,
+    /// The inherited context is Secure, None if not inherited
+    pub inherited_secure_context: Option<bool>,
 }
 
 /// The result of evaluating a javascript scheme url.
@@ -202,6 +204,7 @@ impl LoadData {
         creator_pipeline_id: Option<PipelineId>,
         referrer: Referrer,
         referrer_policy: Option<ReferrerPolicy>,
+        inherited_secure_context: Option<bool>,
     ) -> LoadData {
         LoadData {
             load_origin,
@@ -214,6 +217,7 @@ impl LoadData {
             referrer: referrer,
             referrer_policy: referrer_policy,
             srcdoc: "".to_string(),
+            inherited_secure_context,
         }
     }
 }
@@ -639,6 +643,8 @@ pub struct InitialScriptState {
     pub top_level_browsing_context_id: TopLevelBrowsingContextId,
     /// The ID of the opener, if any.
     pub opener: Option<BrowsingContextId>,
+    /// Loading into a Secure Context
+    pub inherited_secure_context: Option<bool>,
     /// A channel with which messages can be sent to us (the script thread).
     pub control_chan: IpcSender<ConstellationControlMsg>,
     /// A port on which messages sent by the constellation to script can be received.
@@ -751,6 +757,8 @@ pub struct IFrameLoadInfo {
     pub new_pipeline_id: PipelineId,
     ///  Whether this iframe should be considered private
     pub is_private: bool,
+    ///  Whether this iframe should be considered secure
+    pub inherited_secure_context: Option<bool>,
     /// Wether this load should replace the current entry (reload). If true, the current
     /// entry will be replaced instead of a new entry being added.
     pub replace: HistoryEntryReplacement,
@@ -872,6 +880,8 @@ pub struct WorkerGlobalScopeInit {
     pub is_headless: bool,
     /// An optional string allowing the user agnet to be set for testing.
     pub user_agent: Cow<'static, str>,
+    /// True if secure context
+    pub inherited_secure_context: Option<bool>,
 }
 
 /// Common entities representing a network load origin

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -175,44 +175,12 @@ impl ServoUrl {
         Ok(Self::from_url(Url::from_file_path(path)?))
     }
 
-    /// <https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-url>
     pub fn is_potentially_trustworthy(&self) -> bool {
-        // Step 1
-        if self.as_str() == "about:blank" || self.as_str() == "about:srcdoc" {
-            return true;
-        }
-        // Step 2
-        if self.scheme() == "data" {
-            return true;
-        }
-        // Step 3
-        self.is_origin_trustworthy()
+        self.origin().is_potentially_trustworthy()
     }
 
-    /// <https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy>
     pub fn is_origin_trustworthy(&self) -> bool {
-        // Step 1
-        if !self.origin().is_tuple() {
-            return false;
-        }
-
-        // Step 3
-        if self.scheme() == "https" || self.scheme() == "wss" {
-            true
-        // Steps 4-5
-        } else if self.host().is_some() {
-            let host = self.host_str().unwrap();
-            // Step 4
-            if let Ok(ip_addr) = host.parse::<IpAddr>() {
-                ip_addr.is_loopback()
-            // Step 5
-            } else {
-                host == "localhost" || host.ends_with(".localhost")
-            }
-        // Step 6
-        } else {
-            self.scheme() == "file"
-        }
+        self.origin().is_origin_trustworthy()
     }
 }
 

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -644,7 +644,14 @@ impl Handler {
 
         let top_level_browsing_context_id = self.session()?.top_level_browsing_context_id;
 
-        let load_data = LoadData::new(LoadOrigin::WebDriver, url, None, Referrer::NoReferrer, None);
+        let load_data = LoadData::new(
+            LoadOrigin::WebDriver,
+            url,
+            None,
+            Referrer::NoReferrer,
+            None,
+            None,
+        );
         let cmd_msg = WebDriverCommandMsg::LoadUrl(
             top_level_browsing_context_id,
             load_data,

--- a/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/isSecureContext.https.html.ini
+++ b/tests/wpt/metadata/service-workers/service-worker/ServiceWorkerGlobalScope/isSecureContext.https.html.ini
@@ -1,4 +1,0 @@
-[isSecureContext.https.html]
-  [Setting up tests]
-    expected: FAIL
-


### PR DESCRIPTION
Proof of concept implementation for implementing secure contexts.

## Blob URLs issue
Currently blobs don't work as the origin is created into an opaque which means the `is_potentially_trustworthy` won't pass.
This code creates script threads with new origins:
https://github.com/servo/servo/blob/a3e9095faa885cebf6e17c3c161871e4d896c70b/components/script/script_thread.rs#L807

Some solutions to this:
- Add to the `ImmutableOrigin` code an `is_data` that gets passed with the origin
- Pass this `is_data` flag into the `load_data` itself instead
- Use a `Url` instead for the origin

## Srcdoc issue
https://github.com/servo/servo/issues/27791 it became clear as part of this issue that srcdoc isn't handled in frames.

## Pref gating
As suggested in https://github.com/servo/servo/issues/27268 it might be useful for local development to have a pref on the idl gating to allow `!isSecureContext` pages to access APIs.

## SpiderMonkey creation options

Firefox passes this flag, it's not needed in this PoC as we use the `GlobalScope` to be the canonical source of if the code is considered a secure context. It may make sense to continue to pass it to spider monkey for consistency.

## Member conditions

It appears in the Member condition code in components/script/dom/bindings/codegen/CodegenRust.py it only handles being gated by one of these conditions. Should this be a follow up issue, obviously this exacerbates the issue?

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
