### PR TITLE
Fix the `update-wpt` command for Layout2020

### DIFF
--- a/tests/wpt/servowpt.py
+++ b/tests/wpt/servowpt.py
@@ -208,6 +208,7 @@ def update_tests(**kwargs):
     kwargs["store_state"] = False
 
     updatecommandline.check_args(kwargs)
+    update_args_for_layout_2020(kwargs)
 
     logger = update.setup_logging(kwargs, {"mach": sys.stdout})
     return_value = update.run_update(logger, **kwargs)


### PR DESCRIPTION
After a recent refactor, layout2020 related arguments are no longer being processed. This change fixes that.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they affect scripts.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
