### PR TITLE
Minor fixes in simpleservo

### DIFF
--- a/ports/libsimpleservo/capi/build.rs
+++ b/ports/libsimpleservo/capi/build.rs
@@ -17,11 +17,7 @@ fn main() {
     let profile_dir = env::var("PROFILE").unwrap();
     path.push(profile_dir);
     path.push("simpleservo.h");
-    cbindgen::Builder::new()
-        .with_crate(crate_dir)
-        .with_language(cbindgen::Language::C)
-        .exclude_item("OutputDebugStringA")
-        .generate()
-        .expect("Unable to generate bindings")
+    cbindgen::generate(crate_dir)
+        .expect("Unable to generate C bindings")
         .write_to_file(path);
 }

--- a/ports/libsimpleservo/capi/cbindgen.toml
+++ b/ports/libsimpleservo/capi/cbindgen.toml
@@ -1,0 +1,9 @@
+language = "C"
+include_guard = "simpleservo_h"
+cpp_compat = true
+tab_width = 4
+documentation_style = "c99"
+
+[export]
+exclude = ["OutputDebugStringA"]
+

--- a/ports/libsimpleservo/capi/src/lib.rs
+++ b/ports/libsimpleservo/capi/src/lib.rs
@@ -58,7 +58,8 @@ fn report_panic(reason: &str, backtrace: Option<String>) {
     };
     let error = CString::new(message).expect("Can't create string");
     (ON_PANIC.read().unwrap())(error.as_ptr());
-    panic!("At that point, embedder should have thrown");
+    // At this point, embedder should probably have thrown, so we never reach
+    // this point. But if it didn't, don't recursively panic.
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -490,7 +491,11 @@ pub extern "C" fn init_with_egl(
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+#[cfg(any(
+    target_os = "linux",
+    all(target_os = "windows", not(feature = "no-wgl")),
+    target_os = "macos"
+))]
 #[no_mangle]
 pub extern "C" fn init_with_gl(
     opts: CInitOptions,


### PR DESCRIPTION

<!-- Please describe your changes on the following line: -->
- improve embedding C header generation.
- Don't recursively panic if embedder doesn't throw on panic.
- Make init_with_gl unavailable when doing non-WGL windows build.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
