### PR TITLE
CI: pass github context to linux-wpt job in main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -219,6 +219,7 @@ jobs:
             --log-raw-unexpected unexpected-test-wpt.${{ matrix.chunk_id }}.log \
             --filter-intermittents filtered-test-wpt.${{ matrix.chunk_id }}.json
         env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
           INTERMITTENT_TRACKER_DASHBOARD_SECRET: ${{ secrets.INTERMITTENT_TRACKER_DASHBOARD_SECRET }}
       - name: Archive filtered results
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
The main workflow now sends wpt results to [the dashboard](https://build.servo.org/intermittent-tracker/), but it doesn’t send the branch + build_url + pull_url just yet. This patch fixes that.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they only affect the CI configuration