### PR TITLE
`/cookies/path/match.html` has been broken since Jun 9, 2021

### DIFF
--- a/tests/wpt/metadata/cookies/path/match.html.ini
+++ b/tests/wpt/metadata/cookies/path/match.html.ini
@@ -1,0 +1,25 @@
+[match.html]
+  [`Set-Cookie` on /cookies/resources/echo-cookie.html sets cookie with path: /]
+    expected: FAIL
+    bug: https://chromium-review.googlesource.com/c/chromium/src/+/2872768
+
+  [`Set-Cookie` on /cookies/resources/echo-cookie.html sets cookie with path: match.html]
+    expected: FAIL
+    bug: https://chromium-review.googlesource.com/c/chromium/src/+/2872768
+
+  [`Set-Cookie` on /cookies/resources/echo-cookie.html sets cookie with path: cookies]
+    expected: FAIL
+    bug: https://chromium-review.googlesource.com/c/chromium/src/+/2872768
+
+  [`Set-Cookie` on /cookies/resources/echo-cookie.html sets cookie with path: /cookies]
+    expected: FAIL
+    bug: https://chromium-review.googlesource.com/c/chromium/src/+/2872768
+
+  [`Set-Cookie` on /cookies/resources/echo-cookie.html sets cookie with path: /cookies/]
+    expected: FAIL
+    bug: https://chromium-review.googlesource.com/c/chromium/src/+/2872768
+
+  [`Set-Cookie` on /cookies/resources/echo-cookie.html sets cookie with path: /cookies/resources/echo-cookie.html]
+    expected: FAIL
+    bug: https://chromium-review.googlesource.com/c/chromium/src/+/2872768
+


### PR DESCRIPTION
`/cookies/path/match.html` fails because the cookie expiration date is set to a past date. This is [a known issue][1] in WPT.

<https://github.com/servo/servo/blob/cc1f89863ce0e93ff7ce4f4855bd888df67a51fb/tests/wpt/web-platform-tests/cookies/resources/set-cookie.py#L22>

[1]: https://chromium-review.googlesource.com/c/chromium/src/+/2872768

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #28492

---
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they fix tests
