### PR TITLE
Use same-origin as default credential mode for RequestInit fix

### DIFF
--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -269,7 +269,7 @@ impl RequestBuilder {
             mode: RequestMode::NoCors,
             cache_mode: CacheMode::Default,
             use_cors_preflight: false,
-            credentials_mode: CredentialsMode::Omit,
+            credentials_mode: CredentialsMode::CredentialsSameOrigin,
             use_url_credentials: false,
             origin: ImmutableOrigin::new_opaque(),
             referrer: referrer,

--- a/components/net_traits/request.rs
+++ b/components/net_traits/request.rs
@@ -509,7 +509,7 @@ impl Request {
             synchronous: false,
             mode: RequestMode::NoCors,
             use_cors_preflight: false,
-            credentials_mode: CredentialsMode::Omit,
+            credentials_mode: CredentialsMode::CredentialsSameOrigin,
             use_url_credentials: false,
             cache_mode: CacheMode::Default,
             redirect_mode: RedirectMode::Follow,

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -232,10 +232,7 @@ impl Request {
         }
 
         // Step 19
-        let credentials = init
-            .credentials
-            .as_ref()
-            .map(|m| m.clone().into());
+        let credentials = init.credentials.as_ref().map(|m| m.clone().into());
 
         if let Some(c) = credentials {
             request.credentials_mode = c;

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -79,11 +79,6 @@ impl Request {
         // Step 2
         let mut fallback_mode: Option<NetTraitsRequestMode> = None;
 
-        // FIXME(cybai): As the spec changed in https://github.com/whatwg/fetch/pull/1153,
-        //               we will need to change the default value of credentials for
-        //               NetTraitsRequest and then remove fallback here.
-        let mut fallback_credentials: Option<NetTraitsRequestCredentials> = None;
-
         // Step 3
         let base_url = global.api_base_url();
 
@@ -107,8 +102,6 @@ impl Request {
                 temporary_request = net_request_from_global(global, url);
                 // Step 5.5
                 fallback_mode = Some(NetTraitsRequestMode::CorsMode);
-                // FIXME(cybai): remove this line when we can remove the fallback of credentials
-                fallback_credentials = Some(NetTraitsRequestCredentials::CredentialsSameOrigin);
             },
             // Step 6
             RequestInfo::Request(ref input_request) => {
@@ -242,8 +235,7 @@ impl Request {
         let credentials = init
             .credentials
             .as_ref()
-            .map(|m| m.clone().into())
-            .or(fallback_credentials);
+            .map(|m| m.clone().into());
 
         if let Some(c) = credentials {
             request.credentials_mode = c;

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -232,10 +232,9 @@ impl Request {
         }
 
         // Step 19
-        let credentials = init.credentials.as_ref().map(|m| m.clone().into());
-
-        if let Some(c) = credentials {
-            request.credentials_mode = c;
+        if let Some(init_credentials) = init.credentials.as_ref() {
+            let credentials = init_credentials.clone().into();
+            request.credentials_mode = credentials;
         }
 
         // Step 20


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
- Updated the default credential mode from omit to same-origin as per: https://github.com/whatwg/fetch/pull/1153
- Deleted instances of fallback credentials
---

- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #29633  (GitHub issue number if applicable)
- [X] There are tests for these changes

