### PR TITLE
Add intermittent results for transitions related tests

### DIFF
--- a/tests/wpt/metadata/css/css-transitions/properties-value-001.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/properties-value-001.html.ini
@@ -1,354 +1,864 @@
 [properties-value-001.html]
   [background-position length(pt) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(px) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(cm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(in) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(pc) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position percentage(%) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(em) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position percentage(%) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
+
+  [background-color color(rgba) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(px) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(em) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(in) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(px) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(em) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(in) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(px) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(em) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(in) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(px) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(em) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(in) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-color color(rgba) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-color color(rgba) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-color color(rgba) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-color color(rgba) / values]
+    expected: [FAIL, PASS]
+
+  [padding-bottom length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [padding-bottom length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [padding-bottom length(px) / values]
+    expected: [FAIL, PASS]
+
+  [padding-bottom length(em) / values]
+    expected: [FAIL, PASS]
 
   [padding-bottom length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-bottom length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-bottom length(cm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-bottom length(in) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(pt) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(pc) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(px) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(em) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(cm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(in) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(pt) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(pc) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(px) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(em) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(cm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(in) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(pt) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(pc) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(px) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(em) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(cm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(in) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(pt) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(pc) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(px) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(em) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(cm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(in) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(pt) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(pc) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(px) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(em) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(cm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(in) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-right length(pt) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-right length(pc) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-right length(px) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-right length(em) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-right length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-right length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
+
+  [margin-right length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [margin-right length(in) / values]
+    expected: [FAIL, PASS]
+
+  [margin-top length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [margin-top length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [margin-top length(px) / values]
+    expected: [FAIL, PASS]
+
+  [margin-top length(em) / values]
+    expected: [FAIL, PASS]
+
+  [margin-top length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [margin-top length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [margin-top length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [margin-top length(in) / values]
+    expected: [FAIL, PASS]
+
+  [height length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [height length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [height length(px) / values]
+    expected: [FAIL, PASS]
+
+  [height length(em) / values]
+    expected: [FAIL, PASS]
+
+  [height length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [height length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [height length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [height length(in) / values]
+    expected: [FAIL, PASS]
+
+  [height percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [width length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [width length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [width length(px) / values]
+    expected: [FAIL, PASS]
+
+  [width length(em) / values]
+    expected: [FAIL, PASS]
+
+  [width length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [width length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [width length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [width length(in) / values]
+    expected: [FAIL, PASS]
+
+  [width percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [min-height length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [min-height length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [min-height length(px) / values]
+    expected: [FAIL, PASS]
+
+  [min-height length(em) / values]
+    expected: [FAIL, PASS]
+
+  [min-height length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [min-height length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [min-height length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [min-height length(in) / values]
+    expected: [FAIL, PASS]
+
+  [min-height percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [min-width length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [min-width length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [min-width length(px) / values]
+    expected: [FAIL, PASS]
+
+  [min-width length(em) / values]
+    expected: [FAIL, PASS]
+
+  [min-width length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [min-width length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [min-width length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [min-width length(in) / values]
+    expected: [FAIL, PASS]
+
+  [min-width percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [max-height length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [max-height length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [max-height length(px) / values]
+    expected: [FAIL, PASS]
+
+  [max-height length(em) / values]
+    expected: [FAIL, PASS]
+
+  [max-height length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [max-height length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [max-height length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [max-height length(in) / values]
+    expected: [FAIL, PASS]
+
+  [max-height percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [max-width length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [max-width length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [max-width length(px) / values]
+    expected: [FAIL, PASS]
+
+  [max-width length(em) / values]
+    expected: [FAIL, PASS]
+
+  [max-width length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [max-width length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [max-width length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [max-width length(in) / values]
+    expected: [FAIL, PASS]
+
+  [max-width percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [top length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [top length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [top length(px) / values]
+    expected: [FAIL, PASS]
+
+  [top length(em) / values]
+    expected: [FAIL, PASS]
+
+  [top length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [top length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [top length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [top length(in) / values]
+    expected: [FAIL, PASS]
+
+  [top percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [right length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [right length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [right length(px) / values]
+    expected: [FAIL, PASS]
+
+  [right length(em) / values]
+    expected: [FAIL, PASS]
+
+  [right length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [right length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [right length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [right length(in) / values]
+    expected: [FAIL, PASS]
+
+  [right percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [bottom length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [bottom length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [bottom length(px) / values]
+    expected: [FAIL, PASS]
+
+  [bottom length(em) / values]
+    expected: [FAIL, PASS]
+
+  [bottom length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [bottom length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [bottom length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [bottom length(in) / values]
+    expected: [FAIL, PASS]
+
+  [bottom percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [left length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [left length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [left length(px) / values]
+    expected: [FAIL, PASS]
+
+  [left length(em) / values]
+    expected: [FAIL, PASS]
+
+  [left length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [left length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [left length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [left length(in) / values]
+    expected: [FAIL, PASS]
+
+  [left percentage(%) / values]
+    expected: [FAIL, PASS]
 
   [color color(rgba) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(pt) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(pc) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(px) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(em) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(cm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(in) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size percentage(%) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-weight font-weight(keyword) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-weight font-weight(numeric) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height number(integer) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height number(decimal) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(pt) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(pc) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(px) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(em) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(cm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(in) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height percentage(%) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(pt) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(pc) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(px) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(em) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(cm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(in) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(pt) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(pc) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(px) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(em) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(cm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(in) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing percentage(%) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(pt) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(pc) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(px) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(em) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(cm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(in) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent percentage(%) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-shadow shadow(shadow) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
+
+  [outline-color color(rgba) / values]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(px) / values]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(em) / values]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(in) / values]
+    expected: [FAIL, PASS]
+
+  [outline-width length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [outline-width length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [outline-width length(px) / values]
+    expected: [FAIL, PASS]
+
+  [outline-width length(em) / values]
+    expected: [FAIL, PASS]
+
+  [outline-width length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [outline-width length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [outline-width length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [outline-width length(in) / values]
+    expected: [FAIL, PASS]
+
+  [clip rectangle(rectangle) / values]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(px) / values]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(em) / values]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(in) / values]
+    expected: [FAIL, PASS]
+
+  [vertical-align percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [opacity number[0,1\](zero-to-one) / values]
+    expected: [FAIL, PASS]
+
+  [z-index integer(integer) / values]
+    expected: [FAIL, PASS]

--- a/tests/wpt/metadata/css/css-transitions/properties-value-002.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/properties-value-002.html.ini
@@ -1,3 +1,28 @@
 [properties-value-002.html]
   [vertical-align vertical(keyword) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
+
+  [margin-bottom percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [margin-left percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [margin-right percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [margin-top percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [padding-bottom percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [padding-left percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [padding-right percentage(%) / values]
+    expected: [FAIL, PASS]
+
+  [padding-top percentage(%) / values]
+    expected: [FAIL, PASS]
+

--- a/tests/wpt/metadata/css/css-transitions/properties-value-inherit-001.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/properties-value-inherit-001.html.ini
@@ -1,630 +1,870 @@
 [properties-value-inherit-001.html]
   [background-position length(pt) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(px) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [visibility visibility(keyword) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(cm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(in) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(pc) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position percentage(%) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(em) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position percentage(%) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-right length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-right length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-top length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-top length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-top length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-top length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-top length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-top length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-top length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-top length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [height length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [height length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [height length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [height length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [height length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [height length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [height length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [height length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [height percentage(%) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [width length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [width length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [width length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [width length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [width length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [width length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [width length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [width length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [width percentage(%) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-height length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-height length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-height length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-height length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-height length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-height length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-height length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-height length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-height percentage(%) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-width length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-width length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-width length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-width length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-width length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-width length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-width length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-width length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [min-width percentage(%) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [max-height length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [max-height length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [max-height length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [max-height length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-color color(rgba) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-top-width length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-top-width length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-top-width length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-top-width length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-top-width length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-top-width length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-top-width length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-top-width length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-right-width length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-right-width length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-right-width length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-right-width length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-right-width length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-right-width length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-right-width length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-right-width length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-bottom-width length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-bottom-width length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-bottom-width length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-bottom-width length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-bottom-width length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-bottom-width length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-bottom-width length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-bottom-width length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-left-width length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-left-width length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-left-width length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-left-width length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-left-width length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-left-width length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-left-width length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-left-width length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-top-color color(rgba) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-right-color color(rgba) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-bottom-color color(rgba) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [border-left-color color(rgba) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-bottom length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-bottom length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-bottom length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-bottom length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-bottom length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-bottom length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-bottom length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-bottom length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-left length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-right length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [padding-top length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-bottom length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-left length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-right length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-right length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-right length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-right length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-right length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [margin-right length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [color color(rgba) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-size percentage(%) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-weight font-weight(keyword) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [font-weight font-weight(numeric) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height number(integer) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height number(decimal) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [line-height percentage(%) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [letter-spacing length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [word-spacing percentage(%) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-indent percentage(%) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [text-shadow shadow(shadow) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
+
+  [max-height length(ex) / events]
+    expected: [FAIL, PASS]
+
+  [max-height length(mm) / events]
+    expected: [FAIL, PASS]
+
+  [max-height length(cm) / events]
+    expected: [FAIL, PASS]
+
+  [max-height length(in) / events]
+    expected: [FAIL, PASS]
+
+  [max-height percentage(%) / events]
+    expected: [FAIL, PASS]
+
+  [max-width length(pt) / events]
+    expected: [FAIL, PASS]
+
+  [max-width length(pc) / events]
+    expected: [FAIL, PASS]
+
+  [max-width length(px) / events]
+    expected: [FAIL, PASS]
+
+  [max-width length(em) / events]
+    expected: [FAIL, PASS]
+
+  [max-width length(ex) / events]
+    expected: [FAIL, PASS]
+
+  [max-width length(mm) / events]
+    expected: [FAIL, PASS]
+
+  [max-width length(cm) / events]
+    expected: [FAIL, PASS]
+
+  [max-width length(in) / events]
+    expected: [FAIL, PASS]
+
+  [max-width percentage(%) / events]
+    expected: [FAIL, PASS]
+
+  [top length(pt) / events]
+    expected: [FAIL, PASS]
+
+  [top length(pc) / events]
+    expected: [FAIL, PASS]
+
+  [top length(px) / events]
+    expected: [FAIL, PASS]
+
+  [top length(em) / events]
+    expected: [FAIL, PASS]
+
+  [top length(ex) / events]
+    expected: [FAIL, PASS]
+
+  [top length(mm) / events]
+    expected: [FAIL, PASS]
+
+  [top length(cm) / events]
+    expected: [FAIL, PASS]
+
+  [top length(in) / events]
+    expected: [FAIL, PASS]
+
+  [top percentage(%) / events]
+    expected: [FAIL, PASS]
+
+  [right length(pt) / events]
+    expected: [FAIL, PASS]
+
+  [right length(pc) / events]
+    expected: [FAIL, PASS]
+
+  [right length(px) / events]
+    expected: [FAIL, PASS]
+
+  [right length(em) / events]
+    expected: [FAIL, PASS]
+
+  [right length(ex) / events]
+    expected: [FAIL, PASS]
+
+  [right length(mm) / events]
+    expected: [FAIL, PASS]
+
+  [right length(cm) / events]
+    expected: [FAIL, PASS]
+
+  [right length(in) / events]
+    expected: [FAIL, PASS]
+
+  [right percentage(%) / events]
+    expected: [FAIL, PASS]
+
+  [bottom length(pt) / events]
+    expected: [FAIL, PASS]
+
+  [bottom length(pc) / events]
+    expected: [FAIL, PASS]
+
+  [bottom length(px) / events]
+    expected: [FAIL, PASS]
+
+  [bottom length(em) / events]
+    expected: [FAIL, PASS]
+
+  [bottom length(ex) / events]
+    expected: [FAIL, PASS]
+
+  [bottom length(mm) / events]
+    expected: [FAIL, PASS]
+
+  [bottom length(cm) / events]
+    expected: [FAIL, PASS]
+
+  [bottom length(in) / events]
+    expected: [FAIL, PASS]
+
+  [bottom percentage(%) / events]
+    expected: [FAIL, PASS]
+
+  [left length(pt) / events]
+    expected: [FAIL, PASS]
+
+  [left length(pc) / events]
+    expected: [FAIL, PASS]
+
+  [left length(px) / events]
+    expected: [FAIL, PASS]
+
+  [left length(em) / events]
+    expected: [FAIL, PASS]
+
+  [left length(ex) / events]
+    expected: [FAIL, PASS]
+
+  [left length(mm) / events]
+    expected: [FAIL, PASS]
+
+  [left length(cm) / events]
+    expected: [FAIL, PASS]
+
+  [left length(in) / events]
+    expected: [FAIL, PASS]
+
+  [left percentage(%) / events]
+    expected: [FAIL, PASS]
+
+  [outline-color color(rgba) / events]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(pt) / events]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(pc) / events]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(px) / events]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(em) / events]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(ex) / events]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(mm) / events]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(cm) / events]
+    expected: [FAIL, PASS]
+
+  [outline-offset length(in) / events]
+    expected: [FAIL, PASS]
+
+  [outline-width length(pt) / events]
+    expected: [FAIL, PASS]
+
+  [outline-width length(pc) / events]
+    expected: [FAIL, PASS]
+
+  [outline-width length(px) / events]
+    expected: [FAIL, PASS]
+
+  [outline-width length(em) / events]
+    expected: [FAIL, PASS]
+
+  [outline-width length(ex) / events]
+    expected: [FAIL, PASS]
+
+  [outline-width length(mm) / events]
+    expected: [FAIL, PASS]
+
+  [outline-width length(cm) / events]
+    expected: [FAIL, PASS]
+
+  [outline-width length(in) / events]
+    expected: [FAIL, PASS]
+
+  [clip rectangle(rectangle) / events]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(pt) / events]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(pc) / events]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(px) / events]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(em) / events]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(ex) / events]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(mm) / events]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(cm) / events]
+    expected: [FAIL, PASS]
+
+  [vertical-align length(in) / events]
+    expected: [FAIL, PASS]
+
+  [vertical-align percentage(%) / events]
+    expected: [FAIL, PASS]
+
+  [opacity number[0,1\](zero-to-one) / events]
+    expected: [FAIL, PASS]
+
+  [visibility visibility(keyword) / events]
+    expected: [FAIL, PASS]
+
+  [z-index integer(integer) / events]
+    expected: [FAIL, PASS]

--- a/tests/wpt/metadata/css/css-transitions/properties-value-inherit-002.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/properties-value-inherit-002.html.ini
@@ -1,54 +1,327 @@
 [properties-value-inherit-002.html]
   [background-position length(pt) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(pt) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(px) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(cm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(mm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(in) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(em) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(ex) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(cm) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(ex) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(pc) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(in) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(pc) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position percentage(%) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(mm) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(em) / values]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position percentage(%) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
 
   [background-position length(px) / events]
-    expected: FAIL
+    expected: [FAIL, PASS]
+
+  [background-color color(rgba) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(px) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(em) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-width length(in) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(px) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(em) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-width length(in) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(px) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(em) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-width length(in) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(px) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(em) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-width length(in) / values]
+    expected: [FAIL, PASS]
+
+  [border-top-color color(rgba) / values]
+    expected: [FAIL, PASS]
+
+  [border-right-color color(rgba) / values]
+    expected: [FAIL, PASS]
+
+  [border-bottom-color color(rgba) / values]
+    expected: [FAIL, PASS]
+
+  [border-left-color color(rgba) / values]
+    expected: [FAIL, PASS]
+
+  [padding-bottom length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [padding-bottom length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [padding-bottom length(px) / values]
+    expected: [FAIL, PASS]
+
+  [padding-bottom length(em) / values]
+    expected: [FAIL, PASS]
+
+  [padding-bottom length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [padding-bottom length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [padding-bottom length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [padding-bottom length(in) / values]
+    expected: [FAIL, PASS]
+
+  [padding-left length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [padding-left length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [padding-left length(px) / values]
+    expected: [FAIL, PASS]
+
+  [padding-left length(em) / values]
+    expected: [FAIL, PASS]
+
+  [padding-left length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [padding-left length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [padding-left length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [padding-left length(in) / values]
+    expected: [FAIL, PASS]
+
+  [padding-right length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [padding-right length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [padding-right length(px) / values]
+    expected: [FAIL, PASS]
+
+  [padding-right length(em) / values]
+    expected: [FAIL, PASS]
+
+  [padding-right length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [padding-right length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [padding-right length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [padding-right length(in) / values]
+    expected: [FAIL, PASS]
+
+  [padding-top length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [padding-top length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [padding-top length(px) / values]
+    expected: [FAIL, PASS]
+
+  [padding-top length(em) / values]
+    expected: [FAIL, PASS]
+
+  [padding-top length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [padding-top length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [padding-top length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [padding-top length(in) / values]
+    expected: [FAIL, PASS]
+
+  [margin-bottom length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [margin-bottom length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [margin-bottom length(px) / values]
+    expected: [FAIL, PASS]
+
+  [margin-bottom length(em) / values]
+    expected: [FAIL, PASS]
+
+  [margin-bottom length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [margin-bottom length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [margin-bottom length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [margin-bottom length(in) / values]
+    expected: [FAIL, PASS]
+
+  [margin-left length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [margin-left length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [margin-left length(px) / values]
+    expected: [FAIL, PASS]
+
+  [margin-left length(em) / values]
+    expected: [FAIL, PASS]
+
+  [margin-left length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [margin-left length(mm) / values]
+    expected: [FAIL, PASS]
+
+  [margin-left length(cm) / values]
+    expected: [FAIL, PASS]
+
+  [margin-left length(in) / values]
+    expected: [FAIL, PASS]
+
+  [margin-right length(pt) / values]
+    expected: [FAIL, PASS]
+
+  [margin-right length(pc) / values]
+    expected: [FAIL, PASS]
+
+  [margin-right length(px) / values]
+    expected: [FAIL, PASS]
+
+  [margin-right length(em) / values]
+    expected: [FAIL, PASS]
+
+  [margin-right length(ex) / values]
+    expected: [FAIL, PASS]
+
+  [margin-right length(mm) / values]
+    expected: [FAIL, PASS]


### PR DESCRIPTION
 These tests test the behavior of many properties and due to issues in
 Servo, the results are incredibly unstable. Since the tests use large
 property lists this leads to hundreds of failed subtests every run. We
 let these tests either pass or fail so that results in the CI are
 stable. The ultimate goal here is to fix the instability in Servo so
 that these tests pass or fail consistently.
    
 This change also adds support for intermittent expectations to the
 ServoHandler. Before these kind of test results were interpreted as
 unexpected results.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just update test results.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
