### PR TITLE
layout 2020: Implement justify-content in flexbox

### DIFF
--- a/components/style/properties/longhands/position.mako.rs
+++ b/components/style/properties/longhands/position.mako.rs
@@ -92,12 +92,13 @@ ${helpers.single_keyword(
     gecko_enum_prefix = "StyleFlexWrap",
 )}
 
-% if engine == "servo-2013":
+% if engine in ["servo-2013", "servo-2020"]:
     // FIXME: Update Servo to support the same Syntax as Gecko.
     ${helpers.single_keyword(
         "justify-content",
         "flex-start stretch flex-end center space-between space-around",
-        engines="servo-2013",
+        engines="servo-2013 servo-2020",
+        servo_2020_pref="layout.flexbox.enabled",
         extra_prefixes="webkit",
         spec="https://drafts.csswg.org/css-align/#propdef-justify-content",
         animation_value_type="discrete",

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-factor-less-than-one.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-factor-less-than-one.html.ini
@@ -25,12 +25,3 @@
 
   [.flexbox 19]
     expected: FAIL
-
-  [.flexbox 22]
-    expected: FAIL
-
-  [.flexbox 21]
-    expected: FAIL
-
-  [.flexbox 20]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-014.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flex-minimum-height-flex-items-014.html.ini
@@ -1,2 +1,0 @@
-[flex-minimum-height-flex-items-014.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-items-as-stacking-contexts-003.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-items-as-stacking-contexts-003.html.ini
@@ -1,2 +1,0 @@
-[flexbox-items-as-stacking-contexts-003.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-root-node-001a.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-root-node-001a.html.ini
@@ -1,0 +1,3 @@
+[flexbox-root-node-001a.html]
+  expected: FAIL
+

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-root-node-001b.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox-root-node-001b.html.ini
@@ -1,0 +1,3 @@
+[flexbox-root-node-001b.html]
+  expected: FAIL
+

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_columns-flexitems-2.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_columns-flexitems-2.html.ini
@@ -1,2 +1,0 @@
-[flexbox_columns-flexitems-2.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_columns-flexitems.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_columns-flexitems.html.ini
@@ -1,2 +1,0 @@
-[flexbox_columns-flexitems.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-center-overflow.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-center-overflow.html.ini
@@ -1,9 +1,0 @@
-[flexbox_justifycontent-center-overflow.html]
-  [span 1]
-    expected: FAIL
-
-  [span 2]
-    expected: FAIL
-
-  [span 3]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-rtl-001.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-rtl-001.html.ini
@@ -5,22 +5,19 @@
   [.container > div 2]
     expected: FAIL
 
-  [.container > div 3]
-    expected: FAIL
-
   [.container > div 4]
     expected: FAIL
 
   [.container > div 5]
     expected: FAIL
 
-  [.container > div 6]
-    expected: FAIL
-
   [.container > div 7]
     expected: FAIL
 
   [.container > div 9]
+    expected: FAIL
+
+  [.container > div 10]
     expected: FAIL
 
   [.container > div 12]

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-spacebetween-negative.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_justifycontent-spacebetween-negative.html.ini
@@ -1,0 +1,2 @@
+[flexbox_justifycontent-spacebetween-negative.html]
+  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_order-abspos-space-around.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/flexbox_order-abspos-space-around.html.ini
@@ -1,2 +1,0 @@
-[flexbox_order-abspos-space-around.html]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/getcomputedstyle/flexbox_computedstyle_justify-content-center.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/getcomputedstyle/flexbox_computedstyle_justify-content-center.html.ini
@@ -1,3 +1,0 @@
-[flexbox_computedstyle_justify-content-center.html]
-  [flexbox | computed style | justify-content: center]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/getcomputedstyle/flexbox_computedstyle_justify-content-flex-end.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/getcomputedstyle/flexbox_computedstyle_justify-content-flex-end.html.ini
@@ -1,3 +1,0 @@
-[flexbox_computedstyle_justify-content-flex-end.html]
-  [flexbox | computed style | justify-content: flex-end]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/getcomputedstyle/flexbox_computedstyle_justify-content-flex-start.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/getcomputedstyle/flexbox_computedstyle_justify-content-flex-start.html.ini
@@ -1,3 +1,0 @@
-[flexbox_computedstyle_justify-content-flex-start.html]
-  [flexbox | computed style | justify-content: flex-start]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/getcomputedstyle/flexbox_computedstyle_justify-content-space-around.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/getcomputedstyle/flexbox_computedstyle_justify-content-space-around.html.ini
@@ -1,3 +1,0 @@
-[flexbox_computedstyle_justify-content-space-around.html]
-  [flexbox | computed style | justify-content: space-around]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/getcomputedstyle/flexbox_computedstyle_justify-content-space-between.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/getcomputedstyle/flexbox_computedstyle_justify-content-space-between.html.ini
@@ -1,3 +1,0 @@
-[flexbox_computedstyle_justify-content-space-between.html]
-  [flexbox | computed style | justify-content: space-between]
-    expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/inheritance.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/inheritance.html.ini
@@ -14,8 +14,5 @@
   [Property align-self has initial value auto]
     expected: FAIL
 
-  [Property justify-content does not inherit]
-    expected: FAIL
-
   [Property align-content does not inherit]
     expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/justify-content-001.htm.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/justify-content-001.htm.ini
@@ -1,2 +1,0 @@
-[justify-content-001.htm]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/justify-content-003.htm.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/justify-content-003.htm.ini
@@ -1,2 +1,0 @@
-[justify-content-003.htm]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/justify-content-004.htm.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/justify-content-004.htm.ini
@@ -1,2 +1,0 @@
-[justify-content-004.htm]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/css-flexbox/justify-content-005.htm.ini
+++ b/tests/wpt/metadata-layout-2020/css/css-flexbox/justify-content-005.htm.ini
@@ -1,2 +1,0 @@
-[justify-content-005.htm]
-  expected: FAIL

--- a/tests/wpt/metadata-layout-2020/css/cssom-view/offsetTopLeftInScrollableParent.html.ini
+++ b/tests/wpt/metadata-layout-2020/css/cssom-view/offsetTopLeftInScrollableParent.html.ini
@@ -1,3 +1,0 @@
-[offsetTopLeftInScrollableParent.html]
-  [Margins on child and parent, border on child and parent, padding on child and parent]
-    expected: FAIL


### PR DESCRIPTION
Align the items along the main-axis per justify-content.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [x] `./mach build -d` does not report any errors
- [x] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [x] There are tests for these changes OR
- [ ] These changes do not require tests because ___

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
