### PR TITLE
CI: remove branch check steps that don’t actually do anything

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,6 @@ jobs:
     name: Build (Windows)
     runs-on: windows-2019
     steps:
-      - name: Branch check
-        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-windows', github.ref) }}
-        run: exit 0
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
@@ -44,9 +41,6 @@ jobs:
     name: Build (Windows UWP x64)
     runs-on: windows-2019
     steps:
-      - name: Branch check
-        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-windows', github.ref) }}
-        run: exit 0
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
@@ -72,9 +66,6 @@ jobs:
     name: Build (Windows UWP arm64)
     runs-on: windows-2019
     steps:
-      - name: Branch check
-        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-windows', github.ref) }}
-        run: exit 0
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
@@ -98,9 +89,6 @@ jobs:
     name: Build (macOS)
     runs-on: macos-12
     steps:
-      - name: Branch check
-        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-mac', github.ref) }}
-        run: exit 0
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
@@ -202,9 +190,6 @@ jobs:
     name: Build (Linux)
     runs-on: ubuntu-20.04
     steps:
-      - name: Branch check
-        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-linux refs/heads/try-wpt', github.ref) }}
-        run: exit 0
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
@@ -238,9 +223,6 @@ jobs:
       matrix:
         chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     steps:
-      - name: Branch check
-        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-wpt', github.ref) }}
-        run: exit 0
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2


### PR DESCRIPTION
f165e17ce2fb8795c99dbb998336b7fa54b68f5f (#28778) adds a step to each job of the main build that ostensibly bails out of the job, if the context branch is not `auto` or one of the `try` branches relevant for that platform. But a step that runs `exit 0` doesn’t really have any effect.

Since the main workflow already has `branches` limited to `auto` and the `try` branches, we can safely remove those steps without worrying about the main build running on dependabot branches etc. For example:

* [dependabot/cargo/nom-7.1.2](https://github.com/servo/servo/actions?query=branch%3Adependabot%2Fcargo%2Fnom-7.1.2) only has a run for the pull request workflow
* [this test build](https://github.com/delan/servo/actions/runs/3830596812/jobs/6518672884) shows that even if the branch check fails, the build continues

---

- [ ] ~~`./mach build -d` does not report any errors~~
- [ ] ~~`./mach test-tidy` does not report any errors~~
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they affect the CI configuration