### PR TITLE
Use 2.7-compatible get-pip in docker build.

### DIFF
--- a/etc/taskcluster/docker/base.dockerfile
+++ b/etc/taskcluster/docker/base.dockerfile
@@ -39,6 +39,6 @@ RUN \
     && \
     #
     # Python 2 bits that have been removed from Ubuntu packages
-    curl https://bootstrap.pypa.io/get-pip.py -sSf -o get-pip.py && \
+    curl https://bootstrap.pypa.io/2.7/get-pip.py -sSf -o get-pip.py && \
     python2 get-pip.py && \
     python2 -m pip install virtualenv


### PR DESCRIPTION
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #28122
- [x] There are tests for these changes