### PR TITLE
Allow bootstrap on Pop!_OS 21.10

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -355,7 +355,9 @@ def get_linux_distribution():
         else:
             major = version
 
-        if major == '20':
+        if major == '21':
+            base_version = '21.04'
+        elif major == '20':
             base_version = '20.04'
         elif major == '19':
             base_version = '18.04'


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
bootstrap.py doesn't support Pop!_OS 21.x yet. Adding these lines should make the script works again.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because it seems there no test requires certain version check and test-tidy has passed.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
