### PR TITLE
Abstract platform-specific workflows into separate files

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,170 @@
+name: Linux workflow
+on:
+  workflow_call:
+    inputs:
+      layout:
+        required: true
+        type: string
+      wpt:
+        required: true
+        type: boolean
+      unit-tests:
+        required: false
+        default: false
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      layout:
+        required: true
+        type: choice
+        options: ["2013", "2020"]
+      wpt:
+        default: true
+        required: true
+        type: boolean
+      unit-tests:
+        required: false
+        default: false
+        type: boolean
+  push:
+    branches: ["try-linux", "try-wpt"]
+
+env:
+  RUST_BACKTRACE: 1
+  SHELL: /bin/bash
+  LAYOUT: "${{ contains(inputs.layout, '2020') && 'layout-2020' || 'layout-2013' }}"
+
+jobs:
+  build-linux:
+    if: github.repository == 'servo/servo' || github.event_name == 'push'
+    name: Build
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Bootstrap Python
+        run: python3 -m pip install --upgrade pip virtualenv
+      - name: Bootstrap dependencies
+        run: sudo apt update && python3 ./mach bootstrap
+      - name: Tidy
+        run: python3 ./mach test-tidy --no-progress --all
+      - name: Release build
+        run: python3 ./mach build --release --with-${{ env.LAYOUT }}
+      - name: Smoketest
+        run: xvfb-run python3 ./mach smoketest
+      - name: Unit tests
+        if: ${{ inputs.unit-tests }}
+        run: python3 ./mach test-unit --release --with-${{ env.LAYOUT }}
+      - name: Lockfile check
+        run: ./etc/ci/lockfile_changed.sh
+      - name: Package binary
+        run: tar -czf target.tar.gz target/release/servo resources
+      - name: Archive binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.LAYOUT }}-release-binary
+          path: target.tar.gz
+
+  linux-wpt:
+    if: ${{ github.ref_name == 'try-wpt' || inputs.wpt }}
+    name: Linux WPT Tests
+    runs-on: ubuntu-20.04
+    needs: ["build-linux"]
+    env:
+      max_chunk_id: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.LAYOUT }}-release-binary
+          path: release-binary
+      - name: unPackage binary
+        run: tar -xzf release-binary/target.tar.gz
+      - name: Prep test environment
+        run: |
+          python3 -m pip install --upgrade pip virtualenv
+          sudo apt update
+          sudo apt install -qy --no-install-recommends libgl1 libssl1.1 libdbus-1-3 libxcb-xfixes0-dev libxcb-shape0-dev libunwind8 libegl1-mesa
+          wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
+          sudo apt install ./libffi6_3.2.1-8_amd64.deb
+          python3 ./mach bootstrap-gstreamer
+      - name: Run tests
+        run: |
+          python3 ./mach test-wpt \
+            --release --processes $(nproc) --timeout-multiplier 2 \
+            --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
+            --log-raw test-wpt.${{ matrix.chunk_id }}.log \
+            --log-raw-unexpected unexpected-test-wpt.${{ matrix.chunk_id }}.log \
+            --filter-intermittents filtered-test-wpt.${{ matrix.chunk_id }}.json
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+          INTERMITTENT_TRACKER_DASHBOARD_SECRET: ${{ secrets.INTERMITTENT_TRACKER_DASHBOARD_SECRET }}
+      - name: Archive filtered results
+        uses: actions/upload-artifact@v3
+        if: ${{ always() }}
+        with:
+          name: wpt-filtered-results-linux-${{ env.LAYOUT }}
+          path: |
+            filtered-test-wpt.${{ matrix.chunk_id }}.json
+            unexpected-test-wpt.${{ matrix.chunk_id }}.log
+      - name: Archive logs
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: wpt-logs-linux-${{ env.LAYOUT }}
+          path: |
+            test-wpt.${{ matrix.chunk_id }}.log
+            filtered-wpt-results.${{ matrix.chunk_id }}.json
+
+  report-test-results:
+    name: Reporting test results
+    runs-on: ubuntu-latest
+    if: "!cancelled() && success('build-linux') && ${{ github.ref_name == 'try-wpt' || inputs.wpt }}"
+    needs:
+      - "linux-wpt"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - uses: actions/download-artifact@v3
+        with:
+          name: wpt-filtered-results-linux-${{ env.LAYOUT }}
+          path: wpt-filtered-results-linux
+      - name: Create aggregated unexpected results
+        run: cat wpt-filtered-results-linux/*.log > unexpected-test-wpt.log
+      - name: Archive aggregate results
+        uses: actions/upload-artifact@v3
+        with:
+          name: wpt-filtered-results-linux-${{ env.LAYOUT }}
+          path: |
+            unexpected-test-wpt.log
+      - name: Comment on PR with results
+        run: etc/ci/report_aggregated_expected_results.py wpt-filtered-results-linux/*.json
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build_result:
+    name: homu build finished
+    runs-on: ubuntu-latest
+    if: always()
+    # needs all build to detect cancellation
+    needs:
+      - "build-linux"
+      - "linux-wpt"
+      - "report-test-results"
+
+    steps:
+      - name: Mark the job as successful
+        run: exit 0
+        if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
+      - name: Mark the job as unsuccessful
+        run: exit 1
+        if: contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled')

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,8 +6,8 @@ on:
         required: true
         type: string
       wpt:
-        required: true
-        type: boolean
+        required: false
+        type: string
       unit-tests:
         required: false
         default: false
@@ -19,9 +19,10 @@ on:
         type: choice
         options: ["2013", "2020"]
       wpt:
-        default: true
-        required: true
-        type: boolean
+        default: "test"
+        required: false
+        type: choice
+        options: ["test", "sync"]
       unit-tests:
         required: false
         default: false
@@ -95,7 +96,12 @@ jobs:
           wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
           sudo apt install ./libffi6_3.2.1-8_amd64.deb
           python3 ./mach bootstrap-gstreamer
+      - name: Fetch upstream changes before testing
+        if: ${{ inputs.wpt == 'sync' }}
+        run: |
+          ./etc/ci/update-wpt-checkout fetch-upstream-changes
       - name: Run tests
+        if: ${{ inputs.wpt != 'sync' }}
         run: |
           python3 ./mach test-wpt \
             --release --processes $(nproc) --timeout-multiplier 2 \
@@ -106,9 +112,18 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
           INTERMITTENT_TRACKER_DASHBOARD_SECRET: ${{ secrets.INTERMITTENT_TRACKER_DASHBOARD_SECRET }}
+      - name: Run tests (sync)
+        if: ${{ inputs.wpt == 'sync' }}
+        run: |
+          python3 ./mach test-wpt \
+            --release --processes $(nproc) --timeout-multiplier 2 \
+            --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
+            --log-raw test-wpt.${{ matrix.chunk_id }}.log \
+            --log-servojson wpt-jsonsummary.${{ matrix.chunk_id }}.log \
+            --always-succeed
       - name: Archive filtered results
         uses: actions/upload-artifact@v3
-        if: ${{ always() }}
+        if: ${{ always() && inputs.wpt != 'sync' }}
         with:
           name: wpt-filtered-results-linux-${{ env.LAYOUT }}
           path: |
@@ -116,17 +131,25 @@ jobs:
             unexpected-test-wpt.${{ matrix.chunk_id }}.log
       - name: Archive logs
         uses: actions/upload-artifact@v3
-        if: ${{ failure() }}
+        if: ${{ failure() && inputs.wpt != 'sync' }}
         with:
           name: wpt-logs-linux-${{ env.LAYOUT }}
           path: |
             test-wpt.${{ matrix.chunk_id }}.log
             filtered-wpt-results.${{ matrix.chunk_id }}.json
+      - name: Archive logs
+        uses: actions/upload-artifact@v3
+        if: ${{ inputs.wpt == 'sync' }}
+        with:
+          name: wpt-logs-linux-${{ env.LAYOUT }}
+          path: |
+            test-wpt.${{ matrix.chunk_id }}.log
+            wpt-jsonsummary.${{ matrix.chunk_id }}.log
 
   report-test-results:
     name: Reporting test results
     runs-on: ubuntu-latest
-    if: "!cancelled() && success('build-linux') && ${{ github.ref_name == 'try-wpt' || inputs.wpt }}"
+    if: ${{ always() && !cancelled() && success('build-linux') && (github.ref_name == 'try-wpt' || inputs.wpt == 'test') }}
     needs:
       - "linux-wpt"
     steps:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,134 @@
+name: Mac workflow
+
+on:
+  workflow_call:
+    inputs:
+      layout:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      layout:
+        required: true
+        type: choice
+        options: ["2013", "2020"]
+  push:
+    branches: ["try-mac"]
+
+env:
+  RUST_BACKTRACE: 1
+  SHELL: /bin/bash
+  LAYOUT: "${{ contains(inputs.layout, '2020') && 'layout-2020' || 'layout-2013' }}"
+
+jobs:
+  build-mac:
+    name: Build
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      # TODO: Remove this step when the compatibility issue between mozjs and
+      #       Homebrew's Python 3.10 formula (servo/rust-mozjs#559) is fixed
+      - name: Select Python 3.9
+        run: |
+          brew install python@3.9
+          cd $(dirname $(which python3.9))
+          rm -f python3 pip3
+          ln -s python3.9 python3
+          ln -s pip3.9 pip3
+      - name: Bootstrap
+        run: |
+          python3 -m pip install --upgrade pip virtualenv
+          brew bundle install --verbose --no-upgrade --file=etc/taskcluster/macos/Brewfile
+          brew bundle install --verbose --no-upgrade --file=etc/taskcluster/macos/Brewfile-build
+          rm -rf /usr/local/etc/openssl
+          rm -rf /usr/local/etc/openssl@1.1
+          brew install openssl@1.1 gnu-tar
+      - name: Release build
+        run: |
+          export OPENSSL_INCLUDE_DIR="$(brew --prefix openssl)/include"
+          export OPENSSL_LIB_DIR="$(brew --prefix openssl)/lib"
+          export PKG_CONFIG_PATH="$(brew --prefix libffi)/lib/pkgconfig/"
+          export PKG_CONFIG_PATH="$(brew --prefix zlib)/lib/pkgconfig/:$PKG_CONFIG_PATH"
+          python3 ./mach build --release --with-${{ env.LAYOUT }}
+      - name: Smoketest
+        run: python3 ./mach smoketest
+      - name: Unit tests
+        run: python3 ./mach test-unit --release --with-${{ env.LAYOUT }}
+      - name: Test package
+        run: python3 ./mach package --release
+      - name: Package smoketest
+        run: ./etc/ci/macos_package_smoketest.sh target/release/servo-tech-demo.dmg
+      - name: Package binary
+        run: gtar -czf target.tar.gz target/release/servo target/release/*.dylib resources
+      - name: Archive binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-${{ env.LAYOUT }}-binary-macos
+          path: target.tar.gz
+
+  # mac-wpt:
+  #   name: Mac WPT Tests
+  #   runs-on: macos-12
+  #   needs: ["build-mac"]
+  #   env:
+  #     max_chunk_id: 20
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 2
+  #     - uses: actions/download-artifact@v3
+  #       with:
+  #         name: release-binary-macos
+  #     # TODO: Remove this step when the compatibility issue between mozjs and
+  #     #       Homebrew's Python 3.10 formula (servo/rust-mozjs#559) is fixed
+  #     - name: Select Python 3.9
+  #       run: |
+  #         brew install python@3.9
+  #         cd $(dirname $(which python3.9))
+  #         rm -f python3 pip3
+  #         ln -s python3.9 python3
+  #         ln -s pip3.9 pip3
+  #     - name: Prep test environment
+  #       run: |
+  #         gtar -xzf target.tar.gz
+  #         python3 -m pip install --upgrade pip virtualenv
+  #         brew bundle install --verbose --no-upgrade --file=etc/taskcluster/macos/Brewfile
+  #     - name: Smoketest
+  #       run: python3 ./mach smoketest
+  #     - name: Run tests
+  #       run: |
+  #         python3 ./mach test-wpt \
+  #           --release --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
+  #           --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
+  #           --log-raw test-wpt.${{ matrix.chunk_id }}.log \
+  #           --filter-intermittents=filtered-wpt-summary.${{ matrix.chunk_id }}.log
+  #     - name: Archive logs
+  #       uses: actions/upload-artifact@v3
+  #       if: ${{ failure() }}
+  #       with:
+  #         name: wpt${{ matrix.chunk_id }}-logs-macos
+  #         path: |
+  #           test-wpt.${{ matrix.chunk_id }}.log
+  #           filtered-wpt-summary.${{ matrix.chunk_id }}.log
+
+  build_result:
+    name: homu build finished
+    runs-on: ubuntu-latest
+    if: always()
+    # needs all build to detect cancellation
+    needs:
+      - "build-mac"
+
+    steps:
+      - name: Mark the job as successful
+        run: exit 0
+        if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
+      - name: Mark the job as unsuccessful
+        run: exit 1
+        if: contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,11 @@
 name: Merge queue and try
 
 on:
-  # Triggers the workflow on push events but only for the master branch
   push:
-    branches: [ "auto", "try", "try-linux", "try-mac", "try-windows", "try-wpt"]
+    branches: ["auto", "try"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
-env:
-  RUST_BACKTRACE: 1
-  SHELL: /bin/bash
 
 jobs:
   decision:
@@ -35,242 +30,34 @@ jobs:
               });
 
   build-win:
-    if: contains(fromJSON('["auto", "try", "try-windows"]'), github.ref_name)
-    name: Build (Windows)
-    runs-on: windows-2019
+    name: Windows
     needs: ["decision"]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Copy to C drive
-        run: cp D:\a C:\ -Recurse
-      - name: Bootstrap
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: |
-          python -m pip install --upgrade pip virtualenv
-          python mach fetch
-      - name: Release build
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: python mach build --release --media-stack=dummy
-      - name: Unit tests
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: python mach test-unit --release
-      - name: Smoketest
-        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
-        run: python mach smoketest --angle
+    uses: ./.github/workflows/windows.yml
+    with:
+      layout: '2013'
 
   build-mac:
-    if: contains(fromJSON('["auto", "try", "try-mac"]'), github.ref_name)
-    name: Build (macOS)
-    runs-on: macos-12
+    name: Mac
     needs: ["decision"]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      # TODO: Remove this step when the compatibility issue between mozjs and
-      #       Homebrew's Python 3.10 formula (servo/rust-mozjs#559) is fixed
-      - name: Select Python 3.9
-        run: |
-          brew install python@3.9
-          cd $(dirname $(which python3.9))
-          rm -f python3 pip3
-          ln -s python3.9 python3
-          ln -s pip3.9 pip3
-      - name: Bootstrap
-        run: |
-          python3 -m pip install --upgrade pip virtualenv
-          brew bundle install --verbose --no-upgrade --file=etc/taskcluster/macos/Brewfile
-          brew bundle install --verbose --no-upgrade --file=etc/taskcluster/macos/Brewfile-build
-          rm -rf /usr/local/etc/openssl
-          rm -rf /usr/local/etc/openssl@1.1
-          brew install openssl@1.1 gnu-tar
-      - name: Release build
-        run: |
-          export OPENSSL_INCLUDE_DIR="$(brew --prefix openssl)/include"
-          export OPENSSL_LIB_DIR="$(brew --prefix openssl)/lib"
-          export PKG_CONFIG_PATH="$(brew --prefix libffi)/lib/pkgconfig/"
-          export PKG_CONFIG_PATH="$(brew --prefix zlib)/lib/pkgconfig/:$PKG_CONFIG_PATH"
-          python3 ./mach build --release
-      - name: Smoketest
-        run: python3 ./mach smoketest
-      - name: Unit tests
-        run: python3 ./mach test-unit --release
-      - name: Test package
-        run: python3 ./mach package --release
-      - name: Package smoketest
-        run: ./etc/ci/macos_package_smoketest.sh target/release/servo-tech-demo.dmg
-      - name: Package binary
-        run: gtar -czf target.tar.gz target/release/servo target/release/*.dylib resources
-      - name: Archive binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: release-binary-macos
-          path: target.tar.gz
-
-  # mac-wpt:
-  #   name: Mac WPT Tests
-  #   runs-on: macos-12
-  #   needs: ["build-mac"]
-  #   env:
-  #     max_chunk_id: 20
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 2
-  #     - uses: actions/download-artifact@v3
-  #       with:
-  #         name: release-binary-macos
-  #     # TODO: Remove this step when the compatibility issue between mozjs and
-  #     #       Homebrew's Python 3.10 formula (servo/rust-mozjs#559) is fixed
-  #     - name: Select Python 3.9
-  #       run: |
-  #         brew install python@3.9
-  #         cd $(dirname $(which python3.9))
-  #         rm -f python3 pip3
-  #         ln -s python3.9 python3
-  #         ln -s pip3.9 pip3
-  #     - name: Prep test environment
-  #       run: |
-  #         gtar -xzf target.tar.gz
-  #         python3 -m pip install --upgrade pip virtualenv
-  #         brew bundle install --verbose --no-upgrade --file=etc/taskcluster/macos/Brewfile
-  #     - name: Smoketest
-  #       run: python3 ./mach smoketest
-  #     - name: Run tests
-  #       run: |
-  #         python3 ./mach test-wpt \
-  #           --release --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
-  #           --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
-  #           --log-raw test-wpt.${{ matrix.chunk_id }}.log \
-  #           --filter-intermittents=filtered-wpt-summary.${{ matrix.chunk_id }}.log
-  #     - name: Archive logs
-  #       uses: actions/upload-artifact@v3
-  #       if: ${{ failure() }}
-  #       with:
-  #         name: wpt${{ matrix.chunk_id }}-logs-macos
-  #         path: |
-  #           test-wpt.${{ matrix.chunk_id }}.log
-  #           filtered-wpt-summary.${{ matrix.chunk_id }}.log
+    uses: ./.github/workflows/mac.yml
+    with:
+      layout: '2013'
 
   build-linux:
-    if: contains(fromJSON('["auto", "try", "try-linux", "try-wpt"]'), github.ref_name)
-    name: Build (Linux)
-    runs-on: ubuntu-20.04
+    name: Linux
     needs: ["decision"]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Bootstrap Python
-        run: python3 -m pip install --upgrade pip virtualenv
-      - name: Bootstrap dependencies
-        run: sudo apt update && python3 ./mach bootstrap
-      - name: Release build
-        run: python3 ./mach build --release
-      - name: Lockfile check
-        run: ./etc/ci/lockfile_changed.sh
-      - name: Tidy
-        run: python3 ./mach test-tidy --no-progress --all
-      - name: Package binary
-        run: tar -czf target.tar.gz target/release/servo resources
-      - name: Archive binary
-        uses: actions/upload-artifact@v3
-        with:
-          name: release-binary
-          path: target.tar.gz
-      - name: Release build (Layout 2020)
-        run: python3 ./mach build --release --with-layout-2020
+    uses: ./.github/workflows/linux.yml
+    with:
+      layout: '2013'
+      wpt: true
 
-  linux-wpt:
-    if: contains(fromJSON('["auto", "try", "try-wpt"]'), github.ref_name)
-    name: Linux WPT Tests
-    runs-on: ubuntu-20.04
-    needs: ["build-linux"]
-    env:
-      max_chunk_id: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - uses: actions/download-artifact@v3
-        with:
-          name: release-binary
-          path: release-binary
-      - name: unPackage binary
-        run: tar -xzf release-binary/target.tar.gz
-      - name: Prep test environment
-        run: |
-          python3 -m pip install --upgrade pip virtualenv
-          sudo apt update
-          sudo apt install -qy --no-install-recommends libgl1 libssl1.1 libdbus-1-3 libxcb-xfixes0-dev libxcb-shape0-dev libunwind8 libegl1-mesa
-          wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
-          sudo apt install ./libffi6_3.2.1-8_amd64.deb
-          python3 ./mach bootstrap-gstreamer
-      - name: Run tests
-        run: |
-          python3 ./mach test-wpt \
-            --release --processes $(nproc) --timeout-multiplier 2 \
-            --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
-            --log-raw test-wpt.${{ matrix.chunk_id }}.log \
-            --log-raw-unexpected unexpected-test-wpt.${{ matrix.chunk_id }}.log \
-            --filter-intermittents filtered-test-wpt.${{ matrix.chunk_id }}.json
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-          INTERMITTENT_TRACKER_DASHBOARD_SECRET: ${{ secrets.INTERMITTENT_TRACKER_DASHBOARD_SECRET }}
-      - name: Archive filtered results
-        uses: actions/upload-artifact@v3
-        if: ${{ always() }}
-        with:
-          name: wpt-filtered-results-linux
-          path: |
-            filtered-test-wpt.${{ matrix.chunk_id }}.json
-            unexpected-test-wpt.${{ matrix.chunk_id }}.log
-      - name: Archive logs
-        uses: actions/upload-artifact@v3
-        if: ${{ failure() }}
-        with:
-          name: wpt-logs-linux
-          path: |
-            test-wpt.${{ matrix.chunk_id }}.log
-            filtered-wpt-results.${{ matrix.chunk_id }}.json
-
-  report_test_results:
-    name: Reporting test results
-    runs-on: ubuntu-latest
-    if: "!cancelled() && success('build-linux') && contains(fromJSON('[\"auto\", \"try\", \"try-wpt\"]'), github.ref_name)"
-    needs:
-      - "linux-wpt"
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - uses: actions/download-artifact@v3
-        with:
-          name: wpt-filtered-results-linux
-          path: wpt-filtered-results-linux
-      - name: Create aggregated unexpected results
-        run: cat wpt-filtered-results-linux/*.log > unexpected-test-wpt.log
-      - name: Archive aggregate results
-        uses: actions/upload-artifact@v3
-        with:
-          name: wpt-filtered-results-linux
-          path: |
-            unexpected-test-wpt.log
-      - name: Comment on PR with results
-        run: etc/ci/report_aggregated_expected_results.py wpt-filtered-results-linux/*.json
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build-linux-layout-2020:
+    name: Linux (layout-2020)
+    needs: ["decision"]
+    uses: ./.github/workflows/linux.yml
+    with:
+      layout: '2020'
+      wpt: false
 
   build_result:
     name: homu build finished
@@ -282,13 +69,12 @@ jobs:
       - "build-win"
       - "build-mac"
       - "build-linux"
-      - "linux-wpt"
-      # - "mac-wpt"
+      - "build-linux-layout-2020"
 
     steps:
       - name: Mark the job as successful
         run: exit 0
-        if: "!contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled')"
+        if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
       - name: Mark the job as unsuccessful
         run: exit 1
         if: contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       layout: '2013'
-      wpt: true
+      wpt: 'test'
 
   build-linux-layout-2020:
     name: Linux (layout-2020)
@@ -57,7 +57,6 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       layout: '2020'
-      wpt: false
 
   build_result:
     name: homu build finished

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -3,34 +3,22 @@ on:
   pull_request:
   push:
     branches:
-      [ "**", "!master", "!auto", "!try", "!try-linux", "!try-mac", "!try-windows", "!try-wpt", "!dependabot/**"]
-
-env:
-  RUST_BACKTRACE: 1
-  SHELL: /bin/bash
+      ["**", "!master", "!auto", "!try", "!try-linux", "!try-mac", "!try-windows", "!try-wpt", "!dependabot/**"]
 
 jobs:
   build-linux:
-    if: github.repository == 'servo/servo' || github.event_name == 'push'
-    name: Build (Linux)
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Bootstrap Python
-        run: python3 -m pip install --upgrade pip virtualenv
-      - name: Bootstrap dependencies
-        run: sudo apt update && python3 ./mach bootstrap
-      - name: Tidy
-        run: python3 ./mach test-tidy --no-progress --all
-      - name: Release build
-        run: python3 ./mach build --release
-      - name: Smoketest
-        run: xvfb-run python3 ./mach smoketest
-      - name: Unit tests
-        run: python3 ./mach test-unit --release
-      - name: Lockfile check
-        run: ./etc/ci/lockfile_changed.sh
-      - name: Release build (Layout 2020)
-        run: python3 ./mach build --release --with-layout-2020
+    name: Linux
+    uses: ./.github/workflows/linux.yml
+    with:
+      layout: '2013'
+      wpt: false
+      unit-tests: true
+
+  build-linux-layout-2020:
+    name: Linux (layout-2020)
+    uses: ./.github/workflows/linux.yml
+    with:
+      layout: '2020'
+      wpt: false
+      # TODO: unit tests on layout-2020
+      unit-tests: false

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -11,7 +11,6 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       layout: '2013'
-      wpt: false
       unit-tests: true
 
   build-linux-layout-2020:
@@ -19,6 +18,5 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       layout: '2020'
-      wpt: false
       # TODO: unit tests on layout-2020
       unit-tests: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   build-win:
     name: Build
-    runs-on: windows-2022
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,62 @@
+name: Windows workflow
+
+on:
+  workflow_call:
+    inputs:
+      layout:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      layout:
+        required: true
+        type: choice
+        options: ["2013", "2020"]
+  push:
+    branches: ["try-windows"]
+
+env:
+  RUST_BACKTRACE: 1
+  SHELL: /bin/bash
+  LAYOUT: "${{ contains(inputs.layout, '2020') && 'layout-2020' || 'layout-2013' }}"
+
+jobs:
+  build-win:
+    name: Build
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Copy to C drive
+        run: cp D:\a C:\ -Recurse
+      - name: Bootstrap
+        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+        run: |
+          python -m pip install --upgrade pip virtualenv
+          python mach fetch
+      - name: Release build
+        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+        run: python mach build --release --media-stack=dummy --with-${{ env.LAYOUT }}
+      - name: Unit tests
+        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+        run: python mach test-unit --release --with-${{ env.LAYOUT }}
+      - name: Smoketest
+        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
+        run: python mach smoketest --angle
+
+  build_result:
+    name: homu build finished
+    runs-on: ubuntu-latest
+    if: always()
+    # needs all build to detect cancellation
+    needs:
+      - "build-win"
+
+    steps:
+      - name: Mark the job as successful
+        run: exit 0
+        if: ${{ !contains(join(needs.*.result, ','), 'failure') && !contains(join(needs.*.result, ','), 'cancelled') }}
+      - name: Mark the job as unsuccessful
+        run: exit 1
+        if: contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled')

--- a/.github/workflows/wpt-nightly.yml
+++ b/.github/workflows/wpt-nightly.yml
@@ -9,89 +9,25 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-linux:
+  linux:
     # This job is only useful when run on upstream servo.
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
-    name: Build on Linux
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - name: Bootstrap
-        run: |
-          python3 -m pip install --upgrade pip virtualenv
-          sudo apt update
-          python3 ./mach bootstrap
-      - name: Release build (Layout 2013)
-        run: python3 ./mach build --release
-      - name: Lockfile check
-        run: ./etc/ci/lockfile_changed.sh
-      - name: Package binary (Layout 2013)
-        run: tar -czf target.tar.gz target/release/servo resources
-      - name: Archive binary (Layout 2013)
-        uses: actions/upload-artifact@v3
-        with:
-          name: layout-2013-release-binary
-          path: target.tar.gz
-      - name: Release build (Layout 2020)
-        run: python3 ./mach build --release --with-layout-2020
-      - name: Package binary (Layout 2020)
-        run: tar -czf target.tar.gz target/release/servo resources
-      - name: Archive binary (Layout 2020)
-        uses: actions/upload-artifact@v3
-        with:
-          name: layout-2020-release-binary
-          path: target.tar.gz
+    name: Linux
+    uses: ./.github/workflows/linux.yml
+    with:
+      layout: '2013'
+      wpt: 'sync'
+      unit-tests: false
 
-  linux-wpt:
+  linux-layout-2020:
     # This job is only useful when run on upstream servo.
     if: github.repository == 'servo/servo' || github.event_name == 'workflow_dispatch'
-    name: Linux WPT Tests
-    runs-on: ubuntu-20.04
-    needs: ["build-linux"]
-    env:
-      max_chunk_id: 20
-    strategy:
-      matrix:
-        chunk_id: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
-        configuration: ["layout-2013", "layout-2020"]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-      - uses: actions/download-artifact@v3
-        with:
-          name: ${{ matrix.configuration }}-release-binary
-          path: release-binary
-      - name: unPackage binary
-        run: tar -xzf release-binary/target.tar.gz
-      - name: Prep test environment
-        run: |
-          python3 -m pip install --upgrade pip virtualenv
-          sudo apt update
-          sudo apt install -qy --no-install-recommends libgl1 libssl1.1 libdbus-1-3 libxcb-xfixes0-dev libxcb-shape0-dev libunwind8 libegl1-mesa
-          wget http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb
-          sudo apt install ./libffi6_3.2.1-8_amd64.deb
-          python3 ./mach bootstrap-gstreamer
-      - name: Fetch upstream changes before testing
-        run: |
-          ./etc/ci/update-wpt-checkout fetch-upstream-changes
-      - name: Run tests
-        run: |
-          python3 ./mach test-wpt \
-            --release --processes $(nproc) --timeout-multiplier 2 \
-            --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
-            --log-raw test-wpt.${{ matrix.configuration }}.${{ matrix.chunk_id }}.log \
-            --log-servojson wpt-jsonsummary.${{ matrix.configuration }}.${{ matrix.chunk_id }}.log \
-            --always-succeed
-      - name: Archive logs
-        uses: actions/upload-artifact@v3
-        with:
-          name: wpt-logs-linux
-          path: |
-            test-wpt.${{ matrix.configuration }}.${{ matrix.chunk_id }}.log
-            wpt-jsonsummary.${{ matrix.configuration }}.${{ matrix.chunk_id }}.log
+    name: Linux (layout-2020)
+    uses: ./.github/workflows/linux.yml
+    with:
+      layout: '2020'
+      wpt: 'sync'
+      unit-tests: false
 
   sync:
     # This job is only useful when run on upstream servo.
@@ -99,8 +35,8 @@ jobs:
     name: Synchronize WPT Nightly
     runs-on: ubuntu-latest
     needs:
-      - "build-linux"
-      - "linux-wpt"
+      - "linux"
+      - "linux-layout-2020"
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
Changes:
- split main workflow into multiple modular files & merged linux and quickcheck
- easily allow testing both `layout-2013` and `layout-2020` (currently layout-2020 is build on both quick-check and main workflows, but no actual tests are run)
- workflow_dispatch on any try run

Future work:
- sccache for caching
  - linux (release, layout-2013): 30min -> 15min
  - mac: 1h 30min -> 50min
  - windows: not working yet: 
```console
sccache: encountered fatal error
sccache: error: Invalid timestamp field in entry header ("-1          ")
sccache: caused by: Invalid timestamp field in entry header ("-1          ")
error: could not compile `openssl-sys`

Caused by:
  process didn't exit successfully: `sccache rustc --crate-name openssl_sys --edition=2018 C:\Users\runneradmin\.cargo\registry\src\github.com-1ecc6299db9ec823\openssl-sys-0.9.81\src\lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no -C metadata=15e5a7651b4bbdb6 -C extra-filename=-15e5a7651b4bbdb6 --out-dir C:\a\servo\servo\target\release\deps -C linker=lld-link.exe -L dependency=C:\a\servo\servo\target\release\deps --extern libc=C:\a\servo\servo\target\release\deps\liblibc-1fe4b5632b2d1333.rmeta --cap-lints allow -W unused-extern-crates -L native=C:\a\servo\servo\.servo\msvc-dependencies\openssl\111.3.0+1.1.1c-vs2017-2019-09-18\x64-windows\lib -l static=libssl -l static=libcrypto -l dylib=gdi32 -l dylib=user32 -l dylib=crypt32 -l dylib=ws2_32 -l dylib=advapi32 --cfg const_fn --cfg openssl --cfg "osslconf=\"OPENSSL_NO_COMP\"" --cfg "osslconf=\"OPENSSL_NO_SSL3_METHOD\"" --cfg ossl101 --cfg ossl102 --cfg ossl102f --cfg ossl102h --cfg ossl110 --cfg ossl110f --cfg ossl110g --cfg ossl110h --cfg ossl111 --cfg ossl111b --cfg ossl111c` (exit code: 0xfffffffe)
warning: build failed, waiting for other jobs to finish...
```
- report WPT test results also using GitHub checks (so we get those sexy results even when there is no associated PR) [example](https://github.com/sagudev/servo/runs/12193772513)
- run `WPT export` only when PR changes files in `tests/wpt/**`