### PR TITLE
Fix some build warnings

### DIFF
--- a/components/hashglobe/src/alloc.rs
+++ b/components/hashglobe/src/alloc.rs
@@ -27,7 +27,7 @@ pub use self::platform::{alloc, dealloc, realloc};
 
 #[cfg(any(unix, target_os = "redox"))]
 mod platform {
-    extern crate libc;
+    use libc;
 
     #[cfg(not(any(target_os = "android")))]
     use std::ptr;

--- a/components/hashglobe/src/table.rs
+++ b/components/hashglobe/src/table.rs
@@ -724,7 +724,6 @@ fn test_offset_calculation() {
 
 impl<K, V> RawTable<K, V> {
     unsafe fn new_uninitialized(capacity: usize) -> RawTable<K, V> {
-        extern crate libc;
         if let Ok(table) = Self::try_new_uninitialized(capacity) {
             table
         } else {

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -63,7 +63,6 @@ use layout::traversal::{
 };
 use layout::wrapper::LayoutNodeLayoutData;
 use layout_traits::LayoutThreadFactory;
-use libc::c_void;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use metrics::{PaintTimeMetrics, ProfilerMetadataFactory, ProgressiveWebMetric};
 use msg::constellation_msg::{

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -48,7 +48,6 @@ use layout::query::{
 use layout::traversal::RecalcStyle;
 use layout::{BoxTree, FragmentTree};
 use layout_traits::LayoutThreadFactory;
-use libc::c_void;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use metrics::{PaintTimeMetrics, ProfilerMetadataFactory, ProgressiveWebMetric};
 use msg::constellation_msg::{


### PR DESCRIPTION
Change a use of `extern crate` to be simply `use`, which is what the compiler suggests. In addition, with the change, one of the uses is redundant. In addition, remove two unused `use` statements.



---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they fix some warnings.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
