### PR TITLE
Bump selectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "bitflags",
  "cssparser",

--- a/components/selectors/Cargo.toml
+++ b/components/selectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "selectors"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["The Servo Project Developers"]
 documentation = "https://docs.rs/selectors/"
 description = "CSS Selectors matching for Rust"


### PR DESCRIPTION
Releasing this will help updating dependencies in crates that depend on
selectors.