### PR TITLE
add custom debug formatting for display

### DIFF
--- a/components/style/values/specified/box.rs
+++ b/components/style/values/specified/box.rs
@@ -18,7 +18,7 @@ use crate::Atom;
 use cssparser::Parser;
 use num_traits::FromPrimitive;
 use selectors::parser::SelectorParseErrorKind;
-use std::fmt::{self, Write};
+use std::fmt::{self, Debug, Formatter, Write};
 use style_traits::{CssWriter, KeywordsCollectFn, ParseError};
 use style_traits::{SpecifiedValueInfo, StyleParseErrorKind, ToCss};
 
@@ -121,7 +121,6 @@ pub enum DisplayInside {
 #[derive(
     Clone,
     Copy,
-    Debug,
     Eq,
     FromPrimitive,
     Hash,
@@ -654,6 +653,16 @@ impl SpecifiedValueInfo for Display {
             "-webkit-box",
             "-webkit-inline-box",
         ]);
+    }
+}
+
+impl Debug for Display {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Display")
+            .field("List Item", &self.is_list_item())
+            .field("Inside", &self.inside())
+            .field("Outside", &self.outside())
+            .finish()
     }
 }
 


### PR DESCRIPTION
Signed-off-by: s-maurice <51819025+s-maurice@users.noreply.github.com>

<!-- Please describe your changes on the following line: -->
Implemented `Debug` for `Display` using `debug_struct`.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #28755 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it is a debug formatting display change.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
