### PR TITLE
Fix flakiness in hit testing

### DIFF
--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats/hit-test-floats-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats/hit-test-floats-003.html.ini
@@ -1,3 +1,0 @@
-[hit-test-floats-003.html]
-  [Miss float below something else]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats/hit-test-floats-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats/hit-test-floats-004.html.ini
@@ -1,3 +1,0 @@
-[hit-test-floats-004.html]
-  [Miss float below something else]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/floats/hit-test-floats-005.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/floats/hit-test-floats-005.html.ini
@@ -1,3 +1,0 @@
-[hit-test-floats-005.html]
-  [Miss clipped float]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-in-inline-hittest-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-in-inline-hittest-001.html.ini
@@ -1,3 +1,0 @@
-[block-in-inline-hittest-001.html]
-  [block-in-inline-hittest-001]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-in-inline-hittest-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-in-inline-hittest-002.html.ini
@@ -1,6 +1,3 @@
 [block-in-inline-hittest-002.html]
   [elementsFromPoint]
     expected: FAIL
-
-  [elementFromPoint]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-in-inline-hittest-relpos-zindex.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/block-in-inline-hittest-relpos-zindex.html.ini
@@ -1,6 +1,3 @@
 [block-in-inline-hittest-relpos-zindex.html]
   [position: relative; z-index: -1;]
     expected: FAIL
-
-  [block-in-inline-hittest-relpos-zindex]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/hit-test-anonymous-block.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/CSS2/normal-flow/hit-test-anonymous-block.html.ini
@@ -1,3 +1,0 @@
-[hit-test-anonymous-block.html]
-  [Hit test beside line of text inside anonymous block]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/CaretPosition-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/CaretPosition-001.html.ini
@@ -1,3 +1,0 @@
-[CaretPosition-001.html]
-  [Element at (400, 100)]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPoint-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPoint-001.html.ini
@@ -1,3 +1,0 @@
-[elementFromPoint-001.html]
-  [CSSOM View - 5 - extensions to the Document interface]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPoint-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPoint-002.html.ini
@@ -1,3 +1,0 @@
-[elementFromPoint-002.html]
-  [Checking whether dynamic changes to visibility interact correctly with\n  table anonymous boxes]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPoint-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPoint-003.html.ini
@@ -1,4 +1,0 @@
-[elementFromPoint-003.html]
-  [Checking whether dynamic changes to visibility interact correctly with\n  table anonymous boxes]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPoint-dynamic-anon-box.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPoint-dynamic-anon-box.html.ini
@@ -1,3 +1,0 @@
-[elementFromPoint-dynamic-anon-box.html]
-  [Link should be clickable after hiding a scrollbox with an anonymous table inside]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPoint-visibility-hidden-resizer.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPoint-visibility-hidden-resizer.html.ini
@@ -1,3 +1,0 @@
-[elementFromPoint-visibility-hidden-resizer.html]
-  [elementFromPoint on resizer area of an element with visibility:hidden]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPosition.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/elementFromPosition.html.ini
@@ -13,9 +13,3 @@
 
   [test some point of the element: bottom right corner]
     expected: FAIL
-
-  [test the top of layer]
-    expected: FAIL
-
-  [test some point of the element: top left corner]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/elementsFromPoint-inline-htb-ltr.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/elementsFromPoint-inline-htb-ltr.html.ini
@@ -1,4 +1,0 @@
-[elementsFromPoint-inline-htb-ltr.html]
-  [elementsFromPoint should return all elements under a point]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/scroll-behavior-smooth-navigation.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/scroll-behavior-smooth-navigation.html.ini
@@ -1,0 +1,3 @@
+[scroll-behavior-smooth-navigation.html]
+  [Instant scrolling while doing history navigation.]
+    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
@@ -5,9 +5,6 @@
   [clientWidth/clientHeight on the HTML body element in quirks mode]
     expected: FAIL
 
-  [scrollBy() on the root element in non-quirks mode]
-    expected: FAIL
-
   [scrollLeft/scrollRight of the content in quirks mode]
     expected: FAIL
 
@@ -26,12 +23,6 @@
   [scrollLeft/scrollRight of the content in non-quirks mode]
     expected: FAIL
 
-  [scroll() on the root element in non-quirks mode]
-    expected: FAIL
-
-  [scrollLeft/scrollTop on the root element in non-quirks mode]
-    expected: FAIL
-
   [scrollWidth/scrollHeight on the HTML body element in quirks mode]
     expected: FAIL
 
@@ -42,13 +33,4 @@
     expected: FAIL
 
   [scrollLeft/scrollTop on the HTML body element in non-quirks mode]
-    expected: FAIL
-
-  [scroll() on the HTML body element in quirks mode]
-    expected: FAIL
-
-  [scrollBy() on the HTML body element in quirks mode]
-    expected: FAIL
-
-  [scrollLeft/scrollTop on the HTML body element in quirks mode]
     expected: FAIL

--- a/tests/wpt/metadata/css/CSS2/floats/hit-test-floats-001.html.ini
+++ b/tests/wpt/metadata/css/CSS2/floats/hit-test-floats-001.html.ini
@@ -1,3 +1,0 @@
-[hit-test-floats-001.html]
-  [hit-test-floats-001]
-    expected: FAIL

--- a/tests/wpt/metadata/css/CSS2/floats/hit-test-floats-003.html.ini
+++ b/tests/wpt/metadata/css/CSS2/floats/hit-test-floats-003.html.ini
@@ -1,3 +1,0 @@
-[hit-test-floats-003.html]
-  [Miss float below something else]
-    expected: FAIL

--- a/tests/wpt/metadata/css/CSS2/normal-flow/block-in-inline-hittest-float-001.html.ini
+++ b/tests/wpt/metadata/css/CSS2/normal-flow/block-in-inline-hittest-float-001.html.ini
@@ -1,3 +1,0 @@
-[block-in-inline-hittest-float-001.html]
-  [block-in-inline-hittest-float-001]
-    expected: FAIL

--- a/tests/wpt/metadata/css/cssom-view/elementFromPoint-dynamic-anon-box.html.ini
+++ b/tests/wpt/metadata/css/cssom-view/elementFromPoint-dynamic-anon-box.html.ini
@@ -1,3 +1,0 @@
-[elementFromPoint-dynamic-anon-box.html]
-  [Link should be clickable after hiding a scrollbox with an anonymous table inside]
-    expected: FAIL

--- a/tests/wpt/metadata/css/cssom-view/elementFromPoint-ellipsis-in-inline-box.html.ini
+++ b/tests/wpt/metadata/css/cssom-view/elementFromPoint-ellipsis-in-inline-box.html.ini
@@ -1,3 +1,0 @@
-[elementFromPoint-ellipsis-in-inline-box.html]
-  [elementFromPoint-ellipsis-in-inline-box]
-    expected: FAIL

--- a/tests/wpt/metadata/css/cssom-view/elementFromPoint-list-001.html.ini
+++ b/tests/wpt/metadata/css/cssom-view/elementFromPoint-list-001.html.ini
@@ -22,3 +22,9 @@
 
   [<li>Image Inside 1</li>]
     expected: FAIL
+
+  [<li>Inside 3</li>]
+    expected: FAIL
+
+  [<li>Image Inside 2</li>]
+    expected: FAIL

--- a/tests/wpt/metadata/css/cssom-view/elementFromPosition.html.ini
+++ b/tests/wpt/metadata/css/cssom-view/elementFromPosition.html.ini
@@ -17,6 +17,3 @@
 
   [test some point of the element: bottom right corner]
     expected: FAIL
-
-  [test the top of layer]
-    expected: FAIL

--- a/tests/wpt/metadata/css/cssom-view/elementsFromPoint-iframes.html.ini
+++ b/tests/wpt/metadata/css/cssom-view/elementsFromPoint-iframes.html.ini
@@ -1,3 +1,0 @@
-[elementsFromPoint-iframes.html]
-  [elementsFromPoint on inner documents]
-    expected: FAIL


### PR DESCRIPTION
We need to make sure that hit testing from script reflects the latest display list we have sent from the compositor.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes


<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
