### PR TITLE
Ensure reflow damage is calculated when hypothetical box changes.

### DIFF
--- a/components/style/properties/properties.mako.rs
+++ b/components/style/properties/properties.mako.rs
@@ -4131,6 +4131,9 @@ macro_rules! longhand_properties_idents {
 % for effect_name in ["repaint", "reflow_out_of_flow", "reflow", "rebuild_and_reflow_inline", "rebuild_and_reflow"]:
     macro_rules! restyle_damage_${effect_name} {
         ($old: ident, $new: ident, $damage: ident, [ $($effect:expr),* ]) => ({
+            restyle_damage_${effect_name}!($old, $new, $damage, [$($effect),*], false)
+        });
+        ($old: ident, $new: ident, $damage: ident, [ $($effect:expr),* ], $extra:expr) => ({
             if
                 % for style_struct in data.active_style_structs():
                     % for longhand in style_struct.longhands:
@@ -4141,13 +4144,13 @@ macro_rules! longhand_properties_idents {
                     % endfor
                 % endfor
 
-                false {
+                $extra || false {
                     $damage.insert($($effect)|*);
                     true
             } else {
                 false
             }
-        })
+        });
     }
 % endfor
 % endif

--- a/components/style/servo/restyle_damage.rs
+++ b/components/style/servo/restyle_damage.rs
@@ -210,7 +210,8 @@ fn compute_damage(old: &ComputedValues, new: &ComputedValues) -> ServoRestyleDam
             ServoRestyleDamage::REFLOW_OUT_OF_FLOW,
             ServoRestyleDamage::REFLOW,
             ServoRestyleDamage::RECONSTRUCT_FLOW
-        ]
+        ],
+        old.get_box().original_display != new.get_box().original_display
     ) || (new.get_box().display == Display::Inline &&
         restyle_damage_rebuild_and_reflow_inline!(
             old,

--- a/tests/wpt/metadata/css/CSS2/abspos/hypothetical-box-dynamic.html.ini
+++ b/tests/wpt/metadata/css/CSS2/abspos/hypothetical-box-dynamic.html.ini
@@ -1,2 +1,0 @@
-[hypothetical-box-dynamic.html]
-  expected: FAIL


### PR DESCRIPTION
The layout traversal code has special handling for deciding whether to traverse text nodes or not. Specifically, unless the parent of a text node is restyled in a way that requires reconstructing the text fragment, we skip processing the text nodes as a performance optimization.

The optimization causes a problem in hypothetical-box-dynamic.html, which tests that the rendering doesn't change when an absolutely-positioned span has an explicit block display removed (because absolutely-positioned elements should have hypothetical block boxes, regardless). However, the code to decide what restyling damage occurs when the block display is removed did not consider the hypothetical display, only the internal display value that treats absolute positioning as block display.

By explicitly comparing the hypothetical display as well as the internal display, we ensure the element is restyled appropriately and the layout matches after the change. 

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes