### PR TITLE
Fix an assertion failure in Layout 2020

### DIFF
--- a/tests/wpt/metadata-layout-2020/css/css-transforms/css-transforms-3d-on-anonymous-block-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/css-transforms-3d-on-anonymous-block-001.html.ini
@@ -1,2 +1,0 @@
-[css-transforms-3d-on-anonymous-block-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/perspective-untransformable-no-stacking-context.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/perspective-untransformable-no-stacking-context.html.ini
@@ -1,2 +1,0 @@
-[perspective-untransformable-no-stacking-context.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/transform-applies-to-002.xht.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/transform-applies-to-002.xht.ini
@@ -1,2 +1,0 @@
-[transform-applies-to-002.xht]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/transform-inline-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/transform-inline-001.html.ini
@@ -1,2 +1,0 @@
-[transform-inline-001.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/transform-table-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/transform-table-001.html.ini
@@ -1,0 +1,2 @@
+[transform-table-001.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/transform-table-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/transform-table-002.html.ini
@@ -1,0 +1,2 @@
+[transform-table-002.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/transform-table-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/transform-table-003.html.ini
@@ -1,0 +1,2 @@
+[transform-table-003.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/transform-table-004.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/transform-table-004.html.ini
@@ -1,0 +1,2 @@
+[transform-table-004.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/transform-table-005.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/transform-table-005.html.ini
@@ -1,0 +1,2 @@
+[transform-table-005.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-transforms/transform3d-image-scale-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-transforms/transform3d-image-scale-001.html.ini
@@ -1,0 +1,2 @@
+[transform3d-image-scale-001.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/filter-effects/filter-cb-abspos-inline-002.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/filter-effects/filter-cb-abspos-inline-002.html.ini
@@ -1,2 +1,0 @@
-[filter-cb-abspos-inline-002.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta-layout-2020/mozilla/element_parentOffset.html.ini
+++ b/tests/wpt/mozilla/meta-layout-2020/mozilla/element_parentOffset.html.ini
@@ -1,3 +1,0 @@
-[element_parentOffset.html]
-  [element_parentOffset]
-    expected: FAIL


### PR DESCRIPTION
The recent changes to containing blocks, exposed an issue in the StyleExt trait:

- When deciding whether an element creates a reference frame, whether or not it is a non-replaced inline is taken into account when determining if it has a transform.
- When deciding whether an element creates a stacking context for all descendants, whether or not it is a non-replaced inline is *not* taken into account when determining if it has a transform.

In both cases, elements that are inline should not be considered to have transforms. This commit fixes that issue as well as making it so that inlines cannot be transformed. Note that is also breaks transforms on replaced elements, but that functionality was fairly half-baked due to the inconsistent determination of transforms.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] There are tests for these changes


<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
