### PR TITLE
Fix intermittency when loading poster images

### DIFF
--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -253,6 +253,7 @@ impl LoadKeyGenerator {
     }
 }
 
+#[derive(Debug)]
 enum LoadResult {
     Loaded(Image),
     PlaceholderLoaded(Arc<Image>),
@@ -339,6 +340,7 @@ struct ImageCacheStore {
 impl ImageCacheStore {
     // Change state of a url from pending -> loaded.
     fn complete_load(&mut self, key: LoadKey, mut load_result: LoadResult) {
+        debug!("Completed decoding for {:?}", load_result);
         let pending_load = match self.pending_loads.remove(&key) {
             Some(load) => load,
             None => return,

--- a/tests/wpt/metadata/css/css-images/object-view-box-fit-contain-video.html.ini
+++ b/tests/wpt/metadata/css/css-images/object-view-box-fit-contain-video.html.ini
@@ -1,0 +1,2 @@
+[object-view-box-fit-contain-video.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-images/object-view-box-fit-cover-video.html.ini
+++ b/tests/wpt/metadata/css/css-images/object-view-box-fit-cover-video.html.ini
@@ -1,0 +1,2 @@
+[object-view-box-fit-cover-video.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-images/object-view-box-fit-none-video.html.ini
+++ b/tests/wpt/metadata/css/css-images/object-view-box-fit-none-video.html.ini
@@ -1,0 +1,2 @@
+[object-view-box-fit-none-video.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-images/object-view-box-writing-mode-video.html.ini
+++ b/tests/wpt/metadata/css/css-images/object-view-box-writing-mode-video.html.ini
@@ -1,0 +1,2 @@
+[object-view-box-writing-mode-video.html]
+  expected: FAIL


### PR DESCRIPTION
Wait until a poster image is cached to in order to unblock document load. If not, the document may continue loading before the image is ready to use, leading to intermittency in test output. Now load is unblocked when getting the ImageResponse from the cache, which allows the code to properly unblock the load when the entire load fails or succeeds.

This reveals several false passes in the `object-view-box` test suite which were very flaky.

<!-- Please describe your changes on the following line: -->

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29204. 
- [x] These changes fix #29188.
- [x] These changes fix #29179.

<!-- Either: -->
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
