### PR TITLE
Arch Linux compatibility patch for mach tools.

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -394,6 +394,8 @@ def get_linux_distribution():
         'fedora linux',
         'void',
         'nixos',
+        'arch',
+        'arch linux',
     ]:
         raise Exception('mach bootstrap does not support %s, please file a bug' % distrib)
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This patch adds support for Arch Linux for mach. The error described below is now fixed:
```bash
Traceback (most recent call last):
  File "mach", line 47, in <module>
    main(sys.argv)
  File "mach", line 27, in main
    sys.exit(mach_bootstrap.bootstrap_command_only(topdir))
  File "/home/michael/Public/servo/python/mach_bootstrap.py", line 254, in bootstrap_command_only
    bootstrap(context, force)
  File "/home/michael/Public/servo/python/servo/bootstrap.py", line 411, in bootstrap
    distrib, version = get_linux_distribution()
  File "/home/michael/Public/servo/python/servo/bootstrap.py", line 399, in get_linux_distribution
    raise Exception('mach bootstrap does not support %s, please file a bug' % distrib)
Exception: mach bootstrap does not support Arch Linux, please file a bug
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
