### PR TITLE
CI: Don't cancel the entire job matrix when one of them fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -210,6 +210,7 @@ jobs:
     env:
       max_chunk_id: 20
     strategy:
+      fail-fast: false
       matrix:
         chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     steps:


### PR DESCRIPTION
By default, GitHub Actions [cancels][1] all in-progress jobs in a build matrix when one of them fails. This PR disables this behavior.

[1]: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

---
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they are for CI