### PR TITLE
Update bootstrap to support Pop!_OS 22.04

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -339,7 +339,11 @@ def get_linux_distribution():
         else:
             major = version
 
-        if major == '20':
+        if major == '22':
+            base_version = '22.04'
+        elif major == '21':
+            base_version = '21.04'
+        elif major == '20':
             base_version = '20.04'
         elif major == '19':
             base_version = '18.04'
@@ -355,7 +359,9 @@ def get_linux_distribution():
         else:
             major = version
 
-        if major == '21':
+        if major == '22':
+            base_version = '22.04'
+        elif major == '21':
             base_version = '21.04'
         elif major == '20':
             base_version = '20.04'


### PR DESCRIPTION
Bootstrap downloads dependencies. Updating Pop!_OS and Linux Mint, notable exception being Elementary OS untested

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X ] `./mach build -d` does not report any errors
- [ X] `./mach test-tidy` does not report any errors
- [X ] These changes fix bootstrap (GitHub issue number if applicable)
- 
thank you!