### PR TITLE
Fix corner clipping typos in layout-2020

### DIFF
--- a/components/layout_2020/display_list/mod.rs
+++ b/components/layout_2020/display_list/mod.rs
@@ -374,7 +374,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                         .to_physical(self.fragment.style.writing_mode)
                         .to_webrender(),
                 ),
-                self.border_rect,
+                *self.padding_rect(),
                 builder,
             )
         })
@@ -389,7 +389,7 @@ impl<'a> BuilderForBoxFragment<'a> {
                         .to_physical(self.fragment.style.writing_mode)
                         .to_webrender(),
                 ),
-                self.border_rect,
+                *self.content_rect(),
                 builder,
             )
         })
@@ -662,7 +662,7 @@ fn image_rendering(ir: style::computed_values::image_rendering::T) -> wr::ImageR
 
 /// Radii for the padding edge or content edge
 fn inner_radii(mut radii: wr::BorderRadius, offsets: units::LayoutSideOffsets) -> wr::BorderRadius {
-    radii.top_left.width -= -offsets.left;
+    radii.top_left.width -= offsets.left;
     radii.bottom_left.width -= offsets.left;
 
     radii.top_right.width -= offsets.right;

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-clip-padding-box-with-border-radius.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-clip-padding-box-with-border-radius.html.ini
@@ -1,2 +1,0 @@
-[background-clip-padding-box-with-border-radius.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-rounded-image-clip.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/background-rounded-image-clip.html.ini
@@ -1,2 +1,0 @@
-[background-rounded-image-clip.html]
-  expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
inner_radii() had a minus sign that shouldn't be there.

And padding_edge_clip() and content_edge_clip() clearly need to to use
the padding_rect() and content_rect() instead of border_rect.

Tests:
  - css/css-backgrounds/background-clip-padding-box-with-border-radius.html
  - css/css-backgrounds/background-rounded-image-clip.html

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #29683 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
