### PR TITLE
Preserve URI fragment across redirects

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -844,8 +844,15 @@ pub fn http_fetch(
                     .ok()
             });
 
-        // Substep 4.
-        response.actual_response_mut().location_url = location;
+        // Substep 4.               
+        response.actual_response_mut().location_url = location.map(|res| res.map(|mut url| {
+            let current_url = request.current_url();
+            let current_fragment = current_url.fragment();
+            if url.fragment().is_none() && current_fragment.is_some() {
+                url.set_fragment(current_fragment);
+            }
+            url
+        }));
 
         // Substep 5.
         response = match request.redirect_mode {

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -844,13 +844,11 @@ pub fn http_fetch(
                     .ok()
             });
 
-        // Substep 4.               
-        if let Some(ref mut location) = location {
-            if let Ok(ref mut location) = location {
-                if location.fragment().is_none() {
-                    let current_url = request.current_url();
-                    location.set_fragment(current_url.fragment());
-                }
+        // Substep 4.
+        if let Some(Ok(ref mut location)) = location {
+            if location.fragment().is_none() {
+                let current_url = request.current_url();
+                location.set_fragment(current_url.fragment());
             }
         }
         response.actual_response_mut().location_url = location;

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -847,11 +847,10 @@ pub fn http_fetch(
         // Substep 4.               
         response.actual_response_mut().location_url = location.map(|res| res.map(|mut url| {
             let current_url = request.current_url();
-            let current_fragment = current_url.fragment();
-            if url.fragment().is_none() && current_fragment.is_some() {
-                url.set_fragment(current_fragment);
+            match (current_url.fragment(), url.fragment()) {
+                (fragment @ Some(..), None) => { url.set_fragment(fragment); url },
+                _                           => url
             }
-            url
         }));
 
         // Substep 5.


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc7231#section-7.1.2

```
If the Location value provided in a 3xx (Redirection) response does
   not have a fragment component, a user agent MUST process the
   redirection as if the value inherits the fragment component of the
   URI reference used to generate the request target (i.e., the
   redirection inherits the original reference's fragment, if any).
```

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
