### PR TITLE
Tungestenite upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,15 +182,15 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.7.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2760f968801f873112e651c5a9c3b60c11ae6d66e7ca3f2d51aafbfcef9495fa"
+checksum = "9ce503a5cb1e7450af7d211b86b84807791b251f335b2f43f1e26b85a416f315"
 dependencies = [
  "futures-io",
  "futures-util",
  "log",
  "openssl",
- "pin-project 0.4.22",
+ "pin-project",
  "tokio 0.2.21",
  "tokio-openssl 0.4.0",
  "tungstenite",
@@ -1928,7 +1928,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.2",
+ "pin-project",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -4611,31 +4611,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
-dependencies = [
- "pin-project-internal 0.4.22",
-]
-
-[[package]]
-name = "pin-project"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
 dependencies = [
- "pin-project-internal 1.0.2",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pin-project-internal",
 ]
 
 [[package]]

--- a/components/gfx/platform/macos/font_context.rs
+++ b/components/gfx/platform/macos/font_context.rs
@@ -6,13 +6,13 @@ use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 
 #[derive(Clone, Debug)]
 pub struct FontContextHandle {
-    ctx: (),
+    _ctx: (),
 }
 
 impl FontContextHandle {
     // this is a placeholder until NSFontManager or whatever is bound in here.
     pub fn new() -> FontContextHandle {
-        FontContextHandle { ctx: () }
+        FontContextHandle { _ctx: () }
     }
 }
 

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 
 [dependencies]
 async-recursion = "0.3.2"
-async-tungstenite = { version = "0.7.1", features = ["tokio-openssl"] }
+async-tungstenite = { version = "0.9", features = ["tokio-openssl"] }
 base64 = "0.10.1"
 brotli = "3"
 bytes = "0.4"
@@ -60,7 +60,7 @@ servo_config = { path = "../config" }
 servo_url = { path = "../url" }
 time = "0.1.41"
 tokio = "0.1"
-tokio2 = { version = "0.2", package = "tokio", features = ["sync", "macros", "rt-threaded"] }
+tokio2 = { version = "0.2", package = "tokio", features = ["sync", "macros", "rt-threaded", "tcp"] }
 tokio-compat = "0.1"
 tungstenite = "0.11"
 url = "2.0"

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -12,8 +12,6 @@ use crate::subresource_integrity::is_response_integrity_valid;
 use content_security_policy as csp;
 use crossbeam_channel::Sender;
 use devtools_traits::DevtoolsControlMsg;
-use futures_util::compat::*;
-use futures_util::StreamExt;
 use headers::{AccessControlExposeHeaders, ContentType, HeaderMapExt, Range};
 use http::header::{self, HeaderMap, HeaderName};
 use hyper::Method;

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -57,7 +57,7 @@ struct FileStoreEntry {
 struct FileMetaData {
     path: PathBuf,
     /// Modified time in UNIX Epoch format
-    modified: u64,
+    _modified: u64,
     size: u64,
 }
 
@@ -660,7 +660,7 @@ impl FileManagerStore {
 
         let file_impl = FileImpl::MetaDataOnly(FileMetaData {
             path: file_path.to_path_buf(),
-            modified: modified_epoch,
+            _modified: modified_epoch,
             size: file_size,
         });
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -523,7 +523,7 @@ async fn obtain_response(
             .replace("}", "%7D");
 
         let request = if let Some(chunk_requester) = body {
-            let (mut sink, stream) = if source_is_null {
+            let (sink, stream) = if source_is_null {
                 // Step 4.2 of https://fetch.spec.whatwg.org/#concept-http-network-fetch
                 // TODO: this should not be set for HTTP/2(currently not supported?).
                 headers.insert(TRANSFER_ENCODING, HeaderValue::from_static("chunked"));

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -87,10 +87,6 @@ packages = [
   "opaque-debug",
   "sha-1",
   "block-buffer",
-
-  # Duplicated by futures
-  "pin-project",
-  "pin-project-internal",
 ]
 # Files that are ignored for all tidy and lint checks.
 files = [


### PR DESCRIPTION
This updates our async-tungstenite/tungstenite dependencies to slightly newer versions that still rely on tokio 0.2 and should make #28661 easier.