### PR TITLE
Fix simpleservo binary check on macos

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -373,7 +373,12 @@ class CommandBase(object):
             base_path = path.join(base_path, target)
 
         if simpleservo:
-            binary_name = "simpleservo.dll" if sys.platform == "win32" else "libsimpleservo.so"
+            if sys.platform == "win32":
+                binary_name = "simpleservo.dll"
+            elif sys.platform == "darwin":
+                binary_name = "libsimpleservo.dylib"
+            else:
+                binary_name = "libsimpleservo.so"
 
         release_path = path.join(base_path, "release", binary_name)
         dev_path = path.join(base_path, "debug", binary_name)


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
When compiling libsimpleservo on MacOS 11.5.2 I would get an error at the end of the process saying
```
Error running mach:

    ['build', '-d', '--libsimpleservo']

The error occurred in code that was called by the mach command. This is either
a bug in the called code itself or in the way that mach is calling it.
You can invoke |./mach busted| to check if this issue is already on file. If it
isn't, please use |./mach busted file| to report it. If |./mach busted| is
misbehaving, you can also inspect the dependencies of bug 1543241.

If filing a bug, please include the full output of mach, including this error
message.

The details of the failure are as follows:

servo.command_base.BuildNotFound: No Servo binary found. Perhaps you forgot to run `./mach build`?

  File "/Users/yuriwitte/_HtmlTests/servo/python/servo/build_commands.py", line 734, in build
    self.get_binary_path(release, dev, target=target, simpleservo=libsimpleservo)
  File "/Users/yuriwitte/_HtmlTests/servo/python/servo/command_base.py", line 394, in get_binary_path
    raise BuildNotFound('No Servo binary found.'
```
The binary is there, it's just that `get_binary_path` on `command_base.py` checks for a libsimpleservo **.so** instead of a **.dylib**. This pr fixes this check.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix: didn't find a specific issue for this, but these two are also related to file extensions on MacOS:
https://github.com/servo/servo/issues/27654
https://github.com/servo/servo/issues/27318

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because: they _are_ the tests I guess?

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
