### PR TITLE
Move `FromScriptLogger` and  `FromCompositorLogger`  to seperate file

### DIFF
--- a/components/constellation/lib.rs
+++ b/components/constellation/lib.rs
@@ -14,6 +14,7 @@ extern crate serde;
 mod browsingcontext;
 mod constellation;
 mod event_loop;
+mod logging;
 mod network_listener;
 mod pipeline;
 mod sandboxing;
@@ -21,8 +22,7 @@ mod serviceworker;
 mod session_history;
 mod timer_scheduler;
 
-pub use crate::constellation::{
-    Constellation, FromCompositorLogger, FromScriptLogger, InitialConstellationState,
-};
+pub use crate::constellation::{Constellation, InitialConstellationState};
+pub use crate::logging::{FromCompositorLogger, FromScriptLogger};
 pub use crate::pipeline::UnprivilegedPipelineContent;
 pub use crate::sandboxing::{content_process_sandbox_profile, UnprivilegedContent};

--- a/components/constellation/logging.rs
+++ b/components/constellation/logging.rs
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use backtrace::Backtrace;
+use compositing::ConstellationMsg as FromCompositorMsg;
+use crossbeam_channel::Sender;
+use log::{Level, LevelFilter, Log, Metadata, Record};
+use msg::constellation_msg::TopLevelBrowsingContextId;
+use script_traits::{LogEntry, ScriptMsg as FromScriptMsg, ScriptToConstellationChan};
+use servo_remutex::ReentrantMutex;
+use std::borrow::ToOwned;
+use std::sync::Arc;
+use std::thread;
+
+/// The constellation uses logging to perform crash reporting.
+/// The constellation receives all `warn!`, `error!` and `panic!` messages,
+/// and generates a crash report when it receives a panic.
+
+/// A logger directed at the constellation from content processes
+/// #[derive(Clone)]
+pub struct FromScriptLogger {
+    /// A channel to the constellation
+    pub script_to_constellation_chan: Arc<ReentrantMutex<ScriptToConstellationChan>>,
+}
+
+/// The constellation uses logging to perform crash reporting.
+/// The constellation receives all `warn!`, `error!` and `panic!` messages,
+/// and generates a crash report when it receives a panic.
+
+/// A logger directed at the constellation from content processes
+impl FromScriptLogger {
+    /// Create a new constellation logger.
+    pub fn new(script_to_constellation_chan: ScriptToConstellationChan) -> FromScriptLogger {
+        FromScriptLogger {
+            script_to_constellation_chan: Arc::new(ReentrantMutex::new(
+                script_to_constellation_chan,
+            )),
+        }
+    }
+
+    /// The maximum log level the constellation logger is interested in.
+    pub fn filter(&self) -> LevelFilter {
+        LevelFilter::Warn
+    }
+}
+
+impl Log for FromScriptLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Warn
+    }
+
+    fn log(&self, record: &Record) {
+        if let Some(entry) = log_entry(record) {
+            debug!("Sending log entry {:?}.", entry);
+            let thread_name = thread::current().name().map(ToOwned::to_owned);
+            let msg = FromScriptMsg::LogEntry(thread_name, entry);
+            let chan = self
+                .script_to_constellation_chan
+                .lock()
+                .unwrap_or_else(|err| err.into_inner());
+            let _ = chan.send(msg);
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+/// A logger directed at the constellation from the compositor
+#[derive(Clone)]
+pub struct FromCompositorLogger {
+    /// A channel to the constellation
+    pub constellation_chan: Arc<ReentrantMutex<Sender<FromCompositorMsg>>>,
+}
+
+impl FromCompositorLogger {
+    /// Create a new constellation logger.
+    pub fn new(constellation_chan: Sender<FromCompositorMsg>) -> FromCompositorLogger {
+        FromCompositorLogger {
+            constellation_chan: Arc::new(ReentrantMutex::new(constellation_chan)),
+        }
+    }
+
+    /// The maximum log level the constellation logger is interested in.
+    pub fn filter(&self) -> LevelFilter {
+        LevelFilter::Warn
+    }
+}
+
+impl Log for FromCompositorLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Warn
+    }
+
+    fn log(&self, record: &Record) {
+        if let Some(entry) = log_entry(record) {
+            debug!("Sending log entry {:?}.", entry);
+            let top_level_id = TopLevelBrowsingContextId::installed();
+            let thread_name = thread::current().name().map(ToOwned::to_owned);
+            let msg = FromCompositorMsg::LogEntry(top_level_id, thread_name, entry);
+            let chan = self
+                .constellation_chan
+                .lock()
+                .unwrap_or_else(|err| err.into_inner());
+            let _ = chan.send(msg);
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+/// Rust uses `Record` for storing logging, but servo converts that to
+/// a `LogEntry`. We do this so that we can record panics as well as log
+/// messages, and because `Record` does not implement serde (de)serialization,
+/// so cannot be used over an IPC channel.
+fn log_entry(record: &Record) -> Option<LogEntry> {
+    match record.level() {
+        Level::Error if thread::panicking() => Some(LogEntry::Panic(
+            format!("{}", record.args()),
+            format!("{:?}", Backtrace::new()),
+        )),
+        Level::Error => Some(LogEntry::Error(format!("{}", record.args()))),
+        Level::Warn => Some(LogEntry::Warn(format!("{}", record.args()))),
+        _ => None,
+    }
+}

--- a/docs/HACKING_QUICKSTART.md
+++ b/docs/HACKING_QUICKSTART.md
@@ -240,7 +240,7 @@ Using `RUST_LOG="debug"` is usually the very first thing you might want to do if
 RUST_LOG="debug" ./mach run -d -- -i -y 1 /tmp/a.html 2>&1 | ts -s "%.S: " | tee /tmp/log.txt
 ```
 
-You can filter by crate or module, for example `RUST_LOG="layout::inline=debug" ./mach run …`. Check the [env_logger](https://doc.rust-lang.org/log/env_logger/index.html) documentation for more details.
+You can filter by crate or module, for example `RUST_LOG="layout::inline=debug" ./mach run …`. Check the [env_logger](https://docs.rs/env_logger) documentation for more details.
 
 Use `RUST_BACKTRACE=1` to dump the backtrace when Servo panics.
 


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
This PR is an attempt to refactor the `constellation.rs` file in order to make it more readable.  Starting the initiative with moving `FromScriptLogger` and  `FromCompositorLogger` to a separate`logger.rs` file as they don't have any major dependency to be in the `constellation.rs` file itself.

Also noticed a broken link in `docs/HACKING_QUICKSTART.md` file. Adding the correct url.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
