### PR TITLE
Fix compiler warnings

### DIFF
--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -627,7 +627,7 @@ bitflags! {
         #[doc = "virtual call is too expensive."]
         const FLOATS_RIGHT = 0b0000_0000_0000_0100_0000_0000;
         #[doc = "Text alignment. \
-
+                 \
                  NB: If you update this, update `TEXT_ALIGN_SHIFT` below."]
         const TEXT_ALIGN = 0b0000_0000_0111_1000_0000_0000;
         #[doc = "Whether this flow has a fragment with `counter-reset` or `counter-increment` \

--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#![allow(unsafe_code)]
+
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::CSSRuleListBinding::CSSRuleListMethods;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
@@ -21,7 +23,6 @@ use style::stylesheets::{
     AllowImportRules, CssRules, CssRulesHelpers, KeyframesRule, RulesMutateError,
 };
 
-#[allow(unsafe_code)]
 unsafe_no_jsmanaged_fields!(RulesSource);
 
 unsafe_no_jsmanaged_fields!(CssRules);

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -636,7 +636,7 @@ macro_rules! handle_potential_webgl_error {
         }
     };
     ($context:expr, $call:expr) => {
-        handle_potential_webgl_error!($context, $call, ());
+        handle_potential_webgl_error!($context, $call, ())
     };
 }
 

--- a/components/style/stylesheets/viewport_rule.rs
+++ b/components/style/stylesheets/viewport_rule.rs
@@ -753,7 +753,7 @@ impl MaybeNew for ViewportConstraints {
                     })
                 } else {
                     None
-                };
+                }
             };
         }
 

--- a/components/style/values/generics/mod.rs
+++ b/components/style/values/generics/mod.rs
@@ -136,7 +136,7 @@ impl SpecifiedValueInfo for CounterStyle {
         // approach here.
         macro_rules! predefined {
             ($($name:expr,)+) => {
-                f(&["symbols", $($name,)+]);
+                f(&["symbols", $($name,)+])
             }
         }
         include!("../../counter_style/predefined.rs");


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

While working on my other pull request, I noticed that there were a few compiler warnings that are easy to fix since they simply note some deprecated syntax that can be fixed with no semantic difference. I decided to quickly fix them and submit a PR.

There was also one place where an allowance of unsafe code was not being applied to the correct thing in `components/script/dom/cssrulelist.rs`. It was being applied to a macro `unsafe_no_jsmanaged_fields!` which does contain unsafe code. My understanding (and what the compiler warning states) is that applying that annotation to a macro does nothing even if the macro contains unsafe code. So what I have done is moved this annotation to apply to the entire file. I do not know if that is even necessary since the macro definition is in another file. It would be good to know since it would be best to not add extra allowances when they aren't needed. The compiler warning is below if that helps:
```
warning: unused attribute `allow`
  --> components/script/dom/cssrulelist.rs:24:1
   |
24 | #[allow(unsafe_code)]
   | ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_attributes)]` on by default
note: the built-in attribute `allow` will be ignored, since it's applied to the macro invocation `unsafe_no_jsmanaged_fields`
  --> components/script/dom/cssrulelist.rs:25:1
   |
25 | unsafe_no_jsmanaged_fields!(RulesSource);
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable) (No issue number)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they fix compiler warnings in a way that does not change semantics except as noted.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
