### PR TITLE
Drop impls for DOM types should be forbidden

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,6 +3880,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0419348c027fa7be448d2ae7ea0e4e04c2334c31dc4e74ab29f00a2a7ca69204"
 
 [[package]]
+name = "must_root"
+version = "0.0.1"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "naga"
 version = "0.2.0"
 source = "git+https://github.com/gfx-rs/naga?rev=b278e10ea7c144b2387585c4e81c1d86db8e2def#b278e10ea7c144b2387585c4e81c1d86db8e2def"
@@ -5169,6 +5177,7 @@ dependencies = [
  "mozangle",
  "mozjs",
  "msg",
+ "must_root",
  "net_traits",
  "num-traits",
  "parking_lot 0.10.2",

--- a/components/dom_struct/lib.rs
+++ b/components/dom_struct/lib.rs
@@ -16,8 +16,8 @@ pub fn dom_struct(args: TokenStream, input: TokenStream) -> TokenStream {
         panic!("#[dom_struct] takes no arguments");
     }
     let attributes = quote! {
+        #[must_root::must_root]
         #[derive(DenyPublicFields, DomObject, JSTraceable, MallocSizeOf)]
-        #[unrooted_must_root_lint::must_root]
         #[repr(C)]
     };
 

--- a/components/media/lib.rs
+++ b/components/media/lib.rs
@@ -14,8 +14,8 @@ extern crate serde;
 mod media_channel;
 mod media_thread;
 
-pub use crate::media_channel::glplayer_channel;
-use crate::media_channel::{GLPlayerChan, GLPlayerPipeline, GLPlayerReceiver, GLPlayerSender};
+pub use crate::media_channel::{glplayer_channel, GLPlayerPipeline};
+use crate::media_channel::{GLPlayerChan, GLPlayerReceiver, GLPlayerSender};
 use crate::media_thread::GLPlayerThread;
 use euclid::default::Size2D;
 use servo_media::player::context::{GlApi, GlContext, NativeDisplay, PlayerGLContext};

--- a/components/media/media_channel/mod.rs
+++ b/components/media/media_channel/mod.rs
@@ -104,7 +104,7 @@ impl GLPlayerChan {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, JSTraceable, MallocSizeOf)]
 pub struct GLPlayerPipeline(pub GLPlayerChan);
 
 impl GLPlayerPipeline {

--- a/components/must_root/Cargo.toml
+++ b/components/must_root/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+authors = ["The Servo Project Developers"]
+license = "MPL-2.0"
+name = "must_root"
+publish = false
+version = "0.0.1"
+
+[dependencies]
+quote = "1"
+syn = { version = "1", default-features = false, features = ["clone-impls", "parsing"] }
+
+[lib]
+path = "lib.rs"
+proc-macro = true

--- a/components/must_root/lib.rs
+++ b/components/must_root/lib.rs
@@ -2,50 +2,50 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
- extern crate proc_macro;
- #[macro_use]
- extern crate quote;
- extern crate syn;
- 
- use proc_macro::TokenStream;
- use syn::*;
- 
- #[proc_macro_attribute]
- pub fn must_root(args: TokenStream, input: TokenStream) -> TokenStream {
-     if !args.is_empty() {
-         panic!("#[must_root] takes no arguments");
-     }
-     let attributes = quote! {
-         #[unrooted_must_root_lint::must_root_type]
-     };
+extern crate proc_macro;
+#[macro_use]
+extern crate quote;
+extern crate syn;
 
-     // Work around https://github.com/rust-lang/rust/issues/46489
-     let attributes: TokenStream = attributes.to_string().parse().unwrap();
+use proc_macro::TokenStream;
+use syn::*;
 
-     let output: TokenStream = attributes.into_iter().chain(input.into_iter()).collect();
- 
-     let item: Item = syn::parse(output).unwrap();
+#[proc_macro_attribute]
+pub fn must_root(args: TokenStream, input: TokenStream) -> TokenStream {
+    if !args.is_empty() {
+        panic!("#[must_root] takes no arguments");
+    }
+    let attributes = quote! {
+        #[unrooted_must_root_lint::must_root_type]
+    };
 
-     if let Item::Struct(s) = item {
-         let s2 = s.clone();
-         if s.generics.params.len() > 0 {
-             return quote!(#s2).into();
-         }
-         if let Fields::Named(_) = s.fields {
-             let name = &s.ident;
+    // Work around https://github.com/rust-lang/rust/issues/46489
+    let attributes: TokenStream = attributes.to_string().parse().unwrap();
 
-             quote! (
-                 #s2
+    let output: TokenStream = attributes.into_iter().chain(input.into_iter()).collect();
 
-                 impl Drop for #name {
-                     fn drop(&mut self) {}
-                 }
-             )
-             .into()
-         } else {
-             panic!("#[must_root] only applies to structs with named fields");
-         }
-     } else {
-         panic!("#[must_root] only applies to structs");
-     }
- }
+    let item: Item = syn::parse(output).unwrap();
+
+    if let Item::Struct(s) = item {
+        let s2 = s.clone();
+        if s.generics.params.len() > 0 {
+            return quote!(#s2).into();
+        }
+        if let Fields::Named(_) = s.fields {
+            let name = &s.ident;
+
+            quote! (
+                #s2
+
+                impl Drop for #name {
+                    fn drop(&mut self) {}
+                }
+            )
+            .into()
+        } else {
+            panic!("#[must_root] only applies to structs with named fields");
+        }
+    } else {
+        panic!("#[must_root] only applies to structs");
+    }
+}

--- a/components/must_root/lib.rs
+++ b/components/must_root/lib.rs
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+ extern crate proc_macro;
+ #[macro_use]
+ extern crate quote;
+ extern crate syn;
+ 
+ use proc_macro::TokenStream;
+ use syn::*;
+ 
+ #[proc_macro_attribute]
+ pub fn must_root(args: TokenStream, input: TokenStream) -> TokenStream {
+     if !args.is_empty() {
+         panic!("#[must_root] takes no arguments");
+     }
+     let attributes = quote! {
+         #[unrooted_must_root_lint::must_root_type]
+     };
+
+     // Work around https://github.com/rust-lang/rust/issues/46489
+     let attributes: TokenStream = attributes.to_string().parse().unwrap();
+
+     let output: TokenStream = attributes.into_iter().chain(input.into_iter()).collect();
+ 
+     let item: Item = syn::parse(output).unwrap();
+
+     if let Item::Struct(s) = item {
+         let s2 = s.clone();
+         if s.generics.params.len() > 0 {
+             return quote!(#s2).into();
+         }
+         if let Fields::Named(_) = s.fields {
+             let name = &s.ident;
+
+             quote! (
+                 #s2
+
+                 impl Drop for #name {
+                     fn drop(&mut self) {}
+                 }
+             )
+             .into()
+         } else {
+             panic!("#[must_root] only applies to structs with named fields");
+         }
+     } else {
+         panic!("#[must_root] only applies to structs");
+     }
+ }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -77,6 +77,7 @@ mime = "0.3.13"
 mime_guess = "2.0.0"
 mitochondria = "1.1.2"
 msg = { path = "../msg" }
+must_root = { path = "../must_root" }
 net_traits = { path = "../net_traits" }
 num-traits = "0.2"
 parking_lot = "0.10"

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -173,7 +173,11 @@ pub(crate) struct CanvasState {
 }
 
 impl CanvasState {
-    pub(crate) fn new(global: &GlobalScope, size: Size2D<u64>, remote_canvas_state: RemoteCanvasState) -> CanvasState {
+    pub(crate) fn new(
+        global: &GlobalScope,
+        size: Size2D<u64>,
+        remote_canvas_state: RemoteCanvasState,
+    ) -> CanvasState {
         // Worklets always receive a unique origin. This messes with fetching
         // cached images in the case of paint worklets, since the image cache
         // is keyed on the origin requesting the image data.

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -139,9 +139,9 @@ impl RemoteCanvasState {
         script_to_constellation_chan
             .send(ScriptMsg::CreateCanvasPaintThread(size, sender))
             .unwrap();
-        let remote_canvas_state = receiver.recv().unwrap();
+        let (sender, canvas_id) = receiver.recv().unwrap();
         debug!("Done.");
-        RemoteCanvasState(remote_canvas_state)
+        RemoteCanvasState(sender, canvas_id)
     }
 
     pub(crate) fn get_ipc_renderer(&self) -> &IpcSender<CanvasMsg> {
@@ -187,7 +187,7 @@ impl CanvasState {
             global.origin().immutable().clone()
         };
         CanvasState {
-            ipc_renderer: remote_canvas_state.get_ipc_renderer(),
+            ipc_renderer: remote_canvas_state.get_ipc_renderer().clone(),
             canvas_id: remote_canvas_state.get_canvas_id(),
             state: DomRefCell::new(CanvasContextState::new()),
             origin_clean: Cell::new(true),

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -72,7 +72,7 @@ impl CanvasRenderingContext2D {
                 remote_canvas_state,
             ),
             droppable_fields: DroppableFields {
-                ipc_renderer: remote_canvas_state.get_ipc_renderer(),
+                ipc_renderer: remote_canvas_state.get_ipc_renderer().clone(),
                 canvas_id: remote_canvas_state.get_canvas_id(),
             },
         }

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -31,6 +31,7 @@ use ipc_channel::ipc::IpcSender;
 use servo_url::ServoUrl;
 use std::mem;
 
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableFields {
     ipc_renderer: IpcSender<CanvasMsg>,
     canvas_id: CanvasId,

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -38,10 +38,7 @@ struct DroppableFields {
 
 impl Drop for DroppableFields {
     fn drop(&mut self) {
-        if let Err(err) = self
-            .ipc_renderer
-            .send(CanvasMsg::Close(self.canvas_id))
-        {
+        if let Err(err) = self.ipc_renderer.send(CanvasMsg::Close(self.canvas_id)) {
             warn!("Could not close canvas: {}", err)
         }
     }
@@ -64,7 +61,8 @@ impl CanvasRenderingContext2D {
         canvas: Option<&HTMLCanvasElement>,
         size: Size2D<u32>,
     ) -> CanvasRenderingContext2D {
-        let remote_canvas_state = RemoteCanvasState::new(global, Size2D::new(size.width as u64, size.height as u64));
+        let remote_canvas_state =
+            RemoteCanvasState::new(global, Size2D::new(size.width as u64, size.height as u64));
         CanvasRenderingContext2D {
             reflector_: Reflector::new(),
             canvas: canvas.map(Dom::from_ref),
@@ -76,7 +74,7 @@ impl CanvasRenderingContext2D {
             droppable_fields: DroppableFields {
                 ipc_renderer: remote_canvas_state.get_ipc_renderer(),
                 canvas_id: remote_canvas_state.get_canvas_id(),
-            }
+            },
         }
     }
 

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -56,6 +56,7 @@ enum ReadyState {
     Closed = 2,
 }
 
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableFields {
     canceller: DomRefCell<FetchCanceller>,
 }

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -56,6 +56,19 @@ enum ReadyState {
     Closed = 2,
 }
 
+struct DroppableFields {
+    canceller: DomRefCell<FetchCanceller>,
+}
+
+// https://html.spec.whatwg.org/multipage/#garbage-collection-2
+impl Drop for DroppableFields {
+    fn drop(&mut self) {
+        // If an EventSource object is garbage collected while its connection is still open,
+        // the user agent must abort any instance of the fetch algorithm opened by this EventSource.
+        self.canceller.borrow_mut().cancel();
+    }
+}
+
 #[dom_struct]
 pub struct EventSource {
     eventtarget: EventTarget,
@@ -67,7 +80,7 @@ pub struct EventSource {
 
     ready_state: Cell<ReadyState>,
     with_credentials: bool,
-    canceller: DomRefCell<FetchCanceller>,
+    droppable_fields: DroppableFields,
 }
 
 enum ParserState {
@@ -455,7 +468,9 @@ impl EventSource {
 
             ready_state: Cell::new(ReadyState::Connecting),
             with_credentials: with_credentials,
-            canceller: DomRefCell::new(Default::default()),
+            droppable_fields: DroppableFields {
+                canceller: DomRefCell::new(Default::default()),
+            },
         }
     }
 
@@ -468,7 +483,7 @@ impl EventSource {
 
     // https://html.spec.whatwg.org/multipage/#sse-processing-model:fail-the-connection-3
     pub fn cancel(&self) {
-        self.canceller.borrow_mut().cancel();
+        self.droppable_fields.canceller.borrow_mut().cancel();
         self.fail_the_connection();
     }
 
@@ -577,7 +592,7 @@ impl EventSource {
                 listener.notify_fetch(message.to().unwrap());
             }),
         );
-        let cancel_receiver = ev.canceller.borrow_mut().initialize();
+        let cancel_receiver = ev.droppable_fields.canceller.borrow_mut().initialize();
         global
             .core_resource_thread()
             .send(CoreResourceMsg::Fetch(
@@ -587,15 +602,6 @@ impl EventSource {
             .unwrap();
         // Step 13
         Ok(ev)
-    }
-}
-
-// https://html.spec.whatwg.org/multipage/#garbage-collection-2
-impl Drop for EventSource {
-    fn drop(&mut self) {
-        // If an EventSource object is garbage collected while its connection is still open,
-        // the user agent must abort any instance of the fetch algorithm opened by this EventSource.
-        self.canceller.borrow_mut().cancel();
     }
 }
 
@@ -628,7 +634,7 @@ impl EventSourceMethods for EventSource {
     fn Close(&self) {
         let GenerationId(prev_id) = self.generation_id.get();
         self.generation_id.set(GenerationId(prev_id + 1));
-        self.canceller.borrow_mut().cancel();
+        self.droppable_fields.canceller.borrow_mut().cancel();
         self.ready_state.set(ReadyState::Closed);
     }
 }

--- a/components/script/dom/gpubuffer.rs
+++ b/components/script/dom/gpubuffer.rs
@@ -176,7 +176,7 @@ impl GPUBuffer {
                 buffer,
                 map_promise: DomRefCell::new(None),
                 map_info,
-            }
+            },
         }
     }
 
@@ -193,7 +193,14 @@ impl GPUBuffer {
     ) -> DomRoot<Self> {
         reflect_dom_object(
             Box::new(GPUBuffer::new_inherited(
-                channel, buffer, device, state, size, map_info, label, global.get_cx(),
+                channel,
+                buffer,
+                device,
+                state,
+                size,
+                map_info,
+                label,
+                global.get_cx(),
             )),
             global,
         )
@@ -283,7 +290,9 @@ impl GPUBufferMethods for GPUBuffer {
             return promise;
         }
 
-        self.droppable_field.state.set(GPUBufferState::MappingPending);
+        self.droppable_field
+            .state
+            .set(GPUBufferState::MappingPending);
         *self.droppable_field.map_info.borrow_mut() = Some(GPUBufferMapInfo {
             mapping: Rc::new(RefCell::new(Vec::with_capacity(0))),
             mapping_range: map_range,
@@ -386,11 +395,10 @@ impl AsyncWGPUListener for GPUBuffer {
             },
         }
         *self.droppable_field.map_promise.borrow_mut() = None;
-        if let Err(e) = self
-            .channel
-            .0
-            .send((None, WebGPURequest::BufferMapComplete(self.droppable_field.buffer.0)))
-        {
+        if let Err(e) = self.channel.0.send((
+            None,
+            WebGPURequest::BufferMapComplete(self.droppable_field.buffer.0),
+        )) {
             warn!(
                 "Failed to send BufferMapComplete({:?}) ({})",
                 self.droppable_field.buffer.0, e

--- a/components/script/dom/gpucommandbuffer.rs
+++ b/components/script/dom/gpucommandbuffer.rs
@@ -65,7 +65,7 @@ impl GPUCommandBuffer {
             droppable_field: DroppableField {
                 channel,
                 command_buffer,
-            }
+            },
         }
     }
 

--- a/components/script/dom/gpucommandbuffer.rs
+++ b/components/script/dom/gpucommandbuffer.rs
@@ -22,7 +22,7 @@ impl Hash for DomRoot<GPUBuffer> {
     }
 }
 
-#[derive(MallocSizeOf)]
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
     #[ignore_malloc_size_of = "defined in webgpu"]
     channel: WebGPU,

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -139,7 +139,7 @@ impl GPUTexture {
 
 impl GPUTexture {
     pub fn id(&self) -> WebGPUTexture {
-        self.texture
+        self.droppable_field.texture
     }
 }
 
@@ -202,12 +202,12 @@ impl GPUTextureMethods for GPUTexture {
             .lock()
             .create_texture_view_id(self.device.id().0.backend());
 
-        self.channel
+        self.droppable_field.channel
             .0
             .send((
                 scope_id,
                 WebGPURequest::CreateTextureView {
-                    texture_id: self.texture.0,
+                    texture_id: self.droppable_field.texture.0,
                     texture_view_id,
                     device_id: self.device.id().0,
                     descriptor: desc,

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -26,7 +26,7 @@ use webgpu::{
     WebGPUTextureView,
 };
 
-#[derive(MallocSizeOf)]
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
     texture: WebGPUTexture,
     #[ignore_malloc_size_of = "channels are hard"]

--- a/components/script/dom/gputexture.rs
+++ b/components/script/dom/gputexture.rs
@@ -102,7 +102,7 @@ impl GPUTexture {
                 texture,
                 channel,
                 destroyed: Cell::new(false),
-            }
+            },
         }
     }
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -74,7 +74,7 @@ use html5ever::{LocalName, Prefix};
 use http::header::{self, HeaderMap, HeaderValue};
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
-use media::{glplayer_channel, GLPlayerPipeline, GLPlayerMsg, GLPlayerMsgForward, WindowGLContext};
+use media::{glplayer_channel, GLPlayerMsg, GLPlayerMsgForward, GLPlayerPipeline, WindowGLContext};
 use net_traits::image::base::Image;
 use net_traits::image_cache::ImageResponse;
 use net_traits::request::Destination;
@@ -2449,7 +2449,8 @@ impl VirtualMethods for HTMLMediaElement {
                     self.render_controls();
                 } else {
                     let root = &self.droppable_field.root.unwrap();
-                    self.droppable_field.remove_controls(DomRoot::from_ref(root));
+                    self.droppable_field
+                        .remove_controls(DomRoot::from_ref(root));
                 }
             },
             _ => (),

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1443,7 +1443,7 @@ impl HTMLMediaElement {
             })
             .unwrap_or((0, None));
 
-        self.id.set(player_id);
+        self.droppable_field.id.set(player_id);
         self.video_renderer.lock().unwrap().player_id = Some(player_id);
 
         if let Some(image_receiver) = image_receiver {
@@ -1915,7 +1915,7 @@ impl HTMLMediaElement {
         // `id` needs to match the internally generated UUID assigned to a media element.
         let id = document.register_media_controls(&shadow_root);
         let media_controls_script = media_controls_script.as_mut_str().replace("@@@id@@@", &id);
-        *self.media_controls_id.borrow_mut() = Some(id);
+        *self.droppable_field.media_controls_id.borrow_mut() = Some(id);
         script
             .upcast::<Node>()
             .SetTextContent(Some(DOMString::from(media_controls_script)));

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -297,6 +297,7 @@ impl From<MediaStreamOrBlob> for SrcObject {
     }
 }
 
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
     /// Player Id reported the player thread
     id: Cell<u64>,

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::canvas_state::CanvasState;
+use crate::canvas_state::{CanvasState, RemoteCanvasState};
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasDirection;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasFillRule;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasImageSource;
@@ -49,7 +49,7 @@ impl OffscreenCanvasRenderingContext2D {
             reflector_: Reflector::new(),
             canvas: Dom::from_ref(canvas),
             htmlcanvas: htmlcanvas.map(Dom::from_ref),
-            canvas_state: CanvasState::new(global, canvas.get_size()),
+            canvas_state: CanvasState::new(global, canvas.get_size(), RemoteCanvasState::new(global, canvas.get_size())),
         }
     }
 

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -78,7 +78,9 @@ impl PromiseHelper for Rc<Promise> {
     #[allow(unsafe_code)]
     fn initialize(&self, cx: SafeJSContext) {
         let obj = self.reflector().get_jsobject();
-        self.droppable_field.permanent_js_root.set(ObjectValue(*obj));
+        self.droppable_field
+            .permanent_js_root
+            .set(ObjectValue(*obj));
         unsafe {
             assert!(AddRawValueRoot(
                 *cx,
@@ -117,7 +119,7 @@ impl Promise {
                 reflector: Reflector::new(),
                 droppable_field: DroppableField {
                     permanent_js_root: Heap::default(),
-                }
+                },
             };
             let promise = Rc::new(promise);
             promise.init_reflector(obj.get());

--- a/components/script/dom/rtcdatachannel.rs
+++ b/components/script/dom/rtcdatachannel.rs
@@ -143,8 +143,8 @@ impl RTCDataChannel {
         );
         event.upcast::<Event>().fire(self.upcast());
 
-        self.peer_connection
-            .unregister_data_channel(&self.servo_media_id);
+        self.droppable_field.peer_connection
+            .unregister_data_channel(&self.droppable_field.servo_media_id);
     }
 
     pub fn on_error(&self, error: WebRtcError) {
@@ -241,11 +241,11 @@ impl RTCDataChannel {
             SendSource::ArrayBufferView(array) => DataChannelMessage::Binary(array.to_vec()),
         };
 
-        let controller = self.peer_connection.get_webrtc_controller().borrow();
+        let controller = self.droppable_field.peer_connection.get_webrtc_controller().borrow();
         controller
             .as_ref()
             .unwrap()
-            .send_data_channel_message(&self.servo_media_id, message);
+            .send_data_channel_message(&self.droppable_field.servo_media_id, message);
 
         Ok(())
     }
@@ -324,11 +324,11 @@ impl RTCDataChannelMethods for RTCDataChannel {
 
     // https://www.w3.org/TR/webrtc/#dom-rtcdatachannel-close
     fn Close(&self) {
-        let controller = self.peer_connection.get_webrtc_controller().borrow();
+        let controller = self.droppable_field.peer_connection.get_webrtc_controller().borrow();
         controller
             .as_ref()
             .unwrap()
-            .close_data_channel(&self.servo_media_id);
+            .close_data_channel(&self.droppable_field.servo_media_id);
     }
 
     // https://www.w3.org/TR/webrtc/#dom-datachannel-binarytype

--- a/components/script/dom/rtcdatachannel.rs
+++ b/components/script/dom/rtcdatachannel.rs
@@ -96,7 +96,7 @@ impl RTCDataChannel {
             droppable_field: DroppableField {
                 servo_media_id,
                 peer_connection: Dom::from_ref(&peer_connection),
-            }
+            },
         };
 
         channel

--- a/components/script/dom/webglbuffer.rs
+++ b/components/script/dom/webglbuffer.rs
@@ -21,6 +21,7 @@ fn target_is_copy_buffer(target: u32) -> bool {
         target == WebGL2RenderingContextConstants::COPY_WRITE_BUFFER
 }
 
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
     id: WebGLBufferId,
     marked_for_deletion: Cell<bool>,

--- a/components/script/dom/webglbuffer.rs
+++ b/components/script/dom/webglbuffer.rs
@@ -42,8 +42,12 @@ impl DroppableField {
         assert!(self.is_deleted());
         let cmd = WebGLCommand::DeleteBuffer(self.id);
         match operation_fallibility {
-            Operation::Fallible => self.sender.send(cmd, stub_webgl_backtrace()),
-            Operation::Infallible => self.sender.send(cmd, stub_webgl_backtrace()).unwrap(),
+            Operation::Fallible => {
+                let _ = self.sender.send(cmd, stub_webgl_backtrace());
+            },
+            Operation::Infallible => {
+                self.sender.send(cmd, stub_webgl_backtrace()).unwrap();
+            },
         }
     }
 

--- a/components/script/dom/webglbuffer.rs
+++ b/components/script/dom/webglbuffer.rs
@@ -6,7 +6,7 @@
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants;
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextConstants;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
-use crate::dom::bindings::root::{DomRoot, Dom};
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::webglobject::WebGLObject;
 use crate::dom::webglrenderingcontext::{Operation, WebGLRenderingContext};
 use canvas_traits::webgl::webgl_channel;
@@ -85,7 +85,7 @@ impl WebGLBuffer {
                 marked_for_deletion: Default::default(),
                 attached_counter: Default::default(),
                 context: Dom::from_ref(context),
-            }
+            },
         }
     }
 
@@ -140,7 +140,8 @@ impl WebGLBuffer {
     }
 
     pub fn mark_for_deletion(&self, operation_fallibility: Operation) {
-        self.droppable_field.mark_for_deletion(operation_fallibility);
+        self.droppable_field
+            .mark_for_deletion(operation_fallibility);
     }
 
     fn delete(&self, operation_fallibility: Operation) {
@@ -186,7 +187,8 @@ impl WebGLBuffer {
 
     pub fn increment_attached_counter(&self) {
         self.droppable_field.attached_counter.set(
-            self.droppable_field.attached_counter
+            self.droppable_field
+                .attached_counter
                 .get()
                 .checked_add(1)
                 .expect("refcount overflowed"),
@@ -195,7 +197,8 @@ impl WebGLBuffer {
 
     pub fn decrement_attached_counter(&self, operation_fallibility: Operation) {
         self.droppable_field.attached_counter.set(
-            self.droppable_field.attached_counter
+            self.droppable_field
+                .attached_counter
                 .get()
                 .checked_sub(1)
                 .expect("refcount underflowed"),

--- a/components/script/dom/webglbuffer.rs
+++ b/components/script/dom/webglbuffer.rs
@@ -8,7 +8,7 @@ use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGL
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::{DomRoot};
 use crate::dom::webglobject::WebGLObject;
-use crate::dom::webglrenderingcontext::{Operation, WebGLRenderingContext, WebGLMessageSender, capture_webgl_backtrace};
+use crate::dom::webglrenderingcontext::{Operation, WebGLRenderingContext, WebGLMessageSender, stub_webgl_backtrace};
 use canvas_traits::webgl::webgl_channel;
 use canvas_traits::webgl::{WebGLBufferId, WebGLCommand, WebGLError, WebGLResult};
 use dom_struct::dom_struct;
@@ -42,8 +42,8 @@ impl DroppableField {
         assert!(self.is_deleted());
         let cmd = WebGLCommand::DeleteBuffer(self.id);
         match operation_fallibility {
-            Operation::Fallible => self.sender.send(cmd, capture_webgl_backtrace()),
-            Operation::Infallible => self.sender.send(cmd, capture_webgl_backtrace()).unwrap(),
+            Operation::Fallible => self.sender.send(cmd, stub_webgl_backtrace()),
+            Operation::Infallible => self.sender.send(cmd, stub_webgl_backtrace()).unwrap(),
         }
     }
 
@@ -128,8 +128,8 @@ impl WebGLBuffer {
         self.capacity.set(data.len());
         self.usage.set(usage);
         let (sender, receiver) = ipc::bytes_channel().unwrap();
-        self.droppable_field
-            .context
+        self.upcast::<WebGLObject>()
+            .context()
             .send_command(WebGLCommand::BufferData(target, receiver, usage));
         sender.send(data).unwrap();
         Ok(())

--- a/components/script/dom/webglbuffer.rs
+++ b/components/script/dom/webglbuffer.rs
@@ -5,6 +5,7 @@
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants;
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextConstants;
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::{DomRoot};
 use crate::dom::webglobject::WebGLObject;
@@ -153,7 +154,7 @@ impl WebGLBuffer {
     }
 
     pub fn is_marked_for_deletion(&self) -> bool {
-        self.droppable_field.is_marked_for_deletion();
+        self.droppable_field.marked_for_deletion.get()
     }
 
     pub fn is_deleted(&self) -> bool {

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -84,6 +84,7 @@ pub enum WebGLFramebufferAttachmentRoot {
     Texture(DomRoot<WebGLTexture>),
 }
 
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
     id: WebGLFramebufferId,
     is_deleted: Cell<bool>,

--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -96,8 +96,12 @@ impl DroppableField {
             self.is_deleted.set(true);
             let cmd = WebGLCommand::DeleteFramebuffer(self.id);
             match operation_fallibility {
-                Operation::Fallible => self.sender.send(cmd, stub_webgl_backtrace()),
-                Operation::Infallible => self.sender.send(cmd, stub_webgl_backtrace()).unwrap(),
+                Operation::Fallible => {
+                    let _ = self.sender.send(cmd, stub_webgl_backtrace());
+                },
+                Operation::Infallible => {
+                    self.sender.send(cmd, stub_webgl_backtrace()).unwrap();
+                },
             }
         }
     }

--- a/components/script/dom/webglprogram.rs
+++ b/components/script/dom/webglprogram.rs
@@ -6,6 +6,7 @@
 use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants2;
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextConstants as constants;
+use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
@@ -60,6 +61,10 @@ impl DroppableField {
         if self.is_deleted() {
             self.detach_shaders();
         }
+    }
+
+    pub fn is_deleted(&self) -> bool {
+        self.marked_for_deletion.get() && !self.is_in_use.get()
     }
 
     fn detach_shaders(&self) {
@@ -164,7 +169,7 @@ impl WebGLProgram {
     }
 
     pub fn is_deleted(&self) -> bool {
-        self.droppable_field.marked_for_deletion.get() && !self.droppable_field.is_in_use.get()
+        self.droppable_field.is_deleted()
     }
 
     pub fn is_linked(&self) -> bool {

--- a/components/script/dom/webglprogram.rs
+++ b/components/script/dom/webglprogram.rs
@@ -23,6 +23,7 @@ use dom_struct::dom_struct;
 use fnv::FnvHashSet;
 use std::cell::Cell;
 
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
     id: WebGLProgramId,
     marked_for_deletion: Cell<bool>,

--- a/components/script/dom/webglprogram.rs
+++ b/components/script/dom/webglprogram.rs
@@ -6,9 +6,8 @@
 use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants2;
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextConstants as constants;
-use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{reflect_dom_object, DomObject};
-use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::webglactiveinfo::WebGLActiveInfo;
 use crate::dom::webglobject::WebGLObject;
@@ -23,66 +22,16 @@ use dom_struct::dom_struct;
 use fnv::FnvHashSet;
 use std::cell::Cell;
 
-#[dom_struct]
-pub struct WebGLProgram {
-    webgl_object: WebGLObject,
+struct DroppableField {
     id: WebGLProgramId,
-    is_in_use: Cell<bool>,
     marked_for_deletion: Cell<bool>,
-    link_called: Cell<bool>,
-    linked: Cell<bool>,
-    link_generation: Cell<u64>,
+    is_in_use: Cell<bool>,
     fragment_shader: MutNullableDom<WebGLShader>,
     vertex_shader: MutNullableDom<WebGLShader>,
-    active_attribs: DomRefCell<Box<[ActiveAttribInfo]>>,
-    active_uniforms: DomRefCell<Box<[ActiveUniformInfo]>>,
-    active_uniform_blocks: DomRefCell<Box<[ActiveUniformBlockInfo]>>,
-    transform_feedback_varyings_length: Cell<i32>,
-    transform_feedback_mode: Cell<i32>,
+    context: WebGLRenderingContext,
 }
 
-impl WebGLProgram {
-    fn new_inherited(context: &WebGLRenderingContext, id: WebGLProgramId) -> Self {
-        Self {
-            webgl_object: WebGLObject::new_inherited(context),
-            id: id,
-            is_in_use: Default::default(),
-            marked_for_deletion: Default::default(),
-            link_called: Default::default(),
-            linked: Default::default(),
-            link_generation: Default::default(),
-            fragment_shader: Default::default(),
-            vertex_shader: Default::default(),
-            active_attribs: DomRefCell::new(vec![].into()),
-            active_uniforms: DomRefCell::new(vec![].into()),
-            active_uniform_blocks: DomRefCell::new(vec![].into()),
-            transform_feedback_varyings_length: Default::default(),
-            transform_feedback_mode: Default::default(),
-        }
-    }
-
-    pub fn maybe_new(context: &WebGLRenderingContext) -> Option<DomRoot<Self>> {
-        let (sender, receiver) = webgl_channel().unwrap();
-        context.send_command(WebGLCommand::CreateProgram(sender));
-        receiver
-            .recv()
-            .unwrap()
-            .map(|id| WebGLProgram::new(context, id))
-    }
-
-    pub fn new(context: &WebGLRenderingContext, id: WebGLProgramId) -> DomRoot<Self> {
-        reflect_dom_object(
-            Box::new(WebGLProgram::new_inherited(context, id)),
-            &*context.global(),
-        )
-    }
-}
-
-impl WebGLProgram {
-    pub fn id(&self) -> WebGLProgramId {
-        self.id
-    }
-
+impl DroppableField {
     /// glDeleteProgram
     pub fn mark_for_deletion(&self, operation_fallibility: Operation) {
         if self.marked_for_deletion.get() {
@@ -90,10 +39,9 @@ impl WebGLProgram {
         }
         self.marked_for_deletion.set(true);
         let cmd = WebGLCommand::DeleteProgram(self.id);
-        let context = self.upcast::<WebGLObject>().context();
         match operation_fallibility {
-            Operation::Fallible => context.send_command_ignored(cmd),
-            Operation::Infallible => context.send_command(cmd),
+            Operation::Fallible => self.context.send_command_ignored(cmd),
+            Operation::Infallible => self.context.send_command(cmd),
         }
         if self.is_deleted() {
             self.detach_shaders();
@@ -121,17 +69,98 @@ impl WebGLProgram {
             self.vertex_shader.set(None);
         }
     }
+}
+
+impl Drop for DroppableField {
+    fn drop(&mut self) {
+        self.in_use(false);
+        self.mark_for_deletion(Operation::Fallible);
+    }
+}
+
+#[dom_struct]
+pub struct WebGLProgram {
+    webgl_object: WebGLObject,
+    link_called: Cell<bool>,
+    linked: Cell<bool>,
+    link_generation: Cell<u64>,
+    active_attribs: DomRefCell<Box<[ActiveAttribInfo]>>,
+    active_uniforms: DomRefCell<Box<[ActiveUniformInfo]>>,
+    active_uniform_blocks: DomRefCell<Box<[ActiveUniformBlockInfo]>>,
+    transform_feedback_varyings_length: Cell<i32>,
+    transform_feedback_mode: Cell<i32>,
+    droppable_field: DroppableField,
+}
+
+impl WebGLProgram {
+    fn new_inherited(context: &WebGLRenderingContext, id: WebGLProgramId) -> Self {
+        Self {
+            webgl_object: WebGLObject::new_inherited(context),
+            link_called: Default::default(),
+            linked: Default::default(),
+            link_generation: Default::default(),
+            active_attribs: DomRefCell::new(vec![].into()),
+            active_uniforms: DomRefCell::new(vec![].into()),
+            active_uniform_blocks: DomRefCell::new(vec![].into()),
+            transform_feedback_varyings_length: Default::default(),
+            transform_feedback_mode: Default::default(),
+            droppable_field: DroppableField {
+                id,
+                is_in_use: Default::default(),
+                marked_for_deletion: Default::default(),
+                fragment_shader: Default::default(),
+                vertex_shader: Default::default(),
+                context: Dom::from_ref(context),
+            },
+        }
+    }
+
+    pub fn maybe_new(context: &WebGLRenderingContext) -> Option<DomRoot<Self>> {
+        let (sender, receiver) = webgl_channel().unwrap();
+        context.send_command(WebGLCommand::CreateProgram(sender));
+        receiver
+            .recv()
+            .unwrap()
+            .map(|id| WebGLProgram::new(context, id))
+    }
+
+    pub fn new(context: &WebGLRenderingContext, id: WebGLProgramId) -> DomRoot<Self> {
+        reflect_dom_object(
+            Box::new(WebGLProgram::new_inherited(context, id)),
+            &*context.global(),
+        )
+    }
+}
+
+impl WebGLProgram {
+    pub fn id(&self) -> WebGLProgramId {
+        self.droppable_field.id
+    }
+
+    /// glDeleteProgram
+    pub fn mark_for_deletion(&self, operation_fallibility: Operation) {
+        self.droppable_field
+            .mark_for_deletion(operation_fallibility);
+    }
+
+    pub fn in_use(&self, value: bool) {
+        self.droppable_field.in_use(value);
+    }
+
+    fn detach_shaders(&self) {
+        self.droppable_field.detach_shaders();
+    }
 
     pub fn is_in_use(&self) -> bool {
-        self.is_in_use.get()
+        self.droppable_field.is_in_use.get()
     }
 
     pub fn is_marked_for_deletion(&self) -> bool {
-        self.marked_for_deletion.get()
+        self.droppable_field.marked_for_deletion.get()
     }
 
     pub fn is_deleted(&self) -> bool {
-        self.marked_for_deletion.get() && !self.is_in_use.get()
+        self.droppable_field.marked_for_deletion.get() && !self.droppable_field.is_in_use.get()
     }
 
     pub fn is_linked(&self) -> bool {
@@ -147,20 +176,20 @@ impl WebGLProgram {
         *self.active_uniforms.borrow_mut() = Box::new([]);
         *self.active_uniform_blocks.borrow_mut() = Box::new([]);
 
-        match self.fragment_shader.get() {
+        match self.droppable_field.fragment_shader.get() {
             Some(ref shader) if shader.successfully_compiled() => {},
             _ => return Ok(()), // callers use gl.LINK_STATUS to check link errors
         }
 
-        match self.vertex_shader.get() {
+        match self.droppable_field.vertex_shader.get() {
             Some(ref shader) if shader.successfully_compiled() => {},
             _ => return Ok(()), // callers use gl.LINK_STATUS to check link errors
         }
 
         let (sender, receiver) = webgl_channel().unwrap();
-        self.upcast::<WebGLObject>()
-            .context()
-            .send_command(WebGLCommand::LinkProgram(self.id, sender));
+        self.droppable_field
+            .context
+            .send_command(WebGLCommand::LinkProgram(self.droppable_field.id, sender));
         let link_info = receiver.recv().unwrap();
 
         {
@@ -221,9 +250,9 @@ impl WebGLProgram {
         if self.is_deleted() {
             return Err(WebGLError::InvalidOperation);
         }
-        self.upcast::<WebGLObject>()
-            .context()
-            .send_command(WebGLCommand::ValidateProgram(self.id));
+        self.droppable_field
+            .context
+            .send_command(WebGLCommand::ValidateProgram(self.droppable_field.id));
         Ok(())
     }
 
@@ -233,8 +262,8 @@ impl WebGLProgram {
             return Err(WebGLError::InvalidOperation);
         }
         let shader_slot = match shader.gl_type() {
-            constants::FRAGMENT_SHADER => &self.fragment_shader,
-            constants::VERTEX_SHADER => &self.vertex_shader,
+            constants::FRAGMENT_SHADER => &self.droppable_field.fragment_shader,
+            constants::VERTEX_SHADER => &self.droppable_field.vertex_shader,
             _ => {
                 error!("detachShader: Unexpected shader type");
                 return Err(WebGLError::InvalidValue);
@@ -248,9 +277,12 @@ impl WebGLProgram {
         shader_slot.set(Some(shader));
         shader.increment_attached_counter();
 
-        self.upcast::<WebGLObject>()
-            .context()
-            .send_command(WebGLCommand::AttachShader(self.id, shader.id()));
+        self.droppable_field
+            .context
+            .send_command(WebGLCommand::AttachShader(
+                self.droppable_field.id,
+                shader.id(),
+            ));
 
         Ok(())
     }
@@ -261,8 +293,8 @@ impl WebGLProgram {
             return Err(WebGLError::InvalidOperation);
         }
         let shader_slot = match shader.gl_type() {
-            constants::FRAGMENT_SHADER => &self.fragment_shader,
-            constants::VERTEX_SHADER => &self.vertex_shader,
+            constants::FRAGMENT_SHADER => &self.droppable_field.fragment_shader,
+            constants::VERTEX_SHADER => &self.droppable_field.vertex_shader,
             _ => return Err(WebGLError::InvalidValue),
         };
 
@@ -277,9 +309,12 @@ impl WebGLProgram {
         shader_slot.set(None);
         shader.decrement_attached_counter();
 
-        self.upcast::<WebGLObject>()
-            .context()
-            .send_command(WebGLCommand::DetachShader(self.id, shader.id()));
+        self.droppable_field
+            .context
+            .send_command(WebGLCommand::DetachShader(
+                self.droppable_field.id,
+                shader.id(),
+            ));
 
         Ok(())
     }
@@ -297,10 +332,10 @@ impl WebGLProgram {
             return Err(WebGLError::InvalidOperation);
         }
 
-        self.upcast::<WebGLObject>()
-            .context()
+        self.droppable_field
+            .context
             .send_command(WebGLCommand::BindAttribLocation(
-                self.id,
+                self.droppable_field.id,
                 index,
                 name.into(),
             ));
@@ -376,10 +411,10 @@ impl WebGLProgram {
         }
 
         let (sender, receiver) = webgl_channel().unwrap();
-        self.upcast::<WebGLObject>()
-            .context()
+        self.droppable_field
+            .context
             .send_command(WebGLCommand::GetFragDataLocation(
-                self.id,
+                self.droppable_field.id,
                 name.into(),
                 sender,
             ));
@@ -424,21 +459,21 @@ impl WebGLProgram {
         };
 
         let (sender, receiver) = webgl_channel().unwrap();
-        self.upcast::<WebGLObject>()
-            .context()
+        self.droppable_field
+            .context
             .send_command(WebGLCommand::GetUniformLocation(
-                self.id,
+                self.droppable_field.id,
                 name.into(),
                 sender,
             ));
         let location = receiver.recv().unwrap();
-        let context_id = self.upcast::<WebGLObject>().context().context_id();
+        let context_id = self.droppable_field.context.context_id();
 
         Ok(Some(WebGLUniformLocation::new(
             self.global().as_window(),
             location,
             context_id,
-            self.id,
+            self.droppable_field.id,
             self.link_generation.get(),
             size,
             type_,
@@ -455,10 +490,10 @@ impl WebGLProgram {
         }
 
         let (sender, receiver) = webgl_channel().unwrap();
-        self.upcast::<WebGLObject>()
-            .context()
+        self.droppable_field
+            .context
             .send_command(WebGLCommand::GetUniformBlockIndex(
-                self.id,
+                self.droppable_field.id,
                 name.into(),
                 sender,
             ));
@@ -485,9 +520,13 @@ impl WebGLProgram {
             .collect::<Vec<_>>();
 
         let (sender, receiver) = webgl_channel().unwrap();
-        self.upcast::<WebGLObject>()
-            .context()
-            .send_command(WebGLCommand::GetUniformIndices(self.id, names, sender));
+        self.droppable_field
+            .context
+            .send_command(WebGLCommand::GetUniformIndices(
+                self.droppable_field.id,
+                names,
+                sender,
+            ));
         Ok(receiver.recv().unwrap())
     }
 
@@ -512,10 +551,13 @@ impl WebGLProgram {
         }
 
         let (sender, receiver) = webgl_channel().unwrap();
-        self.upcast::<WebGLObject>()
-            .context()
+        self.droppable_field
+            .context
             .send_command(WebGLCommand::GetActiveUniforms(
-                self.id, indices, pname, sender,
+                self.droppable_field.id,
+                indices,
+                pname,
+                sender,
             ));
         Ok(receiver.recv().unwrap())
     }
@@ -544,9 +586,14 @@ impl WebGLProgram {
         }
 
         let (sender, receiver) = webgl_channel().unwrap();
-        self.upcast::<WebGLObject>().context().send_command(
-            WebGLCommand::GetActiveUniformBlockParameter(self.id, block_index, pname, sender),
-        );
+        self.droppable_field
+            .context
+            .send_command(WebGLCommand::GetActiveUniformBlockParameter(
+                self.droppable_field.id,
+                block_index,
+                pname,
+                sender,
+            ));
         Ok(receiver.recv().unwrap())
     }
 
@@ -560,9 +607,13 @@ impl WebGLProgram {
         }
 
         let (sender, receiver) = webgl_channel().unwrap();
-        self.upcast::<WebGLObject>().context().send_command(
-            WebGLCommand::GetActiveUniformBlockName(self.id, block_index, sender),
-        );
+        self.droppable_field
+            .context
+            .send_command(WebGLCommand::GetActiveUniformBlockName(
+                self.droppable_field.id,
+                block_index,
+                sender,
+            ));
         Ok(receiver.recv().unwrap())
     }
 
@@ -576,10 +627,10 @@ impl WebGLProgram {
             active_uniforms[block_binding as usize].bind_index = Some(block_binding);
         }
 
-        self.upcast::<WebGLObject>()
-            .context()
+        self.droppable_field
+            .context
             .send_command(WebGLCommand::UniformBlockBinding(
-                self.id,
+                self.droppable_field.id,
                 block_index,
                 block_binding,
             ));
@@ -592,7 +643,10 @@ impl WebGLProgram {
             return Err(WebGLError::InvalidValue);
         }
         if self.link_called.get() {
-            let shaders_compiled = match (self.fragment_shader.get(), self.vertex_shader.get()) {
+            let shaders_compiled = match (
+                self.droppable_field.fragment_shader.get(),
+                self.droppable_field.vertex_shader.get(),
+            ) {
                 (Some(fs), Some(vs)) => fs.successfully_compiled() && vs.successfully_compiled(),
                 _ => false,
             };
@@ -601,18 +655,24 @@ impl WebGLProgram {
             }
         }
         let (sender, receiver) = webgl_channel().unwrap();
-        self.upcast::<WebGLObject>()
-            .context()
-            .send_command(WebGLCommand::GetProgramInfoLog(self.id, sender));
+        self.droppable_field
+            .context
+            .send_command(WebGLCommand::GetProgramInfoLog(
+                self.droppable_field.id,
+                sender,
+            ));
         Ok(receiver.recv().unwrap())
     }
 
     pub fn attached_shaders(&self) -> WebGLResult<Vec<DomRoot<WebGLShader>>> {
-        if self.marked_for_deletion.get() {
+        if self.droppable_field.marked_for_deletion.get() {
             return Err(WebGLError::InvalidValue);
         }
         Ok(
-            match (self.vertex_shader.get(), self.fragment_shader.get()) {
+            match (
+                self.droppable_field.vertex_shader.get(),
+                self.droppable_field.fragment_shader.get(),
+            ) {
                 (Some(vertex_shader), Some(fragment_shader)) => {
                     vec![vertex_shader, fragment_shader]
                 },
@@ -632,13 +692,6 @@ impl WebGLProgram {
 
     pub fn transform_feedback_buffer_mode(&self) -> i32 {
         self.transform_feedback_mode.get()
-    }
-}
-
-impl Drop for WebGLProgram {
-    fn drop(&mut self) {
-        self.in_use(false);
-        self.mark_for_deletion(Operation::Fallible);
     }
 }
 

--- a/components/script/dom/webglprogram.rs
+++ b/components/script/dom/webglprogram.rs
@@ -40,8 +40,12 @@ impl DroppableField {
         self.marked_for_deletion.set(true);
         let cmd = WebGLCommand::DeleteProgram(self.id);
         match operation_fallibility {
-            Operation::Fallible => self.sender.send(cmd, stub_webgl_backtrace()),
-            Operation::Infallible => self.sender.send(cmd, stub_webgl_backtrace()).unwrap(),
+            Operation::Fallible => {
+                let _ = self.sender.send(cmd, stub_webgl_backtrace());
+            },
+            Operation::Infallible => {
+                self.sender.send(cmd, stub_webgl_backtrace()).unwrap();
+            },
         }
         if self.is_deleted() {
             self.detach_shaders();

--- a/components/script/dom/webglquery.rs
+++ b/components/script/dom/webglquery.rs
@@ -15,6 +15,7 @@ use canvas_traits::webgl::{webgl_channel, WebGLCommand, WebGLQueryId};
 use dom_struct::dom_struct;
 use std::cell::Cell;
 
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
     sender: WebGLMessageSender,
     gl_id: WebGLQueryId,

--- a/components/script/dom/webglquery.rs
+++ b/components/script/dom/webglquery.rs
@@ -28,8 +28,12 @@ impl DroppableField {
 
             let command = WebGLCommand::DeleteQuery(self.gl_id);
             match operation_fallibility {
-                Operation::Fallible => self.sender.send(command, stub_webgl_backtrace()),
-                Operation::Infallible => self.sender.send(command, stub_webgl_backtrace()).unwrap(),
+                Operation::Fallible => {
+                    let _ = self.sender.send(command, stub_webgl_backtrace());
+                },
+                Operation::Infallible => {
+                    self.sender.send(command, stub_webgl_backtrace()).unwrap();
+                },
             }
         }
     }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -1941,6 +1941,20 @@ pub fn capture_webgl_backtrace<T: DomObject>(obj: &T) -> WebGLCommandBacktrace {
     }
 }
 
+#[cfg(not(feature = "webgl_backtrace"))]
+#[inline]
+pub fn stub_webgl_backtrace() -> WebGLCommandBacktrace {
+    WebGLCommandBacktrace {}
+}
+
+#[cfg(feature = "webgl_backtrace")]
+pub fn stub_webgl_backtrace() -> WebGLCommandBacktrace {
+      WebGLCommandBacktrace {
+          backtrace: String::new(),
+          js_backtrace: None,
+      }
+}
+
 impl Drop for WebGLRenderingContext {
     fn drop(&mut self) {
         let _ = self.webgl_sender.send_remove();

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -160,6 +160,7 @@ pub enum Operation {
     Infallible,
 }
 
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
     webgl_sender: WebGLMessageSender,
 }
@@ -391,7 +392,7 @@ impl WebGLRenderingContext {
     }
 
     pub(crate) fn webgl_sender(&self) -> WebGLMessageSender {
-        self.droppable_filed.webgl_sender.clone()
+        self.droppable_field.webgl_sender.clone()
     }
 
     pub fn context_id(&self) -> WebGLContextId {

--- a/components/script/dom/webglsampler.rs
+++ b/components/script/dom/webglsampler.rs
@@ -12,6 +12,7 @@ use canvas_traits::webgl::{webgl_channel, WebGLCommand, WebGLSamplerId};
 use dom_struct::dom_struct;
 use std::cell::Cell;
 
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
     sender: WebGLMessageSender,
     gl_id: WebGLSamplerId,

--- a/components/script/dom/webglsampler.rs
+++ b/components/script/dom/webglsampler.rs
@@ -24,8 +24,12 @@ impl DroppableField {
 
             let command = WebGLCommand::DeleteSampler(self.gl_id);
             match operation_fallibility {
-                Operation::Fallible => self.sender.send(command, stub_webgl_backtrace),
-                Operation::Infallible => self.sender.send(command, stub_webgl_backtrace).unwrap(),
+                Operation::Fallible => {
+                    let _ = self.sender.send(command, stub_webgl_backtrace());
+                },
+                Operation::Infallible => {
+                    self.sender.send(command, stub_webgl_backtrace()).unwrap();
+                },
             }
         }
     }

--- a/components/script/dom/webglsampler.rs
+++ b/components/script/dom/webglsampler.rs
@@ -14,7 +14,8 @@ use std::cell::Cell;
 
 struct DroppableField {
     sender: WebGLMessageSender,
-    gl_id: WebGLSamplerId
+    gl_id: WebGLSamplerId,
+    marked_for_deletion: Cell<bool>,
 }
 
 impl DroppableField {
@@ -44,7 +45,6 @@ impl Drop for DroppableField {
 #[dom_struct]
 pub struct WebGLSampler {
     webgl_object: WebGLObject,
-    marked_for_deletion: Cell<bool>,
     droppable_field: DroppableField,
 }
 
@@ -102,10 +102,10 @@ impl WebGLSampler {
     fn new_inherited(context: &WebGLRenderingContext, id: WebGLSamplerId) -> Self {
         Self {
             webgl_object: WebGLObject::new_inherited(context),
-            marked_for_deletion: Cell::new(false),
             droppable_field: DroppableField {
                 sender: context.webgl_sender(),
                 gl_id: id,
+                marked_for_deletion: Cell::new(false),
             }
         }
     }
@@ -126,7 +126,7 @@ impl WebGLSampler {
     }
 
     pub fn is_valid(&self) -> bool {
-        !self.marked_for_deletion.get()
+        !self.droppable_field.marked_for_deletion.get()
     }
 
     pub fn bind(

--- a/components/script/dom/webglshader.rs
+++ b/components/script/dom/webglshader.rs
@@ -30,6 +30,7 @@ pub enum ShaderCompilationStatus {
     Failed,
 }
 
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
     marked_for_deletion: Cell<bool>,
     sender: WebGLMessageSender,

--- a/components/script/dom/webglshader.rs
+++ b/components/script/dom/webglshader.rs
@@ -45,8 +45,12 @@ impl DroppableField {
             self.marked_for_deletion.set(true);
             let cmd = WebGLCommand::DeleteShader(self.id);
             match operation_fallibility {
-                Operation::Fallible => self.sender.send(cmd, stub_webgl_backtrace()),
-                Operation::Infallible => self.sender.send(cmd, stub_webgl_backtrace()).unwrap(),
+                Operation::Fallible => {
+                    let _ = self.sender.send(cmd, stub_webgl_backtrace());
+                },
+                Operation::Infallible => {
+                    self.sender.send(cmd, stub_webgl_backtrace()).unwrap();
+                },
             }
         }
     }

--- a/components/script/dom/webglsync.rs
+++ b/components/script/dom/webglsync.rs
@@ -26,8 +26,12 @@ impl DroppableField {
             self.marked_for_deletion.set(true);
             let cmd = WebGLCommand::DeleteSync(self.sync_id);
             match operation_fallibility {
-                Operation::Fallible => self.sender.send(cmd, stub_webgl_backtrace()),
-                Operation::Infallible => self.sender.send(cmd, stub_webgl_backtrace()).unwrap(),
+                Operation::Fallible => {
+                    let _ = self.sender.send(cmd, stub_webgl_backtrace());
+                },
+                Operation::Infallible => {
+                    self.sender.send(cmd, stub_webgl_backtrace()).unwrap();
+                },
             }
         }
     }

--- a/components/script/dom/webglsync.rs
+++ b/components/script/dom/webglsync.rs
@@ -14,6 +14,7 @@ use canvas_traits::webgl::{webgl_channel, WebGLCommand, WebGLSyncId};
 use dom_struct::dom_struct;
 use std::cell::Cell;
 
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
     sender: WebGLMessageSender,
     marked_for_deletion: Cell<bool>,

--- a/components/script/dom/webgltransformfeedback.rs
+++ b/components/script/dom/webgltransformfeedback.rs
@@ -10,6 +10,7 @@ use canvas_traits::webgl::{webgl_channel, WebGLCommand};
 use dom_struct::dom_struct;
 use std::cell::Cell;
 
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
     sender: WebGLMessageSender,
     marked_for_deletion: Cell<bool>,

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -70,13 +70,24 @@ use uuid::Uuid;
 const WORKLET_THREAD_POOL_SIZE: u32 = 3;
 const MIN_GC_THRESHOLD: u32 = 1_000_000;
 
+struct DroppableField {
+    worklet_id: WorkletId,
+}
+
+impl Drop for DroppableField {
+    fn drop(&mut self) {
+        let script_thread = ScriptThread::worklet_thread_pool();
+        script_thread.exit_worklet(self.worklet_id);
+    }
+}
+
 #[dom_struct]
 /// <https://drafts.css-houdini.org/worklets/#worklet>
 pub struct Worklet {
     reflector: Reflector,
     window: Dom<Window>,
-    worklet_id: WorkletId,
     global_type: WorkletGlobalScopeType,
+    droppable_field: DroppableField,
 }
 
 impl Worklet {
@@ -84,8 +95,10 @@ impl Worklet {
         Worklet {
             reflector: Reflector::new(),
             window: Dom::from_ref(window),
-            worklet_id: WorkletId::new(),
             global_type: global_type,
+            droppable_field: DroppableField {
+                worklet_id: WorkletId::new(),
+            }
         }
     }
 
@@ -98,7 +111,7 @@ impl Worklet {
     }
 
     pub fn worklet_id(&self) -> WorkletId {
-        self.worklet_id
+        self.droppable_field.worklet_id
     }
 
     #[allow(dead_code)]
@@ -138,7 +151,7 @@ impl WorkletMethods for Worklet {
 
         pool.fetch_and_invoke_a_worklet_script(
             global.pipeline_id(),
-            self.worklet_id,
+            self.droppable_field.worklet_id,
             self.global_type,
             self.window.origin().immutable().clone(),
             global.api_base_url(),
@@ -151,13 +164,6 @@ impl WorkletMethods for Worklet {
         // Step 5.
         debug!("Returning promise.");
         promise
-    }
-}
-
-impl Drop for Worklet {
-    fn drop(&mut self) {
-        let script_thread = ScriptThread::worklet_thread_pool();
-        script_thread.exit_worklet(self.worklet_id);
     }
 }
 

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -70,6 +70,7 @@ use uuid::Uuid;
 const WORKLET_THREAD_POOL_SIZE: u32 = 3;
 const MIN_GC_THRESHOLD: u32 = 1_000_000;
 
+#[derive(JSTraceable, MallocSizeOf)]
 struct DroppableField {
     worklet_id: WorkletId,
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Drop impls for DOM types should be forbidden.
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes fix #26488 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they will be checked by the compiler.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

## TODO

- [ ] create `#[must_root]` proc macro.
  - [x] output Drop impls.
  - [ ] output `#[unrooted_must_root_lint::must_root_type]` attribute.
- [ ] add inner struct for fixing compile error.
- [ ] rename from `#[unrooted_must_root_lint::must_root]` to `#[unrooted_must_root_lint::must_root_type]`.
