### PR TITLE
Have all mach command accept "--with-layout-2020" and "--layout-2020"

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -845,8 +845,8 @@ install them, let us know by filing a bug!")
                 action='store_true',
                 help='Build with frame pointer enabled, used by the background hang monitor.',
             ),
-            CommandArgument('--with-layout-2020', default=None, action='store_true'),
-            CommandArgument('--with-layout-2013', default=None, action='store_true'),
+            CommandArgument('--with-layout-2020', '--layout-2020', default=None, action='store_true'),
+            CommandArgument('--with-layout-2013', '--layout-2013', default=None, action='store_true'),
             CommandArgument('--without-wgl', default=None, action='store_true'),
         ]
 

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -76,8 +76,8 @@ def create_parser_wpt():
                         help="Run under chaos mode in rr until a failure is captured")
     parser.add_argument('--pref', default=[], action="append", dest="prefs",
                         help="Pass preferences to servo")
-    parser.add_argument('--layout-2020', default=False, action="store_true",
-                        help="Use expected results for the 2020 layout engine")
+    parser.add_argument('--layout-2020', '--with-layout-2020', default=False,
+                        action="store_true", help="Use expected results for the 2020 layout engine")
     parser.add_argument('--log-servojson', action="append", type=mozlog.commandline.log_file,
                         help="Servo's JSON logger of unexpected results")
     parser.add_argument('--always-succeed', default=False, action="store_true",

--- a/tests/wpt/update/updatecommandline.py
+++ b/tests/wpt/update/updatecommandline.py
@@ -13,7 +13,7 @@ def create_parser():
     parser.add_argument("--token-file", action="store", type=wptcommandline.abs_path,
                         help="Path to file containing github token")
     parser.add_argument("--token", action="store", help="GitHub token to use")
-    parser.add_argument('--layout-2020', default=False, action="store_true",
+    parser.add_argument("--layout-2020", "--with-layout-2020", default=False, action="store_true",
                         help="Use expected results for the 2020 layout engine")
     return parser
 


### PR DESCRIPTION
Some command accepted one and some the other. This changes makes them all accept both so it's no longer necessary to remember which uses which.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they change the arguments accepted by mach.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
