### PR TITLE
Fix CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,9 +4304,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.63"
+version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
+checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
 dependencies = [
  "autocfg",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4284,9 +4284,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.34"
+version = "0.10.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
+checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,7 @@
 # Ensure all versions are pinned for repeatability,
 # since `--system-site-packages` is enabled
 
-blessings == 1.6
+blessings == 1.7
 distro == 1.4
 mach == 1.0.0
 mozdebug == 0.3

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -49,7 +49,7 @@ WEB_PLATFORM_TESTS_PATH = os.path.join("tests", "wpt", "web-platform-tests")
 SERVO_TESTS_PATH = os.path.join("tests", "wpt", "mozilla", "tests")
 
 CLANGFMT_CPP_DIRS = ["support/hololens/"]
-CLANGFMT_VERSION = "11"
+CLANGFMT_VERSION = "12"
 
 TEST_SUITES = OrderedDict([
     ("tidy", {"kwargs": {"all_files": False, "no_progress": False, "self_test": False,


### PR DESCRIPTION
This PR fixes CI failures that have occurred due to external reasons.

# Highlights

## `blessing`

Our `mach` script uses [`blessings`][2] for terminal rendering during WPT tests. The `setuptools` script of `blessings` 1.6 activates the option `use_2to3` to convert the code when installing the package for Python 3. However, this option has been [removed][1] in `setuptools` 58. This caused a breakage in our CI pipelines, producing an error message like the following:

```
Collecting blessings==1.6
  Downloading blessings-1.6.tar.gz (19 kB)
    ERROR: Command errored out with exit status 1:
     command: /home/runner/work/servo/servo/python/_virtualenv3.8/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-n51ah1i5/blessings_f1c0f646d72e488e988232f7aeb42946/setup.py'"'"'; __file__='"'"'/tmp/pip-install-n51ah1i5/blessings_f1c0f646d72e488e988232f7aeb42946/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-1eg28bh4
         cwd: /tmp/pip-install-n51ah1i5/blessings_f1c0f646d72e488e988232f7aeb42946/
    Complete output (1 lines):
    error in blessings setup command: use_2to3 is invalid.
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/af/4a/61acd1c6c29662d3fcbcaee5ba95c20b1d315c5a33534732b6d81e0dc8e8/blessings-1.6.tar.gz#sha256=edc5713061f10966048bf6b40d9a514b381e0ba849c64e034c4ef6c1847d3007 (from https://pypi.org/simple/blessings/). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Could not find a version that satisfies the requirement blessings==1.6 (from versions: 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.5.1, 1.6, 1.6.1, 1.7)
ERROR: No matching distribution found for blessings==1.6
"/home/runner/work/servo/servo/python/_virtualenv3.8/bin/python" "-m" "pip" "install" "-I" "-r" "/home/runner/work/servo/servo/python/requirements.txt" failed with error code 1:
Output:
Error:
Error: Process completed with exit code 1.
```

Our `requirements.txt` pins the version of `setuptools`, but this didn't work probably because `virtualenv` uses an embedded version of `setuptools`, which was recently [upgraded][4] to 58 in `virtualenv` 20.8.0.

This PR upgrades `blessings` to a version that [doesn't use][3] the `use_2to3` option anymore to fix this issue.

## OpenSSL Binding

It appears that, when installing OpenSSL, Homebrew now installs version 3.0 by default. OpenSSL 3.0 isn't supported by `openssl-sys` 0.9.63 that we currently use and causes a build error while building the binding.

```
build/expando.c:10:1: error: pasting formed 'RUST_VERSION_OPENSSL_(', an invalid preprocessing token
VERSION(OPENSSL, OPENSSL_VERSION_NUMBER)
^
build/expando.c:5:23: note: expanded from macro 'VERSION'
#define VERSION(n, v) VERSION2(n, v)
                      ^
build/expando.c:4:43: note: expanded from macro 'VERSION2'
#define VERSION2(n, v) RUST_VERSION_##n##_##v
                                          ^
1 error generated.
```

This PR upgrades `openssl[-sys]` to newer versions that were [updated][5] to support OpenSSL 3.0.

## `clang-format`

`mach test-tidy` requires a specific version of `clang-format` so that the formatting result is consistent between build environments. [The virtual environment][6] used by GitHub Actions has been [updated][7] and now provides a version of `clang-format` that is different from the one expected by our `mach` tool. This PR updates our tool to address the issue.

[1]: https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v5800
[2]: https://github.com/erikrose/blessings
[3]: https://github.com/erikrose/blessings/pull/132
[4]: https://github.com/pypa/virtualenv/blob/main/docs/changelog.rst#v2080-2021-09-16
[5]: https://github.com/sfackler/rust-openssl/commit/b4c735e8af546dee49b54679f63bcfec16c15a0f
[6]: https://github.com/actions/virtual-environments
[7]: https://github.com/actions/virtual-environments/pull/3905/files#diff-816219d3c9f30fcc1c40f88ca826c1662bf99eded781c1b419dd2dfb577ae227R380

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

---
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they don't change the production code
