### PR TITLE
Fix some typos

### DIFF
--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -289,7 +289,7 @@ fn tile_image(position: &mut Au, size: &mut Au, absolute_anchor_origin: Au, imag
     *position = new_position;
 }
 
-/// For either the x or the y axis ajust various values to account for tiling.
+/// For either the x or the y axis adjust various values to account for tiling.
 ///
 /// This is done separately for both axes because the repeat keywords may differ.
 fn tile_image_axis(

--- a/components/layout/display_list/gradient.rs
+++ b/components/layout/display_list/gradient.rs
@@ -20,7 +20,7 @@ struct StopRun {
     stop_count: usize,
 }
 
-/// Determines the radius of a circle if it was not explictly provided.
+/// Determines the radius of a circle if it was not explicitly provided.
 /// <https://drafts.csswg.org/css-images-3/#typedef-size>
 fn circle_size_keyword(
     keyword: ShapeExtent,
@@ -57,7 +57,7 @@ where
     )
 }
 
-/// Determines the radius of an ellipse if it was not explictly provided.
+/// Determines the radius of an ellipse if it was not explicitly provided.
 /// <https://drafts.csswg.org/css-images-3/#typedef-size>
 fn ellipse_size_keyword(
     keyword: ShapeExtent,

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -1164,11 +1164,11 @@ impl Fragment {
             // https://drafts.csswg.org/css2/visudet.html#min-max-widths
             (MaybeAuto::Auto, MaybeAuto::Auto) => {
                 if self.has_intrinsic_ratio() {
-                    // This approch follows the spirit of cover and contain constraint.
+                    // This approach follows the spirit of cover and contain constraint.
                     // https://drafts.csswg.org/css-images-3/#cover-contain
 
                     // First, create two rectangles that keep aspect ratio while may be clamped
-                    // by the contraints;
+                    // by the constraints;
                     let first_isize = inline_constraint.clamp(intrinsic_inline_size);
                     let first_bsize = Au::new(
                         (first_isize.0 as i64 * intrinsic_block_size.0 as i64 /

--- a/components/layout/sequential.rs
+++ b/components/layout/sequential.rs
@@ -183,7 +183,7 @@ pub fn guess_float_placement(flow: &mut dyn Flow) {
             .flags
             .contains(FlowFlags::IS_ABSOLUTELY_POSITIONED)
         {
-            // Do not propagate floats in or out, but do propogate between kids.
+            // Do not propagate floats in or out, but do propagate between kids.
             guess_float_placement(kid);
         } else {
             floats_in.compute_floats_in(kid);

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -312,8 +312,8 @@ impl<'a> PostorderFlowTraversal for AssignBSizes<'a> {
     fn should_process(&self, flow: &mut dyn Flow) -> bool {
         let base = flow.base();
         base.restyle_damage.intersects(ServoRestyleDamage::REFLOW_OUT_OF_FLOW | ServoRestyleDamage::REFLOW) &&
-        // The fragmentation countainer is responsible for calling
-        // Flow::fragment recursively
+        // The fragmentation container is responsible for calling
+        // Flow::fragment recursively.
         !base.flags.contains(FlowFlags::CAN_BE_FRAGMENTED)
     }
 }

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -352,7 +352,7 @@ fn layout<'context, 'boxes>(
     let content_block_size = match flex_context.flex_axis {
         FlexAxis::Row => {
             // `container_main_size` ends up unused here but in this case that’s fine
-            // since it was already excatly the one decided by the outer formatting context.
+            // since it was already exactly the one decided by the outer formatting context.
             container_cross_size
         },
         FlexAxis::Column => {
@@ -362,7 +362,7 @@ fn layout<'context, 'boxes>(
             // The spec is missing something to resolve this conflict:
             // https://github.com/w3c/csswg-drafts/issues/5190
             // And we’ll need to change the signature of `IndependentFormattingContext::layout`
-            // to allow the inner formatting context to “negociate” a used inline-size
+            // to allow the inner formatting context to “negotiate” a used inline-size
             // with the outer one somehow.
             container_main_size
         },

--- a/components/layout_2020/replaced.rs
+++ b/components/layout_2020/replaced.rs
@@ -30,7 +30,7 @@ pub(crate) struct ReplacedContent {
     intrinsic: IntrinsicSizes,
 }
 
-/// * Raster images always have an instrinsic width and height, with 1 image pixel = 1px.
+/// * Raster images always have an intrinsic width and height, with 1 image pixel = 1px.
 ///   The intrinsic ratio should be based on dividing those.
 ///   See https://github.com/w3c/csswg-drafts/issues/4572 for the case where either is zero.
 ///   PNG specifically disallows this but I (SimonSapin) am not sure about other formats.

--- a/components/layout_thread/dom_wrapper.rs
+++ b/components/layout_thread/dom_wrapper.rs
@@ -1363,7 +1363,7 @@ impl<'le> ThreadSafeLayoutElement<'le> for ServoThreadSafeLayoutElement<'le> {
 /// but they have no use right now.
 ///
 /// Note that the element implementation is needed only for selector matching,
-/// not for inheritance (styles are inherited appropiately).
+/// not for inheritance (styles are inherited appropriately).
 impl<'le> ::selectors::Element for ServoThreadSafeLayoutElement<'le> {
     type Impl = SelectorImpl;
 


### PR DESCRIPTION
This PR fixes some typos in comments.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they do not change any functionality of servo.