### PR TITLE
chore(deps): bump `smallvec` from 0.6 to 1.9 in all local packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,7 +2080,7 @@ dependencies = [
  "servo_arc",
  "servo_atoms",
  "servo_url",
- "smallvec 0.6.13",
+ "smallvec 1.9.0",
  "style",
  "time",
  "truetype",
@@ -3225,7 +3225,7 @@ dependencies = [
  "servo_geometry",
  "servo_url",
  "size_of_test",
- "smallvec 0.6.13",
+ "smallvec 1.9.0",
  "style",
  "style_traits",
  "unicode-bidi",
@@ -5433,7 +5433,7 @@ dependencies = [
  "servo_geometry",
  "servo_rand",
  "servo_url",
- "smallvec 0.6.13",
+ "smallvec 1.9.0",
  "sparkle",
  "style",
  "style_traits",
@@ -5536,7 +5536,7 @@ dependencies = [
  "serde",
  "servo_atoms",
  "servo_url",
- "smallvec 0.6.13",
+ "smallvec 1.9.0",
  "style_traits",
  "time",
  "uuid",
@@ -6143,7 +6143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 dependencies = [
  "maybe-uninit",
- "serde",
 ]
 
 [[package]]
@@ -7331,7 +7330,7 @@ dependencies = [
  "msg",
  "serde",
  "servo_config",
- "smallvec 0.6.13",
+ "smallvec 1.9.0",
  "webrender_api",
  "webrender_traits",
  "wgpu-core",

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -32,7 +32,7 @@ serde = "1.0"
 servo_arc = { path = "../servo_arc" }
 servo_atoms = { path = "../atoms" }
 servo_url = { path = "../url" }
-smallvec = { version = "0.6", features = ["std", "union"] }
+smallvec = { version = "1.9", features = ["union"] }
 style = { path = "../style", features = ["servo"] }
 time = "0.1.41"
 ucd = "0.1.1"

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -44,7 +44,7 @@ servo_atoms = { path = "../atoms" }
 servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }
 servo_url = { path = "../url" }
-smallvec = { version = "0.6", features = ["std", "union"] }
+smallvec = { version = "1.9", features = ["union"] }
 style = { path = "../style", features = ["servo", "servo-layout-2013"] }
 style_traits = { path = "../style_traits" }
 unicode-bidi = { version = "0.3", features = ["with_serde"] }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -99,7 +99,7 @@ servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }
 servo_rand = { path = "../rand" }
 servo_url = { path = "../url" }
-smallvec = { version = "0.6", features = ["std", "union"] }
+smallvec = { version = "1.9", features = ["union"] }
 sparkle = "0.1"
 style = { path = "../style", features = ["servo"] }
 style_traits = { path = "../style_traits" }

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -37,7 +37,7 @@ profile_traits = { path = "../profile_traits" }
 serde = "1.0"
 servo_atoms = { path = "../atoms" }
 servo_url = { path = "../url" }
-smallvec = "0.6"
+smallvec = "1.9"
 style_traits = { path = "../style_traits", features = ["servo"] }
 time = "0.1.41"
 uuid = { version = "0.8", features = ["v4"] }

--- a/components/webgpu/Cargo.toml
+++ b/components/webgpu/Cargo.toml
@@ -19,7 +19,7 @@ malloc_size_of = { path = "../malloc_size_of" }
 msg = { path = "../msg" }
 serde = { version = "1.0", features = ["serde_derive"] }
 servo_config = { path = "../config" }
-smallvec = { version = "0.6", features = ["serde"] }
+smallvec = { version = "1.9", features = ["serde"] }
 webrender_api = { git = "https://github.com/servo/webrender" }
 webrender_traits = { path = "../webrender_traits" }
 wgpu-core = { version = "0.6.0", git = "https://github.com/gfx-rs/wgpu", features = ["replay", "trace", "serial-pass"], rev = "e72724a6e393503c73f37e86aa9317a5c62e32b8" }


### PR DESCRIPTION
`smallvec ^0.6` no longer compiles after `nightly-2022-07-15` if the `union` feature is enabled.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #28999 (GitHub issue number if applicable)

---
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it's a mere dependency upgrade
