### PR TITLE
Fixed bug where ./mach test-wpt was unable to run on windows due to servowpt…

### DIFF
--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -80,11 +80,12 @@ def run_tests(**kwargs):
         target_dir = os.path.join(os.environ["CARGO_TARGET_DIR"])
     else:
         target_dir = os.path.join(SERVO_ROOT, "target")
+
+    binary_name = ("servo.exe" if sys.platform == "win32" else "servo")
+
     default_binary_path = os.path.join(
-        target_dir, determine_build_type(kwargs, target_dir), "servo"
+        target_dir, determine_build_type(kwargs, target_dir), binary_name
     )
-    if sys.platform == "win32":
-        target_dir += ".exe"
 
     set_if_none(kwargs, "binary", default_binary_path)
     set_if_none(kwargs, "webdriver_binary", default_binary_path)


### PR DESCRIPTION
….py not correctly setting default binary path

<!-- Please describe your changes on the following line: -->
Changed the default_binary_path variable to account for the binary_name change to "servo.exe" on win32 properly. Before, the target_dir was being changed after the default path variable was set. This would result in the following error when ./mach test-wpt was run:

"Binary path C:\Code\servo\target\release\servo does not exist"

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because the validity of the change can be tested by running ./mach test-wpt.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
