### PR TITLE
Implemented special cases for Element.clientWidth() and clientHeight()

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -81,6 +81,7 @@ use crate::dom::text::Text;
 use crate::dom::validation::Validatable;
 use crate::dom::virtualmethods::{vtable_for, VirtualMethods};
 use crate::dom::window::ReflowReason;
+use crate::dom::window::Window;
 use crate::script_thread::ScriptThread;
 use crate::stylesheet_loader::StylesheetOwner;
 use crate::task::TaskOnce;
@@ -2501,11 +2502,32 @@ impl ElementMethods for Element {
 
     // https://drafts.csswg.org/cssom-view/#dom-element-clientwidth
     fn ClientWidth(&self) -> i32 {
+        let owner_doc: &Document = &self.node.owner_doc();
+        if self.local_name().to_string() == "body" ||
+            matches!(owner_doc.quirks_mode(), QuirksMode::Quirks)
+        {
+            let window: &Window = owner_doc.window();
+            return window.window_size().initial_viewport.round().to_i32().width;
+        }
+
         self.client_rect().size.width
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-clientheight
     fn ClientHeight(&self) -> i32 {
+        let owner_doc: &Document = &self.node.owner_doc();
+        if self.local_name().to_string() == "body" ||
+            matches!(owner_doc.quirks_mode(), QuirksMode::Quirks)
+        {
+            let window: &Window = owner_doc.window();
+            return window
+                .window_size()
+                .initial_viewport
+                .round()
+                .to_i32()
+                .height;
+        }
+
         self.client_rect().size.height
     }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2609,7 +2609,13 @@ impl Window {
             layout_chan,
             layout_rpc,
             window_size: Cell::new(window_size),
-            current_viewport: Cell::new(Rect::zero()),
+            current_viewport: Cell::new(Rect::new(
+                Point2D::zero(),
+                Size2D::new(
+                    Au::from_f32_px(window_size.initial_viewport.width.into()),
+                    Au::from_f32_px(window_size.initial_viewport.width.into()),
+                ),
+            )),
             suppress_reflow: Cell::new(true),
             pending_reflow_count: Default::default(),
             current_state: Cell::new(WindowState::Alive),

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2609,13 +2609,7 @@ impl Window {
             layout_chan,
             layout_rpc,
             window_size: Cell::new(window_size),
-            current_viewport: Cell::new(Rect::new(
-                Point2D::zero(),
-                Size2D::new(
-                    Au::from_f32_px(window_size.initial_viewport.width.into()),
-                    Au::from_f32_px(window_size.initial_viewport.width.into()),
-                ),
-            )),
+            current_viewport: Cell::new(Rect::zero()),
             suppress_reflow: Cell::new(true),
             pending_reflow_count: Default::default(),
             current_state: Cell::new(WindowState::Alive),

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/client-props-root.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/client-props-root.html.ini
@@ -1,4 +1,0 @@
-[client-props-root.html]
-  [client* properties on the root element]
-    expected: FAIL
-

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
@@ -2,9 +2,6 @@
   [scrollingElement in non-quirks mode]
     expected: FAIL
 
-  [clientWidth/clientHeight on the HTML body element in quirks mode]
-    expected: FAIL
-
   [scrollLeft/scrollRight of the content in quirks mode]
     expected: FAIL
 
@@ -12,9 +9,6 @@
     expected: FAIL
 
   [scrollingElement in quirks mode]
-    expected: FAIL
-
-  [clientWidth/clientHeight on the root element in non-quirks mode]
     expected: FAIL
 
   [scrollWidth/scrollHeight on the root element in quirks mode]

--- a/tests/wpt/metadata/css/cssom-view/client-props-root.html.ini
+++ b/tests/wpt/metadata/css/cssom-view/client-props-root.html.ini
@@ -1,4 +1,0 @@
-[client-props-root.html]
-  [client* properties on the root element]
-    expected: FAIL
-

--- a/tests/wpt/metadata/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
+++ b/tests/wpt/metadata/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
@@ -8,9 +8,6 @@
   [scrollWidth/scrollHeight on the HTML body element in quirks mode]
     expected: FAIL
 
-  [clientWidth/clientHeight on the HTML body element in quirks mode]
-    expected: FAIL
-
   [scrollLeft/scrollRight of the content in quirks mode]
     expected: FAIL
 
@@ -18,9 +15,6 @@
     expected: FAIL
 
   [scrollWidth/scrollHeight on the root element in non-quirks mode]
-    expected: FAIL
-
-  [clientWidth/clientHeight on the root element in non-quirks mode]
     expected: FAIL
 
   [scroll() on the HTML body element in non-quirks mode]


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
Implemented the special cases for Element.clientWidth() and Element.clientHeight() as outlined in issue #29704.

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors

<!-- Either: -->
- [x] These changes do not require tests because tests already exist.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->

[Specification text](https://w3c.github.io/csswg-drafts/cssom-view/#dom-element-clientwidth):
> If the element is the [root element](https://w3c.github.io/csswg-drafts/css-display-4/#root-element) and the element’s [node document](https://dom.spec.whatwg.org/#concept-node-document) is not in [quirks mode](https://dom.spec.whatwg.org/#concept-document-quirks), or if the element is [the body element](https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2) and the element’s node document is in quirks mode, return the [viewport](https://www.w3.org/TR/CSS21/visuren.html#x1) width excluding the size of a rendered scroll bar (if any).
