### PR TITLE
Move hit testing information out of WebRender

### DIFF
--- a/components/embedder_traits/lib.rs
+++ b/components/embedder_traits/lib.rs
@@ -26,7 +26,7 @@ pub use webxr_api::MainThreadWaker as EventLoopWaker;
 /// A cursor for the window. This is different from a CSS cursor (see
 /// `CursorKind`) in that it has no `Auto` value.
 #[repr(u8)]
-#[derive(Clone, Copy, Deserialize, Eq, FromPrimitive, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, FromPrimitive, PartialEq, Serialize)]
 pub enum Cursor {
     None,
     Default,

--- a/components/layout/display_list/builder.rs
+++ b/components/layout/display_list/builder.rs
@@ -413,11 +413,7 @@ impl<'a> DisplayListBuildState<'a> {
         clipping_and_scrolling: ClippingAndScrolling,
     ) -> BaseDisplayItem {
         BaseDisplayItem::new(
-            DisplayItemMetadata {
-                node,
-                // Store cursor id in display list.
-                pointing: cursor.map(|x| x as u16),
-            },
+            DisplayItemMetadata { node, cursor },
             clip_rect.to_layout(),
             section,
             self.current_stacking_context_id,

--- a/components/layout/display_list/items.rs
+++ b/components/layout/display_list/items.rs
@@ -12,6 +12,7 @@
 //! They are therefore not exactly analogous to constructs like Skia pictures, which consist of
 //! low-level drawing primitives.
 
+use embedder_traits::Cursor;
 use euclid::{SideOffsets2D, Vector2D};
 use gfx_traits::print_tree::PrintTree;
 use gfx_traits::{self, StackingContextId};
@@ -465,7 +466,7 @@ impl BaseDisplayItem {
         BaseDisplayItem {
             metadata: DisplayItemMetadata {
                 node: OpaqueNode(0),
-                pointing: None,
+                cursor: None,
             },
             // Create a rectangle of maximal size.
             clip_rect: LayoutRect::max_rect(),
@@ -542,7 +543,7 @@ pub struct DisplayItemMetadata {
     pub node: OpaqueNode,
     /// The value of the `cursor` property when the mouse hovers over this display item. If `None`,
     /// this display item is ineligible for pointer events (`pointer-events: none`).
-    pub pointing: Option<u16>,
+    pub cursor: Option<Cursor>,
 }
 
 #[derive(Clone, Eq, PartialEq, Serialize)]

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -1345,8 +1345,12 @@ impl LayoutThread {
             self.viewport_size.width.to_f32_px(),
             self.viewport_size.height.to_f32_px(),
         ));
-        self.webrender_api
-            .send_display_list(epoch, viewport_size, display_list.wr.finalize());
+        self.webrender_api.send_display_list(
+            epoch,
+            viewport_size,
+            display_list.compositor_info,
+            display_list.wr.finalize(),
+        );
 
         if self.trace_layout {
             layout_debug::end_trace(self.generation.get());

--- a/components/script_traits/compositor.rs
+++ b/components/script_traits/compositor.rs
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! Defines data structures which are consumed by the Compositor.
+
+use embedder_traits::Cursor;
+
+/// Information that Servo keeps alongside WebRender display items
+/// in order to add more context to hit test results.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct HitTestInfo {
+    /// The id of the node of this hit test item.
+    pub node: u64,
+
+    /// The cursor of this node's hit test item.
+    pub cursor: Option<Cursor>,
+}
+
+/// A data structure which stores compositor-side information about
+/// display lists sent to the compositor.
+/// by a WebRender display list.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct CompositorDisplayListInfo {
+    /// An array of `HitTestInfo` which is used to store information
+    /// to assist the compositor to take various actions (set the cursor,
+    /// scroll without layout) using a WebRender hit test result.
+    pub hit_test_info: Vec<HitTestInfo>,
+}
+
+impl CompositorDisplayListInfo {
+    /// Add or re-use a duplicate HitTestInfo entry in this `CompositorHitTestInfo`
+    /// and return the index.
+    pub fn add_hit_test_info(&mut self, node: u64, cursor: Option<Cursor>) -> usize {
+        if let Some(last) = self.hit_test_info.last() {
+            if node == last.node && cursor == last.cursor {
+                return self.hit_test_info.len() - 1;
+            }
+        }
+
+        self.hit_test_info.push(HitTestInfo { node, cursor });
+        self.hit_test_info.len() - 1
+    }
+}


### PR DESCRIPTION
Store hit testing information in a data structure that sits alongside the display list in the compositor. This will allow the compositor to store more information per-node. The data structure also takes care of de-duplicating information between successive display list entries. In the future, the data structure can be even more aggressive in producing smaller side hit testing lists, if necessary.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they should not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
