### PR TITLE
try-wpt-2020 runner & run wpt test on selected layout

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Run tests
         if: ${{ inputs.wpt != 'sync' }}
         run: |
-          python3 ./mach test-wpt \
+          python3 ./mach test-wpt --with-${{ env.LAYOUT }} \
             --release --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \
@@ -149,7 +149,7 @@ jobs:
       - name: Run tests (sync)
         if: ${{ inputs.wpt == 'sync' }}
         run: |
-          python3 ./mach test-wpt \
+          python3 ./mach test-wpt --with-${{ env.LAYOUT }} \
             --release --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw test-wpt.${{ matrix.chunk_id }}.log \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,13 +39,13 @@ on:
         default: false
         type: boolean
   push:
-    branches: ["try-linux", "try-wpt"]
+    branches: ["try-linux", "try-wpt", "try-wpt-2020"]
 
 env:
   RUST_BACKTRACE: 1
   SHELL: /bin/bash
-  LAYOUT: "${{ contains(inputs.layout, '2020') && 'layout-2020' || 'layout-2013' }}"
-  PACKAGE: "${{ contains(inputs.layout, '2020') && 'linux-layout2020' || 'linux' }}"
+  LAYOUT: "${{ (contains(inputs.layout, '2020') || github.ref_name == 'try-wpt-2020') && 'layout-2020' || 'layout-2013' }}"
+  PACKAGE: "${{ (contains(inputs.layout, '2020') || github.ref_name == 'try-wpt-2020') && 'linux-layout2020' || 'linux' }}"
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   CCACHE: "sccache"
@@ -102,7 +102,7 @@ jobs:
           path: target.tar.gz
 
   linux-wpt:
-    if: ${{ github.ref_name == 'try-wpt' || inputs.wpt }}
+    if: ${{ contains(github.ref_name, 'wpt') || inputs.wpt }}
     name: Linux WPT Tests
     runs-on: ubuntu-20.04
     needs: ["build-linux"]
@@ -183,7 +183,7 @@ jobs:
   report-test-results:
     name: Reporting test results
     runs-on: ubuntu-latest
-    if: ${{ always() && !cancelled() && success('build-linux') && (github.ref_name == 'try-wpt' || inputs.wpt == 'test') }}
+    if: ${{ always() && !cancelled() && success('build-linux') && (contains(github.ref_name, 'wpt') || inputs.wpt == 'test') }}
     needs:
       - "linux-wpt"
     steps:

--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -5,7 +5,7 @@ name: Quick check
 on:
   push:
     branches:
-      ["**", "!master", "!auto", "!try", "!try-linux", "!try-mac", "!try-windows", "!try-wpt", "!dependabot/**"]
+      ["**", "!master", "!auto", "!try", "!try-linux", "!try-mac", "!try-windows", "!try-wpt", "!try-wpt-2020", "!dependabot/**"]
 
 jobs:
   build-linux:

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -352,7 +352,7 @@ class MachCommands(CommandBase):
     def try_jobs(self, jobs):
         branches = []
         # we validate branches because force pushing is destructive
-        VALID_TRY_BRACHES = ["try", "try-linux", "try-mac", "try-windows", "try-wpt"]
+        VALID_TRY_BRACHES = ["try", "try-linux", "try-mac", "try-windows", "try-wpt", "try-wpt-2020"]
         for job in jobs:
             # branches must start with try-
             if "try" not in job:

--- a/python/wpt/__init__.py
+++ b/python/wpt/__init__.py
@@ -33,6 +33,8 @@ def create_parser():
                         help="Pass preferences to servo")
     parser.add_argument('--layout-2020', '--with-layout-2020', default=False,
                         action="store_true", help="Use expected results for the 2020 layout engine")
+    parser.add_argument('--layout-2013', '--with-layout-2013', default=True,
+                        action="store_true", help="Use expected results for the 2013 layout engine")
     parser.add_argument('--log-servojson', action="append", type=mozlog.commandline.log_file,
                         help="Servo's JSON logger of unexpected results")
     parser.add_argument('--always-succeed', default=False, action="store_true",

--- a/python/wpt/importer/__init__.py
+++ b/python/wpt/importer/__init__.py
@@ -47,6 +47,8 @@ def create_parser():
     parser = wptcommandline.create_parser_update()
     parser.add_argument("--layout-2020", "--with-layout-2020", default=False, action="store_true",
                         help="Use expected results for the 2020 layout engine")
+    parser.add_argument("--layout-2013", "--with-layout-2013", default=True, action="store_true",
+                        help="Use expected results for the 2013 layout engine")
     return parser
 
 


### PR DESCRIPTION
wpt-2020 try runner was not enabled as observed in #29655 and even if it was it would have not been working right (as observed in workflow dispatch).

There may be additional changes needed for WPT importer/report_agregator as quick look over it shows flags are not passed over to them.

A lot of layout2020 tests are still falling.

Tests:
- [Quick check](https://github.com/sagudev/servo/actions/runs/4786225230)
- [wpt](https://github.com/sagudev/servo/actions/runs/4786228332)
- [wpt-2020](https://github.com/sagudev/servo/actions/runs/4786229751)
