### PR TITLE
CI: Update the required clang-format version to 13

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -49,7 +49,7 @@ WEB_PLATFORM_TESTS_PATH = os.path.join("tests", "wpt", "web-platform-tests")
 SERVO_TESTS_PATH = os.path.join("tests", "wpt", "mozilla", "tests")
 
 CLANGFMT_CPP_DIRS = ["support/hololens/"]
-CLANGFMT_VERSION = "12"
+CLANGFMT_VERSION = "13"
 
 TEST_SUITES = OrderedDict([
     ("tidy", {"kwargs": {"all_files": False, "no_progress": False, "self_test": False,


### PR DESCRIPTION
`mach test-tidy` requires a specific version of `clang-format` so that the formatting result is consistent between build environments. [The virtual environment][6] used by GitHub Actions has been updated [**again**][1] and now provides a version of `clang-format` that is different from the one expected by our `mach` tool, causing the `mach test-tidy --force-cpp` step to [fail][2]. This PR updates our tool to address the issue.

[6]: https://github.com/actions/virtual-environments
[1]: https://github.com/servo/servo/pull/28602
[2]: https://github.com/servo/servo/pull/28613#issuecomment-944424519

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

---
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they don't change the production code
