### PR TITLE
Non-blocking network IO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-tungstenite"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1909,6 +1920,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
 dependencies = [
+ "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -3534,6 +3546,7 @@ dependencies = [
  "string_cache",
  "thin-slice",
  "time",
+ "tokio 0.2.21",
  "url",
  "uuid",
  "void",
@@ -3949,6 +3962,7 @@ checksum = "c44922cb3dbb1c70b5e5f443d63b64363a898564d739ba5198e3a9138442868d"
 name = "net"
 version = "0.0.1"
 dependencies = [
+ "async-recursion",
  "async-tungstenite",
  "base64 0.10.1",
  "brotli",
@@ -3962,6 +3976,7 @@ dependencies = [
  "flate2",
  "futures 0.1.31",
  "futures 0.3.5",
+ "futures-util",
  "headers",
  "http 0.1.21",
  "hyper",
@@ -3994,7 +4009,9 @@ dependencies = [
  "time",
  "tokio 0.1.22",
  "tokio 0.2.21",
+ "tokio-compat",
  "tokio-openssl 0.3.0",
+ "tokio-test",
  "tungstenite",
  "url",
  "uuid",
@@ -6479,11 +6496,13 @@ checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
 dependencies = [
  "bytes 0.5.5",
  "fnv",
+ "futures-core",
  "iovec",
  "lazy_static",
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "slab",
  "tokio-macros",
 ]
 
@@ -6507,6 +6526,23 @@ dependencies = [
  "bytes 0.4.12",
  "futures 0.1.31",
  "tokio-io",
+]
+
+[[package]]
+name = "tokio-compat"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "107b625135aa7b9297dd2d99ccd6ca6ab124a5d1230778e159b9095adca4c722"
+dependencies = [
+ "futures 0.1.31",
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "tokio 0.2.21",
+ "tokio-current-thread",
+ "tokio-executor",
+ "tokio-reactor",
+ "tokio-timer",
 ]
 
 [[package]]
@@ -6624,6 +6660,17 @@ dependencies = [
  "mio",
  "tokio-io",
  "tokio-reactor",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0049c119b6d505c4447f5c64873636c7af6c75ab0d45fd9f618d82acb8016d"
+dependencies = [
+ "bytes 0.5.5",
+ "futures-core",
+ "tokio 0.2.21",
 ]
 
 [[package]]

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -46,6 +46,7 @@ smallvec = "1.0"
 string_cache = { version = "0.8", optional = true }
 thin-slice = "0.1.0"
 time = { version = "0.1.41", optional = true }
+tokio = "0.2"
 url = { version = "2.0", optional = true }
 uuid = { version = "0.8", features = ["v4"], optional = true }
 void = "1.0.2"

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -950,6 +950,13 @@ impl<T> MallocSizeOf for crossbeam_channel::Sender<T> {
 }
 
 #[cfg(feature = "servo")]
+impl<T> MallocSizeOf for tokio::sync::mpsc::UnboundedSender<T> {
+    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
+        0
+    }
+}
+
+#[cfg(feature = "servo")]
 impl MallocSizeOf for hyper::StatusCode {
     fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
         0

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -15,6 +15,7 @@ test = false
 doctest = false
 
 [dependencies]
+async-recursion = "0.3.2"
 async-tungstenite = { version = "0.7.1", features = ["tokio-openssl"] }
 base64 = "0.10.1"
 brotli = "3"
@@ -28,6 +29,7 @@ embedder_traits = { path = "../embedder_traits" }
 flate2 = "1"
 futures = "0.1"
 futures03 = { version = "0.3", package = "futures" }
+futures-util = { version  = "0.3", features = ["compat"] }
 headers = "0.2"
 http = "0.1"
 hyper = "0.12"
@@ -59,6 +61,7 @@ servo_url = { path = "../url" }
 time = "0.1.41"
 tokio = "0.1"
 tokio2 = { version = "0.2", package = "tokio", features = ["sync", "macros", "rt-threaded"] }
+tokio-compat = "0.1"
 tungstenite = "0.11"
 url = "2.0"
 uuid = { version = "0.8", features = ["v4"] }
@@ -68,6 +71,7 @@ webrender_api = { git = "https://github.com/servo/webrender" }
 futures = "0.1"
 std_test_override = { path = "../std_test_override" }
 tokio-openssl = "0.3"
+tokio-test = "0.2"
 
 [[test]]
 name = "main"

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -8,7 +8,6 @@
 //! and <http://tools.ietf.org/html/rfc7232>.
 
 use crate::fetch::methods::{Data, DoneChannel};
-use crossbeam_channel::{unbounded, Sender};
 use headers::{
     CacheControl, ContentRange, Expires, HeaderMapExt, LastModified, Pragma, Range, Vary,
 };
@@ -30,6 +29,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::SystemTime;
 use time::{Duration, Timespec, Tm};
+use tokio2::sync::mpsc::{unbounded_channel as unbounded, UnboundedSender as TokioSender};
 
 /// The key used to differentiate requests in the cache.
 #[derive(Clone, Eq, Hash, MallocSizeOf, PartialEq)]
@@ -58,7 +58,7 @@ struct CachedResource {
     request_headers: Arc<Mutex<HeaderMap>>,
     body: Arc<Mutex<ResponseBody>>,
     aborted: Arc<AtomicBool>,
-    awaiting_body: Arc<Mutex<Vec<Sender<Data>>>>,
+    awaiting_body: Arc<Mutex<Vec<TokioSender<Data>>>>,
     data: Measurable<MeasurableCachedResource>,
 }
 


### PR DESCRIPTION
The current networking strategy uses a fixed sized thread pool to perform blocking requests on a per call basis. This is inefficient, but can be ~easily~ improved by utilizing the existing tokio runtime instead to submit async networking tasks to its executor. However, since servo is currently using an outdated version of the `hyper` http library (`0.12`) we must use the [`tokio_compat`](https://github.com/tokio-rs/tokio-compat) and [`futures_compat`](https://docs.rs/futures/0.3.1/futures/compat/index.html) libraries to integrate with the older version of [`Future` used in `hyper`](https://docs.rs/hyper/0.12.1/hyper/rt/trait.Future.html). 


~**NOTE**: This PR is just proof of concept at the moment. In addition to test failures, it appears that large javascript downloads are silently failing to stream entire payloads, and occasionally getting cutoff.~

Tests are passing.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix [#22813](https://github.com/servo/servo/issues/22813) (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
