### PR TITLE
Be more verbose when a command fails in the WPT upstream script

### DIFF
--- a/etc/ci/upstream-wpt-changes/wptupstreamer/__init__.py
+++ b/etc/ci/upstream-wpt-changes/wptupstreamer/__init__.py
@@ -60,9 +60,14 @@ class LocalGitRepo:
         env.setdefault("GIT_AUTHOR_NAME", self.sync.github_name)
         env.setdefault("GIT_COMMITTER_NAME", self.sync.github_name)
 
-        return subprocess.check_output(
-            command_line, cwd=self.path, env=env, stderr=subprocess.STDOUT
-        ).decode("utf-8")
+        try:
+            return subprocess.check_output(
+                command_line, cwd=self.path, env=env, stderr=subprocess.STDOUT
+            ).decode("utf-8")
+        except subprocess.CalledProcessError as exception:
+            logging.warning("Process execution failed with output:\n%s",
+                            exception.output.decode("utf-8"))
+            raise exception
 
 
 @dataclasses.dataclass()


### PR DESCRIPTION
This should make it easier to debug the strange script failures we are seeing on some
PRs such as the [one seen here](https://github.com/servo/servo/pull/29396/#issuecomment-1480919565).

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because this just increases debugging output.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
