### PR TITLE
Replace use of the deprecated RUST_SYMBOL_TO_JSID by SymbolId

### DIFF
--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -16,9 +16,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::realms::{AlreadyInRealm, InRealm};
 use crate::script_runtime::JSContext as SafeJSContext;
 use js::conversions::ToJSValConvertible;
-use js::glue::{
-    GetProxyHandler, GetProxyHandlerFamily, InvokeGetOwnPropertyDescriptor, RUST_SYMBOL_TO_JSID,
-};
+use js::glue::{GetProxyHandler, GetProxyHandlerFamily, InvokeGetOwnPropertyDescriptor};
 use js::glue::{GetProxyPrivate, SetProxyPrivate};
 use js::jsapi;
 use js::jsapi::GetStaticPrototype;
@@ -40,6 +38,7 @@ use js::jsapi::{jsid, GetObjectRealmOrNull, GetRealmPrincipals, JSFunctionSpec, 
 use js::jsapi::{DOMProxyShadowsResult, JSContext, JSObject, PropertyDescriptor};
 use js::jsapi::{GetWellKnownSymbol, SymbolCode};
 use js::jsapi::{JSErrNum, SetDOMProxyInformation};
+use js::jsid::SymbolId;
 use js::jsval::ObjectValue;
 use js::jsval::UndefinedValue;
 use js::rust::wrappers::JS_AlreadyHasOwnPropertyById;
@@ -686,10 +685,7 @@ unsafe fn is_cross_origin_allowlisted_prop(cx: SafeJSContext, id: RawHandleId) -
 
     rooted!(in(*cx) let mut allowed_id: jsid);
     ALLOWLISTED_SYMBOL_CODES.iter().any(|&allowed_code| {
-        RUST_SYMBOL_TO_JSID(
-            GetWellKnownSymbol(*cx, allowed_code),
-            allowed_id.handle_mut().into(),
-        );
+        *allowed_id.handle_mut() = SymbolId(GetWellKnownSymbol(*cx, allowed_code));
         // `jsid`s containing `JS::Symbol *` can be compared by
         // referential equality
         allowed_id.get().asBits_ == id.asBits_
@@ -712,10 +708,7 @@ unsafe fn append_cross_origin_allowlisted_prop_keys(
     AppendToIdVector(props, id.handle());
 
     for &allowed_code in ALLOWLISTED_SYMBOL_CODES.iter() {
-        RUST_SYMBOL_TO_JSID(
-            GetWellKnownSymbol(*cx, allowed_code),
-            id.handle_mut().into(),
-        );
+        *id.handle_mut() = SymbolId(GetWellKnownSymbol(*cx, allowed_code));
         AppendToIdVector(props, id.handle());
     }
 }


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

A simple replacement of a deprecated function, according to changes in https://github.com/servo/mozjs/pull/315

That removes the only build warning I saw when doing a clobber.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ X] `./mach build -d` does not report any errors
- [X ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ X] These changes do not require tests because no behavior change is expected.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
