### PR TITLE
Fix num_threads to avoid divide by zero error when running without a thread pool

### DIFF
--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -1404,7 +1404,7 @@ impl LayoutThread {
         let pool;
         let (thread_pool, num_threads) = if self.parallel_flag {
             pool = STYLE_THREAD_POOL.pool();
-            (pool.as_ref(), STYLE_THREAD_POOL.num_threads)
+            (pool.as_ref(), STYLE_THREAD_POOL.num_threads.unwrap_or(1))
         } else {
             (None, 1)
         };

--- a/components/style/global_style_data.rs
+++ b/components/style/global_style_data.rs
@@ -26,8 +26,8 @@ pub struct GlobalStyleData {
 
 /// Global thread pool.
 pub struct StyleThreadPool {
-    /// How many threads parallel styling can use.
-    pub num_threads: usize,
+    /// How many threads parallel styling can use. If not using a thread pool, this is set to `None`.
+    pub num_threads: Option<usize>,
 
     /// The parallel styling thread pool.
     ///
@@ -160,7 +160,11 @@ lazy_static! {
         };
 
         StyleThreadPool {
-            num_threads,
+            num_threads: if num_threads > 0 {
+                Some(num_threads)
+            } else {
+                None
+            },
             style_thread_pool: RwLock::new(pool),
         }
     };


### PR DESCRIPTION
Signed-off-by: teymour-aldridge <teymour.aldridge@icloud.com>

<!-- Please describe your changes on the following line: -->

This updates the style thread pool to set `num_threads` to `None` rather than `0` when running without a thread pool.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

I *think* this change might not need tests, but if it does I'm not sure exactly how to do so.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
