### PR TITLE
bootstrap.py compatibility patch for Fedora.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ sudo dnf install curl libtool gcc-c++ libXi-devel libunwind-devel \
     rpm-build openssl-devel cmake libX11-devel libXcursor-devel \
     libXmu-devel dbus-devel ncurses-devel harfbuzz-devel \
     ccache clang clang-libs python3-devel gstreamer1-devel \
-    gstreamer1-plugins-base-devel gstreamer1-plugins-bad-free-devel autoconf213
+    gstreamer1-plugins-base-devel gstreamer1-plugins-bad-free-devel autoconf213 \
+    libjpeg-turbo-devel zlib libjpeg
 ```
 
 #### On CentOS

--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -110,7 +110,8 @@ def linux(context, force=False):
                 'dbus-devel', 'ncurses-devel', 'harfbuzz-devel', 'ccache',
                 'clang', 'clang-libs', 'llvm', 'autoconf213', 'python3-devel',
                 'gstreamer1-devel', 'gstreamer1-plugins-base-devel',
-                'gstreamer1-plugins-bad-free-devel']
+                'gstreamer1-plugins-bad-free-devel', 'libjpeg-turbo-devel',
+                'zlib', 'libjpeg', 'zlib']
     pkgs_xbps = ['libtool', 'gcc', 'libXi-devel', 'freetype-devel',
                  'libunwind-devel', 'MesaLib-devel', 'glib-devel', 'pkg-config',
                  'libX11-devel', 'libXrandr-devel', 'gperf', 'bzip2-devel',

--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -111,7 +111,7 @@ def linux(context, force=False):
                 'clang', 'clang-libs', 'llvm', 'autoconf213', 'python3-devel',
                 'gstreamer1-devel', 'gstreamer1-plugins-base-devel',
                 'gstreamer1-plugins-bad-free-devel', 'libjpeg-turbo-devel',
-                'zlib', 'libjpeg', 'zlib']
+                'zlib', 'libjpeg']
     pkgs_xbps = ['libtool', 'gcc', 'libXi-devel', 'freetype-devel',
                  'libunwind-devel', 'MesaLib-devel', 'glib-devel', 'pkg-config',
                  'libX11-devel', 'libXrandr-devel', 'gperf', 'bzip2-devel',


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

This issue fixes certain problems with the automatic bootstrapping process of Servo on Fedora. Specifically, this patch adds zlib, libjpeg (also aliased as libjpeg-turbo), libjpeg-turbo-devel dependencies to the Fedora dependency array. The documentation was updated accordingly.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors

`./mach test-tidy` fails, however, I am not too sure if these errors occurred because of my PR:

```py
Traceback (most recent call last):
  File "/home/_/Documents/Projects/oss/servo/./mach", line 47, in <module>
    main(sys.argv)
  File "/home/_/Documents/Projects/oss/servo/./mach", line 29, in main
    mach = mach_bootstrap.bootstrap(topdir)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/_/Documents/Projects/oss/servo/python/mach_bootstrap.py", line 306, in bootstrap
    import mach.main
  File "/home/_/Documents/Projects/oss/servo/python/mach/mach/main.py", line 164, in <module>
    @CommandProvider
     ^^^^^^^^^^^^^^^
  File "/home/_/Documents/Projects/oss/servo/python/mach/mach/decorators.py", line 115, in CommandProvider
    spec = inspect.getargspec(cls.__init__)
           ^^^^^^^^^^^^^^^^^^
AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?
```

- [X] These changes fix #29101

<!-- Either: -->
- [X] These changes do not require tests because we are not changing anything major.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
