### PR TITLE
WPT: remove spurious TIMEOUT expectation for transform-root-bg-002

### DIFF
--- a/tests/wpt/metadata/css/css-transforms/transform-root-bg-002.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/transform-root-bg-002.html.ini
@@ -1,2 +1,0 @@
-[transform-root-bg-002.html]
-  expected: TIMEOUT


### PR DESCRIPTION
/css/css-transforms/transform-root-bg-002.html unexpectedly passed twice in a row:

* https://github.com/servo/servo/actions/runs/3947219863/jobs/6756480536
* https://github.com/servo/servo/actions/runs/3947219863/jobs/6758323513

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [x] These changes fix #29258 (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they affect WPT expectations only