### PR TITLE
Remove arm64 builds from required successes.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -259,7 +259,6 @@ jobs:
     needs:
       - "build-win"
       - "build-uwp-x64"
-      - "build-uwp-arm64"
       - "build-linux"
       - "build-mac"
       - "linux-wpt"


### PR DESCRIPTION
This is a workaround for #28599 to allow us to continue to merge PRs.