### PR TITLE
Approve PR automatically after WPT sync successfully

### DIFF
--- a/.github/workflows/wpt-nightly.yml
+++ b/.github/workflows/wpt-nightly.yml
@@ -134,5 +134,6 @@ jobs:
           r? @servo-wpt-sync
           EOF
           )
-          # TODO: comment `@bors-servo r+` from `@servo-wpt-sync`
-          gh pr create --title "Sync WPT with upstream (${{ env.CURRENT_DATE }})" --body "$BODY" --head ${{ env.UPDATE_BRANCH }}
+          gh pr create \
+            --title "Sync WPT with upstream (${{ env.CURRENT_DATE }})" \
+            --body "$BODY" --head ${{ env.UPDATE_BRANCH }} | xargs gh pr comment $1 --body "@bors-servo r+"


### PR DESCRIPTION
This PR will utilize the `gh pr comment` command to comment `r+` as @servo-wpt-sync so that we can merge WPT sync PRs more easily.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it's related to the WPT sync CI job
