### PR TITLE
Updated to support macOS 11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3786,7 +3786,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/rust-mozjs#e9f71b6458135c1e63fee9261dabcd8c3efa6ccf"
+source = "git+https://github.com/servo/rust-mozjs#db90a4651adcc1447d1eb8c4bb13f18ea957d263"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.68.2"
-source = "git+https://github.com/servo/mozjs?rev=a40b829f0fefa06a743f006260c7facebcfa27aa#a40b829f0fefa06a743f006260c7facebcfa27aa"
+source = "git+https://github.com/servo/mozjs?rev=26a1e8afdb21beec33373ef2a38131272d064bdd#26a1e8afdb21beec33373ef2a38131272d064bdd"
 dependencies = [
  "bindgen",
  "cc",


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Updated Cargo.lock to contain the latest version of the rust-mozjs crate, which supports macOS 11.1

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it adds supported files.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
