### PR TITLE
Warning instead of exception on unsupported Ubuntu

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -250,7 +250,7 @@ def get_linux_distribution():
         distrib, version = 'Ubuntu', base_version
     elif distrib.lower() == 'ubuntu':
         if version > '22.04':
-            raise Exception('unsupported version of %s: %s' % (distrib, version))
+            print('WARNING: unsupported version of %s: %s' % (distrib, version))
     # Fixme: we should allow checked/supported versions only
     elif distrib.lower() not in [
         'centos',


### PR DESCRIPTION
For someone who is always using latest stable Ubuntu version it is pretty annoying to change the script every time, so issuing a warning instead of error would still allow users on unsupported version to continue bootstrapping.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because changes are in bootstrap script

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
