### PR TITLE
Fix for loop over option warnings

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -437,7 +437,7 @@ impl EventTarget {
         let mut handlers = self.handlers.borrow_mut();
 
         let listener = EventListenerType::Additive(listener.clone());
-        for entries in handlers.get_mut(ty) {
+        if let Some(entries) = handlers.get_mut(ty) {
             entries.drain_filter(|e| e.listener == listener && e.once);
         }
     }
@@ -734,7 +734,7 @@ impl EventTarget {
         };
         let mut handlers = self.handlers.borrow_mut();
         let entry = handlers.get_mut(&Atom::from(ty));
-        for entry in entry {
+        if let Some(entry) = entry {
             let phase = if options.capture {
                 ListenerPhase::Capturing
             } else {


### PR DESCRIPTION
I fixed two for loop over an option warnings by using if let instead.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it is a simple code transformation.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
