### PR TITLE
Replaced explicit Default implementation for Seed with derive.

### DIFF
--- a/components/rand/lib.rs
+++ b/components/rand/lib.rs
@@ -66,12 +66,6 @@ impl RngCore for ServoRng {
 #[derive(Default)]
 pub struct Seed([u8; 32]);
 
-// impl Default for Seed {
-//     fn default() -> Self {
-//         Seed([0; 32])
-//     }
-// }
-
 impl AsMut<[u8]> for Seed {
     fn as_mut(&mut self) -> &mut [u8] {
         &mut self.0

--- a/components/rand/lib.rs
+++ b/components/rand/lib.rs
@@ -63,13 +63,14 @@ impl RngCore for ServoRng {
     }
 }
 
+#[derive(Default)]
 pub struct Seed([u8; 32]);
 
-impl Default for Seed {
-    fn default() -> Self {
-        Seed([0; 32])
-    }
-}
+// impl Default for Seed {
+//     fn default() -> Self {
+//         Seed([0; 32])
+//     }
+// }
 
 impl AsMut<[u8]> for Seed {
     fn as_mut(&mut self) -> &mut [u8] {


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This patch replaces the explicit `std::default::Default` implementation of the [Seed](https://github.com/servo/servo/blob/master/components/rand/lib.rs) struct with a derive macro. 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests. 

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
