### PR TITLE
Build CI on macos-12 image.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
 
   build-mac:
     name: Build (macOS)
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
       - name: Branch check
         if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-mac', github.ref) }}
@@ -146,7 +146,7 @@ jobs:
 
   # mac-wpt:
   #   #needs: build-mac
-  #   runs-on: macos-10.15
+  #   runs-on: macos-10.12
   #   env:
   #     max_chunk_id: 20
   #   strategy:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,7 @@ jobs:
 
   upload-mac:
     name: Upload nightly (macOS)
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The macOS-10.15 images will be unsupported as of December 1, 2022.