### PR TITLE
Add trace logs when assigning inline/block sizes

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -1994,6 +1994,7 @@ impl BlockFlow {
                 "block"
             }
         );
+        trace!("BlockFlow before assigning: {:?}", &self);
 
         self.base.floats = Floats::new(self.base.writing_mode);
 
@@ -2003,7 +2004,9 @@ impl BlockFlow {
         // Now compute the real value.
         self.propagate_and_compute_used_inline_size(shared_context);
 
-        self.guess_inline_size_for_block_formatting_context_if_necessary()
+        self.guess_inline_size_for_block_formatting_context_if_necessary();
+
+        trace!("BlockFlow after assigning: {:?}", &self);
     }
 
     /// If this is the root flow, initialize values that would normally be set by the parent.
@@ -2304,25 +2307,32 @@ impl Flow for BlockFlow {
             self.base.flags.contains(FlowFlags::MARGINS_CANNOT_COLLAPSE)
         {
             // Root element margins should never be collapsed according to CSS § 8.3.1.
+            debug!("{}", self.is_root());
             debug!(
-                "assign_block_size: assigning block_size for root flow {:?}",
+                "assign_block_size: assigning block_size for root flow {:#x?}",
                 self.base().debug_id()
             );
-            self.assign_block_size_block_base(
+            trace!("BlockFlow before assigning: {:?}", &self);
+            let flow = self.assign_block_size_block_base(
                 layout_context,
                 fragmentation_context,
                 MarginsMayCollapseFlag::MarginsMayNotCollapse,
-            )
+            );
+            trace!("BlockFlow after assigning: {:?}", &self);
+            flow
         } else {
             debug!(
-                "assign_block_size: assigning block_size for block {:?}",
+                "assign_block_size: assigning block_size for block {:#x?}",
                 self.base().debug_id()
             );
-            self.assign_block_size_block_base(
+            trace!("BlockFlow before assigning: {:?}", &self);
+            let flow = self.assign_block_size_block_base(
                 layout_context,
                 fragmentation_context,
                 MarginsMayCollapseFlag::MarginsMayCollapse,
-            )
+            );
+            trace!("BlockFlow after assigning: {:?}", &self);
+            flow
         }
     }
 

--- a/components/layout/multicol.rs
+++ b/components/layout/multicol.rs
@@ -84,6 +84,8 @@ impl Flow for MulticolFlow {
             "assign_inline_sizes({}): assigning inline_size for flow",
             "multicol"
         );
+        trace!("MulticolFlow before assigning: {:?}", &self);
+
         let shared_context = layout_context.shared_context();
         self.block_flow.compute_inline_sizes(shared_context);
 
@@ -146,10 +148,13 @@ impl Flow for MulticolFlow {
             column_width,
             |_, _, _, _, _, _| {},
         );
+
+        trace!("MulticolFlow after assigning: {:?}", &self);
     }
 
     fn assign_block_size(&mut self, ctx: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for multicol");
+        trace!("MulticolFlow before assigning: {:?}", &self);
 
         let fragmentation_context = Some(FragmentationContext {
             this_fragment_is_empty: true,
@@ -193,6 +198,8 @@ impl Flow for MulticolFlow {
                 None => break,
             };
         }
+
+        trace!("MulticolFlow after assigning: {:?}", &self);
     }
 
     fn compute_stacking_relative_position(&mut self, layout_context: &LayoutContext) {
@@ -289,12 +296,19 @@ impl Flow for MulticolColumnFlow {
             "assign_inline_sizes({}): assigning inline_size for flow",
             "multicol column"
         );
+        trace!("MulticolFlow before assigning: {:?}", &self);
+
         self.block_flow.assign_inline_sizes(layout_context);
+        trace!("MulticolFlow after assigning: {:?}", &self);
     }
 
     fn assign_block_size(&mut self, ctx: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for multicol column");
+        trace!("MulticolFlow before assigning: {:?}", &self);
+
         self.block_flow.assign_block_size(ctx);
+
+        trace!("MulticolFlow after assigning: {:?}", &self);
     }
 
     fn fragment(

--- a/components/layout/table.rs
+++ b/components/layout/table.rs
@@ -419,6 +419,7 @@ impl Flow for TableFlow {
             "assign_inline_sizes({}): assigning inline_size for flow",
             "table"
         );
+        trace!("TableFlow before assigning: {:?}", &self);
 
         let shared_context = layout_context.shared_context();
         // The position was set to the containing block by the flow's parent.
@@ -544,13 +545,19 @@ impl Flow for TableFlow {
                 }
             },
         );
+
+        trace!("TableFlow after assigning: {:?}", &self);
     }
 
     fn assign_block_size(&mut self, lc: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for table");
+        trace!("TableFlow before assigning: {:?}", &self);
+
         let vertical_spacing = self.spacing().vertical();
         self.block_flow
-            .assign_block_size_for_table_like_flow(vertical_spacing, lc)
+            .assign_block_size_for_table_like_flow(vertical_spacing, lc);
+
+        trace!("TableFlow after assigning: {:?}", &self);
     }
 
     fn compute_stacking_relative_position(&mut self, layout_context: &LayoutContext) {

--- a/components/layout/table_caption.rs
+++ b/components/layout/table_caption.rs
@@ -57,12 +57,20 @@ impl Flow for TableCaptionFlow {
             "assign_inline_sizes({}): assigning inline_size for flow",
             "table_caption"
         );
+        trace!("TableCaptionFlow before assigning: {:?}", &self);
+
         self.block_flow.assign_inline_sizes(layout_context);
+
+        trace!("TableCaptionFlow after assigning: {:?}", &self);
     }
 
     fn assign_block_size(&mut self, layout_context: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for table_caption");
+        trace!("TableCaptionFlow before assigning: {:?}", &self);
+
         self.block_flow.assign_block_size(layout_context);
+
+        trace!("TableCaptionFlow after assigning: {:?}", &self);
     }
 
     fn compute_stacking_relative_position(&mut self, layout_context: &LayoutContext) {

--- a/components/layout/table_cell.rs
+++ b/components/layout/table_cell.rs
@@ -252,6 +252,7 @@ impl Flow for TableCellFlow {
             "assign_inline_sizes({}): assigning inline_size for flow",
             "table_cell"
         );
+        trace!("TableCellFlow before assigning: {:?}", &self);
 
         let shared_context = layout_context.shared_context();
         // The position was set to the column inline-size by the parent flow, table row flow.
@@ -280,11 +281,17 @@ impl Flow for TableCellFlow {
             content_inline_size,
             |_, _, _, _, _, _| {},
         );
+
+        trace!("TableCellFlow after assigning: {:?}", &self);
     }
 
     fn assign_block_size(&mut self, layout_context: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for table_cell");
+        trace!("TableCellFlow before assigning: {:?}", &self);
+
         self.assign_block_size_table_cell_base(layout_context);
+
+        trace!("TableCellFlow after assigning: {:?}", &self);
     }
 
     fn compute_stacking_relative_position(&mut self, layout_context: &LayoutContext) {

--- a/components/layout/table_rowgroup.rs
+++ b/components/layout/table_rowgroup.rs
@@ -138,6 +138,7 @@ impl Flow for TableRowGroupFlow {
             "assign_inline_sizes({}): assigning inline_size for flow",
             "table_rowgroup"
         );
+        trace!("TableRowGroupFlow before assigning: {:?}", &self);
 
         let shared_context = layout_context.shared_context();
         // The position was set to the containing block by the flow's parent.
@@ -184,12 +185,18 @@ impl Flow for TableRowGroupFlow {
                 }
             },
         );
+
+        trace!("TableRowGroupFlow after assigning: {:?}", &self);
     }
 
     fn assign_block_size(&mut self, lc: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for table_rowgroup");
+        trace!("TableRowGroupFlow before assigning: {:?}", &self);
+
         self.block_flow
             .assign_block_size_for_table_like_flow(self.spacing.vertical(), lc);
+
+        trace!("TableRowGroupFlow after assigning: {:?}", &self);
     }
 
     fn compute_stacking_relative_position(&mut self, layout_context: &LayoutContext) {

--- a/components/layout/table_wrapper.rs
+++ b/components/layout/table_wrapper.rs
@@ -371,6 +371,7 @@ impl Flow for TableWrapperFlow {
                 "table_wrapper"
             }
         );
+        trace!("TableWrapperFlow before assigning: {:?}", &self);
 
         let shared_context = layout_context.shared_context();
         self.block_flow
@@ -454,16 +455,22 @@ impl Flow for TableWrapperFlow {
                 )
             },
         }
+
+        trace!("TableWrapperFlow after assigning: {:?}", &self);
     }
 
     fn assign_block_size(&mut self, layout_context: &LayoutContext) {
         debug!("assign_block_size: assigning block_size for table_wrapper");
+        trace!("TableWrapperFlow before assigning: {:?}", &self);
+
         let remaining = self.block_flow.assign_block_size_block_base(
             layout_context,
             None,
             MarginsMayCollapseFlag::MarginsMayNotCollapse,
         );
         debug_assert!(remaining.is_none());
+
+        trace!("TableWrapperFlow after assigning: {:?}", &self);
     }
 
     fn compute_stacking_relative_position(&mut self, layout_context: &LayoutContext) {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Adding trace logs before and after assigning inline_size and block_size for flows.
This could help debugging layout changes instead of keep printing manually in a debugger.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it only add trace logs

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
