### PR TITLE
CI: clean up workflow names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Merge queue and try
 
 on:
   # Triggers the workflow on push events but only for the master branch

--- a/.github/workflows/nightly-rust.yml
+++ b/.github/workflows/nightly-rust.yml
@@ -1,4 +1,4 @@
-name: Nightly rustc build
+name: Test with nightly rustc
 
 on:
   schedule:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly builds
+name: Release nightly
 
 on:
   schedule:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: Basic cross-platform builds and checks
+name: Pull request
 on:
   pull_request:
     branches: ["**"]

--- a/.github/workflows/test-upstream-wpt-changes.yml
+++ b/.github/workflows/test-upstream-wpt-changes.yml
@@ -1,4 +1,4 @@
-name: Test changes to upstream-wpt-changes
+name: WPT exporter test
 on:
   pull_request:
     branches: ["**"]

--- a/.github/workflows/upstream-wpt-changes.yml
+++ b/.github/workflows/upstream-wpt-changes.yml
@@ -1,5 +1,5 @@
 # Disabled until the previous bot is turned off.
-#name: Upstream Web Platform Test changes
+#name: WPT export
 #on:
 #  pull_request:
 #    types: ['opened', 'synchronize', 'reopened', 'edited', 'closed']

--- a/.github/workflows/wpt-nightly.yml
+++ b/.github/workflows/wpt-nightly.yml
@@ -1,4 +1,4 @@
-name: Synchronize WPT Nightly
+name: WPT import
 
 on:
   schedule:


### PR DESCRIPTION
The workflow names on [the actions page](https://github.com/servo/servo/actions) could be a bit clearer and more consistent.

This patch gives main.yml and pull-request.yml more meaningful names, clarifies the nightly builds, and groups the WPT-related builds in lexicographic order.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] ~~`./mach build -d` does not report any errors~~
- [ ] ~~`./mach test-tidy` does not report any errors~~
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they affect the CI configuration

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
