### PR TITLE
Remove unnecessary steps from "multipart/form-data encoding algorithm"

### DIFF
--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1744,17 +1744,10 @@ pub fn encode_multipart_form_data(
     let mut result = vec![];
 
     // Step 2
-    let charset = encoding.name();
-
-    // Step 3
     for entry in form_data.iter_mut() {
-        // 3.1
-        if entry.name.to_ascii_lowercase() == "_charset_" && entry.ty == "hidden" {
-            entry.value = FormDatumValue::String(DOMString::from(charset.clone()));
-        }
-        // TODO: 3.2
+        // TODO: Step 2.1
 
-        // Step 4
+        // Step 3
         // https://tools.ietf.org/html/rfc7578#section-4
         // NOTE(izgzhen): The encoding here expected by most servers seems different from
         // what spec says (that it should start with a '\r\n').
@@ -1772,6 +1765,7 @@ pub fn encode_multipart_form_data(
                 result.append(&mut bytes);
             },
             FormDatumValue::File(ref f) => {
+                let charset = encoding.name();
                 let extra = if charset.to_lowercase() == "utf-8" {
                     format!(
                         "filename=\"{}\"",


### PR DESCRIPTION
The specifications for the "multipart/form-data encoding algorithm" has changed [1], and the "_charset_" is not now handled here.

Remove no longer necessary steps from the "multipart/form-data encoding algorithm".

Similar to the "text/plain encoding algorithm" case fixed by f0818aa3 (Remove unnecessary steps from "text/plain encoding algorithm").

[1]: https://github.com/whatwg/html/pull/3645

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29593 (GitHub issue number if applicable)

<!-- Either: -->
- [x]  These changes do not require tests because this patch doesn't expect actual behavior, just removing extra steps.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
