### PR TITLE
Fix UB in hashglobe

### DIFF
--- a/components/hashglobe/src/table.rs
+++ b/components/hashglobe/src/table.rs
@@ -836,7 +836,9 @@ impl<K, V> RawTable<K, V> {
     pub fn new(capacity: usize) -> Result<RawTable<K, V>, FailedAllocationError> {
         unsafe {
             let ret = RawTable::try_new_uninitialized(capacity)?;
-            ptr::write_bytes(ret.hashes.ptr(), 0, capacity);
+            if capacity > 0 {
+                ptr::write_bytes(ret.hashes.ptr(), 0, capacity);
+            }
             Ok(ret)
         }
     }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This is a backport of https://github.com/rust-lang/rust/pull/53804

Currently, this bug cause Firefox crash with Rust 1.56 ( LLVM 13 )

<details>
<summary>backtrace of Firefox</summary>

```
(lldb) bt
* thread #1, name = 'GeckoMain', stop reason = signal SIGSEGV: invalid address (fault address: 0x0)
  * frame #0: 0x00007ffff4ff7bde libxul.so`::RustMozCrash(const char *, int, const char *) [inlined] MOZ_Crash(aLine=2220, aReason="attempt to write to unaligned or null pointer") at Assertions.h:256:3
    frame #1: 0x00007ffff4ff7bd4 libxul.so`::RustMozCrash(aFilename="/rustc/1.56.0/library/core/src/intrinsics.rs", aLine=2220, aReason="attempt to write to unaligned or null pointer") at wrappers.cpp:18:3
    frame #2: 0x00007ffff4ff7b53 libxul.so`mozglue_static::panic_hook::h91947f48d75eb4dd(info=<unavailable>) at lib.rs:91:9
    frame #3: 0x00007ffff4ff6e19 libxul.so`core::ops::function::Fn::call::h2f4e62c593234181((null)=<unavailable>, (null)=<unavailable>) at function.rs:70:5
    frame #4: 0x00007ffff5bd055b libxul.so`std::panicking::rust_panic_with_hook::h41696e81832261ff(payload=&mut dyn core::panic::BoxMeUp @ 0x00007f24a7e5fc70, message=Option<&core::fmt::Arguments> @ r13, location=<unavailable>) at panicking.rs:628:17
    frame #5: 0x00007ffff5bd00a2 libxul.so`std::panicking::begin_panic_handler::_$u7b$$u7b$closure$u7d$$u7d$::hea2a534982472bd3 at panicking.rs:519:13
    frame #6: 0x00007ffff5bcc494 libxul.so`std::sys_common::backtrace::__rust_end_short_backtrace::h793de5eec3283122(f=<unavailable>) at backtrace.rs:141:18
    frame #7: 0x00007ffff5bd0039 libxul.so`rust_begin_unwind(info=0x00007fffffff7a78) at panicking.rs:517:5
    frame #8: 0x00007ffff5c2ece1 libxul.so`core::panicking::panic_fmt::h43c4759d9f1ef313(fmt=<unavailable>) at panicking.rs:101:14
    frame #9: 0x00007ffff5c2ebbd libxul.so`core::panicking::panic::hb6dc0edf878703a5(expr=<unavailable>) at panicking.rs:50:5
    frame #10: 0x00007ffff56dd397 libxul.so`core::intrinsics::write_bytes::h481ad0b8372e9e0a(dst=0x0000000000000000, val='\0', count=0) at intrinsics.rs:2220:5
    frame #11: 0x00007ffff589e749 libxul.so`hashglobe::table::RawTable$LT$K$C$V$GT$::new::h04532bdf928a2865(capacity=0) at table.rs:839:13
    frame #12: 0x00007ffff58b38f0 libxul.so`hashglobe::hash_map::HashMap$LT$K$C$V$C$S$GT$::try_with_hasher::h7086fbc016a9427d(hash_builder=<unavailable>) at hash_map.rs:622:20
    frame #13: 0x00007ffff58b3077 libxul.so`hashglobe::hash_map::HashMap$LT$K$C$V$C$S$GT$::with_hasher::h9ee840b6d255f9fa(hash_builder=<unavailable>) at hash_map.rs:628:9
    frame #14: 0x00007ffff5812c99 libxul.so`_$LT$hashglobe..hash_map..HashMap$LT$K$C$V$C$S$GT$$u20$as$u20$core..default..Default$GT$::default::h7a34c6ba884b9658 at hash_map.rs:1329:9
    frame #15: 0x00007ffff58dfb3a libxul.so`_$LT$style..selector_map..MaybeCaseInsensitiveHashMap$LT$style..gecko_string_cache..Atom$C$V$GT$$u20$as$u20$core..default..Default$GT$::default::h2c19828653342158 at selector_map.rs:704:37
    frame #16: 0x00007ffff5978919 libxul.so`_$LT$style..invalidation..stylesheets..StylesheetInvalidationSet$u20$as$u20$core..default..Default$GT$::default::h16e0d0431f387b3d at stylesheets.rs:103:5
    frame #17: 0x00007ffff58d54b9 libxul.so`style::invalidation::stylesheets::StylesheetInvalidationSet::new::h4eedeb3b15c2c2c5 at stylesheets.rs:112:9
    frame #18: 0x00007ffff58e43a6 libxul.so`style::stylesheet_set::DocumentStylesheetSet$LT$S$GT$::new::hf80ba16d4d55a4ca at stylesheet_set.rs:516:28
    frame #19: 0x00007ffff58f269a libxul.so`style::stylist::StylistStylesheetSet::new::h66b5d09ea8a90d6e at stylist.rs:462:30
    frame #20: 0x00007ffff58f26f0 libxul.so`style::stylist::Stylist::new::h4732ca5247e85cd7(device=<unavailable>, quirks_mode=Quirks) at stylist.rs:562:26
    frame #21: 0x00007ffff593d755 libxul.so`style::gecko::data::PerDocumentStyleData::new::h9dc814d46fec8d6c(document=<unavailable>) at data.rs:145:22
    frame #22: 0x00007ffff56781d9 libxul.so`Servo_StyleSet_Init(doc=<unavailable>) at glue.rs:4175:25
    frame #23: 0x00007ffff2b58416 libxul.so`mozilla::ServoStyleSet::ServoStyleSet(this=0x00007fffe3c5ba90, aDocument=0x00007fffd391d560) at ServoStyleSet.cpp:120:17
    frame #24: 0x00007ffff128ba5e libxul.so`mozilla::dom::Document::Init() [inlined] mozilla::detail::UniqueSelector<mozilla::ServoStyleSet>::SingleObject mozilla::MakeUnique<mozilla::ServoStyleSet, mozilla::dom::Document&>(aArgs=0x00007fffd391d560) at UniquePtr.h:609:27
    frame #25: 0x00007ffff128ba46 libxul.so`mozilla::dom::Document::Init(this=0x00007fffd391d560) at Document.cpp:2657:15
    frame #26: 0x00007ffff20847d9 libxul.so`nsHTMLDocument::Init(this=0x00007fffd391d560) at nsHTMLDocument.cpp:146:27
    frame #27: 0x00007ffff208462a libxul.so`NS_NewHTMLDocument(aInstancePtrResult=0x00007fffffff9c60, aLoadedAsData=false) at nsHTMLDocument.cpp:112:22
    frame #28: 0x00007ffff2ea18cf libxul.so`nsContentDLF::CreateBlankDocument(aLoadGroup=0x00007fffc2ec87a0, aPrincipal=0x00007fffe476cdb0, aPartitionedPrincipal=0x00007fffe476cdb0, aContainer=0x00007fffe34752c0) at nsContentDLF.cpp:212:22
    frame #29: 0x00007ffff32d1ea1 libxul.so`nsDocShell::CreateAboutBlankContentViewer(this=0x00007fffe34752c0, aPrincipal=0x00007fffe476cdb0, aPartitionedPrincipal=0x00007fffe476cdb0, aCSP=0x0000000000000000, aBaseURI=0x0000000000000000, aIsInitialDocument=true, aCOEP=0x00007fffffff9d86, aTryToSaveOldPresentation=<unavailable>, aCheckPermitUnload=<unavailable>, aActor=0x0000000000000000) at nsDocShell.cpp:6588:16
    frame #30: 0x00007ffff332380c libxul.so`nsAppShellService::JustCreateTopWindow(this=<unavailable>, aParent=0x0000000000000000, aUrl=<unavailable>, aChromeMask=4161799686, aInitialWidth=<unavailable>, aInitialHeight=<unavailable>, aIsHiddenWindow=<unavailable>, aResult=<unavailable>) at nsAppShellService.cpp:760:22
    frame #31: 0x00007ffff3323b03 libxul.so`nsAppShellService::CreateTopLevelWindow(this=<unavailable>, aParent=0x0000000000000000, aUrl=<unavailable>, aChromeMask=4161799686, aInitialWidth=<unavailable>, aInitialHeight=<unavailable>, aResult=<unavailable>) at nsAppShellService.cpp:173:8
    frame #32: 0x00007ffff35aad11 libxul.so`nsAppStartup::CreateChromeWindow(this=<unavailable>, aParent=<unavailable>, aChromeFlags=4161799686, aOpenWindowInfo=0x0000000000000000, aCancel=<unavailable>, _retval=0x00007fffffff9ef8) at nsAppStartup.cpp:750:15
    frame #33: 0x00007ffff3627118 libxul.so`nsWindowWatcher::CreateChromeWindow(this=<unavailable>, aParentChrome=<unavailable>, aChromeFlags=<unavailable>, aOpenWindowInfo=<unavailable>, aResult=0x00007fffffff9fd0) at nsWindowWatcher.cpp:419:33
    frame #34: 0x00007ffff3626ae6 libxul.so`nsWindowWatcher::OpenWindowInternal(this=<unavailable>, aParent=0x0000000000000000, aUrl=0x00007fffffffa2d8, aName=0x00007fffffffa288, aFeatures=0x00007fffffffa278, aCalledFromJS=<unavailable>, aDialog=<unavailable>, aNavigate=<unavailable>, aArgv=<unavailable>, aIsPopupSpam=<unavailable>, aForceNoOpener=<unavailable>, aForceNoReferrer=<unavailable>, aPrintKind=<unavailable>, aLoadState=<unavailable>, aResult=<unavailable>) at nsWindowWatcher.cpp:947:12
    frame #35: 0x00007ffff3624d83 libxul.so`nsWindowWatcher::OpenWindow(this=0x00007fffe3f1bbe0, aParent=0x0000000000000000, aUrl=0x00007fffffffa2d8, aName=0x00007fffffffa288, aFeatures=0x00007fffffffa278, aArguments=<unavailable>, aResult=<unavailable>) at nsWindowWatcher.cpp:293:3
    frame #36: 0x00007ffff365c15b libxul.so`ShowProfileManager(aProfileSvc=<unavailable>, aNative=0x00007fffe8ce8ec0) at nsAppRunner.cpp:2553:27
    frame #37: 0x00007ffff365ad8f libxul.so`XREMain::XRE_mainStartup(bool*) [inlined] SelectProfile(aProfileSvc=<unavailable>, aNative=<unavailable>, aRootDir=<unavailable>, aLocalDir=<unavailable>, aProfile=<unavailable>, aWasDefaultSelection=<unavailable>) at nsAppRunner.cpp:0:7
    frame #38: 0x00007ffff365ab56 libxul.so`XREMain::XRE_mainStartup(this=<unavailable>, aExitFlag=<unavailable>) at nsAppRunner.cpp:4501:8
    frame #39: 0x00007ffff365fd00 libxul.so`XREMain::XRE_main(this=0x00007fffffffa500, argc=2, argv=0x00007fffffffb6f8, aConfig=0x00007fffffffa690) at nsAppRunner.cpp:5465:12
    frame #40: 0x00007ffff3660175 libxul.so`XRE_main(argc=<unavailable>, argv=<unavailable>, aConfig=<unavailable>) at nsAppRunner.cpp:5536:21
    frame #41: 0x00007ffff3665ff1 libxul.so`mozilla::BootstrapImpl::XRE_main(this=<unavailable>, argc=<unavailable>, argv=<unavailable>, aConfig=<unavailable>) at Bootstrap.cpp:45:12
    frame #42: 0x0000555555579140 firefox`main [inlined] do_main(argc=<unavailable>, argv=0x00007fffffffb6f8, envp=<unavailable>) at nsBrowserApp.cpp:225:22
    frame #43: 0x0000555555579076 firefox`main(argc=<unavailable>, argv=<unavailable>, envp=<unavailable>) at nsBrowserApp.cpp:392:16
```
</details>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___
