### PR TITLE
Fix license link in contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ on how to start working on Servo.
 - Commits should be accompanied by a Developer Certificate of Origin
   (http://developercertificate.org) sign-off, which indicates that you (and
   your employer if applicable) agree to be bound by the terms of the
-  [project license](LICENSE.md). In git, this is the `-s` option to `git commit`
+  [project license](LICENSE). In git, this is the `-s` option to `git commit`.
 
 - If your patch is not getting reviewed or you need a specific person to review
   it, you can @-reply a reviewer asking for a review in the pull request or a


### PR DESCRIPTION
Fixes a broken link to the license file in the contribution guidelines.

---
<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests, because only a documentation file is changed.