### PR TITLE
 Do not run specialized workflow on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   upload-docs:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
     name: Upload docs to GitHub Pages
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/nightly-rust.yml
+++ b/.github/workflows/nightly-rust.yml
@@ -12,6 +12,8 @@ env:
 
 jobs:
   build-linux-with-rust-nightly:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
     name: Build (Linux) + rustc nightly
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,8 @@ env:
 
 jobs:
   upload-linux:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
     name: Upload nightly (Linux)
     runs-on: ubuntu-20.04
     steps:
@@ -33,6 +35,8 @@ jobs:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
 
   upload-mac:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
     name: Upload nightly (macOS)
     runs-on: macos-12
     steps:
@@ -74,6 +78,8 @@ jobs:
           GITHUB_HOMEBREW_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
 
   upload-win:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
     name: Upload nightly (Windows)
     runs-on: windows-2019
     steps:

--- a/.github/workflows/upstream-wpt-changes.yml
+++ b/.github/workflows/upstream-wpt-changes.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   upstream:
+    # Run job only on servo/servo
+    if: github.repository == 'servo/servo'
     runs-on: ubuntu-latest
     steps:
       - name: Calculate PR fetch depth

--- a/.github/workflows/wpt-nightly.yml
+++ b/.github/workflows/wpt-nightly.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build-linux:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
     name: Build on Linux
     runs-on: ubuntu-20.04
     steps:
@@ -36,6 +38,8 @@ jobs:
           path: target.tar.gz
 
   linux-wpt:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
     name: Linux WPT Tests
     runs-on: ubuntu-20.04
     needs: ["build-linux"]
@@ -82,6 +86,8 @@ jobs:
             wpt-jsonsummary.${{ matrix.chunk_id }}.log
 
   sync:
+    # This job is only useful when run on upstream servo.
+    if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
     name: Synchronize WPT Nightly
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
Per #29379 to make GitHub actions more fork-friendly.

I have not decided yet on how to handle main workflow, as I started to like my `git push origin HEAD:try --force` workflow, but using CI on all forks branches would also help enforce the [rule](https://github.com/servo/servo/blob/master/CONTRIBUTING.md#pull-request-checklist):
> Commits should be as small as possible, while ensuring that each commit is correct independently (i.e., each commit should compile and pass tests).


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes partially fix #29379 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it is only CI stuff

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
