### PR TITLE
CI: run WPT tests on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,87 +13,6 @@ env:
   SHELL: /bin/bash
 
 jobs:
-  build-win:
-    name: Build (Windows)
-    runs-on: windows-2019
-    steps:
-      - name: Branch check
-        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-windows', github.ref) }}
-        run: exit 0
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Copy to C drive
-        run: cp D:\a C:\ -Recurse
-      - name: Bootstrap
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: |
-          python -m pip install --upgrade pip virtualenv
-          python mach fetch
-      - name: Release build
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: python mach build --release --media-stack=dummy
-      - name: Unit tests
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: python mach test-unit --release
-      - name: Smoketest
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: python mach smoketest --angle
-
-  build-uwp-x64:
-    name: Build (Windows UWP x64)
-    runs-on: windows-2019
-    steps:
-      - name: Branch check
-        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-windows', github.ref) }}
-        run: exit 0
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Copy to C drive
-        run: cp D:\a C:\ -Recurse
-      - name: Bootstrap
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: |
-          python -m pip install --upgrade pip virtualenv
-          python mach fetch
-      - name: Release build
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: python mach build --release --target=x86_64-uwp-windows-msvc
-      #- name: Package
-      #  working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-      #  run: python mach package --release --target=x86_64-uwp-windows-msvc --uwp=x64
-      #  env:
-      #    CODESIGN_CERT: ${{ secrets.WINDOWS_CODESIGN_CERT }}
-      - name: Tidy
-        run: python mach test-tidy --force-cpp --no-wpt
-
-  build-uwp-arm64:
-    name: Build (Windows UWP arm64)
-    runs-on: windows-2019
-    steps:
-      - name: Branch check
-        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-windows', github.ref) }}
-        run: exit 0
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Copy to C drive
-        run: cp D:\a C:\ -Recurse
-      - name: Bootstrap
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: |
-          python -m pip install --upgrade pip virtualenv
-          python mach fetch
-      - name: Release build
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: python mach build --release --target=aarch64-uwp-windows-msvc
-      #- name: Package
-      #  working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-      #  run: python mach package --release --target=aarch64-uwp-windows-msvc --uwp=arm64
-      #  env:
-      #    CODESIGN_CERT: ${{ secrets.WINDOWS_CODESIGN_CERT }}
-
   build-mac:
     name: Build (macOS)
     runs-on: macos-12
@@ -144,152 +63,67 @@ jobs:
           name: release-binary-macos
           path: target.tar.gz
 
-  # mac-wpt:
-  #   #needs: build-mac
-  #   runs-on: macos-10.12
-  #   env:
-  #     max_chunk_id: 20
-  #   strategy:
-  #     matrix:
-  #       chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 2
-  #
-  #     #- name: Download release binary
-  #     #  uses: actions/download-artifact@v3
-  #     #  with:
-  #     #    name: release-binary-macos
-  #
-  #     - name: Fake build
-  #       run: |
-  #         wget https://joshmatthews.net/release-binary-macos.zip
-  #         unzip release-binary-macos.zip
-  #
-  #     - name: Prep test environment
-  #       run: |
-  #         brew install gnu-tar
-  #         gtar -xzf target.tar.gz
-  #         python3 -m pip install --upgrade pip virtualenv
-  #         brew bundle install --verbose --no-upgrade --file=etc/taskcluster/macos/Brewfile
-  #     - name: Smoketest
-  #       run: python3 ./mach smoketest
-  #     - name: Run tests
-  #       run: |
-  #         python3 ./mach test-wpt \
-  #           --release --processes=3 --timeout-multiplier=8 \
-  #           --total-chunks=${{ env.max_chunk_id }} --this-chunk=${{ matrix.chunk_id }} \
-  #           --log-raw=test-wpt.log \
-  #           --log-servojson=wpt-jsonsummary.log \
-  #           --always-succeed | cat
-  #         python3 ./mach filter-intermittents wpt-jsonsummary.log \
-  #           --log-intermittents=intermittents.log \
-  #           --log-filteredsummary=filtered-wpt-summary.log \
-  #           --tracker-api=default --reporter-api=default
-  #
-  #     - name: Archive logs
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: wpt${{ matrix.chunk_id }}-logs-macos
-  #         path: |
-  #           test-wpt.log
-  #           wpt-jsonsummary.log
-  #           filtered-wpt-summary.log
-  #           intermittents.log
-
-  build-linux:
-    name: Build (Linux)
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Branch check
-        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-linux refs/heads/try-wpt', github.ref) }}
-        run: exit 0
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Bootstrap
-        run: |
-          python3 -m pip install --upgrade pip virtualenv
-          sudo apt update
-          python3 ./mach bootstrap
-      - name: Release build
-        run: python3 ./mach build --release
-      - name: Lockfile check
-        run: ./etc/ci/lockfile_changed.sh
-      - name: Forbidden panic check
-        run: ./etc/ci/check_no_panic.sh
-      - name: Package binary
-        run: tar -czf target.tar.gz target/release/servo resources
-      - name: Archive binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: release-binary
-          path: target.tar.gz
-
-  linux-wpt:
-    name: Linux WPT Tests
-    runs-on: ubuntu-20.04
-    needs: ["build-linux"]
+  mac-wpt:
+    needs: build-mac
+    runs-on: macos-10.12
     env:
       max_chunk_id: 20
     strategy:
-      fail-fast: false
       matrix:
-        chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        # chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        chunk_id: [1]
     steps:
-      - name: Branch check
-        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-wpt', github.ref) }}
-        run: exit 0
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - uses: actions/download-artifact@v3
-        with:
-          name: release-binary
-          path: release-binary
-      - name: unPackage binary
-        run: tar -xzf release-binary/target.tar.gz
+
+      #- name: Download release binary
+      #  uses: actions/download-artifact@v3
+      #  with:
+      #    name: release-binary-macos
+
+      - name: Fake build
+        run: |
+          wget https://joshmatthews.net/release-binary-macos.zip
+          unzip release-binary-macos.zip
+
       - name: Prep test environment
         run: |
+          brew install gnu-tar
+          gtar -xzf target.tar.gz
           python3 -m pip install --upgrade pip virtualenv
-          sudo apt update
-          sudo apt install -qy --no-install-recommends libgl1 libssl1.1 libdbus-1-3 libxcb-xfixes0-dev libxcb-shape0-dev libunwind8 libegl1-mesa
-          wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
-          sudo apt install ./libffi6_3.2.1-8_amd64.deb
-          python3 ./mach bootstrap-gstreamer
+          brew bundle install --verbose --no-upgrade --file=etc/taskcluster/macos/Brewfile
+      - name: Smoketest
+        run: python3 ./mach smoketest
       - name: Run tests
         run: |
           python3 ./mach test-wpt \
-            --release --processes $(nproc) --timeout-multiplier 2 \
-            --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
-            --log-raw test-wpt.${{ matrix.chunk_id }}.log \
-            --log-servojson wpt-jsonsummary.${{ matrix.chunk_id }}.log \
-            --always-succeed
-          python3 ./mach filter-intermittents wpt-jsonsummary.${{ matrix.chunk_id }}.log \
-            --log-intermittents=intermittents.${{ matrix.chunk_id }}.log \
-            --log-filteredsummary=filtered-wpt-summary.${{ matrix.chunk_id }}.log \
+            --release --processes=3 --timeout-multiplier=8 \
+            --total-chunks=${{ env.max_chunk_id }} --this-chunk=${{ matrix.chunk_id }} \
+            --log-raw=test-wpt.log \
+            --log-servojson=wpt-jsonsummary.log \
+            --always-succeed | cat
+          python3 ./mach filter-intermittents wpt-jsonsummary.log \
+            --log-intermittents=intermittents.log \
+            --log-filteredsummary=filtered-wpt-summary.log \
             --tracker-api=default --reporter-api=default
+
       - name: Archive logs
         uses: actions/upload-artifact@v3
-        if: ${{ failure() }}
         with:
-          name: wpt${{ matrix.chunk_id }}-logs-linux
+          name: wpt${{ matrix.chunk_id }}-logs-macos
           path: |
-            test-wpt.${{ matrix.chunk_id }}.log
-            wpt-jsonsummary.${{ matrix.chunk_id }}.log
-            filtered-wpt-summary.${{ matrix.chunk_id }}.log
-            intermittents.${{ matrix.chunk_id }}.log
+            test-wpt.log
+            wpt-jsonsummary.log
+            filtered-wpt-summary.log
+            intermittents.log
 
   build_result:
     name: homu build finished
     runs-on: ubuntu-latest
     needs:
-      - "build-win"
-      - "build-uwp-x64"
-      - "build-linux"
       - "build-mac"
-      - "linux-wpt"
+      - "mac-wpt"
 
     steps:
       - name: Mark the job as successful

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
 
   mac-wpt:
     needs: build-mac
-    runs-on: macos-10.12
+    runs-on: macos-12
     env:
       max_chunk_id: 20
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,8 +153,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
-        chunk_id: [1]
+        chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,11 +73,13 @@ jobs:
           path: target.tar.gz
 
   mac-wpt:
-    needs: build-mac
+    name: Mac WPT Tests
     runs-on: macos-12
+    needs: ["build-mac"]
     env:
       max_chunk_id: 20
     strategy:
+      fail-fast: false
       matrix:
         # chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
         chunk_id: [1]
@@ -85,8 +87,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - name: Download release binary
-        uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v3
         with:
           name: release-binary-macos
       # TODO: Remove this step when the compatibility issue between mozjs and
@@ -100,7 +101,6 @@ jobs:
           ln -s pip3.9 pip3
       - name: Prep test environment
         run: |
-          brew install gnu-tar
           gtar -xzf target.tar.gz
           python3 -m pip install --upgrade pip virtualenv
           brew bundle install --verbose --no-upgrade --file=etc/taskcluster/macos/Brewfile
@@ -109,25 +109,26 @@ jobs:
       - name: Run tests
         run: |
           python3 ./mach test-wpt \
-            --release --processes=3 --timeout-multiplier=8 \
-            --total-chunks=${{ env.max_chunk_id }} --this-chunk=${{ matrix.chunk_id }} \
-            --log-raw=test-wpt.log \
-            --log-servojson=wpt-jsonsummary.log \
-            --always-succeed | cat
-          python3 ./mach filter-intermittents wpt-jsonsummary.log \
-            --log-intermittents=intermittents.log \
-            --log-filteredsummary=filtered-wpt-summary.log \
+            --release --processes $(nproc) --timeout-multiplier 8 \
+            --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
+            --log-raw test-wpt.${{ matrix.chunk_id }}.log \
+            --log-servojson wpt-jsonsummary.${{ matrix.chunk_id }}.log \
+            --always-succeed
+          python3 ./mach filter-intermittents wpt-jsonsummary.${{ matrix.chunk_id }}.log \
+            --log-intermittents=intermittents.${{ matrix.chunk_id }}.log \
+            --log-filteredsummary=filtered-wpt-summary.${{ matrix.chunk_id }}.log \
             --tracker-api=default --reporter-api=default
 
       - name: Archive logs
         uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
         with:
           name: wpt${{ matrix.chunk_id }}-logs-macos
           path: |
-            test-wpt.log
-            wpt-jsonsummary.log
-            filtered-wpt-summary.log
-            intermittents.log
+            test-wpt.${{ matrix.chunk_id }}.log
+            wpt-jsonsummary.${{ matrix.chunk_id }}.log
+            filtered-wpt-summary.${{ matrix.chunk_id }}.log
+            intermittents.${{ matrix.chunk_id }}.log
 
   build_result:
     name: homu build finished

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,6 @@ jobs:
     name: Build (macOS)
     runs-on: macos-12
     steps:
-      - name: Branch check
-        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-mac', github.ref) }}
-        run: exit 0
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
@@ -40,6 +37,18 @@ jobs:
           rm -rf /usr/local/etc/openssl
           rm -rf /usr/local/etc/openssl@1.1
           brew install openssl@1.1 gnu-tar
+      - name: Cache mach fetch
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.rustup
+            ~/.cargo
+          key: fetch-${{ runner.os }}
+      - name: Cache target
+        uses: actions/cache@v3
+        with:
+          path: target
+          key: target-${{ runner.os }}
       - name: Release build
         run: |
           export OPENSSL_INCLUDE_DIR="$(brew --prefix openssl)/include"
@@ -47,14 +56,14 @@ jobs:
           export PKG_CONFIG_PATH="$(brew --prefix libffi)/lib/pkgconfig/"
           export PKG_CONFIG_PATH="$(brew --prefix zlib)/lib/pkgconfig/:$PKG_CONFIG_PATH"
           python3 ./mach build --release
-      - name: Smoketest
-        run: python3 ./mach smoketest
-      - name: Unit tests
-        run: python3 ./mach test-unit --release
-      - name: Test package
-        run: python3 ./mach package --release
-      - name: Package smoketest
-        run: ./etc/ci/macos_package_smoketest.sh target/release/servo-tech-demo.dmg
+      # - name: Smoketest
+      #   run: python3 ./mach smoketest
+      # - name: Unit tests
+      #   run: python3 ./mach test-unit --release
+      # - name: Test package
+      #   run: python3 ./mach package --release
+      # - name: Package smoketest
+      #   run: ./etc/ci/macos_package_smoketest.sh target/release/servo-tech-demo.dmg
       - name: Package binary
         run: gtar -czf target.tar.gz target/release/servo target/release/*.dylib resources
       - name: Archive binary
@@ -76,17 +85,19 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
-
-      #- name: Download release binary
-      #  uses: actions/download-artifact@v3
-      #  with:
-      #    name: release-binary-macos
-
-      - name: Fake build
+      - name: Download release binary
+        uses: actions/download-artifact@v3
+        with:
+          name: release-binary-macos
+      # TODO: Remove this step when the compatibility issue between mozjs and
+      #       Homebrew's Python 3.10 formula (servo/rust-mozjs#559) is fixed
+      - name: Select Python 3.9
         run: |
-          wget https://joshmatthews.net/release-binary-macos.zip
-          unzip release-binary-macos.zip
-
+          brew install python@3.9
+          cd $(dirname $(which python3.9))
+          rm -f python3 pip3
+          ln -s python3.9 python3
+          ln -s pip3.9 pip3
       - name: Prep test environment
         run: |
           brew install gnu-tar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Run tests
         run: |
           python3 ./mach test-wpt \
-            --release --processes $(nproc) --timeout-multiplier 8 \
+            --release --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
             --log-servojson wpt-jsonsummary.${{ matrix.chunk_id }}.log \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,94 @@ env:
   SHELL: /bin/bash
 
 jobs:
+  build-win:
+    name: Build (Windows)
+    runs-on: windows-2019
+    steps:
+      - name: Branch check
+        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-windows', github.ref) }}
+        run: exit 0
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Copy to C drive
+        run: cp D:\a C:\ -Recurse
+      - name: Bootstrap
+        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+        run: |
+          python -m pip install --upgrade pip virtualenv
+          python mach fetch
+      - name: Release build
+        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+        run: python mach build --release --media-stack=dummy
+      - name: Unit tests
+        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+        run: python mach test-unit --release
+      - name: Smoketest
+        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+        run: python mach smoketest --angle
+
+  build-uwp-x64:
+    name: Build (Windows UWP x64)
+    runs-on: windows-2019
+    steps:
+      - name: Branch check
+        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-windows', github.ref) }}
+        run: exit 0
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Copy to C drive
+        run: cp D:\a C:\ -Recurse
+      - name: Bootstrap
+        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+        run: |
+          python -m pip install --upgrade pip virtualenv
+          python mach fetch
+      - name: Release build
+        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+        run: python mach build --release --target=x86_64-uwp-windows-msvc
+      #- name: Package
+      #  working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+      #  run: python mach package --release --target=x86_64-uwp-windows-msvc --uwp=x64
+      #  env:
+      #    CODESIGN_CERT: ${{ secrets.WINDOWS_CODESIGN_CERT }}
+      - name: Tidy
+        run: python mach test-tidy --force-cpp --no-wpt
+
+  build-uwp-arm64:
+    name: Build (Windows UWP arm64)
+    runs-on: windows-2019
+    steps:
+      - name: Branch check
+        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-windows', github.ref) }}
+        run: exit 0
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Copy to C drive
+        run: cp D:\a C:\ -Recurse
+      - name: Bootstrap
+        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+        run: |
+          python -m pip install --upgrade pip virtualenv
+          python mach fetch
+      - name: Release build
+        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+        run: python mach build --release --target=aarch64-uwp-windows-msvc
+      #- name: Package
+      #  working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+      #  run: python mach package --release --target=aarch64-uwp-windows-msvc --uwp=arm64
+      #  env:
+      #    CODESIGN_CERT: ${{ secrets.WINDOWS_CODESIGN_CERT }}
+
   build-mac:
     name: Build (macOS)
     runs-on: macos-12
     steps:
+      - name: Branch check
+        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-mac', github.ref) }}
+        run: exit 0
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
@@ -37,18 +121,6 @@ jobs:
           rm -rf /usr/local/etc/openssl
           rm -rf /usr/local/etc/openssl@1.1
           brew install openssl@1.1 gnu-tar
-      - name: Cache mach fetch
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.rustup
-            ~/.cargo
-          key: fetch-${{ runner.os }}
-      - name: Cache target
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: target-${{ runner.os }}
       - name: Release build
         run: |
           export OPENSSL_INCLUDE_DIR="$(brew --prefix openssl)/include"
@@ -56,14 +128,14 @@ jobs:
           export PKG_CONFIG_PATH="$(brew --prefix libffi)/lib/pkgconfig/"
           export PKG_CONFIG_PATH="$(brew --prefix zlib)/lib/pkgconfig/:$PKG_CONFIG_PATH"
           python3 ./mach build --release
-      # - name: Smoketest
-      #   run: python3 ./mach smoketest
-      # - name: Unit tests
-      #   run: python3 ./mach test-unit --release
-      # - name: Test package
-      #   run: python3 ./mach package --release
-      # - name: Package smoketest
-      #   run: ./etc/ci/macos_package_smoketest.sh target/release/servo-tech-demo.dmg
+      - name: Smoketest
+        run: python3 ./mach smoketest
+      - name: Unit tests
+        run: python3 ./mach test-unit --release
+      - name: Test package
+        run: python3 ./mach package --release
+      - name: Package smoketest
+        run: ./etc/ci/macos_package_smoketest.sh target/release/servo-tech-demo.dmg
       - name: Package binary
         run: gtar -czf target.tar.gz target/release/servo target/release/*.dylib resources
       - name: Archive binary
@@ -130,11 +202,98 @@ jobs:
             filtered-wpt-summary.${{ matrix.chunk_id }}.log
             intermittents.${{ matrix.chunk_id }}.log
 
+  build-linux:
+    name: Build (Linux)
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Branch check
+        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-linux refs/heads/try-wpt', github.ref) }}
+        run: exit 0
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Bootstrap
+        run: |
+          python3 -m pip install --upgrade pip virtualenv
+          sudo apt update
+          python3 ./mach bootstrap
+      - name: Release build
+        run: python3 ./mach build --release
+      - name: Lockfile check
+        run: ./etc/ci/lockfile_changed.sh
+      - name: Forbidden panic check
+        run: ./etc/ci/check_no_panic.sh
+      - name: Package binary
+        run: tar -czf target.tar.gz target/release/servo resources
+      - name: Archive binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-binary
+          path: target.tar.gz
+
+  linux-wpt:
+    name: Linux WPT Tests
+    runs-on: ubuntu-20.04
+    needs: ["build-linux"]
+    env:
+      max_chunk_id: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    steps:
+      - name: Branch check
+        if: ${{ !contains('refs/heads/auto refs/heads/try refs/heads/try-wpt', github.ref) }}
+        run: exit 0
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: actions/download-artifact@v3
+        with:
+          name: release-binary
+          path: release-binary
+      - name: unPackage binary
+        run: tar -xzf release-binary/target.tar.gz
+      - name: Prep test environment
+        run: |
+          python3 -m pip install --upgrade pip virtualenv
+          sudo apt update
+          sudo apt install -qy --no-install-recommends libgl1 libssl1.1 libdbus-1-3 libxcb-xfixes0-dev libxcb-shape0-dev libunwind8 libegl1-mesa
+          wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
+          sudo apt install ./libffi6_3.2.1-8_amd64.deb
+          python3 ./mach bootstrap-gstreamer
+      - name: Run tests
+        run: |
+          python3 ./mach test-wpt \
+            --release --processes $(nproc) --timeout-multiplier 2 \
+            --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
+            --log-raw test-wpt.${{ matrix.chunk_id }}.log \
+            --log-servojson wpt-jsonsummary.${{ matrix.chunk_id }}.log \
+            --always-succeed
+          python3 ./mach filter-intermittents wpt-jsonsummary.${{ matrix.chunk_id }}.log \
+            --log-intermittents=intermittents.${{ matrix.chunk_id }}.log \
+            --log-filteredsummary=filtered-wpt-summary.${{ matrix.chunk_id }}.log \
+            --tracker-api=default --reporter-api=default
+      - name: Archive logs
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: wpt${{ matrix.chunk_id }}-logs-linux
+          path: |
+            test-wpt.${{ matrix.chunk_id }}.log
+            wpt-jsonsummary.${{ matrix.chunk_id }}.log
+            filtered-wpt-summary.${{ matrix.chunk_id }}.log
+            intermittents.${{ matrix.chunk_id }}.log
+
   build_result:
     name: homu build finished
     runs-on: ubuntu-latest
     needs:
+      - "build-win"
+      - "build-uwp-x64"
+      - "build-linux"
       - "build-mac"
+      - "linux-wpt"
       - "mac-wpt"
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -294,7 +294,7 @@ jobs:
       - "build-linux"
       - "build-mac"
       - "linux-wpt"
-      - "mac-wpt"
+      # - "mac-wpt"
 
     steps:
       - name: Mark the job as successful


### PR DESCRIPTION
This patch uncomments and fixes the mac-wpt job in the main workflow, with a few changes:

* we downgrade python3 and pip3 to 3.9, because inspect.getargspec was [removed in 3.11](https://docs.python.org/3/whatsnew/3.11.html#removed)
    * we should apparently move to [inspect.getfullargspec](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec)
* we download the real Servo artifact, rather than the fake Servo for testing

We also align the rest of the job (other than `--timeout-multiplier`) to be as close as possible to linux-wpt, based on the assumption that linux-wpt is more up to date. This includes:

* setting strategy.fail-fast to false
* adding a failure() condition to the “Archive logs” step
* adding the chunk id to log filenames

There are some failing WPT tests, so for now the job is not required to succeed.

Example run: <https://github.com/delan/servo/actions/runs/3837530905>

---

- [ ] ~~`./mach build -d` does not report any errors~~
- [ ] ~~`./mach test-tidy` does not report any errors~~
- [x] These changes fix #28284 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they affect the CI configuration