### PR TITLE
Fix the layout 2020 build after euclid upgrade

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -355,7 +355,7 @@ impl StackingContext {
             if let Some(transformed) = reference_frame_data
                 .transform
                 .inverse()
-                .and_then(|inversed| inversed.transform_rect(&painting_area))
+                .and_then(|inversed| inversed.outer_transformed_rect(&painting_area))
             {
                 painting_area = transformed
             } else {
@@ -850,12 +850,12 @@ impl BoxFragment {
             .px();
         let transform_origin_z = transform_origin.depth.px();
 
-        let pre_transform = LayoutTransform::create_translation(
+        let pre_transform = LayoutTransform::translation(
             transform_origin_x,
             transform_origin_y,
             transform_origin_z,
         );
-        let post_transform = LayoutTransform::create_translation(
+        let post_transform = LayoutTransform::translation(
             -transform_origin_x,
             -transform_origin_y,
             -transform_origin_z,
@@ -883,16 +883,10 @@ impl BoxFragment {
                         .px(),
                 );
 
-                let pre_transform = LayoutTransform::create_translation(
-                    perspective_origin.x,
-                    perspective_origin.y,
-                    0.0,
-                );
-                let post_transform = LayoutTransform::create_translation(
-                    -perspective_origin.x,
-                    -perspective_origin.y,
-                    0.0,
-                );
+                let pre_transform =
+                    LayoutTransform::translation(perspective_origin.x, perspective_origin.y, 0.0);
+                let post_transform =
+                    LayoutTransform::translation(-perspective_origin.x, -perspective_origin.y, 0.0);
 
                 let perspective_matrix = LayoutTransform::from_untyped(
                     &transform::create_perspective_matrix(length.px()),


### PR DESCRIPTION
The euclid upgrade included some backward incompatible changes to the API. This changes updates a few function calls that used the old names.

<!-- Please describe your changes on the following line: -->

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
