### PR TITLE
Fail faster on CI when Linux bootstrap fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,11 +222,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - name: Bootstrap
-        run: |
-          python3 -m pip install --upgrade pip virtualenv
-          sudo apt update
-          python3 ./mach bootstrap
+      - name: Bootstrap Python
+        run: python3 -m pip install --upgrade pip virtualenv
+      - name: Bootstrap dependencies
+        run: sudo apt update && python3 ./mach bootstrap
       - name: Release build
         run: python3 ./mach build --release
       - name: Lockfile check

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,11 +15,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - name: Bootstrap
-        run: |
-          python3 -m pip install --upgrade pip virtualenv
-          sudo apt update
-          python3 ./mach bootstrap
+      - name: Bootstrap Python
+        run: python3 -m pip install --upgrade pip virtualenv
+      - name: Bootstrap dependencies
+        run: sudo apt update && python3 ./mach bootstrap
       - name: Release build
         run: python3 ./mach build --release
       - name: Unit tests

--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -59,11 +59,13 @@ def install_linux_deps(context, pkgs_ubuntu, pkgs_fedora, pkgs_void, force):
                 install = force = True
                 break
 
-    if install:
-        print("Installing missing dependencies...")
-        run_as_root(command + pkgs, force)
+    if not install:
+        return False
 
-    return install
+    print("Installing missing dependencies...")
+    if run_as_root(command + pkgs, force) != 0:
+        raise Exception("Installation of dependencies failed.")
+    return True
 
 
 def install_salt_dependencies(context, force):


### PR DESCRIPTION
Raise an exception when dependencies fail to install. Also split the run phase of the Linux bootstrap so that either of these failing commands will cause the job to fail.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just change minor script issues.

