### PR TITLE
Fix calculation of block axis for abspos elements in Layout 2020

### DIFF
--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -458,8 +458,7 @@ impl HoistedAbsolutelyPositionedBox {
         };
         let solve_block_axis = |computed_size| {
             solve_axis(
-                // TODO(delan) shouldn’t this be cbbs?
-                cbis,
+                cbbs,
                 pbm.padding_border_sums.block,
                 pbm.margin.block_start,
                 pbm.margin.block_end,

--- a/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-position-152.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/backgrounds/background-position-152.xht.ini
@@ -1,2 +1,0 @@
-[background-position-152.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/height-percentage-003.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/height-percentage-003.xht.ini
@@ -1,2 +1,0 @@
-[height-percentage-003.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/bottom-offset-percentage-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/bottom-offset-percentage-001.xht.ini
@@ -1,2 +1,0 @@
-[bottom-offset-percentage-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/left-offset-percentage-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/left-offset-percentage-002.xht.ini
@@ -1,2 +1,0 @@
-[left-offset-percentage-002.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-offset-percentage-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-offset-percentage-001.xht.ini
@@ -1,2 +1,0 @@
-[top-offset-percentage-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-offset-percentage-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/positioning/top-offset-percentage-002.xht.ini
@@ -1,2 +1,0 @@
-[top-offset-percentage-002.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/visuren/position-absolute-percentage-inherit-001.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/visuren/position-absolute-percentage-inherit-001.xht.ini
@@ -1,2 +1,0 @@
-[position-absolute-percentage-inherit-001.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-position/position-absolute-dynamic-containing-block.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-position/position-absolute-dynamic-containing-block.html.ini
@@ -1,16 +1,4 @@
 [position-absolute-dynamic-containing-block.html]
-  [abs containing block moves from outer to intermediate]
-    expected: FAIL
-
-  [abs containing block moves from intermediate to outer]
-    expected: FAIL
-
-  [target is no longer absolute]
-    expected: FAIL
-
-  [target becomes absolute]
-    expected: FAIL
-
   [fixed containing block moves from outer to intermediate]
     expected: FAIL
 

--- a/tests/wpt/metadata-layout-2020/css/css-position/position-absolute-fit-content.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-position/position-absolute-fit-content.html.ini
@@ -1,0 +1,2 @@
+[position-absolute-fit-content.html]
+  expected: FAIL


### PR DESCRIPTION
The calculation of the block axis positioning of absolutely positioned elements was using the inline size of the containing block instead of the block size.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
