### PR TITLE
Perform non-null checks on pointers used in js stacktrace captures

### DIFF
--- a/components/script/dom/bindings/principals.rs
+++ b/components/script/dom/bindings/principals.rs
@@ -138,7 +138,7 @@ pub unsafe extern "C" fn subsumes(obj: *mut JSPrincipals, other: *mut JSPrincipa
         let other_origin = other.origin();
         obj_origin.same_origin_domain(&other_origin)
     } else {
-        warn!("Received null JSPrincipals asrgument.")
+        warn!("Received null JSPrincipals asrgument.");
         false
     }
 }

--- a/components/script/dom/bindings/principals.rs
+++ b/components/script/dom/bindings/principals.rs
@@ -138,6 +138,7 @@ pub unsafe extern "C" fn subsumes(obj: *mut JSPrincipals, other: *mut JSPrincipa
         let other_origin = other.origin();
         obj_origin.same_origin_domain(&other_origin)
     } else {
+        warn!("Received null JSPrincipals asrgument.")
         false
     }
 }

--- a/components/script/dom/bindings/principals.rs
+++ b/components/script/dom/bindings/principals.rs
@@ -131,9 +131,13 @@ unsafe extern "C" fn principals_is_system_or_addon_principal(_: *mut JSPrincipal
 
 //TODO is same_origin_domain equivalent to subsumes for our purposes
 pub unsafe extern "C" fn subsumes(obj: *mut JSPrincipals, other: *mut JSPrincipals) -> bool {
-    let obj = ServoJSPrincipalsRef::from_raw_unchecked(obj);
-    let other = ServoJSPrincipalsRef::from_raw_unchecked(other);
-    let obj_origin = obj.origin();
-    let other_origin = other.origin();
-    obj_origin.same_origin_domain(&other_origin)
+    if let (Some(obj), Some(other)) = (NonNull::new(obj), NonNull::new(other)) {
+        let obj = ServoJSPrincipalsRef::from_raw_nonnull(obj);
+        let other = ServoJSPrincipalsRef::from_raw_nonnull(other);
+        let obj_origin = obj.origin();
+        let other_origin = other.origin();
+        obj_origin.same_origin_domain(&other_origin)
+    } else {
+        false
+    }
 }


### PR DESCRIPTION
Need to ensure that external passed in pointers are non-null prior to using them unchecked. Seeing sporadic crashes when visiting `https:://cnn.com` and `https://www.bankofamerica.com`:

```
   ...
   6: __sigtramp
   7: core::ptr::non_null::NonNull<T>::as_ref
             at /rustc/0fa3190394475a84360b34e074e719d519bc40f1/library/core/src/ptr/non_null.rs:317:20
   8: alloc::rc::Rc<T>::inner
             at /rustc/0fa3190394475a84360b34e074e719d519bc40f1/library/alloc/src/rc.rs:332:18
      <alloc::rc::Rc<T> as core::clone::Clone>::clone
             at /rustc/0fa3190394475a84360b34e074e719d519bc40f1/library/alloc/src/rc.rs:1479:9
   9: <servo_url::origin::MutableOrigin as core::clone::Clone>::clone
             at /Users/navgattu/Documents/dev-git/servo/components/url/origin.rs:92:26
  10: script::dom::bindings::principals::ServoJSPrincipals::origin
             at /Users/navgattu/Documents/dev-git/servo/components/script/dom/bindings/principals.rs:42:9
  11: script::dom::bindings::principals::subsumes
             at /Users/navgattu/Documents/dev-git/servo/components/script/dom/bindings/principals.rs:136:22
  12: _ZN2jsL30SavedFrameSubsumedByPrincipalsEP9JSContextP12JSPrincipalsN2JS6HandleIPNS_10SavedFrameEEE
             at /Users/navgattu/Documents/dev-git/mozjs/mozjs/js/src/vm/SavedStacks.cpp:617:10
...
```

https://github.com/rust-lang/rust/blob/d384ff79308c4eb0a3679817cd0def0147ad8612/library/core/src/ptr/non_null.rs#L181-L188

Full stacktrace: 
[trace.txt](https://github.com/servo/servo/files/7631210/trace.txt)


<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
