### PR TITLE
Snap border and outline widths at computed-value time

### DIFF
--- a/components/style/values/specified/border.rs
+++ b/components/style/values/specified/border.rs
@@ -151,13 +151,19 @@ impl ToComputedValue for BorderSideWidth {
         // We choose the pixel length of the keyword values the same as both spec and gecko.
         // Spec: https://drafts.csswg.org/css-backgrounds-3/#line-width
         // Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1312155#c0
-        match *self {
+        let width = match *self {
             BorderSideWidth::Thin => NonNegativeLength::from_px(1.).to_computed_value(context),
             BorderSideWidth::Medium => NonNegativeLength::from_px(3.).to_computed_value(context),
             BorderSideWidth::Thick => NonNegativeLength::from_px(5.).to_computed_value(context),
             BorderSideWidth::Length(ref length) => length.to_computed_value(context),
+        };
+        if width.px() == 0.0 {
+            width
+        } else {
+            // https://www.w3.org/TR/css-values-4/#snap-a-length-as-a-border-width
+            let dppx = context.builder.device.device_pixel_ratio().get();
+            Self::ComputedValue::new((width.px() * dppx).floor().max(1.0) / dppx)
         }
-        .into()
     }
 
     #[inline]

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/border-width-pixel-snapping-001-a.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/border-width-pixel-snapping-001-a.html.ini
@@ -1,2 +1,0 @@
-[border-width-pixel-snapping-001-a.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/border-width-small-values-001-a.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/border-width-small-values-001-a.html.ini
@@ -1,4 +1,0 @@
-[border-width-small-values-001-a.html]
-  expected:
-    if os == "linux": FAIL
-    

--- a/tests/wpt/metadata-layout-2020/css/css-backgrounds/border-width-small-values-001-b.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-backgrounds/border-width-small-values-001-b.html.ini
@@ -1,3 +1,0 @@
-[border-width-small-values-001-b.html]
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-borders/subpixel-border-width.tentative.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-borders/subpixel-border-width.tentative.html.ini
@@ -1,2 +1,0 @@
-[subpixel-border-width.tentative.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-borders/subpixel-borders-with-child-border-box-sizing.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-borders/subpixel-borders-with-child-border-box-sizing.html.ini
@@ -1,2 +1,0 @@
-[subpixel-borders-with-child-border-box-sizing.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-borders/subpixel-borders-with-child.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-borders/subpixel-borders-with-child.html.ini
@@ -1,2 +1,0 @@
-[subpixel-borders-with-child.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-outline/outline-width-rounding.tentative.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-outline/outline-width-rounding.tentative.html.ini
@@ -1,3 +1,0 @@
-[outline-width-rounding.tentative.html]
-  [Test that outline widths are rounded up when they are greater than 0px but less than 1px, and rounded down when they are greater than 1px.]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-outline/subpixel-outline-width.tentative.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-outline/subpixel-outline-width.tentative.html.ini
@@ -1,2 +1,0 @@
-[subpixel-outline-width.tentative.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-ui/parsing/outline-width-computed.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-ui/parsing/outline-width-computed.html.ini
@@ -1,3 +1,0 @@
-[outline-width-computed.html]
-  [Property outline-width value '2.5px']
-    expected: FAIL

--- a/tests/wpt/metadata/css/css-backgrounds/border-width-pixel-snapping-001-a.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/border-width-pixel-snapping-001-a.html.ini
@@ -1,2 +1,0 @@
-[border-width-pixel-snapping-001-a.html]
-  expected: FAIL

--- a/tests/wpt/metadata/css/css-backgrounds/border-width-small-values-001-a.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/border-width-small-values-001-a.html.ini
@@ -1,3 +1,0 @@
-[border-width-small-values-001-a.html]
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata/css/css-backgrounds/border-width-small-values-001-b.html.ini
+++ b/tests/wpt/metadata/css/css-backgrounds/border-width-small-values-001-b.html.ini
@@ -1,3 +1,0 @@
-[border-width-small-values-001-b.html]
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/metadata/css/css-borders/subpixel-border-width.tentative.html.ini
+++ b/tests/wpt/metadata/css/css-borders/subpixel-border-width.tentative.html.ini
@@ -1,2 +1,0 @@
-[subpixel-border-width.tentative.html]
-  expected: FAIL

--- a/tests/wpt/metadata/css/css-borders/subpixel-borders-with-child-border-box-sizing.html.ini
+++ b/tests/wpt/metadata/css/css-borders/subpixel-borders-with-child-border-box-sizing.html.ini
@@ -1,2 +1,0 @@
-[subpixel-borders-with-child-border-box-sizing.html]
-  expected: FAIL

--- a/tests/wpt/metadata/css/css-borders/subpixel-borders-with-child.html.ini
+++ b/tests/wpt/metadata/css/css-borders/subpixel-borders-with-child.html.ini
@@ -1,2 +1,0 @@
-[subpixel-borders-with-child.html]
-  expected: FAIL

--- a/tests/wpt/metadata/css/css-outline/outline-width-rounding.tentative.html.ini
+++ b/tests/wpt/metadata/css/css-outline/outline-width-rounding.tentative.html.ini
@@ -1,3 +1,0 @@
-[outline-width-rounding.tentative.html]
-  [Test that outline widths are rounded up when they are greater than 0px but less than 1px, and rounded down when they are greater than 1px.]
-    expected: FAIL

--- a/tests/wpt/metadata/css/css-outline/subpixel-outline-width.tentative.html.ini
+++ b/tests/wpt/metadata/css/css-outline/subpixel-outline-width.tentative.html.ini
@@ -1,2 +1,0 @@
-[subpixel-outline-width.tentative.html]
-  expected: FAIL

--- a/tests/wpt/metadata/css/css-ui/parsing/outline-width-computed.html.ini
+++ b/tests/wpt/metadata/css/css-ui/parsing/outline-width-computed.html.ini
@@ -1,3 +1,0 @@
-[outline-width-computed.html]
-  [Property outline-width value '2.5px']
-    expected: FAIL


### PR DESCRIPTION
<!-- Please describe your changes on the following line: -->
According to the spec:
https://www.w3.org/TR/css-values-4/#snap-a-length-as-a-border-width

Tests:
- /css/css-backgrounds/border-width-pixel-snapping-001-a.html
- /css/css-backgrounds/border-width-small-values-001-a.html
- /css/css-backgrounds/border-width-small-values-001-b.html
- /css/css-borders/subpixel-border-width.tentative.html
- /css/css-borders/subpixel-borders-with-child-border-box-sizing.html
- /css/css-borders/subpixel-borders-with-child.html
- /css/css-outline/outline-width-rounding.tentative.html
- /css/css-outline/subpixel-outline-width.tentative.html
- /css/css-ui/parsing/outline-width-computed.html

---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [X] These changes fix #29696 (GitHub issue number if applicable)

<!-- Either: -->
- [X] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
