### PR TITLE
concept-response-clone: Ensure header guard is cloned after headers

### DIFF
--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -330,8 +330,8 @@ impl ResponseMethods for Response {
 
         // Step 2
         let new_response = Response::new(&self.global());
-        new_response.Headers().set_guard(self.Headers().get_guard());
         new_response.Headers().copy_from_headers(self.Headers())?;
+        new_response.Headers().set_guard(self.Headers().get_guard());
 
         // https://fetch.spec.whatwg.org/#concept-response-clone
         // Instead of storing a net_traits::Response internally, we


### PR DESCRIPTION
https://fetch.spec.whatwg.org/#concept-response-clone

If the header guard of the response to clone is `immutable`, then copying the headers to the new response will fail with `Guard is immutable` unless we ensure the guard is copied _after_ the headers.

https://github.com/servo/servo/blob/8650794391729c6fee34bc2644ccbb85bd8fd58d/components/script/dom/response.rs#L331-L334

https://github.com/servo/servo/blob/8650794391729c6fee34bc2644ccbb85bd8fd58d/components/script/dom/headers.rs#L202-L210

https://github.com/servo/servo/blob/8650794391729c6fee34bc2644ccbb85bd8fd58d/components/script/dom/headers.rs#L73

  
<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
