### PR TITLE
Do not use ParallelIterator if not using rayon

### DIFF
--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -152,9 +152,10 @@ impl BlockContainer {
                 .iter()
                 .map(|box_| {
                     box_.borrow_mut()
-                        .inline_content_sizes(layout_context, writing_mode)                    
+                        .inline_content_sizes(layout_context, writing_mode)
                 })
-                .reduce(ContentSizes::max).unwrap_or_else(ContentSizes::zero),
+                .reduce(ContentSizes::max)
+                .unwrap_or_else(ContentSizes::zero),
             Self::InlineFormattingContext(context) => {
                 context.inline_content_sizes(layout_context, writing_mode)
             },

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -134,20 +134,27 @@ impl BlockContainer {
             ),
         }
     }
-
+    
     pub(super) fn inline_content_sizes(
         &self,
         layout_context: &LayoutContext,
         writing_mode: WritingMode,
     ) -> ContentSizes {
         match &self {
-            Self::BlockLevelBoxes(boxes) => boxes
+            Self::BlockLevelBoxes(boxes) if layout_context.use_rayon => boxes
                 .par_iter()
                 .map(|box_| {
                     box_.borrow_mut()
                         .inline_content_sizes(layout_context, writing_mode)
                 })
                 .reduce(ContentSizes::zero, ContentSizes::max),
+            Self::BlockLevelBoxes(boxes) => boxes
+                .iter()
+                .map(|box_| {
+                    box_.borrow_mut()
+                        .inline_content_sizes(layout_context, writing_mode)                    
+                })
+                .reduce(ContentSizes::max).unwrap_or_else(ContentSizes::zero),
             Self::InlineFormattingContext(context) => {
                 context.inline_content_sizes(layout_context, writing_mode)
             },

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -134,7 +134,7 @@ impl BlockContainer {
             ),
         }
     }
-    
+
     pub(super) fn inline_content_sizes(
         &self,
         layout_context: &LayoutContext,


### PR DESCRIPTION
The rayon [`ParalllelIIterator`](https://github.com/rayon-rs/rayon/blob/master/src/iter/plumbing/README.md) is being used for inline content size calculations irrespective of the `use_rayon` flag, which can lead to an unbounded (dynamically determined) number of threads being spawned during iteration.

The check is performed for static position calculations, however: 
https://github.com/servo/servo/blob/6fced22e4784714540a2bf31b00c5f8149cbba87/components/layout_2020/flow/mod.rs#L235-L242

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
