### PR TITLE
Update shell.nix

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -9,7 +9,8 @@ clangStdenv.mkDerivation rec {
   buildInputs = [
     # Native dependencies
     fontconfig freetype openssl libunwind
-    xorg.libxcb xlibsWrapper
+    xorg.libxcb
+    xorg.libX11
 
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
After https://github.com/NixOS/nixpkgs/pull/207938 was merged the option `pkgs.xlibsWrapper` was removed. This PR replacing it with `xorg.libX11` as this is enouth to build and test in `nix-shell` environment.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [X] These changes do not require tests because PR updates nix build environment.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
