### PR TITLE
Support extra arguments when running with --debug.

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -162,7 +162,7 @@ class PostBuildCommands(CommandBase):
                     command = rustCommand
 
             # Prepend the debugger args.
-            args = ([command] + self.debuggerInfo.args
+            args = ([command] + self.debuggerInfo.args + ["--"]
                     + args + params)
         else:
             args = args + params


### PR DESCRIPTION
This allows things like `./mach run -z -x tests/html/about-mozilla.html --debug` to work as expected.