### PR TITLE
Bump euclid to 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,7 +591,7 @@ dependencies = [
  "half",
  "ipc-channel",
  "log",
- "lyon_geom 0.14.1",
+ "lyon_geom 1.0.4",
  "num-traits",
  "pathfinder_geometry",
  "pixels",
@@ -1652,9 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.20.14"
+version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
+checksum = "b52c2ef4a78da0ba68fbe1fd920627411096d2ac478f7f4c9f3a54ba6705bade"
 dependencies = [
  "num-traits",
  "serde",
@@ -3428,6 +3428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
 name = "libmlservo"
 version = "0.0.1"
 dependencies = [
@@ -3555,22 +3561,22 @@ dependencies = [
 
 [[package]]
 name = "lyon_geom"
-version = "0.14.1"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca04310c9807612a311506106000b6eccb2e27bca9bfb594ce80fb8a31231f9d"
+checksum = "71d89ccbdafd83d259403e22061be27bccc3254bba65cdc5303250c4227c8c8e"
 dependencies = [
- "arrayvec 0.4.12",
+ "arrayvec 0.5.1",
  "euclid",
  "num-traits",
 ]
 
 [[package]]
 name = "lyon_geom"
-version = "0.15.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2a8bde54788e0eb4f1b9f072910bfa1cba95688698f7bb206d13a2f8fd06b3"
+checksum = "74df1ff0a0147282eb10699537a03baa7d31972b58984a1d44ce0624043fe8ad"
 dependencies = [
- "arrayvec 0.5.1",
+ "arrayvec 0.7.1",
  "euclid",
  "num-traits",
 ]
@@ -4304,6 +4310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4613,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "peek-poke"
 version = "0.2.0"
-source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#920168aff79a7cf52980b0c90965a591f2f4204a"
+source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#415b9ba32648667313f6f4ce7965752285bf0b26"
 dependencies = [
  "euclid",
  "peek-poke-derive",
@@ -4622,7 +4629,7 @@ dependencies = [
 [[package]]
 name = "peek-poke-derive"
 version = "0.2.1"
-source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#920168aff79a7cf52980b0c90965a591f2f4204a"
+source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#415b9ba32648667313f6f4ce7965752285bf0b26"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4840,9 +4847,9 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plane-split"
-version = "0.15.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe16a646a08f4b4dd74035b9ff8e378eb1a4012a74f14f5889e7001cdbece33"
+checksum = "f3f7075ec146b897b6e0faca47adeb7ed3d4f6eaa8145bf19db17311081b3f63"
 dependencies = [
  "binary-space-partition",
  "euclid",
@@ -5088,14 +5095,14 @@ checksum = "a871f1e45a3a3f0c73fb60343c811238bb5143a81642e27c2ac7aac27ff01a63"
 
 [[package]]
 name = "raqote"
-version = "0.8.1-alpha.0"
-source = "git+https://github.com/jdm/raqote?branch=fkup#5a650714ea20f44ebe14de9fce60eeef100144c1"
+version = "0.8.2"
+source = "git+https://github.com/jrmuizel/raqote#7b235e9a7721d5db6dbfd82ec69e390111653081"
 dependencies = [
  "euclid",
  "font-kit",
- "lyon_geom 0.15.0",
+ "lyon_geom 0.17.7",
  "pathfinder_geometry",
- "png 0.16.6",
+ "png 0.17.7",
  "sw-composite",
  "typed-arena",
 ]
@@ -5686,7 +5693,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#1ccb9c7ce0acc2637c84f31a1204b1d5798993b9"
+source = "git+https://github.com/servo/media#f53ac0a03a1413362e15d39d1527466986d13c94"
 dependencies = [
  "servo-media-audio",
  "servo-media-player",
@@ -5697,8 +5704,8 @@ dependencies = [
 
 [[package]]
 name = "servo-media-audio"
-version = "0.1.0"
-source = "git+https://github.com/servo/media#1ccb9c7ce0acc2637c84f31a1204b1d5798993b9"
+version = "0.2.0"
+source = "git+https://github.com/servo/media#f53ac0a03a1413362e15d39d1527466986d13c94"
 dependencies = [
  "boxfnonce",
  "byte-slice-cast",
@@ -5807,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#1ccb9c7ce0acc2637c84f31a1204b1d5798993b9"
+source = "git+https://github.com/servo/media#f53ac0a03a1413362e15d39d1527466986d13c94"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -5819,7 +5826,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#1ccb9c7ce0acc2637c84f31a1204b1d5798993b9"
+source = "git+https://github.com/servo/media#f53ac0a03a1413362e15d39d1527466986d13c94"
 dependencies = [
  "lazy_static",
  "uuid",
@@ -5828,12 +5835,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#1ccb9c7ce0acc2637c84f31a1204b1d5798993b9"
+source = "git+https://github.com/servo/media#f53ac0a03a1413362e15d39d1527466986d13c94"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#1ccb9c7ce0acc2637c84f31a1204b1d5798993b9"
+source = "git+https://github.com/servo/media#f53ac0a03a1413362e15d39d1527466986d13c94"
 dependencies = [
  "boxfnonce",
  "lazy_static",
@@ -5911,7 +5918,7 @@ dependencies = [
 [[package]]
 name = "servo_media_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#1ccb9c7ce0acc2637c84f31a1204b1d5798993b9"
+source = "git+https://github.com/servo/media#f53ac0a03a1413362e15d39d1527466986d13c94"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6370,9 +6377,9 @@ dependencies = [
 
 [[package]]
 name = "surfman"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70e69faf378eeb7b44044ab434a06672e0bd495d32a47d84a097e69dd994985"
+checksum = "ab6e313fe157a4f6ecdaff1aa5f866a3191509bf4e1f49ededefce62ccc4a4bb"
 dependencies = [
  "bitflags",
  "cfg_aliases",
@@ -6401,9 +6408,8 @@ dependencies = [
 
 [[package]]
 name = "surfman-chains"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e707090691623a80d36f4faaba50105cc7a611eda51b0312b53eeec36a0a25"
+version = "0.7.0"
+source = "git+https://github.com/servo/surfman-chains.git#f7b30e8736501fe3d326f1c41e7ae0a2bca4e818"
 dependencies = [
  "euclid",
  "fnv",
@@ -6427,9 +6433,9 @@ checksum = "c666f0fed8e1e20e057af770af9077d72f3d5a33157b8537c1475dd8ffd6d32b"
 
 [[package]]
 name = "sw-composite"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e39674047b1748e8bf4865142772a6637bd32d8b4b27e3c2248dd122f637808b"
+checksum = "0b8d4f1dd38540e3f62c393ae78e874c94491c403025368183b018e3fb098b1f"
 
 [[package]]
 name = "swapper"
@@ -7311,7 +7317,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.61.0"
-source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#920168aff79a7cf52980b0c90965a591f2f4204a"
+source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#415b9ba32648667313f6f4ce7965752285bf0b26"
 dependencies = [
  "backtrace",
  "base64 0.10.1",
@@ -7355,7 +7361,7 @@ dependencies = [
 [[package]]
 name = "webrender_api"
 version = "0.61.0"
-source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#920168aff79a7cf52980b0c90965a591f2f4204a"
+source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#415b9ba32648667313f6f4ce7965752285bf0b26"
 dependencies = [
  "app_units",
  "bitflags",
@@ -7376,7 +7382,7 @@ dependencies = [
 [[package]]
 name = "webrender_build"
 version = "0.0.1"
-source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#920168aff79a7cf52980b0c90965a591f2f4204a"
+source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#415b9ba32648667313f6f4ce7965752285bf0b26"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -7402,7 +7408,7 @@ dependencies = [
 [[package]]
 name = "webxr"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#4eb957ac4f0e22ac5baded31eb86eea32862d687"
+source = "git+https://github.com/servo/webxr#3d82ad985764c35aaf389ce83b5f9ba909c23f53"
 dependencies = [
  "android_injected_glue",
  "bindgen",
@@ -7425,7 +7431,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/webxr#4eb957ac4f0e22ac5baded31eb86eea32862d687"
+source = "git+https://github.com/servo/webxr#3d82ad985764c35aaf389ce83b5f9ba909c23f53"
 dependencies = [
  "euclid",
  "ipc-channel",
@@ -7627,7 +7633,7 @@ dependencies = [
 [[package]]
 name = "wr_malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#920168aff79a7cf52980b0c90965a591f2f4204a"
+source = "git+https://github.com/jdm/webrender?branch=crash-backtrace#415b9ba32648667313f6f4ce7965752285bf0b26"
 dependencies = [
  "app_units",
  "euclid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,8 @@ opt-level = 3
 mio = { git = "https://github.com/servo/mio.git", branch = "servo-mio-0.6.22" }
 # Work around bug in winit 0.24 crashing servo headless in macOS
 winit = { git = "https://github.com/rust-windowing/winit.git", rev = "4192d04a53202c199f94d1b7d883a34c9ad09272" }
-
-[patch."https://github.com/jrmuizel/raqote"]
-raqote = { git = "https://github.com/jdm/raqote", branch = "fkup" }
+# surfman-chains has not yet released version 0.7 to crates.io yet.
+surfman-chains = { git = "https://github.com/servo/surfman-chains.git" }
 
 # https://github.com/servo/servo/issues/27515#issuecomment-671474054
 [patch."https://github.com/servo/webrender"]

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -21,7 +21,7 @@ byteorder = "1"
 canvas_traits = { path = "../canvas_traits" }
 crossbeam-channel = "0.4"
 cssparser = "0.29"
-euclid = "0.20"
+euclid = "0.22"
 font-kit = "0.11"
 fnv = "1.0"
 gfx = { path = "../gfx" }
@@ -29,7 +29,7 @@ gleam = "0.12"
 half = "1"
 ipc-channel = "0.14"
 log = "0.4"
-lyon_geom = "0.14"
+lyon_geom = "1.0.4"
 num-traits = "0.2"
 pathfinder_geometry = "0.5"
 pixels = { path = "../pixels" }
@@ -40,8 +40,8 @@ sparkle = "0.1.25"
 style = { path = "../style" }
 style_traits = { path = "../style_traits" }
 # NOTE: the sm-angle feature only enables angle on windows, not other platforms!
-surfman = { version = "0.4", features = ["sm-angle","sm-angle-default"] }
-surfman-chains = "0.6"
+surfman = { version = "0.5", features = ["sm-angle","sm-angle-default"] }
+surfman-chains = "0.7"
 surfman-chains-api = "0.2"
 time = { version = "0.1.41", optional = true }
 webrender = { git = "https://github.com/servo/webrender" }

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -1213,9 +1213,9 @@ impl<'a> CanvasData<'a> {
             ),
             self.drawtarget.get_format(),
         );
-        let matrix = Transform2D::identity()
-            .pre_translate(-source_rect.origin.to_vector().cast::<f32>())
-            .pre_transform(&self.state.transform);
+        let matrix = self.state.transform.then(
+            &Transform2D::identity().pre_translate(-source_rect.origin.to_vector().cast::<f32>()),
+        );
         draw_target.set_transform(&matrix);
         draw_target
     }
@@ -1224,7 +1224,7 @@ impl<'a> CanvasData<'a> {
     where
         F: FnOnce(&mut dyn GenericDrawTarget),
     {
-        let shadow_src_rect = self.state.transform.transform_rect(rect);
+        let shadow_src_rect = self.state.transform.outer_transformed_rect(rect);
         let mut new_draw_target = self.create_draw_target_for_shadow(&shadow_src_rect);
         draw_shadow_source(&mut *new_draw_target);
         self.drawtarget.draw_surface_with_shadow(

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -445,8 +445,8 @@ impl GenericDrawTarget for raqote::DrawTarget {
             Repetition::NoRepeat,
         ));
         let transform =
-            raqote::Transform::create_translation(-dest.origin.x as f32, -dest.origin.y as f32)
-                .post_scale(
+            raqote::Transform::translation(-dest.origin.x as f32, -dest.origin.y as f32)
+                .then_scale(
                     image.width as f32 / dest.size.width as f32,
                     image.height as f32 / dest.size.height as f32,
                 );

--- a/components/canvas/webgl_thread.rs
+++ b/components/canvas/webgl_thread.rs
@@ -606,7 +606,7 @@ impl WebGLThread {
 
         let size = clamp_viewport(&gl, requested_size);
         if safe_size != size {
-            debug!("Resizing swap chain from {} to {}", safe_size, size);
+            debug!("Resizing swap chain from {:?} to {:?}", safe_size, size);
             swap_chain
                 .resize(&mut self.device, &mut ctx, size.to_i32())
                 .map_err(|err| format!("Failed to resize swap chain: {:?}", err))?;

--- a/components/canvas_traits/Cargo.toml
+++ b/components/canvas_traits/Cargo.toml
@@ -17,7 +17,7 @@ xr-profile = ["webxr-api/profile", "time"]
 [dependencies]
 crossbeam-channel = "0.4"
 cssparser = "0.29"
-euclid = "0.20"
+euclid = "0.22"
 ipc-channel = "0.14"
 lazy_static = "1"
 malloc_size_of = { path = "../malloc_size_of" }

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -19,7 +19,7 @@ gl = ["gleam", "pixels"]
 canvas = { path = "../canvas" }
 crossbeam-channel = "0.4"
 embedder_traits = { path = "../embedder_traits" }
-euclid = "0.20"
+euclid = "0.22"
 gfx_traits = { path = "../gfx_traits" }
 gleam = { version = "0.12", optional = true }
 image = "0.24"

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 embedder_traits = { path = "../embedder_traits" }
-euclid = "0.20"
+euclid = "0.22"
 getopts = "0.2.11"
 lazy_static = "1"
 log = "0.4"

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -19,7 +19,7 @@ compositing = { path = "../compositing" }
 crossbeam-channel = "0.4"
 devtools_traits = { path = "../devtools_traits" }
 embedder_traits = { path = "../embedder_traits" }
-euclid = "0.20"
+euclid = "0.22"
 gfx = { path = "../gfx" }
 gfx_traits = { path = "../gfx_traits" }
 http = "0.2"

--- a/components/geometry/Cargo.toml
+++ b/components/geometry/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 
 [dependencies]
 app_units = "0.7"
-euclid = "0.20"
+euclid = "0.22"
 malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = "0.1"
 webrender_api = { git = "https://github.com/servo/webrender" }

--- a/components/gfx/Cargo.toml
+++ b/components/gfx/Cargo.toml
@@ -16,7 +16,7 @@ doctest = false
 [dependencies]
 app_units = "0.7"
 bitflags = "1.0"
-euclid = "0.20"
+euclid = "0.22"
 fnv = "1.0"
 fontsan = { git = "https://github.com/servo/fontsan" }
 gfx_traits = { path = "../gfx_traits" }

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -18,7 +18,7 @@ atomic_refcell = "0.1"
 bitflags = "1.0"
 canvas_traits = { path = "../canvas_traits" }
 embedder_traits = { path = "../embedder_traits" }
-euclid = "0.20"
+euclid = "0.22"
 fnv = "1.0"
 gfx = { path = "../gfx" }
 gfx_traits = { path = "../gfx_traits" }

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -834,7 +834,7 @@ impl Fragment {
             index,
         );
 
-        if placement.tile_size.is_empty_or_negative() {
+        if placement.tile_size.is_empty() {
             return;
         }
 
@@ -2321,7 +2321,7 @@ impl BlockFlow {
             .fragment
             .perspective_matrix(&border_box)
             .unwrap_or(LayoutTransform::identity());
-        let transform = transform.pre_transform(&perspective).inverse();
+        let transform = perspective.then(&transform).inverse();
 
         let origin = border_box.origin;
         let transform_clip = |clip: Rect<Au>| {
@@ -2346,7 +2346,7 @@ impl BlockFlow {
                         clip.size.height.to_f32_px(),
                     );
 
-                    let clip = transform.transform_rect(&clip).unwrap();
+                    let clip = transform.outer_transformed_rect(&clip).unwrap();
 
                     rect(
                         Au::from_f32_px(clip.origin.x),

--- a/components/layout/display_list/webrender_helpers.rs
+++ b/components/layout/display_list/webrender_helpers.rs
@@ -204,7 +204,7 @@ impl DisplayItem {
                                 ),
                                 (Some(t), None) => (t, ReferenceFrameKind::Transform),
                                 (Some(t), Some(p)) => (
-                                    t.pre_transform(&p),
+                                    p.then(&t),
                                     ReferenceFrameKind::Perspective {
                                         scrolling_relative_to: None,
                                     },

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -355,10 +355,10 @@ pub trait Flow: HasBaseFlow + fmt::Debug + Sync + Send + 'static {
             .to_untyped();
         let transformed_overflow = Overflow {
             paint: f32_rect_to_au_rect(
-                transform_2d.transform_rect(&au_rect_to_f32_rect(overflow.paint)),
+                transform_2d.outer_transformed_rect(&au_rect_to_f32_rect(overflow.paint)),
             ),
             scroll: f32_rect_to_au_rect(
-                transform_2d.transform_rect(&au_rect_to_f32_rect(overflow.scroll)),
+                transform_2d.outer_transformed_rect(&au_rect_to_f32_rect(overflow.scroll)),
             ),
         };
 

--- a/components/layout/fragment.rs
+++ b/components/layout/fragment.rs
@@ -3205,22 +3205,18 @@ impl Fragment {
             .to_f32_px();
         let transform_origin_z = transform_origin.depth.px();
 
-        let pre_transform = LayoutTransform::create_translation(
+        let pre_transform = LayoutTransform::translation(
             transform_origin_x,
             transform_origin_y,
             transform_origin_z,
         );
-        let post_transform = LayoutTransform::create_translation(
+        let post_transform = LayoutTransform::translation(
             -transform_origin_x,
             -transform_origin_y,
             -transform_origin_z,
         );
 
-        Some(
-            pre_transform
-                .pre_transform(&transform)
-                .pre_transform(&post_transform),
-        )
+        Some(post_transform.then(&transform).then(&pre_transform))
     }
 
     /// Returns the 4D matrix representing this fragment's perspective.
@@ -3241,25 +3237,19 @@ impl Fragment {
                 )
                 .to_layout();
 
-                let pre_transform = LayoutTransform::create_translation(
-                    perspective_origin.x,
-                    perspective_origin.y,
-                    0.0,
-                );
-                let post_transform = LayoutTransform::create_translation(
-                    -perspective_origin.x,
-                    -perspective_origin.y,
-                    0.0,
-                );
+                let pre_transform =
+                    LayoutTransform::translation(perspective_origin.x, perspective_origin.y, 0.0);
+                let post_transform =
+                    LayoutTransform::translation(-perspective_origin.x, -perspective_origin.y, 0.0);
 
                 let perspective_matrix = LayoutTransform::from_untyped(
                     &transform::create_perspective_matrix(length.px()),
                 );
 
                 Some(
-                    pre_transform
-                        .pre_transform(&perspective_matrix)
-                        .pre_transform(&post_transform),
+                    post_transform
+                        .then(&perspective_matrix)
+                        .then(&pre_transform),
                 )
             },
             Perspective::None => None,

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -18,7 +18,7 @@ atomic_refcell = "0.1.6"
 canvas_traits = { path = "../canvas_traits" }
 cssparser = "0.29"
 embedder_traits = { path = "../embedder_traits" }
-euclid = "0.20"
+euclid = "0.22"
 fnv = "1.0"
 fxhash = "0.2"
 gfx = { path = "../gfx" }

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -802,7 +802,7 @@ impl BoxFragment {
             ),
             (Some(transform), None) => (transform, wr::ReferenceFrameKind::Transform),
             (Some(transform), Some(perspective)) => (
-                transform.pre_transform(&perspective),
+                perspective.then(&transform),
                 wr::ReferenceFrameKind::Perspective {
                     scrolling_relative_to: None,
                 },
@@ -861,11 +861,7 @@ impl BoxFragment {
             -transform_origin_z,
         );
 
-        Some(
-            pre_transform
-                .pre_transform(&transform)
-                .pre_transform(&post_transform),
-        )
+        Some(post_transform.then(&transform).then(&pre_transform))
     }
 
     /// Returns the 4D matrix representing this fragment's perspective.
@@ -903,9 +899,9 @@ impl BoxFragment {
                 );
 
                 Some(
-                    pre_transform
-                        .pre_transform(&perspective_matrix)
-                        .pre_transform(&post_transform),
+                    post_transform
+                        .then(&perspective_matrix)
+                        .then(&pre_transform),
                 )
             },
             Perspective::None => None,

--- a/components/layout_thread/Cargo.toml
+++ b/components/layout_thread/Cargo.toml
@@ -15,7 +15,7 @@ app_units = "0.7"
 atomic_refcell = "0.1"
 crossbeam-channel = "0.4"
 embedder_traits = { path = "../embedder_traits" }
-euclid = "0.20"
+euclid = "0.22"
 fnv = "1.0"
 fxhash = "0.2"
 gfx = { path = "../gfx" }

--- a/components/layout_thread_2020/Cargo.toml
+++ b/components/layout_thread_2020/Cargo.toml
@@ -15,7 +15,7 @@ app_units = "0.7"
 atomic_refcell = "0.1"
 crossbeam-channel = "0.4"
 embedder_traits = { path = "../embedder_traits" }
-euclid = "0.20"
+euclid = "0.22"
 fnv = "1.0"
 fxhash = "0.2"
 gfx = { path = "../gfx" }

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -32,7 +32,7 @@ app_units = "0.7"
 content-security-policy = { version = "0.4.0", features = ["serde"], optional = true }
 crossbeam-channel = { version = "0.4", optional = true }
 cssparser = "0.29"
-euclid = "0.20"
+euclid = "0.22"
 hashglobe = { path = "../hashglobe" }
 http = { version = "0.2", optional = true }
 hyper_serde = { version = "0.13", optional = true }

--- a/components/media/Cargo.toml
+++ b/components/media/Cargo.toml
@@ -11,7 +11,7 @@ name = "media"
 path = "lib.rs"
 
 [dependencies]
-euclid = "0.20"
+euclid = "0.22"
 fnv = "1.0"
 ipc-channel = "0.14"
 lazy_static = "1"

--- a/components/pixels/Cargo.toml
+++ b/components/pixels/Cargo.toml
@@ -11,7 +11,7 @@ name = "pixels"
 path = "lib.rs"
 
 [dependencies]
-euclid = "0.20"
+euclid = "0.22"
 malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -51,7 +51,7 @@ domobject_derive = { path = "../domobject_derive" }
 embedder_traits = { path = "../embedder_traits" }
 encoding_rs = "0.8"
 enum-iterator = "0.3"
-euclid = "0.20"
+euclid = "0.22"
 fnv = "1.0"
 fxhash = "0.2"
 headers = "0.3"

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -1495,14 +1495,9 @@ impl CanvasState {
 
         let (sin, cos) = (angle.sin(), angle.cos());
         let transform = self.state.borrow().transform;
-        self.state.borrow_mut().transform = transform.pre_transform(&Transform2D::row_major(
-            cos as f32,
-            sin as f32,
-            -sin as f32,
-            cos as f32,
-            0.0,
-            0.0,
-        ));
+        self.state.borrow_mut().transform =
+            Transform2D::new(cos as f32, sin as f32, -sin as f32, cos as f32, 0.0, 0.0)
+                .then(&transform);
         self.update_transform()
     }
 
@@ -1530,9 +1525,9 @@ impl CanvasState {
         }
 
         let transform = self.state.borrow().transform;
-        self.state.borrow_mut().transform = transform.pre_transform(&Transform2D::row_major(
-            a as f32, b as f32, c as f32, d as f32, e as f32, f as f32,
-        ));
+        self.state.borrow_mut().transform =
+            Transform2D::new(a as f32, b as f32, c as f32, d as f32, e as f32, f as f32)
+                .then(&transform);
         self.update_transform()
     }
 
@@ -1558,7 +1553,7 @@ impl CanvasState {
         }
 
         self.state.borrow_mut().transform =
-            Transform2D::row_major(a as f32, b as f32, c as f32, d as f32, e as f32, f as f32);
+            Transform2D::new(a as f32, b as f32, c as f32, d as f32, e as f32, f as f32);
         self.update_transform()
     }
 

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -248,7 +248,7 @@ impl PaintWorkletGlobalScope {
         arguments: &[String],
     ) -> DrawAPaintImageResult {
         debug!(
-            "Invoking a paint callback {}({},{}) at {}.",
+            "Invoking a paint callback {}({},{}) at {:?}.",
             name, size_in_px.width, size_in_px.height, device_pixel_ratio
         );
 

--- a/components/script/dom/xrframe.rs
+++ b/components/script/dom/xrframe.rs
@@ -130,7 +130,7 @@ impl XRFrameMethods for XRFrame {
         } else {
             return Ok(None);
         };
-        let pose = relative_to.inverse().pre_transform(&space);
+        let pose = space.then(&relative_to.inverse());
         Ok(Some(XRPose::new(&self.global(), pose)))
     }
 
@@ -158,7 +158,7 @@ impl XRFrameMethods for XRFrame {
         } else {
             return Ok(None);
         };
-        let pose = relative_to.inverse().pre_transform(&joint_frame.pose);
+        let pose = joint_frame.pose.then(&relative_to.inverse());
         Ok(Some(XRJointPose::new(
             &self.global(),
             pose.cast_unit(),

--- a/components/script/dom/xrhittestresult.rs
+++ b/components/script/dom/xrhittestresult.rs
@@ -45,7 +45,7 @@ impl XRHitTestResultMethods for XRHitTestResult {
     // https://immersive-web.github.io/hit-test/#dom-xrhittestresult-getpose
     fn GetPose(&self, base: &XRSpace) -> Option<DomRoot<XRPose>> {
         let base = self.frame.get_pose(base)?;
-        let pose = base.inverse().pre_transform(&self.result.space);
+        let pose = self.result.space.then(&base.inverse());
         Some(XRPose::new(&self.global(), pose.cast_unit()))
     }
 }

--- a/components/script/dom/xrray.rs
+++ b/components/script/dom/xrray.rs
@@ -136,10 +136,10 @@ impl XRRayMethods for XRRay {
             let translation = self.ray.origin;
             // Step 7
             // According to the spec all matrices are column-major,
-            // however euclid uses row vectors so we use .to_row_major_array()
+            // however euclid uses row vectors so we use .to_array()
             let arr = RigidTransform3D::new(rotation, translation)
                 .to_transform()
-                .to_row_major_array();
+                .to_array();
             create_typed_array(cx, &arr, &self.matrix);
         }
         NonNull::new(self.matrix.get()).unwrap()

--- a/components/script/dom/xrreferencespace.rs
+++ b/components/script/dom/xrreferencespace.rs
@@ -73,7 +73,7 @@ impl XRReferenceSpace {
 impl XRReferenceSpaceMethods for XRReferenceSpace {
     /// https://immersive-web.github.io/webxr/#dom-xrreferencespace-getoffsetreferencespace
     fn GetOffsetReferenceSpace(&self, new: &XRRigidTransform) -> DomRoot<Self> {
-        let offset = self.offset.transform().pre_transform(&new.transform());
+        let offset = new.transform().then(&self.offset.transform());
         let offset = XRRigidTransform::new(&self.global(), offset);
         Self::new_offset(
             &self.global(),
@@ -106,7 +106,7 @@ impl XRReferenceSpace {
         // offset is a transform from offset space to unoffset space,
         // we want a transform from unoffset space to native space,
         // which is pose * offset in column vector notation
-        Some(pose.pre_transform(&offset))
+        Some(offset.then(&pose))
     }
 
     /// Gets pose represented by this space

--- a/components/script/dom/xrrigidtransform.rs
+++ b/components/script/dom/xrrigidtransform.rs
@@ -119,8 +119,8 @@ impl XRRigidTransformMethods for XRRigidTransform {
         if self.matrix.get().is_null() {
             let cx = self.global().get_cx();
             // According to the spec all matrices are column-major,
-            // however euclid uses row vectors so we use .to_row_major_array()
-            let arr = self.transform.to_transform().to_row_major_array();
+            // however euclid uses row vectors so we use .to_array()
+            let arr = self.transform.to_transform().to_array();
             create_typed_array(cx, &arr, &self.matrix);
         }
         NonNull::new(self.matrix.get()).unwrap()

--- a/components/script/dom/xrview.rs
+++ b/components/script/dom/xrview.rs
@@ -57,7 +57,7 @@ impl XRView {
         viewport_index: usize,
         to_base: &BaseTransform,
     ) -> DomRoot<XRView> {
-        let transform: RigidTransform3D<f32, V, BaseSpace> = to_base.pre_transform(&view.transform);
+        let transform: RigidTransform3D<f32, V, BaseSpace> = view.transform.then(&to_base);
         let transform = XRRigidTransform::new(global, cast_transform(transform));
 
         reflect_dom_object(
@@ -92,7 +92,7 @@ impl XRViewMethods for XRView {
         if self.proj.get().is_null() {
             let cx = self.global().get_cx();
             // row_major since euclid uses row vectors
-            let proj = self.view.projection.to_row_major_array();
+            let proj = self.view.projection.to_array();
             create_typed_array(cx, &proj, &self.proj);
         }
         NonNull::new(self.proj.get()).unwrap()

--- a/components/script/dom/xrviewerpose.rs
+++ b/components/script/dom/xrviewerpose.rs
@@ -150,7 +150,7 @@ impl XRViewerPose {
             },
         };
         let transform: RigidTransform3D<f32, Viewer, BaseSpace> =
-            to_base.pre_transform(&viewer_pose.transform);
+            viewer_pose.transform.then(&to_base);
         let transform = XRRigidTransform::new(global, cast_transform(transform));
         let pose = reflect_dom_object(Box::new(XRViewerPose::new_inherited(&transform)), global);
 

--- a/components/script_layout_interface/Cargo.toml
+++ b/components/script_layout_interface/Cargo.toml
@@ -15,7 +15,7 @@ app_units = "0.7"
 atomic_refcell = "0.1"
 canvas_traits = { path = "../canvas_traits" }
 crossbeam-channel = "0.4"
-euclid = "0.20"
+euclid = "0.22"
 fxhash = "0.2"
 gfx_traits = { path = "../gfx_traits" }
 html5ever = "0.26"

--- a/components/script_traits/Cargo.toml
+++ b/components/script_traits/Cargo.toml
@@ -18,7 +18,7 @@ cookie = "0.12"
 crossbeam-channel = "0.4"
 devtools_traits = { path = "../devtools_traits" }
 embedder_traits = { path = "../embedder_traits" }
-euclid = "0.20"
+euclid = "0.22"
 gfx_traits = { path = "../gfx_traits" }
 headers = "0.3"
 http = "0.2"

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -50,7 +50,7 @@ devtools = { path = "../devtools" }
 devtools_traits = { path = "../devtools_traits" }
 embedder_traits = { path = "../embedder_traits" }
 env_logger = "0.8"
-euclid = "0.20"
+euclid = "0.22"
 gfx = { path = "../gfx" }
 gfx_traits = { path = "../gfx_traits" }
 gleam = "0.12"
@@ -78,7 +78,7 @@ servo_url = { path = "../url" }
 sparkle = "0.1"
 style = { path = "../style", features = ["servo"] }
 style_traits = { path = "../style_traits", features = ["servo"] }
-surfman = "0.4"
+surfman = "0.5"
 webdriver_server = { path = "../webdriver_server", optional = true }
 webgpu = { path = "../webgpu" }
 webrender = { git = "https://github.com/servo/webrender" }

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -38,7 +38,7 @@ byteorder = "1.0"
 cssparser = "0.29"
 derive_more = "0.99"
 encoding_rs = { version = "0.8", optional = true }
-euclid = "0.20"
+euclid = "0.22"
 fallible = { path = "../fallible" }
 fxhash = "0.2"
 hashglobe = { path = "../hashglobe" }

--- a/components/style/values/generics/transform.rs
+++ b/components/style/values/generics/transform.rs
@@ -76,7 +76,7 @@ pub use self::GenericMatrix3D as Matrix3D;
 impl<T: Into<f64>> From<Matrix<T>> for Transform3D<f64> {
     #[inline]
     fn from(m: Matrix<T>) -> Self {
-        Transform3D::row_major(
+        Transform3D::new(
             m.a.into(), m.b.into(), 0.0, 0.0,
             m.c.into(), m.d.into(), 0.0, 0.0,
             0.0,        0.0,        1.0, 0.0,
@@ -89,7 +89,7 @@ impl<T: Into<f64>> From<Matrix<T>> for Transform3D<f64> {
 impl<T: Into<f64>> From<Matrix3D<T>> for Transform3D<f64> {
     #[inline]
     fn from(m: Matrix3D<T>) -> Self {
-        Transform3D::row_major(
+        Transform3D::new(
             m.m11.into(), m.m12.into(), m.m13.into(), m.m14.into(),
             m.m21.into(), m.m22.into(), m.m23.into(), m.m24.into(),
             m.m31.into(), m.m32.into(), m.m33.into(), m.m34.into(),
@@ -451,64 +451,62 @@ where
                 let theta = TWO_PI - theta.radians64();
                 let (ax, ay, az, theta) =
                     get_normalized_vector_and_angle(ax.into(), ay.into(), az.into(), theta);
-                Transform3D::create_rotation(
+                Transform3D::rotation(
                     ax as f64,
                     ay as f64,
                     az as f64,
-                    euclid::Angle::radians(theta),
+                    -euclid::Angle::radians(theta),
                 )
             },
             RotateX(theta) => {
                 let theta = euclid::Angle::radians(TWO_PI - theta.radians64());
-                Transform3D::create_rotation(1., 0., 0., theta)
+                Transform3D::rotation(1., 0., 0., -theta)
             },
             RotateY(theta) => {
                 let theta = euclid::Angle::radians(TWO_PI - theta.radians64());
-                Transform3D::create_rotation(0., 1., 0., theta)
+                Transform3D::rotation(0., 1., 0., -theta)
             },
             RotateZ(theta) | Rotate(theta) => {
                 let theta = euclid::Angle::radians(TWO_PI - theta.radians64());
-                Transform3D::create_rotation(0., 0., 1., theta)
+                Transform3D::rotation(0., 0., 1., -theta)
             },
             Perspective(ref d) => {
                 let m = create_perspective_matrix(d.to_pixel_length(None)?);
                 m.cast()
             },
-            Scale3D(sx, sy, sz) => Transform3D::create_scale(sx.into(), sy.into(), sz.into()),
-            Scale(sx, sy) => Transform3D::create_scale(sx.into(), sy.into(), 1.),
-            ScaleX(s) => Transform3D::create_scale(s.into(), 1., 1.),
-            ScaleY(s) => Transform3D::create_scale(1., s.into(), 1.),
-            ScaleZ(s) => Transform3D::create_scale(1., 1., s.into()),
+            Scale3D(sx, sy, sz) => Transform3D::scale(sx.into(), sy.into(), sz.into()),
+            Scale(sx, sy) => Transform3D::scale(sx.into(), sy.into(), 1.),
+            ScaleX(s) => Transform3D::scale(s.into(), 1., 1.),
+            ScaleY(s) => Transform3D::scale(1., s.into(), 1.),
+            ScaleZ(s) => Transform3D::scale(1., 1., s.into()),
             Translate3D(ref tx, ref ty, ref tz) => {
                 let tx = tx.to_pixel_length(reference_width)? as f64;
                 let ty = ty.to_pixel_length(reference_height)? as f64;
-                Transform3D::create_translation(tx, ty, tz.to_pixel_length(None)? as f64)
+                Transform3D::translation(tx, ty, tz.to_pixel_length(None)? as f64)
             },
             Translate(ref tx, ref ty) => {
                 let tx = tx.to_pixel_length(reference_width)? as f64;
                 let ty = ty.to_pixel_length(reference_height)? as f64;
-                Transform3D::create_translation(tx, ty, 0.)
+                Transform3D::translation(tx, ty, 0.)
             },
             TranslateX(ref t) => {
                 let t = t.to_pixel_length(reference_width)? as f64;
-                Transform3D::create_translation(t, 0., 0.)
+                Transform3D::translation(t, 0., 0.)
             },
             TranslateY(ref t) => {
                 let t = t.to_pixel_length(reference_height)? as f64;
-                Transform3D::create_translation(0., t, 0.)
+                Transform3D::translation(0., t, 0.)
             },
-            TranslateZ(ref z) => {
-                Transform3D::create_translation(0., 0., z.to_pixel_length(None)? as f64)
-            },
-            Skew(theta_x, theta_y) => Transform3D::create_skew(
+            TranslateZ(ref z) => Transform3D::translation(0., 0., z.to_pixel_length(None)? as f64),
+            Skew(theta_x, theta_y) => Transform3D::skew(
                 euclid::Angle::radians(theta_x.radians64()),
                 euclid::Angle::radians(theta_y.radians64()),
             ),
-            SkewX(theta) => Transform3D::create_skew(
+            SkewX(theta) => Transform3D::skew(
                 euclid::Angle::radians(theta.radians64()),
                 euclid::Angle::radians(0.),
             ),
-            SkewY(theta) => Transform3D::create_skew(
+            SkewY(theta) => Transform3D::skew(
                 euclid::Angle::radians(0.),
                 euclid::Angle::radians(theta.radians64()),
             ),
@@ -547,7 +545,7 @@ impl<T: ToMatrix> Transform<T> {
         let cast_3d_transform = |m: Transform3D<f64>| -> Transform3D<CSSFloat> {
             use std::{f32, f64};
             let cast = |v: f64| { v.min(f32::MAX as f64).max(f32::MIN as f64) as f32 };
-            Transform3D::row_major(
+            Transform3D::new(
                 cast(m.m11), cast(m.m12), cast(m.m13), cast(m.m14),
                 cast(m.m21), cast(m.m22), cast(m.m23), cast(m.m24),
                 cast(m.m31), cast(m.m32), cast(m.m33), cast(m.m34),
@@ -565,7 +563,7 @@ impl<T: ToMatrix> Transform<T> {
         reference_box: Option<&Rect<ComputedLength>>,
     ) -> Result<(Transform3D<f64>, bool), ()> {
         // We intentionally use Transform3D<f64> during computation to avoid error propagation
-        // because using f32 to compute triangle functions (e.g. in create_rotation()) is not
+        // because using f32 to compute triangle functions (e.g. in rotation()) is not
         // accurate enough. In Gecko, we also use "double" to compute the triangle functions.
         // Therefore, let's use Transform3D<f64> during matrix computation and cast it into f32
         // in the end.
@@ -575,7 +573,7 @@ impl<T: ToMatrix> Transform<T> {
         for operation in &*self.0 {
             let matrix = operation.to_3d_matrix(reference_box)?;
             contain_3d |= operation.is_3d();
-            transform = transform.pre_transform(&matrix);
+            transform = matrix.then(&transform);
         }
 
         Ok((transform, contain_3d))
@@ -595,7 +593,7 @@ pub fn create_perspective_matrix(d: CSSFloat) -> Transform3D<CSSFloat> {
     if d <= 0.0 {
         Transform3D::identity()
     } else {
-        Transform3D::create_perspective(d)
+        Transform3D::perspective(d)
     }
 }
 

--- a/components/style_traits/Cargo.toml
+++ b/components/style_traits/Cargo.toml
@@ -17,7 +17,7 @@ gecko = []
 app_units = "0.7"
 bitflags = "1.0"
 cssparser = "0.29"
-euclid = "0.20"
+euclid = "0.22"
 lazy_static = "1"
 malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = "0.1"

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -15,7 +15,7 @@ base64 = "0.10"
 compositing = { path = "../compositing" }
 cookie = "0.12"
 crossbeam-channel = "0.4"
-euclid = "0.20"
+euclid = "0.22"
 headers = "0.3"
 http = "0.2"
 image = "0.24"

--- a/components/webgpu/Cargo.toml
+++ b/components/webgpu/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 
 [dependencies]
 arrayvec = { version = "0.7", features = ["serde"] }
-euclid = "0.20"
+euclid = "0.22"
 ipc-channel = "0.14"
 log = "0.4"
 malloc_size_of = { path = "../malloc_size_of" }

--- a/components/webrender_surfman/Cargo.toml
+++ b/components/webrender_surfman/Cargo.toml
@@ -11,7 +11,7 @@ name = "webrender_surfman"
 path = "lib.rs"
 
 [dependencies]
-euclid = "0.20"
-surfman = "0.4"
-surfman-chains = "0.6"
+euclid = "0.22"
+surfman = "0.5"
+surfman-chains = "0.7"
 

--- a/components/webrender_traits/Cargo.toml
+++ b/components/webrender_traits/Cargo.toml
@@ -11,6 +11,6 @@ name = "webrender_traits"
 path = "lib.rs"
 
 [dependencies]
-euclid = "0.20"
+euclid = "0.22"
 webrender_api = { git = "https://github.com/servo/webrender" }
 

--- a/ports/gstplugin/Cargo.toml
+++ b/ports/gstplugin/Cargo.toml
@@ -16,7 +16,7 @@ path = "lib.rs"
 
 [dependencies]
 crossbeam-channel = "0.4"
-euclid = "0.20"
+euclid = "0.22"
 glib = "0.9"
 gstreamer = "0.15"
 gstreamer-base = "0.15"
@@ -29,8 +29,8 @@ libservo = { path = "../../components/servo" }
 log = "0.4"
 servo-media = { git = "https://github.com/servo/media" }
 sparkle = "0.1"
-surfman = "0.4"
-surfman-chains = "0.6"
+surfman = "0.5"
+surfman-chains = "0.7"
 surfman-chains-api = "0.2"
 webxr = { git = "https://github.com/servo/webxr", features = ["glwindow"] }
 

--- a/ports/libsimpleservo/api/Cargo.toml
+++ b/ports/libsimpleservo/api/Cargo.toml
@@ -12,7 +12,7 @@ ipc-channel = "0.14"
 libservo = { path = "../../../components/servo" }
 log = "0.4"
 servo-media = { git = "https://github.com/servo/media" }
-surfman = { version = "0.4", features = ["sm-angle-default"] }
+surfman = { version = "0.5", features = ["sm-angle-default"] }
 webxr = { git = "https://github.com/servo/webxr"}
 webxr-api = { git = "https://github.com/servo/webxr", features = ["ipc"] }
 

--- a/ports/libsimpleservo/capi/Cargo.toml
+++ b/ports/libsimpleservo/capi/Cargo.toml
@@ -18,7 +18,7 @@ env_logger = "0.8"
 lazy_static = "1"
 log = "0.4"
 simpleservo = { path = "../api" }
-surfman = "0.4"
+surfman = "0.5"
 keyboard-types = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/ports/winit/Cargo.toml
+++ b/ports/winit/Cargo.toml
@@ -48,7 +48,7 @@ xr-profile = ["libservo/xr-profile"]
 [target.'cfg(not(target_os = "android"))'.dependencies]
 backtrace = "0.3"
 clipboard = "0.5"
-euclid = "0.20"
+euclid = "0.22"
 getopts = "0.2.11"
 keyboard-types = "0.6"
 lazy_static = "1"
@@ -57,7 +57,7 @@ libservo = { path = "../../components/servo" }
 log = "0.4"
 servo-media = { git = "https://github.com/servo/media" }
 shellwords = "1.0.0"
-surfman = { version = "0.4", features = ["sm-winit", "sm-x11"] }
+surfman = { version = "0.5", features = ["sm-winit", "sm-x11"] }
 tinyfiledialogs = "3.0"
 webxr = { git = "https://github.com/servo/webxr", features = ["ipc", "glwindow", "headless"] }
 winit = "0.24"

--- a/ports/winit/headed_window.rs
+++ b/ports/winit/headed_window.rs
@@ -762,7 +762,7 @@ impl XRWindowPose {
         }
         let x: Rotation3D<_, UnknownUnit, UnknownUnit> = Rotation3D::around_x(Angle::degrees(x));
         let y: Rotation3D<_, UnknownUnit, UnknownUnit> = Rotation3D::around_y(Angle::degrees(y));
-        let rotation = self.xr_rotation.get().post_rotate(&x).post_rotate(&y);
+        let rotation = self.xr_rotation.get().then(&x).then(&y);
         self.xr_rotation.set(rotation);
     }
 }

--- a/tests/unit/script/Cargo.toml
+++ b/tests/unit/script/Cargo.toml
@@ -10,7 +10,7 @@ name = "script_tests"
 path = "lib.rs"
 
 [dependencies]
-euclid = "0.20"
+euclid = "0.22"
 keyboard-types = "0.6"
 script = {path = "../../../components/script"}
 servo_url = {path = "../../../components/url"}

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 app_units = "0.7"
 cssparser = "0.29"
-euclid = "0.20"
+euclid = "0.22"
 html5ever = "0.26"
 rayon = "1"
 serde_json = "1.0"

--- a/tests/wpt/metadata/html/canvas/element/path-objects/2d.path.arc.shape.1.html.ini
+++ b/tests/wpt/metadata/html/canvas/element/path-objects/2d.path.arc.shape.1.html.ini
@@ -1,0 +1,4 @@
+[2d.path.arc.shape.1.html]
+  [arc() from 0 to pi does not draw anything in the wrong half]
+    bug: https://github.com/jrmuizel/raqote/issues/96
+    expected: FAIL

--- a/tests/wpt/metadata/html/canvas/offscreen/path-objects/2d.path.arc.shape.1.html.ini
+++ b/tests/wpt/metadata/html/canvas/offscreen/path-objects/2d.path.arc.shape.1.html.ini
@@ -1,0 +1,4 @@
+[2d.path.arc.shape.1.html]
+  [arc() from 0 to pi does not draw anything in the wrong half]
+    bug: https://github.com/jrmuizel/raqote/issues/96
+    expected: FAIL

--- a/tests/wpt/metadata/html/canvas/offscreen/path-objects/2d.path.arc.shape.1.worker.js.ini
+++ b/tests/wpt/metadata/html/canvas/offscreen/path-objects/2d.path.arc.shape.1.worker.js.ini
@@ -1,0 +1,4 @@
+[2d.path.arc.shape.1.worker.html]
+  [arc() from 0 to pi does not draw anything in the wrong half]
+    bug: https://github.com/jrmuizel/raqote/issues/96
+    expected: FAIL


### PR DESCRIPTION
Major changes:

- All matrices are now stored in row major order. This means that parameters to rotation functions should no longer be negated.
- `post_...()` functions are now named `then()`. `pre_transform()` is removed, so `then()` is used and the order of operations changed.

In addition, this PR updates lyon_geom to the latest version.

<!-- Please describe your changes on the following line: -->

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #27424
- [x] There are tests for these changes


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
