### PR TITLE
Download prebuilt dependencies from Github instead of S3

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -128,7 +128,7 @@ def windows_msvc(context, force=False):
     '''Bootstrapper for MSVC building on Windows.'''
 
     deps_dir = os.path.join(context.sharedir, "msvc-dependencies")
-    deps_url = "https://servo-deps-2.s3.amazonaws.com/msvc-deps/"
+    deps_url = "https://github.com/servo/servo-build-deps/releases/download/msvc-deps/"
 
     def version(package):
         return packages.WINDOWS_MSVC[package]

--- a/support/linux/gstreamer/gstreamer.sh
+++ b/support/linux/gstreamer/gstreamer.sh
@@ -6,5 +6,5 @@
 
 set -o errexit
 
-curl -L https://servo-deps-2.s3.amazonaws.com/gstreamer/gstreamer-1.16-x86_64-linux-gnu.20190515.tar.gz | tar xz
+curl -L https://github.com/servo/servo-build-deps/releases/download/linux/gstreamer-1.16-x86_64-linux-gnu.20190515.tar.gz | tar xz
 sed -i "s;prefix=/opt/gst;prefix=$PWD/gst;g" $PWD/gst/lib/pkgconfig/*.pc


### PR DESCRIPTION
After moving nightly builds to GitHub releases, the major contributor to AWS cost is now the S3 data transfer charges.

This PR only addresses the data transfer costs incurred due to the download of gstreamer dependency in the linux and the Windows dependencies (llvm, cmake, moztools, openssl etc) for MSVC builds. Android dependencies and UWP/Hololens dependencies will continue to be served from S3. These can be moved to GH as well in a future PR.

The new [servo-build-deps](https://github.com/servo/servo-build-deps/releases) repo now has two tagged releases - linux and msvc. For now, I've manually uploaded the latest versions of the dependencies referred in Servo code to the corresponding releases. We can add the older versions of the dependencies later if needed, potentially using a script to copy from s3.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it is a small change in the CI/bootstrap code.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
