### PR TITLE
Run `test-tidy` sooner for pull requests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,11 +19,11 @@ jobs:
         run: python3 -m pip install --upgrade pip virtualenv
       - name: Bootstrap dependencies
         run: sudo apt update && python3 ./mach bootstrap
+      - name: Tidy
+        run: python3 ./mach test-tidy --no-progress --all
       - name: Release build
         run: python3 ./mach build --release
       - name: Unit tests
         run: python3 ./mach test-unit --release
-      - name: Tidy
-        run: python3 ./mach test-tidy --no-progress --all
       - name: Lockfile check
         run: ./etc/ci/lockfile_changed.sh


### PR DESCRIPTION
This lets the builder fail sooner when there is an issue with the style.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are a small change to the CI.