### PR TITLE
Create only one compartment for each script thread (agent)

### DIFF
--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -637,13 +637,11 @@ impl WindowProxy {
             // The old window proxy no longer owns this browsing context.
             SetProxyReservedSlot(old_js_proxy.get(), 0, &PrivateValue(ptr::null_mut()));
 
-            // Brain transpant the window proxy.
-            // We need to do this, because the Window and WindowProxy
-            // objects need to be in the same realm.
-            // JS_TransplantObject does this by copying the contents
-            // of the old window proxy to the new window proxy, then
-            // making the old window proxy a cross-realm wrapper
-            // pointing to the new window proxy.
+            // Brain transpant the window proxy. Brain transplantation is
+            // usually done to move a window proxy between compartments, but
+            // that's not what we are doing here. We need to do this just
+            // because we want to replace the wrapper's `ProxyTraps`, but we
+            // don't want to update its identity.
             rooted!(in(*cx) let new_js_proxy = NewWindowProxy(*cx, window_jsobject, handler));
             debug!(
                 "Transplanting proxy from {:p} to {:p}.",

--- a/tests/wpt/metadata/dom/events/event-global-extra.window.js.ini
+++ b/tests/wpt/metadata/dom/events/event-global-extra.window.js.ini
@@ -1,19 +1,4 @@
 [event-global-extra.window.html]
-  [window.event for constructors from another global: EventTarget]
-    expected: FAIL
-
-  [window.event for constructors from another global: XMLHttpRequest]
-    expected: FAIL
-
-  [window.event and element from another document]
-    expected: FAIL
-
-  [window.event and moving an element post-dispatch]
-    expected: FAIL
-
   [window.event should not be affected by nodes moving post-dispatch]
-    expected: FAIL
-
-  [Listener from a different global]
     expected: FAIL
 

--- a/tests/wpt/metadata/encoding/single-byte-decoder.html.ini
+++ b/tests/wpt/metadata/encoding/single-byte-decoder.html.ini
@@ -2,7 +2,6 @@
   type: testharness
 
 [single-byte-decoder.html?document]
-  expected: TIMEOUT
   [ISO-8859-4: iso_8859-4:1988 (document.characterSet and document.inputEncoding)]
     expected: FAIL
 
@@ -29,9 +28,6 @@
 
   [ISO-8859-8: iso_8859-8:1988 (document.characterSet and document.inputEncoding)]
     expected: FAIL
-
-  [KOI8-R: cskoi8r (document.characterSet and document.inputEncoding)]
-    expected: TIMEOUT
 
 
 [single-byte-decoder.html?XMLHttpRequest]

--- a/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-return-value-handling-dynamic.html.ini
+++ b/tests/wpt/metadata/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-return-value-handling-dynamic.html.ini
@@ -5,15 +5,3 @@
   [Test javascript URL string return values in direct and indirect (target) frame contexts. 9]
     expected: FAIL
 
-  [Test javascript URL string return values in direct and indirect (target) frame contexts. 5]
-    expected: FAIL
-
-  [Test javascript URL string return values in direct and indirect (target) frame contexts. 6]
-    expected: FAIL
-
-  [Test javascript URL string return values in direct and indirect (target) frame contexts. 7]
-    expected: FAIL
-
-  [Test javascript URL string return values in direct and indirect (target) frame contexts. 8]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/browsers/origin/cross-origin-objects/cross-origin-objects-on-new-window.html.ini
+++ b/tests/wpt/metadata/html/browsers/origin/cross-origin-objects/cross-origin-objects-on-new-window.html.ini
@@ -1,2 +1,0 @@
-[cross-origin-objects-on-new-window.html]
-  expected: TIMEOUT

--- a/tests/wpt/metadata/html/browsers/sandboxing/sandbox-disallow-same-origin.html.ini
+++ b/tests/wpt/metadata/html/browsers/sandboxing/sandbox-disallow-same-origin.html.ini
@@ -1,4 +1,0 @@
-[sandbox-disallow-same-origin.html]
-  [Access to sandbox iframe is disallowed]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/creating_browsing_context_test_01.html.ini
+++ b/tests/wpt/metadata/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/creating_browsing_context_test_01.html.ini
@@ -1,5 +1,4 @@
 [creating_browsing_context_test_01.html]
-  expected: TIMEOUT
   [first argument: absolute url]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-2.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-2.html.ini
@@ -1,5 +1,5 @@
 [iframe_sandbox_popups_escaping-2.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Check that popups from a sandboxed iframe escape the sandbox if\n       allow-popups-to-escape-sandbox is used]
     expected: TIMEOUT
 

--- a/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-1.html.ini
+++ b/tests/wpt/metadata/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-1.html.ini
@@ -1,6 +1,6 @@
 [iframe_sandbox_popups_nonescaping-1.html]
   type: testharness
-  expected: TIMEOUT
+  expected: CRASH
   [Check that popups from a sandboxed iframe do not escape the sandbox]
     expected: NOTRUN
 

--- a/tests/wpt/metadata/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_noopener.html.ini
+++ b/tests/wpt/metadata/html/semantics/links/links-created-by-a-and-area-elements/htmlanchorelement_noopener.html.ini
@@ -1,6 +1,5 @@
 [htmlanchorelement_noopener.html]
   type: testharness
-  expected: TIMEOUT
   [Check that targeting of rel=noopener with a given name ignores an existing window with that name]
     expected: NOTRUN
 
@@ -14,5 +13,5 @@
     expected: FAIL
 
   [Check that rel=noopener with target=_self does a normal load]
-    expected: NOTRUN
+    expected: FAIL
 

--- a/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/execution-timing/084.html.ini
+++ b/tests/wpt/metadata/html/semantics/scripting-1/the-script-element/execution-timing/084.html.ini
@@ -1,6 +1,0 @@
-[084.html]
-  type: testharness
-  expected: ERROR
-  [ scheduler: event listener defined by script in a removed IFRAME]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url-entry-document.window.js.ini
+++ b/tests/wpt/metadata/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/url-entry-document.window.js.ini
@@ -1,4 +1,0 @@
-[url-entry-document.window.html]
-  [document.open() changes document's URL to the entry settings object's responsible document's (through timeouts)]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-1.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-1.html.ini
@@ -1,6 +1,3 @@
 [window-onerror-with-cross-frame-event-listeners-1.html]
   type: testharness
   bug: https://github.com/servo/servo/issues/3311
-  [The error event from an event listener should fire on that listener's global]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-4.html.ini
+++ b/tests/wpt/metadata/html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-4.html.ini
@@ -1,6 +1,3 @@
 [window-onerror-with-cross-frame-event-listeners-4.html]
   type: testharness
   bug: https://github.com/servo/servo/issues/3311
-  [The error event from an event listener should fire on that listener's global]
-    expected: FAIL
-

--- a/tests/wpt/metadata/wasm/jsapi/functions/entry-different-function-realm.html.ini
+++ b/tests/wpt/metadata/wasm/jsapi/functions/entry-different-function-realm.html.ini
@@ -1,5 +1,4 @@
 [entry-different-function-realm.html]
-  expected: ERROR
   [Start function]
-    expected: TIMEOUT
+    expected: FAIL
 

--- a/tests/wpt/metadata/wasm/jsapi/functions/incumbent.html.ini
+++ b/tests/wpt/metadata/wasm/jsapi/functions/incumbent.html.ini
@@ -1,5 +1,0 @@
-[incumbent.html]
-  expected: TIMEOUT
-  [Start function]
-    expected: TIMEOUT
-

--- a/tests/wpt/mozilla/meta/mozilla/cross-origin-objects/cross-origin-objects.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/cross-origin-objects/cross-origin-objects.html.ini
@@ -1,4 +1,0 @@
-[cross-origin-objects.html]
-  [Only whitelisted properties are accessible cross-origin]
-    expected: FAIL
-


### PR DESCRIPTION
Documents in the same [agent][1] can share and exchange JS and DOM objects freely, so putting them in separate compartments would require almost every instance of `Dom` to be capable of handling cross-compartment references.

[1]: https://html.spec.whatwg.org/multipage/webappapis.html#integration-with-the-javascript-agent-formalism

---
- [x] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

---
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because I think there's already a wide test coverage for same-origin-domain JS object passing, albeit this requires Servo to be built with `--debug-mozjs` for the errors to be (reliably) observable
