### PR TITLE
HACKING_QUICKSTART: update vscode guide

### DIFF
--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -138,23 +138,29 @@ For more details about overriding dependencies, see [Cargo's documentation](http
 
 ### Visual Studio Code
 
-Running plain `cargo` will cause problems! This is because the rustflags (flags passed to the rust compiler) that
-standard `cargo` provides are different to what `./mach` uses, and so every time Servo is built using `cargo` it will
-undo all the work done by `./mach` (and vice versa).
+Running plain `cargo` will cause problems! For example, you might get rust-analyzer extension errors
+about build scripts like
+
+* The style crate requires enabling one of its 'servo' or 'gecko' feature flags and, in the 'servo'
+  case, one of 'servo-layout-2013' or 'servo-layout-2020'.
+
+* (if you are on NixOS) thread 'main' panicked at 'called \`Result::unwrap()\` on an \`Err\` value:
+  "Could not run \`PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=\\"1\\" PKG_CONFIG_ALLOW_SYSTEM_LIBS=\\"1\\"
+  \\"pkg-config\\" \\"--libs\\" \\"--cflags\\" \\"fontconfig\\"\`
+
+This is because the rustflags (flags passed to the rust compiler) that standard `cargo` provides are
+different to what `./mach` uses, and so every time Servo is built using `cargo` it will undo all the
+work done by `./mach` (and vice versa).
 
 You can override this in a `.vscode/settings.json` file:
 
 ```
 {
-    "rust-analyzer.checkOnSave.overrideCommand": [
-        "./mach",
-        "check",
-        "--message-format=json",
-    ],
-    "rust-analyzer.rustfmt.overrideCommand": [
-        "./mach",
-        "fmt"
-    ],
+    "rust-analyzer.check.overrideCommand": [
+        "./mach", "check", "--message-format=json" ],
+    "rust-analyzer.cargo.buildScripts.overrideCommand": [
+        "./mach", "check", "--message-format=json" ],
+    "rust-analyzer.rustfmt.overrideCommand": [ "./mach", "fmt" ],
 }
 ```
 
@@ -164,18 +170,15 @@ the amount of disc space used).
 ```
 {
     "rust-analyzer.checkOnSave.overrideCommand": [
-        "./mach",
-        "check",
-        "--message-format=json",
-        "--target-dir",
-        "target/lsp"
-    ],
-    "rust-analyzer.rustfmt.overrideCommand": [
-        "./mach",
-        "fmt"
-    ],
+        "./mach", "check", "--message-format=json", "--target-dir", "target/lsp" ],
+    "rust-analyzer.cargo.buildScripts.overrideCommand": [
+        "./mach", "check", "--message-format=json", "--target-dir", "target/lsp" ],
+    "rust-analyzer.rustfmt.overrideCommand": [ "./mach", "fmt" ],
 }
 ```
+
+If you are on NixOS, these settings should be enough to not need to run `code .` from within a
+`nix-shell etc/shell.nix`, but it wouldn’t hurt to try that if you still have problems.
 
 ## Debugging
 


### PR DESCRIPTION
This patch updates the vscode section of the hacking quickstart guide to:

* provide examples of errors that happen if vscode is misconfigured
* use the current rust-analyzer settings ids
* tell rust-analyzer to use mach for build scripts


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they only affect documentation