### PR TITLE
Build on Mac with the dummy media stack

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -77,7 +77,7 @@ jobs:
           export OPENSSL_LIB_DIR="$(brew --prefix openssl)/lib"
           export PKG_CONFIG_PATH="$(brew --prefix libffi)/lib/pkgconfig/"
           export PKG_CONFIG_PATH="$(brew --prefix zlib)/lib/pkgconfig/:$PKG_CONFIG_PATH"
-          python3 ./mach build --release --with-${{ env.LAYOUT }}
+          python3 ./mach build --release --media-stack=dummy --with-${{ env.LAYOUT }}
       - name: Smoketest
         run: python3 ./mach smoketest
       - name: Unit tests

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -342,7 +342,9 @@ class PackageCommands(CommandBase):
             change_prefs(dir_to_resources, "macosx")
 
             print("Finding dylibs and relinking")
-            copy_dependencies(path.join(content_dir, 'servo'), content_dir)
+            # TODO(mrobinson): GStreamer dependencies don't need to be packaged
+            # with servo until the media backend is re-enabled.
+            # copy_dependencies(path.join(content_dir, 'servo'), content_dir)
 
             print("Adding version to Credits.rtf")
             version_command = [binary_path, '--version']
@@ -403,7 +405,9 @@ class PackageCommands(CommandBase):
             # Note that in the context of Homebrew, libexec is reserved for private use by the formula
             # and therefore is not symlinked into HOMEBREW_PREFIX.
             os.makedirs(path.join(dir_to_brew, 'libexec'))
-            copy_dependencies(path.join(dir_to_brew, 'bin', 'servo'), path.join(dir_to_brew, 'libexec'))
+            # TODO(mrobinson): GStreamer dependencies don't need to be packaged
+            # with servo until the media backend is re-enabled.
+            # copy_dependencies(path.join(dir_to_brew, 'bin', 'servo'), path.join(dir_to_brew, 'libexec'))
             archive_deterministically(dir_to_brew, tar_path, prepend_path='servo/')
             delete(dir_to_brew)
             print("Packaged Servo into " + tar_path)


### PR DESCRIPTION
This is a temporary fix for broken GStreamer homebrew packages.

Fixes #29653.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #29653.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
