### PR TITLE
CI: remove extra “)” in build url sent to intermittent dashboard

### DIFF
--- a/tests/wpt/servowpt.py
+++ b/tests/wpt/servowpt.py
@@ -217,7 +217,7 @@ class TrackerDashboardFilter():
         repo_url = f"https://github.com/{repository}"
 
         run_id = github_context['run_id']
-        build_url = f"{repo_url}/actions/runs/{run_id})"
+        build_url = f"{repo_url}/actions/runs/{run_id}"
 
         commit_title = github_context["event"]["head_commit"]["message"]
         match = re.match(r"^Auto merge of #(\d+)", commit_title)


### PR DESCRIPTION
The build urls on the [intermittent dashboard](https://build.servo.org/intermittent-tracker/) all have an extra “)” due to a typo in servowpt.py. This patch fixes that, though we’ll probably also want to fix the existing production data.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] ~~These changes fix #___ (GitHub issue number if applicable)~~

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they are a trivial CI-only change