### PR TITLE
Remove unnecessary steps from "text/plain encoding algorithm"

### DIFF
--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -659,20 +659,15 @@ impl HTMLFormElement {
         let mut result = String::new();
 
         // Step 2
-        let encoding = self.pick_encoding();
-
-        // Step 3
-        let charset = encoding.name();
-
-        for entry in form_data.iter_mut() {
-            // Step 4, 5
-            let value = entry.replace_value(charset);
-
-            // Step 6
-            result.push_str(&*format!("{}={}\r\n", entry.name, value));
+        for entry in form_data.iter() {
+            let value = match &entry.value {
+                FormDatumValue::File(f) => f.name(),
+                FormDatumValue::String(s) => s,
+            };
+            result.push_str(&format!("{}={}\r\n", entry.name, value));
         }
 
-        // Step 7
+        // Step 3
         result
     }
 


### PR DESCRIPTION
For "text/plain encoding algorithm", the specification [1] has changed [2] and "_charset_" is not now handled here. It's supposed to be handled in "construct the form data set" algorithm, and we've already implemented that [3]. So we now have extra steps for "text/plain encoding" algorithm.

Remove no longer necessary steps from text/plain encoding algorithm so that it meets the specification.

[1]: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#text/plain-encoding-algorithm
[2]: https://github.com/whatwg/html/pull/3645
[3]: https://github.com/servo/servo/pull/25217

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #25221 (GitHub issue number if applicable)

<!-- Either: -->
- [x] These changes do not require tests because this patch doesn't expect actual behavior, just removing extra steps.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
