### PR TITLE
Fix mouse button handling

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -896,7 +896,7 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
             result.point_in_viewport.to_untyped(),
             Some(UntrustedNodeAddress(result.tag.0 as *const c_void)),
             Some(result.point_relative_to_item.to_untyped()),
-            MouseButton::Left as u16,
+            button as u16,
         );
 
         let pipeline_id = PipelineId::from_webrender(result.pipeline);

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1188,7 +1188,7 @@ impl Document {
     pub fn handle_mouse_event(
         &self,
         js_runtime: *mut JSRuntime,
-        _button: MouseButton,
+        button: MouseButton,
         client_point: Point2D<f32>,
         mouse_event_type: MouseEventType,
         node_address: Option<UntrustedNodeAddress>,
@@ -1244,7 +1244,11 @@ impl Document {
             false,
             false,
             false,
-            0i16,
+            match &button {
+                MouseButton::Left => 0i16,
+                MouseButton::Middle => 1i16,
+                MouseButton::Right => 2i16,
+            },
             pressed_mouse_buttons,
             None,
             point_in_node,

--- a/ports/winit/headed_window.rs
+++ b/ports/winit/headed_window.rs
@@ -261,14 +261,20 @@ impl Window {
         use servo::script_traits::MouseButton;
 
         let max_pixel_dist = 10.0 * self.servo_hidpi_factor().get();
+        let mouse_button = match &button {
+            winit::MouseButton::Left => MouseButton::Left,
+            winit::MouseButton::Right => MouseButton::Right,
+            winit::MouseButton::Middle => MouseButton::Middle,
+            _ => MouseButton::Left,
+        };
         let event = match action {
             ElementState::Pressed => {
                 self.mouse_down_point.set(coords);
                 self.mouse_down_button.set(Some(button));
-                MouseWindowEvent::MouseDown(MouseButton::Left, coords.to_f32())
+                MouseWindowEvent::MouseDown(mouse_button, coords.to_f32())
             },
             ElementState::Released => {
-                let mouse_up_event = MouseWindowEvent::MouseUp(MouseButton::Left, coords.to_f32());
+                let mouse_up_event = MouseWindowEvent::MouseUp(mouse_button, coords.to_f32());
                 match self.mouse_down_button.get() {
                     None => mouse_up_event,
                     Some(but) if button == but => {
@@ -280,7 +286,7 @@ impl Window {
                             self.event_queue
                                 .borrow_mut()
                                 .push(WindowEvent::MouseWindowEventClass(mouse_up_event));
-                            MouseWindowEvent::Click(MouseButton::Left, coords.to_f32())
+                            MouseWindowEvent::Click(mouse_button, coords.to_f32())
                         } else {
                             mouse_up_event
                         }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
* Remove hardcoded left button value in mouse event handling as described in issue #27155 
* Tested with `./mach run --release` that right click event works on http://minesweeperonline.com/#
* Part of the changes were inspired by PR #27685 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27155 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
