### PR TITLE
Prevent quick check from running on master&dependabot branches

### DIFF
--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      [ "**", "!master", "!auto", "!try", "!try-linux", "!try-mac", "!try-windows", "!try-wpt"]
+      [ "**", "!master", "!auto", "!try", "!try-linux", "!try-mac", "!try-windows", "!try-wpt", "!dependabot/**"]
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      [ "**", "!auto", "!try", "!try-linux", "!try-mac", "!try-windows", "!try-wpt"]
+      [ "**", "!master", "!auto", "!try", "!try-linux", "!try-mac", "!try-windows", "!try-wpt"]
 
 env:
   RUST_BACKTRACE: 1


### PR DESCRIPTION
This should fix the problem noted in #29423 

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
