### PR TITLE
Allow displaying content with "application/json" mime type

### DIFF
--- a/tests/wpt/metadata/cookies/schemeful-same-site/schemeful-navigation.tentative.html.ini
+++ b/tests/wpt/metadata/cookies/schemeful-same-site/schemeful-navigation.tentative.html.ini
@@ -1,8 +1,3 @@
 [schemeful-navigation.tentative.html]
-  expected: TIMEOUT
   [Navigate cross-scheme]
-    expected: NOTRUN
-
-  [Navigate same-scheme]
-    expected: TIMEOUT
-
+    expected: FAIL

--- a/tests/wpt/metadata/cookies/schemeful-same-site/schemeful-subresource.tentative.html.ini
+++ b/tests/wpt/metadata/cookies/schemeful-same-site/schemeful-subresource.tentative.html.ini
@@ -1,8 +1,3 @@
 [schemeful-subresource.tentative.html]
-  expected: TIMEOUT
   [Cross-scheme subresources cannot sent lax/strict cookies]
-    expected: NOTRUN
-
-  [Same-scheme subresources can send lax/strict cookies]
-    expected: TIMEOUT
-
+    expected: FAIL


### PR DESCRIPTION
For me this allows the WPT test
performance-timeline/tentative/include-frames-one-remote-child.sub.html 
to match expected results. The wptserver is sending a 404 JSON response
because the URL that the test requests is not found.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29136.
- [x] There are tests for these changes.




<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
