### PR TITLE
`etc/shell.nix`: Replace `pkgconfig` with `pkg-config`

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -18,7 +18,7 @@ clangStdenv.mkDerivation rec {
     rustup
 
     # Build utilities
-    cmake dbus gcc git pkgconfig which llvm autoconf213 perl yasm m4
+    cmake dbus gcc git pkg-config which llvm autoconf213 perl yasm m4
     (python3.withPackages (ps: with ps; [virtualenv pip dbus]))
   ] ++ (lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.AppKit


### PR DESCRIPTION
`pkgconfig` is [an old name][1] of `pkg-config` that has been [completely removed][2] in a recent version of nixpkgs.

[1]: https://github.com/NixOS/nixpkgs/pull/55094
[2]: https://github.com/NixOS/nixpkgs/pull/192681

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

---
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they don't affect the production code
