### PR TITLE
Fix absolute descendents being replaced when retreiving root

### DIFF
--- a/components/layout/block.rs
+++ b/components/layout/block.rs
@@ -903,7 +903,7 @@ impl BlockFlow {
     ///   10.6.7.
     ///
     /// For absolute flows, we store the calculated content block-size for the flow. We defer the
-    /// calculation of the other values until a later traversal.
+    /// calculation of the other values until a later traversal at root flow.
     ///
     /// When `fragmentation_context` is given (not `None`), this should fit as much of the content
     /// as possible within the available block size.
@@ -1200,6 +1200,8 @@ impl BlockFlow {
                 .contains(FlowFlags::IS_ABSOLUTELY_POSITIONED)
             {
                 self.propagate_early_absolute_position_info_to_children();
+                // Return early until the absolute flow tree traversal at root flow.
+                // Assigning block size for absolute flow will happen in `traverse_absolute_flows` below.
                 return None;
             }
 

--- a/tests/wpt/metadata/css/CSS2/positioning/abspos-containing-block-005.xht.ini
+++ b/tests/wpt/metadata/css/CSS2/positioning/abspos-containing-block-005.xht.ini
@@ -1,3 +1,0 @@
-[abspos-containing-block-005.xht]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata/css/CSS2/positioning/abspos-containing-block-006.xht.ini
+++ b/tests/wpt/metadata/css/CSS2/positioning/abspos-containing-block-006.xht.ini
@@ -1,3 +1,0 @@
-[abspos-containing-block-006.xht]
-  type: reftest
-  expected: FAIL

--- a/tests/wpt/metadata/css/filter-effects/filtered-html-is-not-container.html.ini
+++ b/tests/wpt/metadata/css/filter-effects/filtered-html-is-not-container.html.ini
@@ -1,2 +1,0 @@
-[filtered-html-is-not-container.html]
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
The cause of #16410 is because calling `try_get_layout_root` will replace its `abs_descendants` even itself isn't absolute positioned. So I pushed them instead if the root isn't absolute. Also add a few docs and comments to help understand how block size of absolute flow is being calculated. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #16410 (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes:
Reduced testcase from the issue.
```html
<style>
  html {
    min-height: 100%;
    position: relative;
  }
  div {
    position: absolute;
    bottom: 0;
    width: 100%;
    height: 25px;
    border: 1px solid black;
  }
</style>
<div>
</div>
```

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
