### PR TITLE
Package and upload linux w/ layout-2020 engine.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,19 @@ jobs:
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
     name: Upload nightly (Linux)
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        layout-engine: ['2013', '2020']
+        include:
+          - layout-engine: '2013'
+            build-flag: '--with-layout-2013'
+            package: 'linux'
+            continue-on-error: false
+          - layout-engine: '2020'
+            build-flag: '--with-layout-2020'
+            package: 'linux-layout2020'
+            continue-on-error: true
+    continue-on-error: ${{ matrix.continue-on-error }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -26,11 +39,11 @@ jobs:
           sudo apt update
           python3 ./mach bootstrap
       - name: Release build
-        run: python3 ./mach build --release
+        run: python3 ./mach build --release ${{ matrix.build-flag }}
       - name: Package
         run: python3 ./mach package --release
       - name: Upload
-        run: python3 ./mach upload-nightly linux --secret-from-environment
+        run: python3 ./mach upload-nightly ${{ matrix.package }} --secret-from-environment
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
 

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -54,6 +54,9 @@ PACKAGES = {
     'linux': [
         'target/release/servo-tech-demo.tar.gz',
     ],
+    'linux-layout2020': [
+        'target/release/servo-tech-demo.tar.gz',
+    ],
     'mac': [
         'target/release/servo-tech-demo.dmg',
     ],


### PR DESCRIPTION
The layout-2020 variant will be consumed by the internal WPT trend [dashboard][1] only and won't be made available on servo.org.

This change will be removed once the layout engine we will use going forward is finalized.

[1]: https://servo.github.io/internal-wpt-dashboard/

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because they modify the nightly CI job.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
