### PR TITLE
Fix the WPT export script

### DIFF
--- a/.github/workflows/upstream-wpt-changes.yml
+++ b/.github/workflows/upstream-wpt-changes.yml
@@ -25,7 +25,12 @@ jobs:
         with:
           path: wpt
           repository: 'web-platform-tests/wpt'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # The token here must be the token that we will use to push to the
+          # WPT repository and not the token used for GitHub actions, because
+          # the checkout action sets up an `extraheader` authorization override
+          # using the token specified here.
+          # See https://github.com/actions/checkout/issues/162.
+          token: ${{ secrets.WPT_SYNC_TOKEN }}
       - name: Install requirements
         run: pip install -r servo/etc/ci/upstream-wpt-changes/requirements.txt
       - name: Process pull request


### PR DESCRIPTION
- Have the WPT exporter script use the WPT_SYNC_TOKEN for checking out
  wpt.
- Make sure the local WPT repository is unshallow when pushing.
- When searching for existing PRs use the main GitHub search API,
  as the pull request search does not seem to properly process
  the "head" parameter.
- When deleting branches in the downstream WPT repository, use
  the full URL to avoid trying to modify the upstream repository.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes OR

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
