### PR TITLE
move servo_version from out of config crate

### DIFF
--- a/components/config/lib.rs
+++ b/components/config/lib.rs
@@ -18,12 +18,3 @@ pub mod prefs;
 pub mod basedir;
 #[allow(unsafe_code)]
 pub mod opts;
-
-pub fn servo_version() -> String {
-    let cargo_version = env!("CARGO_PKG_VERSION");
-    let git_info = option_env!("GIT_INFO");
-    match git_info {
-        Some(info) => format!("Servo {}{}", cargo_version, info),
-        None => format!("Servo {}", cargo_version),
-    }
-}

--- a/ports/libsimpleservo/api/src/lib.rs
+++ b/ports/libsimpleservo/api/src/lib.rs
@@ -185,7 +185,12 @@ pub struct ServoGlue {
 }
 
 pub fn servo_version() -> String {
-    servo::config::servo_version()
+    let cargo_version = env!("CARGO_PKG_VERSION");
+    let git_info = option_env!("GIT_INFO");
+    match git_info {
+        Some(info) => format!("Servo {}{}", cargo_version, info),
+        None => format!("Servo {}", cargo_version),
+    }
 }
 
 /// Test if a url is valid.

--- a/ports/winit/main2.rs
+++ b/ports/winit/main2.rs
@@ -26,7 +26,6 @@ mod window_trait;
 use app::App;
 use getopts::Options;
 use servo::config::opts::{self, ArgumentParsingResult};
-use servo::config::servo_version;
 use servo::servo_config::pref;
 use std::env;
 use std::io::Write;
@@ -162,4 +161,13 @@ pub fn main() {
     App::run(do_not_use_native_titlebar, device_pixels_per_px, user_agent);
 
     platform::deinit(clean_shutdown)
+}
+
+pub fn servo_version() -> String {
+    let cargo_version = env!("CARGO_PKG_VERSION");
+    let git_info = option_env!("GIT_INFO");
+    match git_info {
+        Some(info) => format!("Servo {}{}", cargo_version, info),
+        None => format!("Servo {}", cargo_version),
+    }
 }


### PR DESCRIPTION
`servo_version`'s contents are moved to `simpleservo::servo_version` in `ports/libsimpleservo/api/src/lib.rs`.
`servo_version`'s contents are also duplicated in a new function `servo_version` in `ports/winit/main2.rs`.

It's my first PR, I'm not really sure what is required. Let me know what I need to change to make this work. Thanks!

Signed-off-by: s-maurice <51819025+s-maurice@users.noreply.github.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #28719 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they do not change any logic.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
