### PR TITLE
Make errors during build status notification warnings

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -744,12 +744,15 @@ class MachCommands(CommandBase):
                         -1  # timeout
                     )
                 except ImportError:
-                    raise Exception("Optional Python module 'dbus' is not installed.")
+                    print("[Warning] Could not generate notification: "
+                          "Optional Python module 'dbus' is not installed.",
+                          file=sys.stderr)
                 return True
 
         if notify_command:
             if call([notify_command, title, message]) != 0:
-                raise Exception("Could not run '%s'." % notify_command)
+                print("[Warning] Could not generate notification: "
+                      f"Could not run '{notify_command}'.", file=sys.stderr)
         else:
             notifier = LinuxNotifier if sys.platform.startswith("linux") else None
             notification = notifypy.Notify(use_custom_notifier=notifier)


### PR DESCRIPTION
Instead of raising an exception, simply print a warning on stderr when notification fails.

Fixes #29635.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29635
- [x] These changes do not require tests because they fix a minor tools issue.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
