### PR TITLE
Don't go through app-units-ratio to convert absolute lengths

### DIFF
--- a/components/style/values/specified/font.rs
+++ b/components/style/values/specified/font.rs
@@ -15,7 +15,7 @@ use crate::values::computed::{CSSPixelLength, Context, ToComputedValue};
 use crate::values::generics::font::VariationValue;
 use crate::values::generics::font::{self as generics, FeatureTagValue, FontSettings, FontTag};
 use crate::values::generics::NonNegative;
-use crate::values::specified::length::{FontBaseSize, AU_PER_PT, AU_PER_PX};
+use crate::values::specified::length::{FontBaseSize, PX_PER_PT};
 use crate::values::specified::{AllowQuirks, Angle, Integer, LengthPercentage};
 use crate::values::specified::{NoCalcLength, NonNegativeNumber, Number, Percentage};
 use crate::values::CustomIdent;
@@ -2287,7 +2287,7 @@ impl MozScriptMinSize {
     #[inline]
     /// Calculate initial value of -moz-script-min-size.
     pub fn get_initial_value() -> Length {
-        Length::new(DEFAULT_SCRIPT_MIN_SIZE_PT as f32 * (AU_PER_PT / AU_PER_PX))
+        Length::new(DEFAULT_SCRIPT_MIN_SIZE_PT as f32 * PX_PER_PT)
     }
 }
 

--- a/components/style/values/specified/length.rs
+++ b/components/style/values/specified/length.rs
@@ -32,20 +32,18 @@ pub use super::image::Image;
 pub use super::image::{EndingShape as GradientEndingShape, Gradient};
 pub use crate::values::specified::calc::CalcLengthPercentage;
 
-/// Number of app units per pixel
-pub const AU_PER_PX: CSSFloat = 60.;
-/// Number of app units per inch
-pub const AU_PER_IN: CSSFloat = AU_PER_PX * 96.;
-/// Number of app units per centimeter
-pub const AU_PER_CM: CSSFloat = AU_PER_IN / 2.54;
-/// Number of app units per millimeter
-pub const AU_PER_MM: CSSFloat = AU_PER_IN / 25.4;
-/// Number of app units per quarter
-pub const AU_PER_Q: CSSFloat = AU_PER_MM / 4.;
-/// Number of app units per point
-pub const AU_PER_PT: CSSFloat = AU_PER_IN / 72.;
-/// Number of app units per pica
-pub const AU_PER_PC: CSSFloat = AU_PER_PT * 12.;
+/// Number of pixels per inch
+pub const PX_PER_IN: CSSFloat = 96.;
+/// Number of pixels per centimeter
+pub const PX_PER_CM: CSSFloat = PX_PER_IN / 2.54;
+/// Number of pixels per millimeter
+pub const PX_PER_MM: CSSFloat = PX_PER_IN / 25.4;
+/// Number of pixels per quarter
+pub const PX_PER_Q: CSSFloat = PX_PER_MM / 4.;
+/// Number of pixels per point
+pub const PX_PER_PT: CSSFloat = PX_PER_IN / 72.;
+/// Number of pixels per pica
+pub const PX_PER_PC: CSSFloat = PX_PER_PT * 12.;
 
 /// A font relative length.
 #[derive(Clone, Copy, Debug, MallocSizeOf, PartialEq, ToCss, ToShmem)]
@@ -407,12 +405,12 @@ impl AbsoluteLength {
 
         let pixel = match *self {
             AbsoluteLength::Px(value) => value,
-            AbsoluteLength::In(value) => value * (AU_PER_IN / AU_PER_PX),
-            AbsoluteLength::Cm(value) => value * (AU_PER_CM / AU_PER_PX),
-            AbsoluteLength::Mm(value) => value * (AU_PER_MM / AU_PER_PX),
-            AbsoluteLength::Q(value) => value * (AU_PER_Q / AU_PER_PX),
-            AbsoluteLength::Pt(value) => value * (AU_PER_PT / AU_PER_PX),
-            AbsoluteLength::Pc(value) => value * (AU_PER_PC / AU_PER_PX),
+            AbsoluteLength::In(value) => value * PX_PER_IN,
+            AbsoluteLength::Cm(value) => value * PX_PER_CM,
+            AbsoluteLength::Mm(value) => value * PX_PER_MM,
+            AbsoluteLength::Q(value) => value * PX_PER_Q,
+            AbsoluteLength::Pt(value) => value * PX_PER_PT,
+            AbsoluteLength::Pc(value) => value * PX_PER_PC,
         };
         pixel.min(f32::MAX).max(f32::MIN)
     }


### PR DESCRIPTION
This is a backport of https://phabricator.services.mozilla.com/D143942, by Emilio Cobos Álvarez.

This doesn't change behavior on its own, but the current code introduces some minor floating point error which we can avoid, and which would cause failures with the patch for #29696.

<!-- Please describe your changes on the following line: -->


---
<!-- Thank you for contributing to Servo! Please replace each `[ ]` by `[X]` when the step is complete, and replace `___` with appropriate data: -->
- [X] `./mach build -d` does not report any errors
- [X] `./mach test-tidy` does not report any errors
- [ ] These changes fix #___ (GitHub issue number if applicable)

<!-- Either: -->
- [ ] There are tests for these changes OR
- [X] These changes do not require tests because they don't change behavior on their own.

<!-- Also, please make sure that "Allow edits from maintainers" checkbox is checked, so that we can help you if you get stuck somewhere along the way.-->

<!-- Pull requests that do not address these steps are welcome, but they will require additional verification as part of the review process. -->
