### PR TITLE
Handle non-UTF8 diffs in the WPT upstream script

### DIFF
--- a/etc/ci/upstream-wpt-changes/tests/add-non-utf8-file.diff
+++ b/etc/ci/upstream-wpt-changes/tests/add-non-utf8-file.diff
@@ -1,0 +1,7 @@
+diff --git a/tests/wpt/web-platform-tests/non-utf8-file.txt b/tests/wpt/web-platform-tests/non-utf8-file.txt
+new file mode 100644
+index 0000000..5a992e0
+--- /dev/null
++++ b/tests/wpt/web-platform-tests/non-utf8-file.txt
+@@ -0,0 +1 @@
++foo bÃ©r ÿ "

--- a/etc/ci/upstream-wpt-changes/wptupstreamer/__init__.py
+++ b/etc/ci/upstream-wpt-changes/wptupstreamer/__init__.py
@@ -50,7 +50,7 @@ class LocalGitRepo:
         self.path = path
         self.sync = sync
 
-    def run(self, *args, env: dict = {}):
+    def run_without_encoding(self, *args, env: dict = {}):
         command_line = ["git"] + list(args)
         logging.info("  → Execution (cwd='%s'): %s",
                      self.path, " ".join(command_line))
@@ -63,11 +63,18 @@ class LocalGitRepo:
         try:
             return subprocess.check_output(
                 command_line, cwd=self.path, env=env, stderr=subprocess.STDOUT
-            ).decode("utf-8")
+            )
         except subprocess.CalledProcessError as exception:
             logging.warning("Process execution failed with output:\n%s",
-                            exception.output.decode("utf-8"))
+                            exception.output.decode("utf-8", errors="surrogateescape"))
             raise exception
+
+    def run(self, *args, env: dict = {}):
+        return (
+            self
+            .run_without_encoding(*args, env=env)
+            .decode("utf-8", errors="surrogateescape")
+        )
 
 
 @dataclasses.dataclass()

--- a/etc/ci/upstream-wpt-changes/wptupstreamer/step.py
+++ b/etc/ci/upstream-wpt-changes/wptupstreamer/step.py
@@ -114,7 +114,9 @@ class CreateOrUpdateBranchForPRStep(Step):
             # TODO: If we could cleverly parse and manipulate the full commit diff
             # we could avoid cloning the servo repository altogether and only
             # have to fetch the commit diffs from GitHub.
-            diff = local_servo_repo.run(
+            # NB: The output of git show might include binary files or non-UTF8 text,
+            # so store the content of the diff as a `bytes`.
+            diff = local_servo_repo.run_without_encoding(
                 "show", "--binary", "--format=%b", sha, "--", UPSTREAMABLE_PATH
             )
 
@@ -140,7 +142,7 @@ class CreateOrUpdateBranchForPRStep(Step):
         strip_count = UPSTREAMABLE_PATH.count("/") + 1
 
         try:
-            with open(patch_path, "w", encoding="utf-8") as file:
+            with open(patch_path, "wb") as file:
                 file.write(commit["diff"])
             run.sync.local_wpt_repo.run(
                 "apply", PATCH_FILE_NAME, "-p", str(strip_count)


### PR DESCRIPTION
The output of `git diff` and `git show` can include non-UTF8 text or binary data, so the WPT upstream script should handle this properly.

Fixes #29620.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29620
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
