### PR TITLE
[selectors] Reduces log verbosity

### DIFF
--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -467,9 +467,10 @@ where
     E: Element,
     F: FnMut(&E, ElementSelectorFlags),
 {
-    debug!(
+    trace!(
         "Matching complex selector {:?} for {:?}",
-        selector_iter, element
+        selector_iter,
+        element
     );
 
     let matches_compound_selector = matches_compound_selector(


### PR DESCRIPTION
My root problem: I use the `selectors` component trough the [scraper crate](https://crates.io/crates/scraper) and I usually display the debug log when I develop, but it’s problematic when I looking for a selector in an entire html page…

I think the trace level is more appropriate for this message.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because: non functional modification

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
