### PR TITLE
Fix upstreaming of WPT changes

### DIFF
--- a/.github/workflows/upstream-wpt-changes.yml
+++ b/.github/workflows/upstream-wpt-changes.yml
@@ -1,6 +1,6 @@
 name: WPT export
 on:
-  pull_request:
+  pull_request_target:
     types: ['opened', 'synchronize', 'reopened', 'edited', 'closed']
 
 jobs:
@@ -16,7 +16,8 @@ jobs:
           git init -b main
           git remote add origin ${{ github.event.repository.clone_url}}
           git fetch origin pull/${{ github.event.pull_request.number}}/head:pr --depth ${{ env.PR_FETCH_DEPTH }}
-          git checkout pr
+          git fetch origin master:master --depth 1
+          git checkout master
       - name: Check out wpt
         uses: actions/checkout@v3
         with:

--- a/etc/ci/upstream-wpt-changes/wptupstreamer/step.py
+++ b/etc/ci/upstream-wpt-changes/wptupstreamer/step.py
@@ -99,8 +99,9 @@ class CreateOrUpdateBranchForPRStep(Step):
     def _get_upstreamable_commits_from_local_servo_repo(self, sync: WPTSync):
         local_servo_repo = sync.local_servo_repo
         number_of_commits = self.pull_data["commits"]
+        pr_head = self.pull_data["head"]["sha"]
         commit_shas = local_servo_repo.run(
-            "log", "--pretty=%H", f"-{number_of_commits}"
+            "log", "--pretty=%H", pr_head, f"-{number_of_commits}"
         ).splitlines()
 
         filtered_commits = []


### PR DESCRIPTION
The GitHub Action needs access to Servo repository secrets, so switch to using the 'pull_request_target' event. Since these PRs have more complete access to the Servo repository, do not execute the version of the upstream script that comes with the PR. Instead, simply fetch the changes. To make this work, the script no longer expects the PR commit to be checked out, merely that they exist in the repository somewhere.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes
