### PR TITLE
Upgrade to uluru 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
+
+[[package]]
 name = "ash"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6780,11 +6786,11 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uluru"
-version = "0.4.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7b39d0c32eba57d52d334e4bdd150df6e755264eefaa1ae2e7cd125f35e1ca"
+checksum = "ce7967da538013500fa504ce61af688d6a310e6dea6985c71f3c6be37e2a55c7"
 dependencies = [
- "arrayvec 0.5.1",
+ "arrayvec 0.7.1",
 ]
 
 [[package]]

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -74,7 +74,7 @@ thin-slice = { version = "0.1.0", optional = true }
 time = "0.1"
 to_shmem = { path = "../to_shmem" }
 to_shmem_derive = { path = "../to_shmem_derive" }
-uluru = "0.4"
+uluru = "2"
 unicode-bidi = "0.3"
 unicode-segmentation = "1.0"
 void = "1.0.2"

--- a/components/style/context.rs
+++ b/components/style/context.rs
@@ -42,7 +42,7 @@ use style_traits::DevicePixel;
 #[cfg(feature = "servo")]
 use style_traits::SpeculativePainter;
 use time;
-use uluru::{Entry, LRUCache};
+use uluru::LRUCache;
 
 pub use selectors::matching::QuirksMode;
 
@@ -542,7 +542,7 @@ pub struct SelectorFlagsMap<E: TElement> {
     map: FxHashMap<SendElement<E>, ElementSelectorFlags>,
     /// An LRU cache to avoid hashmap lookups, which can be slow if the map
     /// gets big.
-    cache: LRUCache<[Entry<CacheItem<E>>; 4 + 1]>,
+    cache: LRUCache<CacheItem<E>, { 4 + 1 }>,
 }
 
 #[cfg(debug_assertions)]
@@ -583,7 +583,7 @@ impl<E: TElement> SelectorFlagsMap<E> {
     /// Applies the flags. Must be called on the main thread.
     fn apply_flags(&mut self) {
         debug_assert_eq!(thread_state::get(), ThreadState::LAYOUT);
-        self.cache.evict_all();
+        self.cache.clear();
         for (el, flags) in self.map.drain() {
             unsafe {
                 el.set_selector_flags(flags);

--- a/components/style/sharing/mod.rs
+++ b/components/style/sharing/mod.rs
@@ -85,7 +85,7 @@ use std::marker::PhantomData;
 use std::mem::{self, ManuallyDrop};
 use std::ops::Deref;
 use std::ptr::NonNull;
-use uluru::{Entry, LRUCache};
+use uluru::LRUCache;
 
 mod checks;
 
@@ -457,7 +457,7 @@ impl<E: TElement> StyleSharingTarget<E> {
 }
 
 struct SharingCacheBase<Candidate> {
-    entries: LRUCache<[Entry<Candidate>; SHARING_CACHE_SIZE]>,
+    entries: LRUCache<Candidate, SHARING_CACHE_SIZE>,
 }
 
 impl<Candidate> Default for SharingCacheBase<Candidate> {
@@ -470,11 +470,11 @@ impl<Candidate> Default for SharingCacheBase<Candidate> {
 
 impl<Candidate> SharingCacheBase<Candidate> {
     fn clear(&mut self) {
-        self.entries.evict_all();
+        self.entries.clear();
     }
 
     fn is_empty(&self) -> bool {
-        self.entries.num_entries() == 0
+        self.entries.len() == 0
     }
 }
 


### PR DESCRIPTION
* Update `uluru` dependency from 0.4 to 2, which slightly simplifies the syntax and remove some dependencies.
---
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
---
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it introduces no behavioral changes

