### PR TITLE
Remove UWP/HoloLens CI & Nightly jobs.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,56 +59,6 @@ jobs:
         working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
         run: python mach smoketest --angle
 
-  build-uwp-x64:
-    name: Build (Windows UWP x64)
-    runs-on: windows-2019
-    needs: ["decision"]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Copy to C drive
-        run: cp D:\a C:\ -Recurse
-      - name: Bootstrap
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: |
-          python -m pip install --upgrade pip virtualenv
-          python mach fetch
-      - name: Release build
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: python mach build --release --target=x86_64-uwp-windows-msvc
-      #- name: Package
-      #  working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-      #  run: python mach package --release --target=x86_64-uwp-windows-msvc --uwp=x64
-      #  env:
-      #    CODESIGN_CERT: ${{ secrets.WINDOWS_CODESIGN_CERT }}
-      - name: Tidy
-        run: python mach test-tidy --force-cpp --no-wpt
-
-  build-uwp-arm64:
-    name: Build (Windows UWP arm64)
-    runs-on: windows-2019
-    needs: ["decision"]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Copy to C drive
-        run: cp D:\a C:\ -Recurse
-      - name: Bootstrap
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: |
-          python -m pip install --upgrade pip virtualenv
-          python mach fetch
-      - name: Release build
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: python mach build --release --target=aarch64-uwp-windows-msvc
-      #- name: Package
-      #  working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-      #  run: python mach package --release --target=aarch64-uwp-windows-msvc --uwp=arm64
-      #  env:
-      #    CODESIGN_CERT: ${{ secrets.WINDOWS_CODESIGN_CERT }}
-
   build-mac:
     name: Build (macOS)
     runs-on: macos-12
@@ -296,7 +246,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - "build-win"
-      - "build-uwp-x64"
       - "build-linux"
       - "build-mac"
       - "linux-wpt"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -111,34 +111,3 @@ jobs:
         run: python mach upload-nightly windows-msvc --secret-from-environment
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
-
-  upload-uwp:
-    name: Upload nightly (UWP)
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Copy to C drive
-        run: cp D:\a C:\ -Recurse
-      - name: Bootstrap
-        working-directory: "C:\\a\\servo\\servo"
-        run: |
-          python -m pip install --upgrade pip virtualenv
-          python mach fetch
-      - name: Release build (x64)
-        working-directory: "C:\\a\\servo\\servo"
-        run: python mach build --release --target=x86_64-uwp-windows-msvc
-      - name: Release build (arm64)
-        working-directory: "C:\\a\\servo\\servo"
-        run: python mach build --release --target=aarch64-uwp-windows-msvc
-      - name: Package
-        working-directory: "C:\\a\\servo\\servo"
-        run: python mach package --release --target=x86_64-uwp-windows-msvc --uwp=x64 --uwp=arm64
-        env:
-          CODESIGN_CERT: ${{ secrets.WINDOWS_CODESIGN_CERT }}
-      - name: Upload
-        working-directory: "C:\\a\\servo\\servo"
-        run: python mach upload-nightly uwp --secret-from-environment
-        env:
-          S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}

--- a/docs/hololens.md
+++ b/docs/hololens.md
@@ -1,5 +1,7 @@
 # Using Servo on HoloLens 2
 
+**NOTE: HoloLens is no longer a [supported platform](https://github.com/servo/project/blob/master/governance/tsc/tsc-2023-01-23.md#supported-platforms)**
+
 To build Servo for the HoloLens 2, see [the wiki](https://github.com/servo/servo/wiki/Building-for-UWP).
 
 ## Web development workflow


### PR DESCRIPTION
Servo [TSC has decided][1] to halt support for UWP platform. This PR only removes the CI & Nightly jobs and doesn't modify any code related to UWP support.

[1]: https://github.com/servo/project/blob/master/governance/tsc/tsc-2023-01-23.md#supported-platforms

Signed-off-by: Mukilan Thiyagarajan <mukilanthiagarajan@gmail.com>

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [X] These changes fix #28721 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they are  removing  CI jobs and not modifying code.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
