### PR TITLE
Catch more exceptions when delivering build notifications

### DIFF
--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -743,9 +743,8 @@ class MachCommands(CommandBase):
                         {"transient": True},  # hints
                         -1  # timeout
                     )
-                except ImportError:
-                    print("[Warning] Could not generate notification: "
-                          "Optional Python module 'dbus' is not installed.",
+                except Exception as exception:
+                    print(f"[Warning] Could not generate notification: {exception}",
                           file=sys.stderr)
                 return True
 


### PR DESCRIPTION
It seems that catching ImportError isn't enough, so we must catch any type of exception when trying to deliver a build notification.

Fixes #29645.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because they fix a small build infrastructure issue.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
