### PR TITLE
Split quick check from pull request and rename WPT export actions

### DIFF
--- a/.github/workflows/pull-request-wpt-export.yml
+++ b/.github/workflows/pull-request-wpt-export.yml
@@ -1,4 +1,4 @@
-name: WPT export
+name: Pull request (WPT export)
 on:
   pull_request_target:
     types: ['opened', 'synchronize', 'reopened', 'edited', 'closed']

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,23 @@
+name: Pull request
+on:
+  pull_request:
+    types: ['opened', 'synchronize']
+    branches: ["**"]
+
+
+jobs:
+  build-linux:
+    name: Linux
+    if: github.repository == 'servo/servo'
+    uses: ./.github/workflows/linux.yml
+    with:
+      layout: '2013'
+      unit-tests: true
+
+  build-linux-layout-2020:
+    name: Linux (layout-2020)
+    if: github.repository == 'servo/servo'
+    uses: ./.github/workflows/linux.yml
+    with:
+      layout: '2020'
+      unit-tests: false

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -1,6 +1,8 @@
+# This action is meant as a quick check to be run when pushing to
+# branches on forks. This allows forks to test the build and unit
+# tests automatically without opening a pull request.
 name: Quick check
 on:
-  pull_request:
   push:
     branches:
       ["**", "!master", "!auto", "!try", "!try-linux", "!try-mac", "!try-windows", "!try-wpt", "!dependabot/**"]
@@ -8,6 +10,7 @@ on:
 jobs:
   build-linux:
     name: Linux
+    if: github.repository != 'servo/servo' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/linux.yml
     with:
       layout: '2013'
@@ -15,6 +18,7 @@ jobs:
 
   build-linux-layout-2020:
     name: Linux (layout-2020)
+    if: github.repository != 'servo/servo' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/linux.yml
     with:
       layout: '2020'


### PR DESCRIPTION
Split out the quick check GitHub action (which is really only meant for forks). This prevents the quick check from running twice for PRs from branches on the upstream repository. Also rename the WPT export action file to make it clearer that it runs for pull requests. This change also means we no longer trigger builds when simply editing pull request body or title.



<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29603
- [x] These changes do not require tests because this is just a reorganization of the workflow files.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
