### PR TITLE
Update doc comment for script_plugins/lib.rs

### DIFF
--- a/components/script_plugins/lib.rs
+++ b/components/script_plugins/lib.rs
@@ -4,14 +4,8 @@
 
 //! Servo's compiler plugin/macro crate
 //!
-//! Attributes this crate provides:
-//!
-//!  - `#[derive(DenyPublicFields)]` : Forces all fields in a struct/enum to be private
-//!  - `#[derive(JSTraceable)]` : Auto-derives an implementation of `JSTraceable` for a struct in the script crate
-//!  - `#[unrooted_must_root_lint::must_root]` : Prevents data of the marked type from being used on the stack.
-//!                     See the lints module for more details
-//!  - `#[dom_struct]` : Implies #[derive(JSTraceable, DenyPublicFields)]`, and `#[unrooted_must_root_lint::must_root]`.
-//!                       Use this for structs that correspond to a DOM type
+//! This crate provides the `#[unrooted_must_root_lint::must_root]` lint. This lint prevents data
+//! of the marked type from being used on the stack. See the source for more details.
 
 #![deny(unsafe_code)]
 #![feature(plugin)]


### PR DESCRIPTION
`script_plugins` no longer provides any macros. It currently only provides the must_root lint.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it is a doc comment only change.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
