### PR TITLE
Update cssparser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.28.1"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db8599a9761b371751fbf13e076fa03c6e1a78f8c5288e6ab9467f10a2322c1"
+checksum = "6907f2a003b6abf3a1688f4f74469c6f54d0916dbbbbb9813f89eabe5bc74e3c"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -20,7 +20,7 @@ bitflags = "1.0"
 byteorder = "1"
 canvas_traits = { path = "../canvas_traits" }
 crossbeam-channel = "0.4"
-cssparser = "0.28"
+cssparser = "0.29"
 euclid = "0.20"
 font-kit = "0.10"
 fnv = "1.0"

--- a/components/canvas_traits/Cargo.toml
+++ b/components/canvas_traits/Cargo.toml
@@ -16,7 +16,7 @@ xr-profile = ["webxr-api/profile", "time"]
 
 [dependencies]
 crossbeam-channel = "0.4"
-cssparser = "0.28"
+cssparser = "0.29"
 euclid = "0.20"
 ipc-channel = "0.14"
 lazy_static = "1"

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 app_units = "0.7"
 atomic_refcell = "0.1.6"
 canvas_traits = { path = "../canvas_traits" }
-cssparser = "0.28"
+cssparser = "0.29"
 embedder_traits = { path = "../embedder_traits" }
 euclid = "0.20"
 fnv = "1.0"

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -31,7 +31,7 @@ accountable-refcell = { version = "0.2.0", optional = true }
 app_units = "0.7"
 content-security-policy = { version = "0.4.0", features = ["serde"], optional = true }
 crossbeam-channel = { version = "0.4", optional = true }
-cssparser = "0.28"
+cssparser = "0.29"
 euclid = "0.20"
 hashglobe = { path = "../hashglobe" }
 hyper = { version = "0.12", optional = true }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -42,7 +42,7 @@ chrono = "0.4"
 content-security-policy = { version = "0.4.0", features = ["serde"] }
 cookie = "0.11"
 crossbeam-channel = "0.4"
-cssparser = "0.28"
+cssparser = "0.29"
 data-url = "0.1.0"
 deny_public_fields = { path = "../deny_public_fields" }
 devtools_traits = { path = "../devtools_traits" }

--- a/components/selectors/Cargo.toml
+++ b/components/selectors/Cargo.toml
@@ -19,7 +19,7 @@ bench = []
 
 [dependencies]
 bitflags = "1.0"
-cssparser = "0.28"
+cssparser = "0.29"
 derive_more = "0.99"
 fxhash = "0.2"
 log = "0.4"

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -35,7 +35,7 @@ arrayvec = "0.5"
 atomic_refcell = "0.1"
 bitflags = "1.0"
 byteorder = "1.0"
-cssparser = "0.28"
+cssparser = "0.29"
 derive_more = "0.99"
 encoding_rs = { version = "0.8", optional = true }
 euclid = "0.20"

--- a/components/style/counter_style/mod.rs
+++ b/components/style/counter_style/mod.rs
@@ -143,8 +143,7 @@ struct CounterStyleRuleParser<'a, 'b: 'a> {
 
 /// Default methods reject all at rules.
 impl<'a, 'b, 'i> AtRuleParser<'i> for CounterStyleRuleParser<'a, 'b> {
-    type PreludeNoBlock = ();
-    type PreludeBlock = ();
+    type Prelude = ();
     type AtRule = ();
     type Error = StyleParseErrorKind<'i>;
 }

--- a/components/style/font_face.rs
+++ b/components/style/font_face.rs
@@ -371,8 +371,7 @@ struct FontFaceRuleParser<'a, 'b: 'a> {
 
 /// Default methods reject all at rules.
 impl<'a, 'b, 'i> AtRuleParser<'i> for FontFaceRuleParser<'a, 'b> {
-    type PreludeNoBlock = ();
-    type PreludeBlock = ();
+    type Prelude = ();
     type AtRule = ();
     type Error = StyleParseErrorKind<'i>;
 }

--- a/components/style/properties/declaration_block.rs
+++ b/components/style/properties/declaration_block.rs
@@ -1354,8 +1354,7 @@ struct PropertyDeclarationParser<'a, 'b: 'a> {
 
 /// Default methods reject all at rules.
 impl<'a, 'b, 'i> AtRuleParser<'i> for PropertyDeclarationParser<'a, 'b> {
-    type PreludeNoBlock = ();
-    type PreludeBlock = ();
+    type Prelude = ();
     type AtRule = Importance;
     type Error = StyleParseErrorKind<'i>;
 }

--- a/components/style/stylesheets/font_feature_values_rule.rs
+++ b/components/style/stylesheets/font_feature_values_rule.rs
@@ -18,7 +18,7 @@ use crate::stylesheets::CssRuleType;
 use crate::values::computed::font::FamilyName;
 use crate::values::serialize_atom_identifier;
 use crate::Atom;
-use cssparser::{AtRuleParser, AtRuleType, BasicParseErrorKind, CowRcStr};
+use cssparser::{AtRuleParser, BasicParseErrorKind, CowRcStr};
 use cssparser::{DeclarationListParser, DeclarationParser, Parser};
 use cssparser::{ParserState, QualifiedRuleParser, RuleListParser, SourceLocation, Token};
 use std::fmt::{self, Write};
@@ -188,8 +188,7 @@ struct FFVDeclarationsParser<'a, 'b: 'a, T: 'a> {
 
 /// Default methods reject all at rules.
 impl<'a, 'b, 'i, T> AtRuleParser<'i> for FFVDeclarationsParser<'a, 'b, T> {
-    type PreludeNoBlock = ();
-    type PreludeBlock = ();
+    type Prelude = ();
     type AtRule = ();
     type Error = StyleParseErrorKind<'i>;
 }
@@ -393,18 +392,17 @@ macro_rules! font_feature_values_blocks {
         }
 
         impl<'a, 'i> AtRuleParser<'i> for FontFeatureValuesRuleParser<'a> {
-            type PreludeNoBlock = ();
-            type PreludeBlock = BlockType;
+            type Prelude = BlockType;
             type AtRule = ();
             type Error = StyleParseErrorKind<'i>;
 
             fn parse_prelude<'t>(&mut self,
                                  name: CowRcStr<'i>,
                                  input: &mut Parser<'i, 't>)
-                                 -> Result<AtRuleType<(), BlockType>, ParseError<'i>> {
+                                 -> Result<BlockType, ParseError<'i>> {
                 match_ignore_ascii_case! { &*name,
                     $(
-                        $name => Ok(AtRuleType::WithBlock(BlockType::$ident_camel)),
+                        $name => Ok(BlockType::$ident_camel),
                     )*
                     _ => Err(input.new_error(BasicParseErrorKind::AtRuleBodyInvalid)),
                 }

--- a/components/style/stylesheets/keyframes_rule.rs
+++ b/components/style/stylesheets/keyframes_rule.rs
@@ -505,8 +505,7 @@ pub fn parse_keyframe_list(
 }
 
 impl<'a, 'i> AtRuleParser<'i> for KeyframeListParser<'a> {
-    type PreludeNoBlock = ();
-    type PreludeBlock = ();
+    type Prelude = ();
     type AtRule = Arc<Locked<Keyframe>>;
     type Error = StyleParseErrorKind<'i>;
 }
@@ -580,8 +579,7 @@ struct KeyframeDeclarationParser<'a, 'b: 'a> {
 
 /// Default methods reject all at rules.
 impl<'a, 'b, 'i> AtRuleParser<'i> for KeyframeDeclarationParser<'a, 'b> {
-    type PreludeNoBlock = ();
-    type PreludeBlock = ();
+    type Prelude = ();
     type AtRule = ();
     type Error = StyleParseErrorKind<'i>;
 }

--- a/components/style/stylesheets/rule_parser.rs
+++ b/components/style/stylesheets/rule_parser.rs
@@ -26,7 +26,7 @@ use crate::stylesheets::{NamespaceRule, PageRule, StyleRule, SupportsRule, Viewp
 use crate::values::computed::font::FamilyName;
 use crate::values::{CssUrl, CustomIdent, KeyframesName};
 use crate::{Namespace, Prefix};
-use cssparser::{AtRuleParser, AtRuleType, Parser, QualifiedRuleParser, RuleListParser};
+use cssparser::{AtRuleParser, Parser, QualifiedRuleParser, RuleListParser};
 use cssparser::{BasicParseError, BasicParseErrorKind, CowRcStr, ParserState, SourcePosition};
 use selectors::SelectorList;
 use servo_arc::Arc;
@@ -146,7 +146,7 @@ pub enum VendorPrefix {
 }
 
 /// A rule prelude for at-rule with block.
-pub enum AtRuleBlockPrelude {
+pub enum AtRulePrelude {
     /// A @font-face rule prelude.
     FontFace,
     /// A @font-feature-values rule prelude, with its FamilyName list.
@@ -165,10 +165,6 @@ pub enum AtRuleBlockPrelude {
     Page,
     /// A @document rule, with its conditional.
     Document(DocumentCondition),
-}
-
-/// A rule prelude for at-rule without block.
-pub enum AtRuleNonBlockPrelude {
     /// A @import rule prelude.
     Import(CssUrl, Arc<Locked<MediaList>>),
     /// A @namespace rule prelude.
@@ -176,8 +172,7 @@ pub enum AtRuleNonBlockPrelude {
 }
 
 impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
-    type PreludeNoBlock = AtRuleNonBlockPrelude;
-    type PreludeBlock = AtRuleBlockPrelude;
+    type Prelude = AtRulePrelude;
     type AtRule = (SourcePosition, CssRule);
     type Error = StyleParseErrorKind<'i>;
 
@@ -185,7 +180,7 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
         &mut self,
         name: CowRcStr<'i>,
         input: &mut Parser<'i, 't>,
-    ) -> Result<AtRuleType<AtRuleNonBlockPrelude, AtRuleBlockPrelude>, ParseError<'i>> {
+    ) -> Result<AtRulePrelude, ParseError<'i>> {
         match_ignore_ascii_case! { &*name,
             "import" => {
                 if !self.check_state(State::Imports) {
@@ -211,7 +206,7 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
 
                 let prelude = AtRuleNonBlockPrelude::Import(url, media);
 
-                return Ok(AtRuleType::WithoutBlock(prelude));
+                return Ok(prelude);
             },
             "namespace" => {
                 if !self.check_state(State::Namespaces) {
@@ -229,7 +224,7 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
                 };
                 let url = Namespace::from(maybe_namespace.as_ref());
                 let prelude = AtRuleNonBlockPrelude::Namespace(prefix, url);
-                return Ok(AtRuleType::WithoutBlock(prelude));
+                return Ok(prelude);
             },
             // @charset is removed by rust-cssparser if it’s the first rule in the stylesheet
             // anything left is invalid.
@@ -250,7 +245,7 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
     #[inline]
     fn parse_block<'t>(
         &mut self,
-        prelude: AtRuleBlockPrelude,
+        prelude: AtRulePrelude,
         start: &ParserState,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self::AtRule, ParseError<'i>> {
@@ -262,11 +257,11 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
     #[inline]
     fn rule_without_block(
         &mut self,
-        prelude: AtRuleNonBlockPrelude,
+        prelude: AtRulePrelude,
         start: &ParserState,
     ) -> Self::AtRule {
         let rule = match prelude {
-            AtRuleNonBlockPrelude::Import(url, media) => {
+            AtRulePrelude::Import(url, media) => {
                 let loader = self
                     .loader
                     .expect("Expected a stylesheet loader for @import");
@@ -282,7 +277,7 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
                 self.state = State::Imports;
                 CssRule::Import(import_rule)
             },
-            AtRuleNonBlockPrelude::Namespace(prefix, url) => {
+            AtRulePrelude::Namespace(prefix, url) => {
                 let prefix = if let Some(prefix) = prefix {
                     self.namespaces.prefixes.insert(prefix.clone(), url.clone());
                     Some(prefix)
@@ -298,9 +293,10 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a> {
                     source_location: start.source_location(),
                 })))
             },
+            _ => return Err(()),
         };
 
-        (start.position(), rule)
+        Ok((start.position(), rule))
     }
 }
 
@@ -372,8 +368,7 @@ impl<'a, 'b> NestedRuleParser<'a, 'b> {
 }
 
 impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
-    type PreludeNoBlock = AtRuleNonBlockPrelude;
-    type PreludeBlock = AtRuleBlockPrelude;
+    type Prelude = AtRulePrelude;
     type AtRule = CssRule;
     type Error = StyleParseErrorKind<'i>;
 
@@ -381,19 +376,19 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
         &mut self,
         name: CowRcStr<'i>,
         input: &mut Parser<'i, 't>,
-    ) -> Result<AtRuleType<AtRuleNonBlockPrelude, AtRuleBlockPrelude>, ParseError<'i>> {
+    ) -> Result<Self::Prelude, ParseError<'i>> {
         match_ignore_ascii_case! { &*name,
             "media" => {
                 let media_queries = MediaList::parse(self.context, input);
                 let arc = Arc::new(self.shared_lock.wrap(media_queries));
-                Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Media(arc)))
+                Ok(AtRuleBlockPrelude::Media(arc))
             },
             "supports" => {
                 let cond = SupportsCondition::parse(input)?;
-                Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Supports(cond)))
+                Ok(AtRuleBlockPrelude::Supports(cond))
             },
             "font-face" => {
-                Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::FontFace))
+                Ok(AtRuleBlockPrelude::FontFace)
             },
             "font-feature-values" => {
                 if !cfg!(feature = "gecko") {
@@ -401,7 +396,7 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
                     return Err(input.new_custom_error(StyleParseErrorKind::UnsupportedAtRule(name.clone())))
                 }
                 let family_names = parse_family_name_list(self.context, input)?;
-                Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::FontFeatureValues(family_names)))
+                Ok(AtRuleBlockPrelude::FontFeatureValues(family_names))
             },
             "counter-style" => {
                 if !cfg!(feature = "gecko") {
@@ -409,11 +404,11 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
                     return Err(input.new_custom_error(StyleParseErrorKind::UnsupportedAtRule(name.clone())))
                 }
                 let name = parse_counter_style_name_definition(input)?;
-                Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::CounterStyle(name)))
+                Ok(AtRuleBlockPrelude::CounterStyle(name))
             },
             "viewport" => {
                 if viewport_rule::enabled() {
-                    Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Viewport))
+                    Ok(AtRuleBlockPrelude::Viewport)
                 } else {
                     Err(input.new_custom_error(StyleParseErrorKind::UnsupportedAtRule(name.clone())))
                 }
@@ -433,11 +428,11 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
                 }
                 let name = KeyframesName::parse(self.context, input)?;
 
-                Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Keyframes(name, prefix)))
+                Ok(AtRuleBlockPrelude::Keyframes(name, prefix))
             },
             "page" => {
                 if cfg!(feature = "gecko") {
-                    Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Page))
+                    Ok(AtRuleBlockPrelude::Page)
                 } else {
                     Err(input.new_custom_error(StyleParseErrorKind::UnsupportedAtRule(name.clone())))
                 }
@@ -450,7 +445,7 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
                 }
 
                 let cond = DocumentCondition::parse(self.context, input)?;
-                Ok(AtRuleType::WithBlock(AtRuleBlockPrelude::Document(cond)))
+                Ok(AtRuleBlockPrelude::Document(cond))
             },
             _ => Err(input.new_custom_error(StyleParseErrorKind::UnsupportedAtRule(name.clone())))
         }
@@ -458,12 +453,12 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
 
     fn parse_block<'t>(
         &mut self,
-        prelude: AtRuleBlockPrelude,
+        prelude: AtRulePrelude,
         start: &ParserState,
         input: &mut Parser<'i, 't>,
     ) -> Result<CssRule, ParseError<'i>> {
         match prelude {
-            AtRuleBlockPrelude::FontFace => {
+            AtRulePrelude::FontFace => {
                 let context = ParserContext::new_with_rule_type(
                     self.context,
                     CssRuleType::FontFace,
@@ -474,7 +469,7 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
                     parse_font_face_block(&context, input, start.source_location()).into(),
                 ))))
             },
-            AtRuleBlockPrelude::FontFeatureValues(family_names) => {
+            AtRulePrelude::FontFeatureValues(family_names) => {
                 let context = ParserContext::new_with_rule_type(
                     self.context,
                     CssRuleType::FontFeatureValues,
@@ -490,7 +485,7 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
                     ),
                 ))))
             },
-            AtRuleBlockPrelude::CounterStyle(name) => {
+            AtRulePrelude::CounterStyle(name) => {
                 let context = ParserContext::new_with_rule_type(
                     self.context,
                     CssRuleType::CounterStyle,
@@ -504,14 +499,14 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
                     ),
                 )))
             },
-            AtRuleBlockPrelude::Media(media_queries) => {
+            AtRulePrelude::Media(media_queries) => {
                 Ok(CssRule::Media(Arc::new(self.shared_lock.wrap(MediaRule {
                     media_queries,
                     rules: self.parse_nested_rules(input, CssRuleType::Media),
                     source_location: start.source_location(),
                 }))))
             },
-            AtRuleBlockPrelude::Supports(condition) => {
+            AtRulePrelude::Supports(condition) => {
                 let eval_context = ParserContext::new_with_rule_type(
                     self.context,
                     CssRuleType::Style,
@@ -528,7 +523,7 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
                     },
                 ))))
             },
-            AtRuleBlockPrelude::Viewport => {
+            AtRulePrelude::Viewport => {
                 let context = ParserContext::new_with_rule_type(
                     self.context,
                     CssRuleType::Viewport,
@@ -539,7 +534,7 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
                     self.shared_lock.wrap(ViewportRule::parse(&context, input)?),
                 )))
             },
-            AtRuleBlockPrelude::Keyframes(name, vendor_prefix) => {
+            AtRulePrelude::Keyframes(name, vendor_prefix) => {
                 let context = ParserContext::new_with_rule_type(
                     self.context,
                     CssRuleType::Keyframes,
@@ -555,7 +550,7 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
                     },
                 ))))
             },
-            AtRuleBlockPrelude::Page => {
+            AtRulePrelude::Page => {
                 let context = ParserContext::new_with_rule_type(
                     self.context,
                     CssRuleType::Page,
@@ -568,7 +563,7 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
                     source_location: start.source_location(),
                 }))))
             },
-            AtRuleBlockPrelude::Document(condition) => {
+            AtRulePrelude::Document(condition) => {
                 if !cfg!(feature = "gecko") {
                     unreachable!()
                 }
@@ -579,6 +574,10 @@ impl<'a, 'b, 'i> AtRuleParser<'i> for NestedRuleParser<'a, 'b> {
                         source_location: start.source_location(),
                     },
                 ))))
+            },
+            AtRulePrelude::Import(..) | AtRulePrelude::Namespace(..) => {
+                // These rules don't have blocks.
+                Err(input.new_unexpected_token_error(cssparser::Token::CurlyBracketBlock))
             },
         }
     }

--- a/components/style/stylesheets/viewport_rule.rs
+++ b/components/style/stylesheets/viewport_rule.rs
@@ -241,8 +241,7 @@ fn parse_shorthand<'i, 't>(
 }
 
 impl<'a, 'b, 'i> AtRuleParser<'i> for ViewportRuleParser<'a, 'b> {
-    type PreludeNoBlock = ();
-    type PreludeBlock = ();
+    type Prelude = ();
     type AtRule = Vec<ViewportDescriptorDeclaration>;
     type Error = StyleParseErrorKind<'i>;
 }

--- a/components/style_traits/Cargo.toml
+++ b/components/style_traits/Cargo.toml
@@ -16,7 +16,7 @@ gecko = []
 [dependencies]
 app_units = "0.7"
 bitflags = "1.0"
-cssparser = "0.28"
+cssparser = "0.29"
 euclid = "0.20"
 lazy_static = "1"
 malloc_size_of = { path = "../malloc_size_of" }

--- a/components/to_shmem/Cargo.toml
+++ b/components/to_shmem/Cargo.toml
@@ -14,7 +14,7 @@ servo = ["cssparser/serde", "string_cache"]
 gecko = []
 
 [dependencies]
-cssparser = "0.28"
+cssparser = "0.29"
 servo_arc = { path = "../servo_arc" }
 smallbitvec = "2.1.1"
 smallvec = "1.0"

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 
 [dependencies]
 app_units = "0.7"
-cssparser = "0.28"
+cssparser = "0.29"
 euclid = "0.20"
 html5ever = "0.25"
 rayon = "1"


### PR DESCRIPTION
Updates `cssparser` to 0.29. Mainly so the `selectors` crate has an up to date version. Commit backported from gecko: https://github.com/mozilla/gecko-dev/commit/4b3dc2089155b56de5cb84674cd54602234c95bd.

See also #28632. If the current version of `selectors` is in gecko, maybe it should be released from there rather than here?