### PR TITLE
Use swap() instead of load()/store() in get_and_reset_text_shaping_performance_counter()

### DIFF
--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -522,8 +522,7 @@ impl RunMetrics {
 }
 
 pub fn get_and_reset_text_shaping_performance_counter() -> usize {
-    let value = TEXT_SHAPING_PERFORMANCE_COUNTER.load(Ordering::SeqCst);
-    TEXT_SHAPING_PERFORMANCE_COUNTER.store(0, Ordering::SeqCst);
+    let value = TEXT_SHAPING_PERFORMANCE_COUNTER.swap(0,Ordering::SeqCst);
     value
 }
 

--- a/components/gfx/font.rs
+++ b/components/gfx/font.rs
@@ -522,7 +522,7 @@ impl RunMetrics {
 }
 
 pub fn get_and_reset_text_shaping_performance_counter() -> usize {
-    let value = TEXT_SHAPING_PERFORMANCE_COUNTER.swap(0,Ordering::SeqCst);
+    let value = TEXT_SHAPING_PERFORMANCE_COUNTER.swap(0, Ordering::SeqCst);
     value
 }
 


### PR DESCRIPTION

<!-- Please describe your changes on the following line: -->
Replaced usage of `.load()` then `.store()` with `.swap()` to prevent possible atomicity issues.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #28245

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because: They do not change function of the code.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
