### PR TITLE
Sccache in actions (linux & mac)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,6 +34,10 @@ env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   LAYOUT: "${{ contains(inputs.layout, '2020') && 'layout-2020' || 'layout-2013' }}"
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  CCACHE: "sccache"
+  CARGO_INCREMENTAL: 0
 
 jobs:
   build-linux:
@@ -44,6 +48,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.3
       - name: Bootstrap Python
         run: python3 -m pip install --upgrade pip virtualenv
       - name: Bootstrap dependencies

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -19,6 +19,10 @@ env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
   LAYOUT: "${{ contains(inputs.layout, '2020') && 'layout-2020' || 'layout-2013' }}"
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  CCACHE: "sccache"
+  CARGO_INCREMENTAL: 0
 
 jobs:
   build-mac:
@@ -28,6 +32,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.3
       # TODO: Remove this step when the compatibility issue between mozjs and
       #       Homebrew's Python 3.10 formula (servo/rust-mozjs#559) is fixed
       - name: Select Python 3.9


### PR DESCRIPTION
Coming from #29534.
- linux (release, layout-2013): 30min -> 15min
- mac: 1h 30min -> 50min
- windows: not working yet

Windows problems are very weird, when using `RUSTC_WRAPPER: sccache` we get:
```console
sccache: encountered fatal error
sccache: error: Invalid timestamp field in entry header ("-1          ")
sccache: caused by: Invalid timestamp field in entry header ("-1          ")
error: could not compile `openssl-sys`

Caused by:
  process didn't exit successfully: `sccache rustc --crate-name openssl_sys --edition=2018 C:\Users\runneradmin\.cargo\registry\src\github.com-1ecc6299db9ec823\openssl-sys-0.9.81\src\lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no -C metadata=15e5a7651b4bbdb6 -C extra-filename=-15e5a7651b4bbdb6 --out-dir C:\a\servo\servo\target\release\deps -C linker=lld-link.exe -L dependency=C:\a\servo\servo\target\release\deps --extern libc=C:\a\servo\servo\target\release\deps\liblibc-1fe4b5632b2d1333.rmeta --cap-lints allow -W unused-extern-crates -L native=C:\a\servo\servo\.servo\msvc-dependencies\openssl\111.3.0+1.1.1c-vs2017-2019-09-18\x64-windows\lib -l static=libssl -l static=libcrypto -l dylib=gdi32 -l dylib=user32 -l dylib=crypt32 -l dylib=ws2_32 -l dylib=advapi32 --cfg const_fn --cfg openssl --cfg "osslconf=\"OPENSSL_NO_COMP\"" --cfg "osslconf=\"OPENSSL_NO_SSL3_METHOD\"" --cfg ossl101 --cfg ossl102 --cfg ossl102f --cfg ossl102h --cfg ossl110 --cfg ossl110f --cfg ossl110g --cfg ossl110h --cfg ossl111 --cfg ossl111b --cfg ossl111c` (exit code: 0xfffffffe)
warning: build failed, waiting for other jobs to finish...
```
and when using only `CCACHE: sccache` we get [0 cache hits/misses which is weird as at least mozjs is using CCACHE variable and should have same sccache requests](https://github.com/sagudev/servo/actions/runs/4587126100/jobs/8100424378).