### PR TITLE
Set `DedicatedWorkerGlobalScope`'s origin correctly

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -389,7 +389,7 @@ impl DedicatedWorkerGlobalScope {
 
                 // Step 8 "Set up a worker environment settings object [...]"
                 //
-                // <https://html.spec.whatwg.org/multipage/workers.html#script-settings-for-workers>
+                // <https://html.spec.whatwg.org/multipage/#script-settings-for-workers>
                 //
                 // > The origin: Return a unique opaque origin if `worker global
                 // > scope`'s url's scheme is "data", and `inherited origin`

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -464,7 +464,7 @@ impl DedicatedWorkerGlobalScope {
                     .mem_profiler_chan()
                     .run_with_memory_reporting(
                         || {
-                            // Step 29, Run the responsible event loop specified
+                            // Step 27, Run the responsible event loop specified
                             // by inside settings until it is destroyed.
                             // The worker processing model remains on this step
                             // until the event loop is destroyed,

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -280,7 +280,7 @@ impl ServiceWorkerGlobalScope {
     }
 
     #[allow(unsafe_code)]
-    // https://html.spec.whatwg.org/multipage/#run-a-worker
+    // https://w3c.github.io/ServiceWorker/#run-service-worker-algorithm
     pub fn run_serviceworker_scope(
         scope_things: ScopeThings,
         own_sender: Sender<ServiceWorkerScriptMsg>,
@@ -382,7 +382,7 @@ impl ServiceWorkerGlobalScope {
                     .mem_profiler_chan()
                     .run_with_memory_reporting(
                         || {
-                            // Step 29, Run the responsible event loop specified
+                            // Step 18, Run the responsible event loop specified
                             // by inside settings until it is destroyed.
                             // The worker processing model remains on this step
                             // until the event loop is destroyed,

--- a/tests/wpt/metadata-layout-2020/workers/dedicated-worker-in-data-url-context.window.js.ini
+++ b/tests/wpt/metadata-layout-2020/workers/dedicated-worker-in-data-url-context.window.js.ini
@@ -1,4 +1,0 @@
-[dedicated-worker-in-data-url-context.window.html]
-  [Create a dedicated worker in a data url dedicated worker]
-    expected: FAIL
-

--- a/tests/wpt/metadata/fetch/api/cors/data-url-worker.html.ini
+++ b/tests/wpt/metadata/fetch/api/cors/data-url-worker.html.ini
@@ -1,4 +1,0 @@
-[data-url-worker.html]
-  [fetching "top.txt" without ACAO should be rejected.]
-    expected: FAIL
-

--- a/tests/wpt/metadata/html/webappapis/the-windoworworkerglobalscope-mixin/Worker_Self_Origin.html.ini
+++ b/tests/wpt/metadata/html/webappapis/the-windoworworkerglobalscope-mixin/Worker_Self_Origin.html.ini
@@ -3,9 +3,6 @@
   [Same Origin SharedWorker]
     expected: FAIL
 
-  [Data Url Worker]
-    expected: FAIL
-
   [Data Url SharedWorker]
     expected: FAIL
 

--- a/tests/wpt/metadata/workers/dedicated-worker-in-data-url-context.window.js.ini
+++ b/tests/wpt/metadata/workers/dedicated-worker-in-data-url-context.window.js.ini
@@ -1,4 +1,0 @@
-[dedicated-worker-in-data-url-context.window.html]
-  [Create a dedicated worker in a data url dedicated worker]
-    expected: FAIL
-


### PR DESCRIPTION
<https://html.spec.whatwg.org/multipage/workers.html#script-settings-for-workers>

> To **set up a worker environment settings object**, given a JavaScript execution context *execution context* and environment settings object *outside settings*: [...]
>
> 4. Let *settings object* be a new environment settings object whose algorithms are defined as follows:
>
>    **The origin** Return a unique opaque origin if *worker global scope*'s url's scheme is "data", and *inherited origin* otherwise.

---
- [x] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

---
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___
