### PR TITLE
Make WPT results output more useful

### DIFF
--- a/python/wpt/grouping_formatter.py
+++ b/python/wpt/grouping_formatter.py
@@ -93,7 +93,8 @@ class UnexpectedResult():
 
         # Test names sometimes contain control characters, which we want
         # to be printed in their raw form, and not their interpreted form.
-        first_line += f" {result.path.encode('unicode-escape').decode('utf-8')}"
+        title = result.subtest if isinstance(result, UnexpectedSubtestResult) else result.path
+        first_line += f" {title.encode('unicode-escape').decode('utf-8')}"
 
         if isinstance(result, UnexpectedResult) and result.issues:
             first_line += f" ({', '.join([f'#{bug}' for bug in result.issues])})"


### PR DESCRIPTION
Before when a subtest failed, the text of the failed assertion was not printed. This changes makes sure that it is printed in both the console and the aggregated test output.

Also fix a couple typing errors.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because these are improvements to build tools.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
