### PR TITLE
intermittent dashboard: Actually send results to the dashboard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -218,6 +218,8 @@ jobs:
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
             --log-raw-unexpected unexpected-test-wpt.${{ matrix.chunk_id }}.log \
             --filter-intermittents filtered-test-wpt.${{ matrix.chunk_id }}.json
+        env:
+          INTERMITTENT_TRACKER_DASHBOARD_SECRET: ${{ secrets.INTERMITTENT_TRACKER_DASHBOARD_SECRET }}
       - name: Archive filtered results
         uses: actions/upload-artifact@v3
         if: ${{ always() }}


### PR DESCRIPTION
This change adds the secret to the environment, which should trigger the filtering intermittents script to actually upload new results to the intermittent dashboard instead of simply querying.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just adjust the CI environment.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
