### PR TITLE
Switch to immeta fork to remove arrayvec dupe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,15 +153,6 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
-
-[[package]]
-name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
@@ -2885,11 +2876,10 @@ dependencies = [
 
 [[package]]
 name = "immeta"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7371aa3c98fad60de2d9b517e2e1ed45593c32b0c77249310fa507749a2a318b"
+version = "0.4.1"
+source = "git+https://github.com/fabricedesre/immeta.git#7f08e1bd465078baedfb37269aea1612af9bfd5f"
 dependencies = [
- "arrayvec 0.4.12",
+ "arrayvec 0.7.1",
  "byteorder",
  "num-traits",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ opt-level = 3
 mio = { git = "https://github.com/servo/mio.git", branch = "servo-mio-0.6.22" }
 # surfman-chains has not yet released version 0.7 to crates.io yet.
 surfman-chains = { git = "https://github.com/servo/surfman-chains.git" }
+# fork that bumps crates since the original repo is archived.
+immeta = { git = "https://github.com/fabricedesre/immeta.git" }
 
 # https://github.com/servo/servo/issues/27515#issuecomment-671474054
 [patch."https://github.com/servo/webrender"]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The original immeta crate is archived (https://github.com/netvl/immeta) so I forked it, updated it to newer crates and edition 2021. No public api change.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because just fighting dupes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
