### PR TITLE
Fix text-decoration for block containers in layout-2020

### DIFF
--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -712,10 +712,13 @@ where
                 )
         });
 
+        let mut ifc = InlineFormattingContext::new(
+            self.ongoing_inline_formatting_context.text_decoration_line,
+            /* has_first_formatted_line = */ false,
+        );
+        std::mem::swap(&mut self.ongoing_inline_formatting_context, &mut ifc);
         let kind = BlockLevelCreator::SameFormattingContextBlock(
-            IntermediateBlockContainer::InlineFormattingContext(std::mem::take(
-                &mut self.ongoing_inline_formatting_context,
-            )),
+            IntermediateBlockContainer::InlineFormattingContext(ifc),
         );
         let info = self.info.new_replacing_style(anonymous_style.clone());
         self.block_level_boxes.push(BlockLevelJob {

--- a/components/layout_2020/flow/inline.rs
+++ b/components/layout_2020/flow/inline.rs
@@ -31,7 +31,7 @@ use style::values::specified::text::TextDecorationLine;
 use style::Zero;
 use webrender_api::FontInstanceKey;
 
-#[derive(Debug, Default, Serialize)]
+#[derive(Debug, Serialize)]
 pub(crate) struct InlineFormattingContext {
     pub(super) inline_level_boxes: Vec<ArcRefCell<InlineLevelBox>>,
     pub(super) text_decoration_line: TextDecorationLine,

--- a/tests/wpt/web-platform-tests/css/css-text-decor/reference/text-decoration-propagation-04-ref.html
+++ b/tests/wpt/web-platform-tests/css/css-text-decor/reference/text-decoration-propagation-04-ref.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<title>CSS Test reference: text-decoration propagation</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com" />
+<link rel="help" href="https://www.w3.org/TR/css-text-decor-3/#line-decoration">
+<style>
+div { margin: 1em 0 }
+</style>
+<div style="text-decoration: underline">
+  lorem
+</div>
+<div style="text-decoration: underline overline">
+  ipsum
+</div>
+<div style="text-decoration: underline">
+  dolor
+</div>
+<div style="text-decoration: underline overline">
+  sit
+</div>
+<div style="text-decoration: underline overline line-through">
+  amet
+</div>
+<div style="text-decoration: underline overline">
+  consectetur
+</div>
+<div style="text-decoration: underline">
+  adipiscing
+</div>

--- a/tests/wpt/web-platform-tests/css/css-text-decor/text-decoration-propagation-04.html
+++ b/tests/wpt/web-platform-tests/css/css-text-decor/text-decoration-propagation-04.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>CSS Test: text-decoration propagation</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com" />
+<link rel="help" href="https://www.w3.org/TR/css-text-decor-3/#line-decoration">
+<link rel="help" href="https://github.com/servo/servo/issues/29654">
+<link rel="match" href="reference/text-decoration-propagation-04-ref.html">
+<style>
+div { margin: 1em 0 }
+</style>
+<div style="text-decoration: underline">
+  lorem
+  <div style="text-decoration: overline">
+    ipsum
+  </div>
+  dolor
+  <div style="text-decoration: overline">
+    sit
+    <div style="text-decoration: line-through">
+      amet
+    </div>
+    consectetur
+  </div>
+  adipiscing
+</span>


### PR DESCRIPTION
It was only applied to the 1st inline formatting context of a block container. Other IFCs were created with the Default trait, implying TextDecorationLine::NONE.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #29654

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
