### PR TITLE
script: fix BorrowError in (new Blob).slice(0,0).text()

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -1838,13 +1838,16 @@ impl GlobalScope {
             };
             match parent {
                 Some((parent_id, rel_pos)) => {
-                    let parent_file_id = {
-                        let parent_info = blobs_map
-                            .get_mut(&parent_id)
-                            .expect("Parent of blob whose url is requested is unknown.");
-                        self.promote(parent_info, /* set_valid is */ false)
+                    let parent_info = blobs_map
+                        .get_mut(&parent_id)
+                        .expect("Parent of blob whose url is requested is unknown.");
+                    let parent_file_id = self.promote(parent_info, /* set_valid is */ false);
+                    let parent_size = match parent_info.blob_impl.blob_data() {
+                        BlobData::File(ref f) => f.get_size(),
+                        BlobData::Memory(ref v) => v.len() as u64,
+                        BlobData::Sliced(_, _) => panic!("Blob ancestry should be only one level."),
                     };
-                    let parent_size = self.get_blob_size(&parent_id);
+                    let parent_size = rel_pos.to_abs_range(parent_size as usize).len() as u64;
                     let blob_info = blobs_map
                         .get_mut(blob_id)
                         .expect("Blob whose url is requested is unknown.");

--- a/tests/wpt/metadata/fetch/api/basic/scheme-blob.sub.any.js.ini
+++ b/tests/wpt/metadata/fetch/api/basic/scheme-blob.sub.any.js.ini
@@ -1,5 +1,44 @@
 [scheme-blob.sub.any.html]
-  expected: CRASH
+  [Fetching URL.createObjectURL(empty_blob) is OK]
+    expected: FAIL
+
+  [Fetching URL.createObjectURL(empty_type_blob) is OK]
+    expected: FAIL
+
+  [Blob content is not sniffed for a content type [image/png\]]
+    expected: FAIL
+
+  [Blob content is not sniffed for a content type [text/xml\]]
+    expected: FAIL
+
+  [Set content type to the empty string for slice with invalid content type]
+    expected: FAIL
+
+  [Set content type to the empty string for slice with no content type ]
+    expected: FAIL
+
+  [Blob.slice should not sniff the content for a content type]
+    expected: FAIL
+
 
 [scheme-blob.sub.any.worker.html]
-  expected: CRASH
+  [Fetching URL.createObjectURL(empty_blob) is OK]
+    expected: FAIL
+
+  [Fetching URL.createObjectURL(empty_type_blob) is OK]
+    expected: FAIL
+
+  [Blob content is not sniffed for a content type [image/png\]]
+    expected: FAIL
+
+  [Blob content is not sniffed for a content type [text/xml\]]
+    expected: FAIL
+
+  [Set content type to the empty string for slice with invalid content type]
+    expected: FAIL
+
+  [Set content type to the empty string for slice with no content type ]
+    expected: FAIL
+
+  [Blob.slice should not sniff the content for a content type]
+    expected: FAIL


### PR DESCRIPTION
When getting the text of a sliced Blob, we call GlobalScope.get_blob_url_id, which borrows the blob_state field mutably and calls the get_blob_size method (aka [Blob#size](https://w3c.github.io/FileAPI/#dfn-size)), which tries to borrow the same field immutably, causing a panic.

This patch inlines the relevant parts of get_blob_size into get_blob_url_id, so we can reuse the mutable borrow.

* /FileAPI/Blob-methods-from-detached-frame.html was 4/4 FAIL, will be 4/4 PASS once #29396 also lands
* /fetch/api/basic/scheme-blob.sub.any.html was CRASH, now 10/17 PASS and 7/17 FAIL
* /fetch/api/basic/scheme-blob.sub.any.worker.html was CRASH, now 10/17 PASS and 7/17 FAIL

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29450

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___