### PR TITLE
`etc/shell.nix`: Add `AppKit` to `buildInputs` on Darwin

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -20,7 +20,9 @@ clangStdenv.mkDerivation rec {
     # Build utilities
     cmake dbus gcc git pkgconfig which llvm autoconf213 perl yasm m4
     (python3.withPackages (ps: with ps; [virtualenv pip dbus]))
-  ];
+  ] ++ (lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.AppKit
+  ]);
 
   LIBCLANG_PATH = llvmPackages.clang-unwrapped.lib + "/lib/";
 


### PR DESCRIPTION
System framework dependencies need to be specified explicitly on Darwin.

Fixes a linker error when building Servo inside a Nix shell on macOS.

Signed-off-by: yvt <i@yvt.jp>

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

---
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they don't affect the production code