### PR TITLE
Allow builds / tests on Ubuntu 21.10

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -374,7 +374,7 @@ def get_linux_distribution():
             raise Exception('unsupported version of %s: %s' % (distrib, version))
         distrib, version = 'Ubuntu', base_version
     elif distrib.lower() == 'ubuntu':
-        if version > '21.04':
+        if version > '21.10':
             raise Exception('unsupported version of %s: %s' % (distrib, version))
     # Fixme: we should allow checked/supported versions only
     elif distrib.lower() not in [

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -787,7 +787,7 @@ def setup_clangfmt(env):
     try:
         version = check_output([cmd, "--version"], env=env, universal_newlines=True).rstrip()
         print(version)
-        if not version.startswith("clang-format version {}.".format(CLANGFMT_VERSION)):
+        if version.find("clang-format version {}.".format(CLANGFMT_VERSION)) == -1:
             print("clang-format: wrong version (v{} required). Skipping CPP formatting.".format(CLANGFMT_VERSION))
             return False, None, None
     except OSError:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR updates the version check in `python/servo/bootstrap.py` for Ubuntu to `> 21.10` to accommodate the latest version. It also updates the `clang-format` check in `test_commands.py` to use `find()` instead of `startswith()` to account for possible distro-specific insertions into the `clang-format --version` command. 

Ubuntu, for example, outputs `Ubuntu clang-format version 13.0.0-2`, which caused `version.startswith()` to throw an error as it looked for `clang-format` at the beginning of the string. This would cause `./mach test-tidy` to skip the CPP formatting portion.
![image](https://user-images.githubusercontent.com/17208534/146147849-92dd9849-5fc4-4632-b8d0-23b51dc34706.png)

These two changes should help run bootstrap and test commands on the latest Ubuntu version.
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because: I do not believe there are any current tests for the version checks (as the version checks are in-and-of themselves a test before running the bootstrap/test commands)

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
