### PR TITLE
remaining components to edition 2018 & cargo-fix & cargo-clippy in mach

### DIFF
--- a/components/derive_common/Cargo.toml
+++ b/components/derive_common/Cargo.toml
@@ -3,6 +3,7 @@ name = "derive_common"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
+edition = "2018"
 publish = false
 
 [lib]

--- a/components/derive_common/cg.rs
+++ b/components/derive_common/cg.rs
@@ -4,8 +4,8 @@
 
 use darling::{FromDeriveInput, FromField, FromVariant};
 use proc_macro2::{Span, TokenStream};
-use quote::TokenStreamExt;
-use syn::{self, AngleBracketedGenericArguments, Binding, DeriveInput, Field};
+use quote::{quote, TokenStreamExt};
+use syn::{self, parse_quote, AngleBracketedGenericArguments, Binding, DeriveInput, Field};
 use syn::{GenericArgument, GenericParam, Ident, Path};
 use syn::{PathArguments, PathSegment, QSelf, Type, TypeArray, TypeGroup};
 use syn::{TypeParam, TypeParen, TypePath, TypeSlice, TypeTuple};

--- a/components/derive_common/lib.rs
+++ b/components/derive_common/lib.rs
@@ -2,12 +2,4 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-extern crate darling;
-extern crate proc_macro2;
-#[macro_use]
-extern crate quote;
-#[macro_use]
-extern crate syn;
-extern crate synstructure;
-
 pub mod cg;

--- a/components/dom_struct/Cargo.toml
+++ b/components/dom_struct/Cargo.toml
@@ -2,6 +2,7 @@
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 name = "dom_struct"
+edition = "2018"
 publish = false
 version = "0.0.1"
 

--- a/components/dom_struct/lib.rs
+++ b/components/dom_struct/lib.rs
@@ -2,12 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-extern crate proc_macro;
-#[macro_use]
-extern crate quote;
-extern crate syn;
-
 use proc_macro::TokenStream;
+use quote::quote;
 use syn::*;
 
 #[proc_macro_attribute]

--- a/components/fallible/Cargo.toml
+++ b/components/fallible/Cargo.toml
@@ -3,6 +3,7 @@ name = "fallible"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
+edition = "2018"
 publish = false
 
 [lib]

--- a/components/fallible/lib.rs
+++ b/components/fallible/lib.rs
@@ -2,9 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-extern crate hashglobe;
-extern crate smallvec;
-
 #[cfg(feature = "known_system_malloc")]
 use hashglobe::alloc;
 use hashglobe::FailedAllocationError;

--- a/components/hashglobe/Cargo.toml
+++ b/components/hashglobe/Cargo.toml
@@ -7,6 +7,7 @@ description = "Fork of std::HashMap with stable fallible allocation."
 documentation = "https://docs.rs/hashglobe"
 repository = "https://github.com/Manishearth/hashglobe"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 libc = "0.2"

--- a/components/hashglobe/src/hash_map.rs
+++ b/components/hashglobe/src/hash_map.rs
@@ -2218,7 +2218,7 @@ mod test_map {
     use super::Entry::{Occupied, Vacant};
     use super::HashMap;
     use super::RandomState;
-    use cell::RefCell;
+    use std::cell::RefCell;
 
     #[test]
     fn test_zero_capacities() {

--- a/components/hashglobe/src/hash_set.rs
+++ b/components/hashglobe/src/hash_set.rs
@@ -1577,7 +1577,7 @@ mod test_set {
 
     #[test]
     fn test_replace() {
-        use hash;
+        use std::hash;
 
         #[derive(Debug)]
         struct Foo(&'static str, i32);

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -3,6 +3,7 @@ name = "malloc_size_of"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
+edition = "2018"
 publish = false
 
 [lib]

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -47,45 +47,6 @@
 //!   publishing this crate on crates.io.
 
 #[cfg(feature = "servo")]
-extern crate accountable_refcell;
-extern crate app_units;
-#[cfg(feature = "servo")]
-extern crate content_security_policy;
-#[cfg(feature = "servo")]
-extern crate crossbeam_channel;
-extern crate cssparser;
-extern crate euclid;
-extern crate hashglobe;
-#[cfg(feature = "servo")]
-extern crate http;
-#[cfg(feature = "servo")]
-extern crate hyper_serde;
-#[cfg(feature = "servo")]
-extern crate keyboard_types;
-extern crate selectors;
-#[cfg(feature = "servo")]
-extern crate serde;
-#[cfg(feature = "servo")]
-extern crate serde_bytes;
-extern crate servo_arc;
-extern crate smallbitvec;
-extern crate smallvec;
-#[cfg(feature = "servo")]
-extern crate string_cache;
-extern crate thin_slice;
-#[cfg(feature = "servo")]
-extern crate time;
-#[cfg(feature = "url")]
-extern crate url;
-#[cfg(feature = "servo")]
-extern crate uuid;
-extern crate void;
-#[cfg(feature = "webrender_api")]
-extern crate webrender_api;
-#[cfg(feature = "servo")]
-extern crate xml5ever;
-
-#[cfg(feature = "servo")]
 use content_security_policy as csp;
 #[cfg(feature = "servo")]
 use serde_bytes::ByteBuf;

--- a/components/script_plugins/Cargo.toml
+++ b/components/script_plugins/Cargo.toml
@@ -3,6 +3,7 @@ name = "script_plugins"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
+edition = "2018"
 publish = false
 
 [lib]

--- a/components/selectors/Cargo.toml
+++ b/components/selectors/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["css", "selectors"]
 license = "MPL-2.0"
 build = "build.rs"
+edition = "2018"
 
 [lib]
 name = "selectors"

--- a/components/selectors/attr.rs
+++ b/components/selectors/attr.rs
@@ -5,6 +5,8 @@
 use crate::parser::SelectorImpl;
 use cssparser::ToCss;
 use std::fmt;
+#[cfg(feature = "shmem")]
+use to_shmem_derive::ToShmem;
 
 #[derive(Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "shmem", derive(ToShmem))]

--- a/components/selectors/build.rs
+++ b/components/selectors/build.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-extern crate phf_codegen;
-
 use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};

--- a/components/selectors/builder.rs
+++ b/components/selectors/builder.rs
@@ -19,12 +19,16 @@
 
 use crate::parser::{Combinator, Component, SelectorImpl};
 use crate::sink::Push;
+use bitflags::bitflags;
+use derive_more::{Add, AddAssign};
 use servo_arc::{Arc, HeaderWithLength, ThinArc};
 use smallvec::{self, SmallVec};
 use std::cmp;
 use std::iter;
 use std::ptr;
 use std::slice;
+#[cfg(feature = "shmem")]
+use to_shmem_derive::ToShmem;
 
 /// Top-level SelectorBuilder struct. This should be stack-allocated by the
 /// consumer and never moved (because it contains a lot of inline data that

--- a/components/selectors/lib.rs
+++ b/components/selectors/lib.rs
@@ -5,25 +5,6 @@
 // Make |cargo bench| work.
 #![cfg_attr(feature = "bench", feature(test))]
 
-#[macro_use]
-extern crate bitflags;
-#[macro_use]
-extern crate cssparser;
-#[macro_use]
-extern crate derive_more;
-extern crate fxhash;
-#[macro_use]
-extern crate log;
-extern crate phf;
-extern crate precomputed_hash;
-extern crate servo_arc;
-extern crate smallvec;
-#[cfg(feature = "shmem")]
-extern crate to_shmem;
-#[cfg(feature = "shmem")]
-#[macro_use]
-extern crate to_shmem_derive;
-
 pub mod attr;
 pub mod bloom;
 mod builder;

--- a/components/selectors/matching.rs
+++ b/components/selectors/matching.rs
@@ -8,6 +8,8 @@ use crate::nth_index_cache::NthIndexCacheInner;
 use crate::parser::{AncestorHashes, Combinator, Component, LocalName};
 use crate::parser::{NonTSPseudoClass, Selector, SelectorImpl, SelectorIter, SelectorList};
 use crate::tree::Element;
+use bitflags::bitflags;
+use log::debug;
 use smallvec::SmallVec;
 use std::borrow::Borrow;
 use std::iter;

--- a/components/selectors/parser.rs
+++ b/components/selectors/parser.rs
@@ -10,7 +10,8 @@ use crate::builder::{SelectorBuilder, SelectorFlags, SpecificityAndFlags};
 use crate::context::QuirksMode;
 use crate::sink::Push;
 pub use crate::visitor::SelectorVisitor;
-use cssparser::parse_nth;
+use bitflags::bitflags;
+use cssparser::{match_ignore_ascii_case, parse_nth, *};
 use cssparser::{BasicParseError, BasicParseErrorKind, ParseError, ParseErrorKind};
 use cssparser::{CowRcStr, Delimiter, SourceLocation};
 use cssparser::{Parser as CssParser, ToCss, Token};
@@ -21,6 +22,8 @@ use std::borrow::{Borrow, Cow};
 use std::fmt::{self, Debug};
 use std::iter::Rev;
 use std::slice;
+#[cfg(feature = "shmem")]
+use to_shmem_derive::ToShmem;
 
 /// A trait that represents a pseudo-element.
 pub trait PseudoElement: Sized + ToCss {

--- a/components/servo_arc/Cargo.toml
+++ b/components/servo_arc/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/servo"
 description = "A fork of std::sync::Arc with some extra functionality and without weak references"
+edition = "2018"
 
 [lib]
 name = "servo_arc"

--- a/components/servo_arc/lib.rs
+++ b/components/servo_arc/lib.rs
@@ -25,11 +25,6 @@
 // duplicate those here.
 #![allow(missing_docs)]
 
-extern crate nodrop;
-#[cfg(feature = "servo")]
-extern crate serde;
-extern crate stable_deref_trait;
-
 use nodrop::NoDrop;
 #[cfg(feature = "servo")]
 use serde::{Deserialize, Serialize};

--- a/components/size_of_test/Cargo.toml
+++ b/components/size_of_test/Cargo.toml
@@ -3,6 +3,7 @@ name = "size_of_test"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
+edition = "2018"
 publish = false
 
 [lib]

--- a/components/std_test_override/Cargo.toml
+++ b/components/std_test_override/Cargo.toml
@@ -3,6 +3,7 @@ name = "std_test_override"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
+edition = "2018"
 publish = false
 
 [lib]

--- a/components/std_test_override/lib.rs
+++ b/components/std_test_override/lib.rs
@@ -4,7 +4,6 @@
 
 #![feature(test)]
 
-extern crate embedder_traits;
 extern crate test;
 
 pub use test::*;

--- a/components/style_derive/Cargo.toml
+++ b/components/style_derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "style_derive"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
+edition = "2018"
 publish = false
 
 [lib]

--- a/components/style_derive/animate.rs
+++ b/components/style_derive/animate.rs
@@ -3,10 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use darling::util::PathList;
+use darling::FromDeriveInput;
+use darling::FromField;
+use darling::FromVariant;
 use derive_common::cg;
 use proc_macro2::TokenStream;
+use quote::quote;
 use quote::TokenStreamExt;
-use syn::{DeriveInput, WhereClause};
+use syn::{parse_quote, DeriveInput, WhereClause};
 use synstructure::{Structure, VariantInfo};
 
 pub fn derive(mut input: DeriveInput) -> TokenStream {

--- a/components/style_derive/compute_squared_distance.rs
+++ b/components/style_derive/compute_squared_distance.rs
@@ -3,10 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::animate::{AnimationFieldAttrs, AnimationInputAttrs, AnimationVariantAttrs};
+use darling::FromField;
 use derive_common::cg;
 use proc_macro2::TokenStream;
+use quote::quote;
 use quote::TokenStreamExt;
-use syn::{DeriveInput, WhereClause};
+use syn::{parse_quote, DeriveInput, WhereClause};
 use synstructure;
 
 pub fn derive(mut input: DeriveInput) -> TokenStream {

--- a/components/style_derive/lib.rs
+++ b/components/style_derive/lib.rs
@@ -4,17 +4,6 @@
 
 #![recursion_limit = "128"]
 
-#[macro_use]
-extern crate darling;
-extern crate derive_common;
-extern crate proc_macro;
-extern crate proc_macro2;
-#[macro_use]
-extern crate quote;
-#[macro_use]
-extern crate syn;
-extern crate synstructure;
-
 use proc_macro::TokenStream;
 
 mod animate;

--- a/components/style_derive/parse.rs
+++ b/components/style_derive/parse.rs
@@ -3,8 +3,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::to_css::CssVariantAttrs;
+use darling::FromField;
+use darling::FromVariant;
 use derive_common::cg;
 use proc_macro2::TokenStream;
+use quote::quote;
+use syn::parse_quote;
 use syn::{self, DeriveInput, Path};
 use synstructure::{Structure, VariantInfo};
 
@@ -54,7 +58,7 @@ fn parse_non_keyword_variant(
         }
     } else {
         quote! {
-            if let Ok(v) = input.try(|i| <#ty as crate::parser::Parse>::parse(context, i)) {
+            if let Ok(v) = input.r#try(|i| <#ty as crate::parser::Parse>::parse(context, i)) {
                 return Ok(#name::#variant_name(v));
             }
         }

--- a/components/style_derive/specified_value_info.rs
+++ b/components/style_derive/specified_value_info.rs
@@ -4,10 +4,14 @@
 
 use crate::parse::ParseVariantAttrs;
 use crate::to_css::{CssFieldAttrs, CssInputAttrs, CssVariantAttrs};
+use darling::FromDeriveInput;
+use darling::FromField;
+use darling::FromVariant;
 use derive_common::cg;
 use proc_macro2::TokenStream;
+use quote::quote;
 use quote::TokenStreamExt;
-use syn::{Data, DeriveInput, Fields, Ident, Type};
+use syn::{parse_quote, Data, DeriveInput, Fields, Ident, Type};
 
 pub fn derive(mut input: DeriveInput) -> TokenStream {
     let css_attrs = cg::parse_input_attrs::<CssInputAttrs>(&input);

--- a/components/style_derive/to_animated_value.rs
+++ b/components/style_derive/to_animated_value.rs
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::to_computed_value;
 use proc_macro2::TokenStream;
-use syn::DeriveInput;
+use quote::quote;
+use syn::{parse_quote, DeriveInput};
 use synstructure::BindStyle;
-use to_computed_value;
 
 pub fn derive(input: DeriveInput) -> TokenStream {
     let trait_impl = |from_body, to_body| {

--- a/components/style_derive/to_animated_zero.rs
+++ b/components/style_derive/to_animated_zero.rs
@@ -5,8 +5,9 @@
 use crate::animate::{AnimationFieldAttrs, AnimationInputAttrs, AnimationVariantAttrs};
 use derive_common::cg;
 use proc_macro2::TokenStream;
+use quote::quote;
 use quote::TokenStreamExt;
-use syn;
+use syn::{self, parse_quote};
 use synstructure;
 
 pub fn derive(mut input: syn::DeriveInput) -> TokenStream {

--- a/components/style_derive/to_computed_value.rs
+++ b/components/style_derive/to_computed_value.rs
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use darling::FromField;
 use derive_common::cg;
 use proc_macro2::TokenStream;
+use quote::quote;
+use syn::parse_quote;
 use syn::{DeriveInput, Ident, Path};
 use synstructure::{BindStyle, BindingInfo};
 

--- a/components/style_derive/to_css.rs
+++ b/components/style_derive/to_css.rs
@@ -3,9 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use darling::util::Override;
+use darling::FromDeriveInput;
+use darling::FromField;
+use darling::FromVariant;
 use derive_common::cg;
 use proc_macro2::TokenStream;
+use quote::quote;
 use quote::{ToTokens, TokenStreamExt};
+use syn::parse_quote;
 use syn::{self, Data, Path, WhereClause};
 use synstructure::{BindingInfo, Structure, VariantInfo};
 

--- a/components/style_derive/to_resolved_value.rs
+++ b/components/style_derive/to_resolved_value.rs
@@ -2,11 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::to_computed_value;
+use darling::FromField;
 use derive_common::cg;
 use proc_macro2::TokenStream;
-use syn::DeriveInput;
+use quote::quote;
+use syn::{parse_quote, DeriveInput};
 use synstructure::BindStyle;
-use to_computed_value;
 
 pub fn derive(input: DeriveInput) -> TokenStream {
     let trait_impl = |from_body, to_body| {

--- a/components/style_traits/Cargo.toml
+++ b/components/style_traits/Cargo.toml
@@ -3,6 +3,7 @@ name = "style_traits"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
+edition = "2018"
 publish = false
 
 [lib]

--- a/components/style_traits/arc_slice.rs
+++ b/components/style_traits/arc_slice.rs
@@ -4,12 +4,14 @@
 
 //! A thin atomically-reference-counted slice.
 
+use lazy_static::lazy_static;
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 use servo_arc::ThinArc;
 use std::ops::Deref;
 use std::ptr::NonNull;
 use std::{iter, mem};
+use to_shmem_derive::ToShmem;
 
 /// A canary that we stash in ArcSlices.
 ///

--- a/components/style_traits/dom.rs
+++ b/components/style_traits/dom.rs
@@ -4,6 +4,9 @@
 
 //! Types used to access the DOM from style calculation.
 
+use malloc_size_of_derive::MallocSizeOf;
+use serde::{Deserialize, Serialize};
+
 /// An opaque handle to a node, which, unlike UnsafeNode, cannot be transformed
 /// back into a non-opaque representation. The only safe operation that can be
 /// performed on this node is to compare it to another opaque handle or to another

--- a/components/style_traits/lib.rs
+++ b/components/style_traits/lib.rs
@@ -10,30 +10,9 @@
 #![crate_type = "rlib"]
 #![deny(unsafe_code, missing_docs)]
 
-extern crate app_units;
-#[macro_use]
-extern crate bitflags;
-#[macro_use]
-extern crate cssparser;
-extern crate euclid;
-#[macro_use]
-extern crate lazy_static;
-extern crate malloc_size_of;
-#[macro_use]
-extern crate malloc_size_of_derive;
-extern crate selectors;
-#[macro_use]
-extern crate serde;
-extern crate servo_arc;
-#[cfg(feature = "servo")]
-extern crate servo_atoms;
-#[cfg(feature = "servo")]
-extern crate servo_url;
-extern crate to_shmem;
-#[macro_use]
-extern crate to_shmem_derive;
-#[cfg(feature = "servo")]
-extern crate webrender_api;
+use bitflags::bitflags;
+use malloc_size_of_derive::MallocSizeOf;
+use serde::{Deserialize, Serialize};
 #[cfg(feature = "servo")]
 pub use webrender_api::units::DevicePixel;
 

--- a/components/style_traits/owned_str.rs
+++ b/components/style_traits/owned_str.rs
@@ -7,8 +7,10 @@
 //! A replacement for `Box<str>` that has a defined layout for FFI.
 
 use crate::owned_slice::OwnedSlice;
+use malloc_size_of_derive::MallocSizeOf;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
+use to_shmem_derive::ToShmem;
 
 /// A struct that basically replaces a Box<str>, but with a defined layout,
 /// suitable for FFI.

--- a/components/style_traits/viewport.rs
+++ b/components/style_traits/viewport.rs
@@ -5,9 +5,12 @@
 //! Helper types for the `@viewport` rule.
 
 use crate::{CSSPixel, CssWriter, ParseError, PinchZoomFactor, ToCss};
-use cssparser::Parser;
+use cssparser::*;
 use euclid::Size2D;
+use malloc_size_of_derive::MallocSizeOf;
+use serde::{Deserialize, Serialize};
 use std::fmt::{self, Write};
+use to_shmem_derive::ToShmem;
 
 define_css_keyword_enum! {
     pub enum UserZoom {
@@ -114,7 +117,6 @@ impl Zoom {
     pub fn parse<'i, 't>(input: &mut Parser<'i, 't>) -> Result<Zoom, ParseError<'i>> {
         use crate::values::specified::AllowedNumericType::NonNegative;
         use crate::ParsingMode;
-        use cssparser::Token;
 
         let location = input.current_source_location();
         match *input.next()? {

--- a/components/to_shmem/Cargo.toml
+++ b/components/to_shmem/Cargo.toml
@@ -3,6 +3,7 @@ name = "to_shmem"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
+edition = "2018"
 publish = false
 
 [lib]

--- a/components/to_shmem/lib.rs
+++ b/components/to_shmem/lib.rs
@@ -12,14 +12,6 @@
 #![crate_name = "to_shmem"]
 #![crate_type = "rlib"]
 
-extern crate cssparser;
-extern crate servo_arc;
-extern crate smallbitvec;
-extern crate smallvec;
-#[cfg(feature = "string_cache")]
-extern crate string_cache;
-extern crate thin_slice;
-
 use servo_arc::{Arc, ThinArc};
 use smallbitvec::{InternalStorage, SmallBitVec};
 use smallvec::{Array, SmallVec};

--- a/components/to_shmem_derive/Cargo.toml
+++ b/components/to_shmem_derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "to_shmem_derive"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
+edition = "2018"
 publish = false
 
 [lib]

--- a/components/to_shmem_derive/lib.rs
+++ b/components/to_shmem_derive/lib.rs
@@ -4,17 +4,6 @@
 
 #![recursion_limit = "128"]
 
-#[macro_use]
-extern crate darling;
-extern crate derive_common;
-extern crate proc_macro;
-extern crate proc_macro2;
-#[macro_use]
-extern crate quote;
-#[macro_use]
-extern crate syn;
-extern crate synstructure;
-
 use proc_macro::TokenStream;
 
 mod to_shmem;

--- a/components/to_shmem_derive/to_shmem.rs
+++ b/components/to_shmem_derive/to_shmem.rs
@@ -2,9 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use darling::{FromDeriveInput, FromField};
 use derive_common::cg;
 use proc_macro2::TokenStream;
-use syn;
+use quote::quote;
+use syn::{self, parse_quote};
 use synstructure::{BindStyle, Structure};
 
 pub fn derive(mut input: syn::DeriveInput) -> TokenStream {

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -178,6 +178,54 @@ class MachCommands(CommandBase):
         self.ensure_bootstrapped()
         return self.call_rustup_run(["rustc"] + params, env=self.build_env())
 
+    @Command('cargo-fix',
+             description='Run "cargo fix"',
+             category='devenv')
+    @CommandArgument(
+        'params', default=None, nargs='...',
+        help="Command-line arguments to be passed through to cargo-fix")
+    @CommandBase.build_like_command_arguments
+    def cargo_fix(self, params, features=[], media_stack=None, target=None,
+                  android=False, magicleap=False, **kwargs):
+        if not params:
+            params = []
+
+        features = features or []
+
+        target, android = self.pick_target_triple(target, android, magicleap)
+
+        features += self.pick_media_stack(media_stack, target)
+
+        self.ensure_bootstrapped(target=target)
+        self.ensure_clobbered()
+        env = self.build_env()
+
+        return self.run_cargo_build_like_command("fix", params, env=env, features=features, **kwargs)
+
+    @Command('cargo-clippy',
+             description='Run "cargo clippy"',
+             category='devenv')
+    @CommandArgument(
+        'params', default=None, nargs='...',
+        help="Command-line arguments to be passed through to cargo-clippy")
+    @CommandBase.build_like_command_arguments
+    def cargo_clippy(self, params, features=[], media_stack=None, target=None,
+                     android=False, magicleap=False, **kwargs):
+        if not params:
+            params = []
+
+        features = features or []
+
+        target, android = self.pick_target_triple(target, android, magicleap)
+
+        features += self.pick_media_stack(media_stack, target)
+
+        self.ensure_bootstrapped(target=target)
+        self.ensure_clobbered()
+        env = self.build_env()
+
+        return self.run_cargo_build_like_command("clippy", params, env=env, features=features, **kwargs)
+
     @Command('grep',
              description='`git grep` for selected directories.',
              category='devenv')


### PR DESCRIPTION
Added `cargo fix` and `cargo clippy` wrappers to mach and upgrade remaining components to edition 2018. Currently there are only two `Cargo.toml` (three if you count workspace) that are still on 2015 edition, but they are not in components directory.

In the future we should migrate to workspace inheritance and edition 2021.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because are not functional changes.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
