### PR TITLE
Replace usage of six.moves.urllib with urllib

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -10,7 +10,7 @@ import os
 import distro
 import subprocess
 import six
-import six.moves.urllib as urllib
+import urllib
 from subprocess import PIPE
 from zipfile import BadZipfile
 

--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import base64
+import glob
 import json
 import os
 import os.path as path
@@ -18,8 +19,7 @@ import re
 import subprocess
 import sys
 import traceback
-import six.moves.urllib as urllib
-import glob
+import urllib
 
 from mach.decorators import (
     CommandArgument,

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -15,11 +15,11 @@ import os
 import os.path as path
 import platform
 import shutil
+import stat
 import subprocess
 import sys
-import six.moves.urllib as urllib
+import urllib
 import zipfile
-import stat
 
 from time import time
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -9,35 +9,36 @@
 
 from __future__ import print_function
 
-from errno import ENOENT as NO_SUCH_FILE_OR_DIRECTORY
-from glob import glob
-import shutil
+import contextlib
+import distro
+import functools
 import gzip
 import itertools
+import json
 import locale
 import os
-from os import path
 import platform
-import distro
 import re
-import contextlib
-import subprocess
-from subprocess import PIPE
+import shutil
 import six
+import subprocess
 import sys
 import tarfile
+import urllib
 import zipfile
-import functools
+
+from errno import ENOENT as NO_SUCH_FILE_OR_DIRECTORY
+from glob import glob
+from os import path
+from subprocess import PIPE
+
+import toml
+
 from xml.etree.ElementTree import XML
 from servo.util import download_file
-import six.moves.urllib as urllib
 from .bootstrap import check_gstreamer_lib
-
 from mach.decorators import CommandArgument
 from mach.registrar import Registrar
-import toml
-import json
-
 from servo.packages import WINDOWS_MSVC as msvc_deps
 from servo.util import host_triple
 

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -11,12 +11,12 @@ from __future__ import print_function, unicode_literals
 from os import path, listdir, getcwd
 from time import time
 
+import json
 import signal
+import subprocess
 import sys
 import tempfile
-import six.moves.urllib as urllib
-import json
-import subprocess
+import urllib
 
 from mach.decorators import (
     CommandArgument,

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -21,7 +21,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import six.moves.urllib as urllib
+import urllib
 import xml
 
 from mach.decorators import (

--- a/python/servo/util.py
+++ b/python/servo/util.py
@@ -14,14 +14,14 @@ import os
 import os.path
 import platform
 import shutil
-from socket import error as socket_error
 import stat
-from io import BytesIO
 import sys
 import time
+import urllib
 import zipfile
-import six.moves.urllib as urllib
 
+from io import BytesIO
+from socket import error as socket_error
 
 try:
     from ssl import HAS_SNI

--- a/tests/jquery/run_jquery.py
+++ b/tests/jquery/run_jquery.py
@@ -14,7 +14,7 @@ import six.moves.BaseHTTPServer
 import six.moves.SimpleHTTPServer
 import six.moves.socketserver
 import threading
-import six.moves.urllib.parse
+import urllib
 import six
 
 # List of jQuery modules that will be tested.
@@ -149,13 +149,13 @@ def run_http_server():
             path = self.translate_path(self.path)
             f = None
             if os.path.isdir(path):
-                parts = six.moves.urllib.parse.urlsplit(self.path)
+                parts = urllib.parse.urlsplit(self.path)
                 if not parts.path.endswith('/'):
                     # redirect browser - doing basically what apache does
                     self.send_response(301)
                     new_parts = (parts[0], parts[1], parts[2] + '/',
                                  parts[3], parts[4])
-                    new_url = six.moves.urllib.parse.urlunsplit(new_parts)
+                    new_url = urllib.parse.urlunsplit(new_parts)
                     self.send_header("Location", new_url)
                     self.end_headers()
                     return None

--- a/tests/wpt/update/github.py
+++ b/tests/wpt/update/github.py
@@ -5,7 +5,8 @@
 from __future__ import print_function
 
 import json
-from six.moves.urllib.parse import urljoin
+import urllib
+
 requests = None
 
 class GitHubError(Exception):
@@ -36,7 +37,7 @@ class GitHub(object):
         return self._request("PUT", path, data=data)
 
     def _request(self, method, path, data=None):
-        url = urljoin(self.url_base, path)
+        url = urllib.parse.urljoin(self.url_base, path)
 
         kwargs = {"headers": self.headers,
                   "auth": self.auth}
@@ -96,7 +97,7 @@ class GitHubRepo(object):
         return PullRequest.from_number(self, number)
 
     def path(self, suffix):
-        return urljoin(self.url_base, suffix)
+        return urllib.parse.urljoin(self.url_base, suffix)
 
 
 class PullRequest(object):
@@ -126,7 +127,7 @@ class PullRequest(object):
         return cls(repo, data)
 
     def path(self, suffix):
-        return urljoin(self.repo.path("pulls/%i/" % self.number), suffix)
+        return urllib.parse.urljoin(self.repo.path("pulls/%i/" % self.number), suffix)
 
     @property
     def issue(self):
@@ -160,7 +161,7 @@ class Issue(object):
         return cls(repo, data)
 
     def path(self, suffix):
-        return urljoin(self.repo.path("issues/%i/" % self.number), suffix)
+        return urllib.parse.urljoin(self.repo.path("issues/%i/" % self.number), suffix)
 
     def add_label(self, label):
         """Add a label to the issue.

--- a/tests/wpt/update/upstream.py
+++ b/tests/wpt/update/upstream.py
@@ -4,7 +4,7 @@ import os
 import re
 import subprocess
 import sys
-import six.moves.urllib as urllib
+import urllib
 from six.moves import input
 from six import iteritems
 


### PR DESCRIPTION
Also organize some of the imports. Now that Servo only uses Python 3, this module is unnecessary. This is part of the gradual migration to using only Python 3.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
