### PR TITLE
Added basic console.table() implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ opt-level = 3
 # debug = true
 # lto = false
 
+[profile.dev]
+incremental = true
+opt-level = 1
+
+
 [patch.crates-io]
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,6 @@ opt-level = 3
 # debug = true
 # lto = false
 
-[profile.dev]
-incremental = true
-opt-level = 1
-
-
 [patch.crates-io]
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -2,15 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::dom::bindings::conversions::{
+    is_array_like, FromJSValConvertible, StringificationBehavior,
+};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
+use crate::script_runtime::JSContext as SafeJSContext;
 use devtools_traits::{ConsoleMessage, LogLevel, ScriptToDevtoolsControlMsg};
+use js::jsapi::JSContext;
 use js::rust::describe_scripted_caller;
-use std::{io};
-use std::any::Any;
+use js::rust::HandleValue;
+use std::io;
 use std::option::Option;
+use std::cmp::max;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Console
 pub struct Console(());
@@ -67,42 +73,52 @@ fn console_message(global: &GlobalScope, message: DOMString, level: LogLevel) {
     })
 }
 
-enum TabularData {
-    PrimitiveArray(Vec<DOMString>)
-}
+///Generates matrix of table elements, and then converts matrix into a properly formatted DOMString
+///TODO: Implement generate_table for objects and arrays of objects
+#[allow(unsafe_code)]
+unsafe fn generate_table(
+    cx: *mut JSContext,
+    tabular_data: &HandleValue
+) -> Option<DOMString> {
+    if !tabular_data.get().is_object() || !is_array_like(cx, *tabular_data) {
+        return None;
+    }
+    
+    let vec: Vec<DOMString> =
+        Vec::<DOMString>::from_jsval(cx, *tabular_data, StringificationBehavior::Empty)
+            .expect("Unable to convert Array object to Vec<DOMString>")
+            .get_success_value()
+            .unwrap_or(&Vec::new())
+            .to_vec();
 
-//handle case where tabular data is an array of DOMStrings
-fn generate_table_from_primitive_array(tabularData: &Vec<DOMString>) -> Vec<Vec<DOMString>> {
-    let mut tableMatrix: Vec<Vec<DOMString>> = vec![vec![DOMString::from_string(String::from("(index)")),
-                                                     DOMString::from_string(String::from("Value"))]];
-
-    for (index, value) in tabularData.iter().enumerate() {
-        tableMatrix.push(vec![DOMString::from_string(index.to_string()), value.clone()]);
+    let mut table_matrix: Vec<Vec<DOMString>> = Vec::new();
+    //Only two columns because we don't expect objects as input yet
+    table_matrix.push(vec!["(index)".into(), "Values".into()]);
+    for (index, word) in vec.into_iter().enumerate() {
+        table_matrix.push(vec![index.to_string().into(), word]);
     }
 
-    tableMatrix
-}
-
-//generate 2D vector from tabular data
-fn generate_table(tabularData: &Option<TabularData>) -> Vec<Vec<DOMString>> {
-    let table: Vec<Vec<DOMString>> = match tabularData {
-        Some(TabularData::PrimitiveArray(arr)) => generate_table_from_primitive_array(arr),
-        None => Vec::new()
-    };
-
-    table
-}
-
-//squash table 2d array into a printable string
-fn generate_table_display_string(tableMatrix: &Vec<Vec<DOMString>>) -> DOMString {
-    let mut displayString: DOMString = DOMString::new();
-    for row in tableMatrix.iter() {
-        for col in row.iter() {
-            displayString.extend(col.chars());
+    let mut result: DOMString = DOMString::new();
+    let mut max_lengths: Vec<usize> = vec![0; table_matrix[0].len()];
+    for row in table_matrix.iter() {
+        for (index, column_value) in row.iter().enumerate() {
+            let column_str = column_value as &str;
+            max_lengths[index] = max(column_str.chars().count(), max_lengths[index]);
         }
     }
 
-    displayString
+    for row in table_matrix.iter() {
+        for (index, column) in row.iter().enumerate() {
+            let column_str = column as &str;
+            let padding_width = max_lengths[index] - column_str.chars().count() + 1;
+            result.push_str(column_str);
+            result.push_str(&" ".repeat(padding_width));
+        }
+
+        result.push_str("\n");
+    }
+
+    Some(result)
 }
 
 #[allow(non_snake_case)]
@@ -112,12 +128,28 @@ impl Console {
         console_messages(global, &messages, LogLevel::Log)
     }
 
-    //https://developer.mozilla.org/en-US/docs/Web/API/Console/table
-    pub fn Table(global: &GlobalScope, tabularData: Box<dyn Any>, properties: Option<Vec<DOMString>>) {
-        // console_messages(global, &messages, LogLevel::Log)
-        // let tableMatrix = generate_table(&tabularData);
-        let displayString: DOMString = "hello".into();
-        console_messages(global, &[displayString], LogLevel::Log);
+    // https://console.spec.whatwg.org/#table
+    pub fn Table(
+        cx: SafeJSContext,
+        global: &GlobalScope,
+        tabular_data: HandleValue,
+        properties: Option<Vec<DOMString>>,
+    ) {
+        let cx_ptr: *mut JSContext = *cx as *mut JSContext;
+
+        #[allow(unsafe_code)]
+        let table: Option<DOMString> = unsafe {
+            generate_table(cx_ptr, &tabular_data)
+        };
+
+        match table {
+            Some(table_string) => {
+                console_messages(global, &[table_string], LogLevel::Log)
+            },
+            None => {
+                console_messages(global, &[], LogLevel::Log)
+            }
+        }
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/Console/clear

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -14,9 +14,9 @@ use devtools_traits::{ConsoleMessage, LogLevel, ScriptToDevtoolsControlMsg};
 use js::jsapi::JSContext;
 use js::rust::describe_scripted_caller;
 use js::rust::HandleValue;
+use std::cmp::max;
 use std::io;
 use std::option::Option;
-use std::cmp::max;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Console
 pub struct Console(());
@@ -76,14 +76,11 @@ fn console_message(global: &GlobalScope, message: DOMString, level: LogLevel) {
 ///Generates matrix of table elements, and then converts matrix into a properly formatted DOMString
 ///TODO: Implement generate_table for objects and arrays of objects
 #[allow(unsafe_code)]
-unsafe fn generate_table(
-    cx: *mut JSContext,
-    tabular_data: &HandleValue
-) -> Option<DOMString> {
+unsafe fn generate_table(cx: *mut JSContext, tabular_data: &HandleValue) -> Option<DOMString> {
     if !tabular_data.get().is_object() || !is_array_like(cx, *tabular_data) {
         return None;
     }
-    
+
     let vec: Vec<DOMString> =
         Vec::<DOMString>::from_jsval(cx, *tabular_data, StringificationBehavior::Empty)
             .expect("Unable to convert Array object to Vec<DOMString>")
@@ -138,17 +135,11 @@ impl Console {
         let cx_ptr: *mut JSContext = *cx as *mut JSContext;
 
         #[allow(unsafe_code)]
-        let table: Option<DOMString> = unsafe {
-            generate_table(cx_ptr, &tabular_data)
-        };
+        let table: Option<DOMString> = unsafe { generate_table(cx_ptr, &tabular_data) };
 
         match table {
-            Some(table_string) => {
-                console_messages(global, &[table_string], LogLevel::Log)
-            },
-            None => {
-                console_messages(global, &[], LogLevel::Log)
-            }
+            Some(table_string) => console_messages(global, &[table_string], LogLevel::Log),
+            None => console_messages(global, &[], LogLevel::Log),
         }
     }
 

--- a/components/script/dom/webidls/Console.webidl
+++ b/components/script/dom/webidls/Console.webidl
@@ -14,6 +14,7 @@ namespace console {
   undefined info(DOMString... messages);
   undefined warn(DOMString... messages);
   undefined error(DOMString... messages);
+  undefined table(optional any tabularData, optional sequence<DOMString> properties);
   undefined assert(boolean condition, optional DOMString message);
   undefined clear();
 

--- a/tests/html/console-table.html
+++ b/tests/html/console-table.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Console.table() better work!</title>
+    <script>
+        let obj = {
+            a: 1,
+            b: 2,
+            c: "Hello",
+            d: 4.42
+        };
+
+        //Array of string primitives
+        console.table(["Hello", "world"]);
+
+        //2D Array of string primitives
+        console.table([["a", "b"], ["c", "d"]]);
+
+        //Array of int primitives
+        console.table([1, 2, 3, 4, 5]);
+
+        //Array of objects
+        console.table([obj, obj, obj]);
+
+        //String
+        console.table("Stringed!");
+
+        //Int
+        console.table(1);
+
+        //Object
+        console.table([obj, obj], ["a"]);
+
+        //console log obj
+        console.log(obj);
+
+        //Extremely long strings
+        console.table(["hellooooooooooooooooooooooooooooooo", "world"]);
+    </script>
+</head>
+<body>
+    <p>console.table() better work!</p>
+</body>
+</html>


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Implemented a basic version of console.table() that supports arrays of primitives as input. The full functionality as described in the spec as mentioned in #27212 will also be implemented later.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because this is only an initial implementation, and tests will be added later if needed.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
