### PR TITLE
Integrate filter-intermittents into test-wpt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,12 +212,7 @@ jobs:
   #           --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
   #           --log-raw test-wpt.${{ matrix.chunk_id }}.log \
   #           --log-servojson wpt-jsonsummary.${{ matrix.chunk_id }}.log \
-  #           --always-succeed
-  #         python3 ./mach filter-intermittents wpt-jsonsummary.${{ matrix.chunk_id }}.log \
-  #           --log-intermittents=intermittents.${{ matrix.chunk_id }}.log \
-  #           --log-filteredsummary=filtered-wpt-summary.${{ matrix.chunk_id }}.log \
-  #           --tracker-api=default --reporter-api=default
-
+  #           --filter-intermittents=filtered-wpt-summary.${{ matrix.chunk_id }}.log
   #     - name: Archive logs
   #       uses: actions/upload-artifact@v3
   #       if: ${{ failure() }}
@@ -227,7 +222,6 @@ jobs:
   #           test-wpt.${{ matrix.chunk_id }}.log
   #           wpt-jsonsummary.${{ matrix.chunk_id }}.log
   #           filtered-wpt-summary.${{ matrix.chunk_id }}.log
-  #           intermittents.${{ matrix.chunk_id }}.log
 
   build-linux:
     name: Build (Linux)
@@ -290,11 +284,7 @@ jobs:
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
             --log-servojson wpt-jsonsummary.${{ matrix.chunk_id }}.log \
-            --always-succeed
-          python3 ./mach filter-intermittents wpt-jsonsummary.${{ matrix.chunk_id }}.log \
-            --log-intermittents=intermittents.${{ matrix.chunk_id }}.log \
-            --log-filteredsummary=filtered-wpt-summary.${{ matrix.chunk_id }}.log \
-            --tracker-api=default --reporter-api=default
+            --filter-intermittents=filtered-wpt-summary.${{ matrix.chunk_id }}.log
       - name: Archive logs
         uses: actions/upload-artifact@v3
         if: ${{ failure() }}
@@ -304,7 +294,6 @@ jobs:
             test-wpt.${{ matrix.chunk_id }}.log
             wpt-jsonsummary.${{ matrix.chunk_id }}.log
             filtered-wpt-summary.${{ matrix.chunk_id }}.log
-            intermittents.${{ matrix.chunk_id }}.log
 
   build_result:
     name: homu build finished

--- a/.github/workflows/wpt-nightly.yml
+++ b/.github/workflows/wpt-nightly.yml
@@ -80,8 +80,6 @@ jobs:
           path: |
             test-wpt.${{ matrix.chunk_id }}.log
             wpt-jsonsummary.${{ matrix.chunk_id }}.log
-            filtered-wpt-summary.${{ matrix.chunk_id }}.log
-            intermittents.${{ matrix.chunk_id }}.log
 
   sync:
     name: Synchronize WPT Nightly


### PR DESCRIPTION
This change integrates the `filter-intermittents` command into `test-wpt`. This is in preparation for future work on tracking intermittent failures. This change also:
- Removes `ServoJsonFormatter` and replaces it with a generic WPT log handler which tracks unexpected results.
- The intermittent filter is now controlled via environment variables and the GitHub version requires a token instead of credentials.
- Output is saved to a single file and is always text.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are changes to build infrastructure.
