### PR TITLE
The condition for exposing a cross-origin setter should be `CrossOriginWritable`, not `CrossOriginReadable`

### DIFF
--- a/components/script/dom/bindings/codegen/CodegenRust.py
+++ b/components/script/dom/bindings/codegen/CodegenRust.py
@@ -1936,7 +1936,7 @@ class AttrDefiner(PropertyDefiner):
         def setter(attr):
             attr = attr['attr']
 
-            if ((self.crossorigin and not attr.getExtendedAttribute("CrossOriginReadable"))
+            if ((self.crossorigin and not attr.getExtendedAttribute("CrossOriginWritable"))
                 or (attr.readonly
                     and not attr.getExtendedAttribute("PutForwards")
                     and not attr.getExtendedAttribute("Replaceable"))):

--- a/tests/wpt/metadata/html/browsers/origin/cross-origin-objects/cross-origin-objects.html.ini
+++ b/tests/wpt/metadata/html/browsers/origin/cross-origin-objects/cross-origin-objects.html.ini
@@ -188,12 +188,6 @@
   [Same-origin observers get different accessors for cross-origin Window (cross-site)]
     expected: FAIL
 
-  [Same-origin observers get different accessors for cross-origin Location (cross-origin)]
-    expected: FAIL
-
-  [Same-origin observers get different accessors for cross-origin Location (same-origin + document.domain)]
-    expected: FAIL
-
   [Same-origin observers get different accessors for cross-origin Location (cross-site)]
     expected: FAIL
 


### PR DESCRIPTION
Fixes `Location#href` being inaccessible from a cross-origin document.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

---
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___
