### PR TITLE
Throw HierarchyRequest error for attr node in pre-insertion

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1872,8 +1872,7 @@ impl Node {
             NodeTypeId::Element(_) |
             NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) |
             NodeTypeId::CharacterData(CharacterDataTypeId::Comment) => (),
-            NodeTypeId::Document(_) => return Err(Error::HierarchyRequest),
-            NodeTypeId::Attr => unreachable!(),
+            NodeTypeId::Document(_) | NodeTypeId::Attr => return Err(Error::HierarchyRequest),
         }
 
         // Step 6.
@@ -1942,8 +1941,9 @@ impl Node {
                     }
                 },
                 NodeTypeId::CharacterData(_) => (),
-                NodeTypeId::Document(_) => unreachable!(),
-                NodeTypeId::Attr => unreachable!(),
+                // Because Document and Attr should already throw `HierarchyRequest`
+                // error, both of them are unreachable here.
+                NodeTypeId::Document(_) | NodeTypeId::Attr => unreachable!(),
             }
         }
         Ok(())
@@ -2628,7 +2628,7 @@ impl NodeMethods for Node {
             NodeTypeId::DocumentType if !self.is::<Document>() => {
                 return Err(Error::HierarchyRequest);
             },
-            NodeTypeId::Document(_) => return Err(Error::HierarchyRequest),
+            NodeTypeId::Document(_) | NodeTypeId::Attr => return Err(Error::HierarchyRequest),
             _ => (),
         }
 
@@ -2679,6 +2679,8 @@ impl NodeMethods for Node {
                     }
                 },
                 NodeTypeId::CharacterData(..) => (),
+                // Because Document and Attr should already throw `HierarchyRequest`
+                // error, both of them are unreachable here.
                 NodeTypeId::Document(_) => unreachable!(),
                 NodeTypeId::Attr => unreachable!(),
             }

--- a/tests/wpt/metadata-layout-2020/dom/attributes-are-nodes.html.ini
+++ b/tests/wpt/metadata-layout-2020/dom/attributes-are-nodes.html.ini
@@ -1,2 +1,0 @@
-[attributes-are-nodes.html]
-  expected: CRASH

--- a/tests/wpt/metadata/dom/attributes-are-nodes.html.ini
+++ b/tests/wpt/metadata/dom/attributes-are-nodes.html.ini
@@ -1,2 +1,0 @@
-[attributes-are-nodes.html]
-  expected: CRASH


### PR DESCRIPTION
Based on Step 4 of https://dom.spec.whatwg.org/#concept-node-ensure-pre-insertion-validity, we should throw `HierarchyRequest` error when the node is not a [DocumentFragment](https://dom.spec.whatwg.org/#documentfragment), [DocumentType](https://dom.spec.whatwg.org/#documenttype), [Element](https://dom.spec.whatwg.org/#element), or [CharacterData](https://dom.spec.whatwg.org/#characterdata) [node](https://dom.spec.whatwg.org/#concept-node).

Thus, Attr is not one of them; we should throw an error in this case.

(I'm guessing it was a kind of typo in https://github.com/servo/servo/pull/25310 because we need to handle Attr with `unreachable` in line 1946)

So, with doing so, we can fix the CRASH in `/dom/attributes-are-nodes.html`.

---

- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)
- [x] There are tests for these changes
