### PR TITLE
add NixOS support to mach and automatically re-launch mach in nix-shell

### DIFF
--- a/mach
+++ b/mach
@@ -110,6 +110,7 @@ if __name__ == '__main__':
         import subprocess
         from shlex import quote
         mach_dir = os.path.abspath(os.path.dirname(__file__))
+        print('NOTE: Entering nix-shell etc/shell.nix')
         try:
             # sys argv already contains the ./mach part, so we just need to pass it as-is
             subprocess.Popen(['nix-shell', mach_dir + '/etc/shell.nix', '--run', ' '.join(map(quote, sys.argv))]).wait()

--- a/mach
+++ b/mach
@@ -106,4 +106,14 @@ if __name__ == '__main__':
         orig_command_line = forking.get_command_line
         forking.get_command_line = my_get_command_line
 
-    main(sys.argv)
+    if os.path.exists('/etc/NIXOS') and not 'IN_NIX_SHELL' in os.environ: # we're on a nixOS system, need to run mach in nix-shell
+        import subprocess
+        from shlex import quote
+        mach_dir = os.path.abspath(os.path.dirname(__file__))
+        try:
+            # sys argv already contains the ./mach part, so we just need to pass it as-is
+            subprocess.Popen(['nix-shell', mach_dir + '/etc/shell.nix', '--run', ' '.join(map(quote, sys.argv))]).wait()
+        except KeyboardInterrupt:
+            sys.exit(0)
+    else:
+        main(sys.argv)

--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -400,8 +400,12 @@ def bootstrap(context, force=False, specific=None):
         distrib, version = get_linux_distribution()
 
         if distrib.lower() == 'nixos':
-            print('NixOS does not need bootstrap')
-            print('just run ./mach build')
+            print('NixOS does not need bootstrap, it will automatically enter a nix-shell')
+            print('Just run ./mach build')
+            print('')
+            print('You will need to run a nix-shell if you are trying to run any of the built binaries')
+            print('To enter the nix-shell manually use:')
+            print('  $ nix-shell etc/shell.nix')
             return
 
         context.distro = distrib

--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -383,6 +383,7 @@ def get_linux_distribution():
         'debian gnu/linux',
         'fedora',
         'void',
+        'nixos',
     ]:
         raise Exception('mach bootstrap does not support %s, please file a bug' % distrib)
 
@@ -397,6 +398,11 @@ def bootstrap(context, force=False, specific=None):
         bootstrapper = windows_msvc
     elif "linux-gnu" in host_triple():
         distrib, version = get_linux_distribution()
+
+        if distrib.lower() == 'nixos':
+            print('NixOS does not need bootstrap')
+            print('just run ./mach build')
+            return
 
         context.distro = distrib
         context.distro_version = version


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is a followup for #28454 which adds nixos support directly to mach, saving the user from typing `nix-shell` everytime

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they just extend mach

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
