### PR TITLE
Revert LLVM downgrade & fix nighly build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,11 +39,6 @@ jobs:
     runs-on: windows-2019
     needs: ["decision"]
     steps:
-      # FIXME LLVM 15 breaks Windows builds https://github.com/servo/servo/issues/29269
-      - name: LLVM 14
-        run: |
-          $llvmVersion = Get-LatestChocoPackageVersion -TargetVersion 14 -PackageName llvm
-          Choco-Install -PackageName llvm -ArgumentList '--allow-downgrade', '--version', $llvmVersion
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
@@ -69,11 +64,6 @@ jobs:
     runs-on: windows-2019
     needs: ["decision"]
     steps:
-      # FIXME LLVM 15 breaks Windows builds https://github.com/servo/servo/issues/29269
-      - name: LLVM 14
-        run: |
-          $llvmVersion = Get-LatestChocoPackageVersion -TargetVersion 14 -PackageName llvm
-          Choco-Install -PackageName llvm -ArgumentList '--allow-downgrade', '--version', $llvmVersion
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
@@ -100,11 +90,6 @@ jobs:
     runs-on: windows-2019
     needs: ["decision"]
     steps:
-      # FIXME LLVM 15 breaks Windows builds https://github.com/servo/servo/issues/29269
-      - name: LLVM 14
-        run: |
-          $llvmVersion = Get-LatestChocoPackageVersion -TargetVersion 14 -PackageName llvm
-          Choco-Install -PackageName llvm -ArgumentList '--allow-downgrade', '--version', $llvmVersion
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2

--- a/python/servo/packages.py
+++ b/python/servo/packages.py
@@ -4,7 +4,7 @@
 
 WINDOWS_MSVC = {
     "cmake": "3.14.3",
-    "llvm": "14.0.6",
+    "llvm": "15.0.5",
     "moztools": "3.2",
     "ninja": "1.7.1",
     "nuget": "08-08-2019",

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -49,7 +49,7 @@ WEB_PLATFORM_TESTS_PATH = os.path.join("tests", "wpt", "web-platform-tests")
 SERVO_TESTS_PATH = os.path.join("tests", "wpt", "mozilla", "tests")
 
 CLANGFMT_CPP_DIRS = ["support/hololens/"]
-CLANGFMT_VERSION = "14"
+CLANGFMT_VERSION = "15"
 
 TEST_SUITES = OrderedDict([
     ("tidy", {"kwargs": {"all_files": False, "no_progress": False, "self_test": False,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Windows MSCV nightly builds have been failing
since Jan 18. The failure is similar to the
one @delan identified & fixed, where CI build started
to fail after the version of LLVM included in
Github Actions runner images was bumped from
14 to 15.

As discussed on Zulip, we have existing support
in ./mach bootstrap to download the LLVM binaries
from our s3 bucket. Following the documented
[process][1], new LLVM 15.0.5 binaries have now been
uploaded to S3.

I've validated that the windows msvc build no longer fails:
https://github.com/mukilan/servo/actions/runs/3996453221/jobs/6856528077

[1]: https://github.com/servo/servo/wiki/Upgrading-the-windows-LLVM-binaries

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #29269  (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they modify only CI steps that have been validated by manual run.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
