### PR TITLE
Replace use of c++ keyword 'default' in c++ code and C APIs. Also cor…

### DIFF
--- a/ports/libsimpleservo/capi/src/lib.rs
+++ b/ports/libsimpleservo/capi/src/lib.rs
@@ -216,11 +216,8 @@ pub struct CHostCallbacks {
     pub prompt_alert: extern "C" fn(message: *const c_char, trusted: bool),
     pub prompt_ok_cancel: extern "C" fn(message: *const c_char, trusted: bool) -> CPromptResult,
     pub prompt_yes_no: extern "C" fn(message: *const c_char, trusted: bool) -> CPromptResult,
-    pub prompt_input: extern "C" fn(
-        message: *const c_char,
-        def: *const c_char,
-        trusted: bool,
-    ) -> *const c_char,
+    pub prompt_input:
+        extern "C" fn(message: *const c_char, def: *const c_char, trusted: bool) -> *const c_char,
     pub on_devtools_started:
         extern "C" fn(result: CDevtoolsServerState, port: c_uint, token: *const c_char),
     pub show_context_menu:

--- a/ports/libsimpleservo/capi/src/lib.rs
+++ b/ports/libsimpleservo/capi/src/lib.rs
@@ -218,7 +218,7 @@ pub struct CHostCallbacks {
     pub prompt_yes_no: extern "C" fn(message: *const c_char, trusted: bool) -> CPromptResult,
     pub prompt_input: extern "C" fn(
         message: *const c_char,
-        default: *const c_char,
+        def: *const c_char,
         trusted: bool,
     ) -> *const c_char,
     pub on_devtools_started:

--- a/support/hololens/ServoApp/App.h
+++ b/support/hololens/ServoApp/App.h
@@ -16,7 +16,7 @@ struct App : AppT<App> {
 
   void createRootFrame(Controls::Frame &, bool, IInspectable const &);
   void OnLaunched(LaunchActivatedEventArgs const &);
-  void App::OnActivated(IActivatedEventArgs const &);
+  void OnActivated(IActivatedEventArgs const &);
   void OnSuspending(IInspectable const &, SuspendingEventArgs const &);
   void OnNavigationFailed(IInspectable const &,
                           Navigation::NavigationFailedEventArgs const &);

--- a/support/hololens/ServoApp/ServoControl/Servo.cpp
+++ b/support/hololens/ServoApp/ServoControl/Servo.cpp
@@ -152,10 +152,10 @@ Servo::PromptResult prompt_yes_no(const char *message, bool trusted) {
   return sServo->Delegate().OnServoPromptYesNo(char2hstring(message), trusted);
 }
 
-const char *prompt_input(const char *message, const char *default,
+const char *prompt_input(const char *message, const char *def,
                          bool trusted) {
   auto input = sServo->Delegate().OnServoPromptInput(
-      char2hstring(message), char2hstring(default), trusted);
+      char2hstring(message), char2hstring(def), trusted);
   if (input.has_value()) {
     return *hstring2char(*input);
   } else {

--- a/support/hololens/ServoApp/ServoControl/Servo.cpp
+++ b/support/hololens/ServoApp/ServoControl/Servo.cpp
@@ -152,8 +152,7 @@ Servo::PromptResult prompt_yes_no(const char *message, bool trusted) {
   return sServo->Delegate().OnServoPromptYesNo(char2hstring(message), trusted);
 }
 
-const char *prompt_input(const char *message, const char *def,
-                         bool trusted) {
+const char *prompt_input(const char *message, const char *def, bool trusted) {
   auto input = sServo->Delegate().OnServoPromptInput(
       char2hstring(message), char2hstring(def), trusted);
   if (input.has_value()) {

--- a/support/hololens/ServoApp/ServoControl/ServoControl.cpp
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.cpp
@@ -671,13 +671,13 @@ Servo::PromptResult ServoControl::OnServoPromptYesNo(winrt::hstring message,
 }
 
 std::optional<hstring> ServoControl::OnServoPromptInput(winrt::hstring message,
-                                                        winrt::hstring default,
+                                                        winrt::hstring def,
                                                         bool trusted) {
   auto titlefmt =
       format(mL10NStrings->PromptTitle.c_str(), mCurrentUrl.c_str());
   hstring title{trusted ? L"" : titlefmt};
   auto [button, string] = PromptSync(title, message, mL10NStrings->PromptOk,
-                                     mL10NStrings->PromptCancel, default);
+                                     mL10NStrings->PromptCancel, def);
   return string;
 }
 

--- a/support/hololens/ServoApp/ServoControl/ServoControl.h
+++ b/support/hololens/ServoApp/ServoControl/ServoControl.h
@@ -239,7 +239,7 @@ private:
   bool mTransient = false;
   std::optional<hstring> mInitUrl = {};
 
-  Windows::UI::Xaml::Controls::SwapChainPanel ServoControl::Panel();
+  Windows::UI::Xaml::Controls::SwapChainPanel Panel();
   void CreateNativeWindow();
   EGLNativeWindowType GetNativeWindow();
   void RecoverFromLostDevice();


### PR DESCRIPTION
…rect obsolete use of qualified name in member declaration.

<!-- Please describe your changes on the following line: -->

Minor c++ fixes to allow building with latest Visual Studio toolchain:
- Replace use of reserved c++ keyword 'default' in c++ code. Also in libsimpleservo API that is turned into a c header.
- Use of a qualified name in a member declaration is obsolete syntax. Removed in two places.
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because build-time-only changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
