### PR TITLE
Update actions/upload-artifact in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Package binary
         run: gtar -czf target.tar.gz target/release/servo target/release/*.dylib resources
       - name: Archive binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: release-binary-macos
           path: target.tar.gz
@@ -189,7 +189,7 @@ jobs:
   #           --tracker-api=default --reporter-api=default
   #
   #     - name: Archive logs
-  #       uses: actions/upload-artifact@v2
+  #       uses: actions/upload-artifact@v3
   #       with:
   #         name: wpt${{ matrix.chunk_id }}-logs-macos
   #         path: |
@@ -222,7 +222,7 @@ jobs:
       - name: Package binary
         run: tar -czf target.tar.gz target/release/servo resources
       - name: Archive binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: release-binary
           path: target.tar.gz
@@ -271,7 +271,7 @@ jobs:
             --log-filteredsummary=filtered-wpt-summary.${{ matrix.chunk_id }}.log \
             --tracker-api=default --reporter-api=default
       - name: Archive logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: wpt${{ matrix.chunk_id }}-logs-linux

--- a/.github/workflows/wpt-nightly.yml
+++ b/.github/workflows/wpt-nightly.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Package binary
         run: tar -czf target.tar.gz target/release/servo resources
       - name: Archive binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: release-binary
           path: target.tar.gz
@@ -74,7 +74,7 @@ jobs:
             --log-servojson wpt-jsonsummary.${{ matrix.chunk_id }}.log \
             --always-succeed
       - name: Archive logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wpt${{ matrix.chunk_id }}-logs-linux
           path: |


### PR DESCRIPTION
Updates the `actions/upload-artifact` action used in the GitHub Actions workflow to its newest major version.

Changes in [actions/upload-artifact](https://github.com/actions/upload-artifact):

> ## v3.1.1
> - Update actions/core package to latest version to remove `set-output` deprecation warning
>
> ## v3.1.0
> - Bump @actions/artifact to v1.1.0
>   - Adds checksum headers on artifact upload
>
> ## v3.0.0
>
> - Update default runtime to node16
> - Update package-lock.json file version to 2

Still using v2 of `actions/upload-artifact` will generate some warning like in this run: https://github.com/servo/servo/actions/runs/3718806495

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2

The PR will get rid of those warnings for `actions/upload-artifact`, because v3 uses Node.js 16.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they only update components used in the CI workflows and those workflows still passing should be enough tests.