### PR TITLE
Refactor scrolling on the window object

### DIFF
--- a/components/layout_2020/fragment_tree/fragment.rs
+++ b/components/layout_2020/fragment_tree/fragment.rs
@@ -167,6 +167,15 @@ impl Fragment {
         }
     }
 
+    pub fn scrolling_area(&self, containing_block: &PhysicalRect<Length>) -> PhysicalRect<Length> {
+        match self {
+            Fragment::Box(fragment) | Fragment::Float(fragment) => fragment
+                .scrollable_overflow(containing_block)
+                .translate(containing_block.origin.to_vector()),
+            _ => self.scrollable_overflow(containing_block),
+        }
+    }
+
     pub fn scrollable_overflow(
         &self,
         containing_block: &PhysicalRect<Length>,

--- a/components/layout_thread/lib.rs
+++ b/components/layout_thread/lib.rs
@@ -41,10 +41,9 @@ use layout::flow_ref::FlowRef;
 use layout::incremental::{RelayoutMode, SpecialRestyleDamage};
 use layout::query::{
     process_client_rect_query, process_content_box_request, process_content_boxes_request,
-    process_element_inner_text_query, process_node_scroll_area_request,
-    process_node_scroll_id_request, process_offset_parent_query,
-    process_resolved_font_style_request, process_resolved_style_request, LayoutRPCImpl,
-    LayoutThreadData,
+    process_element_inner_text_query, process_node_scroll_id_request, process_offset_parent_query,
+    process_resolved_font_style_request, process_resolved_style_request,
+    process_scrolling_area_request, LayoutRPCImpl, LayoutThreadData,
 };
 use layout::traversal::{
     construct_flows_at_ancestors, ComputeStackingRelativePositions, PreorderFlowTraversal,
@@ -492,7 +491,7 @@ impl LayoutThread {
                 content_boxes_response: Vec::new(),
                 client_rect_response: Rect::zero(),
                 scroll_id_response: None,
-                scroll_area_response: Rect::zero(),
+                scrolling_area_response: Rect::zero(),
                 resolved_style_response: String::new(),
                 resolved_font_style_response: None,
                 offset_parent_response: OffsetParentResponse::empty(),
@@ -1121,8 +1120,8 @@ impl LayoutThread {
                         &QueryMsg::ClientRectQuery(_) => {
                             rw_data.client_rect_response = Rect::zero();
                         },
-                        &QueryMsg::NodeScrollGeometryQuery(_) => {
-                            rw_data.scroll_area_response = Rect::zero();
+                        &QueryMsg::ScrollingAreaQuery(_) => {
+                            rw_data.scrolling_area_response = Rect::zero();
                         },
                         &QueryMsg::NodeScrollIdQuery(_) => {
                             rw_data.scroll_id_response = None;
@@ -1431,9 +1430,9 @@ impl LayoutThread {
                 &QueryMsg::ClientRectQuery(node) => {
                     rw_data.client_rect_response = process_client_rect_query(node, root_flow);
                 },
-                &QueryMsg::NodeScrollGeometryQuery(node) => {
-                    rw_data.scroll_area_response =
-                        process_node_scroll_area_request(node, root_flow);
+                &QueryMsg::ScrollingAreaQuery(node) => {
+                    rw_data.scrolling_area_response =
+                        process_scrolling_area_request(node, root_flow);
                 },
                 &QueryMsg::NodeScrollIdQuery(node) => {
                     let node: ServoLayoutNode<LayoutData> = unsafe { ServoLayoutNode::new(&node) };

--- a/components/layout_thread_2020/lib.rs
+++ b/components/layout_thread_2020/lib.rs
@@ -469,7 +469,7 @@ impl LayoutThread {
                 content_boxes_response: Vec::new(),
                 client_rect_response: Rect::zero(),
                 scroll_id_response: None,
-                scroll_area_response: Rect::zero(),
+                scrolling_area_response: Rect::zero(),
                 resolved_style_response: String::new(),
                 resolved_font_style_response: None,
                 offset_parent_response: OffsetParentResponse::empty(),
@@ -817,8 +817,8 @@ impl LayoutThread {
                         &QueryMsg::ClientRectQuery(_) => {
                             rw_data.client_rect_response = Rect::zero();
                         },
-                        &QueryMsg::NodeScrollGeometryQuery(_) => {
-                            rw_data.scroll_area_response = Rect::zero();
+                        &QueryMsg::ScrollingAreaQuery(_) => {
+                            rw_data.scrolling_area_response = Rect::zero();
                         },
                         &QueryMsg::NodeScrollIdQuery(_) => {
                             rw_data.scroll_id_response = None;
@@ -1096,8 +1096,8 @@ impl LayoutThread {
                     rw_data.client_rect_response =
                         process_node_geometry_request(node, self.fragment_tree.borrow().clone());
                 },
-                &QueryMsg::NodeScrollGeometryQuery(node) => {
-                    rw_data.scroll_area_response =
+                &QueryMsg::ScrollingAreaQuery(node) => {
+                    rw_data.scrolling_area_response =
                         process_node_scroll_area_request(node, self.fragment_tree.borrow().clone());
                 },
                 &QueryMsg::NodeScrollIdQuery(node) => {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -584,6 +584,13 @@ impl Element {
                 node.parent_directionality()
             })
     }
+
+    pub(crate) fn is_root(&self) -> bool {
+        match self.node.GetParentNode() {
+            None => false,
+            Some(node) => node.is::<Document>(),
+        }
+    }
 }
 
 #[inline]
@@ -3194,10 +3201,7 @@ impl<'a> SelectorsElement for DomRoot<Element> {
     }
 
     fn is_root(&self) -> bool {
-        match self.node.GetParentNode() {
-            None => false,
-            Some(node) => node.is::<Document>(),
-        }
+        Element::is_root(self)
     }
 
     fn is_empty(&self) -> bool {

--- a/components/script_layout_interface/message.rs
+++ b/components/script_layout_interface/message.rs
@@ -101,7 +101,7 @@ pub enum QueryMsg {
     ContentBoxQuery(OpaqueNode),
     ContentBoxesQuery(OpaqueNode),
     ClientRectQuery(OpaqueNode),
-    NodeScrollGeometryQuery(OpaqueNode),
+    ScrollingAreaQuery(Option<OpaqueNode>),
     OffsetParentQuery(OpaqueNode),
     TextIndexQuery(OpaqueNode, Point2D<f32>),
     NodesFromPointQuery(Point2D<f32>, NodesFromPointQueryType),
@@ -143,7 +143,7 @@ impl ReflowGoal {
                 QueryMsg::ContentBoxQuery(_) |
                 QueryMsg::ContentBoxesQuery(_) |
                 QueryMsg::ClientRectQuery(_) |
-                QueryMsg::NodeScrollGeometryQuery(_) |
+                QueryMsg::ScrollingAreaQuery(_) |
                 QueryMsg::NodeScrollIdQuery(_) |
                 QueryMsg::ResolvedStyleQuery(..) |
                 QueryMsg::ResolvedFontStyleQuery(..) |
@@ -165,7 +165,7 @@ impl ReflowGoal {
                 QueryMsg::ContentBoxQuery(_) |
                 QueryMsg::ContentBoxesQuery(_) |
                 QueryMsg::ClientRectQuery(_) |
-                QueryMsg::NodeScrollGeometryQuery(_) |
+                QueryMsg::ScrollingAreaQuery(_) |
                 QueryMsg::NodeScrollIdQuery(_) |
                 QueryMsg::ResolvedStyleQuery(..) |
                 QueryMsg::ResolvedFontStyleQuery(..) |

--- a/components/script_layout_interface/rpc.rs
+++ b/components/script_layout_interface/rpc.rs
@@ -27,7 +27,7 @@ pub trait LayoutRPC {
     /// Requests the geometry of this node. Used by APIs such as `clientTop`.
     fn node_geometry(&self) -> NodeGeometryResponse;
     /// Requests the scroll geometry of this node. Used by APIs such as `scrollTop`.
-    fn node_scroll_area(&self) -> NodeGeometryResponse;
+    fn scrolling_area(&self) -> NodeGeometryResponse;
     /// Requests the scroll id of this node. Used by APIs such as `scrollTop`
     fn node_scroll_id(&self) -> NodeScrollIdResponse;
     /// Query layout for the resolved value of a given CSS property

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-hyperlink.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-hyperlink.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-hyperlink.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13794,7 +13794,7 @@
      ]
     ],
     "scrollTo.html": [
-     "f1b4384e63bfc12c45c3eca5edcd98ad32a85502",
+     "b90c4e69344216372c9f118d70f4989e82a6fce7",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/scrollTo.html
+++ b/tests/wpt/mozilla/tests/mozilla/scrollTo.html
@@ -3,6 +3,7 @@
 <title></title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<div style="position: absolute; top: 0; left: 0; width: 10000px; height: 10000px; background: purple"></div>
 <script>
 test(function() {
     scrollTo(0, 5000);
@@ -18,4 +19,3 @@ test(function() {
     assert_equals(pageYOffset, 0);
 });
 </script>
-<div style="position: absolute; top: 0; left: 0; width: 10000px; height: 10000px; background: purple"></div>


### PR DESCRIPTION
Refactor the scrolling and scrollable area calculation on the window object, to make it better match the specification. This has some mild changes to behavior, but in general things work the same as they did before. This is mainly preparation for properly handling viewport propagation of the `overflow` property.
    
There is one new pass in Layout 2020 regarding `position: sticky`, but this isn't a big deal because there is no support for `position: sticky` in Layout 2020 yet. In addition, `tests/wpt/mozilla/tests/mozilla/scrollTo.html` is updated to fix a flakiness timing issue. It tries to scroll the page before the entire page is loaded.
    
Co-authored-by: Rakhi Sharma <atbrakhi@igalia.com>

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #21321.
- [x] There are tests for these changes


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
