### PR TITLE
ci: Produce a single WPT log artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,7 +224,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
-          name: wpt${{ matrix.chunk_id }}-logs-linux
+          name: wpt-logs-linux
           path: |
             test-wpt.${{ matrix.chunk_id }}.log
             wpt-jsonsummary.${{ matrix.chunk_id }}.log

--- a/.github/workflows/wpt-nightly.yml
+++ b/.github/workflows/wpt-nightly.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Archive logs
         uses: actions/upload-artifact@v3
         with:
-          name: wpt${{ matrix.chunk_id }}-logs-linux
+          name: wpt-logs-linux
           path: |
             test-wpt.${{ matrix.chunk_id }}.log
             wpt-jsonsummary.${{ matrix.chunk_id }}.log

--- a/etc/ci/wpt-nightly-update.sh
+++ b/etc/ci/wpt-nightly-update.sh
@@ -31,7 +31,7 @@ function main() {
     for n in $(seq 1 "${MAX_CHUNK_ID}")
     do
         code=""
-        update_metadata "wpt${n}-logs-linux/test-wpt.${n}.log" || \
+        update_metadata "wpt-logs-linux/test-wpt.${n}.log" || \
             code="${?}"
         if [[ "${code}" != "" ]]; then
             return "${code}"


### PR DESCRIPTION
GitHub supports adding files to an artifact in parallel, as long as the filenames are unique. This makes it easier to download build results when more than a single builder fails.

<!-- Please describe your changes on the following line: -->
---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this is a small change to the CI.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
