### PR TITLE
Pass S3 secrets for nightly builds and fix windows build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       layout: '2013'
       upload: true
+    secrets: inherit
 
   upload-mac:
     # This job is only useful when run on upstream servo.
@@ -28,6 +29,7 @@ jobs:
     with:
       layout: '2013'
       upload: true
+    secrets: inherit
 
   upload-linux:
     # This job is only useful when run on upstream servo.
@@ -37,6 +39,7 @@ jobs:
     with:
       layout: '2013'
       upload: true
+    secrets: inherit
 
   upload-linux-2020:
     # This job is only useful when run on upstream servo.
@@ -46,3 +49,4 @@ jobs:
     with:
       layout: '2020'
       upload: true
+    secrets: inherit

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,6 +82,7 @@ jobs:
           path: C:\\a\\servo\\servo\\target/release/msi/Servo.exe
       - name: Upload
         if: ${{ inputs.upload }}
+        working-directory: "C:\\a\\${{ github.event.repository.name }}\\${{ github.event.repository.name }}"
         run: python mach upload-nightly windows-msvc --secret-from-environment
         env:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

Secrets need to be passed to reusable workflows either by name or by `secrets: inherit` from the caller workflow. The latter allows accessing all secrets in scope.

Windows build has a bug where the upload-nightly command is not run from the correct working directory.


[This manual build](https://github.com/servo/servo/actions/runs/4665552398) based on this branch has passed and the binaries have also been updated in servo.org for today.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29614

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it fixes bug in CI configuration.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
