### PR TITLE
Revert #29331 (Bump exr from 1.5.1 to 1.5.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
  "font-kit",
  "gfx",
  "gleam 0.12.1",
- "half 1.8.2",
+ "half",
  "ipc-channel",
  "log",
  "lyon_geom 1.0.4",
@@ -1192,12 +1192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,18 +1662,17 @@ dependencies = [
 
 [[package]]
 name = "exr"
-version = "1.5.3"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8af5ef47e2ed89d23d0ecbc1b681b30390069de70260937877514377fc24feb"
+checksum = "c9a7880199e74c6d3fe45579df2f436c5913a71405494cb89d59234d86b47dc5"
 dependencies = [
  "bit_field",
  "flume",
- "half 2.2.1",
+ "half",
  "lebe",
- "miniz_oxide 0.6.2",
+ "miniz_oxide 0.5.4",
  "smallvec",
  "threadpool",
- "zune-inflate",
 ]
 
 [[package]]
@@ -2684,15 +2677,6 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
-
-[[package]]
-name = "half"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
-dependencies = [
- "crunchy",
-]
 
 [[package]]
 name = "harfbuzz-sys"
@@ -6054,12 +6038,6 @@ version = "0.1.0"
 source = "git+https://github.com/pcwalton/signpost.git#7ed712507f343c38646b9d1fefd049166f9c9a18"
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a5df39617d7c8558154693a1bb8157a4aab8179209540cc0b10e5dc24e0b18"
-
-[[package]]
 name = "simpleservo"
 version = "0.0.1"
 dependencies = [
@@ -7784,13 +7762,4 @@ dependencies = [
  "msdos_time",
  "podio",
  "time",
-]
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c473377c11c4a3ac6a2758f944cd336678e9c977aa0abf54f6450cf77e902d6d"
-dependencies = [
- "simd-adler32",
 ]


### PR DESCRIPTION
This reverts commit 8a8a5879088f8ed8220145661a57fe7e63f003ac, reversing changes made to a01035e6fdeae7ead2304dafe8df8f6e4c6a0734.

Reason: breaks tidy:

```
./Cargo.lock:1: duplicate versions for package `half`
	The following packages depend on version 1.8.2 from 'crates.io':
		canvas 0.0.1
	The following packages depend on version 2.2.1 from 'crates.io':
		exr 1.5.3
```

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they only affect dependency versions

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->