### PR TITLE
Update to image 0.24.2, implement WebP support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
  "euclid",
  "gfx_traits",
  "gleam 0.12.1",
- "image 0.24.1",
+ "image 0.24.2",
  "ipc-channel",
  "keyboard-types",
  "libc",
@@ -1689,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "exr"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4badb9489a465cb2c555af1f00f0bfd8cecd6fc12ac11da9d5b40c5dd5f0200"
+checksum = "14cc0e06fb5f67e5d6beadf3a382fec9baca1aa751c6d5368fdeee7e5932c215"
 dependencies = [
  "bit_field",
  "deflate 1.0.0",
@@ -2977,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db207d030ae38f1eb6f240d5a1c1c88ff422aa005d10f8c6c6fc5e75286ab30e"
+checksum = "28edd9d7bc256be2502e325ac0628bde30b7001b9b52e0abe31a1a9dc2701212"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -4180,7 +4180,7 @@ dependencies = [
  "http",
  "hyper 0.14.5",
  "hyper_serde",
- "image 0.24.1",
+ "image 0.24.2",
  "ipc-channel",
  "lazy_static",
  "log",
@@ -5387,7 +5387,7 @@ dependencies = [
  "html5ever",
  "http",
  "hyper_serde",
- "image 0.24.1",
+ "image 0.24.2",
  "indexmap",
  "ipc-channel",
  "itertools",
@@ -5665,7 +5665,7 @@ dependencies = [
  "clipboard",
  "euclid",
  "getopts",
- "image 0.24.1",
+ "image 0.24.2",
  "keyboard-types",
  "lazy_static",
  "libc",
@@ -7301,7 +7301,7 @@ dependencies = [
  "euclid",
  "headers",
  "http",
- "image 0.24.1",
+ "image 0.24.2",
  "ipc-channel",
  "keyboard-types",
  "log",

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -20,6 +20,7 @@ headers = "0.3"
 http = "0.2"
 hyper = "0.14"
 hyper_serde = "0.13"
+image = "0.24"
 ipc-channel = "0.14"
 lazy_static = "1"
 log = "0.4"
@@ -29,7 +30,6 @@ mime = "0.3"
 msg = { path = "../msg" }
 num-traits = "0.2"
 percent-encoding = "2.0"
-piston_image = { package = "image", version = "0.24" }
 pixels = { path = "../pixels" }
 serde = "1.0"
 servo_arc = { path = "../servo_arc" }

--- a/components/net_traits/image/base.rs
+++ b/components/net_traits/image/base.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::image_cache::CorsStatus;
+use image::ImageFormat;
 use ipc_channel::ipc::IpcSharedMemory;
-use piston_image::ImageFormat;
 use pixels::PixelFormat;
 use std::fmt;
 
@@ -50,7 +50,7 @@ pub fn load_from_memory(buffer: &[u8], cors_status: CorsStatus) -> Option<Image>
             debug!("{}", msg);
             None
         },
-        Ok(_) => match piston_image::load_from_memory(buffer) {
+        Ok(_) => match image::load_from_memory(buffer) {
             Ok(image) => {
                 let mut rgba = image.into_rgba8();
                 pixels::rgba8_byte_swap_colors_inplace(&mut *rgba);
@@ -79,6 +79,8 @@ pub fn detect_image_format(buffer: &[u8]) -> Result<ImageFormat, &str> {
         Ok(ImageFormat::Jpeg)
     } else if is_png(buffer) {
         Ok(ImageFormat::Png)
+    } else if is_webp(buffer) {
+        Ok(ImageFormat::WebP)
     } else if is_bmp(buffer) {
         Ok(ImageFormat::Bmp)
     } else if is_ico(buffer) {
@@ -106,4 +108,8 @@ fn is_bmp(buffer: &[u8]) -> bool {
 
 fn is_ico(buffer: &[u8]) -> bool {
     buffer.starts_with(&[0x00, 0x00, 0x01, 0x00])
+}
+
+fn is_webp(buffer: &[u8]) -> bool {
+    buffer.starts_with(b"RIFF") && buffer.len() >= 14 && &buffer[8..14] == b"WEBPVP"
 }

--- a/components/net_traits/tests/image.rs
+++ b/components/net_traits/tests/image.rs
@@ -10,6 +10,9 @@ fn test_supported_images() {
     let gif2 = [b'G', b'I', b'F', b'8', b'9', b'a'];
     let jpeg = [0xff, 0xd8, 0xff];
     let png = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+    let webp = [
+        b'R', b'I', b'F', b'F', 0x01, 0x02, 0x03, 0x04, b'W', b'E', b'B', b'P', b'V', b'P',
+    ];
     let bmp = [0x42, 0x4D];
     let ico = [0x00, 0x00, 0x01, 0x00];
     let junk_format = [0x01, 0x02, 0x03, 0x04, 0x05];
@@ -18,6 +21,7 @@ fn test_supported_images() {
     assert!(detect_image_format(&gif2).is_ok());
     assert!(detect_image_format(&jpeg).is_ok());
     assert!(detect_image_format(&png).is_ok());
+    assert!(detect_image_format(&webp).is_ok());
     assert!(detect_image_format(&bmp).is_ok());
     assert!(detect_image_format(&ico).is_ok());
     assert!(detect_image_format(&junk_format).is_err());


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR updates image to 0.24.2 and implements WebP support. I've been watching the progress on image-rs's WebP implementation, and from what I've seen, the situation has changed from "can only decode the luma channel from lossy WebPs" to pretty much full support (with image 0.24.2 implementing support for the extended WebP format).

Here are screenshots of it viewing the WebP page's example:
<details>
<summary>Screenshots</summary>

Servo viewing the main WebP gallery:
![A screenshot of Servo viewing the WebP Gallery](https://user-images.githubusercontent.com/85590273/167732100-957fe4a9-1752-491b-90e4-ffb2aa0552a4.png)
Servo viewing a lossless example from WebP's Lossless and Alpha Demonstration:
![A screenshot of Servo viewing the lossless version of the "Transparent compass card for overlays" example from WebP's Lossless and Alpha Demonstration](https://user-images.githubusercontent.com/85590273/167732333-d082c9d0-e390-49c1-bfb0-9ba3e717367c.png)
Servo viewing a lossy-with-alpha example from WebP's Lossless and Alpha Demonstration
![A screenshot of Servo viewing the lossy-with-alpha version of the "Transparent compass card for overlays" example from WebP's Lossless and Alpha Demonstration](https://user-images.githubusercontent.com/85590273/167731987-393f4931-4276-4cfb-94da-adacb07e5ca9.png)
</details>

This also changes the package name from `piston_image` to simply `image`. It appeared to be a piece of legacy from ages ago which can be safely changed now.

(PS: I'm still pretty new at Rust, please let me know if I have done any mistakes in the process)

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #20045 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
