### PR TITLE
Upgrade boto3 python module.

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -22,7 +22,7 @@ ply == 3.8
 colorama == 0.3.7
 
 # For package uploading
-boto3 == 1.17.27
+boto3 == 1.26.127
 PyGithub == 1.58.1
 
 # Default root CAs on Windows CI do not trust CloudFront certificates,


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->

The current version seem to be broken due to API change in one of the transitive dependency (urllib3) causing nightly builds to fail during package upload step with error:

```
ImportError: cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_' (C:\a\servo\servo\python\_virtualenv3.7\Lib\site-packages\urllib3\util\ssl_.py)
```

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [x] These changes fix #29714 

<!-- Either: -->
- [ ] There are tests for these changes OR
- [x] These changes do not require tests because it is only used by CI workflow which has been tested in a [manual run](https://github.com/servo/servo/actions/runs/4892112991).
