### PR TITLE
Disable hanging hang monitor tests on windows

### DIFF
--- a/components/background_hang_monitor/tests/hang_monitor_tests.rs
+++ b/components/background_hang_monitor/tests/hang_monitor_tests.rs
@@ -127,6 +127,8 @@ fn test_hang_monitoring() {
 }
 
 #[test]
+// https://github.com/servo/servo/issues/28270
+#[cfg(not(target_os = "windows"))]
 fn test_hang_monitoring_unregister() {
     let _lock = SERIAL.lock().unwrap();
 
@@ -161,6 +163,8 @@ fn test_hang_monitoring_unregister() {
 }
 
 #[test]
+// https://github.com/servo/servo/issues/28270
+#[cfg(not(target_os = "windows"))]
 fn test_hang_monitoring_exit_signal() {
     let _lock = SERIAL.lock().unwrap();
 

--- a/components/background_hang_monitor/tests/hang_monitor_tests.rs
+++ b/components/background_hang_monitor/tests/hang_monitor_tests.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#![allow(unused_imports)]
+
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
This avoids long-running builds due to #28270.