### PR TITLE
Update more deprecated python imports.

### DIFF
--- a/python/mach/mach/config.py
+++ b/python/mach/mach/config.py
@@ -144,7 +144,7 @@ def reraise_attribute_error(func):
     return _
 
 
-class ConfigSettings(collections.Mapping):
+class ConfigSettings(collections.abc.Mapping):
     """Interface for configuration settings.
 
     This is the main interface to the configuration.
@@ -190,7 +190,7 @@ class ConfigSettings(collections.Mapping):
     will result in exceptions being raised.
     """
 
-    class ConfigSection(collections.MutableMapping, object):
+    class ConfigSection(collections.abc.MutableMapping, object):
         """Represents an individual config section."""
         def __init__(self, config, name, settings):
             object.__setattr__(self, '_config', config)

--- a/python/mach/mach/decorators.py
+++ b/python/mach/mach/decorators.py
@@ -152,7 +152,7 @@ def CommandProvider(cls):
               'Conditions argument must take a list ' + \
               'of functions. Found %s instead.'
 
-        if not isinstance(command.conditions, collections.Iterable):
+        if not isinstance(command.conditions, collections.abc.Iterable):
             msg = msg % (command.name, type(command.conditions))
             raise MachError(msg)
 


### PR DESCRIPTION
`mach` still uses some deprecated imports that were removed in Python 3.10, and currently fails when using Python 3.10.

This is in the same line as #28649.