### PR TITLE
Update pip when building docker image.

### DIFF
--- a/etc/taskcluster/docker/base.dockerfile
+++ b/etc/taskcluster/docker/base.dockerfile
@@ -41,6 +41,6 @@ RUN \
     # Python 2 bits that have been removed from Ubuntu packages
     curl https://bootstrap.pypa.io/2.7/get-pip.py -sSf -o get-pip.py && \
     python2 get-pip.py && \
-    python2 -m pip install virtualenv \
+    python2 -m pip install virtualenv && \
     # Ensure modern pip is present.
     python3 -m pip install -U pip

--- a/etc/taskcluster/docker/base.dockerfile
+++ b/etc/taskcluster/docker/base.dockerfile
@@ -41,6 +41,6 @@ RUN \
     # Python 2 bits that have been removed from Ubuntu packages
     curl https://bootstrap.pypa.io/2.7/get-pip.py -sSf -o get-pip.py && \
     python2 get-pip.py && \
-    python2 -m pip install virtualenv
+    python2 -m pip install virtualenv \
     # Ensure modern pip is present.
     python3 -m pip install -U pip

--- a/etc/taskcluster/docker/base.dockerfile
+++ b/etc/taskcluster/docker/base.dockerfile
@@ -42,3 +42,5 @@ RUN \
     curl https://bootstrap.pypa.io/2.7/get-pip.py -sSf -o get-pip.py && \
     python2 get-pip.py && \
     python2 -m pip install virtualenv
+    # Ensure modern pip is present.
+    python3 -m pip install -U pip


### PR DESCRIPTION
Outdated versions of pip can't find a Rust compiler that's required when installing the python cryptography package.