### PR TITLE
Update step numbers in URL constructor

### DIFF
--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -77,38 +77,38 @@ impl URL {
         url: USVString,
         base: Option<USVString>,
     ) -> Fallible<DomRoot<URL>> {
+        // Step 1. Parse url with base.
         let parsed_base = match base {
-            None => {
-                // Step 1.
-                None
-            },
-            Some(base) =>
-            // Step 2.1.
-            {
+            None => None,
+            Some(base) => {
                 match ServoUrl::parse(&base.0) {
                     Ok(base) => Some(base),
                     Err(error) => {
-                        // Step 2.2.
+                        // Step 2. Throw a TypeError if URL parsing fails.
                         return Err(Error::Type(format!("could not parse base: {}", error)));
                     },
                 }
             },
         };
-        // Step 3.
         let parsed_url = match ServoUrl::parse_with_base(parsed_base.as_ref(), &url.0) {
             Ok(url) => url,
             Err(error) => {
-                // Step 4.
+                // Step 2. Throw a TypeError if URL parsing fails.
                 return Err(Error::Type(format!("could not parse URL: {}", error)));
             },
         };
-        // Step 5: Skip (see step 8 below).
-        // Steps 6-7.
-        let result = URL::new(global, parsed_url);
-        // Step 8: Instead of construcing a new `URLSearchParams` object here, construct it
-        //         on-demand inside `URL::SearchParams`.
-        // Step 9.
-        Ok(result)
+
+        // Skip the steps below.
+        // Instead of construcing a new `URLSearchParams` object here, construct it
+        // on-demand inside `URL::SearchParams`.
+        //
+        // Step 3. Let query be parsedURL’s query.
+        // Step 5. Set this’s query object to a new URLSearchParams object.
+        // Step 6. Initialize this’s query object with query.
+        // Step 7. Set this’s query object’s URL object to this.
+
+        // Step 4. Set this’s URL to parsedURL.
+        Ok(URL::new(global, parsed_url))
     }
 
     // https://url.spec.whatwg.org/#dom-url-canparse


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Two commits have been made ahead of the current implementation of
Servo's URL constructor:

- Align with a more modern IDL definition style [1]
- Add URL.canParse() [2]

Since these commits don't alter the actual behavior, this commit only
updates the step numbers and adds brief descriptions for each step.

No behavior change is expected with this commit.

[1]: https://github.com/whatwg/url/commit/ea3b75d333cbce91f73676ef2d21bcadb12b4419
[2]: https://github.com/whatwg/url/commit/ae3c28b84e3e7122c2807401c26b8a63cb2ab445


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] These changes do not require tests because no behavior has changed.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
