### PR TITLE
Make `mach` work on Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,26 +93,12 @@ If you get an undefined symbol error on `gst_player_get_config` try removing `gi
 
 #### On Fedora
 
-```sh
-sudo dnf install python3.7 python3-devel
+``` sh
+sudo dnf install python3 python3-virtualenv python3-pip python3-devel
+python3 ./mach bootstrap
 ```
 
-Installing pip 3.7 alongside Python 3.7 is vital. You might run into issues with virtualenv
-when trying to use Mach tools. You can install pip3.7 alongside virtualenv by executing:
-
-```sh
-curl https://bootstrap.pypa.io/get-pip.py | sudo -H python3.7
-python3.7 -m pip install virtualenv
-```
-
-Fedora 37 aliases python3.11 as `python3` by default. For this reason, when running Mach tools, make sure you
-execeute them with Python 3.7:
-
-```py
-python3.7 ./mach run https://servo.org/
-```
-
-If `python3.7 ./mach bootstrap` doesn't work, file a bug, and run the commands below:
+If `python3 ./mach bootstrap` doesn't work, file a bug, and, run the commands below:
 
 ``` sh
 sudo dnf install curl libtool gcc-c++ libXi-devel libunwind-devel \
@@ -124,7 +110,6 @@ sudo dnf install curl libtool gcc-c++ libXi-devel libunwind-devel \
     gstreamer1-plugins-base-devel gstreamer1-plugins-bad-free-devel autoconf213 \
     libjpeg-turbo-devel zlib libjpeg
 ```
-
 
 #### On CentOS
 

--- a/python/mach/mach/decorators.py
+++ b/python/mach/mach/decorators.py
@@ -112,7 +112,7 @@ def CommandProvider(cls):
 
     isfunc = inspect.ismethod if sys.version_info < (3, 0) else inspect.isfunction
     if isfunc(cls.__init__):
-        spec = inspect.getargspec(cls.__init__)
+        spec = inspect.getfullargspec(cls.__init__)
 
         if len(spec.args) > 2:
             msg = 'Mach @CommandProvider class %s implemented incorrectly. ' + \


### PR DESCRIPTION
This PR fixes the bug where `mach` fails when run on Python 3.11. It also reverts #29124, which added a workaround for this bug on the documentation.


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #29107 (already closed due to the workaround in #29124, but this PR fixes it)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they only involve tooling and documentation

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
