### PR TITLE
Add try command to mach & try build partitioned

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
               });
 
   build-win:
+    if: contains(fromJSON('["auto", "try", "try-windows"]'), github.ref_name)
     name: Build (Windows)
     runs-on: windows-2019
     needs: ["decision"]
@@ -60,6 +61,7 @@ jobs:
         run: python mach smoketest --angle
 
   build-mac:
+    if: contains(fromJSON('["auto", "try", "try-mac"]'), github.ref_name)
     name: Build (macOS)
     runs-on: macos-12
     needs: ["decision"]
@@ -157,6 +159,7 @@ jobs:
   #           filtered-wpt-summary.${{ matrix.chunk_id }}.log
 
   build-linux:
+    if: contains(fromJSON('["auto", "try", "try-linux", "try-wpt"]'), github.ref_name)
     name: Build (Linux)
     runs-on: ubuntu-20.04
     needs: ["decision"]
@@ -183,6 +186,7 @@ jobs:
           path: target.tar.gz
 
   linux-wpt:
+    if: contains(fromJSON('["auto", "try", "try-wpt"]'), github.ref_name)
     name: Linux WPT Tests
     runs-on: ubuntu-20.04
     needs: ["build-linux"]
@@ -241,7 +245,7 @@ jobs:
   report_test_results:
     name: Reporting test results
     runs-on: ubuntu-latest
-    if: always()
+    if: "!cancelled() && success('build-linux') && contains(fromJSON('[\"auto\", \"try\", \"try-wpt\"]'), github.ref_name)"
     needs:
       - "linux-wpt"
     steps:
@@ -269,16 +273,20 @@ jobs:
   build_result:
     name: homu build finished
     runs-on: ubuntu-latest
+    if: always()
+    # needs all build to detect cancellation
     needs:
+      - "decision"
       - "build-win"
       - "build-mac"
+      - "build-linux"
       - "linux-wpt"
       # - "mac-wpt"
 
     steps:
       - name: Mark the job as successful
         run: exit 0
-        if: success()
+        if: "!contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled')"
       - name: Mark the job as unsuccessful
         run: exit 1
-        if: "!success()"
+        if: contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled')

--- a/tests/wpt/servowpt.py
+++ b/tests/wpt/servowpt.py
@@ -226,7 +226,7 @@ class TrackerDashboardFilter():
         self.headers = {
             "Content-Type": "application/json"
         }
-        if TRACKER_DASHBOARD_SECRET_ENV_VAR in os.environ:
+        if TRACKER_DASHBOARD_SECRET_ENV_VAR in os.environ and os.environ[TRACKER_DASHBOARD_SECRET_ENV_VAR]:
             self.url = f"{base_url}/dashboard/attempts"
             secret = os.environ[TRACKER_DASHBOARD_SECRET_ENV_VAR]
             self.headers["Authorization"] = f"Bearer {secret}"


### PR DESCRIPTION
Adds `./mach try` command that enables anybody to easily test their changes without opening PR and requesting try from bors-servo, by force pushing HEAD to appropriate branch. Command accepts branches names to select only partial runs of CI (same like bors try command). So if you only want to test mac build (that would be `@bors-servo try=mac`) you run `./mach try mac`. If no job is specified, try branch is used.

As partitioned CI jobs were not working after migration to GitHub Actions I remade them by using if guards.
Also WPT jobs were failing due to empty `INTERMITTENT_TRACKER_DASHBOARD_SECRET` on my fork, so I added additional check to prevent failed run.

And that concludes my work on #29379 🎉 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29379 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it's CI

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
