### PR TITLE
Store cross-origin properties holders for maybe-cross-origin objects

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -5498,6 +5498,7 @@ class CGDOMJSProxyHandler_getOwnPropertyDescriptor(CGAbstractExternMethod):
                     rooted!(in(*cx) let mut holder = ptr::null_mut::<JSObject>());
                     proxyhandler::ensure_cross_origin_property_holder(
                         cx,
+                        proxy,
                         holder_map,
                         &CROSS_ORIGIN_PROPERTIES,
                         holder.handle_mut().into(),
@@ -5728,6 +5729,7 @@ class CGDOMJSProxyHandler_ownPropertyKeys(CGAbstractExternMethod):
                     rooted!(in(*cx) let mut holder = ptr::null_mut::<JSObject>());
                     proxyhandler::ensure_cross_origin_property_holder(
                         cx,
+                        proxy,
                         holder_map,
                         &CROSS_ORIGIN_PROPERTIES,
                         holder.handle_mut().into(),
@@ -5862,6 +5864,7 @@ class CGDOMJSProxyHandler_hasOwn(CGAbstractExternMethod):
                     rooted!(in(*cx) let mut holder = ptr::null_mut::<JSObject>());
                     proxyhandler::ensure_cross_origin_property_holder(
                         cx,
+                        proxy,
                         holder_map,
                         &CROSS_ORIGIN_PROPERTIES,
                         holder.handle_mut().into(),

--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -47,7 +47,9 @@ use js::rust::wrappers::JS_NewObjectWithGivenProto;
 use js::rust::wrappers::{
     AppendToIdVector, SetDataPropertyDescriptor, RUST_INTERNED_STRING_TO_JSID,
 };
-use js::rust::{get_context_realm, Handle, HandleObject, HandleValue, MutableHandle, MutableHandleObject};
+use js::rust::{
+    get_context_realm, Handle, HandleObject, HandleValue, MutableHandle, MutableHandleObject,
+};
 use std::{os::raw::c_char, ptr};
 
 /// Determine if this id shadows any existing properties for this proxy.

--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -721,6 +721,7 @@ pub struct CrossOriginPropertiesHolderMap {
 /// [`CrossOriginGetOwnPropertyHelper`]: https://html.spec.whatwg.org/multipage/#crossorigingetownpropertyhelper-(-o,-p-)
 pub unsafe fn ensure_cross_origin_property_holder(
     cx: SafeJSContext,
+    proxy: RawHandleObject,
     holder_map: &CrossOriginPropertiesHolderMap,
     cross_origin_properties: &'static CrossOriginProperties,
     out_holder: RawMutableHandleObject,
@@ -729,6 +730,7 @@ pub unsafe fn ensure_cross_origin_property_holder(
 
     // Create an inner holder map if it doesn't exist yet.
     if inner_holder_map_slot.get().is_null() {
+        let _ac = JSAutoRealm::new(*cx, proxy.get());
         inner_holder_map_slot.set(jsapi::NewWeakMapObject(*cx));
         if inner_holder_map_slot.get().is_null() {
             return false;

--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -28,6 +28,7 @@ use js::jsapi::JSAutoRealm;
 use js::jsapi::JS_AtomizeAndPinString;
 use js::jsapi::JS_DefinePropertyById;
 use js::jsapi::JS_GetOwnPropertyDescriptorById;
+use js::jsapi::JS_HasOwnPropertyById;
 use js::jsapi::JS_IsExceptionPending;
 use js::jsapi::MutableHandle as RawMutableHandle;
 use js::jsapi::MutableHandleIdVector as RawMutableHandleIdVector;
@@ -35,7 +36,7 @@ use js::jsapi::MutableHandleObject as RawMutableHandleObject;
 use js::jsapi::MutableHandleValue as RawMutableHandleValue;
 use js::jsapi::ObjectOpResult;
 use js::jsapi::{jsid, GetObjectRealmOrNull, GetRealmPrincipals, JSFunctionSpec, JSPropertySpec};
-use js::jsapi::{DOMProxyShadowsResult, JSContext, JSObject, PropertyDescriptor};
+use js::jsapi::{DOMProxyShadowsResult, Heap, JSContext, JSObject, PropertyDescriptor};
 use js::jsapi::{GetWellKnownSymbol, SymbolCode};
 use js::jsapi::{JSErrNum, SetDOMProxyInformation};
 use js::jsid::SymbolId;
@@ -46,10 +47,8 @@ use js::rust::wrappers::JS_NewObjectWithGivenProto;
 use js::rust::wrappers::{
     AppendToIdVector, SetDataPropertyDescriptor, RUST_INTERNED_STRING_TO_JSID,
 };
-use js::rust::{
-    get_context_realm, Handle, HandleObject, HandleValue, MutableHandle, MutableHandleObject,
-};
-use std::{ffi::CStr, os::raw::c_char, ptr};
+use js::rust::{get_context_realm, Handle, HandleObject, HandleValue, MutableHandle, MutableHandleObject};
+use std::{os::raw::c_char, ptr};
 
 /// Determine if this id shadows any existing properties for this proxy.
 pub unsafe extern "C" fn shadow_check_callback(
@@ -277,34 +276,26 @@ pub struct CrossOriginProperties {
     pub methods: &'static [JSFunctionSpec],
 }
 
-impl CrossOriginProperties {
-    /// Enumerate the property keys defined by `self`.
-    fn keys(&self) -> impl Iterator<Item = *const c_char> + '_ {
-        // Safety: All cross-origin property keys are strings, not symbols
-        self.attributes
-            .iter()
-            .map(|spec| unsafe { spec.name.string_ })
-            .chain(self.methods.iter().map(|spec| unsafe { spec.name.string_ }))
-            .filter(|ptr| !ptr.is_null())
-    }
-}
-
 /// Implementation of [`CrossOriginOwnPropertyKeys`].
+///
+/// `holder` should point to a cross-origin properties holder returned by
+/// `ensure_cross_origin_property_holder`.
 ///
 /// [`CrossOriginOwnPropertyKeys`]: https://html.spec.whatwg.org/multipage/#crossoriginownpropertykeys-(-o-)
 pub unsafe fn cross_origin_own_property_keys(
     cx: SafeJSContext,
-    _proxy: RawHandleObject,
-    cross_origin_properties: &'static CrossOriginProperties,
+    holder: RawHandleObject,
     props: RawMutableHandleIdVector,
 ) -> bool {
     // > 2. For each `e` of `! CrossOriginProperties(O)`, append
     // >    `e.[[Property]]` to `keys`.
-    for key in cross_origin_properties.keys() {
-        rooted!(in(*cx) let rooted = JS_AtomizeAndPinString(*cx, key));
-        rooted!(in(*cx) let mut rooted_jsid: jsid);
-        RUST_INTERNED_STRING_TO_JSID(*cx, rooted.handle().get(), rooted_jsid.handle_mut());
-        AppendToIdVector(props, rooted_jsid.handle());
+    if !jsapi::GetPropertyKeys(
+        *cx,
+        holder,
+        jsapi::JSITER_OWNONLY | jsapi::JSITER_HIDDEN | jsapi::JSITER_SYMBOLS,
+        props,
+    ) {
+        return false;
     }
 
     // > 3. Return the concatenation of `keys` and `« "then", @@toStringTag,
@@ -592,51 +583,32 @@ fn is_data_descriptor(d: &PropertyDescriptor) -> bool {
 /// SpiderMonkey-specific.
 ///
 /// `cx` and `proxy` are expected to be different-Realm here. `proxy` is a proxy
-/// for a maybe-cross-origin object.
+/// for a maybe-cross-origin object. `holder` should point to a cross-origin
+/// properties holder returned by `ensure_cross_origin_property_holder`.
 pub unsafe fn cross_origin_has_own(
     cx: SafeJSContext,
-    _proxy: RawHandleObject,
-    cross_origin_properties: &'static CrossOriginProperties,
+    holder: RawHandleObject,
     id: RawHandleId,
     bp: *mut bool,
 ) -> bool {
-    // TODO: Once we have the slot for the holder, it'd be more efficient to
-    //       use `ensure_cross_origin_property_holder`. We'll need `_proxy` to
-    //       do that.
-    *bp = jsid_to_string(*cx, Handle::from_raw(id)).map_or(false, |key| {
-        cross_origin_properties.keys().any(|defined_key| {
-            let defined_key = CStr::from_ptr(defined_key);
-            defined_key.to_bytes() == key.as_bytes()
-        })
-    });
-
-    true
+    JS_HasOwnPropertyById(*cx, holder, id, bp)
 }
 
 /// Implementation of [`CrossOriginGetOwnPropertyHelper`].
 ///
 /// `cx` and `proxy` are expected to be different-Realm here. `proxy` is a proxy
-/// for a maybe-cross-origin object.
+/// for a maybe-cross-origin object. `holder` should point to a cross-origin
+/// properties holder returned by `ensure_cross_origin_property_holder`.
 ///
 /// [`CrossOriginGetOwnPropertyHelper`]: https://html.spec.whatwg.org/multipage/#crossorigingetownpropertyhelper-(-o,-p-)
 pub unsafe fn cross_origin_get_own_property_helper(
     cx: SafeJSContext,
-    proxy: RawHandleObject,
-    cross_origin_properties: &'static CrossOriginProperties,
+    holder: RawHandleObject,
     id: RawHandleId,
     desc: RawMutableHandle<PropertyDescriptor>,
     is_none: &mut bool,
 ) -> bool {
-    rooted!(in(*cx) let mut holder = ptr::null_mut::<JSObject>());
-
-    ensure_cross_origin_property_holder(
-        cx,
-        proxy,
-        cross_origin_properties,
-        holder.handle_mut().into(),
-    );
-
-    return JS_GetOwnPropertyDescriptorById(*cx, holder.handle().into(), id, desc, is_none);
+    JS_GetOwnPropertyDescriptorById(*cx, holder.into(), id, desc, is_none)
 }
 
 /// Implementation of [`CrossOriginPropertyFallback`].
@@ -713,30 +685,92 @@ unsafe fn append_cross_origin_allowlisted_prop_keys(
     }
 }
 
-/// Get the holder for cross-origin properties for the current global of the
-/// `JSContext`, creating one and storing it in a slot of the proxy object if it
-/// doesn't exist yet.
+/// Provides access to the cross-origin property holder map associated with a
+/// maybe-cross-origin DOM object.
+pub trait CrossOriginPropertiesHolderMapAccess {
+    /// Get the cross-origin property holder map.
+    fn holder_map(&self) -> &CrossOriginPropertiesHolderMap;
+}
+
+/// A cross-origin property holder map.
 ///
-/// This essentially creates a cache of [`CrossOriginGetOwnPropertyHelper`]'s
-/// results for all property keys.
+/// This is our representation of [`[[CrossOriginPropertyDescriptorMap]]`].
+///
+/// [`[[CrossOriginPropertyDescriptorMap]]`]: https://html.spec.whatwg.org/multipage/#crossoriginpropertydescriptormap
+#[allow(unrooted_must_root)]
+#[derive(Default, JSTraceable, MallocSizeOf)]
+#[unrooted_must_root_lint::must_root]
+pub struct CrossOriginPropertiesHolderMap {
+    /// The slot to hold the inner holder map, which is a weak map.
+    /// Initialized lazily.
+    #[ignore_malloc_size_of = "mozjs"]
+    inner_holder_map_slot: Heap<*mut JSObject>,
+}
+
+/// Get the holder for cross-origin properties for the current global of the
+/// `JSContext`, creating one and storing it in the given holder map if it
+/// hasn't been created yet.
+///
+/// This essentially precalculates [`CrossOriginGetOwnPropertyHelper`]'s
+/// results for all property keys at once.
 ///
 /// `cx` and `proxy` are expected to be different-Realm here. `proxy` is a proxy
 /// for a maybe-cross-origin object. The `out_holder` return value will always
 /// be in the Realm of `cx`.
 ///
 /// [`CrossOriginGetOwnPropertyHelper`]: https://html.spec.whatwg.org/multipage/#crossorigingetownpropertyhelper-(-o,-p-)
-unsafe fn ensure_cross_origin_property_holder(
+pub unsafe fn ensure_cross_origin_property_holder(
     cx: SafeJSContext,
-    _proxy: RawHandleObject,
+    holder_map: &CrossOriginPropertiesHolderMap,
     cross_origin_properties: &'static CrossOriginProperties,
     out_holder: RawMutableHandleObject,
 ) -> bool {
-    // TODO: We don't have the slot to store the holder yet. For now,
-    //       the holder is constructed every time this function is called,
-    //       which is not only inefficient but also deviates from the
-    //       specification in a subtle yet observable way.
+    let inner_holder_map_slot = &holder_map.inner_holder_map_slot;
 
-    // Create a holder for the current Realm
+    // Create an inner holder map if it doesn't exist yet.
+    if inner_holder_map_slot.get().is_null() {
+        inner_holder_map_slot.set(jsapi::NewWeakMapObject(*cx));
+        if inner_holder_map_slot.get().is_null() {
+            return false;
+        }
+    }
+
+    // Get the inner holder map.
+    rooted!(in(*cx) let inner_holder_map = inner_holder_map_slot.get());
+
+    assert!(jsapi::IsWeakMapObject(inner_holder_map.get()));
+
+    // Per spec, the key for this map is supposed to be `(current settings,
+    // O's relevant settings)` where `current settings` corresponds to the
+    // current Realm of `cx`, and `O's relevant settings` corresponds to the
+    // Realm of the owner of `holder_map`. But since all of our objects are
+    // per-Realm singletons, we are basically using `holder_map` as part of
+    // the key.
+    //
+    // To represent the current settings, we use the current global object.
+    rooted!(in(*cx) let key = jsapi::CurrentGlobalOrNull(*cx));
+    if key.get().is_null() {
+        return false;
+    }
+
+    rooted!(in(*cx) let mut holder_val = UndefinedValue());
+
+    if !jsapi::GetWeakMapEntry(
+        *cx,
+        inner_holder_map.handle().into(),
+        key.handle().into(),
+        holder_val.handle_mut().into(),
+    ) {
+        return false;
+    }
+
+    // Did we get a holder?
+    if holder_val.get().is_object() {
+        out_holder.set(holder_val.to_object());
+        return true;
+    }
+
+    // We didn't. Create a holder for the current Realm
     out_holder.set(jsapi::JS_NewObjectWithGivenProto(
         *cx,
         ptr::null_mut(),
@@ -758,7 +792,16 @@ unsafe fn ensure_cross_origin_property_holder(
         return false;
     }
 
-    // TODO: Store the holder in the slot that we don't have yet.
+    // Store the holder in the inner holder map
+    out_holder.get().to_jsval(*cx, holder_val.handle_mut());
+    if !jsapi::SetWeakMapEntry(
+        *cx,
+        inner_holder_map.handle().into(),
+        key.handle().into(),
+        holder_val.handle().into(),
+    ) {
+        return false;
+    }
 
     true
 }

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -6,6 +6,9 @@ use crate::dom::bindings::codegen::Bindings::LocationBinding::LocationMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowBinding::WindowMethods;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::proxyhandler::{
+    CrossOriginPropertiesHolderMap, CrossOriginPropertiesHolderMapAccess,
+};
 use crate::dom::bindings::reflector::{reflect_dom_object, Reflector};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
@@ -21,6 +24,7 @@ use servo_url::{MutableOrigin, ServoUrl};
 pub struct Location {
     reflector_: Reflector,
     window: Dom<Window>,
+    holder_map: CrossOriginPropertiesHolderMap,
 }
 
 impl Location {
@@ -28,6 +32,7 @@ impl Location {
         Location {
             reflector_: Reflector::new(),
             window: Dom::from_ref(window),
+            holder_map: CrossOriginPropertiesHolderMap::default(),
         }
     }
 
@@ -90,6 +95,12 @@ impl Location {
     #[allow(dead_code)]
     pub fn origin(&self) -> &MutableOrigin {
         self.window.origin()
+    }
+}
+
+impl CrossOriginPropertiesHolderMapAccess for Location {
+    fn holder_map(&self) -> &CrossOriginPropertiesHolderMap {
+        &self.holder_map
     }
 }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -10494,7 +10494,13 @@
      "cross-origin-postMessage-child2.html": [
       "a1395ad2b51415b251fb7e27ef6fdfe3d87ae3ef",
       []
-     ]
+     ],
+     "support": {
+      "frame.html": [
+       "3fc532e5a005f3d557e912249f6a74bf6337b6a0",
+       []
+      ]
+     }
     },
     "details_ui_closed_ref.html": [
      "b7db1ce810c09c9169142db4333f2648ed098239",
@@ -12872,6 +12878,13 @@
      ],
      "cross-origin-postMessage.html": [
       "143240c97aa60b52c8d2e0067c25e4509bf6481d",
+      [
+       null,
+       {}
+      ]
+     ],
+     "cross-origin-properties-holders.html": [
+      "4987cb56a7dbff9712b72d879bb07d6fe9fa628a",
       [
        null,
        {}

--- a/tests/wpt/mozilla/meta/mozilla/cross-origin-objects/cross-origin-properties-holders.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/cross-origin-objects/cross-origin-properties-holders.html.ini
@@ -1,0 +1,19 @@
+[cross-origin-properties-holders.html]
+  [property descriptors of windowProxy, no navigation (cross-origin)]
+    expected: FAIL
+
+  [property descriptors of windowProxy, no navigation (same-origin + document.domain)]
+    expected: FAIL
+
+  [property descriptors of windowProxy, no navigation (cross-site)]
+    expected: FAIL
+
+  [property descriptors of windowProxy.location, no navigation (cross-site)]
+    expected: FAIL
+
+  [property descriptors of windowProxy across navigation (cross-site)]
+    expected: FAIL
+
+  [property descriptors of windowProxy.location across navigation (cross-site)]
+    expected: FAIL
+

--- a/tests/wpt/mozilla/tests/mozilla/cross-origin-objects/cross-origin-properties-holders.html
+++ b/tests/wpt/mozilla/tests/mozilla/cross-origin-objects/cross-origin-properties-holders.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Cross-origin property descriptor maps</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#cross-origin-objects">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<div id=log></div>
+<iframe id="C"></iframe>
+<iframe id="E"></iframe>
+<iframe id="G"></iframe>
+<script>
+
+/*
+ * Setup boilerplate. This gives us
+ *
+ *  - a cross-origin window "C",
+ *  - an initially same-origin but then changing document.domain window "E",
+ *  - and a not-same-site (also cross-origin, of course) window "G".
+ */
+var host_info = get_host_info();
+
+path = location.pathname.substring(0, location.pathname.lastIndexOf('/')) + '/support/frame.html';
+var C = document.getElementById('C');
+var E = document.getElementById('E');
+var G = document.getElementById('G');
+C.src = C.uriToLoad = host_info.HTTP_REMOTE_ORIGIN + path;
+E.src = E.uriToLoad = path + "?setdomain";
+G.src = G.uriToLoad = host_info.HTTP_NOTSAMESITE_ORIGIN + path;
+
+const waitWindowLoad = new Promise(r => window.addEventListener('load', r));
+
+function promise_test_for_each_case(func, desc) {
+  promise_test(t => func(t, C), desc + " (cross-origin)");
+  promise_test(t => func(t, E), desc + " (same-origin + document.domain)");
+  promise_test(t => func(t, G), desc + " (cross-site)");
+}
+
+const interfaces = [
+  ['windowProxy', windowProxy => windowProxy, ['close', 'frames'], 'open'],
+  ['windowProxy.location', windowProxy => windowProxy.location, ['href', 'replace'], 'hash'],
+];
+
+for (let [lensName, lensFn, propKeys, nonXoPropKey] of interfaces) {
+  promise_test_for_each_case(async (t, frame) => {
+    await waitWindowLoad;
+    const win = frame.contentWindow;
+    const theObject = lensFn(win);
+    const myObject = lensFn(window);
+
+    // Precondition: `IsPlatformObjectSameOrigin(theObject) == false`
+    assert_throws_dom("SecurityError", () => theObject[nonXoPropKey],
+      `Sanity check: Accessing non-cross-origin property ${nonXoPropKey} ` +
+      `should throw SecurityError`);
+
+    for (let propKey of propKeys) {
+      const desc = Object.getOwnPropertyDescriptor(theObject, propKey);
+      assert_not_equals(desc, null, `Property ${propKey} has a non-null property descriptor`);
+
+      // `CrossOriginGetOwnPropertyHelper` creates descriptors lazily for given property keys.
+      // The created descriptors must be held in `[[CrossOriginPropertyDescriptorMap]]` and
+      // returned in next calls.
+      const desc2 = Object.getOwnPropertyDescriptor(theObject, propKey);
+      assert_equals(desc.get, desc2.get, `Property ${propKey} has a stable getter`);
+      assert_equals(desc.set, desc2.set, `Property ${propKey} has a stable setter`);
+      assert_equals(desc.value, desc2.value, `Property ${propKey} has a stable value`);
+
+      // Check the descriptors' globals. The getters, setters, and values must
+      // be created in our Realm (rather than those of these documents).
+      const myDesc = Object.getOwnPropertyDescriptor(myObject, propKey);
+      if (desc.get) {
+        assert_equals(desc.get.__proto__, myDesc.get.__proto__,
+          `Property ${propKey}'s getter should be created in the current Realm`);
+      }
+      if (desc.set) {
+        assert_equals(desc.set.__proto__, myDesc.set.__proto__,
+          `Property ${propKey}'s setter should be created in the current Realm`);
+      }
+      if (desc.value) {
+        assert_equals(desc.value.__proto__, myDesc.value.__proto__,
+          `Property ${propKey}'s value should be created in the current Realm`);
+      }
+    }
+  }, `property descriptors of ${lensName}, no navigation`);
+}
+
+let i = 0;
+
+for (let [lensName, lensFn, propKeys] of interfaces) {
+  promise_test_for_each_case(async (t, frame) => {
+    // Get the old descriptors
+    const oldDescs = propKeys.map(propKey => {
+      const theObject = lensFn(frame.contentWindow);
+      return Object.getOwnPropertyDescriptor(theObject, propKey);
+    });
+
+    // Navigate the frame
+    const waitFrameLoad = new Promise(r => frame.addEventListener('load', r));
+    frame.src = frame.uriToLoad + '?' + (i++);
+    await waitFrameLoad;
+
+    // Check the new descriptors
+    for (let propKey of propKeys) {
+      const oldDesc = oldDescs.shift();
+
+      const theObject = lensFn(frame.contentWindow);
+      const desc = Object.getOwnPropertyDescriptor(theObject, propKey);
+
+      // Since each `O` has a unique instance of `[[CrossOriginPropertyDescriptorMap]]`, the result
+      // of `CrossOriginGetOwnPropertyHelper(O, P)` should change if `O` changes
+      if (desc.get) {
+        assert_not_equals(desc.get, oldDesc.get, `${lensName}.${propKey} should change across navigation`);
+      }
+      if (desc.set) {
+        assert_not_equals(desc.set, oldDesc.set, `${lensName}.${propKey} should change across navigation`);
+      }
+      if (desc.value) {
+        assert_not_equals(desc.value, oldDesc.value, `${lensName}.${propKey} should change across navigation`);
+      }
+    }
+  }, `property descriptors of ${lensName} across navigation`);
+}
+
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/cross-origin-objects/support/frame.html
+++ b/tests/wpt/mozilla/tests/mozilla/cross-origin-objects/support/frame.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+<script>
+  if (location.search.indexOf("?setdomain") >= 0) {
+    document.domain = document.domain;
+  }
+</script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
This mostly follows [Firefox's][1] [approach][2] except that the holder maps are stored in DOM struct fields (e.g., `Location::holder_map`) instead of proxy internal slots. This approach provides superior type safety and maintainability (e.g., we don't have to be cautious about how each proxy internal slot index is used).

[1]: https://searchfox.org/mozilla-central/rev/072710086ddfe25aa2962c8399fefb2304e8193b/dom/bindings/Codegen.py#621-628
[2]: https://searchfox.org/mozilla-central/rev/072710086ddfe25aa2962c8399fefb2304e8193b/dom/base/MaybeCrossOriginObject.cpp#232-253

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #28557

---
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___
