### PR TITLE
Remove a print statement mistakenly added in a previous change

### DIFF
--- a/python/tidy/servo_tidy/tidy.py
+++ b/python/tidy/servo_tidy/tidy.py
@@ -546,7 +546,6 @@ def check_rust(file_name, lines):
     ]
     is_panic_not_allowed_rs_file = any([
         glob.fnmatch.fnmatch(file_name, path) for path in PANIC_NOT_ALLOWED_PATHS])
-    print(file_name)
 
     prev_open_brace = False
     multi_line_string = False


### PR DESCRIPTION
This statement is totally unnecessary and interferes with the console commands which erase and rewrite the current tidy status.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they just remove a print statement.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
