### PR TITLE
NOT FOR LANDING: investigate inner_radii

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -661,19 +661,8 @@ fn image_rendering(ir: style::computed_values::image_rendering::T) -> wr::ImageR
 }
 
 /// Radii for the padding edge or content edge
-fn inner_radii(mut radii: wr::BorderRadius, offsets: units::LayoutSideOffsets) -> wr::BorderRadius {
-    radii.top_left.width -= -offsets.left;
-    radii.bottom_left.width -= offsets.left;
-
-    radii.top_right.width -= offsets.right;
-    radii.bottom_right.width -= offsets.right;
-
-    radii.top_left.height -= offsets.top;
-    radii.top_right.height -= offsets.top;
-
-    radii.bottom_left.height -= offsets.bottom;
-    radii.bottom_right.height -= offsets.bottom;
-    radii
+fn inner_radii(_radii: wr::BorderRadius, _offsets: units::LayoutSideOffsets) -> wr::BorderRadius {
+    wr::BorderRadius::uniform(1e5)
 }
 
 fn clip_for_radii(


### PR DESCRIPTION
What's using this? The logic seems wrong for overlapping radii.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [ ] `./mach build -d` does not report any errors
- [ ] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
