### PR TITLE
Add a "shmem" feature to selectors to avoid publishing that dependency

### DIFF
--- a/components/layout_thread/Cargo.toml
+++ b/components/layout_thread/Cargo.toml
@@ -39,7 +39,7 @@ rayon = "1"
 script = { path = "../script" }
 script_layout_interface = { path = "../script_layout_interface" }
 script_traits = { path = "../script_traits" }
-selectors = { path = "../selectors" }
+selectors = { path = "../selectors", features = ["shmem"] }
 serde_json = "1.0"
 servo_allocator = { path = "../allocator" }
 servo_arc = { path = "../servo_arc" }

--- a/components/layout_thread_2020/Cargo.toml
+++ b/components/layout_thread_2020/Cargo.toml
@@ -37,7 +37,7 @@ range = { path = "../range" }
 script = { path = "../script" }
 script_layout_interface = { path = "../script_layout_interface" }
 script_traits = { path = "../script_traits" }
-selectors = { path = "../selectors" }
+selectors = { path = "../selectors", features = ["shmem"] }
 servo_allocator = { path = "../allocator" }
 servo_arc = { path = "../servo_arc" }
 servo_atoms = { path = "../atoms" }

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -37,7 +37,7 @@ hashglobe = { path = "../hashglobe" }
 http = { version = "0.2", optional = true }
 hyper_serde = { version = "0.13", optional = true }
 keyboard-types = { version = "0.6", optional = true }
-selectors = { path = "../selectors" }
+selectors = { path = "../selectors", features = ["shmem"] }
 serde = { version = "1.0.27", optional = true }
 serde_bytes = { version = "0.11", optional = true }
 servo_arc = { path = "../servo_arc" }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -88,7 +88,7 @@ regex = "1.1"
 script_layout_interface = { path = "../script_layout_interface" }
 script_plugins = { path = "../script_plugins" }
 script_traits = { path = "../script_traits" }
-selectors = { path = "../selectors" }
+selectors = { path = "../selectors", features = ["shmem"] }
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 servo-media = { git = "https://github.com/servo/media" }

--- a/components/script_layout_interface/Cargo.toml
+++ b/components/script_layout_interface/Cargo.toml
@@ -30,7 +30,7 @@ parking_lot = "0.11"
 profile_traits = { path = "../profile_traits" }
 range = { path = "../range" }
 script_traits = { path = "../script_traits" }
-selectors = { path = "../selectors" }
+selectors = { path = "../selectors", features = ["shmem"] }
 servo_arc = { path = "../servo_arc" }
 servo_atoms = { path = "../atoms" }
 servo_url = { path = "../url" }

--- a/components/selectors/Cargo.toml
+++ b/components/selectors/Cargo.toml
@@ -16,6 +16,7 @@ path = "lib.rs"
 
 [features]
 bench = []
+shmem = [ "dep:to_shmem", "dep:to_shmem_derive" ]
 
 [dependencies]
 bitflags = "1.0"
@@ -27,8 +28,8 @@ phf = "0.8"
 precomputed-hash = "0.1"
 servo_arc = { version = "0.1", path = "../servo_arc" }
 smallvec = "1.0"
-to_shmem = { path = "../to_shmem" }
-to_shmem_derive = { path = "../to_shmem_derive" }
+to_shmem = { path = "../to_shmem", optional = true }
+to_shmem_derive = { path = "../to_shmem_derive", optional = true }
 
 [build-dependencies]
 phf_codegen = "0.8"

--- a/components/selectors/attr.rs
+++ b/components/selectors/attr.rs
@@ -6,15 +6,16 @@ use crate::parser::SelectorImpl;
 use cssparser::ToCss;
 use std::fmt;
 
-#[derive(Clone, Eq, PartialEq, ToShmem)]
-#[shmem(no_bounds)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "shmem", derive(ToShmem))]
+#[cfg_attr(feature = "shmem", shmem(no_bounds))]
 pub struct AttrSelectorWithOptionalNamespace<Impl: SelectorImpl> {
-    #[shmem(field_bound)]
+    #[cfg_attr(feature = "shmem", shmem(field_bound))]
     pub namespace: Option<NamespaceConstraint<(Impl::NamespacePrefix, Impl::NamespaceUrl)>>,
-    #[shmem(field_bound)]
+    #[cfg_attr(feature = "shmem", shmem(field_bound))]
     pub local_name: Impl::LocalName,
     pub local_name_lower: Impl::LocalName,
-    #[shmem(field_bound)]
+    #[cfg_attr(feature = "shmem", shmem(field_bound))]
     pub operation: ParsedAttrSelectorOperation<Impl::AttrValue>,
     pub never_matches: bool,
 }
@@ -28,7 +29,8 @@ impl<Impl: SelectorImpl> AttrSelectorWithOptionalNamespace<Impl> {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, ToShmem)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "shmem", derive(ToShmem))]
 pub enum NamespaceConstraint<NamespaceUrl> {
     Any,
 
@@ -36,7 +38,8 @@ pub enum NamespaceConstraint<NamespaceUrl> {
     Specific(NamespaceUrl),
 }
 
-#[derive(Clone, Eq, PartialEq, ToShmem)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "shmem", derive(ToShmem))]
 pub enum ParsedAttrSelectorOperation<AttrValue> {
     Exists,
     WithValue {
@@ -76,7 +79,8 @@ impl<AttrValue> AttrSelectorOperation<AttrValue> {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq, ToShmem)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[cfg_attr(feature = "shmem", derive(ToShmem))]
 pub enum AttrSelectorOperator {
     Equal,
     Includes,
@@ -136,7 +140,8 @@ impl AttrSelectorOperator {
 /// The definition of whitespace per CSS Selectors Level 3 § 4.
 pub static SELECTOR_WHITESPACE: &[char] = &[' ', '\t', '\n', '\r', '\x0C'];
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ToShmem)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "shmem", derive(ToShmem))]
 pub enum ParsedCaseSensitivity {
     // 's' was specified.
     ExplicitCaseSensitive,

--- a/components/selectors/builder.rs
+++ b/components/selectors/builder.rs
@@ -193,7 +193,8 @@ fn split_from_end<T>(s: &[T], at: usize) -> (&[T], &[T]) {
 
 bitflags! {
     /// Flags that indicate at which point of parsing a selector are we.
-    #[derive(Default, ToShmem)]
+    #[derive(Default)]
+    #[cfg_attr(feature = "shmem", derive(ToShmem))]
     pub (crate) struct SelectorFlags : u8 {
         const HAS_PSEUDO = 1 << 0;
         const HAS_SLOTTED = 1 << 1;
@@ -201,7 +202,8 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ToShmem)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "shmem", derive(ToShmem))]
 pub struct SpecificityAndFlags {
     /// There are two free bits here, since we use ten bits for each specificity
     /// kind (id, class, element).

--- a/components/selectors/lib.rs
+++ b/components/selectors/lib.rs
@@ -18,7 +18,9 @@ extern crate phf;
 extern crate precomputed_hash;
 extern crate servo_arc;
 extern crate smallvec;
+#[cfg(feature = "shmem")]
 extern crate to_shmem;
+#[cfg(feature = "shmem")]
 #[macro_use]
 extern crate to_shmem_derive;
 

--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -327,10 +327,11 @@ pub trait Parser<'i> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, ToShmem)]
-#[shmem(no_bounds)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "shmem", derive(ToShmem))]
+#[cfg_attr(feature = "shmem", shmem(no_bounds))]
 pub struct SelectorList<Impl: SelectorImpl>(
-    #[shmem(field_bound)] pub SmallVec<[Selector<Impl>; 1]>,
+    #[cfg_attr(feature = "shmem", shmem(field_bound))] pub SmallVec<[Selector<Impl>; 1]>,
 );
 
 /// How to treat invalid selectors in a selector list.
@@ -555,10 +556,12 @@ pub fn namespace_empty_string<Impl: SelectorImpl>() -> Impl::NamespaceUrl {
 ///
 /// This reordering doesn't change the semantics of selector matching, and we
 /// handle it in to_css to make it invisible to serialization.
-#[derive(Clone, Eq, PartialEq, ToShmem)]
-#[shmem(no_bounds)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "shmem", derive(ToShmem))]
+#[cfg_attr(feature = "shmem", shmem(no_bounds))]
 pub struct Selector<Impl: SelectorImpl>(
-    #[shmem(field_bound)] ThinArc<SpecificityAndFlags, Component<Impl>>,
+    #[cfg_attr(feature = "shmem", shmem(field_bound))]
+    ThinArc<SpecificityAndFlags, Component<Impl>>,
 );
 
 impl<Impl: SelectorImpl> Selector<Impl> {
@@ -934,7 +937,8 @@ impl<'a, Impl: SelectorImpl> Iterator for AncestorIter<'a, Impl> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, ToShmem)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "shmem", derive(ToShmem))]
 pub enum Combinator {
     Child,        //  >
     Descendant,   // space
@@ -985,27 +989,28 @@ impl Combinator {
 /// optimal packing and cache performance, see [1].
 ///
 /// [1] https://bugzilla.mozilla.org/show_bug.cgi?id=1357973
-#[derive(Clone, Eq, PartialEq, ToShmem)]
-#[shmem(no_bounds)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "shmem", derive(ToShmem))]
+#[cfg_attr(feature = "shmem", shmem(no_bounds))]
 pub enum Component<Impl: SelectorImpl> {
     Combinator(Combinator),
 
     ExplicitAnyNamespace,
     ExplicitNoNamespace,
-    DefaultNamespace(#[shmem(field_bound)] Impl::NamespaceUrl),
+    DefaultNamespace(#[cfg_attr(feature = "shmem", shmem(field_bound))] Impl::NamespaceUrl),
     Namespace(
-        #[shmem(field_bound)] Impl::NamespacePrefix,
-        #[shmem(field_bound)] Impl::NamespaceUrl,
+        #[cfg_attr(feature = "shmem", shmem(field_bound))] Impl::NamespacePrefix,
+        #[cfg_attr(feature = "shmem", shmem(field_bound))] Impl::NamespaceUrl,
     ),
 
     ExplicitUniversalType,
     LocalName(LocalName<Impl>),
 
-    ID(#[shmem(field_bound)] Impl::Identifier),
-    Class(#[shmem(field_bound)] Impl::Identifier),
+    ID(#[cfg_attr(feature = "shmem", shmem(field_bound))] Impl::Identifier),
+    Class(#[cfg_attr(feature = "shmem", shmem(field_bound))] Impl::Identifier),
 
     AttributeInNoNamespaceExists {
-        #[shmem(field_bound)]
+        #[cfg_attr(feature = "shmem", shmem(field_bound))]
         local_name: Impl::LocalName,
         local_name_lower: Impl::LocalName,
     },
@@ -1013,7 +1018,7 @@ pub enum Component<Impl: SelectorImpl> {
     AttributeInNoNamespace {
         local_name: Impl::LocalName,
         operator: AttrSelectorOperator,
-        #[shmem(field_bound)]
+        #[cfg_attr(feature = "shmem", shmem(field_bound))]
         value: Impl::AttrValue,
         case_sensitivity: ParsedCaseSensitivity,
         never_matches: bool,
@@ -1036,7 +1041,7 @@ pub enum Component<Impl: SelectorImpl> {
     FirstOfType,
     LastOfType,
     OnlyOfType,
-    NonTSPseudoClass(#[shmem(field_bound)] Impl::NonTSPseudoClass),
+    NonTSPseudoClass(#[cfg_attr(feature = "shmem", shmem(field_bound))] Impl::NonTSPseudoClass),
     /// The ::slotted() pseudo-element:
     ///
     /// https://drafts.csswg.org/css-scoping/#slotted-pseudo
@@ -1051,7 +1056,7 @@ pub enum Component<Impl: SelectorImpl> {
     Slotted(Selector<Impl>),
     /// The `::part` pseudo-element.
     ///   https://drafts.csswg.org/css-shadow-parts/#part
-    Part(#[shmem(field_bound)] Box<[Impl::Identifier]>),
+    Part(#[cfg_attr(feature = "shmem", shmem(field_bound))] Box<[Impl::Identifier]>),
     /// The `:host` pseudo-class:
     ///
     /// https://drafts.csswg.org/css-scoping/#host-selector
@@ -1076,7 +1081,7 @@ pub enum Component<Impl: SelectorImpl> {
     /// Same comment as above re. the argument.
     Is(Box<[Selector<Impl>]>),
     /// An implementation-dependent pseudo-element selector.
-    PseudoElement(#[shmem(field_bound)] Impl::PseudoElement),
+    PseudoElement(#[cfg_attr(feature = "shmem", shmem(field_bound))] Impl::PseudoElement),
 }
 
 impl<Impl: SelectorImpl> Component<Impl> {
@@ -1219,10 +1224,11 @@ impl<Impl: SelectorImpl> Component<Impl> {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, ToShmem)]
-#[shmem(no_bounds)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "shmem", derive(ToShmem))]
+#[cfg_attr(feature = "shmem", shmem(no_bounds))]
 pub struct LocalName<Impl: SelectorImpl> {
-    #[shmem(field_bound)]
+    #[cfg_attr(feature = "shmem", shmem(field_bound))]
     pub name: Impl::LocalName,
     pub lower_name: Impl::LocalName,
 }

--- a/components/style/Cargo.toml
+++ b/components/style/Cargo.toml
@@ -59,7 +59,7 @@ owning_ref = "0.4"
 parking_lot = "0.11"
 precomputed-hash = "0.1.1"
 rayon = "1"
-selectors = { path = "../selectors" }
+selectors = { path = "../selectors", features = ["shmem"]  }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 servo_arc = { path = "../servo_arc" }
 servo_atoms = { path = "../atoms", optional = true }

--- a/components/style_traits/Cargo.toml
+++ b/components/style_traits/Cargo.toml
@@ -21,7 +21,7 @@ euclid = "0.22"
 lazy_static = "1"
 malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = "0.1"
-selectors = { path = "../selectors" }
+selectors = { path = "../selectors", features = ["shmem"] }
 serde = "1.0"
 servo_arc = { path = "../servo_arc" }
 servo_atoms = { path = "../atoms", optional = true }

--- a/tests/unit/style/Cargo.toml
+++ b/tests/unit/style/Cargo.toml
@@ -16,7 +16,7 @@ euclid = "0.22"
 html5ever = "0.26"
 rayon = "1"
 serde_json = "1.0"
-selectors = {path = "../../../components/selectors"}
+selectors = {path = "../../../components/selectors", features = ["shmem"] }
 servo_arc = {path = "../../../components/servo_arc"}
 servo_atoms = {path = "../../../components/atoms"}
 servo_config = {path = "../../../components/config"}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Hopefully as a way to help #29105, this PR adds a `shmem` feature to the selectors crate.  This is so that the crate can be released with that feature off by default, as the `ToShmem` derives are only of interest to Servo, I think.

All the places where servo's source code includes the selectors crate are made to turn on this feature.