### PR TITLE
Remove LLVM package.

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -605,7 +605,7 @@ install them, let us know by filing a bug!")
         extra_lib = []
         if "msvc" in (target or host_triple()):
             extra_path += [path.join(self.msvc_package_dir("cmake"), "bin")]
-            extra_path += [path.join(self.msvc_package_dir("llvm"), "bin")]
+            #extra_path += [path.join(self.msvc_package_dir("llvm"), "bin")]
             extra_path += [path.join(self.msvc_package_dir("ninja"), "bin")]
             extra_path += [self.msvc_package_dir("nuget")]
             extra_path += [path.join(self.msvc_package_dir("xargo"))]
@@ -639,7 +639,7 @@ install them, let us know by filing a bug!")
             # Link autoconf 2.13, used for building SpiderMonkey
             env["AUTOCONF"] = path.join(self.msvc_package_dir("moztools"), "msys", "local", "bin", "autoconf-2.13")
             # Link LLVM
-            env["LIBCLANG_PATH"] = path.join(self.msvc_package_dir("llvm"), "lib")
+            # env["LIBCLANG_PATH"] = path.join(self.msvc_package_dir("llvm"), "lib")
 
             if not os.environ.get("NATIVE_WIN32_PYTHON"):
                 env["NATIVE_WIN32_PYTHON"] = sys.executable

--- a/python/servo/packages.py
+++ b/python/servo/packages.py
@@ -4,7 +4,7 @@
 
 WINDOWS_MSVC = {
     "cmake": "3.14.3",
-    "llvm": "9.0.0",
+    #"llvm": "9.0.0",
     "moztools": "3.2",
     "ninja": "1.7.1",
     "nuget": "08-08-2019",


### PR DESCRIPTION
I'm curious if we can depend on the clang binaries provided by MSVC instead of downloading a separate LLVM package. This would fix #27545.