### PR TITLE
Rename `ComputedValuesExt::establishes_containing_block`

### DIFF
--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -540,7 +540,10 @@ impl BoxFragment {
         padding_rect: &PhysicalRect<Length>,
         containing_block_info: &mut ContainingBlockInfo,
     ) {
-        if !self.style.establishes_containing_block() {
+        if !self
+            .style
+            .establishes_containing_block_for_absolute_descendants()
+        {
             return;
         }
 

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -196,7 +196,7 @@ impl PositioningContext {
     pub(crate) fn new_for_style(style: &ComputedValues) -> Option<Self> {
         if style.establishes_containing_block_for_all_descendants() {
             Some(Self::new_for_containing_block_for_all_descendants())
-        } else if style.establishes_containing_block() {
+        } else if style.establishes_containing_block_for_absolute_descendants() {
             Some(Self {
                 for_nearest_positioned_ancestor: Some(Vec::new()),
                 for_nearest_containing_block_for_all_descendants: Vec::new(),


### PR DESCRIPTION
This renames the helper method to be a bit more accurate. For elements with static, relative, and sticky positioning, their containing block is always formed by their nearest block container ancestor. This method is really dealing with style that means an element will establish a containing block for absolutely positioned descendants.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they do not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
