### PR TITLE
Fix some build warnings

### DIFF
--- a/components/gfx/platform/freetype/font.rs
+++ b/components/gfx/platform/freetype/font.rs
@@ -68,12 +68,15 @@ struct OS2Table {
 }
 
 #[derive(Debug)]
+#[allow(unused)]
 pub struct FontHandle {
     // The font binary. This must stay valid for the lifetime of the font,
     // if the font is created using FT_Memory_Face.
     font_data: Arc<FontTemplateData>,
     face: FT_Face,
-    handle: FontContextHandle,
+    // `context_handle` is unused, but here to ensure that the underlying
+    // FreeTypeLibraryHandle is not dropped.
+    context_handle: FontContextHandle,
     can_do_fast_shaping: bool,
 }
 
@@ -144,7 +147,7 @@ impl FontHandleMethods for FontHandle {
         let mut handle = FontHandle {
             face: face,
             font_data: template,
-            handle: fctx.clone(),
+            context_handle: fctx.clone(),
             can_do_fast_shaping: false,
         };
         // TODO (#11310): Implement basic support for GPOS and GSUB.

--- a/components/gfx/platform/freetype/font_context.rs
+++ b/components/gfx/platform/freetype/font_context.rs
@@ -75,6 +75,7 @@ pub struct FreeTypeLibraryHandle {
 }
 
 impl Drop for FreeTypeLibraryHandle {
+    #[allow(unused)]
     fn drop(&mut self) {
         assert!(!self.ctx.is_null());
         unsafe {
@@ -130,11 +131,7 @@ impl FontContextHandle {
             FT_Add_Default_Modules(ctx);
 
             FontContextHandle {
-                ctx: Rc::new(FreeTypeLibraryHandle {
-                    ctx: ctx,
-                    mem: mem,
-                    user: user,
-                }),
+                ctx: Rc::new(FreeTypeLibraryHandle { ctx, mem, user }),
             }
         }
     }

--- a/components/script/dom/bindings/principals.rs
+++ b/components/script/dom/bindings/principals.rs
@@ -115,6 +115,7 @@ impl Deref for ServoJSPrincipalsRef<'_> {
     }
 }
 
+#[allow(unused)]
 pub unsafe extern "C" fn destroy_servo_jsprincipal(principals: *mut JSPrincipals) {
     Box::from_raw(GetRustJSPrincipalsPrivate(principals) as *mut MutableOrigin);
     DestroyRustJSPrincipals(principals);

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -38,7 +38,7 @@ use dom_struct::dom_struct;
 use euclid::default::{Rect, Size2D};
 use html5ever::{LocalName, Prefix};
 use image::codecs::png::PngEncoder;
-use image::ColorType;
+use image::{ColorType, ImageEncoder};
 use ipc_channel::ipc::{self as ipcchan, IpcSharedMemory};
 use js::error::throw_type_error;
 use js::rust::HandleValue;
@@ -427,7 +427,7 @@ impl HTMLCanvasElementMethods for HTMLCanvasElement {
         // FIXME(nox): https://github.com/image-rs/image-png/issues/86
         // FIXME(nox): https://github.com/image-rs/image-png/issues/87
         PngEncoder::new(&mut png)
-            .encode(&file, self.Width(), self.Height(), ColorType::Rgba8)
+            .write_image(&file, self.Width(), self.Height(), ColorType::Rgba8)
             .unwrap();
         let mut url = "data:image/png;base64,".to_owned();
         // FIXME(nox): Should this use base64::URL_SAFE?

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -51,9 +51,7 @@ impl ServoUrl {
     }
 
     pub fn into_string(self) -> String {
-        Arc::try_unwrap(self.0)
-            .unwrap_or_else(|s| (*s).clone())
-            .into_string()
+        String::from(Arc::try_unwrap(self.0).unwrap_or_else(|s| (*s).clone()))
     }
 
     pub fn into_url(self) -> Url {


### PR DESCRIPTION
- Mark some instances of unused fields and variables as as allowed, when they are used for memory management.
- Remove the use of some deprecated function.s

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
