### PR TITLE
Add support for KDE neon in bootstrap

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -333,7 +333,7 @@ def get_linux_distribution():
     distrib = six.ensure_str(distrib)
     version = six.ensure_str(version)
 
-    if distrib == 'LinuxMint' or distrib == 'Linux Mint':
+    if distrib in ['LinuxMint', 'Linux Mint', 'KDE neon']:
         if '.' in version:
             major, _ = version.split('.', 1)
         else:


### PR DESCRIPTION
it's based on Ubuntu but provides recent (User edition) or git versions of the KDE Plasma desktop environment and ecosystem

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they affect just the bootstrap script

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
