### PR TITLE
Fix installing dependencies on Fedora and remove usage of distro.linux_distribution()

### DIFF
--- a/python/servo/bootstrap.py
+++ b/python/servo/bootstrap.py
@@ -39,7 +39,7 @@ def install_linux_deps(context, pkgs_ubuntu, pkgs_fedora, pkgs_void, force):
         pkgs = pkgs_ubuntu
         if subprocess.call(['dpkg', '-s'] + pkgs, stdout=PIPE, stderr=PIPE) != 0:
             install = True
-    elif context.distro in ['CentOS', 'CentOS Linux', 'Fedora']:
+    elif context.distro in ['CentOS', 'CentOS Linux', 'Fedora', 'Fedora Linux']:
         installed_pkgs = str(subprocess.check_output(['rpm', '-qa'])).replace('\n', '|')
         pkgs = pkgs_fedora
         for p in pkgs:
@@ -196,9 +196,8 @@ LINUX_SPECIFIC_BOOTSTRAPPERS = {
 
 
 def get_linux_distribution():
-    distrib, version, _ = distro.linux_distribution()
-    distrib = six.ensure_str(distrib)
-    version = six.ensure_str(version)
+    distrib = six.ensure_str(distro.name())
+    version = six.ensure_str(distro.version())
 
     if distrib in ['LinuxMint', 'Linux Mint', 'KDE neon']:
         if '.' in version:


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
`./mach bootstrap` wasn't installing dependencies on Fedora, so I fixed that.
And I removed the usage of `distro.linux_distribution()`, because it's a deprecated function.
This is my first attempt at contributing to Servo, so I hope I did everything right :D

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because this pull request only touches `python/servo/bootstrap.py`

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
