### PR TITLE
`shell.nix`: Add `libxkbcommon` to `LD_LIBRARY_PATH`

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -32,7 +32,7 @@ clangStdenv.mkDerivation rec {
 
   shellHook = ''
     # Fix missing libraries errors (those libraries aren't linked against, so we need to dynamically supply them)
-    export LD_LIBRARY_PATH=${lib.makeLibraryPath [ xorg.libXcursor xorg.libXrandr xorg.libXi ]}
+    export LD_LIBRARY_PATH=${lib.makeLibraryPath [ xorg.libXcursor xorg.libXrandr xorg.libXi libxkbcommon ]}
     # Fix invalid option errors during linking
     # https://github.com/mozilla/nixpkgs-mozilla/commit/c72ff151a3e25f14182569679ed4cd22ef352328
     unset AS

--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -30,9 +30,10 @@ clangStdenv.mkDerivation rec {
   # Enable colored cargo and rustc output
   TERMINFO = "${ncurses.out}/share/terminfo";
 
+  # Fix missing libraries errors (those libraries aren't linked against, so we need to dynamically supply them)
+  LD_LIBRARY_PATH = lib.makeLibraryPath [ xorg.libXcursor xorg.libXrandr xorg.libXi libxkbcommon ];
+
   shellHook = ''
-    # Fix missing libraries errors (those libraries aren't linked against, so we need to dynamically supply them)
-    export LD_LIBRARY_PATH=${lib.makeLibraryPath [ xorg.libXcursor xorg.libXrandr xorg.libXi libxkbcommon ]}
     # Fix invalid option errors during linking
     # https://github.com/mozilla/nixpkgs-mozilla/commit/c72ff151a3e25f14182569679ed4cd22ef352328
     unset AS


### PR DESCRIPTION
`libxkbcommon` is a runtime dependency of winit's Wayland backend. Servo crashes with [a very confusing panic message][1] if the Wayland backend is selected, and `libxkbcommon.so` can't be found at runtime.

[1]: https://github.com/rust-windowing/winit/issues/1760

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

---
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they don't affect the production code
