### PR TITLE
Replace generic 'value' variable name with 'id' and 'name' to reduce confusion

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2988,16 +2988,16 @@ impl VirtualMethods for Element {
 
         self.update_sequentially_focusable_status();
 
-        if let Some(ref value) = *self.id_attribute.borrow() {
+        if let Some(ref id) = *self.id_attribute.borrow() {
             if let Some(shadow_root) = self.upcast::<Node>().containing_shadow_root() {
-                shadow_root.register_element_id(self, value.clone());
+                shadow_root.register_element_id(self, id.clone());
             } else {
-                doc.register_element_id(self, value.clone());
+                doc.register_element_id(self, id.clone());
             }
         }
-        if let Some(ref value) = self.name_attribute() {
+        if let Some(ref name) = self.name_attribute() {
             if self.upcast::<Node>().containing_shadow_root().is_none() {
-                doc.register_element_name(self, value.clone());
+                doc.register_element_name(self, name.clone());
             }
         }
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

I was digging through this code trying to fix a WPT and thought these could be named a bit more clearly.  `value` is vague, and the fact it was used in both cases falsely implied they were related.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because there are no functional changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
