### PR TITLE
Detect body elements during layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3147,6 +3147,7 @@ version = "0.0.1"
 dependencies = [
  "app_units",
  "atomic_refcell",
+ "bitflags",
  "canvas_traits",
  "cssparser",
  "embedder_traits",

--- a/components/layout/flow.rs
+++ b/components/layout/flow.rs
@@ -967,13 +967,23 @@ impl fmt::Debug for BaseFlow {
             "".to_owned()
         };
 
+        let flags_string = if !self.flags.is_empty() {
+            format!("\nflags={:?}", self.flags)
+        } else {
+            "".to_owned()
+        };
+
         write!(
             f,
             "\nsc={:?}\
              \npos={:?}{}{}\
              \nfloatspec-in={:?}\
              \nfloatspec-out={:?}\
-             \noverflow={:?}{}{}{}",
+             \noverflow={:?}\
+             {child_count_string}\
+             {absolute_descendants_string}\
+             {damage_string}\
+             {flags_string}",
             self.stacking_context_id,
             self.position,
             if self.flags.contains(FlowFlags::FLOATS_LEFT) {
@@ -989,9 +999,6 @@ impl fmt::Debug for BaseFlow {
             self.speculated_float_placement_in,
             self.speculated_float_placement_out,
             self.overflow,
-            child_count_string,
-            absolute_descendants_string,
-            damage_string
         )
     }
 }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -9,7 +9,7 @@ use crate::context::LayoutContext;
 use crate::display_list::items::{DisplayList, OpaqueNode, ScrollOffsetMap};
 use crate::display_list::IndexableText;
 use crate::flow::{Flow, GetBaseFlow};
-use crate::fragment::{Fragment, FragmentBorderBoxIterator, SpecificFragmentInfo};
+use crate::fragment::{Fragment, FragmentBorderBoxIterator, FragmentFlags, SpecificFragmentInfo};
 use crate::inline::InlineFragmentNodeFlags;
 use crate::opaque_node::OpaqueNodeMethods;
 use crate::sequential;
@@ -666,11 +666,9 @@ impl FragmentBorderBoxIterator for ParentOffsetBorderBoxIterator {
                 self.has_processed_node = true;
             }
         } else if self.node_offset_box.is_none() {
-            // TODO(gw): Is there a less fragile way of checking whether this
-            // fragment is the body element, rather than just checking that
-            // it's at level 1 (below the root node)?
-            let is_body_element = level == 1;
-
+            let is_body_element = fragment
+                .flags
+                .contains(FragmentFlags::IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT);
             let is_valid_parent = match (
                 is_body_element,
                 fragment.style.get_box().position,

--- a/components/layout_2020/Cargo.toml
+++ b/components/layout_2020/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 app_units = "0.7"
 atomic_refcell = "0.1.6"
 canvas_traits = { path = "../canvas_traits" }
+bitflags = "1.0"
 cssparser = "0.29"
 embedder_traits = { path = "../embedder_traits" }
 euclid = "0.22"

--- a/components/layout_2020/display_list/stacking_context.rs
+++ b/components/layout_2020/display_list/stacking_context.rs
@@ -384,8 +384,8 @@ impl StackingContext {
 
         // The `StackingContextFragment` we found is for the root DOM element:
         debug_assert_eq!(
-            box_fragment.tag.node(),
-            fragment_tree.canvas_background.root_element
+            fragment.tag().map(|tag| tag.node),
+            Some(fragment_tree.canvas_background.root_element),
         );
 
         // The root element may have a CSS transform,
@@ -868,8 +868,8 @@ impl BoxFragment {
             return None;
         }
 
-        let external_id =
-            wr::ExternalScrollId(self.tag.to_display_list_fragment_id(), wr.pipeline_id);
+        let tag = self.base.tag?;
+        let external_id = wr::ExternalScrollId(tag.to_display_list_fragment_id(), wr.pipeline_id);
 
         let sensitivity =
             if ComputedOverflow::Hidden == overflow_x && ComputedOverflow::Hidden == overflow_y {

--- a/components/layout_2020/flexbox/construct.rs
+++ b/components/layout_2020/flexbox/construct.rs
@@ -10,7 +10,6 @@ use crate::dom_traversal::{
 };
 use crate::element_data::LayoutBox;
 use crate::formatting_contexts::IndependentFormattingContext;
-use crate::fragments::Tag;
 use crate::positioned::AbsolutelyPositionedBox;
 use crate::style_ext::DisplayGeneratingBox;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -150,7 +149,7 @@ where
                             .info
                             .new_replacing_style(anonymous_style.clone().unwrap()),
                         runs.into_iter().map(|run| crate::flow::inline::TextRun {
-                            tag: Tag::from_node_and_style_info(&run.info),
+                            base_fragment_info: (&run.info).into(),
                             text: run.text.into(),
                             parent_style: run.info.style,
                         }),

--- a/components/layout_2020/flexbox/layout.rs
+++ b/components/layout_2020/flexbox/layout.rs
@@ -732,7 +732,7 @@ impl FlexLine<'_> {
                 let margin = flex_context.sides_to_flow_relative(*margin);
                 let collapsed_margin = CollapsedBlockMargins::from_margin(&margin);
                 BoxFragment::new(
-                    item.box_.tag(),
+                    item.box_.base_fragment_info(),
                     item.box_.style().clone(),
                     fragments,
                     content_rect,

--- a/components/layout_2020/flow/construct.rs
+++ b/components/layout_2020/flow/construct.rs
@@ -12,7 +12,6 @@ use crate::flow::float::FloatBox;
 use crate::flow::inline::{InlineBox, InlineFormattingContext, InlineLevelBox, TextRun};
 use crate::flow::{BlockContainer, BlockFormattingContext, BlockLevelBox};
 use crate::formatting_contexts::IndependentFormattingContext;
-use crate::fragments::Tag;
 use crate::positioned::AbsolutelyPositionedBox;
 use crate::style_ext::{DisplayGeneratingBox, DisplayInside, DisplayOutside};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -384,7 +383,7 @@ where
 
         if let Some(text) = new_text_run_contents {
             inlines.push(ArcRefCell::new(InlineLevelBox::TextRun(TextRun {
-                tag: Tag::from_node_and_style_info(info),
+                base_fragment_info: info.into(),
                 parent_style: Arc::clone(&info.style),
                 text,
             })))
@@ -495,7 +494,7 @@ where
             // Whatever happened before, all we need to do before recurring
             // is to remember this ongoing inline level box.
             self.ongoing_inline_boxes_stack.push(InlineBox {
-                tag: Tag::from_node_and_style_info(info),
+                base_fragment_info: info.into(),
                 style: info.style.clone(),
                 first_fragment: true,
                 last_fragment: false,
@@ -556,7 +555,7 @@ where
                 .rev()
                 .map(|ongoing| {
                     let fragmented = InlineBox {
-                        tag: ongoing.tag,
+                        base_fragment_info: ongoing.base_fragment_info,
                         style: ongoing.style.clone(),
                         first_fragment: ongoing.first_fragment,
                         // The fragmented boxes before the block level element
@@ -755,7 +754,7 @@ where
             BlockLevelCreator::SameFormattingContextBlock(contents) => {
                 let (contents, contains_floats) = contents.finish(context, info);
                 let block_level_box = ArcRefCell::new(BlockLevelBox::SameFormattingContextBlock {
-                    tag: Tag::from_node_and_style_info(info),
+                    base_fragment_info: info.into(),
                     contents,
                     style: Arc::clone(&info.style),
                 });

--- a/components/layout_2020/flow/mod.rs
+++ b/components/layout_2020/flow/mod.rs
@@ -11,8 +11,9 @@ use crate::flow::inline::InlineFormattingContext;
 use crate::formatting_contexts::{
     IndependentFormattingContext, IndependentLayout, NonReplacedFormattingContext,
 };
+use crate::fragment_tree::BaseFragmentInfo;
 use crate::fragments::{
-    AnonymousFragment, BoxFragment, CollapsedBlockMargins, CollapsedMargin, Fragment, Tag,
+    AnonymousFragment, BoxFragment, CollapsedBlockMargins, CollapsedMargin, Fragment,
 };
 use crate::geom::flow_relative::{Rect, Sides, Vec2};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
@@ -50,7 +51,7 @@ pub(crate) enum BlockContainer {
 #[derive(Debug, Serialize)]
 pub(crate) enum BlockLevelBox {
     SameFormattingContextBlock {
-        tag: Tag,
+        base_fragment_info: BaseFragmentInfo,
         #[serde(skip_serializing)]
         style: Arc<ComputedValues>,
         contents: BlockContainer,
@@ -306,7 +307,7 @@ impl BlockLevelBox {
     ) -> Fragment {
         match self {
             BlockLevelBox::SameFormattingContextBlock {
-                tag,
+                base_fragment_info: tag,
                 style,
                 contents,
             } => Fragment::Box(positioning_context.layout_maybe_position_relative_fragment(
@@ -335,7 +336,7 @@ impl BlockLevelBox {
                         |_positioning_context| {
                             layout_in_flow_replaced_block_level(
                                 containing_block,
-                                replaced.tag,
+                                replaced.base_fragment_info,
                                 &replaced.style,
                                 &replaced.contents,
                             )
@@ -352,7 +353,7 @@ impl BlockLevelBox {
                                 layout_context,
                                 positioning_context,
                                 containing_block,
-                                non_replaced.tag,
+                                non_replaced.base_fragment_info,
                                 &non_replaced.style,
                                 NonReplacedContents::EstablishesAnIndependentFormattingContext(
                                     non_replaced,
@@ -420,7 +421,7 @@ fn layout_in_flow_non_replaced_block_level(
     layout_context: &LayoutContext,
     positioning_context: &mut PositioningContext,
     containing_block: &ContainingBlock,
-    tag: Tag,
+    base_fragment_info: BaseFragmentInfo,
     style: &Arc<ComputedValues>,
     block_level_kind: NonReplacedContents,
     tree_rank: usize,
@@ -559,7 +560,7 @@ fn layout_in_flow_non_replaced_block_level(
         },
     };
     BoxFragment::new(
-        tag,
+        base_fragment_info,
         style.clone(),
         fragments,
         content_rect,
@@ -575,7 +576,7 @@ fn layout_in_flow_non_replaced_block_level(
 /// https://drafts.csswg.org/css2/visudet.html#inline-replaced-height
 fn layout_in_flow_replaced_block_level<'a>(
     containing_block: &ContainingBlock,
-    tag: Tag,
+    base_fragment_info: BaseFragmentInfo,
     style: &Arc<ComputedValues>,
     replaced: &ReplacedContent,
 ) -> BoxFragment {
@@ -600,7 +601,7 @@ fn layout_in_flow_replaced_block_level<'a>(
     };
     let block_margins_collapsed_with_children = CollapsedBlockMargins::from_margin(&margin);
     BoxFragment::new(
-        tag,
+        base_fragment_info,
         style.clone(),
         fragments,
         content_rect,

--- a/components/layout_2020/fragment_tree/base.rs
+++ b/components/layout_2020/fragment_tree/base.rs
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::layout_debug::DebugId;
+use bitflags::bitflags;
+use gfx_traits::{combine_id_with_fragment_type, FragmentType};
+use style::dom::OpaqueNode;
+use style::selector_parser::PseudoElement;
+
+/// This data structure stores fields that are common to all non-base
+/// Fragment types and should generally be the first member of all
+/// concrete fragments.
+#[derive(Debug, Serialize)]
+pub(crate) struct BaseFragment {
+    /// A tag which identifies the DOM node and pseudo element of this
+    /// Fragment's content. If this fragment isn't related to any DOM
+    /// node at all, the tag will be None.
+    pub tag: Option<Tag>,
+
+    /// An id used to uniquely identify this Fragment in debug builds.
+    pub debug_id: DebugId,
+
+    /// Flags which various information about this fragment used during
+    /// layout.
+    pub flags: FragmentFlags,
+}
+
+impl BaseFragment {
+    pub(crate) fn anonymous() -> Self {
+        BaseFragment {
+            tag: None,
+            debug_id: DebugId::new(),
+            flags: FragmentFlags::empty(),
+        }
+    }
+
+    /// Returns true if this fragment is non-anonymous and it is for the given
+    /// OpaqueNode, regardless of the pseudo element.
+    pub(crate) fn is_for_node(&self, node: OpaqueNode) -> bool {
+        self.tag.map(|tag| tag.node == node).unwrap_or(false)
+    }
+}
+
+/// Information necessary to construct a new BaseFragment.
+#[derive(Clone, Copy, Debug, Serialize)]
+pub(crate) struct BaseFragmentInfo {
+    /// The tag to use for the new BaseFragment.
+    pub tag: Tag,
+
+    /// The flags to use for the new BaseFragment.
+    pub flags: FragmentFlags,
+}
+
+impl BaseFragmentInfo {
+    pub(crate) fn new_for_node(node: OpaqueNode) -> Self {
+        Self {
+            tag: Tag::new(node),
+            flags: FragmentFlags::empty(),
+        }
+    }
+}
+
+impl From<BaseFragmentInfo> for BaseFragment {
+    fn from(info: BaseFragmentInfo) -> Self {
+        Self {
+            tag: Some(info.tag),
+            debug_id: DebugId::new(),
+            flags: info.flags,
+        }
+    }
+}
+
+bitflags! {
+    #[doc = "Flags used to track various information about a DOM node during layout."]
+    #[derive(Serialize)]
+    pub(crate) struct FragmentFlags: u8 {
+        #[doc = "Whether or not this node is a body element on an HTML document."]
+        const IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT = 0b00000001;
+    }
+}
+
+/// A data structure used to hold DOM and pseudo-element information about
+/// a particular layout object.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct Tag {
+    pub(crate) node: OpaqueNode,
+    pub(crate) pseudo: Option<PseudoElement>,
+}
+
+impl Tag {
+    /// Create a new Tag for a non-pseudo element. This is mainly used for
+    /// matching existing tags, since it does not accept an `info` argument.
+    pub(crate) fn new(node: OpaqueNode) -> Self {
+        Tag { node, pseudo: None }
+    }
+
+    /// Create a new Tag for a pseudo element. This is mainly used for
+    /// matching existing tags, since it does not accept an `info` argument.
+    pub(crate) fn new_pseudo(node: OpaqueNode, pseudo: Option<PseudoElement>) -> Self {
+        Tag { node, pseudo }
+    }
+
+    /// Returns true if this tag is for a pseudo element.
+    pub(crate) fn is_pseudo(&self) -> bool {
+        self.pseudo.is_some()
+    }
+
+    pub(crate) fn to_display_list_fragment_id(&self) -> u64 {
+        let fragment_type = match self.pseudo {
+            Some(PseudoElement::Before) => FragmentType::BeforePseudoContent,
+            Some(PseudoElement::After) => FragmentType::AfterPseudoContent,
+            _ => FragmentType::FragmentBody,
+        };
+        combine_id_with_fragment_type(self.node.id() as usize, fragment_type) as u64
+    }
+}

--- a/components/layout_2020/fragment_tree/mod.rs
+++ b/components/layout_2020/fragment_tree/mod.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+mod base;
+
+pub(crate) use base::*;

--- a/components/layout_2020/lib.rs
+++ b/components/layout_2020/lib.rs
@@ -18,6 +18,7 @@ pub mod element_data;
 mod flexbox;
 pub mod flow;
 mod formatting_contexts;
+mod fragment_tree;
 mod fragments;
 pub mod geom;
 #[macro_use]

--- a/components/layout_2020/positioned.rs
+++ b/components/layout_2020/positioned.rs
@@ -632,7 +632,7 @@ impl HoistedAbsolutelyPositionedBox {
             };
 
             BoxFragment::new(
-                absolutely_positioned_box.context.tag(),
+                absolutely_positioned_box.context.base_fragment_info(),
                 absolutely_positioned_box.context.style().clone(),
                 fragments,
                 content_rect,

--- a/components/layout_thread_2020/dom_wrapper.rs
+++ b/components/layout_thread_2020/dom_wrapper.rs
@@ -428,6 +428,40 @@ impl<'le> fmt::Debug for ServoLayoutElement<'le> {
     }
 }
 
+impl<'dom> ServoLayoutElement<'dom> {
+    /// Returns true if this element is the body child of an html element root element.
+    fn is_body_element_of_html_element_root(&self) -> bool {
+        if self.element.local_name() != &local_name!("body") {
+            return false;
+        }
+
+        self.parent_element()
+            .map(|element| {
+                element.is_root() && element.element.local_name() == &local_name!("html")
+            })
+            .unwrap_or(false)
+    }
+
+    /// Returns the parent element of this element, if it has one.
+    fn parent_element(&self) -> Option<Self> {
+        self.element
+            .upcast()
+            .composed_parent_node_ref()
+            .and_then(as_element)
+    }
+
+    // Returns true is this is the root element.
+    fn is_root(&self) -> bool {
+        match self.as_node().parent_node() {
+            None => false,
+            Some(node) => match node.script_type_id() {
+                NodeTypeId::Document(_) => true,
+                _ => false,
+            },
+        }
+    }
+}
+
 impl<'le> TElement for ServoLayoutElement<'le> {
     type ConcreteNode = ServoLayoutNode<'le>;
     type TraversalChildrenIterator = DomChildren<Self::ConcreteNode>;
@@ -679,11 +713,7 @@ impl<'le> TElement for ServoLayoutElement<'le> {
     }
 
     fn is_html_document_body_element(&self) -> bool {
-        // This is only used for the "tables inherit from body" quirk, which we
-        // don't implement.
-        //
-        // FIXME(emilio): We should be able to give the right answer though!
-        false
+        self.is_body_element_of_html_element_root()
     }
 
     fn synthesize_presentational_hints_for_legacy_attributes<V>(
@@ -839,13 +869,7 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
     }
 
     fn is_root(&self) -> bool {
-        match self.as_node().parent_node() {
-            None => false,
-            Some(node) => match node.script_type_id() {
-                NodeTypeId::Document(_) => true,
-                _ => false,
-            },
-        }
+        ServoLayoutElement::is_root(self)
     }
 
     fn is_empty(&self) -> bool {
@@ -981,11 +1005,7 @@ impl<'le> ::selectors::Element for ServoLayoutElement<'le> {
     }
 
     fn is_html_element_in_html_document(&self) -> bool {
-        if !self.element.is_html_element() {
-            return false;
-        }
-
-        self.as_node().owner_doc().is_html_document()
+        self.element.is_html_element() && self.as_node().owner_doc().is_html_document()
     }
 }
 
@@ -1360,6 +1380,10 @@ impl<'le> ThreadSafeLayoutElement<'le> for ServoThreadSafeLayoutElement<'le> {
 
     fn is_shadow_host(&self) -> bool {
         self.element.shadow_root().is_some()
+    }
+
+    fn is_body_element_of_html_element_root(&self) -> bool {
+        self.element.is_body_element_of_html_element_root()
     }
 }
 

--- a/components/script_layout_interface/wrapper_traits.rs
+++ b/components/script_layout_interface/wrapper_traits.rs
@@ -491,4 +491,14 @@ pub trait ThreadSafeLayoutElement<'dom>:
     }
 
     fn is_shadow_host(&self) -> bool;
+
+    /// Returns whether this node is a body element of an html element root
+    /// in an HTML element document.
+    ///
+    /// Note that this does require accessing the parent, which this interface
+    /// technically forbids. But accessing the parent is only unsafe insofar as
+    /// it can be used to reach siblings and cousins. A simple immutable borrow
+    /// of the parent data is fine, since the bottom-up traversal will not process
+    /// the parent until all the children have been processed.
+    fn is_body_element_of_html_element_root(&self) -> bool;
 }


### PR DESCRIPTION
During layout it is often useful, for various specification reasons, to know if an element is the `<body>` element of an `<html>` element root. There are a couple places where a brittle heuristic is used to detect `<body>` elements. This information is going to be even more important to properly handle `<html>` elements that inherit their overflow property from their `<body>` children.

Implementing this properly requires updating the DOM wrapper interface. This check does reach up to the parent of thread-safe nodes, but this is essentially the same kind of operation that `parent_style()` does, so is ostensibly safe.

This change should not change any behavior and is just a preparation step for properly handle `<body>` overflow.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes do not require tests because it does not change behavior.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
