### PR TITLE
Fix typos in markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Servo is built with [Cargo](https://crates.io/), the Rust package manager.
 We also use Mozilla's Mach tools to orchestrate the build and other tasks.
 You can call Mach like this:
 
-On Unix sytems:
+On Unix systems:
 ```
 ./mach [command] [arguments]
 ```

--- a/etc/taskcluster/README.md
+++ b/etc/taskcluster/README.md
@@ -11,7 +11,7 @@ For some things however that is not practical,
 or some deployment step that mutates global state is required.
 That configuration is split between the [mozilla/community-tc-config] and
 [servo/taskcluster-config] repositories,
-managed by the Taskcluster team and the Servo team repsectively.
+managed by the Taskcluster team and the Servo team respectively.
 
 [mozilla/community-tc-config]: https://github.com/mozilla/community-tc-config/blob/master/config/projects.yml
 [servo/taskcluster-config]: https://github.com/servo/taskcluster-config/tree/master/config
@@ -148,7 +148,7 @@ which is visible on the [credentials] page
 (reachable from clicking on one’s own name on the top-right of any page).
 
 A running task has a set of scopes allowing it access to various functionality and APIs.
-It can grant those scopes (and at most only thoses) to sub-tasks that it schedules
+It can grant those scopes (and at most only those) to sub-tasks that it schedules
 (if it has the scope allowing it to schedule new tasks in the first place).
 
 [Roles] represent each a set of scopes.
@@ -192,7 +192,7 @@ to those roles from the [servo/taskcluster-config] repository.
 The [`project-servo/daily`] hook in Taskcluster’s [Hooks service]
 is used to run some tasks automatically ever 24 hours.
 In this case as well we use a decision task.
-The `decision_task.py` script can differenciate this from a GitHub push
+The `decision_task.py` script can differentiate this from a GitHub push
 based on the `$TASK_FOR` environment variable.
 Daily tasks can also be triggered manually.
 

--- a/support/magicleap/gstreamer/README.md
+++ b/support/magicleap/gstreamer/README.md
@@ -1,6 +1,6 @@
 # Building the binary .tgz for magicleap gstreamer
 
-`mach` downloads prebuilt gstreamer libaries, which are built using this script.
+`mach` downloads prebuilt gstreamer libraries, which are built using this script.
 
 # Requirements
 - Magic Leap SDK >= 0.22.0 for MacOSX

--- a/tests/wpt/README.md
+++ b/tests/wpt/README.md
@@ -50,7 +50,7 @@ Running the tests without mach
 
 When avoiding `mach` for some reason, one can run `run.py`
 directly. However, this requires that all the dependencies for
-`wptrunner` are avaliable in the current python environment.
+`wptrunner` are available in the current python environment.
 
 Running the tests manually
 --------------------------


### PR DESCRIPTION
Fixes a number of typographical errors across markdown documentation files.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
