### PR TITLE
Switch to the sha2 crate for SRI digests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,13 +961,13 @@ dependencies = [
 
 [[package]]
 name = "content-security-policy"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ea9f813e3c5ece60232e2b5d0d8187d310bf1e5641c5457e54099780a892a8"
+checksum = "1780f19455c4d346013dc4fb3e9c329c64c7c300b0ebeff786743f4b9f34ec0e"
 dependencies = [
- "base64 0.12.0",
+ "base64 0.13.0",
  "bitflags",
- "lazy_static",
+ "once_cell",
  "percent-encoding",
  "regex",
  "serde",
@@ -1410,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
@@ -3995,6 +3995,7 @@ dependencies = [
  "flate2",
  "futures 0.3.5",
  "futures-util",
+ "generic-array 0.14.4",
  "headers",
  "http",
  "hyper 0.14.5",
@@ -4023,6 +4024,7 @@ dependencies = [
  "servo_arc",
  "servo_config",
  "servo_url",
+ "sha2",
  "std_test_override",
  "time",
  "tokio 0.2.24",
@@ -5948,19 +5950,18 @@ checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.8.1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.6",
 ]
 
 [[package]]

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -30,7 +30,7 @@ servo = [
 [dependencies]
 accountable-refcell = { version = "0.2.0", optional = true }
 app_units = "0.7"
-content-security-policy = { version = "0.4.0", features = ["serde"], optional = true }
+content-security-policy = { version = "0.5", features = ["serde"], optional = true }
 crossbeam-channel = { version = "0.4", optional = true }
 cssparser = "0.29"
 euclid = "0.22"

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -20,7 +20,7 @@ async-tungstenite = { version = "0.9", features = ["tokio-openssl"] }
 base64 = "0.10.1"
 brotli = "3"
 bytes = "1"
-content-security-policy = { version = "0.4.0", features = ["serde"] }
+content-security-policy = { version = "0.5", features = ["serde"] }
 cookie_rs = { package = "cookie", version = "0.12" }
 crossbeam-channel = "0.4"
 data-url = "0.1.0"
@@ -29,6 +29,7 @@ embedder_traits = { path = "../embedder_traits" }
 flate2 = "1"
 futures = { version = "0.3", package = "futures" }
 futures-util = { version  = "0.3" }
+generic-array = "0.14"
 headers = "0.3"
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1", "http2", "tcp", "stream"] }
@@ -57,6 +58,7 @@ servo_allocator = { path = "../allocator" }
 servo_arc = { path = "../servo_arc" }
 servo_config = { path = "../config" }
 servo_url = { path = "../url" }
+sha2 = "0.10"
 time = "0.1.41"
 tokio = { version = "1", package = "tokio", features = ["sync", "macros", "rt-multi-thread"] }
 tokio2 = { version = "0.2", package = "tokio", features = ["sync", "macros", "rt-threaded", "tcp"] }

--- a/components/net_traits/Cargo.toml
+++ b/components/net_traits/Cargo.toml
@@ -13,7 +13,7 @@ test = false
 doctest = false
 
 [dependencies]
-content-security-policy = { version = "0.4.0", features = ["serde"] }
+content-security-policy = { version = "0.5", features = ["serde"] }
 cookie = "0.12"
 embedder_traits = { path = "../embedder_traits" }
 headers = "0.3"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -39,7 +39,7 @@ bitflags = "1.0"
 bluetooth_traits = { path = "../bluetooth_traits" }
 canvas_traits = { path = "../canvas_traits" }
 chrono = "0.4"
-content-security-policy = { version = "0.4.0", features = ["serde"] }
+content-security-policy = { version = "0.5", features = ["serde"] }
 cookie = "0.12"
 crossbeam-channel = "0.4"
 cssparser = "0.29"


### PR DESCRIPTION
This removes one (simple) use of OpenSSL

The update of `content-security-policy` ensures that we don't add a duplicate sha2 crate.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because it's a refactoring, no behavior change expected.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
