### PR TITLE
Introduce `Untransplantable` trait and implement it on `WindowProxy`

### DIFF
--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -32,7 +32,7 @@
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
-use crate::dom::bindings::reflector::{DomObject, Reflector};
+use crate::dom::bindings::reflector::{DomObject, Reflector, Untransplantable};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::utils::WindowProxyHandler;
@@ -1192,7 +1192,7 @@ impl<'a, T: 'static + JSTraceable> RootedVec<'a, T> {
     }
 }
 
-impl<'a, T: 'static + JSTraceable + DomObject> RootedVec<'a, Dom<T>> {
+impl<'a, T: 'static + JSTraceable + DomObject + Untransplantable> RootedVec<'a, Dom<T>> {
     /// Create a vector of items of type Dom<T> that is rooted for
     /// the lifetime of this struct
     pub fn from_iter<I>(root: &'a mut RootableVec<Dom<T>>, iter: I) -> Self

--- a/components/script/dom/webgl_extensions/extension.rs
+++ b/components/script/dom/webgl_extensions/extension.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use super::WebGLExtensions;
-use crate::dom::bindings::reflector::DomObject;
+use crate::dom::bindings::reflector::{DomObject, Untransplantable};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::webglrenderingcontext::WebGLRenderingContext;
@@ -12,7 +12,7 @@ use canvas_traits::webgl::WebGLVersion;
 /// Trait implemented by WebGL extensions.
 pub trait WebGLExtension: Sized
 where
-    Self::Extension: DomObject + JSTraceable,
+    Self::Extension: DomObject + JSTraceable + Untransplantable,
 {
     type Extension;
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -23,7 +23,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomObject;
-use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom, MutNullableTransplantableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::structuredclone;
 use crate::dom::bindings::trace::{JSTraceable, RootedTraceableBox};
@@ -192,7 +192,7 @@ pub struct Window {
     image_cache: Arc<dyn ImageCache>,
     #[ignore_malloc_size_of = "channels are hard"]
     image_cache_chan: Sender<ImageCacheMsg>,
-    window_proxy: MutNullableDom<WindowProxy>,
+    window_proxy: MutNullableTransplantableDom<WindowProxy>,
     document: MutNullableDom<Document>,
     location: MutNullableDom<Location>,
     history: MutNullableDom<History>,
@@ -373,7 +373,7 @@ impl Window {
     pub fn clear_js_runtime_for_script_deallocation(&self) {
         unsafe {
             *self.js_runtime.borrow_for_script_deallocation() = None;
-            self.window_proxy.set(None);
+            self.window_proxy.set(None, &self.global().upcast());
             self.current_state.set(WindowState::Zombie);
             self.ignore_all_tasks();
         }
@@ -1500,7 +1500,7 @@ impl Window {
             let pipeline_id = self.upcast::<GlobalScope>().pipeline_id();
             if let Some(currently_active) = proxy.currently_active() {
                 if currently_active == pipeline_id {
-                    self.window_proxy.set(None);
+                    self.window_proxy.set(None, &self.global());
                 }
             }
         }
@@ -2008,7 +2008,7 @@ impl Window {
     #[allow(unsafe_code)]
     pub fn init_window_proxy(&self, window_proxy: &WindowProxy) {
         assert!(self.window_proxy.get().is_none());
-        self.window_proxy.set(Some(&window_proxy));
+        self.window_proxy.set(Some(&window_proxy), &self.global());
     }
 
     #[allow(unsafe_code)]
@@ -2414,7 +2414,8 @@ impl Window {
             location: Default::default(),
             history: Default::default(),
             custom_element_registry: Default::default(),
-            window_proxy: Default::default(),
+            // Safety: This field won't be assigned until it's pinned
+            window_proxy: unsafe { MutNullableTransplantableDom::new() },
             document: Default::default(),
             performance: Default::default(),
             navigation_start: Cell::new(navigation_start),

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -58,7 +58,8 @@ use std::ptr;
 use style::attr::parse_integer;
 
 #[dom_struct]
-// `dom_object(transplantable)` removes `!Untransplantable` impl.
+// `dom_object(transplantable)` suppress the implicit derivation of an
+// `Untransplantable` impl by `derive(DomObject)`.
 #[dom_object(transplantable)]
 // NOTE: the browsing context for a window is managed in two places:
 // here, in script, but also in the constellation. The constellation


### PR DESCRIPTION
This PR fixes some cases of compartment mismatch that have been reported in <https://github.com/servo/servo/pull/27952#issuecomment-817338319>.

SpiderMonkey requires a `WindowProxy` object to be in the same compartment as its `Window`, so when a `WindowProxy` changes `Window`, it must be transplanted to the new `Window`'s realm. When this happens, `WindowProxy::reflector` is replaced with a new `JSObject` that belongs to the new realm, and the old `reflector` is overwritten with a CCW. (So if there's an existing reference to `reflector` somewhere else, it will now refer to the CCW.) `*Dom<T>` types always trace through `T::reflector ()`.

`WindowProxy` is referenced by `Window` through `MutNullableDom<WindowProxy>`. SpiderMonkey prohibit cross-compartment references from being formed directly. However, when the transplantation happens, `MutNullableDom<WindowProxy>` turns into a cross-compartment reference as `WindowProxy::reflector()` now returns the transplanted `JSObject`.

(This violation can be detected at runtime if Servo is built with `--debug-mozjs`. It can be observed in test cases such as those in `tests/wpt/web-platform-tests/html/browsers/the-window-object/named-access-on-the-window-object`. The minimum reproducing example I found is rather small: `<iframe src="about:blank"></iframe>`.)

This PR attempts to alleviate this problem by introducing a new trait named `Untransplantable` to express transplantability at the type level. Existing similar reference wrapper types, including but not limited to `Dom`, now require `Untransplantable` on the wrapped type. For transplantable types, this commit introduces a new family of reference wrapper types: `MutNullableTransplantableDom` and `TransplantableDom- OnceCell`. These types are essentially `(*const T, Heap<*mut JSObject>)` and always trace through `Heap<*mut JSObject>` (a reference to `T`'s reflector or CCW). Its API is similar to the corresponding non-`TransplantableDom` types except that the caller must supply a containing global scope, which is used to wrap `T::reflector()` properly before storing it to `Heap<*mut JSObject>`. Even if the target object is transplanted, `Heap<*mut JSObject>` keeps tracking the wrapper object in the original realm, maintaining the compartment invariants.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

---
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they are already covered by existing tests, albeit this requires Servo to be built with `--debug-mozjs` for the errors to be (reliably) observable
