### PR TITLE
Fix scrolling on root element

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -490,7 +490,8 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                     self.ready_to_save_state,
                     ReadyState::WaitingForConstellationReply
                 );
-                if is_ready && !self.waiting_on_pending_frame {
+                if is_ready && !self.waiting_on_pending_frame && !self.waiting_for_results_of_scroll
+                {
                     self.ready_to_save_state = ReadyState::ReadyToSaveImage;
                     if self.is_running_problem_test {
                         println!("ready to save image!");
@@ -623,8 +624,11 @@ impl<Window: WindowMethods + ?Sized> IOCompositor<Window> {
                 scroll_id,
                 clamping,
             )) => {
+                self.waiting_for_results_of_scroll = true;
+
                 let mut txn = webrender_api::Transaction::new();
                 txn.scroll_node_with_id(point, scroll_id, clamping);
+                txn.generate_frame();
                 self.webrender_api
                     .send_transaction(self.webrender_document, txn);
             },

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1708,13 +1708,18 @@ impl Window {
         let body = self.Document().GetBody();
         let (x, y) = match body {
             Some(e) => {
-                let scroll_area = e.upcast::<Node>().scroll_area();
+                // This doesn't properly take into account the overflow set on <body>
+                // and the root element, which might affect how much the root can
+                // scroll. That requires properly handling propagating those values
+                // according to the rules defined in in the specification at:
+                // https://w3c.github.io/csswg-drafts/css-overflow/#overflow-propagation
+                let scroll_area = e.upcast::<Node>().bounding_content_box_or_zero();
                 (
                     xfinite
-                        .min(scroll_area.width() as f64 - viewport.width as f64)
+                        .min(scroll_area.width().to_f64_px() - viewport.width as f64)
                         .max(0.0f64),
                     yfinite
-                        .min(scroll_area.height() as f64 - viewport.height as f64)
+                        .min(scroll_area.height().to_f64_px() - viewport.height as f64)
                         .max(0.0f64),
                 )
             },

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/long_scroll_composited.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/long_scroll_composited.html.ini
@@ -1,2 +1,0 @@
-[long_scroll_composited.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
@@ -34,3 +34,21 @@
 
   [scrollLeft/scrollTop on the HTML body element in non-quirks mode]
     expected: FAIL
+
+  [scroll() on the root element in non-quirks mode]
+    expected: FAIL
+
+  [scrollBy() on the root element in non-quirks mode]
+    expected: FAIL
+
+  [scrollLeft/scrollTop on the root element in non-quirks mode]
+    expected: FAIL
+
+  [scroll() on the HTML body element in quirks mode]
+    expected: FAIL
+
+  [scrollBy() on the HTML body element in quirks mode]
+    expected: FAIL
+
+  [scrollLeft/scrollTop on the HTML body element in quirks mode]
+    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/filter-effects/backdrop-filter-edge-behavior.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/filter-effects/backdrop-filter-edge-behavior.html.ini
@@ -1,2 +1,0 @@
-[backdrop-filter-edge-behavior.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/filter-effects/filtered-html-is-not-container.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/filter-effects/filtered-html-is-not-container.html.ini
@@ -1,0 +1,2 @@
+[filtered-html-is-not-container.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/filter-effects/filtered-inline-is-container.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/filter-effects/filtered-inline-is-container.html.ini
@@ -1,0 +1,2 @@
+[filtered-inline-is-container.html]
+  expected: FAIL

--- a/tests/wpt/metadata/css/css-position/sticky/position-sticky-bottom-002.html.ini
+++ b/tests/wpt/metadata/css/css-position/sticky/position-sticky-bottom-002.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-bottom-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata/css/css-position/sticky/position-sticky-flexbox.html.ini
+++ b/tests/wpt/metadata/css/css-position/sticky/position-sticky-flexbox.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-flexbox.html]
-  expected: FAIL

--- a/tests/wpt/metadata/css/css-position/sticky/position-sticky-rendering.html.ini
+++ b/tests/wpt/metadata/css/css-position/sticky/position-sticky-rendering.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-rendering.html]
-  expected: FAIL

--- a/tests/wpt/metadata/css/css-position/sticky/position-sticky-top-002.html.ini
+++ b/tests/wpt/metadata/css/css-position/sticky/position-sticky-top-002.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-top-002.html]
-  expected: FAIL

--- a/tests/wpt/metadata/css/cssom-view/long_scroll_composited.html.ini
+++ b/tests/wpt/metadata/css/cssom-view/long_scroll_composited.html.ini
@@ -1,2 +1,0 @@
-[long_scroll_composited.html]
-  expected: FAIL

--- a/tests/wpt/metadata/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
+++ b/tests/wpt/metadata/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
@@ -34,3 +34,21 @@
 
   [scrollLeft/scrollRight of the content in non-quirks mode]
     expected: FAIL
+
+  [scroll() on the root element in non-quirks mode]
+    expected: FAIL
+
+  [scrollBy() on the root element in non-quirks mode]
+    expected: FAIL
+
+  [scrollLeft/scrollTop on the root element in non-quirks mode]
+    expected: FAIL
+
+  [scroll() on the HTML body element in quirks mode]
+    expected: FAIL
+
+  [scrollBy() on the HTML body element in quirks mode]
+    expected: FAIL
+
+  [scrollLeft/scrollTop on the HTML body element in quirks mode]
+    expected: FAIL

--- a/tests/wpt/metadata/css/filter-effects/filtered-inline-is-container.html.ini
+++ b/tests/wpt/metadata/css/filter-effects/filtered-inline-is-container.html.ini
@@ -1,0 +1,2 @@
+[filtered-inline-is-container.html]
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/scroll_root.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/scroll_root.html.ini
@@ -1,2 +1,0 @@
-[scroll_root.html]
-  expected: FAIL


### PR DESCRIPTION
eca0acf4598c173c71765b961bd2079c0bb48cd2 uncovered a bug in the way that the scrolling area of `window` was calculated and broke scrolling on the root element. This change does two things in order to fix that:

1. Does a partial revert of eca0acf4598c173c71765b961bd2079c0bb48cd2 in order to get scrolling from script working again on the window object.
2. Has the compositor always generate a frame for scrolls starting from script and waits for them. This is speculative fix for flakiness in root scrolling tests on CI.

The changes to the compositor expose some hidden failures, which is why some tests are marked as failing now.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
