### PR TITLE
wpt: Make WPT result formatting logic independent of ServoHandler

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,6 +8,7 @@ mozinfo == 1.2.1
 mozlog == 7.1.0
 setuptools == 65.5.1
 toml == 0.9.2
+dataclasses == 0.8; python_version < "3.7"
 
 # For Python linting
 flake8 == 3.8.3

--- a/tests/wpt/servowpt.py
+++ b/tests/wpt/servowpt.py
@@ -222,17 +222,17 @@ def filter_intermittents(
     actually_unexpected = []
     for i, result in enumerate(unexpected_results):
         print(f" [{i}/{len(unexpected_results)}]", file=sys.stderr, end="\r")
-        if filter.is_failure_intermittent(result.test_name):
+        if filter.is_failure_intermittent(result.path):
             intermittents.append(result)
         else:
             actually_unexpected.append(result)
 
     output = "\n".join([
         f"{len(intermittents)} known-intermittent unexpected result",
-        *[result.output.strip() for result in intermittents],
+        *[str(result) for result in intermittents],
         "",
         f"{len(actually_unexpected)} unexpected results that are NOT known-intermittents",
-        *[result.output.strip() for result in actually_unexpected],
+        *[str(result) for result in actually_unexpected],
     ])
 
     if output_file:


### PR DESCRIPTION
This will allow results to be formatted by other parts of the code (such as the intermittent filtering code). Previously formatting was handled in ServoHandler, which was a bit strange as it's really only necessary for GroupingFormatter and the intermittent filtering code. This also allows the results to be properly typed by the Python typing system.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are part of the testing infrastructure that is generally untested.