### PR TITLE
Unbreak lldb invocations.

### DIFF
--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -162,8 +162,7 @@ class PostBuildCommands(CommandBase):
                     command = rustCommand
 
             # Prepend the debugger args.
-            args = ([command] + self.debuggerInfo.args + ["--"]
-                    + args + params)
+            args = ([command] + self.debuggerInfo.args + args + params)
         else:
             args = args + params
 


### PR DESCRIPTION
The underlying mozdebug now includes a -- in the command line, so `./mach run --debug` is broken if we add it explicitly.