### PR TITLE
Aggregate unexpected results into logs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,14 +216,16 @@ jobs:
             --release --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
-            --filter-intermittents=filtered-wpt-results.${{ matrix.chunk_id }}.json
+            --log-raw-unexpected unexpected-test-wpt.${{ matrix.chunk_id }}.log \
+            --filter-intermittents filtered-test-wpt.${{ matrix.chunk_id }}.json
       - name: Archive filtered results
         uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: wpt-filtered-results-linux
           path: |
-            filtered-wpt-results.${{ matrix.chunk_id }}.json
+            filtered-test-wpt.${{ matrix.chunk_id }}.json
+            unexpected-test-wpt.${{ matrix.chunk_id }}.log
       - name: Archive logs
         uses: actions/upload-artifact@v3
         if: ${{ failure() }}
@@ -247,8 +249,16 @@ jobs:
         with:
           name: wpt-filtered-results-linux
           path: wpt-filtered-results-linux
+      - name: Create aggregated unexpected results
+        run: cat wpt-filtered-results-linux/*.log > unexpected-test-wpt.log
+      - name: Archive aggregate results
+        uses: actions/upload-artifact@v3
+        with:
+          name: wpt-filtered-results-linux
+          path: |
+            unexpected-test-wpt.log
       - name: Comment on PR with results
-        run: etc/ci/report_aggregated_expected_results.py wpt-filtered-results-linux/*
+        run: etc/ci/report_aggregated_expected_results.py wpt-filtered-results-linux/*.json
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -87,6 +87,9 @@ def create_parser_wpt():
     parser.add_argument('--filter-intermittents', default=None, action="store",
                         help="Filter intermittents against known intermittents "
                              "and save the filtered output to the given file.")
+    parser.add_argument('--log-raw-unexpected', default=None, action="store",
+                        help="Raw structured log messages for unexpected results."
+                             " '--log-raw' Must also be passed in order to use this.")
     return parser
 
 


### PR DESCRIPTION
This makes it easier to run `update-wpt` based on results from the bots by writing a new version of the raw log that filters out all tests with expected results.  Then aggregate this output into the filtered results archive. A future version of this could aggregate all unexpected results that were not filtered as intermittents.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they are infrastructure changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
