### PR TITLE
Fix Windows startup crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3810,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#f87705d61015bf1646b33f33664da51f31b23b74"
+source = "git+https://github.com/servo/mozjs#d2a3526611cc123139d01f9ac4ff915f805f9e74"
 dependencies = [
  "cc",
  "lazy_static",
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.68.2"
-source = "git+https://github.com/servo/mozjs#f87705d61015bf1646b33f33664da51f31b23b74"
+source = "git+https://github.com/servo/mozjs#d2a3526611cc123139d01f9ac4ff915f805f9e74"
 dependencies = [
  "bindgen",
  "cc",


### PR DESCRIPTION
Updates mozjs to address crashes around off-thread script compilation.

---
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29404 and fix #29214.
- [x] These changes do not require tests because we don't run tests in CI in the affected configurations (Windows and debug-mozjs)