### PR TITLE
Add docs that say, somewhere, what `non_ts` means

### DIFF
--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -262,6 +262,9 @@ pub trait Parser<'i> {
         false
     }
 
+    /// Parses non-tree-structural pseudo-classes. Tree structural pseudo-classes,
+    /// like `:first-child`, are built into this library.
+    ///
     /// This function can return an "Err" pseudo-element in order to support CSS2.1
     /// pseudo-elements.
     fn parse_non_ts_pseudo_class(


### PR DESCRIPTION
- [x] These changes do not require tests because it's just updating a doc comment