### PR TITLE
Remove unused salt bootstrapping process.

### DIFF
--- a/python/requirements-salt.txt
+++ b/python/requirements-salt.txt
@@ -1,6 +1,0 @@
-# Ensure all versions are pinned for repeatability,
-# since `--system-site-packages` is enabled
-
-# For boostrapping, make sure versions match those in saltfs
-salt == 2016.3.4
-GitPython == 0.3.2

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -46,15 +46,6 @@ class MachCommands(CommandBase):
         # it can install dependencies without needing mach's dependencies
         return bootstrap.bootstrap(self.context, force=force)
 
-    @Command('bootstrap-salt',
-             description='Install and set up the salt environment.',
-             category='bootstrap')
-    @CommandArgument('--force', '-f',
-                     action='store_true',
-                     help='Boostrap without confirmation')
-    def bootstrap_salt(self, force=False):
-        return bootstrap.bootstrap(self.context, force=force, specific="salt")
-
     @Command('bootstrap-gstreamer',
              description='Set up a local copy of the gstreamer libraries (linux only).',
              category='bootstrap')


### PR DESCRIPTION
This used to be used for taskcluster or buildbot, I believe. Searching github for `org:servo bootstrap-salt` returns no results now.