### PR TITLE
Fix the build URL send to the intermittent dashboard

### DIFF
--- a/tests/wpt/servowpt.py
+++ b/tests/wpt/servowpt.py
@@ -243,7 +243,7 @@ class TrackerDashboardFilter():
         repo_url = f"https://github.com/{repository}"
 
         run_id = github_context['run_id']
-        build_url = f"{repo_url}/actions/runs/{run_id})"
+        build_url = f"{repo_url}/actions/runs/{run_id}"
 
         commit_title = github_context["event"]["head_commit"]["message"]
         match = re.match(r"^Auto merge of #(\d+)", commit_title)


### PR DESCRIPTION
This URL contained a spurious ")".

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they simply change the CI scripts.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
