### PR TITLE
Do a bit of test gardening of unstable results

### DIFF
--- a/tests/wpt/metadata/css/css-fonts/variations/at-font-face-font-matching.html.ini
+++ b/tests/wpt/metadata/css/css-fonts/variations/at-font-face-font-matching.html.ini
@@ -1,324 +1,338 @@
 [at-font-face-font-matching.html]
+  bug: https://github.com/servo/servo/issues/29376
+
   [Descriptor mathcing priority: Stretch has higher priority than style]
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Descriptor mathcing priority: Stretch has higher priority than weight]
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '400' should prefer '500' over '350 399']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '400' should prefer '350 399' over '351 398']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '400' should prefer '501 550' over '502 560']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '500' should prefer '501 550' over '502 560']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 0deg' should prefer 'oblique -50deg -20deg' over 'oblique -40deg -30deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -10deg' should prefer 'oblique -10deg' over 'oblique -5deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -10deg' should prefer 'oblique -20deg -15deg' over 'oblique -60deg -30deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -10deg' should prefer 'oblique 0deg 10deg' over 'oblique 40deg 50deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Descriptor mathcing priority: Style has higher priority than weight]
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-stretch: '110%' should prefer '115% 116%' over '105%']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-stretch: '90%' should prefer '50% 80%' over '60% 70%']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Descriptor matching priority: Stretch has higher priority than weight]
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Descriptor matching priority: Stretch has higher priority than style]
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Descriptor matching priority: Style has higher priority than weight]
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '430' should prefer '420 440' over '450 460']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 0deg' should prefer 'oblique 15deg 20deg' over 'oblique 30deg 60deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 20deg' should prefer 'oblique -50deg -20deg' over 'oblique -40deg -30deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 10deg' should prefer 'italic' over 'oblique 0deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'italic' should prefer 'oblique 20deg' over 'oblique 30deg 60deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'normal' should prefer 'oblique 10deg 40deg' over 'oblique 20deg 30deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '399' should prefer '450 460' over '500 501']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '500' should prefer '400' over '350 399']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '501' should prefer '501' over '502 510']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 0deg' should prefer 'oblique 30deg 60deg' over 'oblique 40deg 50deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '400' should prefer '450 460' over '500']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 0deg' should prefer 'italic' over 'oblique -50deg -20deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -20deg' should prefer 'oblique -10deg' over 'italic']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -20deg' should prefer 'oblique -20deg' over 'oblique -60deg -40deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 20deg' should prefer 'oblique 10deg' over 'italic']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 21deg' should prefer 'oblique 21deg' over 'oblique 30deg 60deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -10deg' should prefer 'italic' over 'oblique 0deg 10deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-stretch: '100%' should prefer '110% 120%' over '115% 116%']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'italic' should prefer 'oblique 30deg 60deg' over 'oblique 40deg 50deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '501' should prefer '503 520' over '500']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 20deg' should prefer 'oblique 20deg' over 'oblique 30deg 60deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 10deg' should prefer 'oblique 5deg' over 'oblique 15deg 20deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '399' should prefer '400' over '450 460']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '399' should prefer '500 501' over '502 510']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-stretch: '90%' should prefer '110% 140%' over '120% 130%']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 21deg' should prefer 'oblique -50deg -20deg' over 'oblique -40deg -30deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-stretch: '110%' should prefer '50% 80%' over '60% 70%']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'italic' should prefer 'oblique -60deg -30deg' over 'oblique -50deg -40deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '430' should prefer '500' over '400 425']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '400' should prefer '351 398' over '501 550']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '430' should prefer '400 425' over '350 399']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 21deg' should prefer 'oblique 20deg' over 'oblique 10deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 21deg' should prefer 'oblique 0deg' over 'oblique -50deg -20deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 20deg' should prefer 'italic' over 'oblique 0deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 21deg' should prefer 'italic' over 'oblique 0deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-stretch: '110%' should prefer '105%' over '100%']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 20deg' should prefer 'oblique 30deg 60deg' over 'oblique 40deg 50deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 20deg' should prefer 'oblique 40deg 50deg' over 'oblique 10deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '430' should prefer '450 460' over '500']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 0deg' should prefer 'oblique 0deg' over 'oblique 5deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -10deg' should prefer 'oblique -5deg' over 'oblique -1deg 0deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -10deg' should prefer 'oblique -50deg -40deg' over 'italic']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -20deg' should prefer 'oblique -60deg -40deg' over 'oblique -10deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -20deg' should prefer 'italic' over 'oblique 0deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -21deg' should prefer 'oblique -21deg' over 'oblique -60deg -40deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '399' should prefer '340 360' over '200 300']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-stretch: '110%' should prefer '100%' over '50% 80%']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -10deg' should prefer 'oblique -1deg 0deg' over 'oblique -20deg -15deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 21deg' should prefer 'oblique 30deg 60deg' over 'oblique 40deg 50deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 21deg' should prefer 'oblique 40deg 50deg' over 'oblique 20deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -21deg' should prefer 'oblique 0deg' over 'oblique 30deg 60deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -20deg' should prefer 'oblique 0deg' over 'oblique 30deg 60deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 20deg' should prefer 'oblique 0deg' over 'oblique -50deg -20deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 10deg' should prefer 'oblique 15deg 20deg' over 'oblique 30deg 60deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 10deg' should prefer 'oblique 40deg 50deg' over 'italic']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -21deg' should prefer 'oblique -60deg -40deg' over 'oblique -10deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -21deg' should prefer 'oblique 30deg 60deg' over 'oblique 40deg 50deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '430' should prefer '350 399' over '340 398']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '501' should prefer '502 510' over '503 520']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '501' should prefer '500' over '450 460']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '501' should prefer '390 410' over '300 350']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '399' should prefer '350 399' over '340 360']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-stretch: '90%' should prefer '90% 100%' over '50% 80%']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-stretch: '90%' should prefer '60% 70%' over '110% 140%']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'normal' should prefer 'normal' over 'oblique 0deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 10deg' should prefer 'oblique 30deg 60deg' over 'oblique 40deg 50deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'italic' should prefer 'oblique 5deg' over 'normal']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '400' should prefer '400' over '450 460']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '399' should prefer '200 300' over '400']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-stretch: '110%' should prefer '110% 120%' over '115% 116%']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 21deg' should prefer 'oblique 10deg' over 'italic']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '501' should prefer '450 460' over '390 410']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'italic' should prefer 'oblique 40deg 50deg' over 'oblique 5deg 10deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 10deg' should prefer 'oblique -50deg -20deg' over 'oblique -40deg -30deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 0deg' should prefer 'oblique 5deg' over 'oblique 15deg 20deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -21deg' should prefer 'oblique -10deg' over 'italic']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-stretch: '100%' should prefer '100%' over '110% 120%']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'normal' should prefer 'oblique 20deg 30deg' over 'oblique -50deg -20deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'italic' should prefer 'oblique 5deg 10deg' over 'oblique 5deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 10deg' should prefer 'oblique 10deg' over 'oblique 5deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -21deg' should prefer 'italic' over 'oblique 0deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '500' should prefer '450 460' over '400']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '430' should prefer '340 398' over '501 550']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '500' should prefer '351 398' over '501 550']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'italic' should prefer 'italic' over 'oblique 20deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique 10deg' should prefer 'oblique 0deg' over 'oblique -50deg -20deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-weight: '500' should prefer '500' over '450 460']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'normal' should prefer 'oblique 0deg' over 'oblique 10deg 40deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'normal' should prefer 'oblique -50deg -20deg' over 'oblique -40deg -30deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'italic' should prefer 'oblique 0deg' over 'oblique -60deg -30deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -10deg' should prefer 'oblique -60deg -30deg' over 'oblique -50deg -40deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [Matching font-style: 'oblique -20deg' should prefer 'oblique 30deg 60deg' over 'oblique 40deg 50deg']
-    expected: FAIL
+    expected: [PASS, FAIL]
+
+  [Matching font-weight: '430' should prefer '501 550' over '502 560']
+    expected: [PASS, FAIL]
+
+  [Matching font-weight: '500' should prefer '350 399' over '351 398']
+    expected: [PASS, FAIL]
+
+  [Matching font-style: 'italic' should prefer 'normal' over 'oblique 0deg']
+    expected: [PASS, FAIL]
+
+  [Matching font-style: 'oblique 0deg' should prefer 'oblique 40deg 50deg' over 'italic']
+    expected: [PASS, FAIL]

--- a/tests/wpt/metadata/css/css-transitions/properties-value-001.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/properties-value-001.html.ini
@@ -1,4 +1,6 @@
 [properties-value-001.html]
+  bug: https://github.com/servo/servo/issues/21486
+
   [background-position length(pt) / values]
     expected: [FAIL, PASS]
 

--- a/tests/wpt/metadata/css/css-transitions/properties-value-002.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/properties-value-002.html.ini
@@ -1,4 +1,6 @@
 [properties-value-002.html]
+  bug: https://github.com/servo/servo/issues/21486
+
   [vertical-align vertical(keyword) / values]
     expected: [FAIL, PASS]
 

--- a/tests/wpt/metadata/css/css-transitions/properties-value-003.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/properties-value-003.html.ini
@@ -1,4 +1,6 @@
 [properties-value-003.html]
+  bug: https://github.com/servo/servo/issues/21486
+
   [outline-radius-bottomleft length(em) / events]
     expected: FAIL
 

--- a/tests/wpt/metadata/css/css-transitions/properties-value-inherit-001.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/properties-value-inherit-001.html.ini
@@ -1,4 +1,6 @@
 [properties-value-inherit-001.html]
+  bug: https://github.com/servo/servo/issues/21486
+
   [background-position length(pt) / values]
     expected: [FAIL, PASS]
 

--- a/tests/wpt/metadata/css/css-transitions/properties-value-inherit-002.html.ini
+++ b/tests/wpt/metadata/css/css-transitions/properties-value-inherit-002.html.ini
@@ -1,4 +1,6 @@
 [properties-value-inherit-002.html]
+  bug: https://github.com/servo/servo/issues/21486
+
   [background-position length(pt) / values]
     expected: [FAIL, PASS]
 


### PR DESCRIPTION
This change updates results that are reliably flaky on the bots and also adds bug references for previously updated results. The bug annotations here are the same that are used for Gecko.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they simply update expectations.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
