### PR TITLE
Update actions/download-artifact in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,7 +158,7 @@ jobs:
   #         fetch-depth: 2
   #
   #     #- name: Download release binary
-  #     #  uses: actions/download-artifact@v2
+  #     #  uses: actions/download-artifact@v3
   #     #  with:
   #     #    name: release-binary-macos
   #
@@ -244,7 +244,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: release-binary
           path: release-binary

--- a/.github/workflows/wpt-nightly.yml
+++ b/.github/workflows/wpt-nightly.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: release-binary
           path: release-binary
@@ -95,7 +95,7 @@ jobs:
         with:
           fetch-depth: 2
       # Download all artifacts
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
       - name: Prep environment
         run: |
           python3 -m pip install --upgrade pip virtualenv


### PR DESCRIPTION
Updates the `actions/download-artifact` action used in the GitHub Actions workflow to its newest major version.

Changes in [actions/download-artifact](https://github.com/actions/download-artifact):

> ## v3.0.1
> - Bump @actions/core to 1.10.0
>
> ## v3.0.0
>
> - Update default runtime to node16
> - Update package-lock.json file version to 2

Still using v2 of `actions/download-artifact` will generate some warning like in this run: https://github.com/servo/servo/actions/runs/3718806495

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/download-artifact@v2

The PR will get rid of those warnings for `actions/download-artifact`, because v3 uses Node.js 16.

---

- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they only update components used in the CI workflows and those workflows still passing should be enough tests.