### PR TITLE
Try to isolate true intermittents

### DIFF
--- a/tests/wpt/metadata/css/CSS2/floats/hit-test-floats-001.html.ini
+++ b/tests/wpt/metadata/css/CSS2/floats/hit-test-floats-001.html.ini
@@ -1,0 +1,3 @@
+[hit-test-floats-001.html]
+  [hit-test-floats-001]
+    expected: FAIL

--- a/tests/wpt/metadata/css/css-fonts/variations/at-font-face-font-matching.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/variations/at-font-face-font-matching.html.ini
@@ -134,9 +134,6 @@
   [Matching font-style: 'oblique -20deg' should prefer 'oblique -20deg' over 'oblique -60deg -40deg']
     expected: FAIL
 
-  [Matching font-style: 'oblique 20deg' should prefer 'oblique 10deg' over 'italic']
-    expected: FAIL
-
   [Matching font-style: 'oblique 21deg' should prefer 'oblique 21deg' over 'oblique 30deg 60deg']
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transforms/transform-scale-hittest.html.ini
+++ b/tests/wpt/metadata/css/css-transforms/transform-scale-hittest.html.ini
@@ -1,3 +1,6 @@
 [transform-scale-hittest.html]
   [Hit test intersecting scaled box]
     expected: FAIL
+
+  [Hit test within unscaled box]
+    expected: FAIL

--- a/tests/wpt/metadata/fetch/metadata/generated/css-images.sub.tentative.html.ini
+++ b/tests/wpt/metadata/fetch/metadata/generated/css-images.sub.tentative.html.ini
@@ -146,3 +146,6 @@
 
   [list-style-image sec-fetch-site - HTTPS downgrade-upgrade]
     expected: FAIL
+
+  [border-image sec-fetch-site - HTTPS downgrade (header not sent)]
+    expected: FAIL

--- a/tests/wpt/metadata/html/browsers/browsing-the-web/read-media/pageload-image-in-popup.html.ini
+++ b/tests/wpt/metadata/html/browsers/browsing-the-web/read-media/pageload-image-in-popup.html.ini
@@ -1,0 +1,3 @@
+[pageload-image-in-popup.html]
+  [The document for a standalone media file should have one child in the body.]
+    expected: FAIL

--- a/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse-during-unload.html.ini
+++ b/tests/wpt/metadata/html/browsers/history/the-history-interface/traverse-during-unload.html.ini
@@ -1,4 +1,0 @@
-[traverse-during-unload.html]
-  expected: TIMEOUT
-  [Traversing the history during unload]
-    expected: TIMEOUT

--- a/tests/wpt/metadata/resource-timing/content-type-parsing.html.ini
+++ b/tests/wpt/metadata/resource-timing/content-type-parsing.html.ini
@@ -31,13 +31,13 @@
     expected: FAIL
 
   [content-type 10 : text/plain,*/*]
-    expected: FAIL
+    expected: NOTRUN
 
   [content-type 11 : text/html,*/*]
-    expected: FAIL
+    expected: NOTRUN
 
   [content-type 12 : */*,text/html]
-    expected: FAIL
+    expected: NOTRUN
 
   [content-type 13 : text/plain,*/*;charset=gbk]
     expected: TIMEOUT

--- a/tests/wpt/metadata/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.html.ini
+++ b/tests/wpt/metadata/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.html.ini
@@ -1,5 +1,5 @@
 [audiocontextoptions.html]
-  expected: TIMEOUT
+  expected: CRASH
   [X context = new AudioContext({sampleRate: 1}) did not throw an exception.]
     expected: FAIL
 

--- a/tests/wpt/metadata/workers/constructors/Worker/Worker-constructor.html.ini
+++ b/tests/wpt/metadata/workers/constructors/Worker/Worker-constructor.html.ini
@@ -1,0 +1,2 @@
+[Worker-constructor.html]
+  expected: ERROR

--- a/tests/wpt/mozilla/meta/css/stylesheet_media_queries.html.ini
+++ b/tests/wpt/mozilla/meta/css/stylesheet_media_queries.html.ini
@@ -1,0 +1,3 @@
+[stylesheet_media_queries.html]
+  [Media queries within stylesheets]
+    expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/scrollBy.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/scrollBy.html.ini
@@ -1,3 +1,0 @@
-[scrollBy.html]
-  [Ensure that the window.scrollBy function affects scroll position as expected]
-    expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/task_queue_throttling.any.js.ini
+++ b/tests/wpt/mozilla/meta/mozilla/task_queue_throttling.any.js.ini
@@ -1,0 +1,6 @@
+[task_queue_throttling.any.html]
+  [Throttling the performance timeline task queue.]
+    expected: FAIL
+
+
+[task_queue_throttling.any.worker.html]


### PR DESCRIPTION
Re-run WPT tests with unexpected results to try to sniff out true intermittents. Only filter these unstable results when filtering intermittents. Mark the stable unexpected results as failures.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes
