### PR TITLE
Stringify unknown JavaScript objects in global exception handlers

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13746,6 +13746,13 @@
       {}
      ]
     ],
+    "global_exception_stringification.html": [
+     "b1c6cb6c390cca290085eea61ba4bf2f34aa4475",
+     [
+      null,
+      {}
+     ]
+    ],
     "globals": {
      "entry.html": [
       "f963385342adbd92e4858a507c88155b4ed4371f",

--- a/tests/wpt/mozilla/tests/mozilla/global_exception_stringification.html
+++ b/tests/wpt/mozilla/tests/mozilla/global_exception_stringification.html
@@ -1,0 +1,36 @@
+<!-- doctype html -->
+<!DOCTYPE html>
+<meta charset=utf-8>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+    <div id="testOutput"></div>
+</body>
+
+<script>
+    setup({ 'allow_uncaught_exception': true });
+    promise_test(async t => {
+        function CustomError(message) {
+            this.message = message;
+        }
+        CustomError.prototype = Object.create(Error.prototype);
+
+        let message = null;
+        let waitForError = new Promise(resolve => {
+            window.onerror = (errorMessage) => {
+                message = errorMessage;
+                resolve();
+            };
+        });
+
+        setTimeout(() => {
+            throw new CustomError("An exceptional exception.");
+        }, 0);
+
+        await waitForError;
+        assert_equals(message, "uncaught exception: Error: An exceptional exception.");
+    }, "Exception is stringified properly.");
+</script>
+


### PR DESCRIPTION
When turning DOM exceptions into `ErrorInfo` always try to stringify
the JavaScript value, even if it's an object that isn't a `DOMException`
or native exception.  This means that exceptions that extend the `Error`
prototype are now stringified. The result is that test output for WPT
global assertion failures is more useful. For instance for the test
include-frames-from-child-same-origin-grandchild.sub.html:

Before:
```
uncaught exception: unknown (can't convert to string)
```

After:
```
uncaught exception: Error: assert_equals: expected 4 but got 3
```
---

<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes. 