### PR TITLE
add etc/shell.nix for nix/nixOS and instructions - fixes #10468

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ With the following environment variable set:
 export LIBCLANG_PATH=$(llvm-config --prefix)/lib64
 ```
 
+#### On nixOS Linux
+
+```sh
+nix-shell etc/shell.nix
+```
+
+You will need to run this in every shell before running mach.
+
 #### On Windows (MSVC)
 
 1. Install Python 3.9 for Windows (https://www.python.org/downloads/release/python-392/). The Windows x86-64 MSI installer is fine. This is required in order to build the JavaScript engine, SpiderMonkey.

--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -1,0 +1,40 @@
+# This provides a shell with all the necesarry packages required to run mach and build servo
+# NOTE: This does not work offline or for nix-build
+
+with import <nixpkgs> {};
+
+clangStdenv.mkDerivation rec {
+  name = "servo-env";
+
+  buildInputs = [
+    # Native dependencies
+    fontconfig freetype openssl libunwind
+    xlibs.libxcb x11
+
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-bad
+
+    rustup
+
+    # Build utilities
+    cmake dbus gcc git pkgconfig which llvm autoconf213 perl yasm m4
+    (python3.withPackages (ps: with ps; [virtualenv pip dbus]))
+  ];
+
+  LIBCLANG_PATH = llvmPackages.clang-unwrapped.lib + "/lib/";
+
+  # Allow cargo to download crates
+  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  # Enable colored cargo and rustc output
+  TERMINFO = "${ncurses.out}/share/terminfo";
+
+  shellHook = ''
+    # Fix missing libraries errors (those libraries aren't linked against, so we need to dynamically supply them)
+    export LD_LIBRARY_PATH=${lib.makeLibraryPath [ xorg.libXcursor xorg.libXrandr xorg.libXi ]}
+    # Fix invalid option errors during linking
+    # https://github.com/mozilla/nixpkgs-mozilla/commit/c72ff151a3e25f14182569679ed4cd22ef352328
+    unset AS
+  '';
+}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This adds instructions for building servo on nixOS and the required shell.nix to prepare the environment

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes fix #10468 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they relate to adding a new build environment, not any servo code

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
