### PR TITLE
Allow gradient interpolation hints to influence color-stop fixup

### DIFF
--- a/components/layout/display_list/gradient.rs
+++ b/components/layout/display_list/gradient.rs
@@ -90,16 +90,13 @@ fn convert_gradient_stops(
                 color: Some(color),
                 position: None,
             }),
-            GradientItem::ComplexColorStop {
-                color,
-                position,
-            } => Some(ColorStop {
+            GradientItem::ComplexColorStop { color, position } => Some(ColorStop {
                 color: Some(color),
                 position: Some(position.clone()),
             }),
             GradientItem::InterpolationHint(position) => Some(ColorStop {
                 color: None,
-                position: Some(position.clone())
+                position: Some(position.clone()),
             }),
         })
         .collect::<Vec<_>>();

--- a/components/layout_2020/display_list/gradient.rs
+++ b/components/layout_2020/display_list/gradient.rs
@@ -292,10 +292,12 @@ fn fixup_stops(
                 // FIXME: approximate like in:
                 // https://searchfox.org/mozilla-central/rev/f98dad153b59a985efd4505912588d4651033395/layout/painting/nsCSSRenderingGradients.cpp#315-391
                 // Ensure that interpolation hints influence fixup. This does not yet implement midpoints
-                stops.push( ColorStop {
+                stops.push(ColorStop {
                     color: None,
-                    position: Some(position.percentage_relative_to(gradient_line_length).px() /
-                        gradient_line_length.px())
+                    position: Some(
+                        position.percentage_relative_to(gradient_line_length).px() /
+                            gradient_line_length.px(),
+                    ),
                 })
             },
         }
@@ -328,7 +330,9 @@ fn fixup_stops(
     let first_stop_position = first.position.unwrap();
     wr_stops.push(wr::GradientStop {
         offset: first_stop_position,
-        color: first.color.expect("Interpolation hints can only be interior items"),
+        color: first
+            .color
+            .expect("Interpolation hints can only be interior items"),
     });
 
     let mut last_positioned_stop_index = 0;

--- a/components/style/values/generics/image.rs
+++ b/components/style/values/generics/image.rs
@@ -335,7 +335,8 @@ pub use self::GenericGradientItem as GradientItem;
 )]
 pub struct ColorStop<Color, T> {
     /// The color of this stop.
-    pub color: Color,
+    /// If the color is None, this stop is used for color-stop fixup only, not for display.
+    pub color: Option<Color>,
     /// The position of this stop.
     pub position: Option<T>,
 }
@@ -344,12 +345,16 @@ impl<Color, T> ColorStop<Color, T> {
     /// Convert the color stop into an appropriate `GradientItem`.
     #[inline]
     pub fn into_item(self) -> GradientItem<Color, T> {
-        match self.position {
-            Some(position) => GradientItem::ComplexColorStop {
-                color: self.color,
-                position,
+        match (self.position, self.color) {
+            (Some(position), Some(color)) => {
+                GradientItem::ComplexColorStop {
+                    color,
+                    position,
+                }
             },
-            None => GradientItem::SimpleColorStop(self.color),
+            (Some(position), None) => {GradientItem::InterpolationHint(position)},
+            (None, Some(color)) => {GradientItem::SimpleColorStop(color)},
+            (None, None) => panic!("Non-positioned, non-colored GradientItems don't exist yet")
         }
     }
 }

--- a/components/style/values/generics/image.rs
+++ b/components/style/values/generics/image.rs
@@ -346,15 +346,10 @@ impl<Color, T> ColorStop<Color, T> {
     #[inline]
     pub fn into_item(self) -> GradientItem<Color, T> {
         match (self.position, self.color) {
-            (Some(position), Some(color)) => {
-                GradientItem::ComplexColorStop {
-                    color,
-                    position,
-                }
-            },
-            (Some(position), None) => {GradientItem::InterpolationHint(position)},
-            (None, Some(color)) => {GradientItem::SimpleColorStop(color)},
-            (None, None) => panic!("Non-positioned, non-colored GradientItems don't exist yet")
+            (Some(position), Some(color)) => GradientItem::ComplexColorStop { color, position },
+            (Some(position), None) => GradientItem::InterpolationHint(position),
+            (None, Some(color)) => GradientItem::SimpleColorStop(color),
+            (None, None) => panic!("Non-positioned, non-colored GradientItems don't exist yet"),
         }
     }
 }

--- a/components/style/values/specified/image.rs
+++ b/components/style/values/specified/image.rs
@@ -1187,7 +1187,7 @@ impl<T> generic::ColorStop<Color, T> {
         ) -> Result<T, ParseError<'i1>>,
     ) -> Result<Self, ParseError<'i>> {
         Ok(generic::ColorStop {
-            color: Color::parse(context, input)?,
+            color: Some(Color::parse(context, input)?),
             position: input.try_parse(|i| parse_position(context, i)).ok(),
         })
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

I am working on the [easing gradients feature for CSS](https://github.com/w3c/csswg-drafts/issues/1332). I want to eventually implement that in Servo as a demonstration since Servo is a bit easier (in my opinion) to modify than Firefox or Chromium. However, at this point, Servo does not even support gradient interpolation hints so I am working towards that support. I think that it will require modifications to [webrender](https://github.com/servo/webrender) if we don't want to use [Firefox's approximation](https://searchfox.org/mozilla-central/rev/f98dad153b59a985efd4505912588d4651033395/layout/painting/nsCSSRenderingGradients.cpp#315-391). I am happy to implement that approximation though if we want something that works now.

This pull request just makes it so that the interpolation hints influence the position of unpositioned stops. Specifically, on [my test website](https://brycemw.ca/experiments/gradients), the first and third gradients look the same prior to this fix and they look correct after this fix. It is also important to note that the white colour-stop of the first gradient should be further to the right than the white colour-stop of the second gradient. There's a bit more [discussion about this effect here](https://github.com/w3c/csswg-drafts/issues/3931).

I've implemented this in both layout_2017 and layout_2020. I had to change a few things in 2017 that I don't fully understand so I would appreciate if someone could make sure that I didn't cause a subtle bug or performance issue. Especially around line 88 and 116 of `components/layout/display_list/gradient.rs`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors (and `./mach build -d --with-layout-2020`)
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] There are tests for these changes (Should be covered by the reftests)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
