### PR TITLE
bootstrap: add support for Ubuntu 21.04

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -374,7 +374,7 @@ def get_linux_distribution():
             raise Exception('unsupported version of %s: %s' % (distrib, version))
         distrib, version = 'Ubuntu', base_version
     elif distrib.lower() == 'ubuntu':
-        if version > '20.10':
+        if version > '21.04':
             raise Exception('unsupported version of %s: %s' % (distrib, version))
     # Fixme: we should allow checked/supported versions only
     elif distrib.lower() not in [


### PR DESCRIPTION
Signed-off-by: Tristan Matthews <tmatth@videolan.org>

<!-- Please describe your changes on the following line: -->
Allow `./mach bootstrap` to run on Ubuntu 21.04

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~These changes fix #___ (GitHub issue number if applicable)~ (Happy to create an issue retroactively if that's preferable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they can be trivially tested by running `./mach bootstrap` on Ubuntu 21.04

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
